### PR TITLE
feat(channels): archive channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,3 +217,10 @@ Vue components must have a single root element.
 - **100% code coverage is required — this is non-negotiable.** The test suite is gated at `--min=100` (see the `test` script in `composer.json`), so any line left uncovered fails the build.
 - **Always check coverage before pushing.** Run the full gate — which also runs Pint and PHPStan — with `./vendor/bin/sail composer test` (this executes `lint:check`, `types:check`, and `php artisan test --coverage --min=100`). Do not push or open/update a PR until it reports `Total: 100.0 %`.
 - If new code drops coverage, add or update tests until it is back at 100%. When a line reads as uncovered even though a test exercises it (e.g. the `: null` branch of a multi-line ternary is a known PCOV line-attribution quirk), collapse it onto a single line rather than leaving the gate red.
+
+## Reporting Bugs Found While Doing Something Else
+
+- **When you discover a bug, broken tooling, or other pre-existing defect while implementing an unrelated feature, do not fix it inline.** Keep the current change focused on its own scope.
+- Instead, open a GitHub issue with `gh issue create` describing the problem: what's broken, how it surfaced (reference the PR/feature you were working on), why it matters, and clear acceptance criteria for the fix. Apply a fitting label (e.g. `tech-debt`).
+- Mention the new issue in the PR of the feature you're working on so the discovery is traceable, then continue with the original task.
+- Only fix the defect inline if it directly blocks the feature you're implementing; otherwise defer it to the issue.

--- a/app/Actions/Channels/ArchiveChannel.php
+++ b/app/Actions/Channels/ArchiveChannel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Channel;
+use Illuminate\Support\Facades\DB;
+
+class ArchiveChannel
+{
+    /**
+     * Archive a channel, marking it read-only and hidden from the active sidebar.
+     *
+     * Archiving is a soft state (never a hard delete): messages are retained and
+     * stay searchable. An already-archived channel is left untouched.
+     */
+    public function handle(Channel $channel): Channel
+    {
+        return DB::transaction(function () use ($channel) {
+            if (! $channel->isArchived()) {
+                $channel->update(['archived_at' => now()]);
+            }
+
+            return $channel;
+        });
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Channels;
 
+use App\Actions\Channels\ArchiveChannel;
 use App\Actions\Channels\CreateChannel;
 use App\Actions\Channels\JoinChannel;
 use App\Data\ChannelData;
@@ -64,6 +65,9 @@ class ChannelController extends Controller
                 'slug' => $team->slug,
             ],
             'channel' => ChannelData::fromChannel($channel),
+            // Drives the header's archive control; authoritative so the button
+            // only appears for a creator or Admin+ on a non-#general channel.
+            'canArchive' => Gate::allows('archive', $channel),
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),
@@ -114,5 +118,23 @@ class ChannelController extends Controller
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Joined #:channel.', ['channel' => $channel->name])]);
 
         return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+
