### PR TITLE
feat(threads): per-thread read state + thread-unread dots (#71)

### DIFF
--- a/app/Actions/Channels/MarkThreadRead.php
+++ b/app/Actions/Channels/MarkThreadRead.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Message;
+use App\Models\ThreadRead;
+use App\Models\User;
+
+class MarkThreadRead
+{
+    /**
+     * Advance the user's read pointer to the thread's most recent reply.
+     *
+     * Pointing at the latest reply id (soft-deleted rows included, so the pointer
+     * never lags behind a deleted tail) clears the thread's unread dot. A thread
+     * with no replies leaves no pointer to set. This never touches the channel's
+     * `last_read_message_id`, so a thread's read state stays independent of the
+     * channel's.
+     */
+    public function handle(Message $root, User $user): void
+    {
+        $latestReplyId = $root->threadReplies()->withTrashed()->orderByDesc('id')->value('id');
+
+        if ($latestReplyId === null) {
+            return;
+        }
+
+        ThreadRead::query()->updateOrCreate(
+            ['thread_root_id' => $root->id, 'user_id' => $user->id],
+            ['last_read_reply_id' => $latestReplyId],
+        );
+    }
+}

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -29,6 +29,8 @@ class MessageData extends Data
         public int $threadReplyCount,
         public ?string $threadLastReplyAt,
         public array $threadParticipants,
+        public bool $threadFollowed = false,
+        public bool $threadUnread = false,
     ) {}
 
     /**
@@ -47,10 +49,19 @@ class MessageData extends Data
      * `threadParticipants`) are structural, so they survive a soft delete — a
      * deleted root still shows its "N replies" affordance. `threadParticipants`
      * resolves from the eager-loaded relation when present, empty otherwise.
+     *
+     * `threadFollowed` and `threadUnread` are per-viewer and only populated when
+     * the message was loaded through {@see ChannelController::withThreadReadState()};
+     * elsewhere (broadcast payloads carry no viewer) they fall back to false and
+     * the client keeps whatever state it already derived. `threadUnread` is the
+     * conjunction of following the thread and it holding unread replies.
      */
     public static function fromMessage(Message $message): self
     {
         $isDeleted = $message->trashed();
+
+        $threadFollowed = (int) ($message->getAttribute('thread_followed') ?? 0) === 1;
+        $threadHasUnread = (int) ($message->getAttribute('thread_has_unread') ?? 0) === 1;
 
         return new self(
             id: $message->id,
@@ -71,6 +82,8 @@ class MessageData extends Data
             threadParticipants: $message->relationLoaded('threadParticipants')
                 ? $message->threadParticipants->map(fn (User $user) => MentionData::fromUser($user))->all()
                 : [],
+            threadFollowed: $threadFollowed,
+            threadUnread: $threadFollowed && $threadHasUnread,
         );
     }
 }

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -6,6 +6,7 @@ use App\Actions\Channels\ArchiveChannel;
 use App\Actions\Channels\CreateChannel;
 use App\Actions\Channels\JoinChannel;
 use App\Actions\Channels\MarkChannelRead;
+use App\Actions\Channels\MarkThreadRead;
 use App\Data\ChannelData;
 use App\Data\MessageData;
 use App\Data\UserData;
@@ -16,6 +17,7 @@ use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -88,6 +90,13 @@ class ChannelController extends Controller
         $channel->setAttribute('muted', $membership->muted ?? false);
         $channel->setAttribute('notification_level', $membership?->notification_level->value ?? NotificationLevel::All->value);
 
+        // Thread-unread dots follow the same suppression as the sidebar's unread
+        // badge: a muted channel or a level below "all" silences them. `thread_*`
+        // annotations still compute follow state so the client can derive live
+        // dots, but the unread flag is forced off when dots are suppressed.
+        $showThreadDots = ! ($membership->muted ?? false)
+            && ($membership->notification_level ?? NotificationLevel::All)->alertsOnUnread();
+
         // When arriving from a search result the URL carries the target message
         // id. If it belongs to this channel, cap the initial window a few messages
         // above the target so it loads with context on both sides; the client
