### PR TITLE
feat(channels): window the initial page around the unread boundary (#76)

### DIFF
--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -16,6 +16,7 @@ use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -29,6 +30,20 @@ class ChannelController extends Controller
      * jumped-to message shows following context and is not pinned to the bottom.
      */
     private const int JUMP_CONTEXT = 15;
+
+    /**
+     * How many messages the initial timeline window loads. Mirrors the page size
+     * of {@see Builder::cursorPaginate()} below and
+     * feeds the read-boundary window math.
+     */
+    private const int MESSAGE_PAGE_SIZE = 50;
+
+    /**
+     * How many already-read messages to keep loaded above the "New messages"
+     * boundary when a channel opens deep enough into unread history that the
+     * boundary would otherwise fall outside the initial window.
+     */
+    private const int UNREAD_CONTEXT = 10;
 
     /**
      * Redirect a bare team URL to the team's #general channel.
@@ -77,11 +92,13 @@ class ChannelController extends Controller
         // id. If it belongs to this channel, cap the initial window a few messages
         // above the target so it loads with context on both sides; the client
         // scrolls to and highlights it, and older history still pages in above via
-        // InfiniteScroll.
+        // InfiniteScroll. Absent a jump, anchor the window around the read pointer
+        // so a channel with more unread than a page holds still loads the
+        // "New messages" boundary rather than freezing it at the oldest loaded row.
         $jumpToMessageId = $this->resolveJumpTarget($request, $channel);
-        $windowCeilingId = $jumpToMessageId === null
-            ? null
-            : $this->jumpWindowCeiling($channel, $jumpToMessageId);
+        $windowCeilingId = $jumpToMessageId !== null
+            ? $this->jumpWindowCeiling($channel, $jumpToMessageId)
+            : $this->unreadWindowCeiling($channel, $membership?->last_read_message_id);
 
         return Inertia::render('channels/Show', [
             'team' => [
@@ -118,15 +135,13 @@ class ChannelController extends Controller
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a
             // "message deleted" tombstone in place; MessageData blanks their body.
-            'messages' => Inertia::scroll(fn () => $channel->messages()
-                ->withTrashed()
+            'messages' => Inertia::scroll(fn () => $this->mainTimeline(
+                $channel->messages()->withTrashed()->getQuery()
+            )
                 ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
-                // Thread replies live in the thread view, not the main timeline —
-                // except a reply explicitly "also sent to channel".
-                ->where(fn ($query) => $query->whereNull('thread_root_id')->orWhere('sent_to_channel', true))
-                ->when($windowCeilingId, fn ($query) => $query->where('id', '<=', $windowCeilingId))
+                ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
-                ->cursorPaginate(50)
+                ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
                 ->through(fn (Message $message) => MessageData::fromMessage($message))),
         ]);
     }
@@ -208,6 +223,67 @@ class ChannelController extends Controller
             ->orderBy('id')
             ->offset(self::JUMP_CONTEXT - 1)
             ->value('id');
+    }
+
+    /**
+     * Resolve the id that caps the initial window so the "New messages" boundary
+     * loads, or null to keep the default "open at newest" window.
+     *
+     * The boundary sits at the first message newer than the viewer's read
+     * pointer. When few enough messages sit at or after it to fit inside the
+     * newest page, the boundary already loads and no window is needed. A busier
+     * channel is anchored: the window is capped UNREAD_CONTEXT read messages
+     * above the boundary so it opens with the "New messages" line near the top
+     * and unread history below, while older history still pages in above via
+     * InfiniteScroll.
+     *
+     * A never-read channel (null pointer) has no last-read boundary to anchor,
+     * so it keeps the default "open at newest" window rather than landing the
+     * viewer on the oldest message of a long backlog.
+     */
+    private function unreadWindowCeiling(Channel $channel, ?string $lastReadMessageId): ?string
+    {
+        if ($lastReadMessageId === null) {
+            return null;
+        }
+
+        $firstUnreadId = $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
+            ->where('id', '>', $lastReadMessageId)
+            ->orderBy('id')
+            ->value('id');
+
+        if ($firstUnreadId === null) {
+            return null;
+        }
+
+        // The boundary already loads when the messages at or after it fit in the
+        // newest page, so keep opening at newest for read/lightly-unread channels.
+        $atOrAfterBoundary = $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
+            ->where('id', '>=', $firstUnreadId)
+            ->count();
+
+        if ($atOrAfterBoundary <= self::MESSAGE_PAGE_SIZE) {
+            return null;
+        }
+
+        return $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
+            ->where('id', '>', $firstUnreadId)
+            ->orderBy('id')
+            ->offset(self::MESSAGE_PAGE_SIZE - self::UNREAD_CONTEXT - 1)
+            ->value('id');
+    }
+
+    /**
+     * Constrain a message query to the main channel timeline: top-level messages
+     * plus thread replies explicitly "also sent to channel". Thread replies
+     * otherwise live only in the thread view.
+     *
+     * @param  Builder<Message>  $query
+     * @return Builder<Message>
+     */
+    private function mainTimeline(Builder $query): Builder
+    {
+        return $query->where(fn (Builder $inner) => $inner->whereNull('thread_root_id')->orWhere('sent_to_channel', true));
     }
 
     /**

--- a/resources/js/lib/unreadDivider.test.ts
+++ b/resources/js/lib/unreadDivider.test.ts
@@ -2,10 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { unreadDividerMessageId } from '@/lib/unreadDivider';
 
 /**
+ * A time-ordered, uuid-shaped id for a given sequence number. Zero-padded to a
+ * fixed width so the ids sort chronologically under a lexicographic comparison,
+ * mirroring the ordered UUIDs the server assigns to real messages.
+ */
+function id(seq: number): string {
+    return `019f44c7-0000-7000-8000-${String(seq).padStart(12, '0')}`;
+}
+
+/**
  * A minimal message row for boundary computation: only the id and author matter.
  */
-function message(id: string, userId: string) {
-    return { id, user: { id: userId, name: `User ${userId}` } };
+function message(messageId: string, userId: string) {
+    return { id: messageId, user: { id: userId, name: `User ${userId}` } };
 }
 
 const ME = 'me';
@@ -14,60 +23,62 @@ const PEER = 'peer';
 describe('unreadDividerMessageId', () => {
     it('marks the first message posted after the read pointer', () => {
         const messages = [
-            message('1', PEER),
-            message('2', PEER),
-            message('3', PEER),
-            message('4', PEER),
+            message(id(1), PEER),
+            message(id(2), PEER),
+            message(id(3), PEER),
+            message(id(4), PEER),
         ];
 
-        expect(unreadDividerMessageId(messages, '2', ME)).toBe('3');
+        expect(unreadDividerMessageId(messages, id(2), ME)).toBe(id(3));
     });
 
     it('returns null when every message has been read', () => {
-        const messages = [message('1', PEER), message('2', PEER)];
+        const messages = [message(id(1), PEER), message(id(2), PEER)];
 
-        expect(unreadDividerMessageId(messages, '2', ME)).toBeNull();
+        expect(unreadDividerMessageId(messages, id(2), ME)).toBeNull();
     });
 
     it('treats a null pointer as an entirely unread channel', () => {
-        const messages = [message('1', PEER), message('2', PEER)];
+        const messages = [message(id(1), PEER), message(id(2), PEER)];
 
-        expect(unreadDividerMessageId(messages, null, ME)).toBe('1');
+        expect(unreadDividerMessageId(messages, null, ME)).toBe(id(1));
     });
 
     it("skips the reader's own messages at the boundary", () => {
         const messages = [
-            message('1', PEER),
-            message('2', ME),
-            message('3', ME),
-            message('4', PEER),
+            message(id(1), PEER),
+            message(id(2), ME),
+            message(id(3), ME),
+            message(id(4), PEER),
         ];
 
         // Read up to 1; 2 and 3 are your own, so the "New" line sits above 4.
-        expect(unreadDividerMessageId(messages, '1', ME)).toBe('4');
+        expect(unreadDividerMessageId(messages, id(1), ME)).toBe(id(4));
     });
 
     it("returns null when the only unread messages are the reader's own", () => {
         const messages = [
-            message('1', PEER),
-            message('2', ME),
-            message('3', ME),
+            message(id(1), PEER),
+            message(id(2), ME),
+            message(id(3), ME),
         ];
 
-        expect(unreadDividerMessageId(messages, '1', ME)).toBeNull();
+        expect(unreadDividerMessageId(messages, id(1), ME)).toBeNull();
     });
 
-    it('ignores non-numeric ids from optimistic sends awaiting confirmation', () => {
+    it('ignores a random client uuid from an optimistic send awaiting confirmation', () => {
         const messages = [
-            message('1', PEER),
-            message('c1d2-uuid', ME),
-            message('2', PEER),
+            message(id(1), PEER),
+            // A random v4 client uuid that sorts *after* the ordered read pointer,
+            // yet is the reader's own send and must not become the boundary.
+            message('c1d2e3f4-5a6b-4c7d-8e9f-0a1b2c3d4e5f', ME),
+            message(id(2), PEER),
         ];
 
-        expect(unreadDividerMessageId(messages, '1', ME)).toBe('2');
+        expect(unreadDividerMessageId(messages, id(1), ME)).toBe(id(2));
     });
 
     it('returns null for an empty channel', () => {
-        expect(unreadDividerMessageId([], '5', ME)).toBeNull();
+        expect(unreadDividerMessageId([], id(5), ME)).toBeNull();
     });
 });

--- a/resources/js/lib/unreadDivider.ts
+++ b/resources/js/lib/unreadDivider.ts
@@ -11,24 +11,22 @@ import type { Message } from '@/types';
  * marker above something you just posted — so an entirely-own unread tail yields
  * null.
  *
- * Message ids are monotonic auto-increment values delivered as numeric strings,
- * so the comparison is numeric. A non-numeric id (an optimistic send still keyed
- * by its client uuid) is never treated as unread: those are always the reader's
- * own, and the boundary is fixed at channel open rather than moved by later
- * traffic.
+ * Message ids are time-ordered UUIDs, so they sort chronologically under a plain
+ * lexicographic string comparison — no numeric coercion (a UUID is `NaN` as a
+ * number). An optimistic send still keyed by its random client uuid is always
+ * the reader's own message, so the author check below drops it regardless of
+ * where its random id happens to sort; the boundary is fixed at channel open
+ * rather than moved by later traffic.
  */
 export function unreadDividerMessageId(
     messages: Pick<Message, 'id' | 'user'>[],
     lastReadMessageId: string | null,
     currentUserId: string,
 ): string | null {
-    const readPointer =
-        lastReadMessageId === null ? -Infinity : Number(lastReadMessageId);
-
     for (const message of messages) {
-        const id = Number(message.id);
-
-        if (!Number.isFinite(id) || id <= readPointer) {
+        // A null pointer means the channel has never been read, so nothing is
+        // yet read and the first peer message wins.
+        if (lastReadMessageId !== null && message.id <= lastReadMessageId) {
             continue;
         }
 

--- a/tests/Feature/Channels/ChannelTest.php
+++ b/tests/Feature/Channels/ChannelTest.php
@@ -129,3 +129,98 @@ test('the read pointer is null on a channel the viewer has never read', function
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page->where('lastReadMessageId', null));
 });
+
+test('opening a channel with more unread than a page windows the initial page around the read boundary', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    // Authorship is irrelevant to the id-based window; only the read pointer is.
+    $messages = collect(range(1, 100))->map(
+        fn (int $i) => Message::factory()->for($general)->for($user)->create(['body' => "message {$i}"])
+    );
+
+    // Read through message 30, so messages 31..100 (70 unread) exceed one page.
+    $user->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $messages[29]->id]);
+
+    $this->actingAs($user)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            // The window is capped 39 messages past the boundary (message 71) and
+            // holds the newest 50 rows at or below that cap — messages 22..71 —
+            // so the boundary (message 31) is loaded while the newest history
+            // (up to message 100) pages in below via InfiniteScroll.
+            ->has('messages.data', 50)
+            ->where('messages.data.0.body', 'message 71')
+            ->where('messages.data.49.body', 'message 22')
+        );
+});
+
+test('opening a channel with unread within a page keeps the default newest window', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    $messages = collect(range(1, 60))->map(
+        fn (int $i) => Message::factory()->for($general)->for($user)->create(['body' => "message {$i}"])
+    );
+
+    // Read through message 20, so messages 21..60 (40 unread) fit within one page.
+    $user->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $messages[19]->id]);
+
+    $this->actingAs($user)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            // No window: the boundary already sits in the newest page, so the view
+            // opens at newest (messages 11..60) with the boundary (message 21) loaded.
+            ->has('messages.data', 50)
+            ->where('messages.data.0.body', 'message 60')
+            ->where('messages.data.49.body', 'message 11')
+        );
+});
+
+test('a never-read channel with a long backlog still opens at newest', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    // Auto-joined with a null read pointer: there is no last-read boundary to
+    // anchor, so #76 deliberately leaves the default newest window in place
+    // rather than dropping the viewer at the oldest message.
+    collect(range(1, 60))->each(
+        fn (int $i) => Message::factory()->for($general)->for($user)->create(['body' => "message {$i}"])
+    );
+
+    $this->actingAs($user)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('messages.data', 50)
+            ->where('messages.data.0.body', 'message 60')
+            ->where('messages.data.49.body', 'message 11')
+        );
+});
+
+test('a fully-read channel opens at newest without a window', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    $messages = collect(range(1, 60))->map(
+        fn (int $i) => Message::factory()->for($general)->for($user)->create(['body' => "message {$i}"])
+    );
+
+    // Read pointer at the newest message: nothing is unread, so no window applies.
+    $user->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $messages[59]->id]);
+
+    $this->actingAs($user)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('messages.data', 50)
+            ->where('messages.data.0.body', 'message 60')
+            ->where('messages.data.49.body', 'message 11')
+        );
+});


