### PR TITLE
test: backfill scaffold coverage, widen 100% gate to all of app/

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,22 +12,9 @@
             <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <!--
-        Coverage is gated at 100% (see the `test` composer script). The source
-        set is scoped to feature code as it lands so the gate stays green while
-        the pre-existing scaffold is backfilled separately. Extend this list as
-        each new feature is built. Currently: Channels foundation (#13).
-    -->
     <source>
         <include>
-            <directory>app/Actions/Channels</directory>
-            <directory>app/Http/Controllers/Channels</directory>
-            <file>app/Data/ChannelData.php</file>
-            <file>app/Enums/ChannelVisibility.php</file>
-            <file>app/Models/Channel.php</file>
-            <file>app/Models/ChannelMember.php</file>
-            <file>app/Observers/MembershipObserver.php</file>
-            <file>app/Policies/ChannelPolicy.php</file>
+            <directory>app</directory>
         </include>
     </source>
     <php>

--- a/tests/Feature/Concerns/GeneratesUniqueTeamSlugsTest.php
+++ b/tests/Feature/Concerns/GeneratesUniqueTeamSlugsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\Team;
+
+test('non numeric slug suffixes are ignored when choosing the next suffix', function () {
+    // Matches the "acme-%" LIKE clause but not the numeric pattern, exercising the
+    // null branch in the suffix mapper.
+    Team::factory()->create(['name' => 'Acme Beta', 'slug' => 'acme-beta']);
+
+    $team = Team::factory()->create(['name' => 'Acme', 'slug' => '']);
+
+    expect($team->slug)->toBe('acme-1');
+});
+
+test('a fresh name keeps its bare slug', function () {
+    $team = Team::factory()->create(['name' => 'Unique Co', 'slug' => '']);
+
+    expect($team->slug)->toBe('unique-co');
+});

--- a/tests/Feature/Concerns/HasTeamsTest.php
+++ b/tests/Feature/Concerns/HasTeamsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+
+test('personal team returns the users personal team', function () {
+    $user = User::factory()->create();
+
+    $personal = $user->personalTeam();
+
+    expect($personal)->not->toBeNull()
+        ->and($personal->is_personal)->toBeTrue()
+        ->and($personal->id)->toBe($user->currentTeam->id);
+});
+
+test('owned teams returns only teams the user owns', function () {
+    $user = User::factory()->create();
+    $personal = $user->currentTeam;
+
+    $ownedTeam = Team::factory()->create();
+    $ownedTeam->members()->attach($user, ['role' => TeamRole::Owner->value]);
+
+    $memberTeam = Team::factory()->create();
+    $memberTeam->members()->attach($user, ['role' => TeamRole::Member->value]);
+
+    $ownedIds = $user->ownedTeams()->pluck('teams.id');
+
+    expect($ownedIds)->toContain($personal->id)
+        ->toContain($ownedTeam->id)
+        ->not->toContain($memberTeam->id);
+});
+
+test('switching to a team the user does not belong to returns false', function () {
+    $user = User::factory()->create();
+    $current = $user->currentTeam;
+
+    $foreignTeam = Team::factory()->create();
+
+    expect($user->switchTeam($foreignTeam))->toBeFalse()
+        ->and($user->refresh()->current_team_id)->toBe($current->id);
+});
+
+test('fallback team returns the first team ordered by name', function () {
+    // Name the user last so their personal team never wins the ordering.
+    $user = User::factory()->create(['name' => 'Zzz']);
+
+    $alpha = Team::factory()->create(['name' => 'Alpha']);
+    $zulu = Team::factory()->create(['name' => 'Zulu']);
+
+    foreach ([$alpha, $zulu] as $team) {
+        $team->members()->attach($user, ['role' => TeamRole::Member->value]);
+    }
+
+    expect($user->fallbackTeam()->id)->toBe($alpha->id);
+});
+
+test('fallback team can exclude a given team', function () {
+    $user = User::factory()->create(['name' => 'Zzz']);
+
+    $alpha = Team::factory()->create(['name' => 'Alpha']);
+    $bravo = Team::factory()->create(['name' => 'Bravo']);
+
+    foreach ([$alpha, $bravo] as $team) {
+        $team->members()->attach($user, ['role' => TeamRole::Member->value]);
+    }
+
+    expect($user->fallbackTeam(excluding: $alpha)->id)->toBe($bravo->id);
+});

--- a/tests/Feature/Http/Responses/AuthResponsesTest.php
+++ b/tests/Feature/Http/Responses/AuthResponsesTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Http\Responses\LoginResponse;
+use App\Http\Responses\RegisterResponse;
+use App\Http\Responses\TwoFactorLoginResponse;
+use App\Http\Responses\VerifyEmailResponse;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Build a request whose authenticated user resolves to the given user.
+ */
+function requestForUser(?User $user, bool $wantsJson): Request
+{
+    $request = Request::create('/', 'POST');
+
+    if ($wantsJson) {
+        $request->headers->set('Accept', 'application/json');
+    }
+
+    $request->setUserResolver(fn () => $user);
+
+    return $request;
+}
+
+dataset('auth responses', [
+    'login' => [fn () => new LoginResponse, 200],
+    'register' => [fn () => new RegisterResponse, 201],
+    'two factor login' => [fn () => new TwoFactorLoginResponse, 200],
+    'verify email' => [fn () => new VerifyEmailResponse, 204],
+]);
+
+test('json requests receive a json response', function (Closure $make, int $status) {
+    $response = $make()->toResponse(requestForUser(User::factory()->create(), wantsJson: true));
+
+    expect($response)->toBeInstanceOf(JsonResponse::class)
+        ->and($response->getStatusCode())->toBe($status);
+})->with('auth responses');
+
+test('browser requests redirect to the current team path', function (Closure $make) {
+    $user = User::factory()->create();
+    $slug = $user->currentTeam->slug;
+
+    $response = $make()->toResponse(requestForUser($user, wantsJson: false));
+
+    expect($response)->toBeInstanceOf(RedirectResponse::class)
+        ->and($response->getTargetUrl())->toContain("/{$slug}");
+})->with('auth responses');
+
+test('the verify email redirect marks the address as verified', function () {
+    $user = User::factory()->create();
+
+    $response = (new VerifyEmailResponse)->toResponse(requestForUser($user, wantsJson: false));
+
+    expect($response->getTargetUrl())->toContain('verified=1');
+});
+
+test('a request without a user is forbidden', function () {
+    $this->expectException(HttpException::class);
+
+    (new LoginResponse)->toResponse(requestForUser(null, wantsJson: false));
+});

--- a/tests/Feature/Middleware/EnsureTeamMembershipTest.php
+++ b/tests/Feature/Middleware/EnsureTeamMembershipTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Http\Middleware\EnsureTeamMembership;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Register a throwaway route guarded by the middleware for the given minimum role
+ * and return its URL for the given team slug.
+ */
+function gatedTeamUrl(string $slug, ?string $role = null): string
+{
+    $suffix = $role ?? 'any';
+    $middleware = $role === null
+        ? EnsureTeamMembership::class
+        : EnsureTeamMembership::class.':'.$role;
+
+    Route::middleware($middleware)
+        ->get('_test/gated/'.$suffix.'/{current_team}', fn () => response('ok'));
+
+    return '/_test/gated/'.$suffix.'/'.$slug;
+}
+
+test('members are allowed through', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(gatedTeamUrl($user->currentTeam->slug))
+        ->assertOk();
+});
+
+test('non members are forbidden', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $this->actingAs($user)
+        ->get(gatedTeamUrl($team->slug))
+        ->assertForbidden();
+});
+
+test('unknown team slug is forbidden', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(gatedTeamUrl('does-not-exist'))
+        ->assertForbidden();
+});
+
+test('members with a sufficient role are allowed through', function () {
+    $user = User::factory()->create();
+
+    // Personal-team owners outrank the admin requirement.
+    $this->actingAs($user)
+        ->get(gatedTeamUrl($user->currentTeam->slug, TeamRole::Admin->value))
+        ->assertOk();
+});
+
+test('members with an insufficient role are forbidden', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $this->actingAs($member)
+        ->get(gatedTeamUrl($team->slug, TeamRole::Admin->value))
+        ->assertForbidden();
+});
+
+test('an unknown minimum role is forbidden', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(gatedTeamUrl($user->currentTeam->slug, 'superuser'))
+        ->assertForbidden();
+});
+
+test('visiting a team route switches the current team', function () {
+    $user = User::factory()->create();
+    $current = $user->currentTeam;
+
+    $other = Team::factory()->create();
+    $other->members()->attach($user, ['role' => TeamRole::Owner->value]);
+
+    expect($user->isCurrentTeam($current))->toBeTrue();
+
+    $this->actingAs($user)
+        ->get(route('dashboard', ['current_team' => $other->slug]))
+        ->assertOk();
+
+    expect($user->refresh()->current_team_id)->toBe($other->id);
+});

