### PR TITLE
feat(sidebar): live unread & mention badges

### DIFF
--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -1,0 +1,133 @@
+import { router, usePage } from '@inertiajs/vue3';
+import { echo } from '@laravel/echo-vue';
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
+import type { Message } from '@/types';
+
+/** Coalesce a burst of arrivals into a single sidebar reload. */
+const REFRESH_DEBOUNCE_MS = 500;
+
+/**
+ * Keep the sidebar's unread and mention badges live.
+ *
+ * The shared `channels` prop is recomputed server-side (see HandleInertiaRequests)
+ * but only refreshes on navigation and when the open channel is marked read, so a
+ * message posted in a channel the user belongs to but is not viewing would not move
+ * its badge until the next visit. Mounted once in the persistent channel layout,
+ * this subscribes to each sidebar channel's private broadcast and, on a qualifying
+ * MessageSent, debounces a partial reload of `channels` so the badge updates without
+ * a manual navigation. A single reload recomputes every channel's count, so bursts
+ * across channels collapse to one request.
+ *
+ * It mirrors useChimeNotifications' subscription bookkeeping: Show.vue owns the open
+ * channel's subscription and tears it down with a full `leave` on navigation, which
+ * also drops our listener on it; the post-flush reconcile re-attaches the channel it
+ * just left.
+ */
+export function useSidebarBadges(): void {
+    const page = usePage();
+
+    const currentUserId = computed(() => String(page.props.auth.user.id));
+    const channels = computed(() => page.props.channels ?? []);
+    const activeChannelId = computed(
+        () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
+    );
+
+    // Only reconcile when the set of channels or the open one actually changes,
+    // not on every badge-count refresh of the shared `channels` prop.
+    const subscriptionKey = computed(
+        () =>
+            `${channels.value.map((channel) => channel.id).join('|')}::${activeChannelId.value ?? ''}`,
+    );
+
+    const bound = new Set<string>();
+    let previousActiveId: string | null = null;
+    let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function channelName(id: string): string {
+        return `channel.${id}`;
+    }
+
+    function scheduleRefresh(): void {
+        if (refreshTimer) {
+            clearTimeout(refreshTimer);
+        }
+
+        refreshTimer = setTimeout(() => {
+            // reload defaults to preserving scroll and page state; it re-evaluates
+            // only the shared `channels` prop to recompute every badge count.
+            router.reload({ only: ['channels'] });
+        }, REFRESH_DEBOUNCE_MS);
+    }
+
+    function handleMessage(channelId: string, message: Message): void {
+        const decision = shouldRefreshSidebar({
+            isOwnMessage: message.user.id === currentUserId.value,
+            isChannelMessage:
+                message.threadRootId === null || message.sentToChannel,
+            mentionsCurrentUser: message.mentions.some(
+                (mention) => mention.id === currentUserId.value,
+            ),
+            isActiveChannel: channelId === activeChannelId.value,
+            tabHasFocus: typeof document !== 'undefined' && document.hasFocus(),
+        });
+
+        if (decision) {
+            scheduleRefresh();
+        }
+    }
+
+    function listen(id: string): void {
+        echo()
+            .private(channelName(id))
+            .listen('MessageSent', (message: Message) => {
+                handleMessage(id, message);
+            });
+    }
+
+    function reconcile(): void {
+        const desired = new Set(channels.value.map((channel) => channel.id));
+        const active = activeChannelId.value;
+
+        if (previousActiveId !== null && previousActiveId !== active) {
+            bound.delete(previousActiveId);
+        }
+
+        previousActiveId = active;
+
+        for (const id of desired) {
+            if (!bound.has(id)) {
+                listen(id);
+                bound.add(id);
+            }
+        }
+
+        for (const id of [...bound]) {
+            if (!desired.has(id)) {
+                echo().leave(channelName(id));
+                bound.delete(id);
+            }
+        }
+    }
+
+    function leaveAll(): void {
+        for (const id of bound) {
+            echo().leave(channelName(id));
+        }
+
+        bound.clear();
+    }
+
+    onMounted(reconcile);
+
+    // Post-flush so it runs after Show.vue's own per-channel teardown.
+    watch(subscriptionKey, reconcile, { flush: 'post' });
+
+    onBeforeUnmount(() => {
+        if (refreshTimer) {
+            clearTimeout(refreshTimer);
+        }
+
+        leaveAll();
+    });
+}

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -35,12 +35,17 @@ import {
 } from '@/components/ui/tooltip';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useInitials } from '@/composables/useInitials';
+import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
 
 const page = usePage();
 
 // Chime for qualifying messages across every channel while the workspace is open.
 useChimeNotifications();
+
+// Keep the sidebar unread/mention badges live as messages arrive in channels the
+// user is a member of but not currently viewing.
+useSidebarBadges();
 
 const currentTeam = computed(() => page.props.currentTeam);
 const teams = computed(() => page.props.teams ?? []);

