### PR TITLE
feat(channels): per-member notification preferences (mute & level)

### DIFF
--- a/app/Actions/Channels/UpdateChannelPreference.php
+++ b/app/Actions/Channels/UpdateChannelPreference.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Enums\NotificationLevel;
+use App\Models\Channel;
+use App\Models\User;
+
+class UpdateChannelPreference
+{
+    /**
+     * Persist the user's notification preferences for the channel.
+     *
+     * Writes only the member's own pivot row; a non-member is a no-op because
+     * there is no membership to update.
+     */
+    public function handle(Channel $channel, User $user, bool $muted, NotificationLevel $notificationLevel): void
+    {
+        $user->channels()->updateExistingPivot($channel->id, [
+            'muted' => $muted,
+            'notification_level' => $notificationLevel->value,
+        ]);
+    }
+}

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -2,6 +2,7 @@
 
 namespace App\Data;
 
+use App\Enums\NotificationLevel;
 use App\Models\Channel;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -17,6 +18,8 @@ class ChannelData extends Data
         public ?string $topic,
         public bool $isGeneral,
         public bool $isArchived,
+        public bool $muted = false,
+        public string $notificationLevel = NotificationLevel::All->value,
         public int $unreadCount = 0,
         public int $mentionCount = 0,
     ) {}
@@ -24,12 +27,25 @@ class ChannelData extends Data
     /**
      * Build the DTO from a Channel model.
      *
-     * `unread_count` and `mention_count` are populated only when the channel was
-     * loaded for the current user's sidebar; elsewhere they are absent and
-     * default to zero.
+     * `unread_count`, `mention_count`, `muted` and `notification_level` are the
+     * current user's per-channel state, populated only when the channel was
+     * loaded for their sidebar or view; elsewhere they are absent and fall back
+     * to the defaults (unmuted, "all", zero badges).
+     *
+     * The badge counts are suppressed here so the sidebar prop is authoritative:
+     * a muted channel or the "nothing" level shows no badge at all, and the
+     * "mentions" level keeps only the mention badge (a direct @mention still
+     * alerts while ordinary unread traffic is silenced).
      */
     public static function fromChannel(Channel $channel): self
     {
+        $muted = (bool) ($channel->getAttribute('muted') ?? false);
+
+        $level = NotificationLevel::tryFrom((string) ($channel->getAttribute('notification_level') ?? NotificationLevel::All->value)) ?? NotificationLevel::All;
+
+        $unreadCount = (int) ($channel->getAttribute('unread_count') ?? 0);
+        $mentionCount = (int) ($channel->getAttribute('mention_count') ?? 0);
+
         return new self(
             id: $channel->id,
             name: $channel->name,
@@ -38,8 +54,10 @@ class ChannelData extends Data
             topic: $channel->topic,
             isGeneral: $channel->isGeneral(),
             isArchived: $channel->isArchived(),
-            unreadCount: (int) ($channel->getAttribute('unread_count') ?? 0),
-            mentionCount: (int) ($channel->getAttribute('mention_count') ?? 0),
+            muted: $muted,
+            notificationLevel: $level->value,
+            unreadCount: ! $muted && $level->alertsOnUnread() ? $unreadCount : 0,
+            mentionCount: ! $muted && $level->alertsOnMention() ? $mentionCount : 0,
         );
     }
 }

