### PR TITLE
feat(channels): unread & mention badges (#10)

### DIFF
--- a/app/Actions/Channels/MarkChannelRead.php
+++ b/app/Actions/Channels/MarkChannelRead.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Channel;
+use App\Models\User;
+
+class MarkChannelRead
+{
+    /**
+     * Advance the user's read pointer to the channel's most recent message.
+     *
+     * Pointing at the latest message id (soft-deleted rows included, so the
+     * pointer never lags behind a deleted tail) zeroes the sidebar's unread and
+     * mention badges. A channel with no messages leaves the pointer untouched,
+     * and a non-member is a no-op because there is no pivot row to update.
+     */
+    public function handle(Channel $channel, User $user): void
+    {
+        $latestMessageId = $channel->messages()->withTrashed()->orderByDesc('id')->value('id');
+
+        if ($latestMessageId === null) {
+            return;
+        }
+
+        $user->channels()->updateExistingPivot($channel->id, [
+            'last_read_message_id' => $latestMessageId,
+        ]);
+    }
+}

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -17,10 +17,16 @@ class ChannelData extends Data
         public ?string $topic,
         public bool $isGeneral,
         public bool $isArchived,
+        public int $unreadCount = 0,
+        public int $mentionCount = 0,
     ) {}
 
     /**
      * Build the DTO from a Channel model.
+     *
+     * `unread_count` and `mention_count` are populated only when the channel was
+     * loaded for the current user's sidebar; elsewhere they are absent and
+     * default to zero.
      */
     public static function fromChannel(Channel $channel): self
     {
@@ -32,6 +38,8 @@ class ChannelData extends Data
             topic: $channel->topic,
             isGeneral: $channel->isGeneral(),
             isArchived: $channel->isArchived(),
+            unreadCount: (int) ($channel->getAttribute('unread_count') ?? 0),
+            mentionCount: (int) ($channel->getAttribute('mention_count') ?? 0),
         );
     }
 }

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Channels;
 use App\Actions\Channels\ArchiveChannel;
 use App\Actions\Channels\CreateChannel;
 use App\Actions\Channels\JoinChannel;
+use App\Actions\Channels\MarkChannelRead;
 use App\Data\ChannelData;
 use App\Data\MessageData;
 use App\Data\UserData;
@@ -118,6 +119,21 @@ class ChannelController extends Controller
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Joined #:channel.', ['channel' => $channel->name])]);
 
         return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+
