### PR TITLE
feat(messages): edit & delete channel messages

### DIFF
--- a/app/Actions/Channels/DeleteMessage.php
+++ b/app/Actions/Channels/DeleteMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Data\MessageData;
+use App\Events\MessageDeleted;
+use App\Models\Channel;
+use App\Models\Message;
+
+class DeleteMessage
+{
+    /**
+     * Soft-delete a message and broadcast the tombstone.
+     *
+     * The row is kept so the client can render a "message deleted" placeholder
+     * in place. The broadcast reuses {@see MessageData}, which blanks the body of
+     * a trashed message, so no deleted content ever reaches other subscribers.
+     */
+    public function handle(Channel $channel, Message $message): void
+    {
+        $message->delete();
+
+        $message->loadMissing('user');
+        MessageDeleted::dispatch($channel, MessageData::fromMessage($message));
+    }
+}

--- a/app/Actions/Channels/EditMessage.php
+++ b/app/Actions/Channels/EditMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Data\MessageData;
+use App\Events\MessageUpdated;
+use App\Models\Channel;
+use App\Models\Message;
+
+class EditMessage
+{
+    /**
+     * Edit a message's body on behalf of its author.
+     *
+     * Stamps `edited_at` so the client can show the "(edited)" marker, then
+     * broadcasts the new state so every subscriber reconciles the row in place.
+     */
+    public function handle(Channel $channel, Message $message, string $body): Message
+    {
+        $message->update([
+            'body' => $body,
+            'edited_at' => now(),
+        ]);
+
+        $message->loadMissing('user');
+        MessageUpdated::dispatch($channel, MessageData::fromMessage($message));
+
+        return $message;
+    }
+}

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -16,22 +16,28 @@ class MessageData extends Data
         public UserData $user,
         public string $createdAt,
         public ?string $editedAt,
+        public bool $isDeleted,
     ) {}
 
     /**
      * Build the DTO from a Message model.
      *
      * The message's `user` relation should be eager-loaded to avoid N+1 queries.
+     * A soft-deleted message renders as a tombstone: its body is never sent to
+     * the client, only the `isDeleted` flag.
      */
     public static function fromMessage(Message $message): self
     {
+        $isDeleted = $message->trashed();
+
         return new self(
             id: $message->id,
             clientUuid: $message->client_uuid,
-            body: $message->body,
+            body: $isDeleted ? '' : $message->body,
             user: UserData::fromUser($message->user),
             createdAt: $message->created_at->toIso8601String(),
             editedAt: $message->edited_at?->toIso8601String(),
+            isDeleted: $isDeleted,
         );
     }
 }

