### PR TITLE
feat(messages): inline quoted replies (#27)

### DIFF
--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -19,18 +19,22 @@ class PostMessage
      * to the row that already exists instead of creating a duplicate. Only a
      * genuinely new message parses its mentions and broadcasts, keeping the retry
      * path side-effect free.
+     *
+     * When `$replyToId` is set the message renders as an inline quote of that
+     * parent; the request layer has already checked it points at a live message
+     * in the same channel.
      */
-    public function handle(Channel $channel, User $author, string $body, string $clientUuid): Message
+    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null): Message
     {
         $message = $channel->messages()->firstOrCreate(
             ['client_uuid' => $clientUuid],
-            ['user_id' => $author->id, 'body' => $body],
+            ['user_id' => $author->id, 'body' => $body, 'reply_to_id' => $replyToId],
         );
 
         if ($message->wasRecentlyCreated) {
             $this->syncMentions->handle($channel, $message);
             $message->setRelation('user', $author);
-            $message->load('mentionedUsers');
+            $message->load(['mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers']);
             MessageSent::dispatch($channel, MessageData::fromMessage($message));
         }
 

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -44,6 +44,6 @@ class SearchMessages
             ->whereIn('channel_id', $channelIds)
             ->take(self::RESULT_LIMIT)
             ->get()
-            ->load(['user', 'channel', 'mentionedUsers']);
+            ->load(['user', 'channel', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers']);
     }
 }

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -22,6 +22,7 @@ class MessageData extends Data
         public ?string $editedAt,
         public bool $isDeleted,
         public array $mentions,
+        public ?MessageReplyData $replyTo,
     ) {}
 
     /**
@@ -30,6 +31,11 @@ class MessageData extends Data
      * The message's `user` and `mentionedUsers` relations should be eager-loaded
      * to avoid N+1 queries. A soft-deleted message renders as a tombstone: its
      * body and mentions are never sent to the client, only the `isDeleted` flag.
+     *
+     * The `replyTo` relation is expected to be eager-loaded (with its own `user`
+     * and `mentionedUsers`) when the message quotes a parent; a deleted parent
+     * still resolves so the quote can render a stub. A tombstone carries no
+     * quote of its own — a deleted message shows only its own placeholder.
      */
     public static function fromMessage(Message $message): self
     {
@@ -44,6 +50,9 @@ class MessageData extends Data
             editedAt: $message->edited_at?->toIso8601String(),
             isDeleted: $isDeleted,
             mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn (User $user) => MentionData::fromUser($user))->all(),
+            replyTo: ! $isDeleted && $message->replyTo !== null
+                ? MessageReplyData::fromMessage($message->replyTo)
+                : null,
         );
     }
 }

