### PR TITLE
feat(messages): @mention team members

### DIFF
--- a/app/Actions/Channels/EditMessage.php
+++ b/app/Actions/Channels/EditMessage.php
@@ -9,10 +9,13 @@ use App\Models\Message;
 
 class EditMessage
 {
+    public function __construct(private SyncMentions $syncMentions) {}
+
     /**
      * Edit a message's body on behalf of its author.
      *
-     * Stamps `edited_at` so the client can show the "(edited)" marker, then
+     * Stamps `edited_at` so the client can show the "(edited)" marker, re-syncs
+     * the mention rows against the new body (adding new, removing stale), then
      * broadcasts the new state so every subscriber reconciles the row in place.
      */
     public function handle(Channel $channel, Message $message, string $body): Message
@@ -22,7 +25,10 @@ class EditMessage
             'edited_at' => now(),
         ]);
 
+        $this->syncMentions->handle($channel, $message);
+
         $message->loadMissing('user');
+        $message->load('mentionedUsers');
         MessageUpdated::dispatch($channel, MessageData::fromMessage($message));
 
         return $message;

--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -10,12 +10,15 @@ use App\Models\User;
 
 class PostMessage
 {
+    public function __construct(private SyncMentions $syncMentions) {}
+
     /**
      * Post a message to a channel on behalf of a user.
      *
      * Keyed on the client-generated uuid so a resent optimistic message resolves
      * to the row that already exists instead of creating a duplicate. Only a
-     * genuinely new message broadcasts, keeping the retry path side-effect free.
+     * genuinely new message parses its mentions and broadcasts, keeping the retry
+     * path side-effect free.
      */
     public function handle(Channel $channel, User $author, string $body, string $clientUuid): Message
     {
@@ -25,7 +28,9 @@ class PostMessage
         );
 
         if ($message->wasRecentlyCreated) {
+            $this->syncMentions->handle($channel, $message);
             $message->setRelation('user', $author);
+            $message->load('mentionedUsers');
             MessageSent::dispatch($channel, MessageData::fromMessage($message));
         }
 

--- a/app/Actions/Channels/SyncMentions.php
+++ b/app/Actions/Channels/SyncMentions.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+
+class SyncMentions
+{
+    /**
+     * The composer inserts a `@[Display Name](user-id)` token for every member it
+     * resolves; this captures each token's user id so the parser can round-trip
+     * it back to a real member unambiguously, regardless of display-name clashes.
+     */
+    private const string TOKEN_PATTERN = '/@\[[^\]]+\]\(([0-9a-fA-F-]{36})\)/';
+
+    /**
+     * Parse the message body and reconcile its mention rows.
+     *
+     * Only tokens that resolve to an actual member of the channel's team are
+     * kept; unknown ids and non-members are ignored. Because this uses `sync`,
+     * an edit adds newly-mentioned members and drops any no longer referenced.
+     */
+    public function handle(Channel $channel, Message $message): void
+    {
+        $message->mentionedUsers()->sync(
+            $this->resolveMemberIds($channel, $message->body),
+        );
+    }
+
+    /**
+     * Resolve the distinct team-member user ids referenced by mention tokens.
+     *
+     * @return array<int, string>
+     */
+    private function resolveMemberIds(Channel $channel, string $body): array
+    {
+        preg_match_all(self::TOKEN_PATTERN, $body, $matches);
+
+        $ids = array_unique($matches[1]);
+
+        if ($ids === []) {
+            return [];
+        }
+
+        return User::query()
+            ->whereIn('users.id', $ids)
+            ->whereHas('teams', fn ($query) => $query->whereKey($channel->team_id))
+            ->pluck('users.id')
+            ->all();
+    }
+}

--- a/app/Data/MentionData.php
+++ b/app/Data/MentionData.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\User;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class MentionData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+    ) {}
+
+    /**
+     * Build the DTO from a mentioned User model.
+     */
+    public static function fromUser(User $user): self
+    {
+        return new self(
+            id: $user->id,
+            name: $user->name,
+        );
+    }
+}

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -3,12 +3,16 @@
 namespace App\Data;
 
 use App\Models\Message;