@@ -127,7 +136,7 @@ class ChannelController extends Controller
             // query param, or null for a normal visit. The client opens a thread
             // with a partial reload of just this prop; on a full visit the closure
             // returns null cheaply when no thread is requested.
-            'thread' => fn () => $this->threadPayload($request, $channel),
+            'thread' => fn () => $this->threadPayload($request, $channel, $showThreadDots),
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),
@@ -135,8 +144,10 @@ class ChannelController extends Controller
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a
             // "message deleted" tombstone in place; MessageData blanks their body.
-            'messages' => Inertia::scroll(fn () => $this->mainTimeline(
-                $channel->messages()->withTrashed()->getQuery()
+            'messages' => Inertia::scroll(fn () => $this->withThreadReadState(
+                $this->mainTimeline($channel->messages()->withTrashed()->getQuery()),
+                $request->user(),
+                $showThreadDots,
             )
                 ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
                 ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
@@ -156,7 +167,7 @@ class ChannelController extends Controller
      *
      * @return array{root: MessageData, replies: array<int, MessageData>}|null
      */
-    private function threadPayload(Request $request, Channel $channel): ?array
+    private function threadPayload(Request $request, Channel $channel, bool $showThreadDots): ?array
     {
         $rootId = $request->query('thread');
 
@@ -164,8 +175,11 @@ class ChannelController extends Controller
             return null;
         }
 
-        $root = $channel->messages()
-            ->whereNull('thread_root_id')
+        $root = $this->withThreadReadState(
+            $channel->messages()->whereNull('thread_root_id')->getQuery(),
+            $request->user(),
+            $showThreadDots,
+        )
             ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
             ->find($rootId);
 
@@ -287,6 +301,61 @@ class ChannelController extends Controller
     }
 
     /**
+     * Annotate each row with the viewer's per-thread follow and unread state.
+     *
+     * `thread_followed` mirrors the Slack-style auto-follow rule: the user
+     * follows a thread when they authored its root, replied in it, or were
+     *
+     * @mentioned anywhere in it. `thread_has_unread` is whether a followed
+     * thread holds a live reply by someone else that lands after the viewer's
+     * `thread_reads` pointer (a null pointer means the thread was never opened,
+     * so every reply counts). Both are correlated on the outer `messages.id`
+     * treated as a root, so a single query fills the page without an N+1.
+     *
+     * `MessageData` combines the two into the client's `threadUnread` flag. When
+     * dots are suppressed (muted channel / quieted level) the unread column is a
+     * constant zero so no dot ever shows, while follow state stays accurate.
+     *
+     * @param  Builder<Message>  $query
+     * @return Builder<Message>
+     */
+    private function withThreadReadState(Builder $query, User $user, bool $showUnread): Builder
+    {
+        $query->addSelect('messages.*')->selectRaw(
+            '(exists (
+                select 1 from messages tm
+                where (tm.id = messages.id or tm.thread_root_id = messages.id)
+                  and (
+                      tm.user_id = ?
+                      or exists (
+                          select 1 from mentions mn
+                          where mn.message_id = tm.id and mn.mentioned_user_id = ?
+                      )
+                  )
+            ))::int as thread_followed',
+            [$user->id, $user->id],
+        );
+
+        if ($showUnread) {
+            $query->selectRaw(
+                '(exists (
+                    select 1 from messages r
+                    left join thread_reads tr on tr.thread_root_id = messages.id and tr.user_id = ?
+                    where r.thread_root_id = messages.id
+                      and r.deleted_at is null
+                      and r.user_id <> ?
+                      and (tr.last_read_reply_id is null or r.id > tr.last_read_reply_id)
+                ))::int as thread_has_unread',
+                [$user->id, $user->id],
+            );
+        } else {
+            $query->selectRaw('0 as thread_has_unread');
+        }
+
+        return $query;
+    }
+
+    /**
      * List public channels in the team the current user can still join.
      */
     public function browse(Request $request, Team $team): Response
@@ -333,6 +402,23 @@ class ChannelController extends Controller
         Gate::authorize('view', $channel);
 
         $markChannelRead->handle($channel, $request->user());