--- a/app/Events/MessageDeleted.php
+++ b/app/Events/MessageDeleted.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Events;
+
+use App\Data\MessageData;
+use App\Models\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageDeleted implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * The payload is the same {@see MessageData} DTO the HTTP endpoints return —
+     * with the body blanked and `isDeleted` set — so every client can replace the
+     * row it already renders with a tombstone, matched by `clientUuid`.
+     */
+    public function __construct(
+        public Channel $channel,
+        public MessageData $message,
+    ) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel.'.$this->channel->id),
+        ];
+    }
+
+    /**
+     * Get the data to broadcast, matching the HTTP `MessageData` shape.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return $this->message->toArray();
+    }
+}

--- a/app/Events/MessageUpdated.php
+++ b/app/Events/MessageUpdated.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Events;
+
+use App\Data\MessageData;
+use App\Models\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageUpdated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * The payload is the same {@see MessageData} DTO the HTTP endpoints return, so
+     * every client can reconcile the edit against the row it already renders by
+     * `clientUuid`.
+     */
+    public function __construct(
+        public Channel $channel,
+        public MessageData $message,
+    ) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel.'.$this->channel->id),
+        ];
+    }
+
+    /**
+     * Get the data to broadcast, matching the HTTP `MessageData` shape.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return $this->message->toArray();
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -65,7 +65,10 @@ class ChannelController extends Controller
             'channel' => ChannelData::fromChannel($channel),
             // Newest 50 first; the InfiniteScroll composer runs in reverse mode, so
             // scrolling up appends older pages and the client reverses for display.
+            // Deleted rows are kept (withTrashed) so the client can render a
+            // "message deleted" tombstone in place; MessageData blanks their body.
             'messages' => Inertia::scroll(fn () => $channel->messages()
+                ->withTrashed()
                 ->with('user')
                 ->orderByDesc('id')
                 ->cursorPaginate(50)

--- a/app/Http/Controllers/Channels/MessageController.php
+++ b/app/Http/Controllers/Channels/MessageController.php
@@ -2,10 +2,15 @@
 
 namespace App\Http\Controllers\Channels;
 
+use App\Actions\Channels\DeleteMessage;
+use App\Actions\Channels\EditMessage;
 use App\Actions\Channels\PostMessage;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\DeleteMessageRequest;
+use App\Http\Requests\Channels\EditMessageRequest;
 use App\Http\Requests\Channels\PostMessageRequest;
 use App\Models\Channel;
+use App\Models\Message;
 use App\Models\Team;
 use Illuminate\Http\RedirectResponse;
 
@@ -22,6 +27,26 @@ class MessageController extends Controller
             body: $request->validated('body'),
             clientUuid: $request->validated('client_uuid'),
         );
+
+        return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+
+    /**
+     * Edit the author's own message.
+     */
+    public function update(EditMessageRequest $request, Team $team, Channel $channel, Message $message, EditMessage $editMessage): RedirectResponse
+    {
+        $editMessage->handle($channel, $message, $request->validated('body'));
+
+        return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+
+    /**
+     * Soft-delete a message, leaving a tombstone in its place.
+     */
+    public function destroy(DeleteMessageRequest $request, Team $team, Channel $channel, Message $message, DeleteMessage $deleteMessage): RedirectResponse
+    {
+        $deleteMessage->handle($channel, $message);
 
         return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
     }

--- a/app/Http/Requests/Channels/DeleteMessageRequest.php
+++ b/app/Http/Requests/Channels/DeleteMessageRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Message;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class DeleteMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('delete', $this->message());
+    }
+
+    /**
+     * Get the message being deleted.
+     */
+    public function message(): Message
+    {
+        $message = $this->route('message');
+
+        abort_if(! $message instanceof Message, 404);
+
+        return $message;
+    }
+}

--- a/app/Http/Requests/Channels/EditMessageRequest.php
+++ b/app/Http/Requests/Channels/EditMessageRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Message;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class EditMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('update', $this->message());
+    }
+
+    /**
+     * Trim surrounding whitespace while preserving the message's inner newlines.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'body' => trim((string) $this->input('body')),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'max:8000'],
+        ];
+    }
+
+    /**
+     * Get the message being edited.
+     */
+    public function message(): Message
+    {
+        $message = $this->route('message');
+
+        abort_if(! $message instanceof Message, 404);
+
+        return $message;
+    }
+}

--- a/app/Policies/MessagePolicy.php
+++ b/app/Policies/MessagePolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\TeamRole;
+use App\Models\Message;
+use App\Models\User;
+
+class MessagePolicy
+{
+    /**
+     * Determine whether the user can edit the message.
+     *
+     * Only the author may edit their own message; edits are never a moderation
+     * action.
+     */
+    public function update(User $user, Message $message): bool
+    {
+        return $message->user_id === $user->id;
+    }
+
+    /**
+     * Determine whether the user can delete the message.
+     *
+     * The author may delete their own message, and a team Admin+ may delete any
+     * message in the team as a moderation action.
+     */
+    public function delete(User $user, Message $message): bool
+    {
+        return $message->user_id === $user->id
+            || ($user->teamRole($message->channel->team)?->isAtLeast(TeamRole::Admin) ?? false);
+    }
+}

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1,5 +1,16 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { Pencil, Trash2 } from '@lucide/vue';
+import { computed, nextTick, ref } from 'vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 import { useInitials } from '@/composables/useInitials';
 import { renderMessageBody } from '@/lib/messageBody';
 import type { Message, MessageAuthor } from '@/types';
