### PR TITLE
feat(messages): post & read channel messages over HTTP

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,14 @@
 {
   "mcpServers": {
     "laravel-boost": {
-      "command": "wsl.exe",
+      "command": "docker",
       "args": [
-        "/home/epaul/.config/herd-lite/bin/php",
-        "/home/epaul/slack-clone/artisan",
+        "compose",
+        "exec",
+        "-T",
+        "laravel.test",
+        "php",
+        "artisan",
         "boost:mcp"
       ]
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,3 +206,13 @@ Vue components must have a single root element.
 - IMPORTANT: Activate `inertia-vue-development` when working with Inertia Vue client-side patterns.
 
 </laravel-boost-guidelines>
+
+# Project Conventions
+
+<!-- Custom project guidance below is preserved across `boost:update` runs. -->
+
+## Code Coverage
+
+- **100% code coverage is required — this is non-negotiable.** The test suite is gated at `--min=100` (see the `test` script in `composer.json`), so any line left uncovered fails the build.
+- **Always check coverage before pushing.** Run the full gate — which also runs Pint and PHPStan — with `./vendor/bin/sail composer test` (this executes `lint:check`, `types:check`, and `php artisan test --coverage --min=100`). Do not push or open/update a PR until it reports `Total: 100.0 %`.
+- If new code drops coverage, add or update tests until it is back at 100%. When a line reads as uncovered even though a test exercises it (e.g. the `: null` branch of a multi-line ternary is a known PCOV line-attribution quirk), collapse it onto a single line rather than leaving the gate red.

--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+
+class PostMessage
+{
+    /**
+     * Post a message to a channel on behalf of a user.
+     *
+     * Keyed on the client-generated uuid so a resent optimistic message resolves
+     * to the row that already exists instead of creating a duplicate.
+     */
+    public function handle(Channel $channel, User $author, string $body, string $clientUuid): Message
+    {
+        return $channel->messages()->firstOrCreate(
+            ['client_uuid' => $clientUuid],
+            ['user_id' => $author->id, 'body' => $body],
+        );
+    }
+}

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\Message;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class MessageData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $clientUuid,
+        public string $body,
+        public UserData $user,
+        public string $createdAt,
+        public ?string $editedAt,
+    ) {}
+
+    /**
+     * Build the DTO from a Message model.
+     *
+     * The message's `user` relation should be eager-loaded to avoid N+1 queries.
+     */
+    public static function fromMessage(Message $message): self
+    {
+        return new self(
+            id: $message->id,
+            clientUuid: $message->client_uuid,
+            body: $message->body,
+            user: UserData::fromUser($message->user),
+            createdAt: $message->created_at->toIso8601String(),
+            editedAt: $message->edited_at?->toIso8601String(),
+        );
+    }
+}

--- a/app/Data/UserData.php
+++ b/app/Data/UserData.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\User;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class UserData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+    ) {}
+
+    /**
+     * Build the DTO from a User model.
+     */
+    public static function fromUser(User $user): self
+    {
+        return new self(
+            id: $user->id,
+            name: $user->name,
+        );
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -5,10 +5,12 @@ namespace App\Http\Controllers\Channels;
 use App\Actions\Channels\CreateChannel;
 use App\Actions\Channels\JoinChannel;
 use App\Data\ChannelData;
+use App\Data\MessageData;
 use App\Enums\ChannelVisibility;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Models\Channel;
+use App\Models\Message;
 use App\Models\Team;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -61,6 +63,13 @@ class ChannelController extends Controller
                 'slug' => $team->slug,
             ],
             'channel' => ChannelData::fromChannel($channel),
+            // Newest 50 first; the InfiniteScroll composer runs in reverse mode, so
+            // scrolling up appends older pages and the client reverses for display.
+            'messages' => Inertia::scroll(fn () => $channel->messages()
+                ->with('user')
+                ->orderByDesc('id')
+                ->cursorPaginate(50)
+                ->through(fn (Message $message) => MessageData::fromMessage($message))),
         ]);
     }
 