--- a/app/Data/MessageReplyData.php
+++ b/app/Data/MessageReplyData.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\Message;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class MessageReplyData extends Data
+{
+    /**
+     * @param  array<int, MentionData>  $mentions
+     */
+    public function __construct(
+        public string $id,
+        public string $body,
+        public string $authorName,
+        public bool $isDeleted,
+        public array $mentions,
+    ) {}
+
+    /**
+     * Build the compact quote preview for a parent message.
+     *
+     * This is intentionally flat — it carries no nested `replyTo` — so a quote
+     * never recurses into the chain of messages it answers. A soft-deleted
+     * parent blanks its body and mentions, leaving only the `isDeleted` flag so
+     * the client can render a "message deleted" stub.
+     */
+    public static function fromMessage(Message $message): self
+    {
+        $isDeleted = $message->trashed();
+
+        return new self(
+            id: $message->id,
+            body: $isDeleted ? '' : $message->body,
+            authorName: $message->user->name,
+            isDeleted: $isDeleted,
+            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn ($user) => MentionData::fromUser($user))->all(),
+        );
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -110,7 +110,7 @@ class ChannelController extends Controller
             // "message deleted" tombstone in place; MessageData blanks their body.
             'messages' => Inertia::scroll(fn () => $channel->messages()
                 ->withTrashed()
-                ->with(['user', 'mentionedUsers'])
+                ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers'])
                 ->when($windowCeilingId, fn ($query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
                 ->cursorPaginate(50)

--- a/app/Http/Controllers/Channels/MessageController.php
+++ b/app/Http/Controllers/Channels/MessageController.php
@@ -26,6 +26,7 @@ class MessageController extends Controller
             author: $request->user(),
             body: $request->validated('body'),
             clientUuid: $request->validated('client_uuid'),
+            replyToId: $request->validated('reply_to_id'),
         );
 
         return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);

--- a/app/Http/Requests/Channels/PostMessageRequest.php
+++ b/app/Http/Requests/Channels/PostMessageRequest.php
@@ -6,6 +6,7 @@ use App\Models\Channel;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
 
 class PostMessageRequest extends FormRequest
 {
@@ -37,6 +38,16 @@ class PostMessageRequest extends FormRequest
         return [
             'body' => ['required', 'string', 'max:8000'],
             'client_uuid' => ['required', 'uuid'],
+            // An inline reply must quote a live (non-deleted) message that
+            // belongs to this same channel; a cross-channel or deleted target
+            // is rejected rather than silently dropped.
+            'reply_to_id' => [
+                'nullable',
+                'uuid',
+                Rule::exists('messages', 'id')
+                    ->where('channel_id', $this->channel()->id)
+                    ->whereNull('deleted_at'),
+            ],
         ];
     }
 

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -19,6 +19,7 @@ use Laravel\Scout\Searchable;
  * @property string $channel_id
  * @property string $user_id
  * @property string $client_uuid
+ * @property string|null $reply_to_id
  * @property string $body
  * @property Carbon|null $edited_at
  * @property Carbon|null $deleted_at
@@ -26,9 +27,10 @@ use Laravel\Scout\Searchable;
  * @property Carbon|null $updated_at
  * @property-read Channel $channel
  * @property-read User $user
+ * @property-read Message|null $replyTo
  * @property-read Collection<int, User> $mentionedUsers
  */
-#[Fillable(['channel_id', 'user_id', 'client_uuid', 'body', 'edited_at'])]
+#[Fillable(['channel_id', 'user_id', 'client_uuid', 'reply_to_id', 'body', 'edited_at'])]
 class Message extends Model
 {
     /** @use HasFactory<MessageFactory> */
@@ -52,6 +54,19 @@ class Message extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the parent message this one quotes inline, if any.
+     *
+     * A soft-deleted parent is still resolved (withTrashed) so the client can
+     * render a "message deleted" stub in the quote rather than dropping it.
+     *
+     * @return BelongsTo<Message, $this>
+     */
+    public function replyTo(): BelongsTo
+    {
+        return $this->belongsTo(Message::class, 'reply_to_id')->withTrashed();
     }
 
     /**

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -37,4 +37,14 @@ class MessageFactory extends Factory
             'edited_at' => now(),
         ]);
     }
+
+    /**
+     * Indicate that the message quotes another message inline.
+     */
+    public function replyTo(Message $parent): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'reply_to_id' => $parent->id,
+        ]);
+    }
 }

--- a/database/migrations/2026_07_09_030947_add_reply_to_id_to_messages_table.php
+++ b/database/migrations/2026_07_09_030947_add_reply_to_id_to_messages_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            // The parent this message quotes inline, or null for a normal
+            // message. A quoted parent that is later force-deleted nulls the
+            // reference; a soft-deleted parent keeps it so the client renders a
+            // "message deleted" stub in the quote.
+            $table->foreignUuid('reply_to_id')
+                ->nullable()
+                ->after('client_uuid')
+                ->constrained('messages')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('reply_to_id');
+        });
+    }
+};

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1,24 +1,38 @@
 <script setup lang="ts">
-import { ArrowUp, Plus } from '@lucide/vue';
-import { computed, nextTick, ref } from 'vue';
+import { ArrowUp, Plus, X } from '@lucide/vue';
+import { computed, nextTick, ref, watch } from 'vue';
+import MessageQuote from '@/components/MessageQuote.vue';
 import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