+    /**
+     * Archive a channel and redirect to the team's #general channel.
+     *
+     * The archived channel becomes read-only and drops out of the active
+     * sidebar, so we send the user back to #general rather than to a channel
+     * that no longer appears in their list.
+     */
+    public function archive(Request $request, Team $team, Channel $channel, ArchiveChannel $archiveChannel): RedirectResponse
+    {
+        Gate::authorize('archive', $channel);
+
+        $archiveChannel->handle($channel);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Archived #:channel.', ['channel' => $channel->name])]);
+
+        return to_route('channels.index', ['team' => $team->slug]);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -71,6 +71,7 @@ class HandleInertiaRequests extends Middleware
 
         $channels = $user->channels()
             ->where('channels.team_id', $team->id)
+            ->whereNull('channels.archived_at')
             ->orderBy('name')
             ->get();
 

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Head, InfiniteScroll, router, usePage } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
+import { Archive, EllipsisVertical } from '@lucide/vue';
 import {
     computed,
     nextTick,
@@ -10,6 +11,7 @@ import {
     watch,
 } from 'vue';
 import { toast } from 'vue-sonner';
+import { archive as archiveChannel } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import {
     destroy as destroyMessage,
     store as storeMessage,
@@ -18,12 +20,26 @@ import {
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
 import TypingIndicator from '@/components/TypingIndicator.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
-import {
-    useTypingIndicator,
-    type TypingUser,
-} from '@/composables/useTypingIndicator';
+import { useTypingIndicator } from '@/composables/useTypingIndicator';
+import type { TypingUser } from '@/composables/useTypingIndicator';
 import type { Channel, Mention, Message, MessagePage } from '@/types';
 
 const props = defineProps<{
@@ -31,6 +47,7 @@ const props = defineProps<{
     channel: Channel;
     messages: MessagePage;
     members: Mention[];
+    canArchive: boolean;
 }>();
 
 const page = usePage();
@@ -288,6 +305,7 @@ function editMessage(message: Message, body: string): void {
                 } else {
                     patches.value.delete(message.clientUuid);
                 }
+
                 toast.error('Your edit failed to save. Please try again.');
             },
         },
@@ -314,7 +332,26 @@ function deleteMessage(message: Message): void {
                 } else {
                     patches.value.delete(message.clientUuid);
                 }
+
                 toast.error('Failed to delete the message. Please try again.');
+            },
+        },
+    );
+}
+
+// Drives the archive confirmation dialog opened from the channel header menu.
+const confirmingArchive = ref(false);
+
+function archive(): void {
+    confirmingArchive.value = false;
+
+    router.post(
+        archiveChannel({ team: props.team.slug, channel: props.channel.slug })
+            .url,
+        {},
+        {
+            onError: () => {
+                toast.error('Failed to archive the channel. Please try again.');
             },
         },
     );
@@ -340,6 +377,37 @@ function deleteMessage(message: Message): void {
                 {{ props.channel.topic }}
             </p>
         </template>
+
+        <span
+            v-if="props.channel.isArchived"
+            class="ml-1 inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+        >
+            <Archive class="size-3" />
+            Archived
+        </span>
+
+        <DropdownMenu v-if="props.canArchive">
+            <DropdownMenuTrigger as-child>
+                <button
+                    type="button"
+                    aria-label="Channel options"
+                    data-test="channel-options"
+                    class="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                    <EllipsisVertical class="size-4" />
+                </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                    data-test="archive-channel"
+                    class="text-destructive focus:text-destructive"
+                    @select="confirmingArchive = true"
+                >
+                    <Archive class="size-4" />
+                    Archive channel
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
     </header>
 
     <div class="flex min-h-0 flex-1 flex-col">
@@ -379,13 +447,50 @@ function deleteMessage(message: Message): void {
             </div>
         </div>
 
-        <TypingIndicator :names="typingNames" class="mx-5 shrink-0" />
+        <div
+            v-if="props.channel.isArchived"
+            data-test="archived-notice"
+            class="m-5 shrink-0 rounded-lg border border-border bg-muted/40 px-4 py-3 text-center text-[13px] text-muted-foreground"
+        >
+            This channel is archived. It's read-only, but its history is
+            preserved.
+        </div>
 
-        <MessageComposer
-            :channel-name="props.channel.name"
-            :members="mentionableMembers"
-            @send="send"
-            @typing="onTyping"
-        />
+        <template v-else>
+            <TypingIndicator :names="typingNames" class="mx-5 shrink-0" />
+
+            <MessageComposer
+                :channel-name="props.channel.name"
+                :members="mentionableMembers"
+                @send="send"
+                @typing="onTyping"
+            />
+        </template>
     </div>
+
+    <Dialog v-model:open="confirmingArchive">
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle>Archive #{{ props.channel.name }}</DialogTitle>
+                <DialogDescription>
+                    The channel becomes read-only and leaves the sidebar. Its
+                    messages are kept and stay searchable.
+                </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter class="gap-2">
+                <DialogClose as-child>
+                    <Button variant="secondary"> Cancel </Button>
+                </DialogClose>
+
+                <Button
+                    data-test="archive-channel-confirm"
+                    variant="destructive"
+                    @click="archive"
+                >
+                    Archive
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,9 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/join', [ChannelController::class, 'join'])
         ->scopeBindings()
         ->name('channels.join');
+    Route::post('t/{team}/c/{channel}/archive', [ChannelController::class, 'archive'])
+        ->scopeBindings()
+        ->name('channels.archive');
     Route::post('t/{team}/c/{channel}/messages', [MessageController::class, 'store'])
         ->scopeBindings()
         ->name('channels.messages.store');

--- a/tests/Feature/Channels/ArchiveChannelTest.php
+++ b/tests/Feature/Channels/ArchiveChannelTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+test('a channel creator can archive their channel and is redirected to #general', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+    $channel->members()->attach($owner->id);
+
+    $this->actingAs($owner)
+        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertRedirect(route('channels.index', ['team' => $team->slug]));
+
+    expect($channel->fresh()->isArchived())->toBeTrue();
+});
+
+test('a team admin can archive a channel they did not create', function () {
+    $owner = User::factory()->create();
+    $admin = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+    $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+
+    $this->actingAs($admin)
+        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertRedirect();
+
+    expect($channel->fresh()->isArchived())->toBeTrue();
+});
+
+test('a plain member who did not create a channel cannot archive it', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+
+    $this->actingAs($member)
+        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertForbidden();
+
+    expect($channel->fresh()->isArchived())->toBeFalse();
+});
+
+test('the #general channel cannot be archived', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+
+    $this->actingAs($owner)
+        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertForbidden();
+
+    expect($general->fresh()->isArchived())->toBeFalse();
+});
+
+test('an already-archived channel cannot be archived again', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $channel = Channel::factory()->for($team)->archived()->create(['created_by' => $owner->id]);
+
+    $this->actingAs($owner)
+        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertForbidden();
+});
+
+test('archiving keeps the channel and its messages, only setting archived_at', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+    Message::factory()->for($channel)->for($owner)->create(['body' => 'Still here after archiving.']);
+
+    $this->actingAs($owner)
+        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $channel->slug]));
+
+    expect(Channel::whereKey($channel->id)->exists())->toBeTrue()
+        ->and($channel->fresh()->messages()->count())->toBe(1);
+});
+
+test('an archived channel is hidden from the active sidebar channel list', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $active = Channel::factory()->for($team)->create(['name' => 'Announcements', 'slug' => 'announcements', 'created_by' => $owner->id]);
+    $active->members()->attach($owner->id);
+    $archived = Channel::factory()->for($team)->archived()->create(['created_by' => $owner->id]);
+    $archived->members()->attach($owner->id);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
+        ->assertInertia(fn ($page) => $page
+            ->has('channels', 2)
+            ->where('channels.0.slug', 'announcements')
+            ->where('channels.1.slug', Channel::GENERAL_SLUG));
+});
+
+test('the archive control is offered to a user who may archive the channel', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+    $channel->members()->attach($owner->id);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertInertia(fn ($page) => $page->where('canArchive', true));
+});
+
+test('the archive control is withheld from a user who may not archive the channel', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn ($page) => $page->where('canArchive', false));
+});
+
+test('a user who cannot post to an archived channel is forbidden', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $channel = Channel::factory()->for($team)->archived()->create(['created_by' => $owner->id]);
+    $channel->members()->attach($owner->id);
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
+            'body' => 'This should be rejected.',
+            'client_uuid' => (string) Str::uuid(),
+        ])
+        ->assertForbidden();
+});


