### PR TITLE
fix(navigation): never land on a 404 after team switch or login

### DIFF
--- a/app/Http/Responses/Concerns/RedirectsToCurrentTeam.php
+++ b/app/Http/Responses/Concerns/RedirectsToCurrentTeam.php
@@ -3,6 +3,7 @@
 namespace App\Http\Responses\Concerns;
 
 use App\Models\Team;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\URL;
 
@@ -18,6 +19,57 @@ trait RedirectsToCurrentTeam
         URL::defaults(['current_team' => $team->slug]);
 
         return route('channels.index', ['team' => $team->slug], absolute: false);
+    }
+
+    /**
+     * Drop the stored "intended" URL when the authenticated user cannot view
+     * it, so login falls back to a valid workspace instead of a 404/403.
+     */
+    protected function forgetUnreachableIntendedUrl(Request $request): void
+    {
+        if (! $request->hasSession()) {
+            return;
+        }
+
+        $intended = $request->session()->get('url.intended');
+
+        if (is_string($intended) && ! $this->intendedUrlIsReachable($request->user(), $intended)) {
+            $request->session()->forget('url.intended');
+        }
+    }
+
+    /**
+     * Determine whether the authenticated user can actually reach a stored
+     * workspace URL. Non-workspace targets are honoured as-is; a `/t/{team}`
+     * URL requires membership, and a `/t/{team}/c/{channel}` URL additionally
+     * requires the channel to exist within that team (scoped bindings 404).
+     */
+    protected function intendedUrlIsReachable(?User $user, string $intended): bool
+    {
+        $path = parse_url($intended, PHP_URL_PATH);
+
+        if (! $user || ! is_string($path)) {
+            return false;
+        }
+
+        $segments = explode('/', trim($path, '/'));
+
+        if ($segments[0] !== 't') {
+            return true;
+        }
+
+        $team = ($slug = $segments[1] ?? null) ? Team::where('slug', $slug)->first() : null;
+
+        if (! $team || ! $user->belongsToTeam($team)) {
+            return false;
+        }
+
+        if (($segments[2] ?? null) !== 'c') {
+            return true;
+        }
+
+        return ($channelSlug = $segments[3] ?? null) !== null
+            && $team->channels()->where('slug', $channelSlug)->exists();
     }
 
     protected function currentTeam(Request $request): Team

--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -13,8 +13,12 @@ class LoginResponse implements LoginResponseContract
 
     public function toResponse($request): Response
     {
-        return $request->wantsJson()
-            ? new JsonResponse(['two_factor' => false], 200)
-            : redirect()->intended($this->redirectPathForCurrentTeam($request));
+        if ($request->wantsJson()) {
+            return new JsonResponse(['two_factor' => false], 200);
+        }
+
+        $this->forgetUnreachableIntendedUrl($request);
+
+        return redirect()->intended($this->redirectPathForCurrentTeam($request));
     }
 }

--- a/app/Http/Responses/RegisterResponse.php
+++ b/app/Http/Responses/RegisterResponse.php
@@ -13,8 +13,12 @@ class RegisterResponse implements RegisterResponseContract
 
     public function toResponse($request): Response
     {
-        return $request->wantsJson()
-            ? new JsonResponse(['two_factor' => false], 201)
-            : redirect()->intended($this->redirectPathForCurrentTeam($request));
+        if ($request->wantsJson()) {
+            return new JsonResponse(['two_factor' => false], 201);
+        }
+
+        $this->forgetUnreachableIntendedUrl($request);
+
+        return redirect()->intended($this->redirectPathForCurrentTeam($request));
     }
 }

--- a/app/Http/Responses/TwoFactorLoginResponse.php
+++ b/app/Http/Responses/TwoFactorLoginResponse.php
@@ -13,8 +13,12 @@ class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
 
     public function toResponse($request): Response
     {
-        return $request->wantsJson()
-            ? new JsonResponse(['two_factor' => false], 200)
-            : redirect()->intended($this->redirectPathForCurrentTeam($request));
+        if ($request->wantsJson()) {
+            return new JsonResponse(['two_factor' => false], 200);
+        }
+
+        $this->forgetUnreachableIntendedUrl($request);
+
+        return redirect()->intended($this->redirectPathForCurrentTeam($request));
     }
 }

--- a/app/Http/Responses/VerifyEmailResponse.php
+++ b/app/Http/Responses/VerifyEmailResponse.php
@@ -13,8 +13,12 @@ class VerifyEmailResponse implements VerifyEmailResponseContract
 
     public function toResponse($request): Response
     {
-        return $request->wantsJson()
-            ? new JsonResponse('', 204)
-            : redirect()->intended($this->redirectPathForCurrentTeam($request).'?verified=1');
+        if ($request->wantsJson()) {
+            return new JsonResponse('', 204);
+        }
+
+        $this->forgetUnreachableIntendedUrl($request);
+
+        return redirect()->intended($this->redirectPathForCurrentTeam($request).'?verified=1');
     }
 }