+    /**
+     * Mark the channel read for the current user, clearing its sidebar badges.
+     *
+     * Called by the open channel view (debounced, on focus), so it redirects
+     * back and lets Inertia recompute the shared `channels` prop.
+     */
+    public function read(Request $request, Team $team, Channel $channel, MarkChannelRead $markChannelRead): RedirectResponse
+    {
+        Gate::authorize('view', $channel);
+
+        $markChannelRead->handle($channel, $request->user());
+
+        return back();
     }
 
     /**

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,9 +3,11 @@
 namespace App\Http\Middleware;
 
 use App\Data\ChannelData;
+use App\Models\Message;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Middleware;
@@ -72,10 +74,35 @@ class HandleInertiaRequests extends Middleware
         $channels = $user->channels()
             ->where('channels.team_id', $team->id)
             ->whereNull('channels.archived_at')
+            ->select('channels.*')
+            ->selectSub($this->unreadMessages($user), 'unread_count')
+            ->selectSub($this->unreadMessages($user)->whereHas('mentionedUsers', fn ($query) => $query->whereKey($user->id)), 'mention_count')
             ->orderBy('name')
             ->get();
 
         return ChannelData::collect($channels, 'array');
+    }
+
+    /**
+     * A correlated sub-query counting a channel's messages the user has not yet read.
+     *
+     * "Unread" is every non-deleted message authored by someone else that lands
+     * after the user's `last_read_message_id` (a null pointer means the channel
+     * was never opened, so everything counts). It is correlated against the outer
+     * sidebar query's `channels` and `channel_members` rows, so a single query
+     * fills every channel's badge without an N+1.
+     *
+     * @return Builder<Message>
+     */
+    protected function unreadMessages(User $user): Builder
+    {
+        return Message::query()
+            ->selectRaw('count(*)')
+            ->whereColumn('messages.channel_id', 'channels.id')
+            ->where('messages.user_id', '!=', $user->id)
+            ->where(fn (Builder $query) => $query
+                ->whereNull('channel_members.last_read_message_id')
+                ->orWhereColumn('messages.id', '>', 'channel_members.last_read_message_id'));
     }
 
     /**

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -25,6 +25,8 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $archived_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property-read int|null $unread_count
+ * @property-read int|null $mention_count
  * @property-read Team $team
  * @property-read User $creator
  * @property-read Collection<int, ChannelMember> $channelMembers

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -190,14 +190,30 @@ onMounted(() => {
                                                 <span
                                                     class="truncate"
                                                     :class="
-                                                        channel.hasUnread
+                                                        channel.unreadCount > 0
                                                             ? 'font-semibold text-sidebar-foreground'
                                                             : ''
                                                     "
                                                     >{{ channel.name }}</span
                                                 >
+                                                <!-- A numeric badge for unread @mentions takes priority; -->
+                                                <!-- otherwise a plain dot marks the channel as unread. -->
                                                 <span
-                                                    v-if="channel.hasUnread"
+                                                    v-if="
+                                                        channel.mentionCount > 0
+                                                    "
+                                                    data-test="mention-badge"
+                                                    class="ml-auto flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary px-1 text-[11px] font-semibold text-primary-foreground tabular-nums"
+                                                    :aria-label="`${channel.mentionCount} unread mentions`"
+                                                    >{{
+                                                        channel.mentionCount
+                                                    }}</span
+                                                >
+                                                <span
+                                                    v-else-if="
+                                                        channel.unreadCount > 0
+                                                    "
+                                                    data-test="unread-dot"
                                                     aria-hidden="true"
                                                     class="ml-auto size-1.5 rounded-full bg-primary"
                                                 />

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -11,7 +11,10 @@ import {
     watch,
 } from 'vue';
 import { toast } from 'vue-sonner';
-import { archive as archiveChannel } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import {
+    archive as archiveChannel,
+    read as markChannelRead,
+} from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import {
     destroy as destroyMessage,
     store as storeMessage,
@@ -215,6 +218,8 @@ function subscribe(id: string): void {
             // Their message landed; stop showing them as typing.
             typing.forget(message.user.id);
             appendLive(message);
+            // Keep the open, focused channel read as new messages arrive.
+            markRead();
         })
         .listen('MessageUpdated', (message: Message) => {
             applyPatch(message);
@@ -231,8 +236,37 @@ function unsubscribe(id: string): void {
     echo().leave(channelName(id));
 }
 
+// Advance the read pointer for the open channel so its sidebar badge clears.
+// Debounced and gated on tab focus: a channel is only "read" while the user is
+// actually looking at it, and a burst of arriving messages collapses to one
+// request. The redirect refreshes just the shared `channels` prop.
+let markReadTimer: ReturnType<typeof setTimeout> | null = null;
+
+function markRead(): void {
+    if (!document.hasFocus()) {
+        return;
+    }
+
+    if (markReadTimer) {
+        clearTimeout(markReadTimer);
+    }
+
+    markReadTimer = setTimeout(() => {
+        router.post(
+            markChannelRead({
+                team: props.team.slug,
+                channel: props.channel.slug,
+            }).url,
+            {},
+            { preserveScroll: true, preserveState: true, only: ['channels'] },
+        );
+    }, 400);
+}
+
 onMounted(() => {
     subscribe(props.channel.id);
+    markRead();
+    window.addEventListener('focus', markRead);
 });
 
 // Inertia may reuse this page component when navigating between channels; move
@@ -249,11 +283,17 @@ watch(
         patches.value = new Map();
         typing.reset();
         subscribe(newId);
+        markRead();
     },
 );
 
 onBeforeUnmount(() => {
     unsubscribe(props.channel.id);
+    window.removeEventListener('focus', markRead);
+
+    if (markReadTimer) {
+        clearTimeout(markReadTimer);
+    }
 });
 
 function send(body: string, mentions: Mention[]): void {

--- a/resources/js/types/channels.ts
+++ b/resources/js/types/channels.ts
@@ -6,5 +6,6 @@ export type Channel = {
     topic: string | null;
     isGeneral: boolean;
     isArchived: boolean;
-    hasUnread?: boolean;
+    unreadCount: number;
+    mentionCount: number;
 };

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,9 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/join', [ChannelController::class, 'join'])
         ->scopeBindings()
         ->name('channels.join');
+    Route::post('t/{team}/c/{channel}/read', [ChannelController::class, 'read'])
+        ->scopeBindings()
+        ->name('channels.read');
     Route::post('t/{team}/c/{channel}/archive', [ChannelController::class, 'archive'])
         ->scopeBindings()
         ->name('channels.archive');

--- a/tests/Feature/Channels/UnreadBadgeTest.php
+++ b/tests/Feature/Channels/UnreadBadgeTest.php
@@ -1,0 +1,239 @@
+<?php
+
+use App\Actions\Channels\MarkChannelRead;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function unreadTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and the given channel, returning them.
+ */
+function unreadChannelMember(Team $team, Channel $channel, ?string $name = null): User
+{
+    $user = User::factory()->create($name ? ['name' => $name] : []);
+    // Joining the team auto-adds the user to #general via the membership observer,
+    // so create the channel pivot idempotently for any other channel.
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+/**
+ * Post a message to the channel authored by the given user.
+ */
+function unreadPost(Channel $channel, User $author, ?User $mention = null): Message
+{
+    $body = $mention ? "hey @[{$mention->name}]({$mention->id})" : fake()->sentence();
+
+    $message = Message::factory()->for($channel)->for($author)->create(['body' => $body]);
+
+    if ($mention) {
+        $message->mentionedUsers()->attach($mention->id);
+    }
+
+    return $message;
+}
+
+/**
+ * Mark the channel read for the user, pointing the pivot at the given message.
+ */
+function markReadUpTo(User $user, Channel $channel, ?Message $message): void
+{
+    $user->channels()->updateExistingPivot($channel->id, ['last_read_message_id' => $message?->id]);
+}
+
+/**
+ * Resolve the sidebar `channels` prop entry for the given channel as the acting user.
+ *
+ * @return array{unreadCount: int, mentionCount: int}
+ */
+function sidebarChannel(User $user, Team $team, Channel $channel): array
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]))->assertOk();
+
+    $channels = $response->viewData('page')['props']['channels'];
+
+    $entry = collect($channels)->firstWhere('slug', $channel->slug);
+
+    return ['unreadCount' => $entry['unreadCount'], 'mentionCount' => $entry['mentionCount']];
+}
+
+test('unread count reflects only the messages posted after last_read', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general, 'Ada Lovelace');
+
+    $messages = collect(range(1, 5))->map(fn () => unreadPost($general, $owner));
+    markReadUpTo($member, $general, $messages[2]);
+
+    expect(sidebarChannel($member, $team, $general))
+        ->toMatchArray(['unreadCount' => 2, 'mentionCount' => 0]);
+});
+
+test('a null last_read means every message in the channel is unread', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general);
+
+    collect(range(1, 3))->each(fn () => unreadPost($general, $owner));
+
+    expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(3);
+});
+
+test('a member does not see their own messages as unread', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general);
+
+    unreadPost($general, $owner);
+    unreadPost($general, $member);
+    unreadPost($general, $member);
+
+    expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(1);
+});
+
+test('soft-deleted messages are excluded from the unread count', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general);
+
+    unreadPost($general, $owner);
+    $deleted = unreadPost($general, $owner);
+    $deleted->delete();
+
+    expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(1);
+});
+
+test('the mention count only counts unread messages that mention the user', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general, 'Grace Hopper');
+
+    $readMention = unreadPost($general, $owner, $member);
+    markReadUpTo($member, $general, $readMention);
+
+    unreadPost($general, $owner);
+    unreadPost($general, $owner, $member);
+    unreadPost($general, $owner, $member);
+
+    expect(sidebarChannel($member, $team, $general))
+        ->toMatchArray(['unreadCount' => 3, 'mentionCount' => 2]);
+});
+
+test('a mention of another member does not inflate the users mention count', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general);
+    $other = unreadChannelMember($team, $general, 'Someone Else');
+
+    unreadPost($general, $owner, $other);
+
+    expect(sidebarChannel($member, $team, $general)['mentionCount'])->toBe(0);
+});
+
+test('MarkChannelRead advances last_read to the latest message and clears the badge', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general, 'Alan Turing');
+
+    unreadPost($general, $owner, $member);
+    $latest = unreadPost($general, $owner);
+
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'last_read_message_id' => $latest->id,
+    ]);
+
+    expect(sidebarChannel($member, $team, $general))
+        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+});
+
+test('MarkChannelRead leaves the pointer untouched when the channel has no messages', function () {
+    [, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general);
+
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'last_read_message_id' => null,
+    ]);
+});
+
+test('MarkChannelRead is a no-op for a user who is not a channel member', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $private = Channel::factory()->for($team)->create([
+        'visibility' => ChannelVisibility::Private,
+        'created_by' => $owner->id,
+    ]);
+    // A plain team member is auto-joined to #general but not to the private channel.
+    $outsider = unreadChannelMember($team, $general);
+
+    Message::factory()->for($private)->for($owner)->create();
+
+    app(MarkChannelRead::class)->handle($private, $outsider);
+
+    $this->assertDatabaseMissing('channel_members', [
+        'channel_id' => $private->id,
+        'user_id' => $outsider->id,
+    ]);
+});
+
+test('hitting the read endpoint advances the pointer and clears the badges', function () {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general, 'Katherine Johnson');
+
+    unreadPost($general, $owner, $member);
+    $latest = unreadPost($general, $owner);
+
+    // The badges are showing before the channel is marked read.
+    expect(sidebarChannel($member, $team, $general))
+        ->toMatchArray(['unreadCount' => 2, 'mentionCount' => 1]);
+
+    $this->actingAs($member)
+        ->post(route('channels.read', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'last_read_message_id' => $latest->id,
+    ]);
+
+    expect(sidebarChannel($member, $team, $general))
+        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+});
+
+test('the read endpoint is forbidden on a private channel the user cannot view', function () {
+    [$owner, $team] = unreadTeamWithGeneral();
+    $private = Channel::factory()->for($team)->create([
+        'visibility' => ChannelVisibility::Private,
+        'created_by' => $owner->id,
+    ]);
+
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    $this->actingAs($stranger)
+        ->post(route('channels.read', ['team' => $team->slug, 'channel' => $private->slug]))
+        ->assertForbidden();
+});


