### PR TITLE
feat(presence): online dots on member avatars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,7 @@ Vue components must have a single root element.
 ## Reporting Bugs Found While Doing Something Else
 
 - **When you discover a bug, broken tooling, or other pre-existing defect while implementing an unrelated feature, do not fix it inline.** Keep the current change focused on its own scope.
-- Instead, open a GitHub issue with `gh issue create` describing the problem: what's broken, how it surfaced (reference the PR/feature you were working on), why it matters, and clear acceptance criteria for the fix. Apply a fitting label (e.g. `tech-debt`).
+- **Before filing anything, check for an existing issue** covering the same defect: run `gh issue list --state open --search "<keywords>"` (and search closed issues too). If one already exists, reference it in your PR instead of opening a duplicate.
+- If none exists, open a GitHub issue with `gh issue create` describing the problem: what's broken, how it surfaced (reference the PR/feature you were working on), why it matters, and clear acceptance criteria for the fix. Apply a fitting label (e.g. `tech-debt`).
 - Mention the new issue in the PR of the feature you're working on so the discovery is traceable, then continue with the original task.
 - Only fix the defect inline if it directly blocks the feature you're implementing; otherwise defer it to the issue.

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
     pendingUuids?: string[];
     currentUserId: string;
     canModerate?: boolean;
