### PR TITLE
feat(threads): Slack-style threaded replies (#30)

### DIFF
--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -4,6 +4,7 @@ namespace App\Actions\Channels;
 
 use App\Data\MessageData;
 use App\Events\MessageSent;
+use App\Events\MessageUpdated;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\User;
@@ -21,14 +22,22 @@ class PostMessage
      * path side-effect free.
      *
      * When `$replyToId` is set the message renders as an inline quote of that
-     * parent; the request layer has already checked it points at a live message
-     * in the same channel.
+     * parent. When `$threadRootId` is set the message is a thread reply: it stays
+     * out of the main timeline unless `$sentToChannel` is true, and it bumps the
+     * root's denormalized reply count / last-reply time. The request layer has
+     * already checked both references point at live messages in this channel.
      */
-    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null): Message
+    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null, ?string $threadRootId = null, bool $sentToChannel = false): Message
     {
         $message = $channel->messages()->firstOrCreate(
             ['client_uuid' => $clientUuid],
-            ['user_id' => $author->id, 'body' => $body, 'reply_to_id' => $replyToId],
+            [
+                'user_id' => $author->id,
+                'body' => $body,
+                'reply_to_id' => $replyToId,
+                'thread_root_id' => $threadRootId,
+                'sent_to_channel' => $threadRootId !== null && $sentToChannel,
+            ],
         );
 
         if ($message->wasRecentlyCreated) {
@@ -36,8 +45,25 @@ class PostMessage
             $message->setRelation('user', $author);
             $message->load(['mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers']);
             MessageSent::dispatch($channel, MessageData::fromMessage($message));
+
+            if ($threadRootId !== null) {
+                $this->bumpThreadRoot($channel, $threadRootId);
+            }
         }
 
         return $message;
+    }
+
+    /**
+     * Advance the root's reply aggregates and broadcast the fresh count so open
+     * timelines patch the root's "N replies" affordance live.
+     */
+    private function bumpThreadRoot(Channel $channel, string $threadRootId): void
+    {
+        $root = $channel->messages()->withTrashed()->findOrFail($threadRootId);
+        $root->forceFill(['reply_count' => $root->reply_count + 1, 'last_reply_at' => now()])->save();
+
+        $root->load(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants']);
+        MessageUpdated::dispatch($channel, MessageData::fromMessage($root));
     }
 }

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -12,6 +12,7 @@ class MessageData extends Data
 {
     /**
      * @param  array<int, MentionData>  $mentions
+     * @param  array<int, MentionData>  $threadParticipants
      */
     public function __construct(
         public string $id,
@@ -23,6 +24,11 @@ class MessageData extends Data
         public bool $isDeleted,
         public array $mentions,
         public ?MessageReplyData $replyTo,
+        public ?string $threadRootId,
+        public bool $sentToChannel,
+        public int $threadReplyCount,
+        public ?string $threadLastReplyAt,
+        public array $threadParticipants,
     ) {}
 
     /**
@@ -36,6 +42,11 @@ class MessageData extends Data
      * and `mentionedUsers`) when the message quotes a parent; a deleted parent
      * still resolves so the quote can render a stub. A tombstone carries no
      * quote of its own — a deleted message shows only its own placeholder.
+     *
+     * Thread aggregates (`threadReplyCount`, `threadLastReplyAt`,
+     * `threadParticipants`) are structural, so they survive a soft delete — a
+     * deleted root still shows its "N replies" affordance. `threadParticipants`
+     * resolves from the eager-loaded relation when present, empty otherwise.
      */
     public static function fromMessage(Message $message): self
     {
@@ -53,6 +64,13 @@ class MessageData extends Data
             replyTo: ! $isDeleted && $message->replyTo !== null
                 ? MessageReplyData::fromMessage($message->replyTo)
                 : null,
+            threadRootId: $message->thread_root_id,
+            sentToChannel: $message->sent_to_channel,
+            threadReplyCount: $message->reply_count,
+            threadLastReplyAt: $message->last_reply_at?->toIso8601String(),
+            threadParticipants: $message->relationLoaded('threadParticipants')
+                ? $message->threadParticipants->map(fn (User $user) => MentionData::fromUser($user))->all()
+                : [],
         );
     }
 }

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -101,6 +101,11 @@ class ChannelController extends Controller
             // The message the client should scroll to and highlight on load, or
             // null for a normal channel visit.
             'jumpToMessageId' => $jumpToMessageId,
+            // The open thread (root + its replies), resolved from the `?thread=`
+            // query param, or null for a normal visit. The client opens a thread
+            // with a partial reload of just this prop; on a full visit the closure
+            // returns null cheaply when no thread is requested.
+            'thread' => fn () => $this->threadPayload($request, $channel),
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),
@@ -110,12 +115,56 @@ class ChannelController extends Controller
             // "message deleted" tombstone in place; MessageData blanks their body.
             'messages' => Inertia::scroll(fn () => $channel->messages()
                 ->withTrashed()
-                ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers'])
+                ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
+                // Thread replies live in the thread view, not the main timeline —
+                // except a reply explicitly "also sent to channel".
+                ->where(fn ($query) => $query->whereNull('thread_root_id')->orWhere('sent_to_channel', true))
                 ->when($windowCeilingId, fn ($query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
                 ->cursorPaginate(50)
                 ->through(fn (Message $message) => MessageData::fromMessage($message))),
         ]);
+    }
+
+    /**
+     * Resolve the open thread from the `?thread=` query param.
+     *
+     * Returns the root message plus its replies (oldest first, tombstones
+     * included) when the param names a live root in this channel, or null when
+     * it is absent or points elsewhere. The eager-load set mirrors the main
+     * timeline so replies render quotes and thread affordances identically.
+     *
+     * @return array{root: MessageData, replies: array<int, MessageData>}|null
+     */
+    private function threadPayload(Request $request, Channel $channel): ?array
+    {
+        $rootId = $request->query('thread');
+
+        if (! is_string($rootId) || $rootId === '') {
+            return null;
+        }
+
+        $root = $channel->messages()
+            ->whereNull('thread_root_id')
+            ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
+            ->find($rootId);
+
+        if ($root === null) {
+            return null;
+        }
+
+        $replies = $root->threadReplies()
+            ->withTrashed()
+            ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers'])
+            ->orderBy('id')
+            ->get()
+            ->map(fn (Message $message) => MessageData::fromMessage($message))
+            ->all();
+
+        return [
+            'root' => MessageData::fromMessage($root),
+            'replies' => $replies,
+        ];
     }
 
     /**

--- a/app/Http/Controllers/Channels/MessageController.php
+++ b/app/Http/Controllers/Channels/MessageController.php
@@ -27,6 +27,8 @@ class MessageController extends Controller
             body: $request->validated('body'),
             clientUuid: $request->validated('client_uuid'),
             replyToId: $request->validated('reply_to_id'),
+            threadRootId: $request->validated('thread_root_id'),
+            sentToChannel: $request->boolean('sent_to_channel'),
         );
 
         return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -76,7 +76,11 @@ class HandleInertiaRequests extends Middleware
             ->whereNull('channels.archived_at')
             ->select('channels.*')
             ->addSelect(['channel_members.muted', 'channel_members.notification_level'])
-            ->selectSub($this->unreadMessages($user), 'unread_count')
+            // Thread-only replies stay out of the plain unread badge (they live
+            // in the thread view), but a mention anywhere — including inside a
+            // thread — still badges the channel.
+            ->selectSub($this->unreadMessages($user)
+                ->where(fn (Builder $query) => $query->whereNull('messages.thread_root_id')->orWhere('messages.sent_to_channel', true)), 'unread_count')
             ->selectSub($this->unreadMessages($user)->whereHas('mentionedUsers', fn ($query) => $query->whereKey($user->id)), 'mention_count')
             ->orderBy('name')
             ->get();

--- a/app/Http/Requests/Channels/PostMessageRequest.php
+++ b/app/Http/Requests/Channels/PostMessageRequest.php
@@ -25,6 +25,7 @@ class PostMessageRequest extends FormRequest
     {
         $this->merge([
             'body' => trim((string) $this->input('body')),
+            'sent_to_channel' => $this->boolean('sent_to_channel'),
         ]);
     }
 
@@ -48,6 +49,20 @@ class PostMessageRequest extends FormRequest
                     ->where('channel_id', $this->channel()->id)
                     ->whereNull('deleted_at'),
             ],
+            // A thread reply must target a live root message in this same
+            // channel. Requiring the target's own thread_root_id to be null keeps
+            // threads one level deep — you reply to a root, never to a reply.
+            'thread_root_id' => [
+                'nullable',
+                'uuid',
+                Rule::exists('messages', 'id')
+                    ->where('channel_id', $this->channel()->id)
+                    ->whereNull('deleted_at')
+                    ->whereNull('thread_root_id'),
+            ],
+            // Only meaningful alongside thread_root_id; surfaces the reply in the
+            // main timeline in addition to the thread.
+            'sent_to_channel' => ['boolean'],
         ];
     }
 

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Laravel\Scout\Searchable;
@@ -20,6 +21,10 @@ use Laravel\Scout\Searchable;
  * @property string $user_id
  * @property string $client_uuid
  * @property string|null $reply_to_id
+ * @property string|null $thread_root_id
+ * @property bool $sent_to_channel
+ * @property int $reply_count
+ * @property Carbon|null $last_reply_at
  * @property string $body
  * @property Carbon|null $edited_at
  * @property Carbon|null $deleted_at
@@ -28,13 +33,28 @@ use Laravel\Scout\Searchable;
  * @property-read Channel $channel
  * @property-read User $user
  * @property-read Message|null $replyTo
+ * @property-read Collection<int, Message> $threadReplies
+ * @property-read Collection<int, User> $threadParticipants
  * @property-read Collection<int, User> $mentionedUsers
  */