### PR DESCRIPTION
Closes #10.

Track per-channel read state off `channel_members.last_read_message_id` and surface two sidebar badges: a **bold name + dot** for unread messages and a **distinct numeric pill** for unread @mentions.

## What changed

**Backend**
- `MarkChannelRead` action advances the pivot's `last_read_message_id` to the channel's latest message (soft-deleted rows included so the pointer never lags). No-op for empty channels and non-members.
- `POST t/{team}/c/{channel}/read` → `ChannelController@read`, gated by the `view` policy.
- `HandleInertiaRequests::channelsForSidebar()` computes `unread_count` and `mention_count` for the whole sidebar in **one query** via correlated sub-queries — no N+1. Unread = non-deleted messages authored by others after `last_read` (null pointer ⇒ all unread); mentions = that set filtered to the current user.
- `ChannelData` gains `unreadCount` / `mentionCount`.

**Frontend**
- `Layout.vue` bolds unread channels, renders a numeric mention pill when `mentionCount > 0`, else a plain unread dot.
- `Show.vue` marks the open channel read — debounced and focus-gated — on open, channel switch, incoming message, and window focus, refreshing only the shared `channels` prop so badges clear.

## Acceptance criteria
- [x] `MarkChannelRead` advances `last_read_message_id`
- [x] Unread count = messages after `last_read`; mention count = unread mentioning the user
- [x] Sidebar renders unread + mention badges; clears on read
- [x] Feature tests for count computation (TDD)

## Tests & gates
- New `tests/Feature/Channels/UnreadBadgeTest.php` (11 tests, TDD-first): count computation with own/deleted excluded, mention subset, `MarkChannelRead` behavior, the read endpoint clearing badges, and a private-channel 403.
- Full gate green: Pint ✓, PHPStan 0 errors ✓, **100.0% coverage** ✓, and frontend lint/format/types/build ✓.

## Follow-up
Cross-channel **live** badge increments (a teammate posts in a channel you're not viewing) are not realtime — the sidebar refreshes on navigation and on mark-read, not via a push. Outside #10's acceptance criteria; tracked in #66.