+
+        return back();
+    }
+
+    /**
+     * Mark a thread read for the current user, clearing its unread dot.
+     *
+     * Advances the viewer's per-thread pointer to the thread's latest reply,
+     * independently of the channel's read pointer. Called by the open thread
+     * panel (debounced, on focus). The `{message}` binding resolves the root,
+     * including a soft-deleted tombstone root whose thread is still readable.
+     */
+    public function readThread(Request $request, Team $team, Channel $channel, Message $message, MarkThreadRead $markThreadRead): RedirectResponse
+    {
+        Gate::authorize('view', $channel);
+
+        $markThreadRead->handle($message, $request->user());
 
         return back();
     }

--- a/app/Models/ThreadRead.php
+++ b/app/Models/ThreadRead.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\ThreadReadFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * A user's read pointer within a single thread, tracked independently of the
+ * channel's `last_read_message_id`. Marking the channel read never advances it,
+ * and advancing it never touches the channel pointer.
+ *
+ * @property string $id
+ * @property string $thread_root_id
+ * @property string $user_id
+ * @property string|null $last_read_reply_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Message $root
+ * @property-read User $user
+ */
+#[Fillable(['thread_root_id', 'user_id', 'last_read_reply_id'])]
+class ThreadRead extends Model
+{
+    /** @use HasFactory<ThreadReadFactory> */
+    use HasFactory, HasUuids;
+
+    /**
+     * Get the root message whose thread this pointer tracks.
+     *
+     * @return BelongsTo<Message, $this>
+     */
+    public function root(): BelongsTo
+    {
+        return $this->belongsTo(Message::class, 'thread_root_id')->withTrashed();
+    }
+
+    /**
+     * Get the user the read pointer belongs to.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/factories/ThreadReadFactory.php
+++ b/database/factories/ThreadReadFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Message;
+use App\Models\ThreadRead;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ThreadRead>
+ */
+class ThreadReadFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'thread_root_id' => Message::factory(),
+            'user_id' => User::factory(),
+            'last_read_reply_id' => null,
+        ];
+    }
+
+    /**
+     * Point the read pointer at a specific reply the user has seen.
+     */
+    public function upTo(Message $reply): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'last_read_reply_id' => $reply->id,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_09_134136_create_thread_reads_table.php
+++ b/database/migrations/2026_07_09_134136_create_thread_reads_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('thread_reads', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            // The thread's root message. Force-deleting the root cascades this
+            // pointer away; a soft-deleted root keeps its row so the thread — and
+            // its read state — survive as a tombstone.
+            $table->foreignUuid('thread_root_id')->constrained('messages')->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            // The last reply the user has seen in this thread. Unconstrained, like
+            // channel_members.last_read_message_id, so it can point at a since
+            // soft-deleted reply without tripping a foreign key. Null until the
+            // user first opens the thread (everything then counts as unread).
+            $table->uuid('last_read_reply_id')->nullable();
+            $table->timestamps();
+
+            // One read pointer per user per thread.
+            $table->unique(['thread_root_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('thread_reads');
+    }
+};

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -470,6 +470,12 @@ function confirmDelete(): void {
                                 </span>
                             </span>
                             <span
+                                v-if="message.threadUnread"
+                                data-test="thread-unread-dot"
+                                aria-label="Unread replies"
+                                class="size-2 shrink-0 rounded-full bg-rose-500"
+                            ></span>
+                            <span
                                 class="text-[12.5px] font-semibold text-primary hover:underline"
                             >
                                 {{ message.threadReplyCount }}

--- a/resources/js/composables/useMessageStream.ts
+++ b/resources/js/composables/useMessageStream.ts
@@ -94,8 +94,46 @@ export function useMessageStream(
         return true;
     }
 
+    /**
+     * Locate the currently-rendered copy of a message by client uuid, preferring
+     * an existing patch, then a live echo, then the server page.
+     */
+    function currentCopy(clientUuid: string): Message | undefined {
+        return (
+            patches.value.get(clientUuid) ??
+            live.value.find((m) => m.clientUuid === clientUuid) ??
+            serverMessages.value.find((m) => m.clientUuid === clientUuid)
+        );
+    }
+
     function applyPatch(message: Message): void {
-        patches.value.set(message.clientUuid, message);
+        // A broadcast patch (edit, delete, thread reply-count bump) carries no
+        // viewer context, so its `threadFollowed`/`threadUnread` are always the
+        // server defaults. Preserve whatever the client has already derived for
+        // this message so a root's dot isn't cleared by its own reply-count bump.
+        const prior = currentCopy(message.clientUuid);
+
+        patches.value.set(message.clientUuid, {
+            ...message,
+            threadFollowed: prior?.threadFollowed ?? message.threadFollowed,
+            threadUnread: prior?.threadUnread ?? message.threadUnread,
+        });
+    }
+
+    /**
+     * Overlay per-viewer thread read-state on a rendered message, found by its
+     * message id (the id a reply carries as `threadRootId`). Used to raise or
+     * clear a root's unread dot and mark it followed as the viewer engages,
+     * keeping every other field of the rendered copy intact.
+     */
+    function patchThreadState(id: string, partial: Partial<Message>): void {
+        const current = displayMessages.value.find((m) => m.id === id);
+
+        if (!current) {
+            return;
+        }
+
+        patches.value.set(current.clientUuid, { ...current, ...partial });
     }
 
     function getPatch(clientUuid: string): Message | undefined {
@@ -134,6 +172,7 @@ export function useMessageStream(
         pendingUuids,
         appendLive,
         applyPatch,
+        patchThreadState,
         getPatch,
         restorePatch,
         addPending,
@@ -180,5 +219,7 @@ export function optimisticMessage(params: {
         threadReplyCount: 0,
         threadLastReplyAt: null,
         threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
     };
 }

--- a/resources/js/lib/shouldFlagThreadUnread.test.ts
+++ b/resources/js/lib/shouldFlagThreadUnread.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
+import type { ThreadUnreadInput } from '@/lib/shouldFlagThreadUnread';
+
+/**
+ * A qualifying baseline: someone else's reply landing in a followed thread the
+ * viewer isn't looking at, in an unsilenced channel. Each test overrides one axis.
+ */
+function input(overrides: Partial<ThreadUnreadInput> = {}): ThreadUnreadInput {
+    return {
+        isReply: true,
+        isOwnReply: false,
+        isFollowedThread: true,
+        isViewingThreadFocused: false,
+        isSuppressed: false,
+        ...overrides,
+    };
+}
+
+describe('shouldFlagThreadUnread', () => {
+    it('flags a reply from someone else in a followed thread', () => {
+        expect(shouldFlagThreadUnread(input())).toBe(true);
+    });
+
+    it('never flags a non-reply message', () => {
+        expect(shouldFlagThreadUnread(input({ isReply: false }))).toBe(false);
+    });
+
+    it("never flags the viewer's own reply", () => {
+        expect(shouldFlagThreadUnread(input({ isOwnReply: true }))).toBe(false);
+    });
+
+    it('does not flag a thread the viewer does not follow', () => {
+        expect(shouldFlagThreadUnread(input({ isFollowedThread: false }))).toBe(
+            false,
+        );
+    });
+
+    it('does not flag while the thread is open and the tab is focused', () => {
+        expect(
+            shouldFlagThreadUnread(input({ isViewingThreadFocused: true })),
+        ).toBe(false);
+    });
+
+    it('flags while the thread is open but the tab is blurred', () => {
+        expect(
+            shouldFlagThreadUnread(input({ isViewingThreadFocused: false })),
+        ).toBe(true);
+    });
+
+    it('does not flag when thread dots are suppressed', () => {
+        expect(shouldFlagThreadUnread(input({ isSuppressed: true }))).toBe(
+            false,
+        );
+    });
+});

--- a/resources/js/lib/shouldFlagThreadUnread.ts
+++ b/resources/js/lib/shouldFlagThreadUnread.ts
@@ -1,0 +1,44 @@
+export type ThreadUnreadInput = {
+    /** The arriving message is a thread reply (carries a `threadRootId`). */
+    isReply: boolean;
+    /** The reply was authored by the current user (own replies never dot). */
+    isOwnReply: boolean;
+    /**
+     * The viewer follows the reply's thread — they authored its root, replied in
+     * it, or were @mentioned. Only followed threads raise a dot, matching the
+     * server's `threadUnread` derivation.
+     */
+    isFollowedThread: boolean;
+    /**
+     * The thread is open in the panel and the tab is focused, so the reply is
+     * already being read and must not raise a dot. A blurred panel still dots,
+     * mirroring how a blurred channel still badges.
+     */
+    isViewingThreadFocused: boolean;
+    /**
+     * Thread dots are suppressed for this channel (muted or a level below "all"),
+     * mirroring the sidebar's unread-badge suppression.
+     */
+    isSuppressed: boolean;
+};
+
+/**
+ * Decide whether a freshly-arrived realtime reply should raise the unread dot on
+ * its root's "N replies" affordance.
+ *
+ * The gate mirrors the server's per-viewer `threadUnread` derivation so a live
+ * dot and a navigation-time dot agree: a reply only dots a thread the viewer
+ * follows, authored by someone else, while they are not already reading it and
+ * the channel isn't silenced.
+ */
+export function shouldFlagThreadUnread(input: ThreadUnreadInput): boolean {
+    if (!input.isReply || input.isOwnReply) {
+        return false;
+    }
+
+    if (!input.isFollowedThread || input.isSuppressed) {
+        return false;
+    }
+
+    return !input.isViewingThreadFocused;
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -22,6 +22,7 @@ import { toast } from 'vue-sonner';
 import {
     archive as archiveChannel,
     read as markChannelRead,
+    readThread as markThreadReadAction,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
 import {
@@ -63,6 +64,7 @@ import {
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
+import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
 import { unreadDividerMessageId } from '@/lib/unreadDivider';
 import type {
     Channel,
@@ -288,6 +290,69 @@ function routeIncoming(message: Message): void {
     ) {
         threadStream.appendLive(message);
     }
+
+    // A thread reply either keeps the open, focused thread read as it streams in,
+    // or raises the unread dot on its root back in the main timeline.
+    if (message.threadRootId !== null) {
+        const viewingThreadFocused =
+            message.threadRootId === activeThreadRootId.value &&
+            document.hasFocus();
+
+        if (viewingThreadFocused) {
+            markThreadRead();
+
+            return;
+        }
+
+        const root = displayMessages.value.find(
+            (candidate) => candidate.id === message.threadRootId,
+        );
+
+        if (
+            shouldFlagThreadUnread({
+                isReply: true,
+                isOwnReply: message.user.id === currentUser.value.id,
+                isFollowedThread: root?.threadFollowed ?? false,
+                isViewingThreadFocused: false,
+                isSuppressed: threadUnreadSuppressed.value,
+            })
+        ) {
+            mainStream.patchThreadState(message.threadRootId, {
+                threadUnread: true,
+            });
+        }
+    }
+}
+
+// Advance the open thread's read pointer so its unread dot clears, mirroring the
+// channel's markRead: debounced, gated on focus, and optimistically clearing the
+// dot on the root back in the main timeline.
+let threadReadTimer: ReturnType<typeof setTimeout> | null = null;
+
+function markThreadRead(): void {
+    const rootId = activeThreadRootId.value;
+
+    if (!rootId || !document.hasFocus()) {
+        return;
+    }
+
+    if (threadReadTimer) {
+        clearTimeout(threadReadTimer);
+    }
+
+    threadReadTimer = setTimeout(() => {
+        router.post(
+            markThreadReadAction({
+                team: props.team.slug,
+                channel: props.channel.slug,
+                message: rootId,
+            }).url,
+            {},
+            { preserveScroll: true, preserveState: true, only: ['channels'] },
+        );
+
+        mainStream.patchThreadState(rootId, { threadUnread: false });
+    }, 400);
 }
 
 function channelName(id: string): string {
@@ -359,6 +424,7 @@ onMounted(() => {
     computeUnreadDivider();
     markRead();
     window.addEventListener('focus', markRead);
+    window.addEventListener('focus', markThreadRead);
 
     if (props.jumpToMessageId) {
         jumpToMessage(props.jumpToMessageId);
@@ -421,9 +487,14 @@ onBeforeUnmount(() => {
     unsubscribe(props.channel.id);
     unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
+    window.removeEventListener('focus', markThreadRead);
 
     if (markReadTimer) {
         clearTimeout(markReadTimer);
+    }
+
+    if (threadReadTimer) {
+        clearTimeout(threadReadTimer);
     }
 
     if (highlightTimer) {
@@ -500,6 +571,13 @@ function sendThreadReply(
     });
 
     threadStream.addPending(optimistic);
+
+    // Replying makes the viewer a follower of the thread and means they've seen
+    // it, so keep the root's affordance in the main timeline dot-free.
+    mainStream.patchThreadState(rootId, {
+        threadFollowed: true,
+        threadUnread: false,
+    });
 
     if (sendToChannel) {
         appendPendingMain(optimistic);
@@ -601,11 +679,16 @@ function openThread(rootId: string): void {
     threadData.value = null;
     threadLoading.value = true;
 
+    // Opening the thread clears its dot straight away; the read pointer advances
+    // once the replies load (and again on focus / as new replies stream in).
+    mainStream.patchThreadState(rootId, { threadUnread: false });
+
     router.reload({
         only: ['thread'],
         data: { thread: rootId },
         onFinish: () => {
             threadLoading.value = false;
+            markThreadRead();
         },
     });
 }
@@ -625,6 +708,13 @@ const notificationLevel = ref<NotificationLevel>(
     props.channel.notificationLevel,
 );
 const muted = ref<boolean>(props.channel.muted);
+
+// Thread-unread dots are silenced under the same rule as the sidebar's unread
+// badge: a muted channel or any level below "all". Mirrors the server's
+// suppression so a live dot and a navigation-time dot agree.
+const threadUnreadSuppressed = computed(
+    () => muted.value || notificationLevel.value !== 'all',
+);
 
 function savePreferences(rollback: () => void): void {
     router.patch(

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -47,6 +47,17 @@ export type Message = {
     threadReplyCount: number;
     threadLastReplyAt: string | null;
     threadParticipants: Mention[];
+    /**
+     * Per-viewer thread read-state (mirror the `MessageData` DTO), meaningful on
+     * a root. `threadFollowed` is the Slack-style auto-follow signal — the viewer
+     * authored the root, replied, or was mentioned in the thread — and gates
+     * whether a live reply raises the dot. `threadUnread` drives the dot on the
+     * root's "N replies" affordance and clears when the thread is read. Broadcast
+     * payloads omit viewer context, so the client preserves its own values across
+     * patches rather than taking the server's defaults.
+     */
+    threadFollowed: boolean;
+    threadUnread: boolean;
 };
 
 /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,10 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/read', [ChannelController::class, 'read'])
         ->scopeBindings()
         ->name('channels.read');
+    Route::post('t/{team}/c/{channel}/threads/{message}/read', [ChannelController::class, 'readThread'])
+        ->scopeBindings()
+        ->withTrashed()
+        ->name('channels.threads.read');
     Route::patch('t/{team}/c/{channel}/preferences', [ChannelPreferenceController::class, 'update'])
         ->scopeBindings()
         ->name('channels.preferences.update');

--- a/tests/Feature/Channels/ThreadReadTest.php
+++ b/tests/Feature/Channels/ThreadReadTest.php
@@ -1,0 +1,264 @@
+<?php
+
+use App\Actions\Channels\MarkChannelRead;
+use App\Actions\Channels\MarkThreadRead;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\NotificationLevel;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\ThreadRead;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function threadReadSetup(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and #general, returning them.
+ */
+function threadReadMember(Team $team, Channel $channel): User
+{
+    $user = User::factory()->create();
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+/**
+ * Load the channel as the given user and return the root message's payload from
+ * the main timeline (thread-only replies are excluded, so a lone root sits at 0).
+ *
+ * @return array<string, mixed>
+ */
+function rootPayload(User $viewer, Team $team, Channel $channel, Message $root): array
+{
+    $captured = [];
+
+    test()->actingAs($viewer)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertInertia(function (Assert $page) use (&$captured, $root) {
+            $page->has('messages.data');
+            $data = $page->toArray()['props']['messages']['data'];
+            $captured = collect($data)->firstWhere('id', $root->id);
+        });
+
+    return $captured;
+}
+
+test('a followed thread with an unseen reply raises the root unread flag', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $payload = rootPayload($owner, $team, $general, $root);
+
+    expect($payload['threadFollowed'])->toBeTrue()
+        ->and($payload['threadUnread'])->toBeTrue();
+});
+
+test('a non-participant who was never mentioned does not follow the thread', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+    $bob = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $payload = rootPayload($bob, $team, $general, $root);
+
+    expect($payload['threadFollowed'])->toBeFalse()
+        ->and($payload['threadUnread'])->toBeFalse();
+});
+
+test('replying in a thread makes the user a follower', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+    $bob = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($bob)->inThread($root)->create();
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $payload = rootPayload($bob, $team, $general, $root);
+
+    expect($payload['threadFollowed'])->toBeTrue()
+        ->and($payload['threadUnread'])->toBeTrue();
+});
+
+test('a mention inside a reply makes the user a follower', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+    $bob = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    $reply = Message::factory()->for($general)->for($alice)->inThread($root)->create();
+    $reply->mentionedUsers()->attach($bob->id);
+
+    $payload = rootPayload($bob, $team, $general, $root);
+
+    expect($payload['threadFollowed'])->toBeTrue()
+        ->and($payload['threadUnread'])->toBeTrue();
+});
+
+test('a user\'s own replies never raise their unread flag', function () {
+    [$owner, $team, $general] = threadReadSetup();
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($owner)->inThread($root)->create();
+
+    $payload = rootPayload($owner, $team, $general, $root);
+
+    expect($payload['threadFollowed'])->toBeTrue()
+        ->and($payload['threadUnread'])->toBeFalse();
+});
+
+test('a soft-deleted reply does not count as unread', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($alice)->inThread($root)->create(['deleted_at' => now()]);
+
+    $payload = rootPayload($owner, $team, $general, $root);
+
+    expect($payload['threadFollowed'])->toBeTrue()
+        ->and($payload['threadUnread'])->toBeFalse();
+});
+
+test('marking the thread read clears the unread flag and persists the pointer', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    $reply = Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $this->actingAs($owner)
+        ->post(route('channels.threads.read', ['team' => $team->slug, 'channel' => $general->slug, 'message' => $root->id]))
+        ->assertRedirect();
+
+    expect(ThreadRead::where('thread_root_id', $root->id)->where('user_id', $owner->id)->value('last_read_reply_id'))
+        ->toBe($reply->id);
+
+    $payload = rootPayload($owner, $team, $general, $root);
+
+    expect($payload['threadUnread'])->toBeFalse();
+});
+
+test('a newer reply after the read pointer raises the flag again', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    $first = Message::factory()->for($general)->for($alice)->inThread($root)->create();
+    ThreadRead::factory()->for($root, 'root')->for($owner)->upTo($first)->create();
+
+    // Read up to the first reply: nothing unread yet.
+    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeFalse();
+
+    // A later reply lands after the pointer.
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeTrue();
+});
+
+test('thread read state is independent of the channel read pointer', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    // Marking the whole channel read must not clear the thread's unread flag.
+    app(MarkChannelRead::class)->handle($general, $owner);
+
+    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeTrue();
+
+    // And marking the thread read must not move the channel's read pointer.
+    $channelPointer = $general->channelMembers()->where('user_id', $owner->id)->value('last_read_message_id');
+
+    app(MarkThreadRead::class)->handle($root, $owner);
+
+    expect($general->channelMembers()->where('user_id', $owner->id)->value('last_read_message_id'))
+        ->toBe($channelPointer);
+});
+
+test('a muted channel suppresses the thread unread flag', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+
+    $general->channelMembers()->where('user_id', $owner->id)->update(['muted' => true]);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $payload = rootPayload($owner, $team, $general, $root);
+
+    expect($payload['threadFollowed'])->toBeTrue()
+        ->and($payload['threadUnread'])->toBeFalse();
+});
+
+test('a notification level below all suppresses the thread unread flag', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+
+    $general->channelMembers()->where('user_id', $owner->id)
+        ->update(['notification_level' => NotificationLevel::Mentions]);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeFalse();
+});
+
+test('the thread panel root carries the viewer follow and unread state', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $alice = threadReadMember($team, $general);
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $root->id]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('thread.root.threadFollowed', true)
+            ->where('thread.root.threadUnread', true));
+});
+
+test('marking read is a no-op for a thread with no replies', function () {
+    [$owner, $team, $general] = threadReadSetup();
+
+    $root = Message::factory()->for($general)->for($owner)->create();
+
+    app(MarkThreadRead::class)->handle($root, $owner);
+
+    expect(ThreadRead::where('thread_root_id', $root->id)->exists())->toBeFalse();
+});
+
+test('marking a thread read requires permission to view the channel', function () {
+    [$owner, $team, $general] = threadReadSetup();
+    $root = Message::factory()->for($general)->for($owner)->create();
+
+    $private = Channel::factory()->for($team)->create(['visibility' => 'private']);
+    $outsider = threadReadMember($team, $general);
+    $privateRoot = Message::factory()->for($private)->for($owner)->create();
+
+    $this->actingAs($outsider)
+        ->post(route('channels.threads.read', ['team' => $team->slug, 'channel' => $private->slug, 'message' => $privateRoot->id]))
+        ->assertForbidden();
+});


### PR DESCRIPTION
Implements the **core** of #71 — precise, per-thread read state — and defers the Threads inbox + thread-panel pagination to the follow-up #79 (the "core first" split agreed on the issue).

Closes part of #71. Follow-up: #79.

## What this does

Threads previously rode the channel's single `last_read_message_id`, so marking the channel read also cleared unseen thread activity and there was no per-thread signal. This adds a read pointer **per user per thread**, independent of the channel pointer, and an unread dot on a root's "N replies" affordance that clears when the thread is read.

### Backend
- **`thread_reads`** table (`thread_root_id` + `user_id` unique, nullable `last_read_reply_id`) with `ThreadRead` model + factory.
- **`MarkThreadRead`** action — advances the pointer to the thread's latest reply (`withTrashed`, so it never lags a deleted tail; no-op when there are no replies) — behind `POST t/{team}/c/{channel}/threads/{message}/read` (`channels.threads.read`).
- **`ChannelController::withThreadReadState()`** annotates each root with, per viewer:
  - `thread_followed` — Slack-style auto-follow: you authored the root, replied, or were `@mentioned` anywhere in the thread.
  - `thread_has_unread` — a live reply by someone else lands after your pointer (null pointer ⇒ everything unread).
  Applied to both the main timeline and the thread payload.
- **Mute suppression** mirrors the sidebar unread badge (`!muted && level.alertsOnUnread()`).
- **`MessageData`** exposes `threadFollowed` and `threadUnread` (= followed ∧ has-unread), defaulting false on broadcast payloads.

### Frontend
- Unread dot on the "N replies" affordance in `MessageList.vue`.
- `Show.vue` raises the dot in realtime on incoming replies (via the pure, unit-tested `shouldFlagThreadUnread` gate) and marks a thread read (debounced, focus-gated) on open / focus / while viewing; clears it optimistically on open, reply, and read.
- `useMessageStream.applyPatch` preserves per-viewer flags so a root's reply-count-bump broadcast can't clobber its dot; adds a `patchThreadState` helper.

Marking the channel read never advances a thread pointer, and vice versa.

## Tests
- 14 Pest feature tests: follow derivation (author/reply/mention/non-participant), unread transitions, channel↔thread independence, own-reply & soft-deleted-reply exclusion, mute + notification-level suppression, no-reply no-op, and view authorization.
- 7 Vitest cases for `shouldFlagThreadUnread`.

## Quality gate
- Pint ✓ · PHPStan ✓ · **coverage 100.0%** ✓
- ESLint ✓ · Prettier ✓ · vue-tsc ✓ · build ✓ · Vitest ✓