### PR TITLE
feat(search): full-text message search (Scout + Meilisearch)

### DIFF
--- a/.claude/skills/echo-development/SKILL.md
+++ b/.claude/skills/echo-development/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: echo-development
+description: "Develops real-time broadcasting with Laravel Echo. Activates when setting up broadcasting (Reverb, Pusher, Ably); creating ShouldBroadcast events; defining broadcast channels (public, private, presence, encrypted); authorizing channels; configuring Echo; listening for events; implementing client events (whisper); setting up model broadcasting; broadcasting notifications; or when the user mentions broadcasting, Echo, WebSockets, real-time events, Reverb, or presence channels."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Laravel Broadcasting & Echo
+
+## When to Apply
+
+Activate this skill when:
+
+- Installing or configuring Laravel broadcasting (Reverb, Pusher, Ably)
+- Creating events that implement `ShouldBroadcast`
+- Defining broadcast channels and authorization
+- Setting up Laravel Echo on the client side
+- Listening for broadcast events, notifications, or model events
+- Implementing client-to-client events (whisper)
+- Working with presence channels for user awareness
+
+## Documentation
+
+Use `search-docs` for detailed broadcasting patterns and documentation.
+
+## Basic Usage
+
+### Installing Broadcasting
+
+```bash
+php artisan install:broadcasting
+```
+
+Use flags for specific drivers: `--reverb`, `--pusher`, `--ably`. This creates `config/broadcasting.php` and `routes/channels.php`.
+
+### Creating a Broadcast Event
+
+```bash
+php artisan make:event OrderShipped
+```
+
+<!-- Broadcast Event -->
+```php
+namespace App\Events;
+
+use App\Models\Order;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Queue\SerializesModels;
+
+class OrderShipped implements ShouldBroadcast
+{
+    use InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Order $order) {}
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel('orders.'.$this->order->id)];
+    }
+}
+```
+
+Dispatch the event:
+
+<!-- Dispatch Event -->
+```php
+use App\Events\OrderShipped;
+
+OrderShipped::dispatch($order);
+```
+
+### Authorizing Channels
+
+Define authorization in `routes/channels.php`:
+
+<!-- Channel Authorization -->
+```php
+use App\Models\Order;
+use App\Models\User;
+
+Broadcast::channel('orders.{orderId}', function (User $user, int $orderId) {
+    return $user->id === Order::findOrNew($orderId)->user_id;
+});
+```
+
+Create a channel class for complex authorization:
+
+```bash
+php artisan make:channel OrderChannel
+```
+
+List all registered channels:
+
+```bash
+php artisan channel:list
+```
+
+### Client-Side Setup
+
+Install Echo and Pusher JS:
+
+```bash
+npm install --save-dev laravel-echo pusher-js
+```
+
+<!-- Echo Client Configuration -->
+```javascript
+import Echo from 'laravel-echo';
+import Pusher from 'pusher-js';
+window.Pusher = Pusher;
+
+window.Echo = new Echo({
+    broadcaster: 'reverb',
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT ?? 80,
+    wssPort: import.meta.env.VITE_REVERB_PORT ?? 443,
+    forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
+    enabledTransports: ['ws', 'wss'],
+});
+```
+
+### Listening for Events
+
+<!-- Listen on Private Channel -->
+```javascript
+Echo.private(`orders.${orderId}`)
+    .listen('OrderShipmentStatusUpdated', (e) => {
+        console.log(e.order);
+    });
+```
+
+### Running Required Processes
+
+```bash
+php artisan queue:work    # Required for ShouldBroadcast events
+
+php artisan reverb:start  # Required for Reverb driver
+
+```
+
+## What's Possible
+
+Use `search-docs` to find detailed code examples and configuration for each of these:
+
+### Channel Types
+
+- Public (`new Channel`) — no auth, anyone can subscribe. Use for app-wide announcements, public feeds, or status pages.
+- Private (`new PrivateChannel`) — requires authorization. Use for user-specific data like orders, messages, or account updates.
+- Presence (`new PresenceChannel`) — authorized + tracks who's online. Use for chat rooms, collaborative editing, "who's viewing this" features, or typing indicators.
+- EncryptedPrivate — end-to-end encryption, Pusher/Reverb only. Use when payload must be hidden from the broadcast server (e.g., sensitive financial data or private messages).
+- Drivers: `reverb` (self-hosted WebSocket server), `pusher` (managed service), `ably` (managed service), `log` (writes to Laravel log, use for debugging), `null` (no-op, use for testing)
+
+### Event Customization
+
+- `broadcastAs()` — custom event name (client must use dot prefix: `.listen('.custom.name')`). Use when you want stable API names decoupled from PHP class names, or shorter event names for the frontend.
+- `broadcastWith()` — control exact payload. Use to avoid leaking sensitive model attributes, slim down large payloads, or add computed data not on the model.
+- `broadcastWhen()` — conditional broadcasting. Use to skip broadcasting when changes are trivial (e.g., only broadcast order updates above a threshold, or skip unchanged fields).
+- `broadcastQueue()` / `$queue` — route to specific queue. Use to isolate real-time broadcasts from slow background jobs so they're processed faster.
+- `$connection` — set queue connection per event. Use when broadcasts should go through a faster queue backend like Redis while other jobs use the database driver.
+
+### Broadcasting Interfaces
+
+- `ShouldBroadcast` — queue the broadcast (default). Use for most events to avoid blocking the HTTP response.
+- `ShouldBroadcastNow` — broadcast synchronously, skip queue. Use during development or for time-critical events where queue latency is unacceptable.
+- `ShouldDispatchAfterCommit` — wait for DB transaction commit. Use when the event references newly created records that listeners need to query (prevents race conditions).
+- `ShouldRescue` — auto-catch broadcast exceptions. Use to prevent broadcast failures (e.g., WebSocket server down) from disrupting the user's HTTP request.
+- `InteractsWithSockets` — required for `toOthers()`. Use on any event where you want to exclude the sender (optimistic UI updates).
+- `InteractsWithBroadcasting` — override driver per event via `broadcastVia()`. Use in multi-driver setups (e.g., some events via Reverb, others via Pusher).
+
+### Broadcasting Helpers
+
+- `broadcast(new Event)->toOthers()` — exclude current user's socket. Use when the client already updates optimistically from the API response to avoid duplicate updates.
+- `broadcast(new Event)->via('pusher')` — override connection. Use to route specific events through a different broadcast driver than the default.
+- `Broadcast::on()`, `Broadcast::private()`, `Broadcast::presence()` — anonymous broadcasting without event classes. Chain `.as('name')->with($data)->send()` or `.sendNow()`. Use for simple one-off broadcasts where creating a full event class is overkill (e.g., quick status updates, simple notifications).
+
+### Channel Authorization
+
+- Closure-based in `routes/channels.php` — use for simple authorization logic (e.g., checking ownership).
+- Model binding: `Broadcast::channel('orders.{order}', fn (User $user, Order $order) => ...)` — use when authorization depends on the model instance (auto-resolves from route parameter).
+- Channel classes via `php artisan make:channel` — use for complex authorization logic that benefits from dependency injection or reusable logic across channels.
+- Multiple guards: `['guards' => ['web', 'admin']]` — use when the channel should be accessible by users authenticated via different guards (e.g., both regular users and admins).
+
+### Model Broadcasting
+
+- `BroadcastsEvents` trait auto-broadcasts created/updated/deleted/trashed/restored. Use to automatically keep clients in sync with Eloquent model changes without writing individual events.
+- Channel convention: `App.Models.Post.{id}` — clients subscribe to model-specific channels.
+- `broadcastAs($event)` and `broadcastWith($event)` for per-action customization. Use to send different payloads for create vs update, or suppress certain event types.
+- `newBroadcastableEvent($event)` for event instance customization (e.g., `->dontBroadcastToCurrentUser()`). Use when you need to modify the underlying event object before it's dispatched.
+
+### Client-Side Features
+
+- Client events: `whisper()` / `listenForWhisper()` — peer-to-peer without server roundtrip (private/presence channels only). Use for typing indicators, cursor positions, or any ephemeral state that doesn't need server persistence.
+- Presence channels: `Echo.join()` with `here()`, `joining()`, `leaving()`, `error()` callbacks. Use for showing online users, "X is viewing this document" features, or live participant counts.
+- Notification broadcasting: `.notification()` on user's private channel. Use to show real-time notifications (toast, badge counts) pushed from Laravel's notification system.
+- Connection management: `Echo.connectionStatus()`, `Echo.leaveAllChannels()`, `Echo.disconnect()`. Use to show connection indicators, clean up on logout, or handle offline/reconnect scenarios.
+- Custom namespace: `new Echo({ namespace: 'App.Other.Namespace' })`. Use when your events live outside the default `App\Events` namespace.
+
+## Common Pitfalls
+
+- Queue worker must be running for `ShouldBroadcast` events. Use `ShouldBroadcastNow` during development.
+- `BROADCAST_CONNECTION` not `BROADCAST_DRIVER`: Laravel 11+ renamed this env key.
+- `toOthers()` requires `InteractsWithSockets` trait AND `X-Socket-ID` header. Echo auto-adds this to global Axios. For `fetch`, manually send `Echo.socketId()`.
+- CORS: When frontend/backend are on different origins, add `broadcasting/auth` to `config/cors.php` paths and set `supports_credentials` to `true`.
+- Missing `VITE_` prefix: Client-side env vars must start with `VITE_`.
+- `channels.php` not loaded: Verify it's included in `withRouting()` in `bootstrap/app.php`.
+- Reverb is long-running: Code changes require `php artisan reverb:restart`.
+- Presence channel auth must return an array of user data (`['id' => $user->id, 'name' => $user->name]`), not `true`. Returning `true` silently fails.
+- Dot prefix rule: When using `broadcastAs()`, client must prefix with `.` (e.g., `.listen('.custom.name')`). Without the dot, Echo looks for `App\Events\custom.name` which silently fails.
+- Reverb host separation: `REVERB_SERVER_HOST`/`REVERB_SERVER_PORT` (internal bind) vs `REVERB_HOST`/`REVERB_PORT` (public address) vs `VITE_REVERB_HOST`/`VITE_REVERB_PORT` (client JS).
+- Sanctum SPA auth: Ensure `/broadcasting/auth` uses `auth:sanctum` middleware and CSRF tokens are sent with `withCredentials: true`.