--- a/resources/js/composables/targetUrlForTeamSwitch.test.ts
+++ b/resources/js/composables/targetUrlForTeamSwitch.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { targetUrlForTeamSwitch } from '@/composables/useTeamSwitch';
+
+describe('targetUrlForTeamSwitch', () => {
+    it('drops a channel path with no guaranteed counterpart and lands on the target team index', () => {
+        expect(
+            targetUrlForTeamSwitch('/t/acme/c/random', 'acme', 'globex'),
+        ).toBe('/t/globex');
+    });
+
+    it('drops a channel path even when it carries a query or hash', () => {
+        expect(
+            targetUrlForTeamSwitch(
+                '/t/acme/c/random?highlight=5#msg-1',
+                'acme',
+                'globex',
+            ),
+        ).toBe('/t/globex');
+    });
+
+    it('rewrites the bare workspace index to the target team', () => {
+        expect(targetUrlForTeamSwitch('/t/acme', 'acme', 'globex')).toBe(
+            '/t/globex',
+        );
+    });
+
+    it('preserves team-level routes that exist in every workspace', () => {
+        expect(
+            targetUrlForTeamSwitch('/t/acme/channels/browse', 'acme', 'globex'),
+        ).toBe('/t/globex/channels/browse');
+        expect(
+            targetUrlForTeamSwitch('/t/acme/search?q=hi', 'acme', 'globex'),
+        ).toBe('/t/globex/search?q=hi');
+    });
+
+    it('preserves a query string on the workspace index', () => {
+        expect(
+            targetUrlForTeamSwitch('/t/acme?tab=all', 'acme', 'globex'),
+        ).toBe('/t/globex?tab=all');
+    });
+
+    it('returns null when not on a workspace page for the previous team', () => {
+        expect(
+            targetUrlForTeamSwitch('/settings/profile', 'acme', 'globex'),
+        ).toBeNull();
+    });
+
+    it('does not treat a slug that is merely a prefix of the current one as a match', () => {
+        expect(
+            targetUrlForTeamSwitch('/t/acme-corp/c/random', 'acme', 'globex'),
+        ).toBeNull();
+    });
+});

--- a/resources/js/composables/useTeamSwitch.ts
+++ b/resources/js/composables/useTeamSwitch.ts
@@ -8,10 +8,47 @@ export type UseTeamSwitchReturn = {
 };
 
 /**
+ * Compute where to land after switching from `previousTeamSlug` to
+ * `nextTeamSlug`, given the URL the user is currently on.
+ *
+ * Only `/t/{slug}` workspace URLs are rewritten. Channel slugs are per-team, so
+ * a `/t/{slug}/c/{channel}` path has no guaranteed counterpart in the target
+ * team (carrying it over 404s via scoped bindings) — those land on the new
+ * team's channel index instead. Team-level routes (browse, search, …) exist in
+ * every workspace and are preserved. Returns `null` when the current URL is not
+ * a workspace page for the previous team, signalling the caller to reload.
+ */
+export function targetUrlForTeamSwitch(
+    currentUrl: string,
+    previousTeamSlug: string,
+    nextTeamSlug: string,
+): string | null {
+    const prefix = `/t/${previousTeamSlug}`;
+
+    if (!currentUrl.startsWith(prefix)) {
+        return null;
+    }
+
+    const remainder = currentUrl.slice(prefix.length);
+
+    // Guard against a slug that is merely a prefix of another (e.g. previous
+    // `acme` vs. current `/t/acme-corp/...`): the boundary must be a separator.
+    if (remainder !== '' && !'/?#'.includes(remainder[0])) {
+        return null;
+    }
+
+    if (remainder === '' || remainder.startsWith('/c/')) {
+        return `/t/${nextTeamSlug}`;
+    }
+
+    return `/t/${nextTeamSlug}${remainder}`;
+}
+
+/**
  * Shared workspace-switching behaviour used by both the team rail and the
  * TeamSwitcher dropdown. Visiting the switch route swaps the active team, then
- * rewrites the current URL's team segment so the user stays on the equivalent
- * page under the new workspace (falling back to a plain reload).
+ * moves the user to the equivalent page under the new workspace (falling back
+ * to a plain reload).
  */
 export function useTeamSwitch(): UseTeamSwitchReturn {
     const page = usePage();
@@ -29,17 +66,19 @@ export function useTeamSwitch(): UseTeamSwitchReturn {
                 }
 
                 const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-                const segment = `/${previousTeamSlug}`;
+                const target = targetUrlForTeamSwitch(
+                    currentUrl,
+                    previousTeamSlug,
+                    team.slug,
+                );
 
-                if (currentUrl.includes(segment)) {
-                    router.visit(currentUrl.replace(segment, `/${team.slug}`), {
-                        replace: true,
-                    });
+                if (target === null) {
+                    router.reload();
 
                     return;
                 }
 
-                router.reload();
+                router.visit(target, { replace: true });
             },
         });
     };