@@ -7,6 +18,13 @@ import type { Message, MessageAuthor } from '@/types';
 const props = defineProps<{
     messages: Message[];
     pendingUuids?: string[];
+    currentUserId: string;
+    canModerate?: boolean;
+}>();
+
+const emit = defineEmits<{
+    edit: [message: Message, body: string];
+    delete: [message: Message];
 }>();
 
 const { getInitials } = useInitials();
@@ -115,6 +133,76 @@ const pending = computed(() => new Set(props.pendingUuids ?? []));
 function isPending(message: Message): boolean {
     return pending.value.has(message.clientUuid);
 }
+
+function isOwn(message: Message): boolean {
+    return message.user.id === props.currentUserId;
+}
+
+function canEdit(message: Message): boolean {
+    return !message.isDeleted && !isPending(message) && isOwn(message);
+}
+
+function canDelete(message: Message): boolean {
+    return (
+        !message.isDeleted &&
+        !isPending(message) &&
+        (isOwn(message) || Boolean(props.canModerate))
+    );
+}
+
+// The message currently being edited inline, and its working draft.
+const editingId = ref<string | null>(null);
+const editDraft = ref('');
+const editField = ref<HTMLTextAreaElement | null>(null);
+
+// A plain template ref inside v-for collects into an array; a function ref keeps
+// the single visible editor element (only one row edits at a time).
+function setEditField(el: unknown): void {
+    editField.value = (el as HTMLTextAreaElement | null) ?? null;
+}
+
+function startEdit(message: Message): void {
+    editingId.value = message.id;
+    editDraft.value = message.body;
+    nextTick(() => editField.value?.focus());
+}
+
+function cancelEdit(): void {
+    editingId.value = null;
+    editDraft.value = '';
+}
+
+function saveEdit(message: Message): void {
+    const body = editDraft.value.trim();
+
+    // An empty or unchanged draft is a no-op; the server would reject the former.
+    if (body !== '' && body !== message.body) {
+        emit('edit', message, body);
+    }
+
+    cancelEdit();
+}
+
+// The message queued for deletion; a non-null value drives the confirm dialog.
+const pendingDelete = ref<Message | null>(null);
+
+function requestDelete(message: Message): void {
+    pendingDelete.value = message;
+}
+
+function setDeleteOpen(open: boolean): void {
+    if (!open) {
+        pendingDelete.value = null;
+    }
+}
+
+function confirmDelete(): void {
+    if (pendingDelete.value) {
+        emit('delete', pendingDelete.value);
+    }
+
+    pendingDelete.value = null;
+}
 </script>
 
 <template>
@@ -152,19 +240,125 @@ function isPending(message: Message): boolean {
                             formatTime(item.leadCreatedAt)
                         }}</span>
                     </div>
-                    <p
+                    <div
                         v-for="(message, index) in item.messages"
                         :key="message.id"