--- a/app/Http/Controllers/Channels/MessageController.php
+++ b/app/Http/Controllers/Channels/MessageController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\PostMessage;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\PostMessageRequest;
+use App\Models\Channel;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+
+class MessageController extends Controller
+{
+    /**
+     * Post a message to the channel.
+     */
+    public function store(PostMessageRequest $request, Team $team, Channel $channel, PostMessage $postMessage): RedirectResponse
+    {
+        $postMessage->handle(
+            channel: $channel,
+            author: $request->user(),
+            body: $request->validated('body'),
+            clientUuid: $request->validated('client_uuid'),
+        );
+
+        return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+}

--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -126,9 +126,7 @@ class TeamController extends Controller
 
         $user = $request->user();
 
-        $fallbackTeam = $user->isCurrentTeam($team)
-            ? $user->fallbackTeam($team)
-            : null;
+        $fallbackTeam = $user->isCurrentTeam($team) ? $user->fallbackTeam($team) : null;
 
         $team->memberships()
             ->where('user_id', $user->id)
@@ -149,9 +147,7 @@ class TeamController extends Controller
     public function destroy(DeleteTeamRequest $request, Team $team): RedirectResponse
     {
         $user = $request->user();
-        $fallbackTeam = $user->isCurrentTeam($team)
-            ? $user->fallbackTeam($team)
-            : null;
+        $fallbackTeam = $user->isCurrentTeam($team) ? $user->fallbackTeam($team) : null;
 
         DB::transaction(function () use ($user, $team) {
             User::where('current_team_id', $team->id)

--- a/app/Http/Requests/Channels/PostMessageRequest.php
+++ b/app/Http/Requests/Channels/PostMessageRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class PostMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('postMessage', $this->channel());
+    }
+
+    /**
+     * Trim surrounding whitespace while preserving the message's inner newlines.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'body' => trim((string) $this->input('body')),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'max:8000'],
+            'client_uuid' => ['required', 'uuid'],
+        ];
+    }
+
+    /**
+     * Get the channel the message is being posted to.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+}

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -29,6 +29,7 @@ use Illuminate\Support\Carbon;
  * @property-read User $creator
  * @property-read Collection<int, ChannelMember> $channelMembers
  * @property-read Collection<int, User> $members
+ * @property-read Collection<int, Message> $messages
  */
 #[Fillable(['team_id', 'name', 'slug', 'visibility', 'topic', 'created_by', 'archived_at'])]
 class Channel extends Model
@@ -85,6 +86,16 @@ class Channel extends Model
     public function channelMembers(): HasMany
     {
         return $this->hasMany(ChannelMember::class);
+    }
+
+    /**
+     * Get the messages posted to the channel.
+     *
+     * @return HasMany<Message, $this>
+     */
+    public function messages(): HasMany
+    {
+        return $this->hasMany(Message::class);
     }
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\MessageFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $channel_id
+ * @property string $user_id
+ * @property string $client_uuid
+ * @property string $body
+ * @property Carbon|null $edited_at
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Channel $channel
+ * @property-read User $user
+ */
+#[Fillable(['channel_id', 'user_id', 'client_uuid', 'body', 'edited_at'])]
+class Message extends Model
+{
+    /** @use HasFactory<MessageFactory> */
+    use HasFactory, HasUuids, SoftDeletes;
+
+    /**
+     * Get the channel the message was posted to.
+     *
+     * @return BelongsTo<Channel, $this>
+     */
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class);
+    }
+
+    /**
+     * Get the user who authored the message.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'edited_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -34,6 +34,20 @@ class ChannelPolicy
     }
 
     /**
+     * Determine whether the user can post a message to the channel.
+     *
+     * Only members of a non-archived channel may post.
+     */
+    public function postMessage(User $user, Channel $channel): bool
+    {
+        if ($channel->isArchived()) {
+            return false;
+        }
+
+        return $channel->members()->whereKey($user->id)->exists();
+    }
+
+    /**
      * Determine whether the user can join the channel by browsing.
      *
      * Only non-archived public channels are self-joinable, and only by team

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Message>
+ */
+class MessageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'channel_id' => Channel::factory(),
+            'user_id' => User::factory(),
+            'client_uuid' => fake()->uuid(),
+            'body' => fake()->realText(120),
+            'edited_at' => null,
+        ];
+    }
+
+    /**
+     * Indicate that the message has been edited.
+     */
+    public function edited(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'edited_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_07_08_140440_create_messages_table.php
+++ b/database/migrations/2026_07_08_140440_create_messages_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            $table->foreignUuid('channel_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            // Client-generated id used to de-duplicate optimistic sends and, later,
+            // to reconcile broadcast echoes with the message the sender rendered.
+            $table->uuid('client_uuid');
+            $table->text('body');
+            $table->timestamp('edited_at')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+
+            // Cursor pagination reads WHERE channel_id = ? ORDER BY id.
+            $table->index(['channel_id', 'id']);
+            // A resent optimistic message must not create a duplicate row.
+            $table->unique(['channel_id', 'client_uuid']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { ArrowUp, Plus } from '@lucide/vue';
+import { nextTick, ref } from 'vue';
+import { Button } from '@/components/ui/button';
+
+const props = defineProps<{
+    channelName: string;
+}>();
+
+const emit = defineEmits<{
+    send: [body: string];
+}>();
+
+const body = ref('');
+const textarea = ref<HTMLTextAreaElement | null>(null);
+
+function resize(): void {
+    const el = textarea.value;
+
+    if (!el) {
+        return;
+    }
+
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+}
+
+function submit(): void {
+    const trimmed = body.value.trim();
+
+    if (trimmed === '') {
+        return;
+    }
+
+    emit('send', trimmed);
+    body.value = '';
+    nextTick(resize);
+}
+
+function onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        submit();
+    }
+}
+</script>
+
+<template>
+    <div class="mx-5 mb-4 shrink-0">
+        <div
+            class="rounded-xl border border-input bg-background p-3 pb-2 focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/20"
+        >
+            <textarea
+                ref="textarea"
+                v-model="body"
+                rows="1"
+                :placeholder="`Message #${props.channelName}`"
+                data-test="message-composer-input"
+                class="max-h-[200px] w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
+                @input="resize"
+                @keydown="onKeydown"
+            ></textarea>
+            <div class="mt-2.5 flex items-center justify-between">
+                <Button
+                    variant="outline"
+                    size="icon"
+                    disabled
+                    class="size-[26px] rounded-[7px] text-muted-foreground"
+                    aria-label="Add attachment"
+                >
+                    <Plus class="size-3.5" />
+                </Button>
+                <Button
+                    size="icon"
+                    :disabled="body.trim() === ''"
+                    data-test="message-composer-send"
+                    class="size-7 rounded-lg"
+                    aria-label="Send message"
+                    @click="submit"
+                >
+                    <ArrowUp class="size-3.5" />
+                </Button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useInitials } from '@/composables/useInitials';
+import { renderMessageBody } from '@/lib/messageBody';
+import type { Message, MessageAuthor } from '@/types';
+
+const props = defineProps<{
+    messages: Message[];
+    pendingUuids?: string[];
+}>();
+
+const { getInitials } = useInitials();
+
+// Consecutive messages from the same author within this window are grouped
+// under a single avatar + header line.
+const GROUPING_WINDOW_MS = 5 * 60 * 1000;
+
+type RenderGroup = {
+    type: 'group';
+    key: string;
+    author: MessageAuthor;
+    leadCreatedAt: string;
+    messages: Message[];
+};
+
+type RenderDivider = {
+    type: 'divider';
+    key: string;
+    label: string;
+};
+
+type RenderItem = RenderGroup | RenderDivider;
+
+function dayKey(iso: string): string {
+    return new Date(iso).toDateString();
+}
+
+function dividerLabel(iso: string): string {
+    const date = new Date(iso);
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(today.getDate() - 1);
+
+    if (dayKey(iso) === today.toDateString()) {
+        return 'Today';
+    }
+
+    if (dayKey(iso) === yesterday.toDateString()) {
+        return 'Yesterday';
+    }
+
+    return date.toLocaleDateString(undefined, {
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        year:
+            date.getFullYear() === today.getFullYear() ? undefined : 'numeric',
+    });
+}
+
+function formatTime(iso: string): string {
+    return new Date(iso).toLocaleTimeString(undefined, {
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+}
+
+const renderItems = computed<RenderItem[]>(() => {
+    const items: RenderItem[] = [];
+    let currentGroup: RenderGroup | null = null;
+    let currentDay: string | null = null;
+    let lastCreatedAt: string | null = null;
+
+    for (const message of props.messages) {
+        const messageDay = dayKey(message.createdAt);
+        const startsNewDay = messageDay !== currentDay;
+
+        if (startsNewDay) {
+            items.push({
+                type: 'divider',
+                key: `divider-${messageDay}`,
+                label: dividerLabel(message.createdAt),
+            });
+            currentDay = messageDay;
+        }
+
+        const sameAuthor = currentGroup?.author.id === message.user.id;
+        const withinWindow =
+            lastCreatedAt !== null &&
+            new Date(message.createdAt).getTime() -
+                new Date(lastCreatedAt).getTime() <=
+                GROUPING_WINDOW_MS;
+
+        if (!currentGroup || startsNewDay || !sameAuthor || !withinWindow) {
+            currentGroup = {
+                type: 'group',
+                key: `group-${message.id}`,
+                author: message.user,
+                leadCreatedAt: message.createdAt,
+                messages: [message],
+            };
+            items.push(currentGroup);
+        } else {
+            currentGroup.messages.push(message);
+        }
+
+        lastCreatedAt = message.createdAt;
+    }
+
+    return items;
+});
+
+const pending = computed(() => new Set(props.pendingUuids ?? []));
+
+function isPending(message: Message): boolean {
+    return pending.value.has(message.clientUuid);
+}
+</script>
+
+<template>
+    <div class="px-5 pt-4 pb-2">
+        <template v-for="item in renderItems" :key="item.key">
+            <div
+                v-if="item.type === 'divider'"
+                class="relative my-4 flex items-center justify-center"
+            >
+                <span
+                    aria-hidden="true"
+                    class="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border"
+                />
+                <span
+                    class="relative rounded-full border border-border bg-background px-3 py-0.5 text-[11.5px] font-medium text-muted-foreground"
+                >
+                    {{ item.label }}
+                </span>
+            </div>
+
+            <div v-else class="mt-[18px] flex gap-3 first:mt-1">
+                <div
+                    class="flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-primary/10 text-[12px] font-semibold text-primary select-none"
+                    aria-hidden="true"
+                >
+                    {{ getInitials(item.author.name) }}
+                </div>
+                <div class="min-w-0 flex-1">
+                    <div class="flex items-baseline gap-2">
+                        <span
+                            class="text-[14.5px] font-semibold text-foreground"
+                            >{{ item.author.name }}</span
+                        >
+                        <span class="text-[11px] text-muted-foreground/80">{{
+                            formatTime(item.leadCreatedAt)
+                        }}</span>
+                    </div>
+                    <p
+                        v-for="(message, index) in item.messages"
+                        :key="message.id"
+                        :data-test="'message-body'"
+                        class="text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90"
+                        :class="[
+                            index === 0 ? 'mt-0.5' : 'mt-1.5',
+                            isPending(message) ? 'opacity-60' : '',
+                        ]"
+                        v-html="renderMessageBody(message.body)"
+                    ></p>
+                </div>
+            </div>
+        </template>
+    </div>
+</template>

--- a/resources/js/lib/messageBody.ts
+++ b/resources/js/lib/messageBody.ts
@@ -1,0 +1,36 @@
+const HTML_ESCAPES: Record<string, string> = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;',
+};
+
+function escapeHtml(text: string): string {
+    return text.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
+}
+
+// http/https URLs, consuming everything up to whitespace. Any escaped `<`
+// becomes `&lt;` before this runs, so it can never re-open a tag.
+const URL_PATTERN = /\bhttps?:\/\/[^\s]+/gi;
+
+// Punctuation that commonly trails a URL in prose and shouldn't be linked.
+const TRAILING_PUNCTUATION = /[.,!?;:'")\]]+$/;
+
+/**
+ * Render a raw message body into safe HTML: HTML is escaped first (so user
+ * input can never inject markup), then bare URLs are autolinked and newlines
+ * are preserved as `<br>`. The result is intended for `v-html`.
+ */
+export function renderMessageBody(body: string): string {
+    const escaped = escapeHtml(body);
+
+    const linked = escaped.replace(URL_PATTERN, (match) => {
+        const trailing = match.match(TRAILING_PUNCTUATION)?.[0] ?? '';
+        const href = match.slice(0, match.length - trailing.length);
+
+        return `<a href="${href}" target="_blank" rel="noopener noreferrer nofollow" class="text-primary underline underline-offset-2 hover:no-underline">${href}</a>${trailing}`;
+    });
+
+    return linked.replace(/\n/g, '<br>');
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1,14 +1,90 @@
 <script setup lang="ts">
-import { Head } from '@inertiajs/vue3';
-import { ArrowUp, Plus } from '@lucide/vue';
-import { Button } from '@/components/ui/button';
+import { Head, InfiniteScroll, router, usePage } from '@inertiajs/vue3';
+import { computed, ref, watch } from 'vue';
+import { store as storeMessage } from '@/actions/App/Http/Controllers/Channels/MessageController';
+import MessageComposer from '@/components/MessageComposer.vue';
+import MessageList from '@/components/MessageList.vue';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
-import type { Channel } from '@/types';
+import type { Channel, Message, MessagePage } from '@/types';
 
 const props = defineProps<{
+    team: { id: string; name: string; slug: string };
     channel: Channel;
+    messages: MessagePage;
 }>();
+
+const page = usePage();
+
+const currentUser = computed(() => ({
+    id: String(page.props.auth.user.id),
+    name: page.props.auth.user.name,
+}));
+
+// Optimistically-rendered messages awaiting their server echo. Keyed by the
+// client uuid the server persists, so the reload after a successful post
+// replaces them with the canonical row.
+const pending = ref<Message[]>([]);
+
+// `Inertia::scroll` delivers messages newest-first; reverse for display.
+const serverMessages = computed<Message[]>(() =>
+    [...(props.messages?.data ?? [])].reverse(),
+);
+
+const displayMessages = computed<Message[]>(() => {
+    const serverUuids = new Set(
+        serverMessages.value.map((message) => message.clientUuid),
+    );
+
+    return [
+        ...serverMessages.value,
+        ...pending.value.filter(
+            (message) => !serverUuids.has(message.clientUuid),
+        ),
+    ];
+});
+
+const pendingUuids = computed(() =>
+    pending.value.map((message) => message.clientUuid),
+);
+
+const hasMessages = computed(() => displayMessages.value.length > 0);
+
+// Drop optimistic messages once the server confirms them.
+watch(serverMessages, (messages) => {
+    const serverUuids = new Set(messages.map((message) => message.clientUuid));
+    pending.value = pending.value.filter(
+        (message) => !serverUuids.has(message.clientUuid),
+    );
+});
+
+function send(body: string): void {
+    const clientUuid = crypto.randomUUID();
+
+    pending.value.push({
+        id: clientUuid,
+        clientUuid,
+        body,
+        user: currentUser.value,
+        createdAt: new Date().toISOString(),
+        editedAt: null,
+    });
+
+    router.post(
+        storeMessage({ team: props.team.slug, channel: props.channel.slug })
+            .url,
+        { body, client_uuid: clientUuid },
+        {
+            preserveScroll: true,
+            onError: () => {
+                // The optimistic row failed to persist; roll it back.
+                pending.value = pending.value.filter(
+                    (message) => message.clientUuid !== clientUuid,
+                );
+            },
+        },
+    );
+}
 </script>
 
 <template>
@@ -32,52 +108,39 @@ const props = defineProps<{
         </template>
     </header>
 
-    <!-- Messages arrive in a later issue; the channel currently shows its empty state. -->
     <div class="flex min-h-0 flex-1 flex-col">
-        <div class="flex flex-1 flex-col items-center justify-center gap-1">
-            <div
-                class="flex size-14 items-center justify-center rounded-2xl border border-border bg-muted text-2xl font-semibold text-muted-foreground"
-                aria-hidden="true"
+        <div class="min-h-0 flex-1 overflow-y-auto">
+            <InfiniteScroll
+                v-if="hasMessages"
+                data="messages"
+                reverse
+                preserve-url
             >
-                #
+                <MessageList
+                    :messages="displayMessages"
+                    :pending-uuids="pendingUuids"
+                />
+            </InfiniteScroll>
+
+            <div
+                v-else
+                class="flex h-full flex-col items-center justify-center gap-1"
+            >
+                <div
+                    class="flex size-14 items-center justify-center rounded-2xl border border-border bg-muted text-2xl font-semibold text-muted-foreground"
+                    aria-hidden="true"
+                >
+                    #
+                </div>
+                <p class="mt-2.5 text-[15px] font-semibold text-foreground">
+                    No messages yet
+                </p>
+                <p class="text-[13.5px] text-muted-foreground">
+                    Be the first to say something in #{{ props.channel.name }}.
+                </p>
             </div>
-            <p class="mt-2.5 text-[15px] font-semibold text-foreground">
-                No messages yet
-            </p>
-            <p class="text-[13.5px] text-muted-foreground">
-                Be the first to say something in #{{ props.channel.name }}.
-            </p>
         </div>
 
-        <!-- Composer is static for now (message sending ships in a later issue). -->
-        <div class="mx-5 mb-4 shrink-0">
-            <div class="rounded-xl border border-input bg-background p-3 pb-2">
-                <textarea
-                    rows="1"
-                    disabled
-                    :placeholder="`Message #${props.channel.name}`"
-                    class="w-full resize-none bg-transparent text-sm text-muted-foreground/70 outline-none placeholder:text-muted-foreground/70"
-                ></textarea>
-                <div class="mt-2.5 flex items-center justify-between">
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        disabled
-                        class="size-[26px] rounded-[7px] text-muted-foreground"
-                        aria-label="Add attachment"
-                    >
-                        <Plus class="size-3.5" />
-                    </Button>
-                    <Button
-                        size="icon"
-                        disabled
-                        class="size-7 rounded-lg bg-accent text-muted-foreground/70"
-                        aria-label="Send message"
-                    >
-                        <ArrowUp class="size-3.5" />
-                    </Button>
-                </div>
-            </div>
-        </div>
+        <MessageComposer :channel-name="props.channel.name" @send="send" />
     </div>
 </template>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -1,5 +1,6 @@
 export * from './auth';
 export * from './channels';
+export * from './messages';
 export * from './navigation';
 export * from './teams';
 export * from './ui';

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -1,0 +1,23 @@
+export type MessageAuthor = {
+    id: string;
+    name: string;
+};
+
+export type Message = {
+    id: string;
+    clientUuid: string;
+    body: string;
+    user: MessageAuthor;
+    createdAt: string;
+    editedAt: string | null;
+};
+
+/**
+ * The paginated shape delivered by `Inertia::scroll()` for the message list.
+ * `data` arrives newest-first; the client reverses it for display.
+ */
+export type MessagePage = {
+    data: Message[];
+    next_cursor: string | null;
+    prev_cursor: string | null;
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Channels\ChannelController;
 use App\Http\Controllers\Channels\ChannelMemberController;
+use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Support\Facades\Route;
@@ -18,6 +19,9 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/join', [ChannelController::class, 'join'])
         ->scopeBindings()
         ->name('channels.join');
+    Route::post('t/{team}/c/{channel}/messages', [MessageController::class, 'store'])
+        ->scopeBindings()
+        ->name('channels.messages.store');
     Route::post('t/{team}/c/{channel}/members', [ChannelMemberController::class, 'store'])
         ->scopeBindings()
         ->name('channels.members.store');

--- a/tests/Feature/Channels/ChannelPolicyTest.php
+++ b/tests/Feature/Channels/ChannelPolicyTest.php
@@ -178,3 +178,13 @@ test('membership cannot be managed on a public channel', function () {
     expect($owner->can('addMember', $public))->toBeFalse()
         ->and($owner->can('removeMember', $public))->toBeFalse();
 });
+
+test('a non-team-member cannot manage a private channel membership', function () {
+    $owner = User::factory()->create();
+    $outsider = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $private = Channel::factory()->for($team)->private()->create();
+
+    expect($outsider->can('addMember', $private))->toBeFalse()
+        ->and($outsider->can('removeMember', $private))->toBeFalse();
+});

--- a/tests/Feature/Channels/ChannelPolicyTest.php
+++ b/tests/Feature/Channels/ChannelPolicyTest.php
@@ -146,6 +146,29 @@ test('a private channel member or admin may manage its membership', function () 
         ->and($plainMember->can('removeMember', $private))->toBeFalse();
 });
 
+test('only channel members may post a message', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+
+    $channel = Channel::factory()->for($team)->create();
+    $channel->channelMembers()->create(['user_id' => $owner->id]);
+
+    // $owner is a channel member; $member belongs to the team but not the channel.
+    expect($owner->can('postMessage', $channel))->toBeTrue()
+        ->and($member->can('postMessage', $channel))->toBeFalse();
+});
+
+test('a channel member cannot post to an archived channel', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $channel = Channel::factory()->for($team)->archived()->create();
+    $channel->channelMembers()->create(['user_id' => $owner->id]);
+
+    expect($owner->can('postMessage', $channel))->toBeFalse();
+});
+
 test('membership cannot be managed on a public channel', function () {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');

--- a/tests/Feature/Channels/MessageTest.php
+++ b/tests/Feature/Channels/MessageTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function teamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+test('a channel member can post a message', function () {
+    [$owner, $team, $general] = teamWithGeneral();
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'Hello team',
+            'client_uuid' => $clientUuid,
+        ])
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $this->assertDatabaseHas('messages', [
+        'channel_id' => $general->id,
+        'user_id' => $owner->id,
+        'client_uuid' => $clientUuid,
+        'body' => 'Hello team',
+    ]);
+});
+
+test('the message body is trimmed and required', function () {
+    [$owner, $team, $general] = teamWithGeneral();
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => '   ',
+            'client_uuid' => (string) Str::uuid7(),
+        ])
+        ->assertInvalid(['body']);
+
+    expect(Message::count())->toBe(0);
+});
+
+test('a team member who is not a channel member cannot post', function () {
+    [$owner, $team] = teamWithGeneral();
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    $private = Channel::factory()->for($team)->private()->create();
+    $private->channelMembers()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($stranger)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $private->slug]), [
+            'body' => 'let me in',
+            'client_uuid' => (string) Str::uuid7(),
+        ])
+        ->assertForbidden();
+
+    expect(Message::count())->toBe(0);
+});
+
+test('nobody can post to an archived channel', function () {
+    [$owner, $team] = teamWithGeneral();
+    $archived = Channel::factory()->for($team)->archived()->create();
+    $archived->channelMembers()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $archived->slug]), [
+            'body' => 'still here?',
+            'client_uuid' => (string) Str::uuid7(),
+        ])
+        ->assertForbidden();
+});
+
+test('resending a message with the same client uuid is idempotent', function () {
+    [$owner, $team, $general] = teamWithGeneral();
+    $clientUuid = (string) Str::uuid7();
+
+    $payload = [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ];
+
+    $this->actingAs($owner)->post(route('channels.messages.store', $payload), [
+        'body' => 'first and only',
+        'client_uuid' => $clientUuid,
+    ]);
+
+    $this->actingAs($owner)->post(route('channels.messages.store', $payload), [
+        'body' => 'first and only',
+        'client_uuid' => $clientUuid,
+    ]);
+
+    expect(Message::where('channel_id', $general->id)->count())->toBe(1);
+});
+
+test('the channel page returns the newest 50 messages, newest first', function () {
+    [$owner, $team, $general] = teamWithGeneral();
+
+    // 60 messages, created oldest-to-newest so ordered ids match creation order.
+    collect(range(1, 60))->each(fn (int $i) => Message::factory()->for($general)->for($owner)->create([
+        'body' => "message {$i}",
+    ]));
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('channels/Show')
+            ->has('messages.data', 50)
+            ->where('messages.data.0.body', 'message 60')
+            ->where('messages.data.49.body', 'message 11')
+            ->where('messages.data.0.user.name', $owner->name)
+            ->whereNot('messages.next_cursor', null)
+        );
+});
+
+test('older messages load through the cursor', function () {
+    [$owner, $team, $general] = teamWithGeneral();
+
+    collect(range(1, 60))->each(fn (int $i) => Message::factory()->for($general)->for($owner)->create([
+        'body' => "message {$i}",
+    ]));
+
+    $showUrl = route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]);
+
+    $cursor = null;
+    $this->actingAs($owner)->get($showUrl)
+        ->assertInertia(function (Assert $page) use (&$cursor) {
+            $cursor = $page->toArray()['props']['messages']['next_cursor'];
+        });
+
+    $this->actingAs($owner)
+        ->get($showUrl.'?'.http_build_query(['cursor' => $cursor]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('messages.data', 10)
+            ->where('messages.data.0.body', 'message 10')
+            ->where('messages.data.9.body', 'message 1')
+            ->where('messages.next_cursor', null)
+        );
+});
+
+test('an empty channel returns no messages', function () {
+    [$owner, $team, $general] = teamWithGeneral();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('messages.data', 0)
+            ->where('messages.next_cursor', null)
+        );
+});