-#[Fillable(['channel_id', 'user_id', 'client_uuid', 'reply_to_id', 'body', 'edited_at'])]
+#[Fillable(['channel_id', 'user_id', 'client_uuid', 'reply_to_id', 'thread_root_id', 'sent_to_channel', 'body', 'edited_at'])]
 class Message extends Model
 {
     /** @use HasFactory<MessageFactory> */
     use HasFactory, HasUuids, Searchable, SoftDeletes;
+
+    /**
+     * The model's default attribute values.
+     *
+     * Mirrors the database defaults so a freshly created message carries its
+     * thread aggregates in memory (before any refresh) for the broadcast DTO.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'sent_to_channel' => false,
+        'reply_count' => 0,
+    ];
 
     /**
      * Get the channel the message was posted to.
@@ -70,6 +90,33 @@ class Message extends Model
     }
 
     /**
+     * Get the replies posted into this message's thread.
+     *
+     * Only meaningful on a root message. Soft-deleted replies are excluded by
+     * the default scope; callers that render tombstones opt in with withTrashed.
+     *
+     * @return HasMany<Message, $this>
+     */
+    public function threadReplies(): HasMany
+    {
+        return $this->hasMany(Message::class, 'thread_root_id');
+    }
+
+    /**
+     * Get the distinct authors who have replied in this message's thread.
+     *
+     * Uses the `messages` table itself as the pivot (thread_root_id -> user_id),
+     * so a root's participant avatars can be eager-loaded without an N+1.
+     *
+     * @return BelongsToMany<User, $this>
+     */
+    public function threadParticipants(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'messages', 'thread_root_id', 'user_id')
+            ->distinct();
+    }
+
+    /**
      * Get the team members mentioned in this message.
      *
      * Backed by the `mentions` join table; the parser keeps these rows in sync
@@ -92,6 +139,9 @@ class Message extends Model
     {
         return [
             'edited_at' => 'datetime',
+            'last_reply_at' => 'datetime',
+            'sent_to_channel' => 'bool',
+            'reply_count' => 'int',
         ];
     }
 

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -47,4 +47,28 @@ class MessageFactory extends Factory
             'reply_to_id' => $parent->id,
         ]);
     }
+
+    /**
+     * Indicate that the message is a reply in another message's thread.
+     *
+     * The reply inherits the root's channel so it stays consistent with the
+     * one-channel-per-thread rule the request layer enforces.
+     */
+    public function inThread(Message $root): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'thread_root_id' => $root->id,
+            'channel_id' => $root->channel_id,
+        ]);
+    }
+
+    /**
+     * Indicate that the thread reply is also surfaced in the main timeline.
+     */
+    public function sentToChannel(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'sent_to_channel' => true,
+        ]);
+    }
 }

--- a/database/migrations/2026_07_09_120000_add_threading_to_messages_table.php
+++ b/database/migrations/2026_07_09_120000_add_threading_to_messages_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            // The thread this reply belongs to, pointing at the thread's root
+            // message, or null for a root/normal message. Force-deleting the root
+            // nulls the reference; a soft-deleted root keeps it so the thread
+            // survives as a tombstone. Threads are one level deep — a reply's root
+            // is always itself a root (thread_root_id null).
+            $table->foreignUuid('thread_root_id')
+                ->nullable()
+                ->after('reply_to_id')
+                ->constrained('messages')
+                ->nullOnDelete();
+
+            // A thread reply that is also surfaced in the main channel timeline
+            // ("Also send to #channel"). Meaningless on root/normal messages.
+            $table->boolean('sent_to_channel')
+                ->default(false)
+                ->after('thread_root_id');
+
+            // Aggregate thread metadata denormalized onto the root message so the
+            // main timeline can render the "N replies" affordance without a
+            // per-row count. Increment-only: deleted replies stay as tombstones,
+            // so the count keeps matching the rows the thread view shows.
+            $table->unsignedInteger('reply_count')
+                ->default(0)
+                ->after('sent_to_channel');
+            $table->timestamp('last_reply_at')
+                ->nullable()
+                ->after('reply_count');
+
+            // Lists a thread's replies in order.
+            $table->index(['thread_root_id', 'id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropIndex(['thread_root_id', 'id']);
+            $table->dropConstrainedForeignId('thread_root_id');
+            $table->dropColumn(['sent_to_channel', 'reply_count', 'last_reply_at']);
+        });
+    }
+};

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ArrowUp, Plus, X } from '@lucide/vue';
-import { computed, nextTick, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import MessageQuote from '@/components/MessageQuote.vue';
 import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
@@ -10,10 +10,13 @@ const props = defineProps<{
     channelName: string;
     members: Mention[];
     replyTarget?: Message | null;
+    placeholder?: string;
+    allowSendToChannel?: boolean;
+    autofocus?: boolean;
 }>();
 
 const emit = defineEmits<{
-    send: [body: string, mentions: Mention[]];
+    send: [body: string, mentions: Mention[], sendToChannel?: boolean];
     typing: [];
     cancelReply: [];
 }>();
@@ -22,6 +25,21 @@ const { getInitials } = useInitials();
 
 const body = ref('');
 const textarea = ref<HTMLTextAreaElement | null>(null);
+
+// In a thread composer, whether the reply is also surfaced in the main timeline.
+const sendToChannel = ref(false);
+
+const composerPlaceholder = computed(
+    () => props.placeholder ?? `Message #${props.channelName}`,
+);
+
+// Focus on mount when asked (e.g. the thread composer when a thread opens) so
+// the user can type straight away without clicking into the field.
+onMounted(() => {
+    if (props.autofocus) {
+        nextTick(() => textarea.value?.focus());
+    }
+});
 
 // Focus the composer whenever a reply is started so the user can type straight
 // away without reaching for the mouse.
@@ -169,8 +187,9 @@ function submit(): void {
         return;
     }
 
-    emit('send', trimmed, collectMentions(trimmed));
+    emit('send', trimmed, collectMentions(trimmed), sendToChannel.value);
     body.value = '';
+    sendToChannel.value = false;
     menuOpen.value = false;
     nextTick(resize);
 }