### PR DESCRIPTION
Closes #76.

## Problem
The "New messages" divider is placed over whatever messages the client has loaded, and the channel view loads only the newest 50 on open. When a channel has **more than 50 unread**, the true last-read boundary sits *above* that window, so the divider was frozen at the oldest loaded message and older history paged in *above* the "New" line.

## Fix
`unreadWindowCeiling` anchors the initial window around the viewer's read pointer, mirroring the existing `jumpWindowCeiling` used for search jumps:

- **>50 unread** → cap the window `UNREAD_CONTEXT` (10) read messages above the first unread, so the channel opens with the "New messages" line near the top and unread history below; older history still pages in above via InfiniteScroll, newer below.
- **No / few / fully-read** → boundary already fits in the newest page, so the default "open at newest" window is preserved.
- **Never-read** (null pointer) → no last-read boundary to anchor, so it deliberately keeps opening at newest rather than dropping the viewer on the oldest message of a long backlog.

The main-timeline filter (top-level messages + replies "also sent to channel") is factored into a `mainTimeline` helper shared by the page query and the window math.

## Pre-existing #37 bug fixed inline (blocked this feature)
While implementing this I found that `unreadDividerMessageId` compared ids with `Number(message.id)`, but message ids are **ordered UUIDs** (`019f44c7-…`), not the numeric strings its comment claimed. `Number(uuid)` is `NaN`, so it skipped every message and returned `null` — **the divider never rendered in production**, not just in the >50 case. Since #76's "divider renders at the correct boundary" criterion depends on it, it's fixed here: a lexicographic string comparison (ordered UUIDs sort chronologically). The reader's-own-message guard still drops optimistic sends keyed by a random client uuid.

## Acceptance criteria
- [x] Opening a channel with >50 unread loads the true last-read boundary in the initial window
- [x] Divider renders at the correct boundary in that case (required the #37 fix above)
- [x] "Open at newest" preserved for channels with no / few unread (and fully-read / never-read)
- [x] Feature tests covering the >50-unread window, the within-a-page guard, fully-read, and never-read cases

## Testing
- `ChannelTest`: >50-unread windowing, within-a-page guard, fully-read, never-read backlog
- `unreadDivider.test.ts`: updated to realistic ordered-UUID-shaped ids so the string comparison is genuinely exercised
- Full gate green: `composer test` at **100.0%** coverage, Pint, PHPStan, `types:check`, `lint:check`, `format:check`, `build`, and the vitest suite