### PR TITLE
feat(seeders): rich local-dev workspace seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,24 +2,26 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\App;
 
 class DatabaseSeeder extends Seeder
 {
-    use WithoutModelEvents;
-
     /**
      * Seed the application's database.
+     *
+     * Deliberately does NOT use `WithoutModelEvents`: the workspace dataset relies
+     * on `MembershipObserver` firing to create each team's #general channel and
+     * join members to it.
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        if (! App::environment(['local', 'testing'])) {
+            $this->command->warn('Skipping workspace seeding: only intended for local and testing environments.');
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+            return;
+        }
+
+        $this->call(WorkspaceSeeder::class);
     }
 }

--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Actions\Channels\CreateChannel;
+use App\Actions\Channels\JoinChannel;
+use App\Actions\Channels\SyncMentions;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+/**
+ * Stands up a rich, log-in-ready local workspace that exercises every model and
+ * factory state, so a developer can click through the whole MVP after a single
+ * `migrate:fresh --seed`.
+ *
+ * Teams and memberships are seeded exclusively through the event-firing paths
+ * (the domain actions and `members()->attach()`), never with model events
+ * disabled: `MembershipObserver` is what creates each team's protected #general
+ * channel and keeps channel membership in step with team membership.
+ */
+class WorkspaceSeeder extends Seeder
+{
+    /**
+     * The fixed credentials of the demo account devs log in with.
+     */
+    public const string DEMO_EMAIL = 'test@example.com';
+
+    public function __construct(
+        private readonly CreateTeam $createTeam,
+        private readonly CreateChannel $createChannel,
+        private readonly JoinChannel $joinChannel,
+        private readonly SyncMentions $syncMentions,
+    ) {}
+
+    /**
+     * Seed the local workspace dataset.
+     */
+    public function run(): void
+    {
+        $cast = $this->seedUsers();
+        $demo = $cast['demo'];
+
+        $acme = $this->seedOwnedTeam($cast);
+        $this->seedAdminTeam($demo, $cast['globexOwner'], $cast['member2']);
+        $this->seedMemberTeam($demo, $cast['initechOwner']);
+        $this->seedTrashedTeam($cast['ghostOwner']);
+
+        $demo->switchTeam($acme);
+
+        $this->printSummary($acme);
+    }
+
+    /**
+     * Create the demo account plus a supporting cast, covering the unverified and
+     * two-factor user states. Every user also gets a personal team (Owner) via
+     * `UserFactory::configure()`, which exercises `TeamFactory::personal()`.
+     *
+     * @return array{demo: User, admin: User, member1: User, member2: User, twoFactor: User, globexOwner: User, initechOwner: User, ghostOwner: User}
+     */
+    private function seedUsers(): array
+    {
+        $demo = User::factory()->create([
+            'name' => 'Demo User',
+            'email' => self::DEMO_EMAIL,
+        ]);
+
+        User::factory()->unverified()->create([
+            'name' => 'Uma Unverified',
+            'email' => 'unverified@example.com',
+        ]);
+
+        $twoFactor = User::factory()->withTwoFactor()->create([
+            'name' => 'Tina Twofactor',
+            'email' => 'twofactor@example.com',
+        ]);
+
+        return [
+            'demo' => $demo,
+            'admin' => User::factory()->create(['name' => 'Alice Admin']),
+            'member1' => User::factory()->create(['name' => 'Bob Builder']),
+            'member2' => User::factory()->create(['name' => 'Carol Danvers']),
+            'twoFactor' => $twoFactor,
+            'globexOwner' => User::factory()->create(['name' => 'Grace Globex']),
+            'initechOwner' => User::factory()->create(['name' => 'Ivan Initech']),
+            'ghostOwner' => User::factory()->create(['name' => 'Nate Nolonger']),
+        ];
+    }
+
+    /**
+     * The primary busy team the demo user owns: extra public channels (with and
+     * without topics), private channels the demo is and isn't in, an archived
+     * channel, a backfilled #general with edited/deleted/mention messages and
+     * varied unread state, plus invitations covering every role and state.
+     *
+     * @param  array{demo: User, admin: User, member1: User, member2: User, twoFactor: User, globexOwner: User, initechOwner: User, ghostOwner: User}  $cast
+     */
+    private function seedOwnedTeam(array $cast): Team
+    {
+        ['demo' => $demo, 'admin' => $admin, 'member1' => $member1, 'member2' => $member2, 'twoFactor' => $twoFactor] = $cast;
+
+        $acme = $this->createTeam->handle($demo, 'Acme Corp');
+
+        $acme->members()->attach($admin, ['role' => TeamRole::Admin->value]);
+        $acme->members()->attach($member1, ['role' => TeamRole::Member->value]);
+        $acme->members()->attach($member2, ['role' => TeamRole::Member->value]);
+        $acme->members()->attach($twoFactor, ['role' => TeamRole::Member->value]);
+
+        $general = $this->generalChannel($acme);
+        $members = [$demo, $admin, $member1, $member2, $twoFactor];
+
+        // A busy channel: enough backfill to make infinite scroll meaningful.
+        $this->seedMessages($general, $members, 60);
+        $this->seedEditedMessage($general, $admin);
+        $this->seedDeletedMessage($general, $member1);
+        $this->seedMentionMessage($general, $member2, $demo);
+
+        // Extra public channels — one with a topic, one without.
+        $announcements = $this->createChannel->handle($acme, 'announcements', ChannelVisibility::Public, $demo, 'Company-wide news');
+        $random = $this->createChannel->handle($acme, 'random', ChannelVisibility::Public, $member1);
+        $this->joinChannel->handle($announcements, $admin);
+        $this->joinChannel->handle($random, $demo);
+        $this->seedMessages($announcements, [$demo, $admin], 8);
+        $this->seedMessages($random, [$member1, $member2], 5);
+
+        // Private channel the demo is a member of (with a topic).
+        $leadership = Channel::factory()->for($acme)->private()->create([
+            'name' => 'leadership',
+            'slug' => 'leadership',
+            'topic' => 'Founders only',
+            'created_by' => $demo->id,
+        ]);
+        $leadership->members()->attach([$demo->id, $admin->id]);
+        $this->seedMessages($leadership, [$demo, $admin], 6);
+
+        // Private channel the demo is deliberately NOT a member of.
+        $secret = Channel::factory()->for($acme)->private()->create([
+            'name' => 'secret-project',
+            'slug' => 'secret-project',
+            'created_by' => $admin->id,
+        ]);
+        $secret->members()->attach([$admin->id, $member1->id]);
+
+        // An archived channel the demo can still reach from the archive view.
+        $archived = Channel::factory()->for($acme)->archived()->create([
+            'name' => 'old-stuff',
+            'slug' => 'old-stuff',
+            'created_by' => $demo->id,
+        ]);
+        $archived->members()->attach([$demo->id, $admin->id]);
+
+        $this->seedUnreadState($demo, $general, $announcements, $leadership);
+        $this->seedInvitations($acme, $demo);
+
+        return $acme;
+    }
+
+    /**
+     * A team owned by someone else where the demo user is an Admin, so the
+     * admin-gated UI (invitations, channel management) can be exercised.
+     */
+    private function seedAdminTeam(User $demo, User $owner, User $member): void
+    {
+        $globex = $this->createTeam->handle($owner, 'Globex');
+
+        $globex->members()->attach($demo, ['role' => TeamRole::Admin->value]);
+        $globex->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+        $engineering = $this->createChannel->handle($globex, 'engineering', ChannelVisibility::Public, $owner, 'Ship it');
+        $this->joinChannel->handle($engineering, $demo);
+        $this->seedMessages($engineering, [$owner, $demo, $member], 12);
+    }
+
+    /**
+     * A team owned by someone else where the demo user is a plain Member, so
+     * permission-denied paths can be exercised.
+     */
+    private function seedMemberTeam(User $demo, User $owner): void
+    {
+        $initech = $this->createTeam->handle($owner, 'Initech');
+
+        $initech->members()->attach($demo, ['role' => TeamRole::Member->value]);
+
+        $this->seedMessages($this->generalChannel($initech), [$owner, $demo], 7);
+    }
+
+    /**
+     * A soft-deleted team (via `TeamFactory::trashed()`) that still respects the
+     * invariants: #general is created up front so the membership observer takes
+     * its join branch (which never re-queries the now-trashed team) rather than
+     * its create branch (which would resolve the soft-deleted team to null).
+     */
+    private function seedTrashedTeam(User $owner): void
+    {
+        $ghost = Team::factory()->trashed()->create(['name' => 'Umbrella Corp']);
+
+        $this->createChannel->handle($ghost, Channel::GENERAL_SLUG, ChannelVisibility::Public, $owner);
+        $ghost->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    }
+
+    /**
+     * Fan out pending, accepted and expired invitations across every role on a
+     * team the demo user administers, exercising each `TeamInvitationFactory`
+     * state including `expiresIn()`.
+     */
+    private function seedInvitations(Team $team, User $inviter): void
+    {
+        // Pending, no expiry.
+        TeamInvitation::factory()->for($team)->create([
+            'email' => 'pending-member@example.com',
+            'role' => TeamRole::Member,
+            'invited_by' => $inviter->id,
+        ]);
+
+        // Pending, expiring soon.
+        TeamInvitation::factory()->for($team)->expiresIn(7)->create([
+            'email' => 'pending-admin@example.com',
+            'role' => TeamRole::Admin,
+            'invited_by' => $inviter->id,
+        ]);
+
+        // Accepted.
+        TeamInvitation::factory()->for($team)->accepted()->create([
+            'email' => 'accepted-admin@example.com',
+            'role' => TeamRole::Admin,
+            'invited_by' => $inviter->id,
+        ]);
+
+        // Expired, covering the Owner role for full role coverage.
+        TeamInvitation::factory()->for($team)->expired()->create([
+            'email' => 'expired-owner@example.com',
+            'role' => TeamRole::Owner,
+            'invited_by' => $inviter->id,
+        ]);
+    }
+
+    /**
+     * Post a run of messages to a channel, rotating through the given authors and
+     * back-dating them so the channel reads as an ongoing conversation.
+     *
+     * @param  non-empty-list<User>  $authors
+     * @return list<Message>
+     */
+    private function seedMessages(Channel $channel, array $authors, int $count): array
+    {
+        $messages = [];
+
+        for ($index = 0; $index < $count; $index++) {
+            $author = $authors[$index % count($authors)];
+
+            $messages[] = Message::factory()->for($channel)->for($author)->create([
+                'created_at' => now()->subMinutes($count - $index),
+            ]);
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Seed a message that has been edited.
+     */
+    private function seedEditedMessage(Channel $channel, User $author): void
+    {
+        Message::factory()->for($channel)->for($author)->edited()->create([
+            'body' => 'Fixed a typo in my previous message.',
+        ]);
+    }
+
+    /**
+     * Seed a soft-deleted message so tombstone rendering has data.
+     */
+    private function seedDeletedMessage(Channel $channel, User $author): void
+    {
+        Message::factory()->for($channel)->for($author)->create([
+            'body' => 'This message was removed.',
+        ])->delete();
+    }
+
+    /**
+     * Seed a message carrying a real `@[Name](user-id)` token and reconcile its
+     * mention rows through `SyncMentions`.
+     */
+    private function seedMentionMessage(Channel $channel, User $author, User $mentioned): void
+    {
+        $message = Message::factory()->for($channel)->for($author)->create([
+            'body' => "Hey @[{$mentioned->name}]({$mentioned->id}), can you take a look?",
+        ]);
+
+        $this->syncMentions->handle($channel, $message);
+    }
+
+    /**
+     * Vary the demo user's `last_read_message_id` across channels so some show an
+     * unread badge and some are fully caught up.
+     */
+    private function seedUnreadState(
+        User $demo,
+        Channel $general,
+        Channel $announcements,
+        Channel $leadership,
+    ): void {
+        // #general: read up to an earlier message, leaving later ones unread.
+        $readUpTo = $general->messages()->oldest()->skip(39)->first();
+        $demo->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $readUpTo?->id]);
+
+        // Announcements: fully caught up.
+        $latestAnnouncement = $announcements->messages()->latest()->first();
+        $demo->channels()->updateExistingPivot($announcements->id, ['last_read_message_id' => $latestAnnouncement?->id]);
+
+        // Leadership: never opened, so everything is unread.
+        $demo->channels()->updateExistingPivot($leadership->id, ['last_read_message_id' => null]);
+    }
+
+    /**
+     * Resolve a team's protected #general channel.
+     */
+    private function generalChannel(Team $team): Channel
+    {
+        return $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+    }
+
+    /**
+     * Print where to start once seeding finishes.
+     */
+    private function printSummary(Team $primaryTeam): void
+    {
+        $this->command->info('Workspace seeded.');
+        $this->command->info('  Demo login: '.self::DEMO_EMAIL.' / password');
+        $this->command->info('  Lands in "'.$primaryTeam->name.'" (Owner) — also Admin of "Globex" and Member of "Initech".');
+    }
+}

--- a/tests/Feature/DatabaseSeederTest.php
+++ b/tests/Feature/DatabaseSeederTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Database\Seeders\WorkspaceSeeder;
+
+beforeEach(function () {
+    $this->seed();
+
+    $this->demo = User::where('email', WorkspaceSeeder::DEMO_EMAIL)->firstOrFail();
+});
+
+test('it seeds a verified demo user with the documented credentials', function () {
+    expect($this->demo->email_verified_at)->not->toBeNull()
+        ->and(Hash::check('password', $this->demo->password))->toBeTrue();
+});
+
+test('the demo user owns, administers and is a plain member across shared teams', function () {
+    $acme = Team::where('name', 'Acme Corp')->firstOrFail();
+    $globex = Team::where('name', 'Globex')->firstOrFail();
+    $initech = Team::where('name', 'Initech')->firstOrFail();
+
+    expect($this->demo->teamRole($acme))->toBe(TeamRole::Owner)
+        ->and($this->demo->teamRole($globex))->toBe(TeamRole::Admin)
+        ->and($this->demo->teamRole($initech))->toBe(TeamRole::Member)
+        ->and($this->demo->isCurrentTeam($acme))->toBeTrue();
+});
+
+test('every team role is represented in the membership table', function () {
+    $roles = DB::table('team_members')->distinct()->pluck('role')->all();
+
+    foreach (TeamRole::cases() as $role) {
+        expect($roles)->toContain($role->value);
+    }
+});
+
+test('it covers the unverified and two-factor user states', function () {
+    expect(User::whereNull('email_verified_at')->exists())->toBeTrue()
+        ->and(User::whereNotNull('two_factor_confirmed_at')->exists())->toBeTrue();
+});
+
+test('every active team has a #general channel with member rows', function () {
+    $teams = Team::all();
+
+    expect($teams)->not->toBeEmpty();
+
+    $teams->each(function (Team $team) {
+        $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->first();
+
+        expect($general)->not->toBeNull()
+            ->and($general->channelMembers()->count())->toBeGreaterThan(0);
+    });
+});
+
+test('it seeds a soft-deleted team that still keeps its #general', function () {
+    $ghost = Team::onlyTrashed()->firstOrFail();
+
+    expect($ghost->channels()->where('slug', Channel::GENERAL_SLUG)->exists())->toBeTrue();
+});
+
+test('it seeds public, private, archived and topic-bearing channels', function () {
+    expect(Channel::where('visibility', ChannelVisibility::Public)->exists())->toBeTrue()
+        ->and(Channel::where('visibility', ChannelVisibility::Private)->count())->toBeGreaterThanOrEqual(2)
+        ->and(Channel::whereNotNull('archived_at')->exists())->toBeTrue()
+        ->and(Channel::whereNotNull('topic')->exists())->toBeTrue()
+        ->and(Channel::whereNull('topic')->exists())->toBeTrue();
+});
+
+test('the demo user is inside some private channels but excluded from others', function () {
+    $memberOf = $this->demo->channels()->where('visibility', ChannelVisibility::Private)->exists();
+
+    $excludedFrom = Channel::where('visibility', ChannelVisibility::Private)
+        ->whereDoesntHave('members', fn ($query) => $query->whereKey($this->demo->id))
+        ->exists();
+
+    expect($memberOf)->toBeTrue()
+        ->and($excludedFrom)->toBeTrue();
+});
+
+test('it backfills a busy channel to make pagination meaningful', function () {
+    $busiest = Channel::withCount('messages')->orderByDesc('messages_count')->firstOrFail();
+
+    expect($busiest->messages_count)->toBeGreaterThanOrEqual(50);
+});
+
+test('it seeds edited, soft-deleted and mention-bearing messages', function () {
+    expect(Message::whereNotNull('edited_at')->exists())->toBeTrue()
+        ->and(Message::onlyTrashed()->exists())->toBeTrue()
+        ->and(DB::table('mentions')->count())->toBeGreaterThan(0);
+});
+
+test('it varies the demo user unread state across channels', function () {
+    $pivots = $this->demo->channels()->get()
+        ->map(fn (Channel $channel) => $channel->getRelationValue('pivot')->last_read_message_id);
+
+    expect($pivots->filter()->isNotEmpty())->toBeTrue()
+        ->and($pivots->contains(null))->toBeTrue();
+});
+
+test('it seeds pending, accepted and expired invitations across roles on an admin team', function () {
+    $acme = Team::where('name', 'Acme Corp')->firstOrFail();
+    $invitations = $acme->invitations()->get();
+
+    expect($invitations->contains(fn (TeamInvitation $invitation) => $invitation->isPending()))->toBeTrue()
+        ->and($invitations->contains(fn (TeamInvitation $invitation) => $invitation->isAccepted()))->toBeTrue()
+        ->and($invitations->contains(fn (TeamInvitation $invitation) => $invitation->isExpired()))->toBeTrue()
+        ->and($invitations->pluck('role')->unique()->count())->toBeGreaterThan(1);
+});


### PR DESCRIPTION
Closes #58

## What
Replaces the single-`Test User` `DatabaseSeeder` with an environment-guarded `WorkspaceSeeder` that stands up a deterministic, log-in-ready local dataset exercising **every model and every factory state**. After one `./vendor/bin/sail artisan migrate:fresh --seed`, a developer can click through the whole MVP.

**Demo login:** `test@example.com` / `password` — lands in **Acme Corp** (Owner), also **Admin** of Globex and plain **Member** of Initech.

## Dataset
- **Users** — demo + supporting cast; ≥1 `unverified()` and ≥1 `withTwoFactor()`; every user gets a personal team via `UserFactory::configure()` (exercises `TeamFactory::personal()`).
- **Teams & roles** — Acme (Owner) / Globex (Admin) / Initech (Member) cover every `TeamRole`; a soft-deleted **Umbrella Corp** (`TeamFactory::trashed()`) that still keeps its `#general`.
- **Channels** — auto `#general` per team, extra public channels (with and without a topic), private channels the demo is in and deliberately excluded from, and an `archived()` channel.
- **Messages** — a busy `#general` backfilled to 60+ (mixed authors) so infinite scroll is meaningful, plus `edited()`, soft-deleted, and real `@[Name](user-id)` mention messages reconciled through `SyncMentions`.
- **Unread** — varied `last_read_message_id` so some channels show unread badges and some are fully read for the demo user.
- **Invitations** — pending / `accepted()` / `expired()` across roles (incl. `expiresIn()`) on the team the demo administers.

## Invariants respected
Seeds teams/members exclusively through the event-firing paths (`CreateTeam` / `CreateChannel` / `JoinChannel` actions and `members()->attach()`), so `MembershipObserver` creates each team's protected `#general` and keeps channel membership in step with team membership. **Drops `WithoutModelEvents`.** The trashed team pre-creates its `#general` so the observer takes its join branch (the create branch would resolve the soft-deleted team to `null`).

## Safety & determinism
- Guarded to `local`/`testing` only; prints a demo-login summary at the end.
- Fixed demo creds and team/channel names; factory-random bulk filler. `migrate:fresh --seed` is repeatable.

## Testing
- New `tests/Feature/DatabaseSeederTest.php` (12 tests) asserts the produced shape: demo creds & roles, every `TeamRole` present, `#general` + member rows per team, trashed-team `#general`, public/private/archived/topic channels, private-channel inclusion vs exclusion, 50+-message busy channel, edited/deleted/mention rows, unread variance, and pending/accepted/expired invitations across roles.
- Full gate green: `./vendor/bin/sail composer test` → **Total: 100.0 %** (Pint + PHPStan level 7 clean; seeder fully typed).

## Bugs found while doing this (filed, not fixed here — per CLAUDE.md)
The seeded workspaces (genuinely different channel sets per team) made two pre-existing defects easy to hit:
- **#61** — team switcher 404s: `useTeamSwitch.ts` blindly rewrites the team segment, producing `/t/<newteam>/c/<channel>` for a channel that doesn't exist in the target team (`scopeBindings` → 404).
- **#62** — post-login `intended()` redirect can land on a 404: a stale/forbidden stored URL is honoured with no fallback to the user's valid `#general`.