-                        :data-test="'message-body'"
-                        class="text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90"
-                        :class="[
-                            index === 0 ? 'mt-0.5' : 'mt-1.5',
-                            isPending(message) ? 'opacity-60' : '',
-                        ]"
-                        v-html="renderMessageBody(message.body)"
-                    ></p>
+                        class="group/message relative -mx-2 rounded-md px-2 hover:bg-muted/40"
+                        :class="index === 0 ? 'mt-0.5' : 'mt-1.5'"
+                    >
+                        <p
+                            v-if="message.isDeleted"
+                            :data-test="'message-tombstone'"
+                            class="py-0.5 text-[13.5px] text-muted-foreground/70 italic"
+                        >
+                            This message was deleted
+                        </p>
+
+                        <div v-else-if="editingId === message.id" class="py-0.5">
+                            <textarea
+                                :ref="setEditField"
+                                v-model="editDraft"
+                                rows="1"
+                                class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-[14.5px] leading-[1.55] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                                @keydown.enter.exact.prevent="saveEdit(message)"
+                                @keydown.esc.prevent="cancelEdit"
+                            ></textarea>
+                            <div
+                                class="mt-1 flex items-center gap-2 text-[11.5px] text-muted-foreground"
+                            >
+                                <button
+                                    type="button"
+                                    class="rounded bg-primary px-2 py-1 font-medium text-primary-foreground hover:bg-primary/90"
+                                    @click="saveEdit(message)"
+                                >
+                                    Save
+                                </button>
+                                <button
+                                    type="button"
+                                    class="rounded border border-border px-2 py-1 font-medium text-foreground hover:bg-muted"
+                                    @click="cancelEdit"
+                                >
+                                    Cancel
+                                </button>
+                                <span>Enter to save · Esc to cancel</span>
+                            </div>
+                        </div>
+
+                        <p
+                            v-else
+                            :data-test="'message-body'"
+                            class="py-0.5 text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90"
+                            :class="isPending(message) ? 'opacity-60' : ''"
+                        >
+                            <span v-html="renderMessageBody(message.body)"></span>
+                            <span
+                                v-if="message.editedAt"
+                                :data-test="'message-edited'"
+                                class="ml-1 align-baseline text-[11px] text-muted-foreground/70 select-none"
+                                >(edited)</span
+                            >
+                        </p>
+
+                        <div
+                            v-if="
+                                editingId !== message.id &&
+                                (canEdit(message) || canDelete(message))
+                            "
+                            class="absolute -top-3 right-2 hidden items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm group-hover/message:flex"
+                        >
+                            <button
+                                v-if="canEdit(message)"
+                                type="button"
+                                :data-test="'message-edit'"
+                                aria-label="Edit message"
+                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                @click="startEdit(message)"
+                            >
+                                <Pencil class="size-3.5" />
+                            </button>
+                            <button
+                                v-if="canDelete(message)"
+                                type="button"
+                                :data-test="'message-delete'"
+                                aria-label="Delete message"
+                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-destructive"
+                                @click="requestDelete(message)"
+                            >
+                                <Trash2 class="size-3.5" />
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </template>
+
+        <Dialog
+            :open="pendingDelete !== null"
+            @update:open="setDeleteOpen"
+        >
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Delete message</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to delete this message? This can't
+                        be undone.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <DialogFooter class="gap-2">
+                    <DialogClose as-child>
+                        <Button variant="secondary"> Cancel </Button>
+                    </DialogClose>
+
+                    <Button
+                        data-test="delete-message-confirm"
+                        variant="destructive"
+                        @click="confirmDelete"
+                    >
+                        Delete
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     </div>
 </template>

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -10,7 +10,11 @@ import {
     watch,
 } from 'vue';
 import { toast } from 'vue-sonner';
-import { store as storeMessage } from '@/actions/App/Http/Controllers/Channels/MessageController';
+import {
+    destroy as destroyMessage,
+    store as storeMessage,
+    update as updateMessage,
+} from '@/actions/App/Http/Controllers/Channels/MessageController';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
 import { Separator } from '@/components/ui/separator';
@@ -30,6 +34,11 @@ const currentUser = computed(() => ({
     name: page.props.auth.user.name,
 }));
 
+// A team Admin+ may delete anyone's message in the channel (moderation).
+const canModerate = computed(() =>
+    ['admin', 'owner'].includes(page.props.currentTeam?.role ?? ''),
+);
+
 // Distance (px) from the bottom within which the view stays pinned to newest,
 // so an incoming message never yanks a user who is reading older history.
 const NEAR_BOTTOM_THRESHOLD = 120;
@@ -41,6 +50,11 @@ const pending = ref<Message[]>([]);
 
 // Messages received live over the channel's private broadcast channel.
 const live = ref<Message[]>([]);
+
+// Edits and deletions applied on top of whichever copy of a message is rendered,
+// keyed by client uuid. Sourced from our own optimistic mutations and from the
+// MessageUpdated / MessageDeleted echoes, so every client converges in place.
+const patches = ref<Map<string, Message>>(new Map());
 
 const scrollContainer = ref<HTMLElement | null>(null);
 