--- a/tests/Feature/Models/TeamInvitationTest.php
+++ b/tests/Feature/Models/TeamInvitationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Models\TeamInvitation;
+
+test('a fresh invitation is pending', function () {
+    $invitation = TeamInvitation::factory()->create();
+
+    expect($invitation->isPending())->toBeTrue()
+        ->and($invitation->isAccepted())->toBeFalse()
+        ->and($invitation->isExpired())->toBeFalse();
+});
+
+test('an accepted invitation is not pending', function () {
+    $invitation = TeamInvitation::factory()->accepted()->create();
+
+    expect($invitation->isPending())->toBeFalse()
+        ->and($invitation->isAccepted())->toBeTrue();
+});
+
+test('an expired invitation is not pending', function () {
+    $invitation = TeamInvitation::factory()->expired()->create();
+
+    expect($invitation->isPending())->toBeFalse()
+        ->and($invitation->isExpired())->toBeTrue();
+});
+
+test('a generated code is assigned on creation', function () {
+    $invitation = TeamInvitation::factory()->create();
+
+    expect($invitation->code)->toHaveLength(64);
+});

--- a/tests/Feature/Notifications/TeamInvitationNotificationTest.php
+++ b/tests/Feature/Notifications/TeamInvitationNotificationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
+
+beforeEach(function () {
+    $this->team = Team::factory()->create(['name' => 'Laravel Team']);
+    $this->inviter = User::factory()->create(['name' => 'Taylor Otwell']);
+
+    $this->invitation = TeamInvitation::factory()->create([
+        'team_id' => $this->team->id,
+        'invited_by' => $this->inviter->id,
+        'role' => TeamRole::Admin,
+    ]);
+});
+
+test('it is delivered over mail', function () {
+    $notification = new TeamInvitationNotification($this->invitation);
+
+    expect($notification->via(new stdClass))->toBe(['mail']);
+});
+
+test('the mail message links to the login page with the invitation code', function () {
+    $notification = new TeamInvitationNotification($this->invitation);
+
+    $mail = $notification->toMail(new stdClass);
+
+    expect($mail->subject)->toBe("You've been invited to join Laravel Team")
+        ->and($mail->actionText)->toBe('Log in')
+        ->and($mail->actionUrl)->toBe(route('login', ['invitation' => $this->invitation->code]));
+
+    expect($mail->introLines)->toContain('Taylor Otwell has invited you to join the Laravel Team team.');
+});
+
+test('the array representation carries the invitation context', function () {
+    $notification = new TeamInvitationNotification($this->invitation);
+
+    expect($notification->toArray(new stdClass))->toBe([
+        'invitation_id' => $this->invitation->id,
+        'team_id' => $this->team->id,
+        'team_name' => 'Laravel Team',
+        'role' => TeamRole::Admin->value,
+    ]);
+});