--- a/app/Enums/NotificationLevel.php
+++ b/app/Enums/NotificationLevel.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Enums;
+
+enum NotificationLevel: string
+{
+    case All = 'all';
+    case Mentions = 'mentions';
+    case Nothing = 'nothing';
+
+    /**
+     * Get the display label for the notification level.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::All => 'All messages',
+            self::Mentions => 'Mentions only',
+            self::Nothing => 'Nothing',
+        };
+    }
+
+    /**
+     * Determine whether an unread (non-mention) message should raise a badge at this level.
+     */
+    public function alertsOnUnread(): bool
+    {
+        return $this === self::All;
+    }
+
+    /**
+     * Determine whether a direct @mention should raise a badge at this level.
+     *
+     * Only the `nothing` level silences mentions; `mentions` and `all` both alert.
+     */
+    public function alertsOnMention(): bool
+    {
+        return $this !== self::Nothing;
+    }
+
+    /**
+     * Get the selectable levels as value/label pairs for the settings UI.
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public static function options(): array
+    {
+        return array_map(
+            fn (self $level): array => ['value' => $level->value, 'label' => $level->label()],
+            self::cases(),
+        );
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -10,6 +10,7 @@ use App\Data\ChannelData;
 use App\Data\MessageData;
 use App\Data\UserData;
 use App\Enums\ChannelVisibility;
+use App\Enums\NotificationLevel;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Models\Channel;
@@ -55,9 +56,16 @@ class ChannelController extends Controller
     /**
      * Show a channel. The channel sidebar is fed by the globally-shared `channels` prop.
      */
-    public function show(Team $team, Channel $channel): Response
+    public function show(Request $request, Team $team, Channel $channel): Response
     {
         Gate::authorize('view', $channel);
+
+        // Surface the current user's own notification preferences on the channel
+        // so the header settings menu opens on the persisted state. A non-member
+        // viewing a public channel has no pivot row, so the DTO defaults apply.
+        $membership = $channel->channelMembers()->where('user_id', $request->user()->id)->first();
+        $channel->setAttribute('muted', $membership->muted ?? false);
+        $channel->setAttribute('notification_level', $membership?->notification_level->value ?? NotificationLevel::All->value);
 
         return Inertia::render('channels/Show', [
             'team' => [
@@ -69,6 +77,11 @@ class ChannelController extends Controller
             // Drives the header's archive control; authoritative so the button
             // only appears for a creator or Admin+ on a non-#general channel.
             'canArchive' => Gate::allows('archive', $channel),
+            // Gates the notification settings menu; only a member of the channel
+            // has preferences to manage.
+            'canManagePreferences' => Gate::allows('updatePreference', $channel),
+            // Selectable notification levels for the settings menu.
+            'notificationLevels' => NotificationLevel::options(),
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),

--- a/app/Http/Controllers/Channels/ChannelPreferenceController.php
+++ b/app/Http/Controllers/Channels/ChannelPreferenceController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\UpdateChannelPreference;
+use App\Enums\NotificationLevel;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\UpdateChannelPreferenceRequest;
+use App\Models\Channel;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+
+class ChannelPreferenceController extends Controller
+{
+    /**
+     * Update the current user's notification preferences for the channel.
+     *
+     * Redirects back and lets Inertia recompute the shared `channels` prop so
+     * the sidebar badges and dimming reflect the change without a full reload.
+     */
+    public function update(UpdateChannelPreferenceRequest $request, Team $team, Channel $channel, UpdateChannelPreference $updateChannelPreference): RedirectResponse
+    {
+        $updateChannelPreference->handle(
+            channel: $channel,
+            user: $request->user(),
+            muted: $request->boolean('muted'),
+            notificationLevel: NotificationLevel::from($request->validated('notification_level')),
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -75,6 +75,7 @@ class HandleInertiaRequests extends Middleware
             ->where('channels.team_id', $team->id)
             ->whereNull('channels.archived_at')
             ->select('channels.*')
+            ->addSelect(['channel_members.muted', 'channel_members.notification_level'])
             ->selectSub($this->unreadMessages($user), 'unread_count')
             ->selectSub($this->unreadMessages($user)->whereHas('mentionedUsers', fn ($query) => $query->whereKey($user->id)), 'mention_count')
             ->orderBy('name')

--- a/app/Http/Requests/Channels/UpdateChannelPreferenceRequest.php
+++ b/app/Http/Requests/Channels/UpdateChannelPreferenceRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Enums\NotificationLevel;
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+
+class UpdateChannelPreferenceRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('updatePreference', $this->channel());
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'muted' => ['required', 'boolean'],
+            'notification_level' => ['required', Rule::enum(NotificationLevel::class)],
+        ];
+    }
+
+    /**
+     * Get the channel whose preferences are being updated.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+}

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -27,6 +27,8 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read int|null $unread_count
  * @property-read int|null $mention_count
+ * @property-read bool|null $muted
+ * @property-read string|null $notification_level
  * @property-read Team $team
  * @property-read User $creator
  * @property-read Collection<int, ChannelMember> $channelMembers
@@ -108,7 +110,7 @@ class Channel extends Model
     public function members(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'channel_members')
-            ->withPivot(['last_read_message_id'])
+            ->withPivot(['last_read_message_id', 'muted', 'notification_level'])
             ->withTimestamps();
     }
 

--- a/app/Models/ChannelMember.php
+++ b/app/Models/ChannelMember.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\NotificationLevel;
 use Database\Factories\ChannelMemberFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -15,16 +16,31 @@ use Illuminate\Support\Carbon;
  * @property string $channel_id
  * @property string $user_id
  * @property string|null $last_read_message_id
+ * @property bool $muted
+ * @property NotificationLevel $notification_level
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Channel $channel
  * @property-read User $user
  */
-#[Fillable(['channel_id', 'user_id', 'last_read_message_id'])]
+#[Fillable(['channel_id', 'user_id', 'last_read_message_id', 'muted', 'notification_level'])]
 class ChannelMember extends Model
 {
     /** @use HasFactory<ChannelMemberFactory> */
     use HasFactory, HasUuids;
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'muted' => 'boolean',
+            'notification_level' => NotificationLevel::class,
+        ];
+    }
 
     /**
      * Get the channel the membership belongs to.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -62,7 +62,7 @@ class User extends Authenticatable
     public function channels(): BelongsToMany
     {
         return $this->belongsToMany(Channel::class, 'channel_members')
-            ->withPivot(['last_read_message_id'])
+            ->withPivot(['last_read_message_id', 'muted', 'notification_level'])
             ->withTimestamps();
     }
 }

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -34,6 +34,19 @@ class ChannelPolicy
     }
 
     /**
+     * Determine whether the user can update their own notification preferences.
+     *
+     * Preferences live on the membership pivot, so only a member of the channel
+     * (within the team) has any to manage. Each member only ever touches their
+     * own row.
+     */
+    public function updatePreference(User $user, Channel $channel): bool
+    {
+        return $user->belongsToTeam($channel->team)
+            && $channel->members()->whereKey($user->id)->exists();
+    }
+
+    /**
      * Determine whether the user can post a message to the channel.
      *
      * Only members of a non-archived channel may post.

--- a/database/factories/ChannelMemberFactory.php
+++ b/database/factories/ChannelMemberFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\NotificationLevel;
 use App\Models\Channel;
 use App\Models\ChannelMember;
 use App\Models\User;
@@ -23,6 +24,24 @@ class ChannelMemberFactory extends Factory
             'channel_id' => Channel::factory(),
             'user_id' => User::factory(),
             'last_read_message_id' => null,
+            'muted' => false,
+            'notification_level' => NotificationLevel::All,
         ];
+    }
+
+    /**
+     * Indicate that the membership is muted.
+     */
+    public function muted(): static
+    {
+        return $this->state(fn (array $attributes): array => ['muted' => true]);
+    }
+
+    /**
+     * Indicate the membership's notification level.
+     */
+    public function notificationLevel(NotificationLevel $level): static
+    {
+        return $this->state(fn (array $attributes): array => ['notification_level' => $level]);
     }
 }

--- a/database/migrations/2026_07_09_021715_add_preferences_to_channel_members_table.php
+++ b/database/migrations/2026_07_09_021715_add_preferences_to_channel_members_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\NotificationLevel;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channel_members', function (Blueprint $table) {
+            // Per-member notification preferences for the channel. `muted` dims the
+            // channel and is the strongest silence; `notification_level` tunes which
+            // arrivals raise a badge (see App\Enums\NotificationLevel).
+            $table->boolean('muted')->default(false)->after('last_read_message_id');
+            $table->string('notification_level')->default(NotificationLevel::All->value)->after('muted');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channel_members', function (Blueprint $table) {
+            $table->dropColumn(['muted', 'notification_level']);
+        });
+    }
+};

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -158,7 +158,8 @@ onMounted(() => {
                                                 channel.slug ===
                                                 activeChannelSlug
                                             "
-                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13.5px] text-sidebar-foreground/80 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground data-[active=true]:relative data-[active=true]:bg-sidebar-accent data-[active=true]:pl-3.5 data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground"
+                                            :data-muted="channel.muted"
+                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13.5px] text-sidebar-foreground/80 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground data-[active=true]:relative data-[active=true]:bg-sidebar-accent data-[active=true]:pl-3.5 data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100"
                                         >
                                             <Link
                                                 v-if="currentTeam"

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
 import { Head, InfiniteScroll, router, usePage } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