### PR DESCRIPTION
Closes #11.

## What

Adds the **Archive channel** MVP feature: an Admin+ or the channel creator can archive a channel, making it read-only and hiding it from the active sidebar while retaining its messages (still searchable). `#general` can never be archived, and there is no hard delete.

## Changes

- **`ArchiveChannel` action** (`app/Actions/Channels/ArchiveChannel.php`) — sets `archived_at` inside a transaction; a no-op if already archived.
- **`ChannelController::archive`** + `POST t/{team}/c/{channel}/archive` route (`channels.archive`), authorized by the existing `ChannelPolicy@archive` (creator or Admin+, never `#general`, never re-archive). Redirects to `#general` with a success toast.
- **`canArchive` prop** on the channel `show` page so the header control only renders for users who may archive.
- **Sidebar filter** — `HandleInertiaRequests` now excludes archived channels (`whereNull archived_at`) from the active channel list.
- **Read-only UI** — `Show.vue` gains a header options menu with an archive confirmation dialog, an "Archived" badge, and swaps the composer for a read-only notice when the channel is archived. (Posting was already blocked server-side by `ChannelPolicy@postMessage`.)

## Tests

New `tests/Feature/Channels/ArchiveChannelTest.php` covers: creator + admin can archive, plain member forbidden, `#general` guard, already-archived guard, messages retained, sidebar hides archived channels, `canArchive` prop true/false, and posting to an archived channel is forbidden.

Full gate green: `composer test` reports **Total: 100.0 %** (Pint + PHPStan + coverage).

> Note: the repo's frontend build/eslint/vue-tsc tooling currently fails locally on a pre-existing native-binding / npm optional-deps issue (unrelated to this change) — see the follow-up issue.