+use App\Models\User;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
 #[TypeScript]
 class MessageData extends Data
 {
+    /**
+     * @param  array<int, MentionData>  $mentions
+     */
     public function __construct(
         public string $id,
         public string $clientUuid,
@@ -17,14 +21,15 @@ class MessageData extends Data
         public string $createdAt,
         public ?string $editedAt,
         public bool $isDeleted,
+        public array $mentions,
     ) {}
 
     /**
      * Build the DTO from a Message model.
      *
-     * The message's `user` relation should be eager-loaded to avoid N+1 queries.
-     * A soft-deleted message renders as a tombstone: its body is never sent to
-     * the client, only the `isDeleted` flag.
+     * The message's `user` and `mentionedUsers` relations should be eager-loaded
+     * to avoid N+1 queries. A soft-deleted message renders as a tombstone: its
+     * body and mentions are never sent to the client, only the `isDeleted` flag.
      */
     public static function fromMessage(Message $message): self
     {
@@ -38,6 +43,7 @@ class MessageData extends Data
             createdAt: $message->created_at->toIso8601String(),
             editedAt: $message->edited_at?->toIso8601String(),
             isDeleted: $isDeleted,
+            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn (User $user) => MentionData::fromUser($user))->all(),
         );
     }
 }

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -6,6 +6,7 @@ use App\Actions\Channels\CreateChannel;
 use App\Actions\Channels\JoinChannel;
 use App\Data\ChannelData;
 use App\Data\MessageData;
+use App\Data\UserData;
 use App\Enums\ChannelVisibility;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\CreateChannelRequest;
@@ -63,13 +64,16 @@ class ChannelController extends Controller
                 'slug' => $team->slug,
             ],
             'channel' => ChannelData::fromChannel($channel),
+            // Team members feed the composer's @mention autocomplete; mentions are
+            // scoped to the team, never limited to the current channel's members.
+            'members' => UserData::collect($team->members()->orderBy('name')->get()),
             // Newest 50 first; the InfiniteScroll composer runs in reverse mode, so
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a
             // "message deleted" tombstone in place; MessageData blanks their body.
             'messages' => Inertia::scroll(fn () => $channel->messages()
                 ->withTrashed()
-                ->with('user')
+                ->with(['user', 'mentionedUsers'])
                 ->orderByDesc('id')
                 ->cursorPaginate(50)
                 ->through(fn (Message $message) => MessageData::fromMessage($message))),

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use Database\Factories\MessageFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
@@ -23,6 +25,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read Channel $channel
  * @property-read User $user
+ * @property-read Collection<int, User> $mentionedUsers
  */
 #[Fillable(['channel_id', 'user_id', 'client_uuid', 'body', 'edited_at'])]
 class Message extends Model