+    onlineIds?: Set<string>;
 }>();
 
 const emit = defineEmits<{
@@ -28,6 +29,13 @@ const emit = defineEmits<{
 }>();
 
 const { getInitials } = useInitials();
+
+/**
+ * Whether a message author is currently present on the team presence roster.
+ */
+function isOnline(authorId: string): boolean {
+    return props.onlineIds?.has(authorId) ?? false;
+}
 
 // Consecutive messages from the same author within this window are grouped
 // under a single avatar + header line.
@@ -224,11 +232,26 @@ function confirmDelete(): void {
             </div>
 
             <div v-else class="mt-[18px] flex gap-3 first:mt-1">
-                <div
-                    class="flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-primary/10 text-[12px] font-semibold text-primary select-none"
-                    aria-hidden="true"
-                >
-                    {{ getInitials(item.author.name) }}
+                <div class="relative size-9 shrink-0">
+                    <div
+                        class="flex size-9 items-center justify-center rounded-[10px] bg-primary/10 text-[12px] font-semibold text-primary select-none"
+                        aria-hidden="true"
+                    >
+                        {{ getInitials(item.author.name) }}
+                    </div>
+                    <span
+                        data-test="presence-dot"
+                        :data-online="isOnline(item.author.id)"
+                        :aria-label="
+                            isOnline(item.author.id) ? 'Online' : 'Offline'
+                        "
+                        class="absolute -right-0.5 -bottom-0.5 size-2.5 rounded-full ring-2 ring-background"
+                        :class="
+                            isOnline(item.author.id)
+                                ? 'bg-emerald-500'
+                                : 'bg-transparent ring-muted-foreground/40 ring-inset'
+                        "
+                    />
                 </div>
                 <div class="min-w-0 flex-1">
                     <div class="flex items-baseline gap-2">
@@ -254,7 +277,10 @@ function confirmDelete(): void {
                             This message was deleted
                         </p>
 
-                        <div v-else-if="editingId === message.id" class="py-0.5">
+                        <div
+                            v-else-if="editingId === message.id"
+                            class="py-0.5"
+                        >
                             <textarea
                                 :ref="setEditField"
                                 v-model="editDraft"
@@ -339,10 +365,7 @@ function confirmDelete(): void {
             </div>
         </template>
 
-        <Dialog
-            :open="pendingDelete !== null"
-            @update:open="setDeleteOpen"
-        >
+        <Dialog :open="pendingDelete !== null" @update:open="setDeleteOpen">
             <DialogContent>
                 <DialogHeader>
                     <DialogTitle>Delete message</DialogTitle>

--- a/resources/js/composables/useTeamPresence.ts
+++ b/resources/js/composables/useTeamPresence.ts
@@ -1,0 +1,90 @@
+import { echo } from '@laravel/echo-vue';
+import { onBeforeUnmount, onMounted, ref, toValue, watch } from 'vue';
+import type { MaybeRefOrGetter } from 'vue';
+
+/**
+ * A team member as carried on the `team.{id}` presence roster. Mirrors the
+ * `user_info` returned by the channel authorization callback.
+ */
+export type PresenceMember = {
+    id: string;
+    name: string;
+};
+
+/**
+ * Tracks which members of a team are currently online via the `team.{id}`
+ * Reverb presence channel. `here` seeds the roster on join, while `joining`
+ * and `leaving` keep it live as members open and close the workspace.
+ *
+ * The subscription follows the given team id: switching teams leaves the old
+ * presence channel and joins the new one, and the channel is left on unmount.
+ */
+export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
+    // Ids of the members currently present, driving the online dots.
+    const onlineIds = ref<Set<string>>(new Set());
+
+    function channelName(id: string): string {
+        return `team.${id}`;
+    }
+
+    function replace(ids: Iterable<string>): void {
+        onlineIds.value = new Set(ids);
+    }
+
+    function join(id: string): void {
+        echo()
+            .join(channelName(id))
+            .here((members: PresenceMember[]) => {
+                replace(members.map((member) => member.id));
+            })
+            .joining((member: PresenceMember) => {
+                onlineIds.value = new Set(onlineIds.value).add(member.id);
+            })
+            .leaving((member: PresenceMember) => {
+                const next = new Set(onlineIds.value);
+                next.delete(member.id);
+                onlineIds.value = next;
+            });
+    }
+
+    function leave(id: string): void {
+        echo().leave(channelName(id));
+    }
+
+    // Echo opens a websocket, so it must only be touched in the browser: joining
+    // during setup would run on the SSR pass and try to connect there.
+    onMounted(() => {
+        const id = toValue(teamId);
+
+        if (id) {
+            join(id);
+        }
+    });
+
+    // Follow the active team once mounted: re-subscribe when it changes,
+    // clearing the roster so a stale team's presence never bleeds into the next.
+    watch(
+        () => toValue(teamId),
+        (newId, oldId) => {
+            if (oldId) {
+                leave(oldId);
+            }
+
+            replace([]);
+
+            if (newId) {
+                join(newId);
+            }
+        },
+    );
+
+    onBeforeUnmount(() => {
+        const id = toValue(teamId);
+
+        if (id) {
+            leave(id);
+        }
+    });
+
+    return { onlineIds };
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -38,6 +38,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
 import type { Channel, Mention, Message, MessagePage } from '@/types';
@@ -64,6 +65,10 @@ const typing = useTypingIndicator((user: TypingUser) => {
 });
 
 const typingNames = typing.typingNames;
+
+// Live roster of team members currently online, driving the presence dots on
+// message avatars. Follows the team across channel switches.
+const { onlineIds } = useTeamPresence(() => props.team.id);
 
 function onTyping(): void {
     typing.signalTyping(currentUser.value);
@@ -423,6 +428,7 @@ function archive(): void {
                     :pending-uuids="pendingUuids"
                     :current-user-id="currentUser.id"
                     :can-moderate="canModerate"
+                    :online-ids="onlineIds"
                     @edit="editMessage"
                     @delete="deleteMessage"
                 />

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Channel;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Broadcast;
 
@@ -14,4 +15,22 @@ Broadcast::channel('channel.{channelId}', function (User $user, string $channelI
 
     return $channel !== null
         && $channel->members()->whereKey($user->id)->exists();
+});
+
+/**
+ * Track which team members are currently online.
+ *
+ * Only members of the team may join, and the identity returned here becomes
+ * their entry in the presence roster that drives the online dots on avatars.
+ *
+ * @return array{id: string, name: string}|null
+ */
+Broadcast::channel('team.{teamId}', function (User $user, string $teamId): ?array {
+    $team = Team::find($teamId);
+
+    if ($team === null || ! $team->members()->whereKey($user->id)->exists()) {
+        return null;
+    }
+
+    return ['id' => $user->id, 'name' => $user->name];
 });

--- a/tests/Feature/Teams/TeamPresenceTest.php
+++ b/tests/Feature/Teams/TeamPresenceTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+/**
+ * Exercise the presence channel authorization against a real broadcaster.
+ *
+ * The test suite defaults to the `null` broadcaster, which authorizes every
+ * subscription without consulting routes/channels.php. Switching to a real
+ * driver and reloading the channel definitions onto it lets the authorization
+ * callback actually run.
+ */
+function usePresenceBroadcaster(): void
+{
+    config(['broadcasting.default' => 'reverb']);
+
+    require base_path('routes/channels.php');
+}
+
+test('a team member is authorized to join the team presence channel and receives their roster identity', function () {
+    usePresenceBroadcaster();
+
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $response = $this->actingAs($member)
+        ->post('/broadcasting/auth', [
+            'channel_name' => 'presence-team.'.$team->id,
+            'socket_id' => '1234.5678',
+        ])
+        ->assertOk();
+
+    $channelData = json_decode($response->json('channel_data'), true);
+
+    expect($channelData['user_info'])->toBe(['id' => $member->id, 'name' => $member->name]);
+});
+
+test('a non-member cannot join the team presence channel', function () {
+    usePresenceBroadcaster();
+
+    $team = Team::factory()->create();
+    $stranger = User::factory()->create();
+
+    $this->actingAs($stranger)
+        ->post('/broadcasting/auth', [
+            'channel_name' => 'presence-team.'.$team->id,
+            'socket_id' => '1234.5678',
+        ])
+        ->assertForbidden();
+});
+
+test('joining the presence channel of an unknown team is denied', function () {
+    usePresenceBroadcaster();
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post('/broadcasting/auth', [
+            'channel_name' => 'presence-team.'.Str::uuid7(),
+            'socket_id' => '1234.5678',
+        ])
+        ->assertForbidden();
+});


### PR DESCRIPTION
Closes #9.

## What
Adds per-team presence tracking and renders live online/offline dots on message author avatars.

## Changes
- **`routes/channels.php`** — new `team.{id}` Reverb presence channel, authorized by team membership. Returns the member's roster identity (`{id, name}`); denies non-members and unknown teams.
- **`useTeamPresence` composable** — joins the presence channel in `onMounted` (SSR-safe), follows the active team across channel switches, leaves on unmount, and exposes a reactive `onlineIds` roster driven by `here`/`joining`/`leaving`.
- **`MessageList.vue`** — renders a green (online) / hollow (offline) presence dot on each author avatar.
- **`Show.vue`** — wires the composable and passes `onlineIds` down.
- **`CLAUDE.md`** — require searching for an existing issue before filing bug reports, to avoid duplicates.

## Acceptance criteria
- [x] presence channel `team.{id}` authorized by team membership
- [x] online roster drives avatar dots; join/leave updates live
- [x] tests for presence auth (TDD) — member / non-member / unknown team

## Tests & gate
- `tests/Feature/Teams/TeamPresenceTest.php` covers presence authorization.
- `php artisan test --coverage --min=100` → **Total: 100.0%**; PHPStan + Pint clean.

## Notes
- Two pre-existing `vue-tsc` errors (`RemoveMemberModal.vue`, `teams/Edit.vue`) are unrelated to this work and already tracked in #60 — not touched here.