--- a/tests/Feature/Auth/IntendedRedirectTest.php
+++ b/tests/Feature/Auth/IntendedRedirectTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+
+/**
+ * Log the user in and return the resulting redirect response, seeding the given
+ * URL as the guest-stored "intended" target when provided.
+ */
+function loginWithIntended(User $user, ?string $intended = null): TestResponse
+{
+    $session = $intended === null ? [] : ['url.intended' => $intended];
+
+    return test()->withSession($session)->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+}
+
+test('login with no intended URL lands on the current team general channel', function () {
+    $user = User::factory()->create();
+
+    loginWithIntended($user)->assertRedirect(
+        route('channels.index', ['team' => $user->currentTeam->slug]),
+    );
+});
+
+test('login honours an intended URL the user can view', function () {
+    $user = User::factory()->create();
+    $channel = Channel::factory()->create([
+        'team_id' => $user->currentTeam->id,
+        'slug' => 'random',
+    ]);
+
+    $intended = route('channels.show', ['team' => $user->currentTeam->slug, 'channel' => $channel->slug]);
+
+    loginWithIntended($user, $intended)->assertRedirect($intended);
+});
+
+test('login honours an intended URL pointing at a team the user belongs to', function () {
+    $user = User::factory()->create();
+
+    $intended = route('channels.index', ['team' => $user->currentTeam->slug]);
+
+    loginWithIntended($user, $intended)->assertRedirect($intended);
+});
+
+test('login honours a non-workspace intended URL as-is', function () {
+    $user = User::factory()->create();
+
+    $intended = route('profile.edit');
+
+    loginWithIntended($user, $intended)->assertRedirect($intended);
+});
+
+test('login falls back when the intended channel no longer exists in the team', function () {
+    $user = User::factory()->create();
+
+    $intended = route('channels.show', ['team' => $user->currentTeam->slug, 'channel' => 'random']);
+
+    loginWithIntended($user, $intended)->assertRedirect(
+        route('channels.index', ['team' => $user->currentTeam->slug]),
+    );
+});
+
+test('login falls back when the intended team does not exist', function () {
+    $user = User::factory()->create();
+
+    loginWithIntended($user, url('/t/does-not-exist'))->assertRedirect(
+        route('channels.index', ['team' => $user->currentTeam->slug]),
+    );
+});
+
+test('login falls back when the intended team is one the user does not belong to', function () {
+    $user = User::factory()->create();
+    $otherTeam = Team::factory()->create();
+    $otherOwner = User::factory()->create();
+    $otherTeam->members()->attach($otherOwner, ['role' => TeamRole::Owner->value]);
+
+    $intended = route('channels.index', ['team' => $otherTeam->slug]);
+
+    loginWithIntended($user, $intended)->assertRedirect(
+        route('channels.index', ['team' => $user->currentTeam->slug]),
+    );
+});
+
+test('login falls back when the intended URL has no path', function () {
+    $user = User::factory()->create();
+
+    loginWithIntended($user, 'http://localhost')->assertRedirect(
+        route('channels.index', ['team' => $user->currentTeam->slug]),
+    );
+});


### PR DESCRIPTION
## Summary

Fixes two related workspace-navigation bugs that could drop a user on a **404** (or **403**) page.

### #61 — Team switcher 404s when the current channel has no counterpart in the target team
`useTeamSwitch` used to string-replace the old team slug with the new one, carrying the per-team channel slug across (`/t/A/c/random` → `/t/B/c/random`), which 404s via scoped bindings when B has no `random` channel. It also replaced the first `/{slug}` occurrence anywhere in the path.

Now the rewrite logic lives in a pure, unit-tested helper `targetUrlForTeamSwitch`:
- `/t/{slug}/c/{channel}` → target team's channel index (`/t/{newSlug}`), since channel slugs are per-team.
- Team-level routes (`/channels/browse`, `/search`, …) and query strings are preserved.
- A slug that is merely a prefix of another (`acme` vs `acme-corp`) no longer matches → reload.

### #62 — Post-login `intended()` redirect can land the user on a 404
Fortify's `redirect()->intended()` replayed whatever guest URL was stashed with no check the authenticated user can view it. A stale `/c/{channel}` (scoped-binding 404) or a non-member team (403) produced a broken landing.

The shared `RedirectsToCurrentTeam` concern now drops an unreachable intended URL before redirecting — unknown team, non-member team, or a channel absent from the team — falling back to the current team's `#general`. Applied to all four Fortify responses (Login, Register, TwoFactorLogin, VerifyEmail).

## Tests
- `tests/Feature/Auth/IntendedRedirectTest.php` — login with (a) no intended, (b) valid intended, (c) valid team index, (d) non-workspace URL, (e) stale channel, (f) unknown team, (g) non-member team, (h) pathless URL.
- `resources/js/composables/targetUrlForTeamSwitch.test.ts` — 7 cases covering the helper.
- Full gate green: backend 100% coverage + Pint + PHPStan; frontend lint/format/types/build; all JS tests.

Closes #61
Closes #62