### PR TITLE
feat(messages): typing indicator

### DIFF
--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
     send: [body: string, mentions: Mention[]];
+    typing: [];
 }>();
 
 const { getInitials } = useInitials();
@@ -240,7 +241,7 @@ function onKeydown(event: KeyboardEvent): void {
                     :placeholder="`Message #${props.channelName}`"
                     data-test="message-composer-input"
                     class="max-h-[200px] w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
-                    @input="resize(), refreshSuggestions()"
+                    @input="resize(), refreshSuggestions(), emit('typing')"
                     @click="refreshSuggestions"
                     @keydown="onKeydown"
                 ></textarea>

--- a/resources/js/components/TypingIndicator.vue
+++ b/resources/js/components/TypingIndicator.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+    names: string[];
+}>();
+
+/**
+ * Human-readable summary of who is typing: one or two names by name, and a
+ * generic phrasing once a third joins so the line never grows unbounded.
+ */
+const label = computed<string>(() => {
+    const [first, second] = props.names;
+
+    if (props.names.length === 1) {
+        return `${first} is typing`;
+    }
+
+    if (props.names.length === 2) {
+        return `${first} and ${second} are typing`;
+    }
+
+    return 'Several people are typing';
+});
+</script>
+
+<template>
+    <!-- Fixed height reserves the line so the composer never jumps as it toggles. -->
+    <div
+        class="flex h-5 items-center gap-1.5 px-1 text-xs text-muted-foreground"
+        aria-live="polite"
+        data-test="typing-indicator"
+    >
+        <template v-if="names.length > 0">
+            <!-- Three dots rippling out of phase, the classic "typing" tell. -->
+            <span class="flex items-end gap-0.5" aria-hidden="true">
+                <span
+                    class="size-1 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.3s]"
+                />
+                <span
+                    class="size-1 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.15s]"
+                />
+                <span
+                    class="size-1 animate-bounce rounded-full bg-muted-foreground/60"
+                />
+            </span>
+            <span class="truncate">{{ label }}</span>
+        </template>
+    </div>
+</template>