-import { Archive, EllipsisVertical } from '@lucide/vue';
+import {
+    Archive,
+    AtSign,
+    BellMinus,
+    BellOff,
+    EllipsisVertical,
+} from '@lucide/vue';
+import type { AcceptableValue } from 'reka-ui';
 import {
     computed,
     nextTick,
@@ -15,6 +22,7 @@ import {
     archive as archiveChannel,
     read as markChannelRead,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
 import {
     destroy as destroyMessage,
     store as storeMessage,
@@ -35,8 +43,13 @@ import {
 } from '@/components/ui/dialog';
 import {
     DropdownMenu,
+    DropdownMenuCheckboxItem,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
@@ -44,7 +57,14 @@ import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
-import type { Channel, Mention, Message, MessagePage } from '@/types';
+import type {
+    Channel,
+    Mention,
+    Message,
+    MessagePage,
+    NotificationLevel,
+    NotificationLevelOption,
+} from '@/types';
 
 const props = defineProps<{
     team: { id: string; name: string; slug: string };
@@ -52,6 +72,8 @@ const props = defineProps<{
     messages: MessagePage;
     members: Mention[];
     canArchive: boolean;
+    canManagePreferences: boolean;
+    notificationLevels: NotificationLevelOption[];
 }>();
 
 const page = usePage();
@@ -282,6 +304,8 @@ watch(
         pending.value = [];
         patches.value = new Map();
         typing.reset();
+        notificationLevel.value = props.channel.notificationLevel;
+        muted.value = props.channel.muted;
         subscribe(newId);
         markRead();
     },
@@ -384,6 +408,70 @@ function deleteMessage(message: Message): void {
     );
 }
 
+// The member's own notification preferences for this channel, seeded from the
+// server and reseeded on every channel switch. Changes are saved optimistically
+// (the sidebar reloads to reflect the new badge/dimming state) and rolled back
+// if the request fails.
+const notificationLevel = ref<NotificationLevel>(
+    props.channel.notificationLevel,
+);
+const muted = ref<boolean>(props.channel.muted);
+
+function savePreferences(rollback: () => void): void {
+    router.patch(
+        updateChannelPreferences({
+            team: props.team.slug,
+            channel: props.channel.slug,
+        }).url,
+        { muted: muted.value, notification_level: notificationLevel.value },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channels'],
+            onError: () => {
+                rollback();
+                toast.error(
+                    'Failed to update notification preferences. Please try again.',
+                );
+            },
+        },
+    );
+}
+
+function onNotificationLevelChange(value: AcceptableValue): void {
+    const previous = notificationLevel.value;
+    notificationLevel.value = value as NotificationLevel;
+    savePreferences(() => {
+        notificationLevel.value = previous;
+    });
+}
+
+function onMuteChange(value: boolean): void {
+    const previous = muted.value;
+    muted.value = value;
+    savePreferences(() => {
+        muted.value = previous;
+    });
+}
+
+// A compact header cue for the member's non-default notification state (muted or
+// a quieted level); the "all" default shows nothing to keep the header clean.
+const notificationStatus = computed(() => {
+    if (muted.value) {
+        return { icon: BellOff, label: 'Muted' };
+    }
+
+    if (notificationLevel.value === 'nothing') {
+        return { icon: BellMinus, label: 'Notifications off' };
+    }
+
+    if (notificationLevel.value === 'mentions') {
+        return { icon: AtSign, label: 'Mentions only' };
+    }
+
+    return null;
+});
+
 // Drives the archive confirmation dialog opened from the channel header menu.
 const confirmingArchive = ref(false);
 
@@ -416,6 +504,16 @@ function archive(): void {
             <span class="mr-0.5 font-medium text-muted-foreground/70">#</span
             >{{ props.channel.name }}
         </h1>
+        <span
+            v-if="notificationStatus"
+            data-test="notification-status"
+            :data-status="muted ? 'muted' : notificationLevel"
+            class="inline-flex items-center text-muted-foreground"
+            :title="notificationStatus.label"
+            :aria-label="notificationStatus.label"
+        >
+            <component :is="notificationStatus.icon" class="size-3.5" />
+        </span>
         <template v-if="props.channel.topic">
             <Separator orientation="vertical" class="h-4" />
             <p class="min-w-0 truncate text-[13px] text-muted-foreground">
@@ -431,7 +529,7 @@ function archive(): void {
             Archived
         </span>
 
-        <DropdownMenu v-if="props.canArchive">
+        <DropdownMenu v-if="props.canManagePreferences || props.canArchive">
             <DropdownMenuTrigger as-child>
                 <button
                     type="button"
@@ -442,15 +540,47 @@ function archive(): void {
                     <EllipsisVertical class="size-4" />
                 </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                    data-test="archive-channel"
-                    class="text-destructive focus:text-destructive"
-                    @select="confirmingArchive = true"
-                >
-                    <Archive class="size-4" />
-                    Archive channel
-                </DropdownMenuItem>
+            <DropdownMenuContent align="end" class="w-56">
+                <template v-if="props.canManagePreferences">
+                    <DropdownMenuLabel
+                        class="text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
+                    >
+                        Notifications
+                    </DropdownMenuLabel>
+                    <DropdownMenuRadioGroup
+                        :model-value="notificationLevel"
+                        @update:model-value="onNotificationLevelChange"
+                    >
+                        <DropdownMenuRadioItem
+                            v-for="level in props.notificationLevels"
+                            :key="level.value"
+                            :value="level.value"
+                            :data-test="`notification-level-${level.value}`"
+                        >
+                            {{ level.label }}
+                        </DropdownMenuRadioItem>
+                    </DropdownMenuRadioGroup>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuCheckboxItem
+                        :model-value="muted"
+                        data-test="mute-channel"
+                        @update:model-value="onMuteChange"
+                        @select="(event: Event) => event.preventDefault()"
+                    >
+                        Mute channel
+                    </DropdownMenuCheckboxItem>
+                </template>
+                <template v-if="props.canArchive">
+                    <DropdownMenuSeparator v-if="props.canManagePreferences" />
+                    <DropdownMenuItem
+                        data-test="archive-channel"
+                        class="text-destructive focus:text-destructive"
+                        @select="confirmingArchive = true"
+                    >
+                        <Archive class="size-4" />
+                        Archive channel
+                    </DropdownMenuItem>
+                </template>
             </DropdownMenuContent>
         </DropdownMenu>
     </header>

--- a/resources/js/types/channels.ts
+++ b/resources/js/types/channels.ts
@@ -1,3 +1,10 @@
+export type NotificationLevel = 'all' | 'mentions' | 'nothing';
+
+export type NotificationLevelOption = {
+    value: NotificationLevel;
+    label: string;
+};
+
 export type Channel = {
     id: string;
     name: string;
@@ -6,6 +13,8 @@ export type Channel = {
     topic: string | null;
     isGeneral: boolean;
     isArchived: boolean;
+    muted: boolean;
+    notificationLevel: NotificationLevel;
     unreadCount: number;
     mentionCount: number;
 };

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Channels\ChannelController;
 use App\Http\Controllers\Channels\ChannelMemberController;
+use App\Http\Controllers\Channels\ChannelPreferenceController;
 use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Middleware\EnsureTeamMembership;
@@ -22,6 +23,9 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/read', [ChannelController::class, 'read'])
         ->scopeBindings()
         ->name('channels.read');
+    Route::patch('t/{team}/c/{channel}/preferences', [ChannelPreferenceController::class, 'update'])
+        ->scopeBindings()
+        ->name('channels.preferences.update');
     Route::post('t/{team}/c/{channel}/archive', [ChannelController::class, 'archive'])
         ->scopeBindings()
         ->name('channels.archive');

--- a/tests/Feature/Channels/ChannelPreferenceTest.php
+++ b/tests/Feature/Channels/ChannelPreferenceTest.php
@@ -1,0 +1,222 @@
+<?php
+
+use App\Actions\Channels\JoinChannel;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelVisibility;
+use App\Enums\NotificationLevel;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function prefTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and the given channel, returning them.
+ */
+function prefMember(Team $team, Channel $channel, ?string $name = null): User
+{
+    $user = User::factory()->create($name ? ['name' => $name] : []);
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+/**
+ * Post a message to the channel, optionally mentioning a member.
+ */
+function prefPost(Channel $channel, User $author, ?User $mention = null): Message
+{
+    $body = $mention ? "hey @[{$mention->name}]({$mention->id})" : fake()->sentence();
+
+    $message = Message::factory()->for($channel)->for($author)->create(['body' => $body]);
+
+    if ($mention) {
+        $message->mentionedUsers()->attach($mention->id);
+    }
+
+    return $message;
+}
+
+/**
+ * Resolve the sidebar `channels` prop entry for the channel as the acting user.
+ *
+ * @return array<string, mixed>
+ */
+function prefSidebarEntry(User $user, Team $team, Channel $channel): array
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]))->assertOk();
+
+    $channels = $response->viewData('page')['props']['channels'];
+
+    return collect($channels)->firstWhere('slug', $channel->slug);
+}
+
+/**
+ * Update the preferences endpoint as the given user.
+ */
+function updatePreferences(User $user, Team $team, Channel $channel, bool $muted, string $level): TestResponse
+{
+    return test()->actingAs($user)->patch(route('channels.preferences.update', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]), ['muted' => $muted, 'notification_level' => $level]);
+}
+
+test('joining a channel applies the default notification preferences', function () {
+    [$owner, $team] = prefTeamWithGeneral();
+    $channel = Channel::factory()->for($team)->create([
+        'visibility' => ChannelVisibility::Public,
+        'created_by' => $owner->id,
+    ]);
+    $user = User::factory()->create();
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+
+    app(JoinChannel::class)->handle($channel, $user);
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $channel->id,
+        'user_id' => $user->id,
+        'muted' => false,
+        'notification_level' => NotificationLevel::All->value,
+    ]);
+});
+
+test('a member can update their notification preferences', function () {
+    [, $team, $general] = prefTeamWithGeneral();
+    $member = prefMember($team, $general);
+
+    updatePreferences($member, $team, $general, muted: true, level: 'mentions')
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'muted' => true,
+        'notification_level' => 'mentions',
+    ]);
+});
+
+test('a non-member cannot update preferences for a channel', function () {
+    [$owner, $team] = prefTeamWithGeneral();
+    $private = Channel::factory()->for($team)->create([
+        'visibility' => ChannelVisibility::Private,
+        'created_by' => $owner->id,
+    ]);
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    updatePreferences($stranger, $team, $private, muted: true, level: 'nothing')
+        ->assertForbidden();
+
+    $this->assertDatabaseMissing('channel_members', [
+        'channel_id' => $private->id,
+        'user_id' => $stranger->id,
+    ]);
+});
+
+test('the notification level must be one of the allowed values', function () {
+    [, $team, $general] = prefTeamWithGeneral();
+    $member = prefMember($team, $general);
+
+    updatePreferences($member, $team, $general, muted: false, level: 'sometimes')
+        ->assertSessionHasErrors('notification_level');
+});
+
+test('the muted flag must be a boolean', function () {
+    [, $team, $general] = prefTeamWithGeneral();
+    $member = prefMember($team, $general);
+
+    test()->actingAs($member)->patch(route('channels.preferences.update', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]), ['muted' => 'maybe', 'notification_level' => 'all'])
+        ->assertSessionHasErrors('muted');
+});
+
+test('the channel view exposes the members own preferences and the level options', function () {
+    [, $team, $general] = prefTeamWithGeneral();
+    $member = prefMember($team, $general);
+    $member->channels()->updateExistingPivot($general->id, [
+        'muted' => true,
+        'notification_level' => 'mentions',
+    ]);
+
+    $response = $this->actingAs($member)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]))->assertOk();
+
+    $props = $response->viewData('page')['props'];
+
+    expect($props['channel'])
+        ->toMatchArray(['muted' => true, 'notificationLevel' => 'mentions'])
+        ->and($props['canManagePreferences'])->toBeTrue()
+        ->and($props['notificationLevels'])->toBe([
+            ['value' => 'all', 'label' => 'All messages'],
+            ['value' => 'mentions', 'label' => 'Mentions only'],
+            ['value' => 'nothing', 'label' => 'Nothing'],
+        ]);
+});
+
+test('a non-member viewing a public channel cannot manage preferences and sees defaults', function () {
+    [$owner, $team] = prefTeamWithGeneral();
+    $public = Channel::factory()->for($team)->create([
+        'visibility' => ChannelVisibility::Public,
+        'created_by' => $owner->id,
+    ]);
+    $outsider = User::factory()->create();
+    $team->memberships()->create(['user_id' => $outsider->id, 'role' => TeamRole::Member]);
+
+    $response = $this->actingAs($outsider)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $public->slug,
+    ]))->assertOk();
+
+    $props = $response->viewData('page')['props'];
+
+    expect($props['channel'])
+        ->toMatchArray(['muted' => false, 'notificationLevel' => 'all'])
+        ->and($props['canManagePreferences'])->toBeFalse();
+});
+
+test('the notification level and mute suppress the sidebar badges', function (bool $muted, string $level, int $expectedUnread, int $expectedMention) {
+    [$owner, $team, $general] = prefTeamWithGeneral();
+    $member = prefMember($team, $general, 'Ada Lovelace');
+
+    // Two unread messages, one of which is a direct @mention of the member.
+    prefPost($general, $owner);
+    prefPost($general, $owner, $member);
+
+    $member->channels()->updateExistingPivot($general->id, [
+        'muted' => $muted,
+        'notification_level' => $level,
+    ]);
+
+    expect(prefSidebarEntry($member, $team, $general))
+        ->toMatchArray(['unreadCount' => $expectedUnread, 'mentionCount' => $expectedMention]);
+})->with([
+    '"all" shows the unread dot and the mention badge' => [false, 'all', 2, 1],
+    '"mentions" keeps the mention badge but silences the unread dot' => [false, 'mentions', 0, 1],
+    '"nothing" suppresses every badge' => [false, 'nothing', 0, 0],
+    'muted suppresses every badge' => [true, 'all', 0, 0],
+    'muted overrides an otherwise-alerting mentions level' => [true, 'mentions', 0, 0],
+]);