--- a/tests/Feature/Policies/TeamPolicyTest.php
+++ b/tests/Feature/Policies/TeamPolicyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use App\Policies\TeamPolicy;
+
+beforeEach(function () {
+    $this->policy = new TeamPolicy;
+});
+
+test('any user can view the team index and create teams', function () {
+    $user = User::factory()->create();
+
+    expect($this->policy->viewAny($user))->toBeTrue()
+        ->and($this->policy->create($user))->toBeTrue();
+});
+
+test('only members can view a team', function () {
+    $member = User::factory()->create();
+    $outsider = User::factory()->create();
+
+    $team = Team::factory()->create();
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    expect($this->policy->view($member, $team))->toBeTrue()
+        ->and($this->policy->view($outsider, $team))->toBeFalse();
+});
+
+test('adding members requires the add member permission', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    expect($this->policy->addMember($owner, $team))->toBeTrue()
+        ->and($this->policy->addMember($member, $team))->toBeFalse();
+});

--- a/tests/Feature/Providers/AppServiceProviderTest.php
+++ b/tests/Feature/Providers/AppServiceProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Providers\AppServiceProvider;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+
+test('production enforces a strong default password policy', function () {
+    $this->app->detectEnvironment(fn () => 'production');
+
+    try {
+        (new AppServiceProvider($this->app))->boot();
+
+        $validator = Validator::make(
+            ['password' => 'weak'],
+            ['password' => Password::defaults()],
+        );
+
+        expect($validator->fails())->toBeTrue()
+            ->and(Password::defaults())->not->toBeNull();
+    } finally {
+        // Restore non-destructive defaults so the test database can be torn down.
+        DB::prohibitDestructiveCommands(false);
+        Password::defaults(fn () => null);
+    }
+});