@@ -284,7 +303,7 @@ function onKeydown(event: KeyboardEvent): void {
                     ref="textarea"
                     v-model="body"
                     rows="1"
-                    :placeholder="`Message #${props.channelName}`"
+                    :placeholder="composerPlaceholder"
                     data-test="message-composer-input"
                     class="max-h-[200px] w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
                     @input="(resize(), refreshSuggestions(), emit('typing'))"
@@ -292,15 +311,29 @@ function onKeydown(event: KeyboardEvent): void {
                     @keydown="onKeydown"
                 ></textarea>
                 <div class="mt-2.5 flex items-center justify-between">
-                    <Button
-                        variant="outline"
-                        size="icon"
-                        disabled
-                        class="size-[26px] rounded-[7px] text-muted-foreground"
-                        aria-label="Add attachment"
-                    >
-                        <Plus class="size-3.5" />
-                    </Button>
+                    <div class="flex items-center gap-2">
+                        <Button
+                            variant="outline"
+                            size="icon"
+                            disabled
+                            class="size-[26px] rounded-[7px] text-muted-foreground"
+                            aria-label="Add attachment"
+                        >
+                            <Plus class="size-3.5" />
+                        </Button>
+                        <label
+                            v-if="props.allowSendToChannel"
+                            class="flex cursor-pointer items-center gap-1.5 text-[12px] text-muted-foreground select-none"
+                        >
+                            <input
+                                v-model="sendToChannel"
+                                type="checkbox"
+                                data-test="send-to-channel"
+                                class="size-3.5 rounded border-input accent-primary"
+                            />
+                            Also send to #{{ props.channelName }}
+                        </label>
+                    </div>
                     <Button
                         size="icon"
                         :disabled="body.trim() === ''"

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CornerUpLeft, Pencil, Trash2 } from '@lucide/vue';
+import { CornerUpLeft, MessageSquareText, Pencil, Trash2 } from '@lucide/vue';
 import { computed, nextTick, ref } from 'vue';
 import MessageQuote from '@/components/MessageQuote.vue';
 import { Button } from '@/components/ui/button';
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { useInitials } from '@/composables/useInitials';
 import { renderMessageBody } from '@/lib/messageBody';
-import type { Message, MessageAuthor } from '@/types';
+import type { Mention, Message, MessageAuthor } from '@/types';
 
 const props = defineProps<{
     messages: Message[];
@@ -23,14 +23,31 @@ const props = defineProps<{
     canModerate?: boolean;
     onlineIds?: Set<string>;
     highlightMessageId?: string | null;
+    // Rendered inside a thread panel: hides the per-message thread affordances
+    // (you're already in the thread), so the panel only shows the conversation.
+    inThread?: boolean;
+    // The root of the currently-open thread, highlighted in the main timeline.
+    activeThreadRootId?: string | null;
 }>();
 
 const emit = defineEmits<{
     edit: [message: Message, body: string];
     delete: [message: Message];
     reply: [message: Message];
+    openThread: [messageId: string];
     jump: [messageId: string];
 }>();
+
+// How many participant avatars to preview on a root's "N replies" affordance.
+const MAX_THREAD_AVATARS = 3;
+
+function threadAvatars(message: Message): Mention[] {
+    return message.threadParticipants.slice(0, MAX_THREAD_AVATARS);
+}
+
+function extraThreadParticipants(message: Message): number {
+    return Math.max(0, message.threadParticipants.length - MAX_THREAD_AVATARS);
+}
 
 const { getInitials } = useInitials();
 
@@ -163,9 +180,24 @@ function canDelete(message: Message): boolean {
 }
 
 // Anyone can reply to any live message; a pending or deleted row has no stable
-// target to quote yet.
+// target to quote yet. Inline quoting is a main-timeline affordance — inside a
+// thread the composer answers the root, so it's suppressed.
 function canReply(message: Message): boolean {
-    return !message.isDeleted && !isPending(message);
+    return !props.inThread && !message.isDeleted && !isPending(message);
+}
+
+// The hover "reply in thread" action shows on live root messages in the main
+// timeline (never on replies inside a panel, nor on messages already in a thread).
+function canStartThread(message: Message): boolean {
+    return (
+        !props.inThread && canReply(message) && message.threadRootId === null
+    );
+}
+
+// The "N replies" affordance shows on any root that has replies, even a deleted
+// one — the thread outlives its root as a tombstone.
+function showThreadSummary(message: Message): boolean {
+    return !props.inThread && message.threadReplyCount > 0;
 }
 
 // The message currently being edited inline, and its working draft.
@@ -283,6 +315,9 @@ function confirmDelete(): void {
                             message.id === props.highlightMessageId
                                 ? 'bg-primary/10'
                                 : '',
+                            message.id === props.activeThreadRootId
+                                ? 'bg-primary/5'
+                                : '',
                         ]"
                     >
                         <button
@@ -366,15 +401,72 @@ function confirmDelete(): void {
                             >
                         </p>
 
+                        <button
+                            v-if="showThreadSummary(message)"
+                            type="button"
+                            data-test="thread-summary"
+                            :aria-label="`View thread, ${message.threadReplyCount} ${message.threadReplyCount === 1 ? 'reply' : 'replies'}`"
+                            class="mt-1 flex items-center gap-2 rounded-md py-0.5 pr-2 text-left"
+                            @click="emit('openThread', message.id)"
+                        >
+                            <span class="flex -space-x-1">
+                                <span
+                                    v-for="participant in threadAvatars(
+                                        message,
+                                    )"
+                                    :key="participant.id"
+                                    class="flex size-5 items-center justify-center rounded-[6px] bg-primary/10 text-[9px] font-semibold text-primary ring-2 ring-background select-none"
+                                    aria-hidden="true"
+                                >
+                                    {{ getInitials(participant.name) }}
+                                </span>
+                                <span
+                                    v-if="extraThreadParticipants(message) > 0"
+                                    class="flex size-5 items-center justify-center rounded-[6px] bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-background select-none"
+                                    aria-hidden="true"
+                                >
+                                    +{{ extraThreadParticipants(message) }}
+                                </span>
+                            </span>
+                            <span
+                                class="text-[12.5px] font-semibold text-primary hover:underline"
+                            >
+                                {{ message.threadReplyCount }}
+                                {{
+                                    message.threadReplyCount === 1
+                                        ? 'reply'
+                                        : 'replies'
+                                }}
+                            </span>
+                            <span
+                                v-if="message.threadLastReplyAt"
+                                class="text-[11.5px] text-muted-foreground"
+                            >
+                                Last reply
+                                {{ formatTime(message.threadLastReplyAt) }}
+                            </span>
+                        </button>
+
                         <div
                             v-if="
                                 editingId !== message.id &&
                                 (canReply(message) ||
+                                    canStartThread(message) ||
                                     canEdit(message) ||
                                     canDelete(message))
                             "
                             class="absolute -top-3 right-2 hidden items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm group-hover/message:flex"
                         >
+                            <button
+                                v-if="canStartThread(message)"
+                                type="button"
+                                data-test="message-thread"
+                                aria-label="Reply in thread"
+                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                @click="emit('openThread', message.id)"
+                            >
+                                <MessageSquareText class="size-3.5" />
+                            </button>
                             <button
                                 v-if="canReply(message)"
                                 type="button"

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { X } from '@lucide/vue';
+import { computed, nextTick, ref, watch } from 'vue';
+import MessageComposer from '@/components/MessageComposer.vue';
+import MessageList from '@/components/MessageList.vue';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { Mention, Message } from '@/types';
+
+const props = defineProps<{
+    channelName: string;
+    // The root followed by its replies (oldest first), merged and deduped by the
+    // parent's thread stream; empty while the thread is still loading.
+    messages: Message[];
+    pendingUuids?: string[];
+    members: Mention[];
+    currentUserId: string;
+    canModerate?: boolean;
+    onlineIds?: Set<string>;
+    loading?: boolean;
+    readOnly?: boolean;
+}>();
+
+const emit = defineEmits<{
+    close: [];
+    send: [body: string, mentions: Mention[], sendToChannel?: boolean];
+    edit: [message: Message, body: string];
+    delete: [message: Message];
+    typing: [];
+    jump: [messageId: string];
+}>();
+
+// The first message is the root; everything after it is a reply.
+const hasRoot = computed(() => props.messages.length > 0);
+const replyCount = computed(() => Math.max(0, props.messages.length - 1));
+const showSkeleton = computed(() => props.loading || !hasRoot.value);
+
+// Distance (px) from the bottom within which the panel stays pinned to newest,
+// matching the main timeline's behaviour.
+const NEAR_BOTTOM_THRESHOLD = 120;
+const scrollContainer = ref<HTMLElement | null>(null);
+
+function isNearBottom(): boolean {
+    const el = scrollContainer.value;
+
+    if (!el) {
+        return true;
+    }
+
+    return (
+        el.scrollHeight - el.scrollTop - el.clientHeight <=
+        NEAR_BOTTOM_THRESHOLD
+    );
+}
+
+function scrollToBottom(): void {
+    const el = scrollContainer.value;
+
+    if (el) {
+        el.scrollTop = el.scrollHeight;
+    }
+}
+
+// Keep the panel pinned to the newest reply as the conversation grows, unless
+// the reader has scrolled up to older replies.
+watch(
+    () => props.messages.length,
+    () => {
+        if (isNearBottom()) {
+            nextTick(scrollToBottom);
+        }
+    },
+);
+</script>
+
+<template>
+    <aside
+        data-test="thread-panel"
+        class="flex w-full min-w-0 shrink-0 flex-col border-l border-border md:w-96"
+    >
+        <header
+            class="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4"
+        >
+            <div class="min-w-0 flex-1">
+                <h2 class="text-[14px] font-semibold text-foreground">
+                    Thread
+                </h2>
+                <p
+                    v-if="replyCount > 0"
+                    data-test="thread-reply-count"
+                    class="text-[11.5px] text-muted-foreground"
+                >
+                    {{ replyCount }}
+                    {{ replyCount === 1 ? 'reply' : 'replies' }}
+                </p>
+            </div>
+            <button
+                type="button"
+                data-test="thread-close"
+                aria-label="Close thread"
+                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                @click="emit('close')"
+            >
+                <X class="size-4" />
+            </button>
+        </header>
+
+        <div ref="scrollContainer" class="min-h-0 flex-1 overflow-y-auto">
+            <div v-if="showSkeleton" class="space-y-4 p-5">
+                <div class="flex gap-3">
+                    <Skeleton class="size-9 rounded-[10px]" />
+                    <div class="flex-1 space-y-2">
+                        <Skeleton class="h-3 w-24" />
+                        <Skeleton class="h-3 w-3/4" />
+                    </div>
+                </div>
+                <div class="flex gap-3">
+                    <Skeleton class="size-9 rounded-[10px]" />
+                    <div class="flex-1 space-y-2">
+                        <Skeleton class="h-3 w-20" />
+                        <Skeleton class="h-3 w-1/2" />
+                    </div>
+                </div>
+            </div>
+
+            <MessageList
+                v-else
+                :messages="props.messages"
+                :pending-uuids="props.pendingUuids"
+                :current-user-id="props.currentUserId"
+                :can-moderate="props.canModerate"
+                :online-ids="props.onlineIds"
+                in-thread
+                @edit="(message, body) => emit('edit', message, body)"
+                @delete="(message) => emit('delete', message)"
+                @jump="(id) => emit('jump', id)"
+            />
+        </div>
+
+        <MessageComposer
+            v-if="hasRoot && !props.readOnly"
+            :key="props.messages[0]?.id"
+            :channel-name="props.channelName"
+            :members="props.members"
+            placeholder="Reply…"
+            allow-send-to-channel
+            autofocus
+            @send="
+                (body, mentions, sendToChannel) =>
+                    emit('send', body, mentions, sendToChannel)
+            "
+            @typing="emit('typing')"
+        />
+    </aside>
+</template>

--- a/resources/js/composables/useMessageStream.ts
+++ b/resources/js/composables/useMessageStream.ts
@@ -1,0 +1,184 @@
+import { computed, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { Mention, Message } from '@/types';
+
+/**
+ * The reactive merge engine behind a message list.
+ *
+ * A rendered list is the union of three client-side sources layered over the
+ * server page, all deduped by the client-generated uuid the server persists:
+ *
+ *  - `pending` — optimistic local sends awaiting confirmation,
+ *  - `live` — messages arriving over the realtime broadcast channel,
+ *  - `patches` — edits/deletions overlaid in place (own mutations + echoes).
+ *
+ * Server copy wins over live wins over the optimistic copy; patches overlay
+ * whichever copy is rendered, keeping its slot. The same engine drives both the
+ * main channel timeline and a thread panel, so optimistic + realtime behaviour
+ * is identical in both places.
+ */
+export function useMessageStream(
+    serverMessages: Ref<Message[]> | ComputedRef<Message[]>,
+) {
+    const pending = ref<Message[]>([]);
+    const live = ref<Message[]>([]);
+    const patches = ref<Map<string, Message>>(new Map());
+
+    const displayMessages = computed<Message[]>(() => {
+        const byUuid = new Map<string, Message>();
+
+        for (const message of serverMessages.value) {
+            byUuid.set(message.clientUuid, message);
+        }
+
+        for (const message of live.value) {
+            if (!byUuid.has(message.clientUuid)) {
+                byUuid.set(message.clientUuid, message);
+            }
+        }
+
+        for (const message of pending.value) {
+            if (!byUuid.has(message.clientUuid)) {
+                byUuid.set(message.clientUuid, message);
+            }
+        }
+
+        // Overlay edits/deletions on the rendered copy, keeping its original slot.
+        for (const [uuid, patch] of patches.value) {
+            if (byUuid.has(uuid)) {
+                byUuid.set(uuid, patch);
+            }
+        }
+
+        return [...byUuid.values()].sort((a, b) =>
+            a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0,
+        );
+    });
+
+    const pendingUuids = computed(() =>
+        pending.value.map((message) => message.clientUuid),
+    );
+
+    // Drop optimistic messages once the server page or a live echo confirms them.
+    const confirmedUuids = computed(
+        () =>
+            new Set([
+                ...serverMessages.value.map((message) => message.clientUuid),
+                ...live.value.map((message) => message.clientUuid),
+            ]),
+    );
+
+    watch(confirmedUuids, (uuids) => {
+        pending.value = pending.value.filter(
+            (message) => !uuids.has(message.clientUuid),
+        );
+    });
+
+    /**
+     * Record a message received over the broadcast channel. Returns whether it
+     * was newly added, so the caller can decide to auto-scroll.
+     */
+    function appendLive(message: Message): boolean {
+        const known =
+            live.value.some((m) => m.clientUuid === message.clientUuid) ||
+            serverMessages.value.some(
+                (m) => m.clientUuid === message.clientUuid,
+            );
+
+        if (known) {
+            return false;
+        }
+
+        live.value.push(message);
+
+        return true;
+    }
+
+    function applyPatch(message: Message): void {
+        patches.value.set(message.clientUuid, message);
+    }
+
+    function getPatch(clientUuid: string): Message | undefined {
+        return patches.value.get(clientUuid);
+    }
+
+    function restorePatch(
+        clientUuid: string,
+        previous: Message | undefined,
+    ): void {
+        if (previous) {
+            patches.value.set(clientUuid, previous);
+        } else {
+            patches.value.delete(clientUuid);
+        }
+    }
+
+    function addPending(message: Message): void {
+        pending.value.push(message);
+    }
+
+    function removePending(clientUuid: string): void {
+        pending.value = pending.value.filter(
+            (message) => message.clientUuid !== clientUuid,
+        );
+    }
+
+    function reset(): void {
+        live.value = [];
+        pending.value = [];
+        patches.value = new Map();
+    }
+
+    return {
+        displayMessages,
+        pendingUuids,
+        appendLive,
+        applyPatch,
+        getPatch,
+        restorePatch,
+        addPending,
+        removePending,
+        reset,
+    };
+}
+
+/**
+ * Build the optimistic copy of a just-sent message so it renders immediately,
+ * before the server echo replaces it (keyed on the same client uuid).
+ */
+export function optimisticMessage(params: {
+    clientUuid: string;
+    body: string;
+    author: Mention;
+    mentions: Mention[];
+    replyTo?: Message | null;
+    threadRootId?: string | null;
+    sentToChannel?: boolean;
+}): Message {
+    const target = params.replyTo ?? null;
+
+    return {
+        id: params.clientUuid,
+        clientUuid: params.clientUuid,
+        body: params.body,
+        user: params.author,
+        createdAt: new Date().toISOString(),
+        editedAt: null,
+        isDeleted: false,
+        mentions: params.mentions,
+        replyTo: target
+            ? {
+                  id: target.id,
+                  body: target.body,
+                  authorName: target.user.name,
+                  isDeleted: target.isDeleted,
+                  mentions: target.mentions,
+              }
+            : null,
+        threadRootId: params.threadRootId ?? null,
+        sentToChannel: params.sentToChannel ?? false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+    };
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -30,6 +30,7 @@ import {
 } from '@/actions/App/Http/Controllers/Channels/MessageController';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
+import ThreadPanel from '@/components/ThreadPanel.vue';
 import TypingIndicator from '@/components/TypingIndicator.vue';
 import { Button } from '@/components/ui/button';
 import {
@@ -54,6 +55,10 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import {
+    useMessageStream,
+    optimisticMessage,
+} from '@/composables/useMessageStream';
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
@@ -64,6 +69,7 @@ import type {
     MessagePage,
     NotificationLevel,
     NotificationLevelOption,
+    Thread,
 } from '@/types';
 
 const props = defineProps<{
@@ -75,6 +81,8 @@ const props = defineProps<{
     canManagePreferences: boolean;
     notificationLevels: NotificationLevelOption[];
     jumpToMessageId?: string | null;
+    // The open thread, loaded on demand as an optional prop keyed by `?thread=`.
+    thread?: Thread | null;
 }>();
 
 const page = usePage();
@@ -114,19 +122,6 @@ const canModerate = computed(() =>
 // so an incoming message never yanks a user who is reading older history.
 const NEAR_BOTTOM_THRESHOLD = 120;
 
-// Optimistically-rendered messages awaiting confirmation, keyed by the client
-// uuid the server persists. Confirmation arrives either as the reloaded server
-// page or as the realtime echo of our own broadcast.
-const pending = ref<Message[]>([]);
-
-// Messages received live over the channel's private broadcast channel.
-const live = ref<Message[]>([]);
-
-// Edits and deletions applied on top of whichever copy of a message is rendered,
-// keyed by client uuid. Sourced from our own optimistic mutations and from the
-// MessageUpdated / MessageDeleted echoes, so every client converges in place.
-const patches = ref<Map<string, Message>>(new Map());
-
 const scrollContainer = ref<HTMLElement | null>(null);
 
 // `Inertia::scroll` delivers messages newest-first; reverse for display.
@@ -134,59 +129,30 @@ const serverMessages = computed<Message[]>(() =>
     [...(props.messages?.data ?? [])].reverse(),
 );
 
-// Merge every source, deduping by client uuid (server wins, then live, then the
-// optimistic copy) and ordering chronologically.
-const displayMessages = computed<Message[]>(() => {
-    const byUuid = new Map<string, Message>();
-
-    for (const message of serverMessages.value) {
-        byUuid.set(message.clientUuid, message);
-    }
-
-    for (const message of live.value) {
-        if (!byUuid.has(message.clientUuid)) {
-            byUuid.set(message.clientUuid, message);
-        }
-    }
-
-    for (const message of pending.value) {
-        if (!byUuid.has(message.clientUuid)) {
-            byUuid.set(message.clientUuid, message);
-        }
-    }
-
-    // Overlay edits/deletions on the rendered copy, keeping its original slot.
-    for (const [uuid, patch] of patches.value) {
-        if (byUuid.has(uuid)) {
-            byUuid.set(uuid, patch);
-        }
-    }
-
-    return [...byUuid.values()].sort((a, b) =>
-        a.createdAt < b.createdAt ? -1 : a.createdAt > b.createdAt ? 1 : 0,
-    );
-});
-
-const pendingUuids = computed(() =>
-    pending.value.map((message) => message.clientUuid),
-);
+// The main channel timeline: optimistic sends + live echoes + edit/delete
+// patches, all merged over the server page and deduped by client uuid.
+const mainStream = useMessageStream(serverMessages);
+const displayMessages = mainStream.displayMessages;
+const pendingUuids = mainStream.pendingUuids;
 
 const hasMessages = computed(() => displayMessages.value.length > 0);
 
-// Drop optimistic messages once the server page or a live echo confirms them.
-const confirmedUuids = computed(
-    () =>
-        new Set([
-            ...serverMessages.value.map((message) => message.clientUuid),
-            ...live.value.map((message) => message.clientUuid),
-        ]),
+// The open thread (root + replies), loaded on demand and kept client-side so a
+// later full-page visit that omits the optional prop can't drop it. The thread
+// panel runs its own stream instance over the root + its replies.
+const activeThreadRootId = ref<string | null>(null);
+const threadData = ref<Thread | null>(null);
+const threadLoading = ref(false);
+
+const threadServerMessages = computed<Message[]>(() =>
+    threadData.value
+        ? [threadData.value.root, ...threadData.value.replies]
+        : [],
 );
 
-watch(confirmedUuids, (uuids) => {
-    pending.value = pending.value.filter(
-        (message) => !uuids.has(message.clientUuid),
-    );
-});
+const threadStream = useMessageStream(threadServerMessages);
+const threadMessages = threadStream.displayMessages;
+const threadPendingUuids = threadStream.pendingUuids;
 
 function isNearBottom(): boolean {
     const el = scrollContainer.value;
@@ -233,20 +199,30 @@ function jumpToMessage(id: string): void {
     });
 }
 
-function appendLive(message: Message): void {
-    const known =
-        live.value.some((m) => m.clientUuid === message.clientUuid) ||
-        serverMessages.value.some((m) => m.clientUuid === message.clientUuid);
+// Append a message to the main timeline, keeping the view pinned to newest only
+// when the reader was already near the bottom.
+function appendLiveMain(message: Message): void {
+    const pinned = isNearBottom();
 
-    if (known) {
-        return;
+    if (mainStream.appendLive(message) && pinned) {
+        nextTick(scrollToBottom);
+    }
+}
+
+// Route a broadcast message to the timeline it belongs to. A thread reply stays
+// out of the main timeline unless it was explicitly "also sent to channel"; the
+// open thread only appends replies belonging to its root. The two are not
+// exclusive — a sent-to-channel reply in the open thread lands in both.
+function routeIncoming(message: Message): void {
+    if (message.threadRootId === null || message.sentToChannel) {
+        appendLiveMain(message);
     }
 
-    const pinned = isNearBottom();
-    live.value.push(message);
-
-    if (pinned) {
-        nextTick(scrollToBottom);
+    if (
+        message.threadRootId !== null &&
+        message.threadRootId === activeThreadRootId.value
+    ) {
+        threadStream.appendLive(message);
     }
 }
 
@@ -254,8 +230,12 @@ function channelName(id: string): string {
     return `channel.${id}`;
 }
 
+// An edit or deletion may touch either timeline (or both, for a sent-to-channel
+// reply); patch both streams, since a patch is ignored where the message isn't
+// rendered.
 function applyPatch(message: Message): void {
-    patches.value.set(message.clientUuid, message);
+    mainStream.applyPatch(message);
+    threadStream.applyPatch(message);
 }
 
 function subscribe(id: string): void {
@@ -264,7 +244,7 @@ function subscribe(id: string): void {
         .listen('MessageSent', (message: Message) => {
             // Their message landed; stop showing them as typing.
             typing.forget(message.user.id);
-            appendLive(message);
+            routeIncoming(message);
             // Keep the open, focused channel read as new messages arrive.
             markRead();
         })
@@ -318,7 +298,27 @@ onMounted(() => {
     if (props.jumpToMessageId) {
         jumpToMessage(props.jumpToMessageId);
     }
+
+    // Reopen a deep-linked thread: the `thread` prop is already resolved from
+    // the `?thread=` param on the initial load, so adopt it directly.
+    if (props.thread) {
+        activeThreadRootId.value = props.thread.root.id;
+        threadData.value = props.thread;
+    }
 });
+
+// The thread prop only arrives on a partial reload that requests it; copy it
+// into client state (guarded to the thread we're actually opening) so a later
+// full visit that omits the optional prop can't blank the open panel.
+watch(
+    () => props.thread,
+    (thread) => {
+        if (thread && thread.root.id === activeThreadRootId.value) {
+            threadData.value = thread;
+            threadLoading.value = false;
+        }
+    },
+);
 
 // A jump to another result in the same already-open channel reuses this
 // component, so the channel-id watch won't fire; react to the target changing.
@@ -340,9 +340,8 @@ watch(
             unsubscribe(oldId);
         }
 
-        live.value = [];
-        pending.value = [];
-        patches.value = new Map();
+        mainStream.reset();
+        closeThread();
         replyTarget.value = null;
         typing.reset();
         notificationLevel.value = props.channel.notificationLevel;
@@ -380,28 +379,17 @@ function send(body: string, mentions: Mention[]): void {
     const clientUuid = crypto.randomUUID();
     const target = replyTarget.value;
 
-    pending.value.push({
-        id: clientUuid,
-        clientUuid,
-        body,
-        user: currentUser.value,
-        createdAt: new Date().toISOString(),
-        editedAt: null,
-        isDeleted: false,
-        mentions,
-        // Mirror the parent as a compact quote so the optimistic row renders the
-        // reference immediately; the server echo replaces it with the canonical
-        // copy keyed on the same client uuid.
-        replyTo: target
-            ? {
-                  id: target.id,
-                  body: target.body,
-                  authorName: target.user.name,
-                  isDeleted: target.isDeleted,
-                  mentions: target.mentions,
-              }
-            : null,
-    });
+    // The optimistic row mirrors the parent quote so the reference renders
+    // immediately; the server echo replaces it, keyed on the same client uuid.
+    mainStream.addPending(
+        optimisticMessage({
+            clientUuid,
+            body,
+            author: currentUser.value,
+            mentions,
+            replyTo: target,
+        }),
+    );
 
     cancelReply();
     nextTick(scrollToBottom);
@@ -414,17 +402,79 @@ function send(body: string, mentions: Mention[]): void {
             preserveScroll: true,
             onError: () => {
                 // The optimistic row failed to persist; roll it back and notify.
-                pending.value = pending.value.filter(
-                    (message) => message.clientUuid !== clientUuid,
-                );
+                mainStream.removePending(clientUuid);
                 toast.error('Your message failed to send. Please try again.');
             },
         },
     );
 }
 
+// Post a reply into the open thread. It renders optimistically in the panel and,
+// when "also send to channel" is checked, in the main timeline too.
+function sendThreadReply(
+    body: string,
+    mentions: Mention[],
+    sendToChannel?: boolean,
+): void {
+    const rootId = activeThreadRootId.value;
+
+    if (!rootId) {
+        return;
+    }
+
+    const clientUuid = crypto.randomUUID();
+    const optimistic = optimisticMessage({
+        clientUuid,
+        body,
+        author: currentUser.value,
+        mentions,
+        threadRootId: rootId,
+        sentToChannel: sendToChannel ?? false,
+    });
+
+    threadStream.addPending(optimistic);
+
+    if (sendToChannel) {
+        appendPendingMain(optimistic);
+    }
+
+    router.post(
+        storeMessage({ team: props.team.slug, channel: props.channel.slug })
+            .url,
+        {
+            body,
+            client_uuid: clientUuid,
+            thread_root_id: rootId,
+            sent_to_channel: sendToChannel ?? false,
+        },
+        {
+            preserveScroll: true,
+            onError: () => {
+                threadStream.removePending(clientUuid);
+
+                if (sendToChannel) {
+                    mainStream.removePending(clientUuid);
+                }
+
+                toast.error('Your reply failed to send. Please try again.');
+            },
+        },
+    );
+}
+
+// Add an optimistic row to the main timeline, keeping the pinned-to-bottom rule.
+function appendPendingMain(message: Message): void {
+    const pinned = isNearBottom();
+    mainStream.addPending(message);
+
+    if (pinned) {
+        nextTick(scrollToBottom);
+    }
+}
+
 function editMessage(message: Message, body: string): void {
-    const previous = patches.value.get(message.clientUuid);
+    const previousMain = mainStream.getPatch(message.clientUuid);
+    const previousThread = threadStream.getPatch(message.clientUuid);
 
     // Optimistically show the edit; the broadcast echo later confirms it.
     applyPatch({ ...message, body, editedAt: new Date().toISOString() });
@@ -439,12 +489,8 @@ function editMessage(message: Message, body: string): void {
         {
             preserveScroll: true,
             onError: () => {
-                if (previous) {
-                    patches.value.set(message.clientUuid, previous);
-                } else {
-                    patches.value.delete(message.clientUuid);
-                }
-
+                mainStream.restorePatch(message.clientUuid, previousMain);
+                threadStream.restorePatch(message.clientUuid, previousThread);
                 toast.error('Your edit failed to save. Please try again.');
             },
         },
@@ -452,7 +498,8 @@ function editMessage(message: Message, body: string): void {
 }
 
 function deleteMessage(message: Message): void {
-    const previous = patches.value.get(message.clientUuid);
+    const previousMain = mainStream.getPatch(message.clientUuid);
+    const previousThread = threadStream.getPatch(message.clientUuid);
 
     // Optimistically show the tombstone; the broadcast echo later confirms it.
     applyPatch({ ...message, body: '', isDeleted: true });
@@ -466,16 +513,41 @@ function deleteMessage(message: Message): void {
         {
             preserveScroll: true,
             onError: () => {
-                if (previous) {
-                    patches.value.set(message.clientUuid, previous);
-                } else {
-                    patches.value.delete(message.clientUuid);
-                }
-
+                mainStream.restorePatch(message.clientUuid, previousMain);
+                threadStream.restorePatch(message.clientUuid, previousThread);
                 toast.error('Failed to delete the message. Please try again.');
             },
         },
     );
+}
+
+// Open the thread rooted at a message. The root's replies load as the optional
+// `thread` prop (a partial reload keyed by `?thread=`), shown as a skeleton
+// until they arrive.
+function openThread(rootId: string): void {
+    if (activeThreadRootId.value === rootId) {
+        return;
+    }
+
+    activeThreadRootId.value = rootId;
+    threadStream.reset();
+    threadData.value = null;
+    threadLoading.value = true;
+
+    router.reload({
+        only: ['thread'],
+        data: { thread: rootId },
+        onFinish: () => {
+            threadLoading.value = false;
+        },
+    });
+}
+
+function closeThread(): void {
+    activeThreadRootId.value = null;
+    threadData.value = null;
+    threadLoading.value = false;
+    threadStream.reset();
 }
 
 // The member's own notification preferences for this channel, seeded from the
@@ -564,159 +636,212 @@ function archive(): void {
 <template>
     <Head :title="`#${props.channel.name}`" />
 
-    <header
-        class="flex h-12 shrink-0 items-center gap-2.5 border-b border-border px-5"
-    >
-        <SidebarTrigger
-            class="-ml-1.5 size-8 text-muted-foreground md:hidden"
-        />
-        <h1 class="text-[15px] font-semibold text-foreground">
-            <span class="mr-0.5 font-medium text-muted-foreground/70">#</span
-            >{{ props.channel.name }}
-        </h1>
-        <span
-            v-if="notificationStatus"
-            data-test="notification-status"
-            :data-status="muted ? 'muted' : notificationLevel"
-            class="inline-flex items-center text-muted-foreground"
-            :title="notificationStatus.label"
-            :aria-label="notificationStatus.label"
-        >
-            <component :is="notificationStatus.icon" class="size-3.5" />
-        </span>
-        <template v-if="props.channel.topic">
-            <Separator orientation="vertical" class="h-4" />
-            <p class="min-w-0 truncate text-[13px] text-muted-foreground">
-                {{ props.channel.topic }}
-            </p>
-        </template>
-
-        <span
-            v-if="props.channel.isArchived"
-            class="ml-1 inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
-        >
-            <Archive class="size-3" />
-            Archived
-        </span>
-
-        <DropdownMenu v-if="props.canManagePreferences || props.canArchive">
-            <DropdownMenuTrigger as-child>
-                <button
-                    type="button"
-                    aria-label="Channel options"
-                    data-test="channel-options"
-                    class="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                >
-                    <EllipsisVertical class="size-4" />
-                </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" class="w-56">
-                <template v-if="props.canManagePreferences">
-                    <DropdownMenuLabel
-                        class="text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
-                    >
-                        Notifications
-                    </DropdownMenuLabel>
-                    <DropdownMenuRadioGroup
-                        :model-value="notificationLevel"
-                        @update:model-value="onNotificationLevelChange"
-                    >
-                        <DropdownMenuRadioItem
-                            v-for="level in props.notificationLevels"
-                            :key="level.value"
-                            :value="level.value"
-                            :data-test="`notification-level-${level.value}`"
-                        >
-                            {{ level.label }}
-                        </DropdownMenuRadioItem>
-                    </DropdownMenuRadioGroup>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuCheckboxItem
-                        :model-value="muted"
-                        data-test="mute-channel"
-                        @update:model-value="onMuteChange"
-                        @select="(event: Event) => event.preventDefault()"
-                    >
-                        Mute channel
-                    </DropdownMenuCheckboxItem>
-                </template>
-                <template v-if="props.canArchive">
-                    <DropdownMenuSeparator v-if="props.canManagePreferences" />
-                    <DropdownMenuItem
-                        data-test="archive-channel"
-                        class="text-destructive focus:text-destructive"
-                        @select="confirmingArchive = true"
-                    >
-                        <Archive class="size-4" />
-                        Archive channel
-                    </DropdownMenuItem>
-                </template>
-            </DropdownMenuContent>
-        </DropdownMenu>
-    </header>
-
-    <div class="flex min-h-0 flex-1 flex-col">
-        <div ref="scrollContainer" class="min-h-0 flex-1 overflow-y-auto">
-            <InfiniteScroll
-                v-if="hasMessages"
-                data="messages"
-                reverse
-                preserve-url
+    <div class="flex min-h-0 flex-1 overflow-hidden">
+        <div class="flex min-w-0 flex-1 flex-col">
+            <header
+                class="flex h-12 shrink-0 items-center gap-2.5 border-b border-border px-5"
             >
-                <MessageList
-                    :messages="displayMessages"
-                    :pending-uuids="pendingUuids"
-                    :current-user-id="currentUser.id"
-                    :can-moderate="canModerate"
-                    :online-ids="onlineIds"
-                    :highlight-message-id="highlightedMessageId"
-                    @edit="editMessage"
-                    @delete="deleteMessage"
-                    @reply="startReply"
-                    @jump="jumpToMessage"
+                <SidebarTrigger
+                    class="-ml-1.5 size-8 text-muted-foreground md:hidden"
                 />
-            </InfiniteScroll>
-
-            <div
-                v-else
-                class="flex h-full flex-col items-center justify-center gap-1"
-            >
-                <div
-                    class="flex size-14 items-center justify-center rounded-2xl border border-border bg-muted text-2xl font-semibold text-muted-foreground"
-                    aria-hidden="true"
+                <h1 class="text-[15px] font-semibold text-foreground">
+                    <span class="mr-0.5 font-medium text-muted-foreground/70"
+                        >#</span
+                    >{{ props.channel.name }}
+                </h1>
+                <span
+                    v-if="notificationStatus"
+                    data-test="notification-status"
+                    :data-status="muted ? 'muted' : notificationLevel"
+                    class="inline-flex items-center text-muted-foreground"
+                    :title="notificationStatus.label"
+                    :aria-label="notificationStatus.label"
                 >
-                    #
+                    <component :is="notificationStatus.icon" class="size-3.5" />
+                </span>
+                <template v-if="props.channel.topic">
+                    <Separator orientation="vertical" class="h-4" />
+                    <p
+                        class="min-w-0 truncate text-[13px] text-muted-foreground"
+                    >
+                        {{ props.channel.topic }}
+                    </p>
+                </template>
+
+                <span
+                    v-if="props.channel.isArchived"
+                    class="ml-1 inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+                >
+                    <Archive class="size-3" />
+                    Archived
+                </span>
+
+                <DropdownMenu
+                    v-if="props.canManagePreferences || props.canArchive"
+                >
+                    <DropdownMenuTrigger as-child>
+                        <button
+                            type="button"
+                            aria-label="Channel options"
+                            data-test="channel-options"
+                            class="ml-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                        >
+                            <EllipsisVertical class="size-4" />
+                        </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" class="w-56">
+                        <template v-if="props.canManagePreferences">
+                            <DropdownMenuLabel
+                                class="text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
+                            >
+                                Notifications
+                            </DropdownMenuLabel>
+                            <DropdownMenuRadioGroup
+                                :model-value="notificationLevel"
+                                @update:model-value="onNotificationLevelChange"
+                            >
+                                <DropdownMenuRadioItem
+                                    v-for="level in props.notificationLevels"
+                                    :key="level.value"
+                                    :value="level.value"
+                                    :data-test="`notification-level-${level.value}`"
+                                >
+                                    {{ level.label }}
+                                </DropdownMenuRadioItem>
+                            </DropdownMenuRadioGroup>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuCheckboxItem
+                                :model-value="muted"
+                                data-test="mute-channel"
+                                @update:model-value="onMuteChange"
+                                @select="
+                                    (event: Event) => event.preventDefault()
+                                "
+                            >
+                                Mute channel
+                            </DropdownMenuCheckboxItem>
+                        </template>
+                        <template v-if="props.canArchive">
+                            <DropdownMenuSeparator
+                                v-if="props.canManagePreferences"
+                            />
+                            <DropdownMenuItem
+                                data-test="archive-channel"
+                                class="text-destructive focus:text-destructive"
+                                @select="confirmingArchive = true"
+                            >
+                                <Archive class="size-4" />
+                                Archive channel
+                            </DropdownMenuItem>
+                        </template>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </header>
+
+            <div class="flex min-h-0 flex-1 flex-col">
+                <div
+                    ref="scrollContainer"
+                    class="min-h-0 flex-1 overflow-y-auto"
+                >
+                    <InfiniteScroll
+                        v-if="hasMessages"
+                        data="messages"
+                        reverse
+                        preserve-url
+                    >
+                        <MessageList
+                            :messages="displayMessages"
+                            :pending-uuids="pendingUuids"
+                            :current-user-id="currentUser.id"
+                            :can-moderate="canModerate"
+                            :online-ids="onlineIds"
+                            :highlight-message-id="highlightedMessageId"
+                            :active-thread-root-id="activeThreadRootId"
+                            @edit="editMessage"
+                            @delete="deleteMessage"
+                            @reply="startReply"
+                            @open-thread="openThread"
+                            @jump="jumpToMessage"
+                        />
+                    </InfiniteScroll>
+
+                    <div
+                        v-else
+                        class="flex h-full flex-col items-center justify-center gap-1"
+                    >
+                        <div
+                            class="flex size-14 items-center justify-center rounded-2xl border border-border bg-muted text-2xl font-semibold text-muted-foreground"
+                            aria-hidden="true"
+                        >
+                            #
+                        </div>
+                        <p
+                            class="mt-2.5 text-[15px] font-semibold text-foreground"
+                        >
+                            No messages yet
+                        </p>
+                        <p class="text-[13.5px] text-muted-foreground">
+                            Be the first to say something in #{{
+                                props.channel.name
+                            }}.
+                        </p>
+                    </div>
                 </div>
-                <p class="mt-2.5 text-[15px] font-semibold text-foreground">
-                    No messages yet
-                </p>
-                <p class="text-[13.5px] text-muted-foreground">
-                    Be the first to say something in #{{ props.channel.name }}.
-                </p>
+
+                <div
+                    v-if="props.channel.isArchived"
+                    data-test="archived-notice"
+                    class="m-5 shrink-0 rounded-lg border border-border bg-muted/40 px-4 py-3 text-center text-[13px] text-muted-foreground"
+                >
+                    This channel is archived. It's read-only, but its history is
+                    preserved.
+                </div>
+
+                <template v-else>
+                    <TypingIndicator
+                        :names="typingNames"
+                        class="mx-5 shrink-0"
+                    />
+
+                    <MessageComposer
+                        :channel-name="props.channel.name"
+                        :members="mentionableMembers"
+                        :reply-target="replyTarget"
+                        @send="send"
+                        @typing="onTyping"
+                        @cancel-reply="cancelReply"
+                    />
+                </template>
             </div>
         </div>
 
-        <div
-            v-if="props.channel.isArchived"
-            data-test="archived-notice"
-            class="m-5 shrink-0 rounded-lg border border-border bg-muted/40 px-4 py-3 text-center text-[13px] text-muted-foreground"
+        <Transition
+            enter-active-class="transition-transform duration-200 ease-out"
+            enter-from-class="translate-x-full"
+            enter-to-class="translate-x-0"
+            leave-active-class="transition-transform duration-150 ease-in"
+            leave-from-class="translate-x-0"
+            leave-to-class="translate-x-full"
         >
-            This channel is archived. It's read-only, but its history is
-            preserved.
-        </div>
-
-        <template v-else>
-            <TypingIndicator :names="typingNames" class="mx-5 shrink-0" />
-
-            <MessageComposer
+            <ThreadPanel
+                v-if="activeThreadRootId"
                 :channel-name="props.channel.name"
+                :messages="threadMessages"
+                :pending-uuids="threadPendingUuids"
                 :members="mentionableMembers"
-                :reply-target="replyTarget"
-                @send="send"
+                :current-user-id="currentUser.id"
+                :can-moderate="canModerate"
+                :online-ids="onlineIds"
+                :loading="threadLoading"
+                :read-only="props.channel.isArchived"
+                @close="closeThread"
+                @send="sendThreadReply"
+                @edit="editMessage"
+                @delete="deleteMessage"
                 @typing="onTyping"
-                @cancel-reply="cancelReply"
+                @jump="jumpToMessage"
             />
-        </template>
+        </Transition>
     </div>
 
     <Dialog v-model:open="confirmingArchive">

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -35,6 +35,27 @@ export type Message = {
     isDeleted: boolean;
     mentions: Mention[];
     replyTo: MessageReply | null;
+    /**
+     * Threading fields (mirror the `MessageData` DTO). `threadRootId` is set on a
+     * thread reply and names its root; null on a root/normal message. The
+     * `thread*` aggregates are populated on a root so the timeline can render its
+     * "N replies" affordance, and survive a soft delete. `sentToChannel` marks a
+     * reply that was also surfaced in the main timeline.
+     */
+    threadRootId: string | null;
+    sentToChannel: boolean;
+    threadReplyCount: number;
+    threadLastReplyAt: string | null;
+    threadParticipants: Mention[];
+};
+
+/**
+ * An open thread: its root message plus every reply (oldest first, tombstones
+ * included). Mirrors the `thread` prop the channel page loads on demand.
+ */
+export type Thread = {
+    root: Message;
+    replies: Message[];
 };
 
 /**

--- a/tests/Feature/Channels/ThreadTest.php
+++ b/tests/Feature/Channels/ThreadTest.php
@@ -1,0 +1,305 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Events\MessageSent;
+use App\Events\MessageUpdated;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function threadTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and #general, returning them.
+ */
+function threadMember(Team $team, Channel $channel, ?string $name = null): User
+{
+    $user = User::factory()->create($name ? ['name' => $name] : []);
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+/**
+ * Post a thread reply through the HTTP endpoint as the given user.
+ */
+function postThreadReply(Team $team, Channel $channel, User $author, Message $root, array $overrides = []): TestResponse
+{
+    return test()->actingAs($author)->post(
+        route('channels.messages.store', ['team' => $team->slug, 'channel' => $channel->slug]),
+        array_merge([
+            'body' => 'a thread reply',
+            'client_uuid' => (string) Str::uuid7(),
+            'thread_root_id' => $root->id,
+        ], $overrides),
+    );
+}
+
+test('a reply persists against its thread root and bumps the root aggregates', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
+    $clientUuid = (string) Str::uuid7();
+
+    postThreadReply($team, $general, $owner, $root, ['body' => 'the reply', 'client_uuid' => $clientUuid])
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $this->assertDatabaseHas('messages', [
+        'client_uuid' => $clientUuid,
+        'body' => 'the reply',
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => false,
+    ]);
+
+    $root->refresh();
+    expect($root->reply_count)->toBe(1)
+        ->and($root->last_reply_at)->not->toBeNull();
+});
+
+test('a second reply increments the root reply count', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create();
+
+    postThreadReply($team, $general, $owner, $root);
+    postThreadReply($team, $general, $owner, $root);
+
+    expect($root->refresh()->reply_count)->toBe(2);
+});
+
+test('a reply cannot target another reply (threads are one level deep)', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create();
+    $reply = Message::factory()->for($owner)->inThread($root)->create();
+
+    postThreadReply($team, $general, $owner, $reply, ['thread_root_id' => $reply->id])
+        ->assertInvalid(['thread_root_id']);
+});
+
+test('the thread root must belong to the same channel', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $other = Channel::factory()->for($team)->create();
+    $other->channelMembers()->create(['user_id' => $owner->id]);
+    $foreign = Message::factory()->for($other)->for($owner)->create();
+
+    postThreadReply($team, $general, $owner, $foreign, ['thread_root_id' => $foreign->id])
+        ->assertInvalid(['thread_root_id']);
+});
+
+test('a reply cannot start on a deleted root', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create();
+    $root->delete();
+
+    postThreadReply($team, $general, $owner, $root, ['thread_root_id' => $root->id])
+        ->assertInvalid(['thread_root_id']);
+});
+
+test('a non-uuid thread root is rejected', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create();
+
+    postThreadReply($team, $general, $owner, $root, ['thread_root_id' => 'not-a-uuid'])
+        ->assertInvalid(['thread_root_id']);
+});
+
+test('sent_to_channel is ignored without a thread root', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)->post(
+        route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]),
+        ['body' => 'plain', 'client_uuid' => $clientUuid, 'sent_to_channel' => true],
+    );
+
+    $this->assertDatabaseHas('messages', [
+        'client_uuid' => $clientUuid,
+        'thread_root_id' => null,
+        'sent_to_channel' => false,
+    ]);
+});
+
+test('the main timeline hides thread-only replies but keeps sent-to-channel replies', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
+    Message::factory()->for($owner)->inThread($root)->create(['body' => 'thread only']);
+    Message::factory()->for($owner)->inThread($root)->sentToChannel()->create(['body' => 'also in channel']);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('messages.data', 2)
+            // Newest-first: the sent-to-channel reply, then the root.
+            ->where('messages.data.0.body', 'also in channel')
+            ->where('messages.data.0.sentToChannel', true)
+            ->where('messages.data.1.body', 'root')
+        );
+});
+
+test('the thread prop returns the root and its replies oldest-first, tombstones included', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
+    Message::factory()->for($owner)->inThread($root)->create(['body' => 'first reply']);
+    $second = Message::factory()->for($owner)->inThread($root)->create(['body' => 'second reply']);
+    $second->delete();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $root->id]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('thread.root.id', $root->id)
+            ->has('thread.replies', 2)
+            ->where('thread.replies.0.body', 'first reply')
+            ->where('thread.replies.1.isDeleted', true)
+            ->where('thread.replies.1.body', '')
+        );
+});
+
+test('the thread prop is null for a normal visit', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page->where('thread', null));
+});
+
+test('the thread prop is null when the param is blank or points elsewhere', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $reply = Message::factory()->for($owner)->inThread(
+        Message::factory()->for($general)->for($owner)->create(),
+    )->create();
+
+    // Blank param.
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => '']))
+        ->assertInertia(fn (Assert $page) => $page->where('thread', null));
+
+    // A reply id is not a root, so it resolves to no thread.
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $reply->id]))
+        ->assertInertia(fn (Assert $page) => $page->where('thread', null));
+});
+
+test('a root exposes its distinct thread participants and survives deletion', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $ada = threadMember($team, $general, 'Ada');
+    $grace = threadMember($team, $general, 'Grace');
+
+    $root = Message::factory()->for($general)->for($owner)->create([
+        'reply_count' => 3,
+        'last_reply_at' => now(),
+    ]);
+    // Ada replies twice, Grace once: two distinct participants.
+    Message::factory()->for($ada)->inThread($root)->count(2)->create();
+    Message::factory()->for($grace)->inThread($root)->create();
+    $root->delete();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('messages.data', 1)
+            ->where('messages.data.0.isDeleted', true)
+            ->where('messages.data.0.body', '')
+            ->where('messages.data.0.threadReplyCount', 3)
+            ->has('messages.data.0.threadParticipants', 2)
+        );
+});
+
+test('posting a reply broadcasts the reply and the updated root aggregate', function () {
+    Event::fake([MessageSent::class, MessageUpdated::class]);
+
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create();
+    $clientUuid = (string) Str::uuid7();
+
+    postThreadReply($team, $general, $owner, $root, ['body' => 'broadcast reply', 'client_uuid' => $clientUuid]);
+
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($root, $clientUuid) {
+        $payload = $event->message->toArray();
+
+        return $payload['clientUuid'] === $clientUuid
+            && $payload['threadRootId'] === $root->id;
+    });
+
+    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event) use ($root) {
+        $payload = $event->message->toArray();
+
+        return $payload['id'] === $root->id && $payload['threadReplyCount'] === 1;
+    });
+});
+
+test('a thread-only reply does not raise the channel unread badge', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $member = threadMember($team, $general, 'Reader');
+    $root = Message::factory()->for($general)->for($owner)->create();
+
+    // A plain timeline message and a thread-only reply, both by someone else.
+    Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($owner)->inThread($root)->create();
+
+    $entry = threadSidebarEntry($member, $team, $general);
+
+    // The root + the plain message count; the thread-only reply does not.
+    expect($entry['unreadCount'])->toBe(2);
+});
+
+test('a sent-to-channel reply raises the channel unread badge', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $member = threadMember($team, $general, 'Reader');
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($owner)->inThread($root)->sentToChannel()->create();
+
+    // The root + the sent-to-channel reply both count.
+    expect(threadSidebarEntry($member, $team, $general)['unreadCount'])->toBe(2);
+});
+
+test('a mention inside a thread still badges the channel', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $member = threadMember($team, $general, 'Reader');
+    $root = Message::factory()->for($general)->for($owner)->create();
+
+    $reply = Message::factory()->for($owner)->inThread($root)->create([
+        'body' => "hey @[{$member->name}]({$member->id})",
+    ]);
+    $reply->mentionedUsers()->attach($member->id);
+
+    $entry = threadSidebarEntry($member, $team, $general);
+
+    // The thread reply is not in the plain unread count, but its mention badges.
+    expect($entry['unreadCount'])->toBe(1)
+        ->and($entry['mentionCount'])->toBe(1);
+});
+
+/**
+ * Resolve the sidebar `channels` prop entry for the given channel as the user.
+ *
+ * @return array{unreadCount: int, mentionCount: int}
+ */
+function threadSidebarEntry(User $user, Team $team, Channel $channel): array
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]))->assertOk();
+
+    $entry = collect($response->viewData('page')['props']['channels'])
+        ->firstWhere('slug', $channel->slug);
+
+    return ['unreadCount' => $entry['unreadCount'], 'mentionCount' => $entry['mentionCount']];
+}