--- a/.claude/skills/echo-vue-development/SKILL.md
+++ b/.claude/skills/echo-vue-development/SKILL.md
@@ -1,0 +1,406 @@
+---
+name: echo-vue-development
+description: "Develops real-time broadcasting in Vue applications with Laravel Echo. Activates when configuring Echo in Vue (configureEcho); using composables (useEcho, useEchoPublic, useEchoPresence, useEchoModel, useEchoNotification, useConnectionStatus); listening for broadcast events in Vue components; implementing client events (whisper) in Vue; or when the user mentions Echo with Vue, real-time Vue composables, or broadcasting in Vue components."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Laravel Echo Vue Integration
+
+## When to Apply
+
+Activate this skill when:
+
+- Configuring Echo in a Vue application (`configureEcho`)
+- Using Echo composables in Vue components
+- Listening for broadcast events, model events, or notifications in Vue
+- Implementing client events (whisper) in Vue
+
+## Documentation
+
+Use `search-docs` for detailed broadcasting patterns. Search for:
+
+- "receiving broadcasts" — composable usage with full examples
+- "model broadcasting" — useEchoModel for Eloquent model events
+- "client events" — whisper/listenForWhisper
+- "presence channels" — useEchoPresence with member tracking
+- "broadcasting installation" — configureEcho setup
+
+## Basic Usage
+
+### Configure Echo
+
+Call once in your app entry point (e.g., `app.ts`):
+
+<!-- Configure Echo for Reverb -->
+```typescript
+import { configureEcho } from "@laravel/echo-vue";
+
+configureEcho({
+    broadcaster: "reverb",
+});
+```
+
+All Reverb connection options (`key`, `wsHost`, `wsPort`, `wssPort`, `forceTLS`, `enabledTransports`) are auto-read from environment variables when omitted. Override explicitly only when needed.
+
+For Pusher:
+
+<!-- Configure Echo for Pusher -->
+```typescript
+import { configureEcho } from "@laravel/echo-vue";
+
+configureEcho({
+    broadcaster: "pusher",
+});
+```
+
+### Listen for Events
+
+<!-- Private Channel Composable -->
+```vue
+<script setup lang="ts">
+import { useEcho } from "@laravel/echo-vue";
+
+const props = defineProps<{ orderId: number }>();
+
+useEcho(`orders.${props.orderId}`, "OrderShipmentStatusUpdated", (e) => {
+    console.log(e.order);
+});
+</script>
+```
+
+`useEcho` defaults to private channels, subscribes on mount, unsubscribes on unmount.
+
+Listen to multiple events:
+
+<!-- Multiple Events -->
+```vue
+<script setup lang="ts">
+import { useEcho } from "@laravel/echo-vue";
+
+useEcho(
+    `orders.${orderId}`,
+    ["OrderShipmentStatusUpdated", "OrderShipped"],
+    (e) => {
+        console.log(e.order);
+    },
+);
+</script>
+```
+
+### Public Channels
+
+<!-- Public Channel Composable -->
+```vue
+<script setup lang="ts">
+import { useEchoPublic } from "@laravel/echo-vue";
+
+useEchoPublic("posts", "PostPublished", (e) => {
+    console.log(e.post);
+});
+</script>
+```
+
+### Presence Channels
+
+<!-- Presence Channel Composable -->
+```vue
+<script setup lang="ts">
+import { useEchoPresence } from "@laravel/echo-vue";
+
+const { channel } = useEchoPresence("chat.1", "NewMessage", (e) => {
+    console.log(e.message);
+});
+
+channel().here((users) => console.log('Current users:', users));
+channel().joining((user) => console.log(`${user.name} joined`));
+channel().leaving((user) => console.log(`${user.name} left`));
+</script>
+```
+
+### Model Broadcasting
+
+<!-- Model Broadcasting Composable -->
+```vue
+<script setup lang="ts">
+import { useEchoModel } from "@laravel/echo-vue";
+
+const props = defineProps<{ userId: number }>();
+
+useEchoModel("App.Models.User", props.userId, ["UserUpdated"], (e) => {
+    console.log(e.model);
+});
+</script>
+```
+
+### Notifications
+
+<!-- Notification Composable -->
+```vue
+<script setup lang="ts">
+import { useEchoNotification } from "@laravel/echo-vue";
+
+useEchoNotification(`App.Models.User.${userId}`, (notification) => {
+    console.log(notification);
+});
+</script>
+```
+
+### Client Events (Whisper)
+
+<!-- Client Events in Vue -->
+```vue
+<script setup lang="ts">
+import { useEcho } from "@laravel/echo-vue";
+
+const { channel } = useEcho(`chat.${roomId}`, ['update'], (e) => {
+    console.log('Chat event received:', e);
+});
+
+// Send typing indicator
+channel().whisper('typing', { name: user.name });
+
+// Listen for typing
+channel().listenForWhisper('typing', (e) => {
+    console.log(`${e.name} is typing...`);
+});
+</script>
+```
+
+### Connection Status
+
+<!-- Connection Status -->
+```vue
+<script setup lang="ts">
+import { useConnectionStatus } from "@laravel/echo-vue";
+
+const status = useConnectionStatus();
+// Possible values: connected, connecting, reconnecting, disconnected, failed
+</script>
+
+<template>
+    <div>Connection: {{ status }}</div>
+</template>
+```
+
+### Type Safety
+
+Specify payload shape using TypeScript generics:
+
+<!-- Type-safe Event Listening -->
+```vue
+<script setup lang="ts">
+import { useEcho } from "@laravel/echo-vue";
+
+type OrderData = {
+    order: { id: number; user: { id: number; name: string } };
+};
+
+useEcho<OrderData>(`orders.${orderId}`, "OrderShipmentStatusUpdated", (e) => {
+    console.log(e.order.id);
+    console.log(e.order.user.name);
+});
+</script>
+```
+
+For model broadcasts:
+
+<!-- Type-safe Model Broadcasting -->
+```vue
+<script setup lang="ts">
+import { useEchoModel } from "@laravel/echo-vue";
+
+type User = { id: number; name: string; email: string };
+
+useEchoModel<User, "App.Models.User">("App.Models.User", userId, ["UserUpdated"], (e) => {
+    console.log(e.model.name);
+});
+</script>
+```
+
+### Manual Control
+
+All composables return methods for manual control:
+
+<!-- Manual Control -->
+```vue
+<script setup lang="ts">
+import { useEcho } from "@laravel/echo-vue";
+
+const { leaveChannel, leave, stopListening, listen } = useEcho(
+    `orders.${orderId}`,
+    "OrderShipmentStatusUpdated",
+    (e) => {
+        console.log(e.order);
+    },
+);
+
+// Stop listening without leaving channel...
+stopListening();
+
+// Start listening again...
+listen();
+
+// Leave channel...
+leaveChannel();
+
+// Leave a channel and its associated private and presence channels...
+leave();
+</script>
+```
+
+## Available Composables
+
+- `useEcho(channel, event, callback, deps?, visibility?)` — Private channels (default). Supports single or array of events.
+- `useEchoPublic(channel, event, callback, deps?)` — Public channels (no auth)
+- `useEchoPresence(channel, event, callback, deps?)` — Presence channels with member tracking
+- `useEchoModel(model, id, events, callback, deps?)` — Eloquent model events (auto-constructs channel name, auto-adds dot prefix)
+- `useEchoNotification(channel, callback, event?, deps?)` — Broadcast notifications
+- `useConnectionStatus()` — Returns a `Ref<ConnectionStatus>` that updates reactively
+
+All composables return `{ listen, stopListening, leaveChannel, leave, channel }` for manual control.
+
+### Utilities
+
+- `configureEcho(options)` — Configure the singleton Echo instance (call once in app entry point)
+- `echo()` — Access the Echo instance directly (e.g., `echo().socketId()` for the X-Socket-ID header)
+- `echoIsConfigured()` — Check if Echo has been configured before accessing `echo()`
+
+### Additional Capabilities via channel()
+
+- Client events: `channel().whisper("typing", data)` / `channel().listenForWhisper("typing", cb)`
+- Notifications: `channel().notification(cb)` — alternative to `useEchoNotification`
+- Channel lifecycle: `channel().subscribed(cb)` / `channel().error(cb)`
+
+## Server-Side Reference
+
+Use `search-docs` for detailed code examples. This section covers what's available on the backend so you can build the full end-to-end flow.
+
+### Creating Broadcast Events
+
+```bash
+php artisan make:event OrderShipped
+```
+
+<!-- Broadcast Event -->
+```php
+namespace App\Events;
+
+use App\Models\Order;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Queue\SerializesModels;
+
+class OrderShipped implements ShouldBroadcast
+{
+    use InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Order $order) {}
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel('orders.'.$this->order->id)];
+    }
+}
+```
+
+### Channel Authorization
+
+Define in `routes/channels.php`:
+
+<!-- Channel Authorization -->
+```php
+use App\Models\Order;
+use App\Models\User;
+
+Broadcast::channel('orders.{orderId}', function (User $user, int $orderId) {
+    return $user->id === Order::findOrNew($orderId)->user_id;
+});
+```
+
+Create a channel class for complex authorization:
+
+```bash
+php artisan make:channel OrderChannel
+```
+
+List all registered channels:
+
+```bash
+php artisan channel:list
+```
+
+### Channel Types
+
+- Public (`new Channel`) — no auth, anyone can subscribe. Use for app-wide announcements, public feeds, or status pages.
+- Private (`new PrivateChannel`) — requires authorization. Use for user-specific data like orders, messages, or account updates.
+- Presence (`new PresenceChannel`) — authorized + tracks who's online. Use for chat rooms, collaborative editing, "who's viewing this" features, or typing indicators.
+- EncryptedPrivate — end-to-end encryption, Pusher/Reverb only. Use when payload must be hidden from the broadcast server (e.g., sensitive financial data or private messages).
+- Drivers: `reverb` (self-hosted WebSocket server), `pusher` (managed service), `ably` (managed service), `log` (writes to Laravel log, use for debugging), `null` (no-op, use for testing)
+
+### Event Customization
+
+- `broadcastAs()` — custom event name (client must use dot prefix: `.listen('.custom.name')`). Use when you want stable API names decoupled from PHP class names, or shorter event names for the frontend.
+- `broadcastWith()` — control exact payload. Use to avoid leaking sensitive model attributes, slim down large payloads, or add computed data not on the model.
+- `broadcastWhen()` — conditional broadcasting. Use to skip broadcasting when changes are trivial (e.g., only broadcast order updates above a threshold, or skip unchanged fields).
+- `broadcastQueue()` / `$queue` — route to specific queue. Use to isolate real-time broadcasts from slow background jobs so they're processed faster.
+- `$connection` — set queue connection per event. Use when broadcasts should go through a faster queue backend like Redis while other jobs use the database driver.
+
+### Broadcasting Interfaces
+
+- `ShouldBroadcast` — queue the broadcast (default). Use for most events to avoid blocking the HTTP response.
+- `ShouldBroadcastNow` — broadcast synchronously, skip queue. Use during development or for time-critical events where queue latency is unacceptable.
+- `ShouldDispatchAfterCommit` — wait for DB transaction commit. Use when the event references newly created records that listeners need to query (prevents race conditions).
+- `ShouldRescue` — auto-catch broadcast exceptions. Use to prevent broadcast failures (e.g., WebSocket server down) from disrupting the user's HTTP request.
+- `InteractsWithSockets` — required for `toOthers()`. Use on any event where you want to exclude the sender (optimistic UI updates).
+- `InteractsWithBroadcasting` — override driver per event via `broadcastVia()`. Use in multi-driver setups (e.g., some events via Reverb, others via Pusher).
+
+### Broadcasting Helpers
+
+- `broadcast(new Event)->toOthers()` — exclude current user's socket. Use when the client already updates optimistically from the API response to avoid duplicate updates.
+- `broadcast(new Event)->via('pusher')` — override connection. Use to route specific events through a different broadcast driver than the default.
+- `Broadcast::on()`, `Broadcast::private()`, `Broadcast::presence()` — anonymous broadcasting without event classes. Chain `.as('name')->with($data)->send()` or `.sendNow()`. Use for simple one-off broadcasts where creating a full event class is overkill (e.g., quick status updates, simple notifications).
+
+### Channel Authorization Options
+
+- Closure-based in `routes/channels.php` — use for simple authorization logic (e.g., checking ownership).
+- Model binding: `Broadcast::channel('orders.{order}', fn (User $user, Order $order) => ...)` — use when authorization depends on the model instance (auto-resolves from route parameter).
+- Channel classes via `php artisan make:channel` — use for complex authorization logic that benefits from dependency injection or reusable logic across channels.
+- Multiple guards: `['guards' => ['web', 'admin']]` — use when the channel should be accessible by users authenticated via different guards (e.g., both regular users and admins).
+
+### Model Broadcasting (Server-Side)
+
+- `BroadcastsEvents` trait auto-broadcasts created/updated/deleted/trashed/restored. Use to automatically keep clients in sync with Eloquent model changes without writing individual events.
+- Channel convention: `App.Models.Post.{id}` — matches `useEchoModel` first argument.
+- `broadcastAs($event)` and `broadcastWith($event)` for per-action customization. Use to send different payloads for create vs update, or suppress certain event types.
+- `newBroadcastableEvent($event)` for event instance customization (e.g., `->dontBroadcastToCurrentUser()`). Use when you need to modify the underlying event object before it's dispatched.
+
+### Running Required Processes
+
+```bash
+php artisan queue:work    # Required for ShouldBroadcast events
+
+php artisan reverb:start  # Required for Reverb driver
+
+```
+
+## Common Pitfalls
+
+- Queue worker must be running for `ShouldBroadcast` events. Use `ShouldBroadcastNow` during development.
+- `BROADCAST_CONNECTION` not `BROADCAST_DRIVER`: Laravel 11+ renamed this env key.
+- Presence channel auth must return an array of user data (`['id' => $user->id, 'name' => $user->name]`), not `true`. Returning `true` silently fails.
+- Dot prefix rule: When using `broadcastAs()`, client must prefix with `.` (e.g., `.listen('.custom.name')`). Without the dot, Echo looks for `App\Events\custom.name` which silently fails.
+- CORS: When frontend/backend are on different origins, add `broadcasting/auth` to `config/cors.php` paths and set `supports_credentials` to `true`.
+- `channels.php` not loaded: Verify it's included in `withRouting()` in `bootstrap/app.php`.
+- Reverb is long-running: Code changes require `php artisan reverb:restart`.
+- Call `configureEcho` before any composables run. Place it in your app entry point (e.g., `app.ts`), not inside a component's `<script setup>`.
+- Composables auto-cleanup on unmount — do NOT manually call `leave()` or `stopListening()` in `onUnmounted`.
+- Composables must be called in `<script setup>` or `setup()` — they rely on the Vue lifecycle.
+- `X-Socket-ID` header is NOT auto-sent with Inertia requests. Manually add `echo().socketId()` when using `broadcast()->toOthers()`.
+- SSR / "window is not defined": Guard `configureEcho` with `typeof window !== 'undefined'` in Nuxt/SSR contexts.
+- One Echo instance: `configureEcho` creates a singleton. Multiple calls reuse the first configuration.
+- Channel reference counting: Multiple components sharing a channel name share one subscription. The channel is only left when ALL components unmount. Don't call `leave()` unless you want to force-unsubscribe all listeners.
+- Dependencies array: Pass reactive state (from `ref()` or props) in the deps array so composables re-subscribe with fresh callbacks.
+- Custom event names need dot prefix: When the server uses `broadcastAs()`, listen with the exact custom name. But `useEchoModel` automatically adds the dot prefix.