@@ -48,6 +51,20 @@ class Message extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the team members mentioned in this message.
+     *
+     * Backed by the `mentions` join table; the parser keeps these rows in sync
+     * with the `@[Name](user-id)` tokens in the body on every post and edit.
+     *
+     * @return BelongsToMany<User, $this>
+     */
+    public function mentionedUsers(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'mentions', 'message_id', 'mentioned_user_id')
+            ->withTimestamps();
     }
 
     /**

--- a/database/migrations/2026_07_08_192231_create_mentions_table.php
+++ b/database/migrations/2026_07_08_192231_create_mentions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('mentions', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            $table->foreignUuid('message_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('mentioned_user_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+
+            // A user is mentioned at most once per message; the parser re-syncs on edit.
+            $table->unique(['message_id', 'mentioned_user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('mentions');
+    }
+};

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1,18 +1,140 @@
 <script setup lang="ts">
 import { ArrowUp, Plus } from '@lucide/vue';
-import { nextTick, ref } from 'vue';
+import { computed, nextTick, ref } from 'vue';
 import { Button } from '@/components/ui/button';
+import { useInitials } from '@/composables/useInitials';
+import type { Mention } from '@/types';
 
 const props = defineProps<{
     channelName: string;
+    members: Mention[];
 }>();
 
 const emit = defineEmits<{
-    send: [body: string];
+    send: [body: string, mentions: Mention[]];
 }>();
+
+const { getInitials } = useInitials();
 
 const body = ref('');
 const textarea = ref<HTMLTextAreaElement | null>(null);
+
+// Well-formed mention token: `@[Display Name](user-id)`. The parser on the
+// server resolves the id; here it lets us collect the mentions being sent and
+// recognise a completed token so it never re-triggers the autocomplete.
+const MENTION_TOKEN = /@\[[^\]]+\]\(([0-9a-fA-F-]{36})\)/g;
+
+// A fresh `@query` at the caret: an `@` at the start or after whitespace,
+// followed by run of non-space characters that isn't already a token.
+const MENTION_QUERY = /(?:^|\s)@([^\s@[\]()]*)$/;
+
+const MAX_SUGGESTIONS = 8;
+
+const suggestions = ref<Mention[]>([]);
+const activeIndex = ref(0);
+const menuOpen = ref(false);
+
+const showMenu = computed(() => menuOpen.value && suggestions.value.length > 0);
+
+/**
+ * The active `@query` immediately before the caret, or null when the caret is
+ * not in a mention context.
+ */
+function activeQuery(): { query: string; start: number } | null {
+    const el = textarea.value;
+    const caret = el ? el.selectionStart : body.value.length;
+    const upToCaret = body.value.slice(0, caret);
+    const match = upToCaret.match(MENTION_QUERY);
+
+    if (!match) {
+        return null;
+    }
+
+    return { query: match[1], start: caret - match[1].length - 1 };
+}
+
+function refreshSuggestions(): void {
+    const active = activeQuery();
+
+    if (!active) {
+        menuOpen.value = false;
+        suggestions.value = [];
+
+        return;
+    }
+
+    const needle = active.query.toLowerCase();
+
+    suggestions.value = props.members
+        .filter((member) => member.name.toLowerCase().includes(needle))
+        .slice(0, MAX_SUGGESTIONS);
+    activeIndex.value = 0;
+    menuOpen.value = suggestions.value.length > 0;
+}
+
+function moveActive(delta: number): void {
+    const count = suggestions.value.length;
+    activeIndex.value = (activeIndex.value + delta + count) % count;
+}
+
+function selectMember(member: Mention): void {
+    const el = textarea.value;
+    const caret = el ? el.selectionStart : body.value.length;
+    const active = activeQuery();
+
+    if (!active) {
+        return;
+    }
+
+    const before = body.value.slice(0, active.start);
+    const after = body.value.slice(caret);
+    const token = `@[${member.name}](${member.id}) `;
+
+    body.value = before + token + after;
+    menuOpen.value = false;
+
+    const nextCaret = before.length + token.length;
+
+    nextTick(() => {
+        const field = textarea.value;
+
+        if (field) {
+            field.focus();
+            field.setSelectionRange(nextCaret, nextCaret);
+        }
+
+        resize();
+    });
+}
+
+function selectActive(): void {
+    const member = suggestions.value[activeIndex.value];
+
+    if (member) {
+        selectMember(member);
+    }
+}
+
+/**
+ * Collect the distinct, resolvable mentions present in the body so the
+ * optimistic row can highlight them before the server echo arrives.
+ */
+function collectMentions(text: string): Mention[] {
+    const seen = new Set<string>();
+    const mentions: Mention[] = [];
+
+    for (const match of text.matchAll(MENTION_TOKEN)) {
+        const id = match[1];
+        const member = props.members.find((candidate) => candidate.id === id);
+
+        if (member && !seen.has(id)) {
+            seen.add(id);
+            mentions.push({ id: member.id, name: member.name });
+        }
+    }
+
+    return mentions;
+}
 
 function resize(): void {
     const el = textarea.value;
@@ -32,12 +154,43 @@ function submit(): void {
         return;
     }
 
-    emit('send', trimmed);
+    emit('send', trimmed, collectMentions(trimmed));
     body.value = '';
+    menuOpen.value = false;
     nextTick(resize);
 }
 
 function onKeydown(event: KeyboardEvent): void {
+    if (showMenu.value) {
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            moveActive(1);
+
+            return;
+        }
+
+        if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            moveActive(-1);
+
+            return;
+        }
+
+        if (event.key === 'Enter' || event.key === 'Tab') {
+            event.preventDefault();
+            selectActive();
+
+            return;
+        }
+
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            menuOpen.value = false;
+
+            return;
+        }
+    }
+
     if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault();
         submit();