### PR DESCRIPTION
Closes #29.

## Summary
Per-member, per-channel notification preferences, persisted server-side on the `channel_members` pivot:
- **`muted`** (bool) — strongest silence; also dims the channel in the sidebar.
- **`notification_level`** — `all` / `mentions` / `nothing`.

Preferences drive the unread & mention badges (#10): `muted` or `nothing` suppress every badge, `mentions` keeps only a direct @mention, `all` shows both. Suppression is applied server-side in `ChannelData::fromChannel`, so the shared `channels` prop remains the single source of truth for the sidebar.

## On the issue comment (spatie/laravel-settings)
Investigated the package directly: it stores **application-wide settings groups** as `(group, name, JSON-payload)` rows, with no per-model/relationship scoping. That's the wrong shape for per-`(user, channel)` state — it would break the single-join badge subquery and lose FK cascades. Went with **pivot columns** instead (consistent with the existing `last_read_message_id` pattern). No new dependency added.

## Changes
**Backend**
- `NotificationLevel` enum (`alertsOnUnread()` / `alertsOnMention()` / `options()`).
- Migration adding `muted` + `notification_level` to `channel_members`; casts, fillable, `withPivot`, factory states.
- `ChannelData` exposes `muted` / `notificationLevel` and suppresses the badge counts per preference.
- `PATCH t/{team}/c/{channel}/preferences` → `ChannelPreferenceController` + `UpdateChannelPreferenceRequest` + `UpdateChannelPreference` action.
- `ChannelPolicy::updatePreference` scopes writes to the member's own channel membership.

**Frontend**
- Channel-header ⋮ menu: notification-level radio group + **Mute channel** toggle (optimistic, with rollback). Menu now shows for any member; Archive stays gated to creators/admins.
- Compact header status icon (BellOff "Muted" / BellMinus "Notifications off" / AtSign "Mentions only"); the `all` default shows nothing.
- Muted channels dimmed in the sidebar.

## Acceptance criteria
- [x] Per-member/per-channel preference persisted (mute + level)
- [x] Channel settings UI to view and change them
- [x] Badges respect the setting (muted/nothing suppress; mentions still alerts on a direct @mention)
- [x] Defaults applied on join; authorization scoped to the member's own preferences
- [x] Test coverage for persistence + notification-suppression rules

## Testing
- `tests/Feature/Channels/ChannelPreferenceTest.php` — 12 tests: defaults on join, update endpoint, authorization (non-member forbidden), validation, view props, and the full suppression matrix (all/mentions/nothing × muted).
- Full gate green: Pint, PHPStan, **100% PHP coverage**, and frontend lint / format / types / build.