--- a/resources/js/lib/shouldRefreshSidebar.test.ts
+++ b/resources/js/lib/shouldRefreshSidebar.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
+import type { SidebarRefreshInput } from '@/lib/shouldRefreshSidebar';
+
+/**
+ * A qualifying baseline: an ordinary message from someone else landing in a
+ * background channel while the tab is blurred. Each test overrides one axis.
+ */
+function input(
+    overrides: Partial<SidebarRefreshInput> = {},
+): SidebarRefreshInput {
+    return {
+        isOwnMessage: false,
+        isChannelMessage: true,
+        mentionsCurrentUser: false,
+        isActiveChannel: false,
+        tabHasFocus: false,
+        ...overrides,
+    };
+}
+
+describe('shouldRefreshSidebar', () => {
+    it('refreshes for an ordinary message in a background channel', () => {
+        expect(shouldRefreshSidebar(input())).toBe(true);
+    });
+
+    it("never refreshes for the user's own message", () => {
+        expect(shouldRefreshSidebar(input({ isOwnMessage: true }))).toBe(false);
+    });
+
+    it('does not refresh for a thread-only reply that does not mention the user', () => {
+        expect(shouldRefreshSidebar(input({ isChannelMessage: false }))).toBe(
+            false,
+        );
+    });
+
+    it('refreshes for a thread-only reply that mentions the user', () => {
+        expect(
+            shouldRefreshSidebar(
+                input({ isChannelMessage: false, mentionsCurrentUser: true }),
+            ),
+        ).toBe(true);
+    });
+
+    it('does not refresh for the active channel while the tab is focused', () => {
+        expect(
+            shouldRefreshSidebar(
+                input({ isActiveChannel: true, tabHasFocus: true }),
+            ),
+        ).toBe(false);
+    });
+
+    it('refreshes for the active channel while the tab is blurred', () => {
+        expect(
+            shouldRefreshSidebar(
+                input({ isActiveChannel: true, tabHasFocus: false }),
+            ),
+        ).toBe(true);
+    });
+
+    it('refreshes for a background channel while the tab is focused elsewhere', () => {
+        expect(
+            shouldRefreshSidebar(
+                input({ isActiveChannel: false, tabHasFocus: true }),
+            ),
+        ).toBe(true);
+    });
+});

--- a/resources/js/lib/shouldRefreshSidebar.ts
+++ b/resources/js/lib/shouldRefreshSidebar.ts
@@ -1,0 +1,45 @@
+export type SidebarRefreshInput = {
+    /** The message was authored by the current user (own messages never badge). */
+    isOwnMessage: boolean;
+    /**
+     * The message counts as ordinary channel traffic — a top-level message or a
+     * thread reply also broadcast to the channel. Thread-only replies are `false`
+     * and only move a badge through the mention path, mirroring how the server's
+     * sidebar unread query excludes them.
+     */
+    isChannelMessage: boolean;
+    /** The current user is directly @mentioned by the message. */
+    mentionsCurrentUser: boolean;
+    /** The message landed in the channel the user is actively viewing on screen. */
+    isActiveChannel: boolean;
+    /** The browser tab currently has focus. */
+    tabHasFocus: boolean;
+};
+
+/**
+ * Decide whether a freshly-arrived realtime message should refresh the sidebar's
+ * unread and mention badges (a partial reload of the shared `channels` prop).
+ *
+ * The gate mirrors the server's badge query so a live badge and a navigation-time
+ * badge agree: a message only moves a count when it is ordinary channel traffic or
+ * a direct @mention — a thread-only reply without a mention lives in the thread
+ * view and never touches the plain count. A user's own message never counts as
+ * unread. The actively-viewed channel is skipped only while its tab is focused,
+ * because Show.vue is already advancing its read pointer and reloading the sidebar;
+ * blurred, that channel must badge like any other.
+ */
+export function shouldRefreshSidebar(input: SidebarRefreshInput): boolean {
+    if (input.isOwnMessage) {
+        return false;
+    }
+
+    if (!input.isChannelMessage && !input.mentionsCurrentUser) {
+        return false;
+    }
+
+    if (input.isActiveChannel && input.tabHasFocus) {
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
Closes #66.

## Problem

Sidebar unread/mention badges only refresh on navigation and when the open channel is marked read (they ride the shared `channels` Inertia prop). A message — or an @mention — posted in a channel the user belongs to but is **not** currently viewing did not move its badge until the next Inertia visit. The open channel already behaved correctly.

## Approach

Mount a new `useSidebarBadges()` composable once in the persistent channel layout. It subscribes to each sidebar channel's private `channel.{id}` broadcast — the same per-channel pattern `useChimeNotifications` already established — and, on a qualifying `MessageSent`, debounces (500ms) a partial `router.reload({ only: ['channels'] })` that recomputes every badge server-side in a single request.

I chose the per-channel private-subscription route over the team-channel broadcast alternative floated in the issue: a `team.{id}` broadcast would deliver "activity in channel X" to every team member, leaking private-channel activity to non-members. The private channel authorization callback already scopes delivery to channel members.

## Details

- **`resources/js/lib/shouldRefreshSidebar.ts`** — pure decision helper mirroring the server's sidebar unread query: the user's own messages and thread-only replies without a mention never refresh; the actively-viewed channel is skipped **only while focused**, where `Show.vue` already advances the read pointer and reloads the sidebar (blurred, it must badge like any other channel).
- **`resources/js/composables/useSidebarBadges.ts`** — reuses the chime composable's `reconcile` / `previousActiveId` subscription bookkeeping so it coexists cleanly with `Show.vue`'s active-channel teardown; a single debounced reload coalesces bursts across channels.
- **`resources/js/layouts/channels/Layout.vue`** — calls `useSidebarBadges()`.

## Acceptance criteria

- [x] Posting/mentioning in a member channel the user isn't viewing increments its badge without manual navigation
- [x] Updates are debounced and don't thrash the sidebar under message bursts
- [x] Opening the channel still clears the badge (no regression to #10 — `Show.vue`'s `markRead` is unchanged, and the helper defers to it while focused)
- [x] Test coverage

## Testing

- `shouldRefreshSidebar` unit-tested with Vitest (mirrors how `shouldChime` is covered) — 27/27 JS tests pass.
- Full gate green: lint, format, types, build, and the PHP suite at `Total: 100.0%` (no PHP changed).

The live increment itself is client-driven (no new server code — the badge computation is already covered by #10's tests), so there's no meaningful PHP feature test to add. An end-to-end assertion of the realtime increment overlaps with #53 (browser/E2E suite for realtime flows) and is better placed there than as one-off browser tooling here.