### PR DESCRIPTION
Closes #30.

Slack-style threading, distinct from the inline quoted replies shipped in #27. Any message can start a thread; replies live in an inline side panel rather than the main timeline; the root shows a **live** reply count with participant avatars; and an optional "Also send to #channel" surfaces a reply back into the main flow. Threads are one level deep (you reply to a root, never to a reply).

## Highlights

**Data model** — `add_threading_to_messages_table`
- `thread_root_id` (self-FK, `nullOnDelete`), `sent_to_channel`, denormalized `reply_count` + `last_reply_at` on the root, and a `(thread_root_id, id)` index.
- `Message` gains `threadReplies` (hasMany) and `threadParticipants` (distinct authors via the `messages` table as pivot); factory `inThread()` / `sentToChannel()` states.

**Backend**
- `PostMessageRequest` validates `thread_root_id` as a **live root** in the same channel — rejecting reply-to-a-reply, cross-channel, and deleted targets — plus `sent_to_channel`.
- `PostMessage` bumps the root's `reply_count`/`last_reply_at` and **reuses existing events**: `MessageSent` (the reply) + `MessageUpdated` (the root aggregate) on the same `channel.{id}` private channel — no new broadcast channel or authorization.
- `ChannelController@show` keeps thread-only replies out of the main timeline (but keeps `sent_to_channel` ones) and exposes a `thread` prop keyed by `?thread=` (root + replies, oldest-first, tombstones included).
- `MessageData` carries `threadRootId`, `sentToChannel`, `threadReplyCount`, `threadLastReplyAt`, `threadParticipants`; the structural fields survive a soft delete so a deleted root still shows its thread.

