### PR TITLE
feat(notifications): audible chimes for incoming messages

### DIFF
--- a/app/Enums/ChimeSound.php
+++ b/app/Enums/ChimeSound.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+enum ChimeSound: string
+{
+    case Off = 'off';
+    case Ping = 'ping';
+    case Chime = 'chime';
+    case Knock = 'knock';
+    case Pop = 'pop';
+
+    /**
+     * Get the display label for the chime sound.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Off => 'Off',
+            self::Ping => 'Ping',
+            self::Chime => 'Chime',
+            self::Knock => 'Knock',
+            self::Pop => 'Pop',
+        };
+    }
+
+    /**
+     * Get the selectable sounds as value/label pairs for the settings UI.
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public static function options(): array
+    {
+        return array_map(
+            fn (self $sound): array => ['value' => $sound->value, 'label' => $sound->label()],
+            self::cases(),
+        );
+    }
+}

--- a/app/Http/Controllers/Settings/NotificationController.php
+++ b/app/Http/Controllers/Settings/NotificationController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Enums\ChimeSound;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\NotificationPreferencesRequest;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class NotificationController extends Controller
+{
+    /**
+     * Show the user's notification settings page.
+     */
+    public function edit(): Response
+    {
+        return Inertia::render('settings/Notifications', [
+            'chimeSounds' => ChimeSound::options(),
+        ]);
+    }
+
+    /**
+     * Update the user's notification preferences.
+     */
+    public function update(NotificationPreferencesRequest $request): RedirectResponse
+    {
+        $request->user()->update($request->validated());
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Notification settings updated.')]);
+
+        return to_route('notifications.edit');
+    }
+}

--- a/app/Http/Requests/Settings/NotificationPreferencesRequest.php
+++ b/app/Http/Requests/Settings/NotificationPreferencesRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use App\Enums\ChimeSound;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class NotificationPreferencesRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'chime_sound' => ['required', Rule::enum(ChimeSound::class)],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Concerns\HasTeams;
+use App\Enums\ChimeSound;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -26,6 +27,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $two_factor_confirmed_at
  * @property string|null $remember_token
  * @property string|null $current_team_id
+ * @property ChimeSound $chime_sound
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Team|null $currentTeam
@@ -34,7 +36,7 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, Team> $teams
  * @property-read Collection<int, Channel> $channels
  */
-#[Fillable(['name', 'email', 'password', 'current_team_id'])]
+#[Fillable(['name', 'email', 'password', 'current_team_id', 'chime_sound'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable
 {
@@ -51,6 +53,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'chime_sound' => ChimeSound::class,
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
             "npm run lint:check",
             "npm run format:check",
             "npm run types:check",
+            "npm run test:js",
             "@test"
         ],
         "types:check": [

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\ChimeSound;
 use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
@@ -35,6 +36,7 @@ class UserFactory extends Factory
             'two_factor_secret' => null,
             'two_factor_recovery_codes' => null,
             'two_factor_confirmed_at' => null,
+            'chime_sound' => ChimeSound::Ping->value,
         ];
     }
 