@@ -67,6 +81,13 @@ const displayMessages = computed<Message[]>(() => {
     for (const message of pending.value) {
         if (!byUuid.has(message.clientUuid)) {
             byUuid.set(message.clientUuid, message);
+        }
+    }
+
+    // Overlay edits/deletions on the rendered copy, keeping its original slot.
+    for (const [uuid, patch] of patches.value) {
+        if (byUuid.has(uuid)) {
+            byUuid.set(uuid, patch);
         }
     }
 
@@ -138,11 +159,21 @@ function channelName(id: string): string {
     return `channel.${id}`;
 }
 
+function applyPatch(message: Message): void {
+    patches.value.set(message.clientUuid, message);
+}
+
 function subscribe(id: string): void {
     echo()
         .private(channelName(id))
         .listen('MessageSent', (message: Message) => {
             appendLive(message);
+        })
+        .listen('MessageUpdated', (message: Message) => {
+            applyPatch(message);
+        })
+        .listen('MessageDeleted', (message: Message) => {
+            applyPatch(message);
         });
 }
 
@@ -165,6 +196,7 @@ watch(
 
         live.value = [];
         pending.value = [];
+        patches.value = new Map();
         subscribe(newId);
     },
 );
@@ -183,6 +215,7 @@ function send(body: string): void {
         user: currentUser.value,
         createdAt: new Date().toISOString(),
         editedAt: null,
+        isDeleted: false,
     });
 
     nextTick(scrollToBottom);
@@ -199,6 +232,59 @@ function send(body: string): void {
                     (message) => message.clientUuid !== clientUuid,
                 );
                 toast.error('Your message failed to send. Please try again.');