-import type { Mention } from '@/types';
+import type { Mention, Message } from '@/types';
 
 const props = defineProps<{
     channelName: string;
     members: Mention[];
+    replyTarget?: Message | null;
 }>();
 
 const emit = defineEmits<{
     send: [body: string, mentions: Mention[]];
     typing: [];
+    cancelReply: [];
 }>();
 
 const { getInitials } = useInitials();
 
 const body = ref('');
 const textarea = ref<HTMLTextAreaElement | null>(null);
+
+// Focus the composer whenever a reply is started so the user can type straight
+// away without reaching for the mouse.
+watch(
+    () => props.replyTarget,
+    (target) => {
+        if (target) {
+            nextTick(() => textarea.value?.focus());
+        }
+    },
+);
 
 // Well-formed mention token: `@[Display Name](user-id)`. The parser on the
 // server resolves the id; here it lets us collect the mentions being sent and
@@ -192,6 +206,14 @@ function onKeydown(event: KeyboardEvent): void {
         }
     }
 
+    // With the mention menu closed, Escape dismisses the active reply context.
+    if (event.key === 'Escape' && props.replyTarget) {
+        event.preventDefault();
+        emit('cancelReply');
+
+        return;
+    }
+
     if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault();
         submit();
@@ -232,7 +254,31 @@ function onKeydown(event: KeyboardEvent): void {
             </ul>
 
             <div
+                v-if="props.replyTarget"
+                data-test="reply-preview"
+                class="flex items-center gap-2 rounded-t-xl border border-b-0 border-input bg-muted/40 px-3 py-1.5"
+            >
+                <span class="min-w-0 flex-1">
+                    <MessageQuote
+                        :author-name="props.replyTarget.user.name"
+                        :body="props.replyTarget.body"
+                        :is-deleted="props.replyTarget.isDeleted"
+                    />
+                </span>
+                <button
+                    type="button"
+                    data-test="reply-preview-dismiss"
+                    aria-label="Cancel reply"
+                    class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    @click="emit('cancelReply')"
+                >
+                    <X class="size-3.5" />
+                </button>
+            </div>
+
+            <div
                 class="rounded-xl border border-input bg-background p-3 pb-2 focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/20"
+                :class="props.replyTarget ? 'rounded-t-none' : ''"
             >
                 <textarea
                     ref="textarea"

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { Pencil, Trash2 } from '@lucide/vue';
+import { CornerUpLeft, Pencil, Trash2 } from '@lucide/vue';
 import { computed, nextTick, ref } from 'vue';
+import MessageQuote from '@/components/MessageQuote.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -27,6 +28,8 @@ const props = defineProps<{
 const emit = defineEmits<{
     edit: [message: Message, body: string];
     delete: [message: Message];
+    reply: [message: Message];
+    jump: [messageId: string];
 }>();
 
 const { getInitials } = useInitials();
@@ -159,6 +162,12 @@ function canDelete(message: Message): boolean {
     );
 }
 
+// Anyone can reply to any live message; a pending or deleted row has no stable
+// target to quote yet.
+function canReply(message: Message): boolean {
+    return !message.isDeleted && !isPending(message);
+}
+
 // The message currently being edited inline, and its working draft.
 const editingId = ref<string | null>(null);
 const editDraft = ref('');
@@ -276,6 +285,24 @@ function confirmDelete(): void {
                                 : '',
                         ]"
                     >
+                        <button
+                            v-if="
+                                message.replyTo &&
+                                !message.isDeleted &&
+                                editingId !== message.id
+                            "
+                            type="button"
+                            data-test="message-quote"
+                            class="mt-0.5 flex max-w-full items-center rounded pr-1 text-left hover:opacity-80"
+                            @click="emit('jump', message.replyTo.id)"
+                        >
+                            <MessageQuote
+                                :author-name="message.replyTo.authorName"
+                                :body="message.replyTo.body"
+                                :is-deleted="message.replyTo.isDeleted"
+                            />
+                        </button>
+
                         <p
                             v-if="message.isDeleted"
                             :data-test="'message-tombstone'"