--- a/database/migrations/2026_07_09_113300_add_chime_sound_to_users_table.php
+++ b/database/migrations/2026_07_09_113300_add_chime_sound_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Enums\ChimeSound;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // The account-wide notification chime the client plays for a qualifying
+            // incoming message. `off` disables chimes entirely (see App\Enums\ChimeSound).
+            $table->string('chime_sound')->default(ChimeSound::Ping->value)->after('current_team_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('chime_sound');
+        });
+    }
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,6 +80,7 @@ export default defineConfigWithVueTs(
             'bootstrap/ssr',
             'tailwind.config.js',
             'vite.config.ts',
+            'vitest.config.ts',
             'resources/js/actions/**',
             'resources/js/components/ui/*',
             'resources/js/routes/**',

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
                 "typescript": "^5.2.2",
                 "typescript-eslint": "^8.23.0",
                 "vite": "^8.0.0",
+                "vitest": "^4.0.0",
                 "vue-tsc": "^2.2.4"
             },
             "optionalDependencies": {
@@ -1636,6 +1637,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@stylistic/eslint-plugin": {
             "version": "5.10.0",
             "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
@@ -1983,6 +1991,24 @@
             "dependencies": {
                 "tslib": "^2.4.0"
             }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.9",
@@ -2617,6 +2643,129 @@
                 "vue": "^3.2.25"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.10",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.10",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.10",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@volar/language-core": {
             "version": "2.4.15",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
@@ -3174,6 +3323,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/ast-types": {
             "name": "ast-types-x",
             "version": "1.18.0",
@@ -3524,6 +3683,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -4558,6 +4727,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -5230,6 +5406,16 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/express": {
@@ -7818,6 +8004,20 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/obug": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/ofetch": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -9430,6 +9630,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -9503,6 +9710,13 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/statuses": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -9512,6 +9726,13 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/std-env": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stdin-discarder": {
             "version": "0.3.2",
@@ -9945,6 +10166,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyexec": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -9969,6 +10197,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -10506,6 +10744,96 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
         "node_modules/vscode-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -10765,6 +11093,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
         "lint:check": "eslint .",
-        "types:check": "vue-tsc --noEmit"
+        "types:check": "vue-tsc --noEmit",
+        "test:js": "vitest run"
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -35,6 +36,7 @@
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.23.0",
         "vite": "^8.0.0",
+        "vitest": "^4.0.0",
         "vue-tsc": "^2.2.4"
     },
     "dependencies": {

--- a/resources/js/composables/useChimeNotifications.ts
+++ b/resources/js/composables/useChimeNotifications.ts
@@ -1,0 +1,130 @@
+import { usePage } from '@inertiajs/vue3';
+import { echo } from '@laravel/echo-vue';
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { playChime, unlockChimeAudio } from '@/lib/chimeSounds';
+import { shouldChime } from '@/lib/shouldChime';
+import type { ChimeSound, Message } from '@/types';
+
+/**
+ * Play a chime for qualifying realtime messages across every channel in the
+ * sidebar — not just the open one — so activity elsewhere is still audible.
+ *
+ * Mounted once in the persistent channel layout, it subscribes to each sidebar
+ * channel's broadcast and runs {@see shouldChime} per arrival. Show.vue owns the
+ * open channel's subscription and tears it down with a full `leave` on navigation,
+ * which also drops our listener on it; the post-flush reconcile below re-attaches
+ * the channel it just left. Chimes for the open channel are suppressed while it is
+ * focused, and Show.vue never chimes, so there is no double playback.
+ */
+export function useChimeNotifications(): void {
+    const page = usePage();
+
+    const currentUserId = computed(() => String(page.props.auth.user.id));
+    const chimeSound = computed<ChimeSound>(
+        () => page.props.auth.user.chime_sound ?? 'ping',
+    );
+    const channels = computed(() => page.props.channels ?? []);
+    const activeChannelId = computed(
+        () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
+    );
+
+    // Only reconcile when the set of channels or the open one actually changes,
+    // not on every badge-count refresh of the shared `channels` prop.
+    const subscriptionKey = computed(
+        () =>
+            `${channels.value.map((channel) => channel.id).join('|')}::${activeChannelId.value ?? ''}`,
+    );
+
+    const bound = new Set<string>();
+    let previousActiveId: string | null = null;
+
+    function channelName(id: string): string {
+        return `channel.${id}`;
+    }
+
+    function handleMessage(channelId: string, message: Message): void {
+        const preference =
+            channels.value.find((channel) => channel.id === channelId) ?? null;
+
+        const decision = shouldChime({
+            chimeEnabled: chimeSound.value !== 'off',
+            isOwnMessage: message.user.id === currentUserId.value,
+            isChannelMessage:
+                message.threadRootId === null || message.sentToChannel,
+            mentionsCurrentUser: message.mentions.some(
+                (mention) => mention.id === currentUserId.value,
+            ),
+            channel: preference
+                ? {
+                      muted: preference.muted,
+                      notificationLevel: preference.notificationLevel,
+                  }
+                : null,
+            tabHasFocus: typeof document !== 'undefined' && document.hasFocus(),
+            isActiveChannel: channelId === activeChannelId.value,
+        });
+
+        if (decision) {
+            playChime(chimeSound.value);
+        }
+    }
+
+    function listen(id: string): void {
+        echo()
+            .private(channelName(id))
+            .listen('MessageSent', (message: Message) => {
+                handleMessage(id, message);
+            });
+    }
+
+    function reconcile(): void {
+        const desired = new Set(channels.value.map((channel) => channel.id));
+        const active = activeChannelId.value;
+
+        if (previousActiveId !== null && previousActiveId !== active) {
+            bound.delete(previousActiveId);
+        }
+
+        previousActiveId = active;
+
+        for (const id of desired) {
+            if (!bound.has(id)) {
+                listen(id);
+                bound.add(id);
+            }
+        }
+
+        for (const id of [...bound]) {
+            if (!desired.has(id)) {
+                echo().leave(channelName(id));
+                bound.delete(id);
+            }
+        }
+    }
+
+    function leaveAll(): void {
+        for (const id of bound) {
+            echo().leave(channelName(id));
+        }
+
+        bound.clear();
+    }
+
+    onMounted(() => {
+        // The autoplay policy keeps the AudioContext suspended until a gesture.
+        window.addEventListener('pointerdown', unlockChimeAudio, {
+            once: true,
+        });
+        window.addEventListener('keydown', unlockChimeAudio, { once: true });
+        reconcile();
+    });
+
+    // Post-flush so it runs after Show.vue's own per-channel teardown.
+    watch(subscriptionKey, reconcile, { flush: 'post' });
+
+    onBeforeUnmount(() => {
+        window.removeEventListener('pointerdown', unlockChimeAudio);
+        window.removeEventListener('keydown', unlockChimeAudio);
+        leaveAll();
+    });
+}

--- a/resources/js/composables/useChimes.ts
+++ b/resources/js/composables/useChimes.ts
@@ -1,0 +1,43 @@
+import { router, usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import { playChime, unlockChimeAudio } from '@/lib/chimeSounds';
+import { update } from '@/routes/notifications';
+import type { ChimeSound } from '@/types';
+
+/**
+ * Read and mutate the current user's account-wide chime preference, and preview
+ * sounds. The preference is the shared `auth.user.chime_sound` prop, so every
+ * consumer (the settings page and the realtime listener) stays in sync.
+ */
+export function useChimes() {
+    const page = usePage();
+
+    const chimeSound = computed<ChimeSound>(
+        () => page.props.auth.user.chime_sound ?? 'ping',
+    );
+
+    const chimeEnabled = computed(() => chimeSound.value !== 'off');
+
+    /**
+     * Play a sound now. Called from a click, so it also unlocks the AudioContext
+     * that the autoplay policy keeps suspended until the first user gesture.
+     */
+    function preview(sound: ChimeSound): void {
+        unlockChimeAudio();
+        playChime(sound);
+    }
+
+    /**
+     * Persist a new chime choice. The shared prop refreshes from the redirect, so
+     * no optimistic state is needed.
+     */
+    function updateChimeSound(sound: ChimeSound): void {
+        router.patch(
+            update().url,
+            { chime_sound: sound },
+            { preserveScroll: true, preserveState: true },
+        );
+    }
+
+    return { chimeSound, chimeEnabled, preview, updateChimeSound };
+}

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -33,10 +33,14 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useInitials } from '@/composables/useInitials';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
 
 const page = usePage();
+
+// Chime for qualifying messages across every channel while the workspace is open.
+useChimeNotifications();
 
 const currentTeam = computed(() => page.props.currentTeam);
 const teams = computed(() => page.props.teams ?? []);

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -6,6 +6,7 @@ import { Separator } from '@/components/ui/separator';
 import { useCurrentUrl } from '@/composables/useCurrentUrl';
 import { toUrl } from '@/lib/utils';
 import { edit as editAppearance } from '@/routes/appearance';
+import { edit as editNotifications } from '@/routes/notifications';
 import { edit as editProfile } from '@/routes/profile';
 import { edit as editSecurity } from '@/routes/security';
 import { index as teams } from '@/routes/teams';
@@ -27,6 +28,10 @@ const sidebarNavItems: NavItem[] = [
     {
         title: 'Appearance',
         href: editAppearance(),
+    },
+    {
+        title: 'Notifications',
+        href: editNotifications(),
     },
 ];
 

--- a/resources/js/lib/chimeSounds.ts
+++ b/resources/js/lib/chimeSounds.ts
@@ -1,0 +1,153 @@
+import type { ChimeSound } from '@/types';
+
+/**
+ * A single synthesized voice: an oscillator at `frequency` that fades in and back
+ * out over `duration`, starting `startAt` seconds after playback begins.
+ */
+type ChimeVoice = {
+    type: OscillatorType;
+    frequency: number;
+    startAt: number;
+    duration: number;
+    gain: number;
+};
+
+/**
+ * Chimes are synthesized on the fly with the Web Audio API rather than shipped as
+ * binary audio, so previews and playback need no bundled assets or network fetch.
+ * Each audible sound maps to a short recipe of one or more voices.
+ */
+const RECIPES: Record<Exclude<ChimeSound, 'off'>, ChimeVoice[]> = {
+    ping: [
+        {
+            type: 'sine',
+            frequency: 880,
+            startAt: 0,
+            duration: 0.16,
+            gain: 0.18,
+        },
+        {
+            type: 'sine',
+            frequency: 1320,
+            startAt: 0.09,
+            duration: 0.22,
+            gain: 0.16,
+        },
+    ],
+    chime: [
+        { type: 'sine', frequency: 660, startAt: 0, duration: 0.5, gain: 0.16 },
+        { type: 'sine', frequency: 990, startAt: 0, duration: 0.5, gain: 0.1 },
+        {
+            type: 'sine',
+            frequency: 1320,
+            startAt: 0.02,
+            duration: 0.45,
+            gain: 0.07,
+        },
+    ],
+    knock: [
+        {
+            type: 'triangle',
+            frequency: 180,
+            startAt: 0,
+            duration: 0.13,
+            gain: 0.3,
+        },
+        {
+            type: 'triangle',
+            frequency: 150,
+            startAt: 0.13,
+            duration: 0.14,
+            gain: 0.26,
+        },
+    ],
+    pop: [
+        {
+            type: 'square',
+            frequency: 520,
+            startAt: 0,
+            duration: 0.08,
+            gain: 0.12,
+        },
+    ],
+};
+
+let sharedContext: AudioContext | null = null;
+
+/**
+ * Lazily create the single shared AudioContext, or return null where Web Audio is
+ * unavailable (SSR, or a browser without support).
+ */
+function audioContext(): AudioContext | null {
+    if (
+        typeof window === 'undefined' ||
+        typeof window.AudioContext === 'undefined'
+    ) {
+        return null;
+    }
+
+    if (sharedContext === null) {
+        sharedContext = new AudioContext();
+    }
+
+    return sharedContext;
+}
+
+/**
+ * Resume the shared AudioContext. Browsers start it "suspended" until a user
+ * gesture, so this must be called from within a real interaction to unlock later
+ * programmatic playback (the browser autoplay policy).
+ */
+export function unlockChimeAudio(): void {
+    const context = audioContext();
+
+    if (context !== null && context.state === 'suspended') {
+        void context.resume();
+    }
+}
+
+/**
+ * Play a chime by its preference value. "off" (or any environment without Web
+ * Audio) is a no-op.
+ */
+export function playChime(sound: ChimeSound): void {
+    if (sound === 'off') {
+        return;
+    }
+
+    const context = audioContext();
+
+    if (context === null) {
+        return;
+    }
+
+    if (context.state === 'suspended') {
+        void context.resume();
+    }
+
+    const now = context.currentTime;
+
+    for (const voice of RECIPES[sound]) {
+        const oscillator = context.createOscillator();
+        const amplifier = context.createGain();
+
+        oscillator.type = voice.type;
+        oscillator.frequency.value = voice.frequency;
+
+        const startTime = now + voice.startAt;
+        const stopTime = startTime + voice.duration;
+
+        // A quick attack then an exponential decay to a near-zero floor keeps each
+        // voice soft and click-free (exponential ramps cannot reach a true zero).
+        amplifier.gain.setValueAtTime(0.0001, startTime);
+        amplifier.gain.exponentialRampToValueAtTime(
+            voice.gain,
+            startTime + 0.01,
+        );
+        amplifier.gain.exponentialRampToValueAtTime(0.0001, stopTime);
+
+        oscillator.connect(amplifier).connect(context.destination);
+        oscillator.start(startTime);
+        oscillator.stop(stopTime);
+    }
+}

--- a/resources/js/lib/shouldChime.test.ts
+++ b/resources/js/lib/shouldChime.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { shouldChime } from '@/lib/shouldChime';
+import type { ChimeDecisionInput } from '@/lib/shouldChime';
+
+/**
+ * A qualifying baseline: an ordinary message from someone else in an unmuted
+ * "all" channel while the tab is blurred. Each test overrides one axis.
+ */
+function input(
+    overrides: Partial<ChimeDecisionInput> = {},
+): ChimeDecisionInput {
+    return {
+        chimeEnabled: true,
+        isOwnMessage: false,
+        isChannelMessage: true,
+        mentionsCurrentUser: false,
+        channel: { muted: false, notificationLevel: 'all' },
+        tabHasFocus: false,
+        isActiveChannel: false,
+        ...overrides,
+    };
+}
+
+describe('shouldChime', () => {
+    it('chimes for an ordinary message in an unmuted "all" channel while blurred', () => {
+        expect(shouldChime(input())).toBe(true);
+    });
+
+    it('never chimes when chimes are disabled', () => {
+        expect(shouldChime(input({ chimeEnabled: false }))).toBe(false);
+    });
+
+    it("never chimes for the user's own message", () => {
+        expect(shouldChime(input({ isOwnMessage: true }))).toBe(false);
+    });
+
+    it('never chimes for a channel the user does not belong to', () => {
+        expect(shouldChime(input({ channel: null }))).toBe(false);
+    });
+
+    it('never chimes for a muted channel, even on a mention', () => {
+        expect(
+            shouldChime(
+                input({
+                    channel: { muted: true, notificationLevel: 'all' },
+                    mentionsCurrentUser: true,
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it('does not chime for ordinary traffic at the "mentions" level', () => {
+        expect(
+            shouldChime(
+                input({
+                    channel: { muted: false, notificationLevel: 'mentions' },
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it('chimes for a direct mention at the "mentions" level', () => {
+        expect(
+            shouldChime(
+                input({
+                    channel: { muted: false, notificationLevel: 'mentions' },
+                    mentionsCurrentUser: true,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it('never chimes at the "nothing" level, even on a mention', () => {
+        expect(
+            shouldChime(
+                input({
+                    channel: { muted: false, notificationLevel: 'nothing' },
+                    mentionsCurrentUser: true,
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it('does not chime for a thread-only reply that does not mention the user', () => {
+        expect(shouldChime(input({ isChannelMessage: false }))).toBe(false);
+    });
+
+    it('chimes for a thread-only reply that mentions the user', () => {
+        expect(
+            shouldChime(
+                input({ isChannelMessage: false, mentionsCurrentUser: true }),
+            ),
+        ).toBe(true);
+    });
+
+    it('does not chime while actively viewing the channel (focused + open)', () => {
+        expect(
+            shouldChime(input({ tabHasFocus: true, isActiveChannel: true })),
+        ).toBe(false);
+    });
+
+    it('chimes for the open channel when the tab is blurred', () => {
+        expect(
+            shouldChime(input({ tabHasFocus: false, isActiveChannel: true })),
+        ).toBe(true);
+    });
+
+    it('chimes for a background channel while focused elsewhere', () => {
+        expect(
+            shouldChime(input({ tabHasFocus: true, isActiveChannel: false })),
+        ).toBe(true);
+    });
+});

--- a/resources/js/lib/shouldChime.ts
+++ b/resources/js/lib/shouldChime.ts
@@ -1,0 +1,75 @@
+import type { NotificationLevel } from '@/types';
+
+export type ChimeChannelPreference = {
+    muted: boolean;
+    notificationLevel: NotificationLevel;
+};
+
+export type ChimeDecisionInput = {
+    /** Whether the user has an audible chime selected (their sound is not "off"). */
+    chimeEnabled: boolean;
+    /** The message was authored by the current user. */
+    isOwnMessage: boolean;
+    /**
+     * The message counts as ordinary channel traffic — a top-level message or a
+     * thread reply that was also broadcast to the channel. Thread-only replies
+     * are `false` and only ever chime through the mention path, mirroring how the
+     * sidebar unread badge excludes them.
+     */
+    isChannelMessage: boolean;
+    /** The current user is directly @mentioned by the message. */
+    mentionsCurrentUser: boolean;
+    /**
+     * The current user's per-channel preference, or `null` when the channel is
+     * not in their sidebar (e.g. they are not a member) — which never chimes.
+     */
+    channel: ChimeChannelPreference | null;
+    /** The browser tab currently has focus. */
+    tabHasFocus: boolean;
+    /** The message landed in the channel the user is actively viewing on screen. */
+    isActiveChannel: boolean;
+};
+
+/**
+ * Decide whether a freshly-arrived realtime message should play a chime.
+ *
+ * The gate mirrors the sidebar badge semantics so a chime, an unread badge and a
+ * mention badge stay consistent: a direct @mention alerts unless the channel is
+ * muted or set to "nothing"; ordinary traffic alerts only at the "all" level. On
+ * top of that a chime is suppressed for the user's own messages, when chimes are
+ * disabled, and when the user is already actively looking at the message (its
+ * channel is open and the tab has focus).
+ */
+export function shouldChime(input: ChimeDecisionInput): boolean {
+    if (!input.chimeEnabled) {
+        return false;
+    }
+
+    if (input.isOwnMessage) {
+        return false;
+    }
+
+    const { channel } = input;
+
+    if (channel === null || channel.muted) {
+        return false;
+    }
+
+    if (input.mentionsCurrentUser) {
+        // A direct @mention is silenced only by the "nothing" level.
+        if (channel.notificationLevel === 'nothing') {
+            return false;
+        }
+    } else if (channel.notificationLevel !== 'all' || !input.isChannelMessage) {
+        // Ordinary traffic chimes only at "all", and thread-only replies never
+        // count as ordinary traffic — they live in the thread view.
+        return false;
+    }
+
+    // Never chime for a message the user is already looking at.
+    if (input.tabHasFocus && input.isActiveChannel) {
+        return false;
+    }
+
+    return true;
+}

--- a/resources/js/pages/settings/Notifications.vue
+++ b/resources/js/pages/settings/Notifications.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3';
+import { Play } from '@lucide/vue';
+import { ref } from 'vue';
+import Heading from '@/components/Heading.vue';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { useChimes } from '@/composables/useChimes';
+import { edit } from '@/routes/notifications';
+import type { ChimeSound, ChimeSoundOption } from '@/types';
+
+defineProps<{
+    chimeSounds: ChimeSoundOption[];
+}>();
+
+defineOptions({
+    layout: {
+        breadcrumbs: [
+            {
+                title: 'Notification settings',
+                href: edit(),
+            },
+        ],
+    },
+});
+
+const { chimeSound, preview, updateChimeSound } = useChimes();
+
+const selected = ref<ChimeSound>(chimeSound.value);
+
+function onSelect(value: unknown): void {
+    if (typeof value !== 'string') {
+        return;
+    }
+
+    selected.value = value as ChimeSound;
+    updateChimeSound(selected.value);
+}
+</script>
+
+<template>
+    <Head title="Notification settings" />
+
+    <h1 class="sr-only">Notification settings</h1>
+
+    <div class="space-y-6">
+        <Heading
+            variant="small"
+            title="Notifications"
+            description="Choose the chime played when a new message arrives while you're away"
+        />
+
+        <div class="grid max-w-md gap-2">
+            <Label for="chime-sound">Chime sound</Label>
+
+            <div class="flex items-center gap-2">
+                <Select :model-value="selected" @update:model-value="onSelect">
+                    <SelectTrigger id="chime-sound" class="w-full">
+                        <SelectValue placeholder="Select a chime" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem
+                            v-for="option in chimeSounds"
+                            :key="option.value"
+                            :value="option.value"
+                        >
+                            {{ option.label }}
+                        </SelectItem>
+                    </SelectContent>
+                </Select>
+
+                <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    :disabled="selected === 'off'"
+                    data-test="preview-chime"
+                    aria-label="Preview chime"
+                    @click="preview(selected)"
+                >
+                    <Play class="size-4" />
+                </Button>
+            </div>
+
+            <p class="text-sm text-muted-foreground">
+                Chimes never play for your own messages, for muted channels, or
+                for the channel you're actively viewing. Choose
+                <span class="font-medium">Off</span> to silence them entirely.
+            </p>
+        </div>
+    </div>
+</template>

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -1,3 +1,5 @@
+import type { ChimeSound } from './chimes';
+
 export type User = {
     id: number;
     name: string;
@@ -6,6 +8,7 @@ export type User = {
     email_verified_at: string | null;
     created_at: string;
     updated_at: string;
+    chime_sound: ChimeSound;
     [key: string]: unknown;
 };
 

--- a/resources/js/types/chimes.ts
+++ b/resources/js/types/chimes.ts
@@ -1,0 +1,6 @@
+export type ChimeSound = 'off' | 'ping' | 'chime' | 'knock' | 'pop';
+
+export type ChimeSoundOption = {
+    value: ChimeSound;
+    label: string;
+};

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -1,5 +1,6 @@
 export * from './auth';
 export * from './channels';
+export * from './chimes';
 export * from './messages';
 export * from './navigation';
 export * from './teams';

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Settings\NotificationController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SecurityController;
 use App\Http\Controllers\Teams\TeamController;
@@ -28,6 +29,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('user-password.update');
 
     Route::inertia('settings/appearance', 'settings/Appearance')->name('appearance.edit');
+
+    Route::get('settings/notifications', [NotificationController::class, 'edit'])->name('notifications.edit');
+    Route::patch('settings/notifications', [NotificationController::class, 'update'])->name('notifications.update');
 
     Route::get('settings/teams', [TeamController::class, 'index'])->name('teams.index');
     Route::post('settings/teams', [TeamController::class, 'store'])->name('teams.store');

--- a/tests/Feature/Settings/NotificationSettingsTest.php
+++ b/tests/Feature/Settings/NotificationSettingsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Enums\ChimeSound;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('notification settings page is displayed with the selectable chime sounds', function () {
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->get(route('notifications.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/Notifications')
+            ->has('chimeSounds', count(ChimeSound::cases()))
+            ->where('chimeSounds.0', ['value' => ChimeSound::Off->value, 'label' => 'Off'])
+        );
+});
+
+test('the chime sound can be updated', function () {
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->patch(route('notifications.update'), [
+            'chime_sound' => ChimeSound::Knock->value,
+        ])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('notifications.edit'));
+
+    expect($user->refresh()->chime_sound)->toBe(ChimeSound::Knock);
+});
+
+test('chimes can be disabled entirely', function () {
+    $user = User::factory()->create(['chime_sound' => ChimeSound::Ping->value]);
+
+    $this
+        ->actingAs($user)
+        ->patch(route('notifications.update'), [
+            'chime_sound' => ChimeSound::Off->value,
+        ])
+        ->assertSessionHasNoErrors();
+
+    expect($user->refresh()->chime_sound)->toBe(ChimeSound::Off);
+});
+
+test('an unknown chime sound is rejected', function () {
+    $user = User::factory()->create(['chime_sound' => ChimeSound::Ping->value]);
+
+    $this
+        ->actingAs($user)
+        ->from(route('notifications.edit'))
+        ->patch(route('notifications.update'), [
+            'chime_sound' => 'foghorn',
+        ])
+        ->assertSessionHasErrors('chime_sound')
+        ->assertRedirect(route('notifications.edit'));
+
+    expect($user->refresh()->chime_sound)->toBe(ChimeSound::Ping);
+});
+
+test('a chime sound is required', function () {
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->from(route('notifications.edit'))
+        ->patch(route('notifications.update'), [])
+        ->assertSessionHasErrors('chime_sound');
+});
+
+test('guests cannot view the notification settings page', function () {
+    $this->get(route('notifications.edit'))->assertRedirect(route('login'));
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['resources/js/**/*.test.ts'],
+    },
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./resources/js', import.meta.url)),
+        },
+    },
+});


### PR DESCRIPTION
Closes #28.

## What
Play a short synthesized **chime** when a qualifying realtime message arrives in **any** sidebar channel while the user is elsewhere — honoring the existing per-channel **mute** and **notification-level** preferences.

## Decision logic
The "should this chime?" gate (`resources/js/lib/shouldChime.ts`) mirrors the sidebar-badge semantics so a chime, an unread badge, and a mention badge stay consistent:

- A direct **@mention** chimes unless the channel is muted or set to *nothing*.
- **Ordinary traffic** chimes only at the *all* level; thread-only replies chime only through the mention path (mirroring how the unread badge excludes them).
- Suppressed for the user's **own messages**, for the channel being **actively viewed** (open + tab focused), and when chimes are **off**.

## Preference
A new account-wide `chime_sound` preference (`App\Enums\ChimeSound`, persisted on `users`) drives playback, with an **Off** option and a **Preview** button on a new **Settings → Notifications** page. Follows the existing `NotificationLevel` enum pattern (migration + cast + `#[Fillable]` + settings controller/FormRequest/route, surfaced via shared `auth.user`).

## Playback
- Chimes are **synthesized via the Web Audio API** (per-sound oscillator recipes) rather than bundled as binary audio — previews and playback need no assets or network.
- Unlocks the `AudioContext` on the first user gesture (browser autoplay policy).
- A global listener mounted in the persistent channel layout subscribes to **every** sidebar channel so background activity is audible. `Show.vue` keeps owning the open channel and never chimes; the listener re-attaches to a channel `Show` tears down on navigation, so there's no double playback or dropped chime.

## Testing
- The project had **no JS test runner**, so this adds **Vitest** (`npm run test:js`, wired into `composer ci:check`) to unit-test every branch of the pure decision function (13 tests).
- Backend covered by Pest at **100%** (`ChimeSound`, `NotificationController`, `NotificationPreferencesRequest`, updated `User`).

## Acceptance criteria
- [x] Chime plays on a qualifying incoming message/mention when the user isn't actively viewing it
- [x] Never chimes for own messages or when the tab/channel is the active focus
- [x] User preference: choose chime sound, preview it, or disable chimes
- [x] Respects channel mute / notification level
- [x] Test coverage for the "should this event chime?" decision logic

## Gate
Pint ✅ · PHPStan 0 errors ✅ · Pest 310 tests / 100% coverage ✅ · ESLint ✅ · Prettier ✅ · vue-tsc ✅ · vite build ✅ · Vitest 13/13 ✅

## Note on scope
The sidebar channel list + subscriptions only exist on `channels/*` routes, so chimes fire anywhere in the workspace but not while on a settings/teams page. Reasonable for now; can be extended if desired.