### PR TITLE
feat(channels): new-messages divider + jump to unread (#37)

### DIFF
--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -101,6 +101,11 @@ class ChannelController extends Controller
             // The message the client should scroll to and highlight on load, or
             // null for a normal channel visit.
             'jumpToMessageId' => $jumpToMessageId,
+            // The viewer's read pointer captured at render time, before the
+            // client's debounced MarkChannelRead advances it. Drives the
+            // "New messages" divider so it lands at the last-read boundary on
+            // open; null when the channel has never been read.
+            'lastReadMessageId' => $membership?->last_read_message_id !== null ? (string) $membership->last_read_message_id : null,
             // The open thread (root + its replies), resolved from the `?thread=`
             // query param, or null for a normal visit. The client opens a thread
             // with a partial reload of just this prop; on a full visit the closure

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -23,6 +23,9 @@ const props = defineProps<{
     canModerate?: boolean;
     onlineIds?: Set<string>;
     highlightMessageId?: string | null;
+    // The message the "New messages" divider sits above — the first unread on
+    // channel open — or null when there's no unread boundary to mark.
+    unreadDividerId?: string | null;
     // Rendered inside a thread panel: hides the per-message thread affordances
     // (you're already in the thread), so the panel only shows the conversation.
     inThread?: boolean;
@@ -74,6 +77,8 @@ type RenderDivider = {
     type: 'divider';
     key: string;
     label: string;
+    // 'day' groups messages by date; 'unread' is the "New messages" boundary.
+    variant: 'day' | 'unread';
 };
 
 type RenderItem = RenderGroup | RenderDivider;
@@ -127,8 +132,24 @@ const renderItems = computed<RenderItem[]>(() => {
                 type: 'divider',
                 key: `divider-${messageDay}`,
                 label: dividerLabel(message.createdAt),
+                variant: 'day',
             });
             currentDay = messageDay;
+        }
+
+        // The "New messages" boundary breaks the run of grouped messages so the
+        // divider sits on its own line directly above the first unread message.
+        const isUnreadBoundary =
+            props.unreadDividerId != null &&
+            message.id === props.unreadDividerId;
+
+        if (isUnreadBoundary) {
+            items.push({
+                type: 'divider',
+                key: 'unread-divider',
+                label: 'New',
+                variant: 'unread',
+            });
         }
 
         const sameAuthor = currentGroup?.author.id === message.user.id;
@@ -138,7 +159,13 @@ const renderItems = computed<RenderItem[]>(() => {
                 new Date(lastCreatedAt).getTime() <=
                 GROUPING_WINDOW_MS;
 
-        if (!currentGroup || startsNewDay || !sameAuthor || !withinWindow) {
+        if (
+            !currentGroup ||
+            startsNewDay ||
+            isUnreadBoundary ||
+            !sameAuthor ||
+            !withinWindow
+        ) {
             currentGroup = {
                 type: 'group',
                 key: `group-${message.id}`,
@@ -259,7 +286,21 @@ function confirmDelete(): void {
     <div class="px-5 pt-4 pb-2">
         <template v-for="item in renderItems" :key="item.key">
             <div
-                v-if="item.type === 'divider'"
+                v-if="item.type === 'divider' && item.variant === 'unread'"
+                id="unread-divider"
+                data-test="unread-divider"
+                class="relative my-3 flex items-center gap-2"
+            >
+                <span aria-hidden="true" class="h-px flex-1 bg-rose-500/50" />
+                <span
+                    class="text-[11px] font-semibold tracking-[0.05em] text-rose-500 uppercase"
+                >
+                    {{ item.label }}
+                </span>
+            </div>
+
+            <div
+                v-else-if="item.type === 'divider'"
                 class="relative my-4 flex items-center justify-center"
             >
                 <span

--- a/resources/js/lib/unreadDivider.test.ts
+++ b/resources/js/lib/unreadDivider.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { unreadDividerMessageId } from '@/lib/unreadDivider';
+
+/**
+ * A minimal message row for boundary computation: only the id and author matter.
+ */
+function message(id: string, userId: string) {
+    return { id, user: { id: userId, name: `User ${userId}` } };
+}
+
+const ME = 'me';
+const PEER = 'peer';
+
+describe('unreadDividerMessageId', () => {
+    it('marks the first message posted after the read pointer', () => {
+        const messages = [
+            message('1', PEER),
+            message('2', PEER),
+            message('3', PEER),
+            message('4', PEER),
+        ];
+
+        expect(unreadDividerMessageId(messages, '2', ME)).toBe('3');
+    });
+
+    it('returns null when every message has been read', () => {
+        const messages = [message('1', PEER), message('2', PEER)];
+
+        expect(unreadDividerMessageId(messages, '2', ME)).toBeNull();
+    });
+
+    it('treats a null pointer as an entirely unread channel', () => {
+        const messages = [message('1', PEER), message('2', PEER)];
+
+        expect(unreadDividerMessageId(messages, null, ME)).toBe('1');
+    });
+
+    it("skips the reader's own messages at the boundary", () => {
+        const messages = [
+            message('1', PEER),
+            message('2', ME),
+            message('3', ME),
+            message('4', PEER),
+        ];
+
+        // Read up to 1; 2 and 3 are your own, so the "New" line sits above 4.
+        expect(unreadDividerMessageId(messages, '1', ME)).toBe('4');
+    });
+
+    it("returns null when the only unread messages are the reader's own", () => {
+        const messages = [
+            message('1', PEER),
+            message('2', ME),
+            message('3', ME),
+        ];
+
+        expect(unreadDividerMessageId(messages, '1', ME)).toBeNull();
+    });
+
+    it('ignores non-numeric ids from optimistic sends awaiting confirmation', () => {
+        const messages = [
+            message('1', PEER),
+            message('c1d2-uuid', ME),
+            message('2', PEER),
+        ];
+
+        expect(unreadDividerMessageId(messages, '1', ME)).toBe('2');
+    });
+
+    it('returns null for an empty channel', () => {
+        expect(unreadDividerMessageId([], '5', ME)).toBeNull();
+    });
+});

--- a/resources/js/lib/unreadDivider.ts
+++ b/resources/js/lib/unreadDivider.ts
@@ -1,0 +1,43 @@
+import type { Message } from '@/types';
+
+/**
+ * The id of the message where a "New messages" divider should sit — the first
+ * message the reader has not yet seen, or null when there is no boundary to mark.
+ *
+ * `lastReadMessageId` is the read pointer captured when the channel opened; a
+ * message is unread when its id sorts after that pointer. A null pointer means
+ * the channel has never been read, so every message counts as unread. The
+ * reader's own messages at the boundary are skipped — you don't need a "new"
+ * marker above something you just posted — so an entirely-own unread tail yields
+ * null.
+ *
+ * Message ids are monotonic auto-increment values delivered as numeric strings,
+ * so the comparison is numeric. A non-numeric id (an optimistic send still keyed
+ * by its client uuid) is never treated as unread: those are always the reader's
+ * own, and the boundary is fixed at channel open rather than moved by later
+ * traffic.
+ */
+export function unreadDividerMessageId(
+    messages: Pick<Message, 'id' | 'user'>[],
+    lastReadMessageId: string | null,
+    currentUserId: string,
+): string | null {
+    const readPointer =
+        lastReadMessageId === null ? -Infinity : Number(lastReadMessageId);
+
+    for (const message of messages) {
+        const id = Number(message.id);
+
+        if (!Number.isFinite(id) || id <= readPointer) {
+            continue;
+        }
+
+        if (message.user.id === currentUserId) {
+            continue;
+        }
+
+        return message.id;
+    }
+
+    return null;
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -3,6 +3,7 @@ import { Head, InfiniteScroll, router, usePage } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
 import {
     Archive,
+    ArrowUp,
     AtSign,
     BellMinus,
     BellOff,
@@ -62,6 +63,7 @@ import {
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
+import { unreadDividerMessageId } from '@/lib/unreadDivider';
 import type {
     Channel,
     Mention,
@@ -81,6 +83,9 @@ const props = defineProps<{
     canManagePreferences: boolean;
     notificationLevels: NotificationLevelOption[];
     jumpToMessageId?: string | null;
+    // The viewer's read pointer at load time, used to place the "New messages"
+    // divider; null when the channel has never been read.
+    lastReadMessageId?: string | null;
     // The open thread, loaded on demand as an optional prop keyed by `?thread=`.
     thread?: Thread | null;
 }>();
@@ -199,6 +204,65 @@ function jumpToMessage(id: string): void {
     });
 }
 
+// The message the "New messages" divider sits above, frozen at the moment the
+// channel opens: the read pointer keeps advancing as the user reads, but the
+// boundary stays put until they leave the channel. Recomputed on open and on
+// every channel switch from the read pointer the server captured before its
+// debounced advance.
+const unreadDividerId = ref<string | null>(null);
+const unreadDividerInView = ref(false);
+let unreadObserver: IntersectionObserver | null = null;
+
+// The floating "jump to new messages" pill shows only while there's a boundary
+// the user hasn't scrolled to yet.
+const showJumpToUnread = computed(
+    () => unreadDividerId.value !== null && !unreadDividerInView.value,
+);
+
+function computeUnreadDivider(): void {
+    unreadDividerId.value = unreadDividerMessageId(
+        displayMessages.value,
+        props.lastReadMessageId ?? null,
+        currentUser.value.id,
+    );
+
+    observeUnreadDivider();
+}
+
+// Watch the divider element so the jump pill hides once it scrolls into view.
+function observeUnreadDivider(): void {
+    unreadObserver?.disconnect();
+    unreadObserver = null;
+    unreadDividerInView.value = false;
+
+    if (unreadDividerId.value === null) {
+        return;
+    }
+
+    nextTick(() => {
+        const el = document.getElementById('unread-divider');
+        const root = scrollContainer.value;
+
+        if (!el || !root) {
+            return;
+        }
+
+        unreadObserver = new IntersectionObserver(
+            ([entry]) => {
+                unreadDividerInView.value = entry.isIntersecting;
+            },
+            { root },
+        );
+        unreadObserver.observe(el);
+    });
+}
+
+function scrollToUnread(): void {
+    document
+        .getElementById('unread-divider')
+        ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+}
+
 // Append a message to the main timeline, keeping the view pinned to newest only
 // when the reader was already near the bottom.
 function appendLiveMain(message: Message): void {
@@ -292,6 +356,7 @@ function markRead(): void {
 
 onMounted(() => {
     subscribe(props.channel.id);
+    computeUnreadDivider();
     markRead();
     window.addEventListener('focus', markRead);
 
@@ -347,12 +412,14 @@ watch(
         notificationLevel.value = props.channel.notificationLevel;
         muted.value = props.channel.muted;
         subscribe(newId);
+        computeUnreadDivider();
         markRead();
     },
 );
 
 onBeforeUnmount(() => {
     unsubscribe(props.channel.id);
+    unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
 
     if (markReadTimer) {
@@ -738,7 +805,27 @@ function archive(): void {
                 </DropdownMenu>
             </header>
 
-            <div class="flex min-h-0 flex-1 flex-col">
+            <div class="relative flex min-h-0 flex-1 flex-col">
+                <Transition
+                    enter-active-class="transition duration-150 ease-out"
+                    enter-from-class="-translate-y-1 opacity-0"
+                    enter-to-class="translate-y-0 opacity-100"
+                    leave-active-class="transition duration-100 ease-in"
+                    leave-from-class="translate-y-0 opacity-100"
+                    leave-to-class="-translate-y-1 opacity-0"
+                >
+                    <button
+                        v-if="showJumpToUnread"
+                        type="button"
+                        data-test="jump-to-unread"
+                        class="absolute top-2.5 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-rose-500 px-3 py-1 text-[12px] font-semibold text-white shadow-md hover:bg-rose-600"
+                        @click="scrollToUnread"
+                    >
+                        <ArrowUp class="size-3.5" />
+                        New messages
+                    </button>
+                </Transition>
+
                 <div
                     ref="scrollContainer"
                     class="min-h-0 flex-1 overflow-y-auto"
@@ -756,6 +843,7 @@ function archive(): void {
                             :can-moderate="canModerate"
                             :online-ids="onlineIds"
                             :highlight-message-id="highlightedMessageId"
+                            :unread-divider-id="unreadDividerId"
                             :active-thread-root-id="activeThreadRootId"
                             @edit="editMessage"
                             @delete="deleteMessage"

--- a/tests/Feature/Channels/ChannelTest.php
+++ b/tests/Feature/Channels/ChannelTest.php
@@ -5,6 +5,7 @@ use App\Actions\Teams\CreateTeam;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
 use App\Models\Channel;
+use App\Models\Message;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -98,4 +99,33 @@ test('a user who is not a team member cannot view the team\'s channels', functio
     $this->actingAs($outsider)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => 'general']))
         ->assertForbidden();
+});
+
+test('the channel page exposes the viewer\'s read pointer for the new-messages divider', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    $messages = Message::factory()->count(3)->for($general)->for($user)->create();
+    $user->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $messages[1]->id]);
+
+    $this->actingAs($user)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('lastReadMessageId', (string) $messages[1]->id)
+        );
+});
+
+test('the read pointer is null on a channel the viewer has never read', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    Message::factory()->for($general)->for($user)->create();
+
+    $this->actingAs($user)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->where('lastReadMessageId', null));
 });


### PR DESCRIPTION
Closes #37.

## What & why
Returning to a channel used to drop you at the newest message with no cue about where you left off. This adds a **"New messages" divider** at the last-read boundary plus a floating **"jump to unread"** pill that scrolls to it.

## How it works
- **Backend** (`ChannelController::show`) exposes the viewer's read pointer (`lastReadMessageId`), captured at render time **before** the client's debounced `MarkChannelRead` advances it — so the boundary is stable.
- **Boundary computation** (`resources/js/lib/unreadDivider.ts`): pure `unreadDividerMessageId()` returns the first unread message, skipping the reader's own sends and ignoring optimistic uuid-keyed rows.
- The boundary is **frozen at channel open** (and on channel switch); it doesn't drift as the read pointer advances or live messages arrive.
- `MessageList.vue` renders the divider, breaking message grouping at the boundary. `Show.vue` shows the jump pill, hidden once the divider scrolls into view (IntersectionObserver).

## Acceptance criteria
- [x] Divider appears at the last-read boundary on channel open
- [x] Jump-to-unread control scrolls to the divider
- [x] Integrates with the read-position / unread tracking (#10)
- [x] Test coverage for boundary computation

## Testing
- Pest feature tests for the new `lastReadMessageId` prop (populated + null cases)
- Vitest suite for boundary computation (read/unread, null pointer, own-message skip, non-numeric ids, empty)
- Full gate green: PHP 100% coverage + Pint + PHPStan; Vitest / lint / format / types / build

## Known limitation
For channels with **>50 unread**, the boundary can fall above the initial 50-message window and the divider is placed at the oldest loaded message. Proper fix (server-side windowing to open at the boundary) is tracked in #76.