--- a/tests/Feature/Providers/FortifyServiceProviderTest.php
+++ b/tests/Feature/Providers/FortifyServiceProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('the login page exposes a pending invitation when the code is valid', function () {
+    $team = Team::factory()->create(['name' => 'Laravel Team']);
+    $invitation = TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'invited_by' => User::factory()->create()->id,
+    ]);
+
+    $this->get(route('login', ['invitation' => $invitation->code]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/Login')
+            ->where('teamInvitation.code', $invitation->code)
+            ->where('teamInvitation.teamName', 'Laravel Team'),
+        );
+});
+
+test('the login page ignores an unknown invitation code', function () {
+    $this->get(route('login', ['invitation' => 'unknown-code']))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('auth/Login')
+            ->where('teamInvitation', null),
+        );
+});

--- a/tests/Feature/Providers/TypeScriptTransformerServiceProviderTest.php
+++ b/tests/Feature/Providers/TypeScriptTransformerServiceProviderTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Providers\TypeScriptTransformerServiceProvider;
+use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
+
+test('it configures the typescript transformer', function () {
+    $this->app->forgetInstance(TypeScriptTransformerConfig::class);
+
+    (new TypeScriptTransformerServiceProvider($this->app))->register();
+
+    expect($this->app->make(TypeScriptTransformerConfig::class))
+        ->toBeInstanceOf(TypeScriptTransformerConfig::class);
+});

--- a/tests/Feature/Rules/TeamNameTest.php
+++ b/tests/Feature/Rules/TeamNameTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Rules\TeamName;
+use Illuminate\Support\Facades\Validator;
+
+test('reserved team names fail validation', function () {
+    $validator = Validator::make(
+        ['name' => 'Settings'],
+        ['name' => new TeamName],
+    );
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->first('name'))
+        ->toBe('This team name is reserved and cannot be used.');
+});
+
+test('ordinary team names pass validation', function () {
+    $validator = Validator::make(
+        ['name' => 'Marketing Wizards'],
+        ['name' => new TeamName],
+    );
+
+    expect($validator->fails())->toBeFalse();
+});