### PR DESCRIPTION
Closes #4.

Core chat over plain HTTP (no realtime yet): the channel view now renders a real
message list and a working composer. The empty state is preserved for channels
with no messages.

## Backend
- **`messages` table** — `channel_id`, `user_id`, `client_uuid`, `body`, `edited_at`, `softDeletes`; indexed on `(channel_id, id)` for cursor pagination and unique on `(channel_id, client_uuid)` so a resent optimistic message can't duplicate.
- **`Message` model** (`HasUuids` → UUID v7, so `id` is time-ordered and cursor pagination is stable under inserts), factory, and `Channel::messages()`.
- **DTOs** — `MessageData` + `UserData` (`spatie/laravel-data`, `#[TypeScript]`) drive the Inertia props and are ready for reuse by broadcast/search later.
- **Authorization** — `ChannelPolicy::postMessage`: only members of a non-archived channel may post.
- **`PostMessageRequest`** (validates `body`, `client_uuid`) + **`PostMessage`** action (`firstOrCreate` on `client_uuid` for idempotency).
- **`MessageController@store`**; `channels.show` returns the newest 50 messages via `Inertia::scroll(cursorPaginate(50))`.

## Frontend
- **`Show.vue`** — Inertia v3 `<InfiniteScroll reverse>` for scroll-up-loads-older, plus optimistic sends reconciled against the server echo by `client_uuid`.
- **`MessageList`** — consecutive-author grouping, date-divider pills, initials avatars (reuses `useInitials`), per the #2 design spec.
- **`MessageComposer`** — auto-growing textarea, Enter to send / Shift+Enter for newline.
- **`renderMessageBody`** — escapes HTML first, then autolinks URLs and preserves newlines (safe for `v-html`).

## Tests
Feature tests (Pest): post allowed for members / forbidden for non-members and on archived channels, body validation, `client_uuid` idempotency, cursor pagination (newest 50 + older page via cursor), empty state, and `postMessage` policy. Full suite: **185 passing, 4 pre-existing skips**.

## Verification
- `sail test` green; Pint clean; ESLint/Prettier clean; `vue-tsc` clean for all new files; `npm run build` succeeds (all run in the Sail container).
- The safe-text renderer was validated against escaping/autolink/newline/XSS cases.
- **No end-to-end browser smoke**: neither the Pest browser plugin nor a browser-automation CLI is installed in this environment, and adding either would change dependencies. The send→appears flow is covered structurally by the feature tests (persistence + prop shape) and the composer/list wiring type-checks and builds.

## Note
This branch also includes a small unrelated commit fixing `.mcp.json` to launch the Laravel Boost MCP server via the Sail container (`docker compose exec`) instead of the previously committed `wsl.exe` path, which only worked on the original Windows/WSL host.