--- a/resources/js/composables/useTypingIndicator.ts
+++ b/resources/js/composables/useTypingIndicator.ts
@@ -1,0 +1,113 @@
+import { computed, onBeforeUnmount, ref } from 'vue';
+
+/**
+ * A channel member currently composing a message, as carried by the `typing`
+ * client whisper. Mirrors the shape of `currentUser` in the channel view.
+ */
+export type TypingUser = {
+    id: string;
+    name: string;
+};
+
+/**
+ * Re-whisper at most this often while the local user keeps typing, so a burst
+ * of keystrokes turns into an occasional heartbeat rather than one event each.
+ */
+const WHISPER_THROTTLE_MS = 2500;
+
+/**
+ * Forget a remote typist this long after their last whisper. Comfortably longer
+ * than the throttle so an actively-typing peer never flickers out between beats.
+ */
+const TYPING_EXPIRY_MS = 4000;
+
+/**
+ * Tracks who is typing on a channel. Outbound keystrokes are throttled into
+ * periodic `typing` whispers; inbound whispers populate a self-expiring roster
+ * so the indicator clears on its own when a peer goes idle. All timers are torn
+ * down on `reset()` (channel switch) and on unmount.
+ */
+export function useTypingIndicator(whisper: (user: TypingUser) => void) {
+    // Roster of remote typists keyed by user id, mapped to their display name.
+    const typists = ref<Map<string, string>>(new Map());
+
+    // Pending expiry timers keyed by user id, kept outside reactivity.
+    const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+    // Timestamp of the last outbound whisper, for leading-edge throttling.
+    let lastWhisperAt = 0;
+
+    const typingNames = computed<string[]>(() => [...typists.value.values()]);
+
+    /**
+     * Signal that the local user is typing, whispering at most once per
+     * throttle window.
+     */
+    function signalTyping(user: TypingUser): void {
+        const now = Date.now();
+
+        if (now - lastWhisperAt < WHISPER_THROTTLE_MS) {
+            return;
+        }
+
+        lastWhisperAt = now;
+        whisper(user);
+    }
+
+    /**
+     * Record (or refresh) a remote typist, resetting their expiry countdown.
+     */
+    function receiveTyping(user: TypingUser): void {
+        clearExpiry(user.id);
+
+        const next = new Map(typists.value);
+        next.set(user.id, user.name);
+        typists.value = next;
+
+        timers.set(
+            user.id,
+            setTimeout(() => forget(user.id), TYPING_EXPIRY_MS),
+        );
+    }
+
+    /**
+     * Drop a typist immediately, e.g. once their message lands.
+     */
+    function forget(id: string): void {
+        clearExpiry(id);
+
+        if (!typists.value.has(id)) {
+            return;
+        }
+
+        const next = new Map(typists.value);
+        next.delete(id);
+        typists.value = next;
+    }
+
+    /**
+     * Clear the whole roster and every timer, e.g. when switching channels.
+     */
+    function reset(): void {
+        for (const timer of timers.values()) {
+            clearTimeout(timer);
+        }
+
+        timers.clear();
+        typists.value = new Map();
+        lastWhisperAt = 0;
+    }
+
+    function clearExpiry(id: string): void {
+        const timer = timers.get(id);
+
+        if (timer) {
+            clearTimeout(timer);
+            timers.delete(id);
+        }
+    }
+
+    onBeforeUnmount(reset);
+
+    return { typingNames, signalTyping, receiveTyping, forget, reset };
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -17,8 +17,13 @@ import {
 } from '@/actions/App/Http/Controllers/Channels/MessageController';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
+import TypingIndicator from '@/components/TypingIndicator.vue';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import {
+    useTypingIndicator,
+    type TypingUser,
+} from '@/composables/useTypingIndicator';
 import type { Channel, Mention, Message, MessagePage } from '@/types';
 
 const props = defineProps<{
@@ -34,6 +39,18 @@ const currentUser = computed(() => ({
     id: String(page.props.auth.user.id),
     name: page.props.auth.user.name,
 }));
+
+// Peers currently composing on this channel, driven by `typing` client
+// whispers over the same private channel as the message events.
+const typing = useTypingIndicator((user: TypingUser) => {
+    echo().private(channelName(props.channel.id)).whisper('typing', user);
+});
+
+const typingNames = typing.typingNames;
+
+function onTyping(): void {
+    typing.signalTyping(currentUser.value);
+}
 
 // You can't @mention yourself; drop the current user from the composer list.
 const mentionableMembers = computed(() =>
@@ -173,6 +190,8 @@ function subscribe(id: string): void {
     echo()
         .private(channelName(id))
         .listen('MessageSent', (message: Message) => {
+            // Their message landed; stop showing them as typing.
+            typing.forget(message.user.id);
             appendLive(message);
         })
         .listen('MessageUpdated', (message: Message) => {
@@ -180,6 +199,9 @@ function subscribe(id: string): void {
         })
         .listen('MessageDeleted', (message: Message) => {
             applyPatch(message);
+        })
+        .listenForWhisper('typing', (user: TypingUser) => {
+            typing.receiveTyping(user);
         });
 }
 
@@ -203,6 +225,7 @@ watch(
         live.value = [];
         pending.value = [];
         patches.value = new Map();
+        typing.reset();
         subscribe(newId);
     },
 );
@@ -356,10 +379,13 @@ function deleteMessage(message: Message): void {
             </div>
         </div>
 
+        <TypingIndicator :names="typingNames" class="mx-5 shrink-0" />
+
         <MessageComposer
             :channel-name="props.channel.name"
             :members="mentionableMembers"
             @send="send"
+            @typing="onTyping"
         />
     </div>
 </template>


### PR DESCRIPTION
Closes #8.

## What
Other channel members see **"X is typing…"** while a peer composes, via a `typing` client whisper — no DB, debounced, auto-clearing.

## How it rides the existing pipeline
Whispers travel over the **same** `echo().private(channel.{id})` subscription that already carries `MessageSent/Updated/Deleted` (from #5), authorized by channel membership in `routes/channels.php`. No new channel, broadcast auth, route, migration, or backend code — this is entirely client-side.

## Event-ownership choice
`MessageComposer` owns the textarea but not the channel, so it just **emits a `typing` event** on input. `Show.vue` owns the Echo channel and turns that into a throttled whisper of `{ id, name }` for the current user. This keeps the composer channel-agnostic and the socket logic in one place.

## Design notes
- **`useTypingIndicator` composable** holds the two pieces of state worth isolating: a leading-edge throttle (~2.5s) on outbound whispers, and a self-expiring roster of remote typists (~4s per peer, refreshed on each whisper) so the line clears on idle with no "stopped typing" signal needed.
- **Reset on channel switch and unmount** mirrors the existing `live`/`pending`/`patches` reset in the `props.channel.id` watcher; all expiry timers are torn down too.
- A typist is **cleared eagerly** when their `MessageSent` echo arrives.
- **`TypingIndicator`** is a single-root, theme-aware line: muted-foreground text with rippling dots, fixed height so the composer never jumps.

## Tests
Whispers are peer-to-peer client events with no server surface, so there's nothing to assert in PHP. No PHP was touched, so the `--min=100` PHP-only coverage gate stays green (verified: `composer test` → `Total: 100.0 %`). `npm run build` and `types:check` pass (only the two pre-existing unrelated `vue-tsc` errors remain).