--- a/tests/Feature/Rules/ValidTeamInvitationTest.php
+++ b/tests/Feature/Rules/ValidTeamInvitationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Rules\ValidTeamInvitation;
+
+/**
+ * Run the rule and capture the first failure message, or null when it passes.
+ */
+function runInvitationRule(?User $user, mixed $value): ?string
+{
+    $message = null;
+
+    (new ValidTeamInvitation($user))->validate('invitation', $value, function (string $failure) use (&$message) {
+        $message ??= $failure;
+    });
+
+    return $message;
+}
+
+test('a missing invitation fails', function () {
+    $user = User::factory()->create();
+
+    expect(runInvitationRule($user, null))
+        ->toBe('This invitation was sent to a different email address.');
+});
+
+test('a missing user fails', function () {
+    $invitation = TeamInvitation::factory()->create();
+
+    expect(runInvitationRule(null, $invitation))
+        ->toBe('This invitation was sent to a different email address.');
+});
+
+test('an accepted invitation fails', function () {
+    $user = User::factory()->create();
+    $invitation = TeamInvitation::factory()->accepted()->create(['email' => $user->email]);
+
+    expect(runInvitationRule($user, $invitation))
+        ->toBe('This invitation has already been accepted.');
+});
+
+test('an expired invitation fails', function () {
+    $user = User::factory()->create();
+    $invitation = TeamInvitation::factory()->expired()->create(['email' => $user->email]);
+
+    expect(runInvitationRule($user, $invitation))
+        ->toBe('This invitation has expired.');
+});
+
+test('an invitation for another email fails', function () {
+    $user = User::factory()->create();
+    $invitation = TeamInvitation::factory()->create(['email' => 'someone-else@example.com']);
+
+    expect(runInvitationRule($user, $invitation))
+        ->toBe('This invitation was sent to a different email address.');
+});
+
+test('a valid invitation passes', function () {
+    $user = User::factory()->create();
+    $invitation = TeamInvitation::factory()->create(['email' => $user->email]);
+
+    expect(runInvitationRule($user, $invitation))->toBeNull();
+});

--- a/tests/Feature/Settings/SecurityTest.php
+++ b/tests/Feature/Settings/SecurityTest.php
@@ -60,6 +60,19 @@ test('security page renders without two factor when feature is disabled', functi
         );
 });
 
+test('security page renders with password rules', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->get(route('security.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/Security')
+            ->has('passwordRules'),
+        );
+});
+
 test('password can be updated', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
## Summary

PR #15 introduced a 100% coverage gate (`composer test` → `--coverage --min=100`) but temporarily scoped `phpunit.xml` `<source>` to the Channels domain so the gate stayed green while the pre-existing scaffold was untested. This PR backfills that scaffold and widens `<source>` back to `<directory>app</directory>`.

Baseline after widening: **94.5%**. Now: **100.0%**, every file at 100%.

## What was covered (all real tests — no exclusions, no `@codeCoverageIgnore`)

| Area | Gap closed |
|------|-----------|
| `Http/Middleware/EnsureTeamMembership` | role gating (`:minimumRole`) + auto team-switch on `{current_team}` routes |
| `Concerns/HasTeams` | `ownedTeams`, `personalTeam`, `fallbackTeam`, `switchTeam` non-member path |
| `Concerns/GeneratesUniqueTeamSlugs` | non-numeric slug-suffix branch |
| `Policies/TeamPolicy` | `viewAny` / `view` / `create` / `addMember` |
| `Rules/TeamName`, `Rules/ValidTeamInvitation` | reserved-name + not-instanceof/null-user branches |
| `Models/TeamInvitation` | `isPending` |
| `Notifications/Teams/TeamInvitation` | `toMail` / `toArray` |
| `Http/Responses/{Login,Register,TwoFactorLogin,VerifyEmail}Response` | `wantsJson` JSON vs. redirect branches |
| `Http/Controllers/Settings/SecurityController::edit` + `TwoFactorAuthenticationRequest` | rendered `security.edit` with 2FA feature off (root cause: `Features::twoFactorAuthentication()` is not enabled, so the existing 2FA tests skip and never exercised `edit()`) |
| `Providers/AppServiceProvider` | production strong-password closure |
| `Providers/FortifyServiceProvider` | invitation-not-found → null on login page |
| `Providers/TypeScriptTransformerServiceProvider` | `configure()` via `register()` resolving the config singleton |

## Notes
- **Exclusions: none.** `TypeScriptTransformerServiceProvider` was flagged as a possible precise exclusion but proved testable by resolving `TypeScriptTransformerConfig` from the container, so no `<exclude>` was added.
- No application behavior changed.
- `composer test` passes end-to-end: Pint + PHPStan + `--min=100` over full `app/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)