--- a/.claude/skills/scout-development/SKILL.md
+++ b/.claude/skills/scout-development/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: scout-development
+description: "Develops full-text search with Laravel Scout. Activates when installing or configuring Scout; choosing a search engine (Algolia, Meilisearch, Typesense, Database, Collection); adding the Searchable trait to models; customizing toSearchableArray or searchableAs; importing or flushing search indexes; writing search queries with where clauses, pagination, or soft deletes; configuring index settings; troubleshooting search results; or when the user mentions Scout, full-text search, search indexing, or search engines in a Laravel project. Make sure to use this skill whenever the user works with search functionality in Laravel, even if they don't explicitly mention Scout."
+license: MIT
+metadata:
+  author: laravel
+---
+
+# Scout Full-Text Search
+
+## Documentation First
+
+**Always use `search-docs` before writing Scout code.** The documentation covers every engine, configuration option, and edge case in detail. This skill teaches you how to navigate Scout — the docs have the implementation specifics.
+
+```
+search-docs(queries: ["Scout installation"], packages: ["laravel/framework@12.x"])
+```
+
+The Scout docs live under the `laravel/framework` package — not `laravel/scout`.
+
+Effective search patterns:
+
+- Installation & setup: `"Scout installation"`, `"Scout queueing"`
+- Engine setup: `"Scout Algolia"`, `"Scout Meilisearch"`, `"Scout Typesense"`
+- Model configuration: `"Scout configuring searchable data"`, `"Scout configuring model indexes"`
+- Searching: `"Scout searching"`, `"Scout where clauses"`, `"Scout pagination"`
+- Indexing: `"Scout batch import"`, `"Scout adding records"`, `"Scout removing records"`
+- Advanced: `"Scout soft deleting"`, `"Scout customizing engine searches"`, `"Scout custom engines"`
+
+The docs are organized into these main sections: Installation, Driver Prerequisites, Configuration, Database/Collection Engines, Indexing, Searching, Custom Engines. Use these section names as search anchors.
+
+## When to Apply
+
+Activate this skill when:
+
+- Installing or configuring Scout
+- Choosing a search engine for a Laravel application
+- Making Eloquent models searchable
+- Customizing indexed data or index names
+- Writing search queries, filters, or pagination
+- Importing or flushing search indexes
+- Troubleshooting search results or indexing issues
+- Choosing between search engines
+
+## Installation
+
+Before installing, check if Scout is already in the project — look for `laravel/scout` in `composer.json` and `config/scout.php`. If already installed, skip to the relevant section (engine configuration, model setup, or searching).
+
+### 1. Install Scout
+
+```bash
+composer require laravel/scout
+php artisan vendor:publish --provider="Laravel\Scout\ScoutServiceProvider"
+```
+
+### 2. Add the Searchable trait
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+class Post extends Model
+{
+    use Searchable;
+}
+```
+
+This registers a model observer that automatically keeps your search index in sync with Eloquent records.
+
+## Choosing an Engine
+
+Before presenting engine options, check if Scout is already configured in the application:
+
+1. Check `.env` for `SCOUT_DRIVER` — if set, the application already has a configured engine.
+2. Check `config/scout.php` for the `driver` key and any engine-specific settings.
+3. Check `composer.json` for engine SDKs (`algolia/algoliasearch-client-php`, `meilisearch/meilisearch-php`, `typesense/typesense-php`).
+
+If an engine is already configured, skip the engine selection step and work with the existing setup. Only present the engine comparison if Scout is not yet installed or the user explicitly wants to switch engines.
+
+When no engine is configured, present these options and let the user decide — never choose for them.
+
+| Engine | Type | Best For | Tradeoffs |
+|--------|------|----------|-----------|
+| **Database** | Built-in | Typical applications, simple search | No external deps. MySQL/PostgreSQL only. LIKE + full-text indexes. No typo tolerance. |
+| **Collection** | Built-in | Local dev, tiny datasets (<500 records) | Loads all records into memory. Most portable but least efficient. |
+| **Algolia** | Hosted SaaS | Advanced search without managing infra | Typo tolerance, analytics, faceting. Paid service. No self-hosting. |
+| **Meilisearch** | Self-hosted / Cloud | Teams wanting infrastructure control | Fast, open-source. Self-hostable or cloud. Requires filterable attribute config. |
+| **Typesense** | Self-hosted / Cloud | Keyword, semantic, geo, vector search | Open-source. Self-hostable or cloud. Strict schema requirements. |
+
+After the user chooses, use `search-docs` for that engine's prerequisites and configuration.
+
+Set the engine in `.env`:
+
+```ini
+SCOUT_DRIVER=database
+```
+
+For third-party engines (Algolia, Meilisearch, Typesense): install their PHP SDK and strongly consider enabling queue support in `config/scout.php` for production.
+
+## Model Configuration
+
+Use `search-docs` for full configuration details. Key customization points:
+
+```php
+// Control what data gets indexed
+public function toSearchableArray(): array
+{
+    return [
+        'id' => $this->id,
+        'title' => $this->title,
+        'body' => $this->body,
+    ];
+}
+
+// Custom index name (no effect with database engine)
+public function searchableAs(): string
+{
+    return 'posts_index';
+}
+```
+
+For Algolia/Meilisearch/Typesense: configure index settings (filterable, sortable, searchable attributes) in `config/scout.php`, then sync:
+
+```bash
+php artisan scout:sync-index-settings
+```
+
+## Searching
+
+Basic patterns:
+
+```php
+// Simple search
+$results = Model::search('query')->get();
+
+// With filtering
+$results = Model::search('query')->where('status', 'active')->get();
+
+// Paginated
+$results = Model::search('query')->paginate(15);
+
+// Eager load relationships on results
+$results = Model::search('query')
+    ->query(fn ($q) => $q->with('category'))
+    ->get();
+
+// Raw engine results
+$results = Model::search('query')->raw();
+```
+
+Use `search-docs` for advanced querying — `whereIn`, `whereNotIn`, soft deletes, custom indexes, and engine-specific options.
+
+## Key Artisan Commands
+
+| Command | Purpose |
+|---------|---------|
+| `php artisan scout:import "App\Models\Post"` | Import model records into search index |
+| `php artisan scout:queue-import "App\Models\Post"` | Import via queued jobs (large datasets) |
+| `php artisan scout:flush "App\Models\Post"` | Remove all model records from search index |
+| `php artisan scout:sync-index-settings` | Sync index settings to the search engine |
+| `php artisan scout:index posts` | Create a search index |
+| `php artisan scout:delete-index posts` | Delete a search index |
+
+## Testing
+
+Scout does **not** have a `Scout::fake()` method. Available approaches:
+
+- **NullEngine** — set `SCOUT_DRIVER=null` to disable all indexing in tests
+- **CollectionEngine** — set `SCOUT_DRIVER=collection` for in-memory search without external services
+- **`Model::withoutSyncingToSearch(fn() => ...)`** — temporarily pause indexing in a callback
+- **`Model::disableSearchSyncing()`** — globally disable syncing in test setUp
+
+Use `search-docs` for detailed testing patterns.
+
+## Common Pitfalls
+
+- **Meilisearch filterable attributes** — you must configure filterable attributes in `config/scout.php` under `meilisearch.index-settings` and run `scout:sync-index-settings` **before** using `where`, `whereIn`, or `whereNotIn`. Without this, filtering silently returns wrong results.
+- **Meilisearch data type casting** — `toSearchableArray()` must return properly cast values: integers as `(int)`, floats as `(float)`. Wrong types cause silent filter failures.
+- **Database engine limitations** — `searchableAs()`, `getScoutKey()`, `getScoutKeyName()`, and `shouldBeSearchable()` have no effect with the database engine. It queries your actual tables directly.
+- **Global scopes break pagination** — search engines are not aware of Eloquent global scopes. Recreate scope constraints using Scout `where` clauses instead.
+- **`query()` is not for filtering** — with third-party engines, the `query()` callback runs after results are already retrieved. Use Scout `where` clauses for filtering; use `query()` only for eager-loading or customizing the Eloquent hydration query.
+- **Missing queue configuration** — third-party engines should always have `scout.queue` enabled in production. Without it, indexing runs synchronously and slows down requests.
+- **Typesense schema requirements** — `id` must be cast as `(string)` and timestamps as Unix integers (`$this->created_at->timestamp`).
+- **`shouldBeSearchable()` bypass** — this method only applies via `save()`, `create()`, queries, or relationships. Calling `searchable()` directly on a model or collection bypasses it entirely.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/framework (LARAVEL) - v13
 - laravel/prompts (PROMPTS) - v0
 - laravel/reverb (REVERB) - v1
+- laravel/scout (SCOUT) - v11
 - laravel/wayfinder (WAYFINDER) - v0
 - larastan/larastan (LARASTAN) - v3
 - laravel/boost (BOOST) - v2
@@ -27,8 +28,10 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - @inertiajs/vue3 (INERTIA_VUE) - v3
 - tailwindcss (TAILWINDCSS) - v4
 - vue (VUE) - v3
+- @laravel/echo-vue (ECHO_VUE) - v2
 - @laravel/vite-plugin-wayfinder (WAYFINDER_VITE) - v0
 - eslint (ESLINT) - v9
+- laravel-echo (ECHO) - v2
 - prettier (PRETTIER) - v3
 
 ## Skills Activation

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+
+class SearchMessages
+{
+    /**
+     * The maximum number of message matches returned for a single search.
+     */
+    private const RESULT_LIMIT = 50;
+
+    /**
+     * Full-text search a team's messages, ACL-filtered to the user's channels.
+     *
+     * The `channel_id` filter is the whole ACL: the id set is exactly the
+     * channels the user belongs to within this team, so it enforces both team
+     * scoping and membership, and messages from private channels the user cannot
+     * see never leak. A blank query, or a user who belongs to no channel in the
+     * team, yields no matches without touching the search engine. Relations are
+     * eager-loaded after the search (not via a `query()` callback, which the
+     * collection engine treats as a signal to skip the ACL filter entirely).
+     *
+     * @return Collection<int, Message>
+     */
+    public function handle(User $user, Team $team, string $query): Collection
+    {
+        $query = trim($query);
+
+        $channelIds = $user->channels()
+            ->where('channels.team_id', $team->id)
+            ->pluck('channels.id')
+            ->all();
+
+        if ($query === '' || $channelIds === []) {
+            return new Collection;
+        }
+
+        return Message::search($query)
+            ->whereIn('channel_id', $channelIds)
+            ->take(self::RESULT_LIMIT)
+            ->get()
+            ->load(['user', 'channel', 'mentionedUsers']);
+    }
+}

--- a/app/Data/MessageSearchResultData.php
+++ b/app/Data/MessageSearchResultData.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\Message;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class MessageSearchResultData extends Data
+{
+    public function __construct(
+        public MessageData $message,
+        public string $channelName,
+        public string $channelSlug,
+    ) {}
+
+    /**
+     * Build the DTO from a search-matched Message.
+     *
+     * The message's `channel`, `user`, and `mentionedUsers` relations should be
+     * eager-loaded so rendering the result and its jump link avoids N+1 queries.
+     */
+    public static function fromMessage(Message $message): self
+    {
+        return new self(
+            message: MessageData::fromMessage($message),
+            channelName: $message->channel->name,
+            channelSlug: $message->channel->slug,
+        );
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -25,6 +25,12 @@ use Inertia\Response;
 class ChannelController extends Controller
 {
     /**
+     * How many messages newer than a jump target to keep loaded below it, so a
+     * jumped-to message shows following context and is not pinned to the bottom.
+     */
+    private const int JUMP_CONTEXT = 15;
+
+    /**
      * Redirect a bare team URL to the team's #general channel.
      */
     public function index(Team $team): RedirectResponse
@@ -67,6 +73,16 @@ class ChannelController extends Controller
         $channel->setAttribute('muted', $membership->muted ?? false);
         $channel->setAttribute('notification_level', $membership?->notification_level->value ?? NotificationLevel::All->value);
 
+        // When arriving from a search result the URL carries the target message
+        // id. If it belongs to this channel, cap the initial window a few messages
+        // above the target so it loads with context on both sides; the client
+        // scrolls to and highlights it, and older history still pages in above via
+        // InfiniteScroll.
+        $jumpToMessageId = $this->resolveJumpTarget($request, $channel);
+        $windowCeilingId = $jumpToMessageId === null
+            ? null
+            : $this->jumpWindowCeiling($channel, $jumpToMessageId);
+
         return Inertia::render('channels/Show', [
             'team' => [
                 'id' => $team->id,
@@ -82,6 +98,9 @@ class ChannelController extends Controller
             'canManagePreferences' => Gate::allows('updatePreference', $channel),
             // Selectable notification levels for the settings menu.
             'notificationLevels' => NotificationLevel::options(),
+            // The message the client should scroll to and highlight on load, or
+            // null for a normal channel visit.
+            'jumpToMessageId' => $jumpToMessageId,
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),
@@ -92,10 +111,49 @@ class ChannelController extends Controller
             'messages' => Inertia::scroll(fn () => $channel->messages()
                 ->withTrashed()
                 ->with(['user', 'mentionedUsers'])
+                ->when($windowCeilingId, fn ($query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
                 ->cursorPaginate(50)
                 ->through(fn (Message $message) => MessageData::fromMessage($message))),
         ]);
+    }
+
+    /**
+     * Resolve the `?message=` jump target to an id belonging to this channel.
+     *
+     * Returns the message id when it identifies a message in the channel
+     * (soft-deleted rows included), or null when the parameter is absent or
+     * points at a message from another channel.
+     */
+    private function resolveJumpTarget(Request $request, Channel $channel): ?string
+    {
+        $messageId = $request->query('message');
+
+        if (! is_string($messageId) || $messageId === '') {
+            return null;
+        }
+
+        return $channel->messages()->withTrashed()->whereKey($messageId)->exists()
+            ? $messageId
+            : null;
+    }
+
+    /**
+     * Resolve the id that caps the initial message window for a jump.
+     *
+     * Returns the id of the message JUMP_CONTEXT positions newer than the target
+     * so it loads with following context below it rather than pinned to the very
+     * bottom of the view. Returns null when fewer than that many newer messages
+     * exist — the target is then already near the newest, so no cap is needed.
+     */
+    private function jumpWindowCeiling(Channel $channel, string $targetId): ?string
+    {
+        return $channel->messages()
+            ->withTrashed()
+            ->where('id', '>', $targetId)
+            ->orderBy('id')
+            ->offset(self::JUMP_CONTEXT - 1)
+            ->value('id');
     }
 
     /**

--- a/app/Http/Controllers/Channels/SearchController.php
+++ b/app/Http/Controllers/Channels/SearchController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\SearchMessages;
+use App\Data\MessageSearchResultData;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\SearchMessagesRequest;
+use App\Models\Message;
+use App\Models\Team;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SearchController extends Controller
+{
+    /**
+     * Search messages in the current team, scoped to the user's channels.
+     *
+     * The ACL-filtered query lives in the SearchMessages action; the controller
+     * only shapes the matches for the client. An empty query renders the page
+     * with no results.
+     */
+    public function index(SearchMessagesRequest $request, Team $team, SearchMessages $searchMessages): Response
+    {
+        $query = trim((string) $request->validated('q'));
+
+        $results = $searchMessages->handle($request->user(), $team, $query)
+            ->map(fn (Message $message) => MessageSearchResultData::fromMessage($message))
+            ->all();
+
+        return Inertia::render('channels/Search', [
+            'team' => [
+                'id' => $team->id,
+                'name' => $team->name,
+                'slug' => $team->slug,
+            ],
+            'query' => $query,
+            'results' => $results,
+        ]);
+    }
+}

--- a/app/Http/Requests/Channels/SearchMessagesRequest.php
+++ b/app/Http/Requests/Channels/SearchMessagesRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchMessagesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Team membership is already enforced by the EnsureTeamMembership middleware
+     * on the route, so any request reaching here is from a team member.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'q' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
+use Laravel\Scout\Searchable;
 
 /**
  * @property string $id
@@ -31,7 +32,7 @@ use Illuminate\Support\Carbon;
 class Message extends Model
 {
     /** @use HasFactory<MessageFactory> */
-    use HasFactory, HasUuids, SoftDeletes;
+    use HasFactory, HasUuids, Searchable, SoftDeletes;
 
     /**
      * Get the channel the message was posted to.
@@ -77,5 +78,33 @@ class Message extends Model
         return [
             'edited_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Get the indexed representation of the message.
+     *
+     * `team_id` is derived from the channel because messages carry no native
+     * team column; the channel relation is eager-loaded when indexing in bulk.
+     *
+     * @return array<string, mixed>
+     */
+    public function toSearchableArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'body' => $this->body,
+            'channel_id' => $this->channel_id,
+            'user_id' => $this->user_id,
+            'team_id' => $this->channel->team_id,
+            'created_at' => $this->created_at?->getTimestamp(),
+        ];
+    }
+
+    /**
+     * Keep soft-deleted messages out of the search index.
+     */
+    public function shouldBeSearchable(): bool
+    {
+        return ! $this->trashed();
     }
 }

--- a/boost.json
+++ b/boost.json
@@ -10,9 +10,12 @@
     "skills": [
         "fortify-development",
         "laravel-best-practices",
+        "scout-development",
         "wayfinder-development",
         "pest-testing",
         "inertia-vue-development",
-        "tailwindcss-development"
+        "tailwindcss-development",
+        "echo-vue-development",
+        "echo-development"
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,10 @@
         "laravel/fortify": "^1.37.2",
         "laravel/framework": "^13.17",
         "laravel/reverb": "^1.0",
+        "laravel/scout": "^11.3",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",
+        "meilisearch/meilisearch-php": "^1.16",
         "spatie/laravel-data": "^4.23",
         "spatie/laravel-typescript-transformer": "^3.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30be12b4d90a20f5215218590f86d540",
+    "content-hash": "f288e00198777acdd8542c54d4dcce28",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -2050,6 +2050,86 @@
             "time": "2026-05-10T15:47:52+00:00"
         },
         {
+            "name": "laravel/scout",
+            "version": "v11.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/scout.git",
+                "reference": "7d0903e083dee7c3d295a27917c82496c5c41970"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/scout/zipball/7d0903e083dee7c3d295a27917c82496c5c41970",
+                "reference": "7d0903e083dee7c3d295a27917c82496c5c41970",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/bus": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/database": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/http": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/pagination": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/queue": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0",
+                "symfony/console": "^6.0|^7.0|^8.0"
+            },
+            "conflict": {
+                "algolia/algoliasearch-client-php": "<3.2.0|>=5.0.0"
+            },
+            "require-dev": {
+                "algolia/algoliasearch-client-php": "^3.2|^4.0",
+                "meilisearch/meilisearch-php": "^1.0",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^7.31|^8.36|^9.15|^10.8|^11.0",
+                "php-http/guzzle7-adapter": "^1.0",
+                "phpstan/phpstan": "^1.10",
+                "typesense/typesense-php": "^4.9.3"
+            },
+            "suggest": {
+                "algolia/algoliasearch-client-php": "Required to use the Algolia engine (^3.2).",
+                "meilisearch/meilisearch-php": "Required to use the Meilisearch engine (^1.0).",
+                "typesense/typesense-php": "Required to use the Typesense engine (^4.9)."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Scout\\ScoutServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "11.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Scout\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Scout provides a driver based solution to searching your Eloquent models.",
+            "keywords": [
+                "algolia",
+                "laravel",
+                "search"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/scout/issues",
+                "source": "https://github.com/laravel/scout"
+            },
+            "time": "2026-06-16T15:48:22+00:00"
+        },
+        {
             "name": "laravel/serializable-closure",
             "version": "v2.0.13",
             "source": {
@@ -2802,6 +2882,86 @@
             "time": "2026-03-08T20:05:35+00:00"
         },
         {
+            "name": "meilisearch/meilisearch-php",
+            "version": "v1.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/meilisearch/meilisearch-php.git",
+                "reference": "f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/meilisearch/meilisearch-php/zipball/f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6",
+                "reference": "f9f63e0e7d12ffaae54f7317fa8f4f4dfa8ae7b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0",
+                "php-http/discovery": "^1.7",
+                "psr/http-client": "^1.0",
+                "symfony/polyfill-php81": "^1.33"
+            },
+            "require-dev": {
+                "http-interop/http-factory-guzzle": "^1.2.0",
+                "php-cs-fixer/shim": "^3.59.3",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.5 || ^10.5",
+                "symfony/http-client": "^5.4|^6.0|^7.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Use Guzzle ^7 as HTTP client",
+                "http-interop/http-factory-guzzle": "Factory for guzzlehttp/guzzle",
+                "symfony/http-client": "Use Symfony Http client"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MeiliSearch\\": "src/",
+                    "Meilisearch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Clémentine Urquizar",
+                    "email": "clementine@meilisearch.com"
+                },
+                {
+                    "name": "Bruno Casali",
+                    "email": "bruno@meilisearch.com"
+                },
+                {
+                    "name": "Laurent Cazanove",
+                    "email": "lau.cazanove@gmail.com"
+                },
+                {
+                    "name": "Tomas Norkūnas",
+                    "email": "norkunas.tom@gmail.com"
+                }
+            ],
+            "description": "PHP wrapper for the Meilisearch API",
+            "keywords": [
+                "api",
+                "client",
+                "instant",
+                "meilisearch",
+                "php",
+                "search"
+            ],
+            "support": {
+                "issues": "https://github.com/meilisearch/meilisearch-php/issues",
+                "source": "https://github.com/meilisearch/meilisearch-php/tree/v1.16.1"
+            },
+            "time": "2025-09-18T10:15:45+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.10.0",
             "source": {
@@ -3379,6 +3539,85 @@
                 "source": "https://github.com/paragonie/constant_time_encoding"
             },
             "time": "2025-09-24T15:06:41+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "reference": "82fe4c73ef3363caed49ff8dd1539ba06044910d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "nyholm/psr7": "<1.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "*",
+                "psr/http-factory-implementation": "*",
+                "psr/http-message-implementation": "*"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "graham-campbell/phpspec-skip-example-extension": "^5.0",
+                "php-http/httplug": "^1.0 || ^2.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Http\\Discovery\\Composer\\Plugin",
+                "plugin-optional": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/Composer/Plugin.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds and installs PSR-7, PSR-17, PSR-18 and HTTPlug implementations",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr17",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/discovery/issues",
+                "source": "https://github.com/php-http/discovery/tree/1.20.0"
+            },
+            "time": "2024-10-02T11:20:13+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -7239,6 +7478,86 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php81",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php84",

--- a/config/scout.php
+++ b/config/scout.php
@@ -1,0 +1,213 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Search Engine
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default search connection that gets used while
+    | using Laravel Scout. This connection is used when syncing all models
+    | to the search service. You should adjust this based on your needs.
+    |
+    | Supported: "algolia", "meilisearch", "typesense",
+    |            "database", "collection", "null"
+    |
+    */
+
+    'driver' => env('SCOUT_DRIVER', 'collection'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Index Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify a prefix that will be applied to all search index
+    | names used by Scout. This prefix may be useful if you have multiple
+    | "tenants" or applications sharing the same search infrastructure.
+    |
+    */
+
+    'prefix' => env('SCOUT_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Data Syncing
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control if the operations that sync your data
+    | with your search engines are queued. When this is set to "true" then
+    | all automatic data syncing will get queued for better performance.
+    |
+    */
+
+    'queue' => env('SCOUT_QUEUE', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Transactions
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option determines if your data will only be synced
+    | with your search indexes after every open database transaction has
+    | been committed, thus preventing any discarded data from syncing.
+    |
+    */
+
+    'after_commit' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Chunk Sizes
+    |--------------------------------------------------------------------------
+    |
+    | These options allow you to control the maximum chunk size when you are
+    | mass importing data into the search engine. This allows you to fine
+    | tune each of these chunk sizes based on the power of the servers.
+    |
+    */
+
+    'chunk' => [
+        'searchable' => 500,
+        'unsearchable' => 500,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Soft Deletes
+    |--------------------------------------------------------------------------
+    |
+    | This option allows to control whether to keep soft deleted records in
+    | the search indexes. Maintaining soft deleted records can be useful
+    | if your application still needs to search for the records later.
+    |
+    */
+
+    'soft_delete' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Identify User
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control whether to notify the search engine
+    | of the user performing the search. This is sometimes useful if the
+    | engine supports any analytics based on this application's users.
+    |
+    | Supported engines: "algolia"
+    |
+    */
+
+    'identify' => env('SCOUT_IDENTIFY', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Algolia Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Algolia settings. Algolia is a cloud hosted
+    | search engine which works great with Scout out of the box. Just plug
+    | in your application ID and admin API key to get started searching.
+    |
+    */
+
+    'algolia' => [
+        'id' => env('ALGOLIA_APP_ID', ''),
+        'secret' => env('ALGOLIA_SECRET', ''),
+        'index-settings' => [
+            // 'users' => [
+            //     'searchableAttributes' => ['id', 'name', 'email'],
+            //     'attributesForFaceting'=> ['filterOnly(email)'],
+            // ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meilisearch Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Meilisearch settings. Meilisearch is an open
+    | source search engine with minimal configuration. Below, you can state
+    | the host and key information for your own Meilisearch installation.
+    |
+    | See: https://www.meilisearch.com/docs/learn/configuration/instance_options#all-instance-options
+    |
+    */
+
+    'meilisearch' => [
+        'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
+        'key' => env('MEILISEARCH_KEY'),
+        'index-settings' => [
+            // `channel_id` is the ACL filter used by message search; `team_id`
+            // and `user_id` are indexed for relevance and future faceting.
+            'messages' => [
+                'filterableAttributes' => ['channel_id'],
+                'sortableAttributes' => ['created_at'],
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Typesense Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Typesense settings. Typesense is an open
+    | source search engine using minimal configuration. Below, you will
+    | state the host, key, and schema configuration for the instance.
+    |
+    */
+
+    'typesense' => [
+        'client-settings' => [
+            'api_key' => env('TYPESENSE_API_KEY', 'xyz'),
+            'nodes' => [
+                [
+                    'host' => env('TYPESENSE_HOST', 'localhost'),
+                    'port' => env('TYPESENSE_PORT', '8108'),
+                    'path' => env('TYPESENSE_PATH', ''),
+                    'protocol' => env('TYPESENSE_PROTOCOL', 'http'),
+                ],
+            ],
+            'nearest_node' => [
+                'host' => env('TYPESENSE_HOST', 'localhost'),
+                'port' => env('TYPESENSE_PORT', '8108'),
+                'path' => env('TYPESENSE_PATH', ''),
+                'protocol' => env('TYPESENSE_PROTOCOL', 'http'),
+            ],
+            'connection_timeout_seconds' => env('TYPESENSE_CONNECTION_TIMEOUT_SECONDS', 2),
+            'healthcheck_interval_seconds' => env('TYPESENSE_HEALTHCHECK_INTERVAL_SECONDS', 30),
+            'num_retries' => env('TYPESENSE_NUM_RETRIES', 3),
+            'retry_interval_seconds' => env('TYPESENSE_RETRY_INTERVAL_SECONDS', 1),
+        ],
+        // 'max_total_results' => env('TYPESENSE_MAX_TOTAL_RESULTS', 1000),
+        'model-settings' => [
+            // User::class => [
+            //     'collection-schema' => [
+            //         'fields' => [
+            //             [
+            //                 'name' => 'id',
+            //                 'type' => 'string',
+            //             ],
+            //             [
+            //                 'name' => 'name',
+            //                 'type' => 'string',
+            //             ],
+            //             [
+            //                 'name' => 'created_at',
+            //                 'type' => 'int64',
+            //             ],
+            //         ],
+            //         'default_sorting_field' => 'created_at',
+            //     ],
+            //     'search-parameters' => [
+            //         'query_by' => 'name'
+            //     ],
+            // ],
+        ],
+        'import_action' => env('TYPESENSE_IMPORT_ACTION', 'upsert'),
+    ],
+
+];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,6 +27,7 @@
         <env name="DB_URL" value=""/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SCOUT_DRIVER" value="collection"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="TELESCOPE_ENABLED" value="false"/>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
     currentUserId: string;
     canModerate?: boolean;
     onlineIds?: Set<string>;
+    highlightMessageId?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -265,9 +266,15 @@ function confirmDelete(): void {
                     </div>
                     <div
                         v-for="(message, index) in item.messages"
+                        :id="`message-${message.id}`"
                         :key="message.id"
-                        class="group/message relative -mx-2 rounded-md px-2 hover:bg-muted/40"
-                        :class="index === 0 ? 'mt-0.5' : 'mt-1.5'"
+                        class="group/message relative -mx-2 rounded-md px-2 transition-colors duration-1000 hover:bg-muted/40"
+                        :class="[
+                            index === 0 ? 'mt-0.5' : 'mt-1.5',
+                            message.id === props.highlightMessageId
+                                ? 'bg-primary/10'
+                                : '',
+                        ]"
                     >
                         <p
                             v-if="message.isDeleted"

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
-import { Plus, Search } from '@lucide/vue';
+import { MessageSquareText, Plus, Search } from '@lucide/vue';
 import { computed, onMounted } from 'vue';
 import {
     browse,
     show,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { index as searchMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
 import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import NavUser from '@/components/NavUser.vue';
@@ -225,6 +226,27 @@ onMounted(() => {
                                         <SidebarMenuButton
                                             as-child
                                             class="mt-1.5 h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                        >
+                                            <Link
+                                                v-if="currentTeam"
+                                                :href="
+                                                    searchMessages(
+                                                        currentTeam.slug,
+                                                    ).url
+                                                "
+                                                data-test="search-messages"
+                                            >
+                                                <MessageSquareText
+                                                    class="size-[13px]"
+                                                />
+                                                <span>Search messages</span>
+                                            </Link>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                    <SidebarMenuItem>
+                                        <SidebarMenuButton
+                                            as-child
+                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
                                         >
                                             <Link
                                                 v-if="currentTeam"

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { Head, Link, router } from '@inertiajs/vue3';
+import { Search } from '@lucide/vue';
+import { ref, watch } from 'vue';
+import {
+    index,
+    show,
+} from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { index as search } from '@/actions/App/Http/Controllers/Channels/SearchController';
+import { Input } from '@/components/ui/input';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { getInitials } from '@/composables/useInitials';
+import { renderMessageBody } from '@/lib/messageBody';
+import type { MessageSearchResult } from '@/types';
+
+interface TeamData {
+    id: string;
+    name: string;
+    slug: string;
+}
+
+const props = defineProps<{
+    team: TeamData;
+    query: string;
+    results: MessageSearchResult[];
+}>();
+
+// Seed the box from the server-echoed query so a shared/reloaded search URL
+// stays in sync with what's rendered.
+const term = ref(props.query);
+
+// Debounce keystrokes into a single scoped reload that only refreshes the
+// results (and the echoed query), preserving the input's focus and caret.
+let debounce: ReturnType<typeof setTimeout> | null = null;
+
+watch(term, (value) => {
+    if (debounce) {
+        clearTimeout(debounce);
+    }
+
+    debounce = setTimeout(() => {
+        router.get(
+            search(props.team.slug).url,
+            { q: value },
+            {
+                preserveState: true,
+                preserveScroll: true,
+                replace: true,
+                only: ['results', 'query'],
+            },
+        );
+    }, 300);
+});
+
+function formatTimestamp(iso: string): string {
+    return new Date(iso).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+}
+
+function jumpHref(result: MessageSearchResult): string {
+    return show(
+        { team: props.team.slug, channel: result.channelSlug },
+        { query: { message: result.message.id } },
+    ).url;
+}
+</script>
+
+<template>
+    <Head title="Search messages" />
+
+    <header
+        class="flex h-12 shrink-0 items-center gap-2.5 border-b border-border px-5"
+    >
+        <SidebarTrigger
+            class="-ml-1.5 size-8 text-muted-foreground md:hidden"
+        />
+        <h1 class="text-[15px] font-semibold text-foreground">
+            Search messages
+        </h1>
+        <Link
+            :href="index(props.team.slug).url"
+            class="ml-auto text-[13px] text-muted-foreground hover:text-foreground"
+            >Back</Link
+        >
+    </header>
+
+    <div class="flex flex-1 justify-center overflow-y-auto px-6 pt-8">
+        <div class="w-full max-w-[640px]">
+            <div class="relative">
+                <Search
+                    class="absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden="true"
+                />
+                <Input
+                    v-model="term"
+                    type="search"
+                    placeholder="Search messages"
+                    aria-label="Search messages"
+                    autofocus
+                    class="h-[38px] rounded-[10px] bg-muted/40 pl-9"
+                />
+            </div>
+
+            <p
+                v-if="props.query === ''"
+                class="pt-16 text-center text-sm text-muted-foreground"
+            >
+                Search your channels for messages.
+            </p>
+
+            <p
+                v-else-if="props.results.length === 0"
+                data-test="search-empty"
+                class="pt-16 text-center text-sm text-muted-foreground"
+            >
+                No messages match &ldquo;{{ props.query }}&rdquo;.
+            </p>
+
+            <template v-else>
+                <p class="mt-4 mb-1 text-xs text-muted-foreground">
+                    {{ props.results.length }} result{{
+                        props.results.length === 1 ? '' : 's'
+                    }}
+                </p>
+
+                <ul>
+                    <li
+                        v-for="result in props.results"
+                        :key="result.message.id"
+                    >
+                        <Link
+                            :href="jumpHref(result)"
+                            data-test="search-result"
+                            class="flex gap-3 rounded-md border-b border-border/60 px-1 py-3 last:border-0 hover:bg-accent/40"
+                        >
+                            <div
+                                class="flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-primary/10 text-[12px] font-semibold text-primary select-none"
+                                aria-hidden="true"
+                            >
+                                {{ getInitials(result.message.user.name) }}
+                            </div>
+                            <div class="min-w-0 flex-1">
+                                <div
+                                    class="flex items-baseline gap-2 text-[13px]"
+                                >
+                                    <span class="font-semibold text-foreground">
+                                        {{ result.message.user.name }}
+                                    </span>
+                                    <span class="text-muted-foreground/70">
+                                        <span class="text-muted-foreground/50"
+                                            >#</span
+                                        >{{ result.channelName }}
+                                    </span>
+                                    <span
+                                        class="ml-auto shrink-0 text-[11px] text-muted-foreground/70"
+                                    >
+                                        {{
+                                            formatTimestamp(
+                                                result.message.createdAt,
+                                            )
+                                        }}
+                                    </span>
+                                </div>
+                                <p
+                                    class="mt-0.5 line-clamp-2 text-[14px] leading-[1.5] break-words text-foreground/90"
+                                >
+                                    <span
+                                        v-html="
+                                            renderMessageBody(
+                                                result.message.body,
+                                                result.message.mentions,
+                                            )
+                                        "
+                                    ></span>
+                                </p>
+                            </div>
+                        </Link>
+                    </li>
+                </ul>
+            </template>
+        </div>
+    </div>
+</template>

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -74,6 +74,7 @@ const props = defineProps<{
     canArchive: boolean;
     canManagePreferences: boolean;
     notificationLevels: NotificationLevelOption[];
+    jumpToMessageId?: string | null;
 }>();
 
 const page = usePage();
@@ -208,6 +209,30 @@ function scrollToBottom(): void {
     }
 }
 
+// The message to briefly highlight after a search jump. The server windows the
+// initial page so the target is loaded; we scroll it into view and clear the
+// highlight after a short beat.
+const highlightedMessageId = ref<string | null>(null);
+let highlightTimer: ReturnType<typeof setTimeout> | null = null;
+
+function jumpToMessage(id: string): void {
+    nextTick(() => {
+        document
+            .getElementById(`message-${id}`)
+            ?.scrollIntoView({ block: 'center' });
+
+        highlightedMessageId.value = id;
+
+        if (highlightTimer) {
+            clearTimeout(highlightTimer);
+        }
+
+        highlightTimer = setTimeout(() => {
+            highlightedMessageId.value = null;
+        }, 2000);
+    });
+}
+
 function appendLive(message: Message): void {
     const known =
         live.value.some((m) => m.clientUuid === message.clientUuid) ||
@@ -289,7 +314,22 @@ onMounted(() => {
     subscribe(props.channel.id);
     markRead();
     window.addEventListener('focus', markRead);
+
+    if (props.jumpToMessageId) {
+        jumpToMessage(props.jumpToMessageId);
+    }
 });
+
+// A jump to another result in the same already-open channel reuses this
+// component, so the channel-id watch won't fire; react to the target changing.
+watch(
+    () => props.jumpToMessageId,
+    (id) => {
+        if (id) {
+            jumpToMessage(id);
+        }
+    },
+);
 
 // Inertia may reuse this page component when navigating between channels; move
 // the subscription and reset per-channel state when the channel changes.
@@ -317,6 +357,10 @@ onBeforeUnmount(() => {
 
     if (markReadTimer) {
         clearTimeout(markReadTimer);
+    }
+
+    if (highlightTimer) {
+        clearTimeout(highlightTimer);
     }
 });
 
@@ -599,6 +643,7 @@ function archive(): void {
                     :current-user-id="currentUser.id"
                     :can-moderate="canModerate"
                     :online-ids="onlineIds"
+                    :highlight-message-id="highlightedMessageId"
                     @edit="editMessage"
                     @delete="deleteMessage"
                 />

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -32,3 +32,14 @@ export type MessagePage = {
     next_cursor: string | null;
     prev_cursor: string | null;
 };
+
+/**
+ * A single message-search match. Mirrors the `MessageSearchResultData` DTO:
+ * the matched message plus the channel it belongs to, for rendering the result
+ * row and building its jump-to-message link.
+ */
+export type MessageSearchResult = {
+    message: Message;
+    channelName: string;
+    channelSlug: string;
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Channels\ChannelController;
 use App\Http\Controllers\Channels\ChannelMemberController;
 use App\Http\Controllers\Channels\ChannelPreferenceController;
 use App\Http\Controllers\Channels\MessageController;
+use App\Http\Controllers\Channels\SearchController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Support\Facades\Route;
@@ -14,6 +15,7 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::get('t/{team}', [ChannelController::class, 'index'])->name('channels.index');
     Route::post('t/{team}/channels', [ChannelController::class, 'store'])->name('channels.store');
     Route::get('t/{team}/channels/browse', [ChannelController::class, 'browse'])->name('channels.browse');
+    Route::get('t/{team}/search', [SearchController::class, 'index'])->name('search');
     Route::get('t/{team}/c/{channel}', [ChannelController::class, 'show'])
         ->scopeBindings()
         ->name('channels.show');

--- a/tests/Feature/Channels/MessageSearchTest.php
+++ b/tests/Feature/Channels/MessageSearchTest.php
@@ -1,0 +1,219 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function searchTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and the given channel, returning them.
+ */
+function searchMember(Team $team, Channel $channel, ?string $name = null): User
+{
+    $user = User::factory()->create($name ? ['name' => $name] : []);
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+/**
+ * Hit the search endpoint for a team as the given user.
+ */
+function performSearch(User $user, Team $team, string $query): TestResponse
+{
+    return test()->actingAs($user)->get(route('search', ['team' => $team->slug, 'q' => $query]));
+}
+
+test('a member searches messages in their channels', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general, 'Ada Lovelace');
+    Message::factory()->for($general)->for($member)->create(['body' => 'the quokka danced at dawn']);
+    Message::factory()->for($general)->for($owner)->create(['body' => 'totally unrelated chatter']);
+
+    performSearch($member, $team, 'quokka')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('channels/Search')
+            ->where('query', 'quokka')
+            ->has('results', 1)
+            ->where('results.0.message.body', 'the quokka danced at dawn')
+            ->where('results.0.message.user.name', 'Ada Lovelace')
+            ->where('results.0.channelName', $general->name)
+            ->where('results.0.channelSlug', $general->slug)
+        );
+});
+
+test('search does not leak messages from channels the user is not a member of', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+    $private = Channel::factory()->for($team)->private()->create(['created_by' => $owner->id]);
+    Message::factory()->for($private)->for($owner)->create(['body' => 'secret zephyr plans']);
+
+    performSearch($member, $team, 'zephyr')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+});
+
+test('search does not leak messages from other teams the member also belongs to', function () {
+    [, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+
+    // A second team the member also belongs to, with a matching message in its
+    // own #general — must never surface when searching the first team.
+    $otherOwner = User::factory()->create();
+    $otherTeam = app(CreateTeam::class)->handle($otherOwner, 'Beta');
+    $otherGeneral = Channel::where('team_id', $otherTeam->id)->where('slug', 'general')->firstOrFail();
+    $otherTeam->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    Message::factory()->for($otherGeneral)->for($otherOwner)->create(['body' => 'crossteam zephyr note']);
+
+    performSearch($member, $team, 'zephyr')
+        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+});
+
+test('soft-deleted messages are excluded from search results', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+    $message = Message::factory()->for($general)->for($owner)->create(['body' => 'deletable zephyr note']);
+    $message->delete();
+
+    performSearch($member, $team, 'zephyr')
+        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+});
+
+test('editing a message changes what search matches', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+    $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original zephyr wording']);
+
+    $message->update(['body' => 'reworded qibble wording']);
+
+    performSearch($member, $team, 'zephyr')
+        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+    performSearch($member, $team, 'qibble')
+        ->assertInertia(fn (Assert $page) => $page->has('results', 1));
+});
+
+test('an empty query renders the page without touching the search engine', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+    Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr']);
+
+    performSearch($member, $team, '')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('channels/Search')
+            ->where('query', '')
+            ->has('results', 0)
+        );
+});
+
+test('a team member who belongs to no channel gets no results', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $loner = User::factory()->create();
+    $team->memberships()->create(['user_id' => $loner->id, 'role' => TeamRole::Member]);
+    // The observer joins new members to #general, so drop that membership to
+    // model a user who belongs to the team but no channel.
+    $loner->channels()->detach($general->id);
+    Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr']);
+
+    performSearch($loner, $team, 'zephyr')
+        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+});
+
+test('a non-member of the team cannot search it', function () {
+    [, $team] = searchTeamWithGeneral();
+    $outsider = User::factory()->create();
+
+    performSearch($outsider, $team, 'zephyr')->assertForbidden();
+});
+
+test('the search query cannot exceed 255 characters', function () {
+    [, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+
+    performSearch($member, $team, str_repeat('a', 256))
+        ->assertSessionHasErrors('q');
+});
+
+test('a jump windows the messages around the target with newer context below', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $messages = collect(range(1, 30))->map(
+        fn (int $i) => Message::factory()->for($general)->for($owner)->create(['body' => "message {$i}"])
+    );
+    $target = $messages[4]; // message 5
+
+    $this->actingAs($owner)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+        'message' => $target->id,
+    ]))->assertInertia(fn (Assert $page) => $page
+        ->where('jumpToMessageId', $target->id)
+        // 15 messages newer than the target cap the window (message 20), so the
+        // window is messages 1..20 newest-first and messages 21..30 are excluded.
+        ->has('messages.data', 20)
+        ->where('messages.data.0.body', 'message 20')
+    );
+});
+
+test('a jump to the newest message keeps it at the bottom of the window', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $messages = collect(range(1, 5))->map(
+        fn (int $i) => Message::factory()->for($general)->for($owner)->create(['body' => "message {$i}"])
+    );
+    $target = $messages[4]; // message 5, the newest
+
+    $this->actingAs($owner)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+        'message' => $target->id,
+    ]))->assertInertia(fn (Assert $page) => $page
+        ->where('jumpToMessageId', $target->id)
+        ->has('messages.data', 5)
+        ->where('messages.data.0.body', 'message 5')
+    );
+});
+
+test('a message param from another channel is ignored', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    Message::factory()->for($general)->for($owner)->create(['body' => 'only message here']);
+    $other = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+    $foreign = Message::factory()->for($other)->for($owner)->create(['body' => 'elsewhere']);
+
+    $this->actingAs($owner)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+        'message' => $foreign->id,
+    ]))->assertInertia(fn (Assert $page) => $page
+        ->where('jumpToMessageId', null)
+        ->has('messages.data', 1)
+    );
+});
+
+test('soft-deleted messages report that they should not be searchable', function () {
+    $message = Message::factory()->create();
+
+    expect($message->shouldBeSearchable())->toBeTrue();
+
+    $message->delete();
+
+    expect($message->shouldBeSearchable())->toBeFalse();
+});


### PR DESCRIPTION
Closes #12.

## What
Full-text message search backed by Laravel Scout + Meilisearch, scoped to the current team and ACL-filtered to the channels the user belongs to.

## Backend
- Install `laravel/scout` + `meilisearch/meilisearch-php`; publish `config/scout.php` with queued indexing and `channel_id` as the filterable attribute (`team_id`/`user_id` indexed for future faceting).
- `Message` is `Searchable`: `toSearchableArray` (body, channel_id, user_id, derived `team_id`, created_at) and `shouldBeSearchable()` keeps soft-deleted rows out. Edits reindex automatically on `saved`.
- `SearchMessages` action holds the ACL query — `whereIn('channel_id', <user's channels in this team>)` enforces both team scope and membership, so private channels never leak. `SearchController` shapes results into `MessageSearchResultData`; `SearchMessagesRequest` validates `q`; route `t/{team}/search` (name `search`).
- **Jump-to-message**: `ChannelController@show` accepts `?message=`, validates it belongs to the channel, and windows the initial page centered on the target (newer context below + history above).

## Frontend
- New `channels/Search.vue` (debounced search box + results list with jump links), a "Search messages" sidebar entry, `MessageSearchResult` type, and per-message DOM anchors + transient highlight in `MessageList.vue` / `Show.vue`.

## Tests
`tests/Feature/Channels/MessageSearchTest.php` (13 tests, TDD with the `collection` Scout driver): member search, private-channel leak, cross-team leak, soft-delete exclusion, edit-changes-match, empty query, zero-channel member, non-member 403, query-length validation, and the jump-window cases.

## Gates
Pint, PHPStan, `Total: 100.0 %`, and frontend lint/format/types/build all pass.

## Notes
- `CLAUDE.md` / `boost.json` / `.claude/skills/*` changes are `boost:update` refreshing guidelines after the Scout install.
- Deploy: run `php artisan scout:sync-index-settings` and `php artisan scout:import "App\Models\Message"` on environments with a live Meilisearch.

## Out of scope (v1)
- Scrolling past the loaded newer-context window after a jump.
- Command-palette UI (the endpoint is built UI-agnostic so it can be reused later).