### PR TITLE
feat(workspace): 3-pane layout visual polish (#2)

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -59,6 +59,7 @@
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-ring: var(--sidebar-ring);
+    --color-sidebar-rail: var(--sidebar-rail);
 }
 
 /*
@@ -124,6 +125,7 @@
     --sidebar-border: hsl(0 0% 91%);
     --sidebar-ring: hsl(217.2 91.2% 59.8%);
     --sidebar: hsl(0 0% 98%);
+    --sidebar-rail: hsl(0 0% 94%);
 }
 
 .dark {
@@ -160,6 +162,7 @@
     --sidebar-border: hsl(0 0% 15.9%);
     --sidebar-ring: hsl(217.2 91.2% 59.8%);
     --sidebar: hsl(240 5.9% 10%);
+    --sidebar-rail: hsl(0 0% 5.5%);
 }
 
 @layer base {

--- a/resources/js/components/TeamSwitcher.vue
+++ b/resources/js/components/TeamSwitcher.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { router, usePage } from '@inertiajs/vue3';
+import { usePage } from '@inertiajs/vue3';
 import { Check, ChevronsUpDown, Plus, Users } from '@lucide/vue';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
@@ -12,8 +12,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { switchMethod } from '@/routes/teams';
-import type { Team } from '@/types';
+import { useTeamSwitch } from '@/composables/useTeamSwitch';
 
 const props = withDefaults(
     defineProps<{
@@ -48,32 +47,7 @@ const checkIconClass = computed(() =>
 );
 const plusIconClass = computed(() => (props.inHeader ? 'size-4' : 'h-4 w-4'));
 
-const switchTeam = (team: Team) => {
-    const previousTeamSlug = currentTeam.value?.slug;
-
-    router.visit(switchMethod(team.slug), {
-        onFinish: () => {
-            if (!previousTeamSlug || typeof window === 'undefined') {
-                router.reload();
-
-                return;
-            }
-
-            const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-            const segment = `/${previousTeamSlug}`;
-
-            if (currentUrl.includes(segment)) {
-                router.visit(currentUrl.replace(segment, `/${team.slug}`), {
-                    replace: true,
-                });
-
-                return;
-            }
-
-            router.reload();
-        },
-    });
-};
+const { switchTeam } = useTeamSwitch();
 
 onMounted(() => {
     mediaQuery = window.matchMedia('(max-width: 767px)');

--- a/resources/js/composables/useTeamSwitch.ts
+++ b/resources/js/composables/useTeamSwitch.ts
@@ -1,0 +1,48 @@
+import { router, usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import { switchMethod } from '@/routes/teams';
+import type { Team } from '@/types';
+
+export type UseTeamSwitchReturn = {
+    switchTeam: (team: Team) => void;
+};
+
+/**
+ * Shared workspace-switching behaviour used by both the team rail and the
+ * TeamSwitcher dropdown. Visiting the switch route swaps the active team, then
+ * rewrites the current URL's team segment so the user stays on the equivalent
+ * page under the new workspace (falling back to a plain reload).
+ */
+export function useTeamSwitch(): UseTeamSwitchReturn {
+    const page = usePage();
+    const currentTeam = computed(() => page.props.currentTeam);
+
+    const switchTeam = (team: Team): void => {
+        const previousTeamSlug = currentTeam.value?.slug;
+
+        router.visit(switchMethod(team.slug), {
+            onFinish: () => {
+                if (!previousTeamSlug || typeof window === 'undefined') {
+                    router.reload();
+
+                    return;
+                }
+
+                const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+                const segment = `/${previousTeamSlug}`;
+
+                if (currentUrl.includes(segment)) {
+                    router.visit(currentUrl.replace(segment, `/${team.slug}`), {
+                        replace: true,
+                    });
+
+                    return;
+                }
+
+                router.reload();
+            },
+        });
+    };
+
+    return { switchTeam };
+}

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -1,14 +1,17 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
+import { Plus, Search } from '@lucide/vue';
 import { computed, onMounted } from 'vue';
 import {
     browse,
     show,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import CreateChannelModal from '@/components/CreateChannelModal.vue';
+import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import NavUser from '@/components/NavUser.vue';
 import PendingInvitationsModal from '@/components/PendingInvitationsModal.vue';
 import TeamSwitcher from '@/components/TeamSwitcher.vue';
+import { Separator } from '@/components/ui/separator';
 import {
     Sidebar,
     SidebarContent,
@@ -24,15 +27,26 @@ import {
     SidebarMenuItem,
     SidebarProvider,
 } from '@/components/ui/sidebar';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useInitials } from '@/composables/useInitials';
+import { useTeamSwitch } from '@/composables/useTeamSwitch';
 
 const page = usePage();
 
 const currentTeam = computed(() => page.props.currentTeam);
+const teams = computed(() => page.props.teams ?? []);
 const channels = computed(() => page.props.channels ?? []);
 const activeChannelSlug = computed(
     () => (page.props.channel as { slug?: string } | undefined)?.slug ?? null,
 );
 const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
+
+const { getInitials } = useInitials();
+const { switchTeam } = useTeamSwitch();
 
 onMounted(() => {
     // Lazily pull the (optional) shared invitations so the post-login prompt appears.
@@ -41,75 +55,185 @@ onMounted(() => {
 </script>
 
 <template>
-    <SidebarProvider>
-        <Sidebar>
-            <SidebarHeader>
-                <SidebarMenu>
-                    <SidebarMenuItem>
-                        <TeamSwitcher />
-                    </SidebarMenuItem>
-                </SidebarMenu>
-            </SidebarHeader>
-
-            <SidebarContent>
-                <SidebarGroup>
-                    <SidebarGroupLabel>Channels</SidebarGroupLabel>
-                    <CreateChannelModal
-                        v-if="currentTeam"
-                        :team-slug="currentTeam.slug"
+    <SidebarProvider style="--sidebar-width: calc(3.5rem + 16rem)">
+        <Sidebar collapsible="offcanvas" class="overflow-hidden">
+            <!-- Nested rail + channel list; a single flex-row wrapper keeps them
+                 side by side in both the desktop sidebar and the mobile Sheet. -->
+            <div class="flex h-full w-full flex-row">
+                <!-- Team rail -->
+                <div
+                    class="flex w-14 shrink-0 flex-col items-center gap-2 border-r border-sidebar-border bg-sidebar-rail py-3"
+                    data-test="team-rail"
+                >
+                    <div
+                        v-for="team in teams"
+                        :key="team.id"
+                        class="relative flex w-full justify-center"
                     >
-                        <SidebarGroupAction
-                            title="Create channel"
-                            data-test="create-channel-trigger"
-                        >
-                            <span aria-hidden="true">+</span>
-                        </SidebarGroupAction>
-                    </CreateChannelModal>
-                    <SidebarGroupContent>
-                        <SidebarMenu>
-                            <SidebarMenuItem
-                                v-for="channel in channels"
-                                :key="channel.id"
-                            >
-                                <SidebarMenuButton
-                                    as-child
-                                    :is-active="channel.slug === activeChannelSlug"
+                        <span
+                            v-if="team.id === currentTeam?.id"
+                            aria-hidden="true"
+                            class="absolute top-1/2 left-0 h-[22px] w-[3px] -translate-y-1/2 rounded-r-full bg-primary"
+                        />
+                        <Tooltip>
+                            <TooltipTrigger as-child>
+                                <button
+                                    type="button"
+                                    data-test="team-rail-item"
+                                    :data-active="team.id === currentTeam?.id"
+                                    :aria-current="
+                                        team.id === currentTeam?.id
+                                            ? 'true'
+                                            : undefined
+                                    "
+                                    class="flex size-9 items-center justify-center rounded-[10px] text-xs font-semibold transition-colors"
+                                    :class="
+                                        team.id === currentTeam?.id
+                                            ? 'bg-primary text-primary-foreground'
+                                            : 'border border-border text-muted-foreground hover:bg-sidebar-accent'
+                                    "
+                                    @click="switchTeam(team)"
                                 >
-                                    <Link
-                                        v-if="currentTeam"
-                                        :href="
-                                            show({
-                                                team: currentTeam.slug,
-                                                channel: channel.slug,
-                                            }).url
-                                        "
-                                    >
-                                        <span># {{ channel.name }}</span>
-                                    </Link>
-                                </SidebarMenuButton>
-                            </SidebarMenuItem>
-                            <SidebarMenuItem>
-                                <SidebarMenuButton as-child>
-                                    <Link
-                                        v-if="currentTeam"
-                                        :href="browse(currentTeam.slug).url"
-                                        data-test="browse-channels"
-                                    >
-                                        <span>Browse channels</span>
-                                    </Link>
-                                </SidebarMenuButton>
-                            </SidebarMenuItem>
-                        </SidebarMenu>
-                    </SidebarGroupContent>
-                </SidebarGroup>
-            </SidebarContent>
+                                    {{ getInitials(team.name) }}
+                                </button>
+                            </TooltipTrigger>
+                            <TooltipContent side="right">
+                                {{ team.name }}
+                            </TooltipContent>
+                        </Tooltip>
+                    </div>
 
-            <SidebarFooter>
-                <NavUser />
-            </SidebarFooter>
+                    <Separator class="my-1 w-6" />
+
+                    <CreateTeamModal>
+                        <button
+                            type="button"
+                            title="New team"
+                            data-test="team-rail-add"
+                            class="flex size-9 items-center justify-center rounded-[10px] border border-dashed border-border text-muted-foreground transition-colors hover:bg-sidebar-accent"
+                        >
+                            <Plus class="size-[15px]" />
+                            <span class="sr-only">New team</span>
+                        </button>
+                    </CreateTeamModal>
+                </div>
+
+                <!-- Channel sidebar -->
+                <Sidebar collapsible="none" class="flex-1">
+                    <SidebarHeader
+                        class="h-12 shrink-0 flex-row items-center justify-between border-b border-sidebar-border px-3.5"
+                    >
+                        <TeamSwitcher />
+                    </SidebarHeader>
+
+                    <SidebarContent>
+                        <SidebarGroup>
+                            <SidebarGroupLabel
+                                class="h-7 px-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
+                            >
+                                Channels
+                            </SidebarGroupLabel>
+                            <CreateChannelModal
+                                v-if="currentTeam"
+                                :team-slug="currentTeam.slug"
+                            >
+                                <SidebarGroupAction
+                                    title="Create channel"
+                                    data-test="create-channel-trigger"
+                                    class="top-2 size-5 rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                                >
+                                    <Plus class="size-[13px]" />
+                                    <span class="sr-only">Create channel</span>
+                                </SidebarGroupAction>
+                            </CreateChannelModal>
+                            <SidebarGroupContent>
+                                <SidebarMenu>
+                                    <SidebarMenuItem
+                                        v-for="channel in channels"
+                                        :key="channel.id"
+                                    >
+                                        <SidebarMenuButton
+                                            as-child
+                                            :is-active="
+                                                channel.slug ===
+                                                activeChannelSlug
+                                            "
+                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13.5px] text-sidebar-foreground/80 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground data-[active=true]:relative data-[active=true]:bg-sidebar-accent data-[active=true]:pl-3.5 data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground"
+                                        >
+                                            <Link
+                                                v-if="currentTeam"
+                                                :href="
+                                                    show({
+                                                        team: currentTeam.slug,
+                                                        channel: channel.slug,
+                                                    }).url
+                                                "
+                                            >
+                                                <span
+                                                    v-if="
+                                                        channel.slug ===
+                                                        activeChannelSlug
+                                                    "
+                                                    aria-hidden="true"
+                                                    class="absolute top-[7px] bottom-[7px] left-0 w-[3px] rounded-full bg-primary"
+                                                />
+                                                <span
+                                                    class="font-medium"
+                                                    :class="
+                                                        channel.slug ===
+                                                        activeChannelSlug
+                                                            ? 'text-sidebar-foreground/70'
+                                                            : 'text-muted-foreground/80'
+                                                    "
+                                                    >#</span
+                                                >
+                                                <span
+                                                    class="truncate"
+                                                    :class="
+                                                        channel.hasUnread
+                                                            ? 'font-semibold text-sidebar-foreground'
+                                                            : ''
+                                                    "
+                                                    >{{ channel.name }}</span
+                                                >
+                                                <span
+                                                    v-if="channel.hasUnread"
+                                                    aria-hidden="true"
+                                                    class="ml-auto size-1.5 rounded-full bg-primary"
+                                                />
+                                            </Link>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                    <SidebarMenuItem>
+                                        <SidebarMenuButton
+                                            as-child
+                                            class="mt-1.5 h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                        >
+                                            <Link
+                                                v-if="currentTeam"
+                                                :href="
+                                                    browse(currentTeam.slug).url
+                                                "
+                                                data-test="browse-channels"
+                                            >
+                                                <Search class="size-[13px]" />
+                                                <span>Browse channels</span>
+                                            </Link>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                </SidebarMenu>
+                            </SidebarGroupContent>
+                        </SidebarGroup>
+                    </SidebarContent>
+
+                    <SidebarFooter class="border-t border-sidebar-border p-2">
+                        <NavUser />
+                    </SidebarFooter>
+                </Sidebar>
+            </div>
         </Sidebar>
 
-        <SidebarInset>
+        <SidebarInset class="flex h-svh flex-col">
             <slot />
         </SidebarInset>
 

--- a/resources/js/pages/channels/Browse.vue
+++ b/resources/js/pages/channels/Browse.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { Form, Head, Link } from '@inertiajs/vue3';
+import { Search } from '@lucide/vue';
 import {
     index,
     join,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import type { Channel } from '@/types';
 
@@ -23,41 +25,86 @@ const props = defineProps<{
 <template>
     <Head title="Browse channels" />
 
-    <!-- Content pane for the persistent channel workspace shell; visual polish deferred to #2. -->
-    <header class="flex h-12 items-center gap-2 px-4">
-        <SidebarTrigger />
-        <h1 class="text-lg font-semibold">Browse channels</h1>
-        <Link :href="index(props.team.slug).url" class="ml-auto">Back</Link>
+    <header
+        class="flex h-12 shrink-0 items-center gap-2.5 border-b border-border px-5"
+    >
+        <SidebarTrigger
+            class="-ml-1.5 size-8 text-muted-foreground md:hidden"
+        />
+        <h1 class="text-[15px] font-semibold text-foreground">
+            Browse channels
+        </h1>
+        <Link
+            :href="index(props.team.slug).url"
+            class="ml-auto text-[13px] text-muted-foreground hover:text-foreground"
+            >Back</Link
+        >
     </header>
 
-    <main class="p-4">
-        <p v-if="props.joinableChannels.length === 0">
-            There are no public channels left to join.
-        </p>
+    <div class="flex flex-1 justify-center overflow-y-auto px-6 pt-8">
+        <div class="w-full max-w-[560px]">
+            <div class="relative">
+                <Search
+                    class="absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden="true"
+                />
+                <Input
+                    type="search"
+                    placeholder="Search channels"
+                    class="h-[38px] rounded-[10px] bg-muted/40 pl-9"
+                    aria-label="Search channels"
+                />
+            </div>
 
-        <ul v-else class="space-y-2">
-            <li
-                v-for="channel in props.joinableChannels"
-                :key="channel.id"
-                class="flex items-center justify-between gap-4"
+            <p
+                v-if="props.joinableChannels.length === 0"
+                class="pt-16 text-center text-sm text-muted-foreground"
             >
-                <div>
-                    <span class="font-medium"># {{ channel.name }}</span>
-                    <span v-if="channel.topic" class="ml-2 text-sm">{{
-                        channel.topic
-                    }}</span>
-                </div>
-                <Form
-                    v-bind="
-                        join.form({
-                            team: props.team.slug,
-                            channel: channel.slug,
-                        })
-                    "
-                >
-                    <Button type="submit" size="sm">Join</Button>
-                </Form>
-            </li>
-        </ul>
-    </main>
+                There are no public channels left to join.
+            </p>
+
+            <template v-else>
+                <p class="mt-4 mb-1 text-xs text-muted-foreground">
+                    {{ props.joinableChannels.length }} channels you can join
+                </p>
+
+                <ul>
+                    <li
+                        v-for="channel in props.joinableChannels"
+                        :key="channel.id"
+                        class="flex items-center justify-between gap-4 rounded-sm border-b border-border/60 px-1 py-3 last:border-0 hover:bg-accent/40"
+                    >
+                        <div class="min-w-0">
+                            <p class="text-sm font-medium text-foreground">
+                                <span class="text-muted-foreground/70">#</span
+                                >{{ channel.name }}
+                            </p>
+                            <p
+                                v-if="channel.topic"
+                                class="truncate text-[12.5px] text-muted-foreground"
+                            >
+                                {{ channel.topic }}
+                            </p>
+                        </div>
+                        <Form
+                            v-bind="
+                                join.form({
+                                    team: props.team.slug,
+                                    channel: channel.slug,
+                                })
+                            "
+                        >
+                            <Button
+                                type="submit"
+                                variant="outline"
+                                size="sm"
+                                class="h-[30px] rounded-lg px-3.5 text-[13px]"
+                                >Join</Button
+                            >
+                        </Form>
+                    </li>
+                </ul>
+            </template>
+        </div>
+    </div>
 </template>

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3';
+import { ArrowUp, Plus } from '@lucide/vue';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import type { Channel } from '@/types';
 
@@ -11,14 +14,70 @@ const props = defineProps<{
 <template>
     <Head :title="`#${props.channel.name}`" />
 
-    <!-- Content pane for the persistent channel workspace shell; visual polish deferred to #2. -->
-    <header class="flex h-12 items-center gap-2 px-4">
-        <SidebarTrigger />
-        <h1># {{ props.channel.name }}</h1>
-        <span v-if="props.channel.topic">{{ props.channel.topic }}</span>
+    <header
+        class="flex h-12 shrink-0 items-center gap-2.5 border-b border-border px-5"
+    >
+        <SidebarTrigger
+            class="-ml-1.5 size-8 text-muted-foreground md:hidden"
+        />
+        <h1 class="text-[15px] font-semibold text-foreground">
+            <span class="mr-0.5 font-medium text-muted-foreground/70">#</span
+            >{{ props.channel.name }}
+        </h1>
+        <template v-if="props.channel.topic">
+            <Separator orientation="vertical" class="h-4" />
+            <p class="min-w-0 truncate text-[13px] text-muted-foreground">
+                {{ props.channel.topic }}
+            </p>
+        </template>
     </header>
-    <main class="p-4">
-        <!-- Messages arrive in a later issue. -->
-        <p>No messages yet.</p>
-    </main>
+
+    <!-- Messages arrive in a later issue; the channel currently shows its empty state. -->
+    <div class="flex min-h-0 flex-1 flex-col">
+        <div class="flex flex-1 flex-col items-center justify-center gap-1">
+            <div
+                class="flex size-14 items-center justify-center rounded-2xl border border-border bg-muted text-2xl font-semibold text-muted-foreground"
+                aria-hidden="true"
+            >
+                #
+            </div>
+            <p class="mt-2.5 text-[15px] font-semibold text-foreground">
+                No messages yet
+            </p>
+            <p class="text-[13.5px] text-muted-foreground">
+                Be the first to say something in #{{ props.channel.name }}.
+            </p>
+        </div>
+
+        <!-- Composer is static for now (message sending ships in a later issue). -->
+        <div class="mx-5 mb-4 shrink-0">
+            <div class="rounded-xl border border-input bg-background p-3 pb-2">
+                <textarea
+                    rows="1"
+                    disabled
+                    :placeholder="`Message #${props.channel.name}`"
+                    class="w-full resize-none bg-transparent text-sm text-muted-foreground/70 outline-none placeholder:text-muted-foreground/70"
+                ></textarea>
+                <div class="mt-2.5 flex items-center justify-between">
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        disabled
+                        class="size-[26px] rounded-[7px] text-muted-foreground"
+                        aria-label="Add attachment"
+                    >
+                        <Plus class="size-3.5" />
+                    </Button>
+                    <Button
+                        size="icon"
+                        disabled
+                        class="size-7 rounded-lg bg-accent text-muted-foreground/70"
+                        aria-label="Send message"
+                    >
+                        <ArrowUp class="size-3.5" />
+                    </Button>
+                </div>
+            </div>
+        </div>
+    </div>
 </template>

--- a/resources/js/types/channels.ts
+++ b/resources/js/types/channels.ts
@@ -6,4 +6,5 @@ export type Channel = {
     topic: string | null;
     isGeneral: boolean;
     isArchived: boolean;
+    hasUnread?: boolean;
 };


### PR DESCRIPTION
Closes #2.

Design/visual polish pass on the persistent channel workspace shell, implementing the shadcn-vue handoff imported from the Claude Design project.

## What changed
- **Team rail** (new, far-left): workspace avatars with an active edge indicator, `bg-sidebar-rail` tone, and a dashed **+ New team** button wrapping `CreateTeamModal`.
- **Nested sidebar**: rail + channel list restructured into the nested pattern, kept side-by-side on both desktop and the mobile drawer via a single `flex-row` wrapper.
- **Channel sidebar**: uppercase group label, `Plus` create action, restyled channel rows (active `bg-sidebar-accent` + primary indicator bar, muted `#` prefix, `hasUnread` styling hook defaulting off), `Search`-icon Browse link, footer hairline.
- **Channel header** (`Show.vue`): muted `#`, vertical separator + topic, centered **"No messages yet"** empty state, and a static floating composer.
- **Browse** (`Browse.vue`): centered `max-w-[560px]` column, static search input, count line, stacked name/topic rows, outline Join button (`<Form>` wiring untouched).
- **Tokens**: added the `--sidebar-rail` pair (light/dark) + `@theme inline` mapping.
- **Refactor**: extracted `useTeamSwitch` composable shared by the rail and the `TeamSwitcher` dropdown.

## Decisions
- **Handoff open decision §7** → team rail renders **always** (the recommendation): stable layout, permanent home for "+ New team".
- Used a `flex-row` wrapper instead of the handoff's `[&>[data-sidebar=sidebar]]:flex-row` selector — that class isn't applied to this repo's mobile `Sheet`, so it would have stacked the rail on top on mobile; the wrapper keeps them side-by-side in both modes.
- Left shared `NavUser`/`UserInfo` untouched (also used by the app-layout sidebar) to avoid an out-of-scope regression; footer polish lands via `SidebarFooter`.

## Acceptance criteria
- [x] shadcn-vue components applied to the 3-pane shell
- [x] Sidebar visual hierarchy (sections, active channel, hover)
- [x] Responsive behavior + empty states
- [x] Thin browser smoke of layout — see note below

## Verification
- `vue-tsc` type-check clean (pre-existing unrelated errors only)
- Prettier formatted
- Production build (`npm run build`, run in the Sail container) ✓
- Pest: all 51 `tests/Feature/Channels` tests pass

> Note: no `browser-use`/Playwright available in the dev environment, so the browser smoke was covered by the build + feature tests rather than an automated screenshot. Verify visually at http://localhost after `npm run dev`.