### PR TITLE
fix(tooling): green the frontend quality gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Build Assets
         run: npm run build
 
+      - name: Check Frontend Types
+        run: npm run types:check
+
       - name: Run Type Analysis
         run: composer types:check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,12 @@ Vue components must have a single root element.
 
 <!-- Custom project guidance below is preserved across `boost:update` runs. -->
 
+## Frontend Tooling (run through Sail)
+
+- **Always run Node/npm tooling through Sail** — `./vendor/bin/sail npm run <script>`, never bare `npm` on the host. `node_modules` is installed inside the Linux container, so its native bindings (`@unrs/resolver-*`, `@rolldown/binding-*`) are Linux-only. Running `npm run build`, `lint`, etc. directly on macOS fails with `Cannot find native binding` (the npm optional-dependencies bug); Sail runs them in the matching Linux environment where the bindings exist.
+- `vue-tsc` (`npm run types:check`) doesn't use those native bindings, so it can run on the host, but prefer Sail for consistency.
+- The frontend quality gate is `./vendor/bin/sail npm run lint:check`, `format:check`, `types:check`, and `build` — all four must pass before pushing. Use `sail npm run lint` / `format` (the write variants) to auto-fix violations.
+
 ## Code Coverage
 
 - **100% code coverage is required — this is non-negotiable.** The test suite is gated at `--min=100` (see the `test` script in `composer.json`), so any line left uncovered fails the build.

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,11 +1,11 @@
 import { createInertiaApp } from '@inertiajs/vue3';
+import { configureEcho } from '@laravel/echo-vue';
 import { initializeTheme } from '@/composables/useAppearance';
 import AppLayout from '@/layouts/AppLayout.vue';
 import AuthLayout from '@/layouts/AuthLayout.vue';
 import ChannelLayout from '@/layouts/channels/Layout.vue';
 import SettingsLayout from '@/layouts/settings/Layout.vue';
 import { initializeFlashToast } from '@/lib/flashToast';
-import { configureEcho } from '@laravel/echo-vue';
 
 configureEcho({
     broadcaster: 'reverb',

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -241,7 +241,7 @@ function onKeydown(event: KeyboardEvent): void {
                     :placeholder="`Message #${props.channelName}`"
                     data-test="message-composer-input"
                     class="max-h-[200px] w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
-                    @input="resize(), refreshSuggestions(), emit('typing')"
+                    @input="(resize(), refreshSuggestions(), emit('typing'))"
                     @click="refreshSuggestions"
                     @keydown="onKeydown"
                 ></textarea>

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -1,7 +1,7 @@
 export type TeamRole = 'owner' | 'admin' | 'member';
 
 export type Team = {
-    id: number;
+    id: string;
     name: string;
     slug: string;
     isPersonal: boolean;
@@ -11,7 +11,7 @@ export type Team = {
 };
 
 export type TeamMember = {
-    id: number;
+    id: string;
     name: string;
     email: string;
     avatar?: string | null;


### PR DESCRIPTION
Closes #60.

## Root cause
The `Cannot find native binding` failures were **not a code bug**: `node_modules` holds Linux-only native bindings (`@unrs/resolver-*`, `@rolldown/binding-*`) because it's installed inside the Sail container, so bare `npm` on the macOS host can't resolve them. Run through Sail (Linux) and they work — as does CI, which is Linux. Behind that masked failure sat a handful of genuine, previously-uncaught lint/type/format violations.

## Changes
- **types** — `TeamMember.id` and `Team.id` are UUIDs; type them as `string`. Fixes the `vue-tsc` `number is not assignable to 'string | { id: string }'` errors in `teams/Edit.vue` and `RemoveMemberModal.vue`.
- **lint** — reorder the `@laravel/echo-vue` import in `app.ts` (`import/order`).
- **format** — normalize a sequence expression in `MessageComposer.vue`.
- **ci** — run `vue-tsc` (`npm run types:check`) in `tests.yml` so frontend type regressions are caught (it was never run in CI before).
- **docs** — CLAUDE.md now mandates running all Node tooling through Sail (`./vendor/bin/sail npm run ...`) and documents why bare host `npm` fails.

## Acceptance criteria
- [x] `npm run build` succeeds locally (via Sail) and in CI
- [x] `npm run lint:check` passes
- [x] `npm run types:check` passes (no `number` vs `string` id mismatches; Wayfinder `.form` helpers already resolve on current generated types)

## Verification (all via `./vendor/bin/sail npm run ...`)
```
build PASS
lint PASS
format PASS
types PASS
```
No PHP touched, so the coverage gate is unaffected.