@@ -47,39 +200,71 @@ function onKeydown(event: KeyboardEvent): void {
 
 <template>
     <div class="mx-5 mb-4 shrink-0">
-        <div
-            class="rounded-xl border border-input bg-background p-3 pb-2 focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/20"
-        >
-            <textarea
-                ref="textarea"
-                v-model="body"
-                rows="1"
-                :placeholder="`Message #${props.channelName}`"
-                data-test="message-composer-input"
-                class="max-h-[200px] w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
-                @input="resize"
-                @keydown="onKeydown"
-            ></textarea>
-            <div class="mt-2.5 flex items-center justify-between">
-                <Button
-                    variant="outline"
-                    size="icon"
-                    disabled
-                    class="size-[26px] rounded-[7px] text-muted-foreground"
-                    aria-label="Add attachment"
-                >
-                    <Plus class="size-3.5" />
-                </Button>
-                <Button
-                    size="icon"
-                    :disabled="body.trim() === ''"
-                    data-test="message-composer-send"
-                    class="size-7 rounded-lg"
-                    aria-label="Send message"
-                    @click="submit"
-                >
-                    <ArrowUp class="size-3.5" />
-                </Button>
+        <div class="relative">
+            <ul
+                v-if="showMenu"
+                data-test="mention-menu"
+                class="absolute bottom-full left-0 z-10 mb-2 max-h-60 w-64 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md"
+            >
+                <li v-for="(member, index) in suggestions" :key="member.id">
+                    <button
+                        type="button"
+                        data-test="mention-option"
+                        class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-popover-foreground"
+                        :class="
+                            index === activeIndex
+                                ? 'bg-accent text-accent-foreground'
+                                : 'hover:bg-accent/60'
+                        "
+                        @mousedown.prevent="selectMember(member)"
+                        @mouseenter="activeIndex = index"
+                    >
+                        <span
+                            class="flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-semibold text-primary select-none"
+                            aria-hidden="true"
+                        >
+                            {{ getInitials(member.name) }}
+                        </span>
+                        <span class="truncate">{{ member.name }}</span>
+                    </button>
+                </li>
+            </ul>
+
+            <div
+                class="rounded-xl border border-input bg-background p-3 pb-2 focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/20"
+            >
+                <textarea
+                    ref="textarea"
+                    v-model="body"
+                    rows="1"
+                    :placeholder="`Message #${props.channelName}`"
+                    data-test="message-composer-input"
+                    class="max-h-[200px] w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
+                    @input="resize(), refreshSuggestions()"
+                    @click="refreshSuggestions"
+                    @keydown="onKeydown"
+                ></textarea>
+                <div class="mt-2.5 flex items-center justify-between">
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        disabled
+                        class="size-[26px] rounded-[7px] text-muted-foreground"
+                        aria-label="Add attachment"
+                    >
+                        <Plus class="size-3.5" />
+                    </Button>
+                    <Button
+                        size="icon"
+                        :disabled="body.trim() === ''"
+                        data-test="message-composer-send"
+                        class="size-7 rounded-lg"
+                        aria-label="Send message"
+                        @click="submit"
+                    >
+                        <ArrowUp class="size-3.5" />
+                    </Button>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -290,7 +290,14 @@ function confirmDelete(): void {
                             class="py-0.5 text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90"
                             :class="isPending(message) ? 'opacity-60' : ''"
                         >
-                            <span v-html="renderMessageBody(message.body)"></span>
+                            <span
+                                v-html="
+                                    renderMessageBody(
+                                        message.body,
+                                        message.mentions,
+                                    )
+                                "
+                            ></span>
                             <span
                                 v-if="message.editedAt"
                                 :data-test="'message-edited'"

--- a/resources/js/lib/messageBody.ts
+++ b/resources/js/lib/messageBody.ts
@@ -1,3 +1,5 @@
+import type { Mention } from '@/types';
+
 const HTML_ESCAPES: Record<string, string> = {
     '&': '&amp;',
     '<': '&lt;',
@@ -10,6 +12,11 @@ function escapeHtml(text: string): string {
     return text.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
 }
 
+// The composer stores each resolved mention as a `@[Display Name](user-id)`
+// token. None of its literal characters are altered by HTML escaping, so the
+// token survives escapeHtml intact and can be matched afterwards.
+const MENTION_PATTERN = /@\[([^\]]+)\]\(([0-9a-fA-F-]{36})\)/g;
+
 // http/https URLs, consuming everything up to whitespace. Any escaped `<`
 // becomes `&lt;` before this runs, so it can never re-open a tag.
 const URL_PATTERN = /\bhttps?:\/\/[^\s]+/gi;
@@ -19,13 +26,30 @@ const TRAILING_PUNCTUATION = /[.,!?;:'")\]]+$/;
 
 /**
  * Render a raw message body into safe HTML: HTML is escaped first (so user
- * input can never inject markup), then bare URLs are autolinked and newlines
- * are preserved as `<br>`. The result is intended for `v-html`.
+ * input can never inject markup), then mention tokens are highlighted, bare
+ * URLs are autolinked, and newlines are preserved as `<br>`. The result is
+ * intended for `v-html`.
+ *
+ * Only mentions whose id is present in `mentions` render as a highlighted pill;
+ * any other well-formed token falls back to its plain `@Name` text so a spoofed
+ * token for a non-member can never masquerade as a resolved mention.
  */
-export function renderMessageBody(body: string): string {
+export function renderMessageBody(
+    body: string,
+    mentions: Mention[] = [],
+): string {
     const escaped = escapeHtml(body);
+    const resolved = new Set(mentions.map((mention) => mention.id));
 
-    const linked = escaped.replace(URL_PATTERN, (match) => {
+    const withMentions = escaped.replace(
+        MENTION_PATTERN,
+        (_match, name: string, id: string) =>
+            resolved.has(id)
+                ? `<span class="rounded px-1 py-0.5 font-medium text-blue-700 bg-blue-500/10 dark:text-blue-300 dark:bg-blue-400/15">@${name}</span>`
+                : `@${name}`,
+    );
+
+    const linked = withMentions.replace(URL_PATTERN, (match) => {
         const trailing = match.match(TRAILING_PUNCTUATION)?.[0] ?? '';
         const href = match.slice(0, match.length - trailing.length);
 

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -19,12 +19,13 @@ import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
-import type { Channel, Message, MessagePage } from '@/types';
+import type { Channel, Mention, Message, MessagePage } from '@/types';
 
 const props = defineProps<{
     team: { id: string; name: string; slug: string };
     channel: Channel;
     messages: MessagePage;
+    members: Mention[];
 }>();
 
 const page = usePage();
@@ -33,6 +34,11 @@ const currentUser = computed(() => ({
     id: String(page.props.auth.user.id),
     name: page.props.auth.user.name,
 }));
+
+// You can't @mention yourself; drop the current user from the composer list.
+const mentionableMembers = computed(() =>
+    props.members.filter((member) => member.id !== currentUser.value.id),
+);
 
 // A team Admin+ may delete anyone's message in the channel (moderation).
 const canModerate = computed(() =>
@@ -205,7 +211,7 @@ onBeforeUnmount(() => {
     unsubscribe(props.channel.id);
 });
 
-function send(body: string): void {
+function send(body: string, mentions: Mention[]): void {
     const clientUuid = crypto.randomUUID();
 
     pending.value.push({
@@ -216,6 +222,7 @@ function send(body: string): void {
         createdAt: new Date().toISOString(),
         editedAt: null,
         isDeleted: false,
+        mentions,
     });
 
     nextTick(scrollToBottom);
@@ -349,6 +356,10 @@ function deleteMessage(message: Message): void {
             </div>
         </div>
 
-        <MessageComposer :channel-name="props.channel.name" @send="send" />
+        <MessageComposer
+            :channel-name="props.channel.name"
+            :members="mentionableMembers"
+            @send="send"
+        />
     </div>
 </template>

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -3,6 +3,15 @@ export type MessageAuthor = {
     name: string;
 };
 
+/**
+ * A team member referenced by an `@mention` in a message body. Mirrors the
+ * `MentionData` DTO and rides on every MessageData payload.
+ */
+export type Mention = {
+    id: string;
+    name: string;
+};
+
 export type Message = {
     id: string;
     clientUuid: string;
@@ -11,6 +20,7 @@ export type Message = {
     createdAt: string;
     editedAt: string | null;
     isDeleted: boolean;
+    mentions: Mention[];
 };
 
 /**

--- a/tests/Feature/Channels/MentionTest.php
+++ b/tests/Feature/Channels/MentionTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Data\MessageData;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function mentionTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team as a plain member and return them.
+ */
+function teamMember(Team $team, ?string $name = null): User
+{
+    $user = User::factory()->create($name ? ['name' => $name] : []);
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+
+    return $user;
+}
+
+/**
+ * Build a mention token the composer inserts and the parser round-trips.
+ */
+function mentionToken(User $user): string
+{
+    return "@[{$user->name}]({$user->id})";
+}
+
+test('posting a message persists a mention row for a real team member', function () {
+    [$owner, $team, $general] = mentionTeamWithGeneral();
+    $mentioned = teamMember($team, 'Ada Lovelace');
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'hey '.mentionToken($mentioned).' welcome',
+            'client_uuid' => (string) Str::uuid7(),
+        ])
+        ->assertRedirect();
+
+    $message = Message::firstOrFail();
+
+    $this->assertDatabaseHas('mentions', [
+        'message_id' => $message->id,
+        'mentioned_user_id' => $mentioned->id,
+    ]);
+    expect($message->mentionedUsers)->toHaveCount(1);
+});
+
+test('parsing resolves only real team members, ignoring non-members and unknown ids', function () {
+    [$owner, $team, $general] = mentionTeamWithGeneral();
+    $member = teamMember($team, 'Real Member');
+    $stranger = User::factory()->create(['name' => 'Outsider']);
+    $bogusId = (string) Str::uuid7();
+
+    $body = mentionToken($member).' '.mentionToken($stranger)." @[Ghost]({$bogusId})";
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => $body,
+            'client_uuid' => (string) Str::uuid7(),
+        ])
+        ->assertRedirect();
+
+    $message = Message::firstOrFail();
+
+    expect($message->mentionedUsers->pluck('id')->all())->toBe([$member->id]);
+    $this->assertDatabaseMissing('mentions', ['mentioned_user_id' => $stranger->id]);
+});
+
+test('a user mentioned twice in one message is persisted once', function () {
+    [$owner, $team, $general] = mentionTeamWithGeneral();
+    $mentioned = teamMember($team);
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => mentionToken($mentioned).' and again '.mentionToken($mentioned),
+            'client_uuid' => (string) Str::uuid7(),
+        ])
+        ->assertRedirect();
+
+    expect(Message::firstOrFail()->mentionedUsers)->toHaveCount(1);
+});
+
+test('editing a message re-syncs mentions: adds new and removes stale', function () {
+    [$owner, $team, $general] = mentionTeamWithGeneral();
+    $first = teamMember($team, 'First Person');
+    $second = teamMember($team, 'Second Person');
+
+    $message = Message::factory()->for($general)->for($owner)->create([
+        'body' => 'ping '.mentionToken($first),
+    ]);
+    $message->mentionedUsers()->sync([$first->id]);
+
+    $this->actingAs($owner)
+        ->patch(route('channels.messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]), ['body' => 'ping '.mentionToken($second)])
+        ->assertRedirect();
+
+    expect($message->refresh()->mentionedUsers->pluck('id')->all())->toBe([$second->id]);
+    $this->assertDatabaseMissing('mentions', ['mentioned_user_id' => $first->id]);
+    $this->assertDatabaseHas('mentions', ['mentioned_user_id' => $second->id]);
+});
+
+test('the mention payload rides the MessageData on the channel page', function () {
+    [$owner, $team, $general] = mentionTeamWithGeneral();
+    $mentioned = teamMember($team, 'Grace Hopper');
+
+    $message = Message::factory()->for($general)->for($owner)->create([
+        'body' => 'hi '.mentionToken($mentioned),
+    ]);
+    $message->mentionedUsers()->sync([$mentioned->id]);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('messages.data.0.mentions', 1)
+            ->where('messages.data.0.mentions.0.id', $mentioned->id)
+            ->where('messages.data.0.mentions.0.name', 'Grace Hopper')
+        );
+});
+
+test('the mention payload rides the broadcast MessageData', function () {
+    [$owner, $team, $general] = mentionTeamWithGeneral();
+    $mentioned = teamMember($team, 'Alan Turing');
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)->post(route('channels.messages.store', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]), [
+        'body' => 'yo '.mentionToken($mentioned),
+        'client_uuid' => $clientUuid,
+    ]);
+
+    $message = Message::where('client_uuid', $clientUuid)->firstOrFail();
+    $payload = MessageData::fromMessage($message->load(['user', 'mentionedUsers']))->toArray();
+
+    expect($payload['mentions'])->toBe([['id' => $mentioned->id, 'name' => 'Alan Turing']]);
+});
+
+test('a deleted message blanks its mentions in the tombstone payload', function () {
+    [$owner, $team, $general] = mentionTeamWithGeneral();
+    $mentioned = teamMember($team);
+
+    $message = Message::factory()->for($general)->for($owner)->create();
+    $message->mentionedUsers()->sync([$mentioned->id]);
+    $message->delete();
+
+    $payload = MessageData::fromMessage($message->load('user'))->toArray();
+
+    expect($payload['isDeleted'])->toBeTrue()
+        ->and($payload['mentions'])->toBe([]);
+});
+
+test('the channel page exposes team members for the composer autocomplete', function () {
+    [$owner, $team, $general] = mentionTeamWithGeneral();
+    teamMember($team, 'Bea Member');
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('members', 2)
+            ->where('members', fn ($members) => collect($members)->pluck('name')->contains('Bea Member')
+                && collect($members)->pluck('name')->contains($owner->name))
+        );
+});


### PR DESCRIPTION
Closes #7.

## What
Composer `@`-autocomplete scoped to team members, mention parsing/persistence on post & edit, and highlighted mention tokens in the rendered message. `MentionData` now rides on `MessageData`.

## Design decision — no `username` column
The schema has `name` + `email` but **no username**, and names aren't unique, so `@username` can't round-trip cleanly. Rather than add a migration to `users`, the composer's autocomplete inserts a **Slack-style token** `@[Display Name](user-id)` that the server parser resolves unambiguously to a real `user_id` (Slack itself stores mentions as `<@U123>`). A plain textarea shows the raw token while composing — an accepted MVP limitation.

## Backend
- **`mentions` table** (`message_id`, `mentioned_user_id`, `unique(message_id, mentioned_user_id)`, cascade deletes on both FKs).
- **`SyncMentions`** action — shared parser used by both post and edit. Extracts token user-ids, keeps only real members of the channel's team (unknown ids / non-members ignored), dedupes, and `sync()`s the rows. On edit this re-syncs (adds new, drops stale).
- **`PostMessage`** parses only when a genuinely new row is created (retry path stays side-effect free); **`EditMessage`** re-syncs every edit.
- **`MentionData`** DTO + `mentions` on `MessageData`. `fromMessage` eager-loads `mentionedUsers` to avoid N+1, so mentions flow to the channel page and every live/edit broadcast for free. Soft-deleted messages keep their rows but blank `mentions` in the tombstone payload (mirrors body blanking; harmless for the future unread-mentions count).
- **`ChannelController@show`** exposes team `members` for the autocomplete and eager-loads `mentionedUsers`.

## Frontend
- **`MessageComposer.vue`** — `@`-autocomplete over team members (current user excluded), keyboard nav (↑/↓, Enter/Tab to select, Esc to dismiss), inserts the token, and emits the resolved mentions with `send` so the optimistic row highlights immediately.
- **`messageBody.ts`** — highlights **only resolved** tokens as a blue pill (escape-first ordering preserved); a spoofed token for a non-member falls back to plain `@Name`.
- Types updated in the hand-written `resources/js/types/messages.ts`.

## Tests
`tests/Feature/Channels/MentionTest.php` (TDD): persistence on post, resolves only real team members (ignores non-members + unknown ids), dedupe, re-sync on edit (add + remove), mention payload on the page and on the broadcast `MessageData`, tombstone blanking, and the members prop for autocomplete.

## Verification
- `sail composer test` → Pint ✓, PHPStan 0 errors, **100% coverage**, 213 passing.
- `vue-tsc` adds no new errors (the two pre-existing ones are unrelated); `npm run build` succeeds.