@@ -342,10 +369,22 @@ function confirmDelete(): void {
                         <div
                             v-if="
                                 editingId !== message.id &&
-                                (canEdit(message) || canDelete(message))
+                                (canReply(message) ||
+                                    canEdit(message) ||
+                                    canDelete(message))
                             "
                             class="absolute -top-3 right-2 hidden items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm group-hover/message:flex"
                         >
+                            <button
+                                v-if="canReply(message)"
+                                type="button"
+                                :data-test="'message-reply'"
+                                aria-label="Reply to message"
+                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                @click="emit('reply', message)"
+                            >
+                                <CornerUpLeft class="size-3.5" />
+                            </button>
                             <button
                                 v-if="canEdit(message)"
                                 type="button"

--- a/resources/js/components/MessageQuote.vue
+++ b/resources/js/components/MessageQuote.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { CornerUpLeft } from '@lucide/vue';
+import { computed } from 'vue';
+import { messageBodyPreview } from '@/lib/messageBody';
+
+const props = defineProps<{
+    authorName: string;
+    body: string;
+    isDeleted: boolean;
+}>();
+
+// A one-line, plain-text snippet of the quoted body; empty for a deleted parent,
+// whose body is never sent to the client.
+const preview = computed(() =>
+    props.isDeleted ? '' : messageBodyPreview(props.body),
+);
+</script>
+
+<template>
+    <span class="flex min-w-0 items-center gap-1.5 text-[12.5px] leading-tight">
+        <CornerUpLeft
+            class="size-3 shrink-0 text-muted-foreground/60"
+            aria-hidden="true"
+        />
+        <span
+            v-if="isDeleted"
+            data-test="quote-deleted"
+            class="truncate text-muted-foreground/70 italic"
+        >
+            Original message was deleted
+        </span>
+        <template v-else>
+            <span class="shrink-0 font-semibold text-muted-foreground">{{
+                authorName
+            }}</span>
+            <span class="truncate text-muted-foreground/80">{{ preview }}</span>
+        </template>
+    </span>
+</template>

--- a/resources/js/lib/messageBody.ts
+++ b/resources/js/lib/messageBody.ts
@@ -58,3 +58,16 @@ export function renderMessageBody(
 
     return linked.replace(/\n/g, '<br>');
 }
+
+/**
+ * Flatten a raw message body to a single line of plain text for a compact quote
+ * preview: mention tokens collapse to their `@Name` text and runs of whitespace
+ * (including newlines) become single spaces. Returned as plain text, never HTML,
+ * so it is safe to render inside an interactive quote without markup injection.
+ */
+export function messageBodyPreview(body: string): string {
+    return body
+        .replace(MENTION_PATTERN, (_match, name: string) => `@${name}`)
+        .replace(/\s+/g, ' ')
+        .trim();
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -343,6 +343,7 @@ watch(
         live.value = [];
         pending.value = [];
         patches.value = new Map();
+        replyTarget.value = null;
         typing.reset();
         notificationLevel.value = props.channel.notificationLevel;
         muted.value = props.channel.muted;
@@ -364,8 +365,20 @@ onBeforeUnmount(() => {
     }
 });
 
+// The message the composer is currently quoting, or null for a normal send.
+const replyTarget = ref<Message | null>(null);
+
+function startReply(message: Message): void {
+    replyTarget.value = message;
+}
+
+function cancelReply(): void {
+    replyTarget.value = null;
+}
+
 function send(body: string, mentions: Mention[]): void {
     const clientUuid = crypto.randomUUID();
+    const target = replyTarget.value;
 
     pending.value.push({
         id: clientUuid,
@@ -376,14 +389,27 @@ function send(body: string, mentions: Mention[]): void {
         editedAt: null,
         isDeleted: false,
         mentions,
+        // Mirror the parent as a compact quote so the optimistic row renders the
+        // reference immediately; the server echo replaces it with the canonical
+        // copy keyed on the same client uuid.
+        replyTo: target
+            ? {
+                  id: target.id,
+                  body: target.body,
+                  authorName: target.user.name,
+                  isDeleted: target.isDeleted,
+                  mentions: target.mentions,
+              }
+            : null,
     });
 
+    cancelReply();
     nextTick(scrollToBottom);
 
     router.post(
         storeMessage({ team: props.team.slug, channel: props.channel.slug })
             .url,
-        { body, client_uuid: clientUuid },
+        { body, client_uuid: clientUuid, reply_to_id: target?.id ?? null },
         {
             preserveScroll: true,
             onError: () => {
@@ -646,6 +672,8 @@ function archive(): void {
                     :highlight-message-id="highlightedMessageId"
                     @edit="editMessage"
                     @delete="deleteMessage"
+                    @reply="startReply"
+                    @jump="jumpToMessage"
                 />
             </InfiniteScroll>
 
@@ -683,8 +711,10 @@ function archive(): void {
             <MessageComposer
                 :channel-name="props.channel.name"
                 :members="mentionableMembers"
+                :reply-target="replyTarget"
                 @send="send"
                 @typing="onTyping"
+                @cancel-reply="cancelReply"
             />
         </template>
     </div>

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -12,6 +12,19 @@ export type Mention = {
     name: string;
 };
 
+/**
+ * A compact quote of the parent message an inline reply answers. Mirrors the
+ * `MessageReplyData` DTO: flat (never nested) so a quote can't recurse, with
+ * the body and mentions blanked when the parent has been deleted.
+ */
+export type MessageReply = {
+    id: string;
+    body: string;
+    authorName: string;
+    isDeleted: boolean;
+    mentions: Mention[];
+};
+
 export type Message = {
     id: string;
     clientUuid: string;
@@ -21,6 +34,7 @@ export type Message = {
     editedAt: string | null;
     isDeleted: boolean;
     mentions: Mention[];
+    replyTo: MessageReply | null;
 };
 
 /**

--- a/tests/Feature/Channels/InlineReplyTest.php
+++ b/tests/Feature/Channels/InlineReplyTest.php
@@ -1,0 +1,195 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Events\MessageSent;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function replyTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+test('a message can reply to another message in the same channel', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'parent']);
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'a reply',
+            'client_uuid' => $clientUuid,
+            'reply_to_id' => $parent->id,
+        ])
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $this->assertDatabaseHas('messages', [
+        'client_uuid' => $clientUuid,
+        'body' => 'a reply',
+        'reply_to_id' => $parent->id,
+    ]);
+});
+
+test('a message without a reply target persists a null reply reference', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'plain message',
+            'client_uuid' => $clientUuid,
+        ]);
+
+    $this->assertDatabaseHas('messages', [
+        'client_uuid' => $clientUuid,
+        'reply_to_id' => null,
+    ]);
+});
+
+test('the reply target must belong to the same channel', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $other = Channel::factory()->for($team)->create();
+    $other->channelMembers()->create(['user_id' => $owner->id]);
+    $foreign = Message::factory()->for($other)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'cross-channel reply',
+            'client_uuid' => (string) Str::uuid7(),
+            'reply_to_id' => $foreign->id,
+        ])
+        ->assertInvalid(['reply_to_id']);
+
+    expect(Message::where('channel_id', $general->id)->count())->toBe(0);
+});
+
+test('a reply cannot target a deleted message', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create();
+    $parent->delete();
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'reply to a ghost',
+            'client_uuid' => (string) Str::uuid7(),
+            'reply_to_id' => $parent->id,
+        ])
+        ->assertInvalid(['reply_to_id']);
+});
+
+test('a non-uuid reply target is rejected', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'bad target',
+            'client_uuid' => (string) Str::uuid7(),
+            'reply_to_id' => 'not-a-uuid',
+        ])
+        ->assertInvalid(['reply_to_id']);
+});
+
+test('the channel page renders a reply as a compact quote of its parent', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'the original']);
+    Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'the answer']);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            // Newest-first: the reply is data.0, its parent data.1.
+            ->where('messages.data.0.body', 'the answer')
+            ->where('messages.data.0.replyTo.id', $parent->id)
+            ->where('messages.data.0.replyTo.body', 'the original')
+            ->where('messages.data.0.replyTo.authorName', $owner->name)
+            ->where('messages.data.0.replyTo.isDeleted', false)
+            ->where('messages.data.1.replyTo', null)
+        );
+});
+
+test('a reply to a deleted parent renders a deleted quote stub with a blanked body', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'secret original']);
+    Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'still here']);
+    $parent->delete();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('messages.data.0.body', 'still here')
+            ->where('messages.data.0.replyTo.id', $parent->id)
+            ->where('messages.data.0.replyTo.isDeleted', true)
+            ->where('messages.data.0.replyTo.body', '')
+        );
+});
+
+test('a deleted reply carries no quote of its own', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
+    $reply = Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'answer']);
+    $reply->delete();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('messages.data.0.isDeleted', true)
+            ->where('messages.data.0.replyTo', null)
+        );
+});
+
+test('posting a reply broadcasts the parent quote in the MessageSent payload', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'parent body']);
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)->post(route('channels.messages.store', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]), [
+        'body' => 'broadcast reply',
+        'client_uuid' => $clientUuid,
+        'reply_to_id' => $parent->id,
+    ]);
+
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($parent) {
+        $payload = $event->message->toArray();
+
+        return $payload['replyTo']['id'] === $parent->id
+            && $payload['replyTo']['body'] === 'parent body';
+    });
+});
+
+test('the reply reference survives an idempotent resend', function () {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create();
+    $clientUuid = (string) Str::uuid7();
+
+    $payload = [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ];
+
+    $body = ['body' => 'once', 'client_uuid' => $clientUuid, 'reply_to_id' => $parent->id];
+
+    $this->actingAs($owner)->post(route('channels.messages.store', $payload), $body);
+    $this->actingAs($owner)->post(route('channels.messages.store', $payload), $body);
+
+    expect(Message::where('client_uuid', $clientUuid)->count())->toBe(1)
+        ->and(Message::where('client_uuid', $clientUuid)->first()->reply_to_id)->toBe($parent->id);
+});


### PR DESCRIPTION
Closes #27.

## What
Adds lightweight **inline quoted replies** — a member can reply to a specific message and the reply renders in the normal channel timeline with a compact, clickable quote of the message it answers. Deliberately **not** a threaded side-panel: no thread view, no reply counts, just a reference to one parent message.

## How it works
**Backend**
- Migration adds `messages.reply_to_id`, a nullable self-reference (`nullOnDelete`). A soft-deleted parent keeps the reference so the quote can render a "deleted" stub; a force-deleted parent nulls it.
- `Message::replyTo()` resolves the parent `withTrashed()`.
- `MessageReplyData` — a flat, **non-recursive** quote DTO (a quote never nests another quote) carried as `replyTo` on `MessageData`. A deleted parent blanks its body/mentions, leaving only `isDeleted`.
- `PostMessageRequest` validates `reply_to_id` points at a **live message in the same channel** (cross-channel / deleted / non-uuid targets rejected).
- `PostMessage` persists the reference and broadcasts it on the existing `MessageSent` payload; eager-loading added in the channel show + search queries.

**Frontend**
- `MessageQuote.vue` — shared, presentational compact quote (plain-text preview via a new `messageBodyPreview` helper, so it's safe inside a clickable button).
- Hover **Reply** affordance on each live message → dismissible quoted preview above the composer (Esc or ✕ to cancel).
- Sent reply renders the inline quote; clicking it scrolls to / highlights the parent when loaded, otherwise shows a deleted stub.
- Reuses the existing realtime + optimistic-send pipeline (keyed on `client_uuid`); the optimistic row mirrors the parent quote immediately.

## Acceptance criteria
- [x] Reply affordance on each message; selecting it shows a dismissible quoted preview in the composer
- [x] Sent reply persists a reference to the parent and renders a compact inline quote
- [x] Clicking the quote scrolls to / highlights the parent when present; deleted stub otherwise
- [x] Realtime + optimistic send behave like normal messages
- [x] Test coverage for the reply reference (persistence, validation, rendering, broadcast)

## Testing
- New `InlineReplyTest` (10 tests) covers persistence, same-channel/deleted/non-uuid validation, quote rendering, deleted-parent stub, deleted-reply, broadcast payload, and idempotent resend.
- Full gate green: `composer test` → **Total: 100.0 %**; lint / types / build all pass.