**Unread / mentions** (mentions-only scope)
- Thread-only replies no longer inflate the plain channel unread badge, but a mention **anywhere** (including inside a thread) still badges the channel.

**Frontend**
- Extracted the optimistic + realtime merge engine into `useMessageStream`, shared by the main timeline and the thread panel (identical dedup-by-`clientUuid` behaviour).
- New `ThreadPanel.vue`: inline split pane with its own header, reused `MessageList`, and composer. It **slides in** (200ms transition) and **auto-focuses** the reply box on open.
- `MessageList` gains a hover "reply in thread" action and a live "N replies" affordance (participant avatars + last-reply time); `MessageComposer` gains an "Also send to #channel" toggle.

## Testing
- New `tests/Feature/Channels/ThreadTest.php` (16 tests): persistence + root aggregate bumps, one-level/cross-channel/deleted-root validation, timeline filtering, the `thread` payload, broadcast of both events, and unread/mention derivation.
- Full gate green: `composer test` → **Total: 100.0 %** coverage (Pint + PHPStan clean, 300 passing), and frontend `lint:check` / `format:check` / `types:check` / `build` all pass.

## Follow-up
- #71 — precise per-thread read state (unread dots, Threads inbox, thread pagination), out of scope here.

## Notes
- `thread` is delivered as a plain closured prop (compatible with the client's `only: ['thread']` partial reload) rather than `Inertia::optional`, so it stays trivially assertable and returns null cheaply on normal loads.
- Not exercised in a live browser (no `browser-use` tooling available in this environment); covered by Inertia integration tests + type/build checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)