+            },
+        },
+    );
+}
+
+function editMessage(message: Message, body: string): void {
+    const previous = patches.value.get(message.clientUuid);
+
+    // Optimistically show the edit; the broadcast echo later confirms it.
+    applyPatch({ ...message, body, editedAt: new Date().toISOString() });
+
+    router.patch(
+        updateMessage({
+            team: props.team.slug,
+            channel: props.channel.slug,
+            message: message.id,
+        }).url,
+        { body },
+        {
+            preserveScroll: true,
+            onError: () => {
+                if (previous) {
+                    patches.value.set(message.clientUuid, previous);
+                } else {
+                    patches.value.delete(message.clientUuid);
+                }
+                toast.error('Your edit failed to save. Please try again.');
+            },
+        },
+    );
+}
+
+function deleteMessage(message: Message): void {
+    const previous = patches.value.get(message.clientUuid);
+
+    // Optimistically show the tombstone; the broadcast echo later confirms it.
+    applyPatch({ ...message, body: '', isDeleted: true });
+
+    router.delete(
+        destroyMessage({
+            team: props.team.slug,
+            channel: props.channel.slug,
+            message: message.id,
+        }).url,
+        {
+            preserveScroll: true,
+            onError: () => {
+                if (previous) {
+                    patches.value.set(message.clientUuid, previous);
+                } else {
+                    patches.value.delete(message.clientUuid);
+                }
+                toast.error('Failed to delete the message. Please try again.');
             },
         },
     );
@@ -237,6 +323,10 @@ function send(body: string): void {
                 <MessageList
                     :messages="displayMessages"
                     :pending-uuids="pendingUuids"
+                    :current-user-id="currentUser.id"
+                    :can-moderate="canModerate"
+                    @edit="editMessage"
+                    @delete="deleteMessage"
                 />
             </InfiniteScroll>
 

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -10,6 +10,7 @@ export type Message = {
     user: MessageAuthor;
     createdAt: string;
     editedAt: string | null;
+    isDeleted: boolean;
 };
 
 /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,12 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/messages', [MessageController::class, 'store'])
         ->scopeBindings()
         ->name('channels.messages.store');
+    Route::patch('t/{team}/c/{channel}/messages/{message}', [MessageController::class, 'update'])
+        ->scopeBindings()
+        ->name('channels.messages.update');
+    Route::delete('t/{team}/c/{channel}/messages/{message}', [MessageController::class, 'destroy'])
+        ->scopeBindings()
+        ->name('channels.messages.destroy');
     Route::post('t/{team}/c/{channel}/members', [ChannelMemberController::class, 'store'])
         ->scopeBindings()
         ->name('channels.members.store');

--- a/tests/Feature/Channels/EditDeleteMessageTest.php
+++ b/tests/Feature/Channels/EditDeleteMessageTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function editTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+test('the author can edit their own message and edited_at is set', function () {
+    [$owner, $team, $general] = editTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
+
+    $this->actingAs($owner)
+        ->patch(route('channels.messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]), ['body' => 'edited body'])
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $message->refresh();
+
+    expect($message->body)->toBe('edited body')
+        ->and($message->edited_at)->not->toBeNull();
+});
+
+test('the message body is trimmed and required on edit', function () {
+    [$owner, $team, $general] = editTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
+
+    $this->actingAs($owner)
+        ->patch(route('channels.messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]), ['body' => '   '])
+        ->assertInvalid(['body']);
+
+    expect($message->refresh()->body)->toBe('original');
+});
+
+test('a user cannot edit another members message', function () {
+    [$owner, $team, $general] = editTeamWithGeneral();
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+
+    $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
+
+    $this->actingAs($other)
+        ->patch(route('channels.messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]), ['body' => 'hijacked'])
+        ->assertForbidden();
+
+    expect($message->refresh()->body)->toBe('original');
+});
+
+test('the author can delete their own message', function () {
+    [$owner, $team, $general] = editTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->delete(route('channels.messages.destroy', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]))
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    expect($message->fresh()->deleted_at)->not->toBeNull();
+});
+
+test('a team admin can delete another members message', function () {
+    [$owner, $team, $general] = editTeamWithGeneral();
+    $admin = User::factory()->create();
+    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+
+    $message = Message::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($admin)
+        ->delete(route('channels.messages.destroy', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]))
+        ->assertRedirect();
+
+    expect($message->fresh()->deleted_at)->not->toBeNull();
+});
+
+test('a plain member cannot delete another members message', function () {
+    [$owner, $team, $general] = editTeamWithGeneral();
+    $member = User::factory()->create();
+    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+
+    $message = Message::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($member)
+        ->delete(route('channels.messages.destroy', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]))
+        ->assertForbidden();
+
+    expect($message->fresh()->deleted_at)->toBeNull();
+});
+
+test('the channel page includes deleted messages as tombstones with a blanked body', function () {
+    [$owner, $team, $general] = editTeamWithGeneral();
+    Message::factory()->for($general)->for($owner)->create(['body' => 'kept']);
+    $deleted = Message::factory()->for($general)->for($owner)->create(['body' => 'secret']);
+    $deleted->delete();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('messages.data', 2)
+            ->where('messages.data.0.isDeleted', true)
+            ->where('messages.data.0.body', '')
+            ->where('messages.data.1.isDeleted', false)
+            ->where('messages.data.1.body', 'kept')
+        );
+});

--- a/tests/Feature/Channels/MessageBroadcastTest.php
+++ b/tests/Feature/Channels/MessageBroadcastTest.php
@@ -3,7 +3,9 @@
 use App\Actions\Teams\CreateTeam;
 use App\Data\MessageData;
 use App\Enums\TeamRole;
+use App\Events\MessageDeleted;
 use App\Events\MessageSent;
+use App\Events\MessageUpdated;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\User;
@@ -88,6 +90,53 @@ test('a resent message with the same client uuid broadcasts only once', function
     ]);
 
     Event::assertDispatchedTimes(MessageSent::class, 1);
+});
+
+test('editing a message broadcasts MessageUpdated on the channel private channel with the MessageData payload', function () {
+    Event::fake([MessageUpdated::class]);
+
+    [$owner, $team, $general] = broadcastTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
+
+    $this->actingAs($owner)->patch(route('channels.messages.update', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+        'message' => $message->id,
+    ]), ['body' => 'edited body']);
+
+    $updated = Message::where('id', $message->id)->with('user')->firstOrFail();
+
+    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event) use ($general, $updated) {
+        $target = $event->broadcastOn()[0];
+
+        expect($target)->toBeInstanceOf(PrivateChannel::class)
+            ->and($target->name)->toBe('private-channel.'.$general->id);
+
+        return $event->broadcastWith() === MessageData::fromMessage($updated)->toArray();
+    });
+});
+
+test('deleting a message broadcasts MessageDeleted as a tombstone with a blanked body', function () {
+    Event::fake([MessageDeleted::class]);
+
+    [$owner, $team, $general] = broadcastTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create(['body' => 'secret']);
+
+    $this->actingAs($owner)->delete(route('channels.messages.destroy', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+        'message' => $message->id,
+    ]));
+
+    Event::assertDispatched(MessageDeleted::class, function (MessageDeleted $event) use ($general) {
+        $target = $event->broadcastOn()[0];
+        $payload = $event->broadcastWith();
+
+        expect($target)->toBeInstanceOf(PrivateChannel::class)
+            ->and($target->name)->toBe('private-channel.'.$general->id);
+
+        return $payload['isDeleted'] === true && $payload['body'] === '';
+    });
 });
 
 test('a channel member is authorized to subscribe to the channel', function () {

--- a/tests/Feature/Channels/MessagePolicyTest.php
+++ b/tests/Feature/Channels/MessagePolicyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Create a team, its #general channel, and a message authored in it by $author.
+ *
+ * @return array{0: User, 1: Team, 2: Channel, 3: Message}
+ */
+function teamWithMessage(User $author): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+    $team->memberships()->firstOrCreate(['user_id' => $author->id], ['role' => TeamRole::Member]);
+    $general->channelMembers()->firstOrCreate(['user_id' => $author->id]);
+    $message = Message::factory()->for($general)->for($author)->create();
+
+    return [$owner, $team, $general, $message];
+}
+
+test('the author can edit their own message', function () {
+    $author = User::factory()->create();
+    [, , , $message] = teamWithMessage($author);
+
+    expect($author->can('update', $message))->toBeTrue();
+});
+
+test('a non-author cannot edit a message even as an admin', function () {
+    $author = User::factory()->create();
+    [$owner, $team, , $message] = teamWithMessage($author);
+
+    $admin = User::factory()->create();
+    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+
+    expect($admin->can('update', $message))->toBeFalse()
+        ->and($owner->can('update', $message))->toBeFalse();
+});
+
+test('the author can delete their own message', function () {
+    $author = User::factory()->create();
+    [, , , $message] = teamWithMessage($author);
+
+    expect($author->can('delete', $message))->toBeTrue();
+});
+
+test('a team admin can delete another members message', function () {
+    $author = User::factory()->create();
+    [$owner, $team, , $message] = teamWithMessage($author);
+
+    $admin = User::factory()->create();
+    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+
+    expect($admin->can('delete', $message))->toBeTrue()
+        ->and($owner->can('delete', $message))->toBeTrue();
+});
+
+test('a plain member cannot delete another members message', function () {
+    $author = User::factory()->create();
+    [, $team, , $message] = teamWithMessage($author);
+
+    $member = User::factory()->create();
+    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+
+    expect($member->can('delete', $message))->toBeFalse();
+});


### PR DESCRIPTION
Closes #6.

## What
Adds message editing and deletion on top of the realtime layer from #5.

- **Edit (author only)** — `EditMessage` stamps `edited_at`; the UI shows an inline editor (Enter to save, Esc to cancel) and an `(edited)` marker.
- **Delete** — `DeleteMessage` soft-deletes the row, leaving a *"This message was deleted"* tombstone. The author may delete their own; a team **Admin+** may delete any message (moderation). Deletion is gated behind a confirmation dialog.
- **Realtime sync** — queued `MessageUpdated` / `MessageDeleted` events broadcast on the same `PrivateChannel('channel.{id}')`, reusing the `MessageData` payload so every client reconciles the row in place by `clientUuid`. The actor also patches optimistically with rollback on error.
- **Authz** — new `MessagePolicy` (`update`: author only; `delete`: author or Admin+), auto-discovered.

## Design notes
- `MessageData` gains an `isDeleted` flag and blanks the body of a trashed message, so deleted content never reaches the client.
- The channel query now includes trashed rows (`withTrashed()`) so tombstones render on load, not just live.
- No migration needed — `edited_at` and `SoftDeletes` already existed on the `messages` table.

## Tests (TDD)
- `MessagePolicyTest` — author-only edit; author + Admin+ delete.
- `EditDeleteMessageTest` — HTTP edit/delete, validation, authorization, and tombstone rendering on the channel page.
- `MessageBroadcastTest` — `Event::fake` assertions that each event broadcasts on the correct private channel with the expected payload.

Full gate green: Pint, PHPStan, and `php artisan test --coverage --min=100` at **100.0%**. Frontend `vue-tsc` clean apart from the two unrelated pre-existing errors.