### PR TITLE
feat(threads): Threads inbox (#79)

### DIFF
--- a/app/Data/ThreadInboxItemData.php
+++ b/app/Data/ThreadInboxItemData.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\Message;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class ThreadInboxItemData extends Data
+{
+    public function __construct(
+        public MessageData $root,
+        public string $channelName,
+        public string $channelSlug,
+    ) {}
+
+    /**
+     * Build the DTO from a followed thread's root message.
+     *
+     * The root's `channel`, `user`, `mentionedUsers`, and `threadParticipants`
+     * relations should be eager-loaded, and the row annotated with the viewer's
+     * thread read-state (see {@see Message::scopeWithThreadReadState()}), so the
+     * inbox renders each row and its unread dot without an N+1.
+     */
+    public static function fromMessage(Message $message): self
+    {
+        return new self(
+            root: MessageData::fromMessage($message),
+            channelName: $message->channel->name,
+            channelSlug: $message->channel->slug,
+        );
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -17,7 +17,6 @@ use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
-use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -90,13 +89,6 @@ class ChannelController extends Controller
         $channel->setAttribute('muted', $membership->muted ?? false);
         $channel->setAttribute('notification_level', $membership?->notification_level->value ?? NotificationLevel::All->value);
 
-        // Thread-unread dots follow the same suppression as the sidebar's unread
-        // badge: a muted channel or a level below "all" silences them. `thread_*`
-        // annotations still compute follow state so the client can derive live
-        // dots, but the unread flag is forced off when dots are suppressed.
-        $showThreadDots = ! ($membership->muted ?? false)
-            && ($membership->notification_level ?? NotificationLevel::All)->alertsOnUnread();
-
         // When arriving from a search result the URL carries the target message
         // id. If it belongs to this channel, cap the initial window a few messages
         // above the target so it loads with context on both sides; the client
@@ -136,7 +128,7 @@ class ChannelController extends Controller
             // query param, or null for a normal visit. The client opens a thread
             // with a partial reload of just this prop; on a full visit the closure
             // returns null cheaply when no thread is requested.
-            'thread' => fn () => $this->threadPayload($request, $channel, $showThreadDots),
+            'thread' => fn () => $this->threadPayload($request, $channel),
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),
@@ -144,11 +136,8 @@ class ChannelController extends Controller
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a
             // "message deleted" tombstone in place; MessageData blanks their body.
-            'messages' => Inertia::scroll(fn () => $this->withThreadReadState(
-                $this->mainTimeline($channel->messages()->withTrashed()->getQuery()),
-                $request->user(),
-                $showThreadDots,
-            )
+            'messages' => Inertia::scroll(fn () => $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
+                ->withThreadReadState($request->user())
                 ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
                 ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
@@ -167,7 +156,7 @@ class ChannelController extends Controller
      *
      * @return array{root: MessageData, replies: array<int, MessageData>}|null
      */
-    private function threadPayload(Request $request, Channel $channel, bool $showThreadDots): ?array
+    private function threadPayload(Request $request, Channel $channel): ?array
     {
         $rootId = $request->query('thread');
 
@@ -175,11 +164,9 @@ class ChannelController extends Controller
             return null;
         }
 
-        $root = $this->withThreadReadState(
-            $channel->messages()->whereNull('thread_root_id')->getQuery(),
-            $request->user(),
-            $showThreadDots,
-        )
+        $root = $channel->messages()
+            ->whereNull('thread_root_id')
+            ->withThreadReadState($request->user())
             ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
             ->find($rootId);
 
@@ -298,61 +285,6 @@ class ChannelController extends Controller
     private function mainTimeline(Builder $query): Builder
     {
         return $query->where(fn (Builder $inner) => $inner->whereNull('thread_root_id')->orWhere('sent_to_channel', true));
-    }
-
-    /**
-     * Annotate each row with the viewer's per-thread follow and unread state.
-     *
-     * `thread_followed` mirrors the Slack-style auto-follow rule: the user
-     * follows a thread when they authored its root, replied in it, or were
-     *
-     * @mentioned anywhere in it. `thread_has_unread` is whether a followed
-     * thread holds a live reply by someone else that lands after the viewer's
-     * `thread_reads` pointer (a null pointer means the thread was never opened,
-     * so every reply counts). Both are correlated on the outer `messages.id`
-     * treated as a root, so a single query fills the page without an N+1.
-     *
-     * `MessageData` combines the two into the client's `threadUnread` flag. When
-     * dots are suppressed (muted channel / quieted level) the unread column is a
-     * constant zero so no dot ever shows, while follow state stays accurate.
-     *
-     * @param  Builder<Message>  $query
-     * @return Builder<Message>
-     */
-    private function withThreadReadState(Builder $query, User $user, bool $showUnread): Builder
-    {
-        $query->addSelect('messages.*')->selectRaw(
-            '(exists (
-                select 1 from messages tm
-                where (tm.id = messages.id or tm.thread_root_id = messages.id)
-                  and (
-                      tm.user_id = ?
-                      or exists (
-                          select 1 from mentions mn
-                          where mn.message_id = tm.id and mn.mentioned_user_id = ?
-                      )
-                  )
-            ))::int as thread_followed',
-            [$user->id, $user->id],
-        );
-
-        if ($showUnread) {
-            $query->selectRaw(
-                '(exists (
-                    select 1 from messages r
-                    left join thread_reads tr on tr.thread_root_id = messages.id and tr.user_id = ?
-                    where r.thread_root_id = messages.id
-                      and r.deleted_at is null
-                      and r.user_id <> ?
-                      and (tr.last_read_reply_id is null or r.id > tr.last_read_reply_id)
-                ))::int as thread_has_unread',
-                [$user->id, $user->id],
-            );
-        } else {
-            $query->selectRaw('0 as thread_has_unread');
-        }
-
-        return $query;
     }
 
     /**

--- a/app/Http/Controllers/Channels/ThreadsController.php
+++ b/app/Http/Controllers/Channels/ThreadsController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Data\ThreadInboxItemData;
+use App\Http\Controllers\Controller;
+use App\Models\Message;
+use App\Models\Team;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ThreadsController extends Controller
+{
+    /**
+     * How many inbox rows a page loads. The client pages older threads in on
+     * scroll via InfiniteScroll.
+     */
+    private const int PAGE_SIZE = 30;
+
+    /**
+     * The current user's Threads inbox: every thread they follow across the
+     * team, newest activity first, with per-thread unread state.
+     *
+     * "Follow" is the Slack-style auto-follow rule (authored the root, replied,
+     * or were @mentioned), and the channel-id filter is the whole ACL — the id
+     * set is exactly the channels the user belongs to in this team, so threads
+     * from channels they cannot see never leak. Unread state is muted per
+     * channel, so a muted channel's threads list without a dot.
+     */
+    public function index(Request $request, Team $team): Response
+    {
+        $user = $request->user();
+
+        $channelIds = $user->channels()
+            ->where('channels.team_id', $team->id)
+            ->pluck('channels.id');
+
+        return Inertia::render('channels/Threads', [
+            'team' => [
+                'id' => $team->id,
+                'name' => $team->name,
+                'slug' => $team->slug,
+            ],
+            'threads' => Inertia::scroll(fn () => Message::query()
+                ->whereIn('channel_id', $channelIds)
+                ->whereNull('thread_root_id')
+                ->where('reply_count', '>', 0)
+                ->followedBy($user)
+                ->withThreadReadState($user)
+                ->with(['user', 'channel', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
+                ->orderByDesc('last_reply_at')
+                ->orderByDesc('id')
+                ->cursorPaginate(self::PAGE_SIZE)
+                ->through(fn (Message $message) => ThreadInboxItemData::fromMessage($message))),
+        ]);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -54,6 +54,7 @@ class HandleInertiaRequests extends Middleware
             'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
             'teams' => fn () => $user?->toUserTeams(includeCurrent: true) ?? [],
             'channels' => fn () => $this->channelsForSidebar($request, $user),
+            'hasUnreadThreads' => fn () => $this->hasUnreadThreads($request, $user),
             'pendingInvitations' => Inertia::optional(fn () => $user ? $this->pendingInvitationsFor($user) : []),
         ];
     }
@@ -86,6 +87,35 @@ class HandleInertiaRequests extends Middleware
             ->get();
 
         return ChannelData::collect($channels, 'array');
+    }
+
+    /**
+     * Whether the user has any unread followed thread in the team, driving the
+     * sidebar's "Threads" unread dot.
+     *
+     * Scoped to the user's channels in the team (the same ACL as the inbox), and
+     * muted per channel, so it agrees with the dots the inbox and channel views
+     * show. Returns false off the channel workspace, where the sidebar is absent.
+     */
+    protected function hasUnreadThreads(Request $request, ?User $user): bool
+    {
+        $team = $request->route('team');
+
+        if (! $user || ! $team instanceof Team || ! $request->routeIs('channels.*')) {
+            return false;
+        }
+
+        $channelIds = $user->channels()
+            ->where('channels.team_id', $team->id)
+            ->pluck('channels.id');
+
+        return Message::query()
+            ->whereIn('channel_id', $channelIds)
+            ->whereNull('thread_root_id')
+            ->where('reply_count', '>', 0)
+            ->followedBy($user)
+            ->whereThreadUnreadFor($user)
+            ->exists();
     }
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -2,8 +2,11 @@
 
 namespace App\Models;
 
+use App\Data\MessageData;
+use App\Enums\NotificationLevel;
 use Database\Factories\MessageFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -128,6 +131,81 @@ class Message extends Model
     {
         return $this->belongsToMany(User::class, 'mentions', 'message_id', 'mentioned_user_id')
             ->withTimestamps();
+    }
+
+    /**
+     * Correlated SQL (on the outer `messages.id` treated as a root) telling
+     * whether a user follows the thread: they authored the root, replied in it,
+     * or were @mentioned anywhere in it — the Slack-style auto-follow rule.
+     * Binds the user id twice.
+     */
+    private const THREAD_FOLLOWED_SQL = '(exists (
+        select 1 from messages tm
+        where (tm.id = messages.id or tm.thread_root_id = messages.id)
+          and (
+              tm.user_id = ?
+              or exists (select 1 from mentions mn where mn.message_id = tm.id and mn.mentioned_user_id = ?)
+          )
+    ))';
+
+    /**
+     * Correlated SQL telling whether the thread holds an unread reply for a user:
+     * a live reply by someone else after their `thread_reads` pointer (a null
+     * pointer means the thread was never opened, so every reply counts). Suppressed
+     * to false when the user has muted or quieted (level below "all") the root's
+     * channel, mirroring the sidebar's unread-badge suppression so a cross-channel
+     * query gets per-channel muting for free. Binds the user id three times, then
+     * the "all" notification level.
+     */
+    private const THREAD_HAS_UNREAD_SQL = '(exists (
+        select 1 from messages r
+        left join thread_reads tr on tr.thread_root_id = messages.id and tr.user_id = ?
+        where r.thread_root_id = messages.id
+          and r.deleted_at is null
+          and r.user_id <> ?
+          and (tr.last_read_reply_id is null or r.id > tr.last_read_reply_id)
+    ) and not exists (
+        select 1 from channel_members cm
+        where cm.channel_id = messages.channel_id and cm.user_id = ?
+          and (cm.muted = true or cm.notification_level <> ?)
+    ))';
+
+    /**
+     * Annotate root messages with the viewer's per-thread follow and unread state
+     * (`thread_followed` / `thread_has_unread`), which {@see MessageData}
+     * reads. Correlated per outer row, so one query fills a page without an N+1.
+     *
+     * @param  Builder<Message>  $query
+     */
+    public function scopeWithThreadReadState(Builder $query, User $user): void
+    {
+        $query->addSelect('messages.*')
+            ->selectRaw(self::THREAD_FOLLOWED_SQL.'::int as thread_followed', [$user->id, $user->id])
+            ->selectRaw(self::THREAD_HAS_UNREAD_SQL.'::int as thread_has_unread', [$user->id, $user->id, $user->id, NotificationLevel::All->value]);
+    }
+
+    /**
+     * Constrain a root query to the threads a user follows (authored the root,
+     * replied, or was @mentioned in the root or a reply). Reuses the same
+     * {@see self::THREAD_FOLLOWED_SQL} the select annotation uses, so the inbox
+     * filter and the `thread_followed` column can never disagree.
+     *
+     * @param  Builder<Message>  $query
+     */
+    public function scopeFollowedBy(Builder $query, User $user): void
+    {
+        $query->whereRaw(self::THREAD_FOLLOWED_SQL, [$user->id, $user->id]);
+    }
+
+    /**
+     * Constrain a root query to threads that hold an unread reply for the user,
+     * with the same mute/level suppression as {@see self::THREAD_HAS_UNREAD_SQL}.
+     *
+     * @param  Builder<Message>  $query
+     */
+    public function scopeWhereThreadUnreadFor(Builder $query, User $user): void
+    {
+        $query->whereRaw(self::THREAD_HAS_UNREAD_SQL, [$user->id, $user->id, $user->id, NotificationLevel::All->value]);
     }
 
     /**

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -55,8 +55,9 @@ export function useSidebarBadges(): void {
 
         refreshTimer = setTimeout(() => {
             // reload defaults to preserving scroll and page state; it re-evaluates
-            // only the shared `channels` prop to recompute every badge count.
-            router.reload({ only: ['channels'] });
+            // the shared `channels` prop to recompute every badge count, plus the
+            // aggregate `hasUnreadThreads` flag behind the sidebar's Threads dot.
+            router.reload({ only: ['channels', 'hasUnreadThreads'] });
         }, REFRESH_DEBOUNCE_MS);
     }
 

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
-import { MessageSquareText, Plus, Search } from '@lucide/vue';
+import { MessageSquareText, MessagesSquare, Plus, Search } from '@lucide/vue';
 import { computed, onMounted } from 'vue';
 import {
     browse,
     show,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { index as searchMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
+import { index as threadsInbox } from '@/actions/App/Http/Controllers/Channels/ThreadsController';
 import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import NavUser from '@/components/NavUser.vue';
@@ -54,6 +55,7 @@ const activeChannelSlug = computed(
     () => (page.props.channel as { slug?: string } | undefined)?.slug ?? null,
 );
 const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
+const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
 
 const { getInitials } = useInitials();
 const { switchTeam } = useTeamSwitch();
@@ -235,6 +237,33 @@ onMounted(() => {
                                         <SidebarMenuButton
                                             as-child
                                             class="mt-1.5 h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                        >
+                                            <Link
+                                                v-if="currentTeam"
+                                                :href="
+                                                    threadsInbox(
+                                                        currentTeam.slug,
+                                                    ).url
+                                                "
+                                                data-test="threads-inbox"
+                                            >
+                                                <MessagesSquare
+                                                    class="size-[13px]"
+                                                />
+                                                <span>Threads</span>
+                                                <span
+                                                    v-if="hasUnreadThreads"
+                                                    data-test="threads-unread-dot"
+                                                    aria-hidden="true"
+                                                    class="ml-auto size-1.5 rounded-full bg-primary"
+                                                />
+                                            </Link>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                    <SidebarMenuItem>
+                                        <SidebarMenuButton
+                                            as-child
+                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
                                         >
                                             <Link
                                                 v-if="currentTeam"

--- a/resources/js/pages/channels/Threads.vue
+++ b/resources/js/pages/channels/Threads.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { Head, InfiniteScroll, Link } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import {
+    index,
+    show,
+} from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { getInitials } from '@/composables/useInitials';
+import { renderMessageBody } from '@/lib/messageBody';
+import type { Message, ThreadInboxItem, ThreadInboxPage } from '@/types';
+
+interface TeamData {
+    id: string;
+    name: string;
+    slug: string;
+}
+
+const props = defineProps<{
+    team: TeamData;
+    threads: ThreadInboxPage;
+}>();
+
+const MAX_THREAD_AVATARS = 3;
+
+const items = computed<ThreadInboxItem[]>(() => props.threads?.data ?? []);
+
+function threadAvatars(root: Message) {
+    return root.threadParticipants.slice(0, MAX_THREAD_AVATARS);
+}
+
+function extraParticipants(root: Message): number {
+    return Math.max(0, root.threadParticipants.length - MAX_THREAD_AVATARS);
+}
+
+function jumpHref(item: ThreadInboxItem): string {
+    return show(
+        { team: props.team.slug, channel: item.channelSlug },
+        { query: { thread: item.root.id } },
+    ).url;
+}
+
+function formatTimestamp(iso: string): string {
+    return new Date(iso).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+}
+</script>
+
+<template>
+    <Head title="Threads" />
+
+    <header
+        class="flex h-12 shrink-0 items-center gap-2.5 border-b border-border px-5"
+    >
+        <SidebarTrigger
+            class="-ml-1.5 size-8 text-muted-foreground md:hidden"
+        />
+        <h1 class="text-[15px] font-semibold text-foreground">Threads</h1>
+        <Link
+            :href="index(props.team.slug).url"
+            class="ml-auto text-[13px] text-muted-foreground hover:text-foreground"
+            >Back</Link
+        >
+    </header>
+
+    <div class="flex flex-1 justify-center overflow-y-auto px-6 py-6">
+        <div class="w-full max-w-[680px]">
+            <p
+                v-if="items.length === 0"
+                data-test="threads-empty"
+                class="pt-16 text-center text-sm text-muted-foreground"
+            >
+                You're not following any threads yet. Reply to a thread or get
+                @mentioned in one and it'll show up here.
+            </p>
+
+            <InfiniteScroll v-else data="threads" preserve-url>
+                <ul>
+                    <li v-for="item in items" :key="item.root.id">
+                        <Link
+                            :href="jumpHref(item)"
+                            data-test="thread-inbox-item"
+                            class="flex gap-3 rounded-md border-b border-border/60 px-1 py-3 last:border-0 hover:bg-accent/40"
+                        >
+                            <div
+                                class="flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-primary/10 text-[12px] font-semibold text-primary select-none"
+                                aria-hidden="true"
+                            >
+                                {{ getInitials(item.root.user.name) }}
+                            </div>
+                            <div class="min-w-0 flex-1">
+                                <div
+                                    class="flex items-baseline gap-2 text-[13px]"
+                                >
+                                    <span class="font-semibold text-foreground">
+                                        {{ item.root.user.name }}
+                                    </span>
+                                    <span class="text-muted-foreground/70">
+                                        <span class="text-muted-foreground/50"
+                                            >#</span
+                                        >{{ item.channelName }}
+                                    </span>
+                                    <span
+                                        v-if="item.root.threadLastReplyAt"
+                                        class="ml-auto shrink-0 text-[11px] text-muted-foreground/70"
+                                    >
+                                        {{
+                                            formatTimestamp(
+                                                item.root.threadLastReplyAt,
+                                            )
+                                        }}
+                                    </span>
+                                </div>
+                                <p
+                                    v-if="!item.root.isDeleted"
+                                    class="mt-0.5 line-clamp-2 text-[14px] leading-[1.5] break-words text-foreground/90"
+                                >
+                                    <span
+                                        v-html="
+                                            renderMessageBody(
+                                                item.root.body,
+                                                item.root.mentions,
+                                            )
+                                        "
+                                    ></span>
+                                </p>
+
+                                <div
+                                    class="mt-1.5 flex items-center gap-2 text-[12px]"
+                                >
+                                    <span class="flex -space-x-1">
+                                        <span
+                                            v-for="participant in threadAvatars(
+                                                item.root,
+                                            )"
+                                            :key="participant.id"
+                                            class="flex size-5 items-center justify-center rounded-[6px] bg-primary/10 text-[9px] font-semibold text-primary ring-2 ring-background select-none"
+                                            aria-hidden="true"
+                                        >
+                                            {{ getInitials(participant.name) }}
+                                        </span>
+                                        <span
+                                            v-if="
+                                                extraParticipants(item.root) > 0
+                                            "
+                                            class="flex size-5 items-center justify-center rounded-[6px] bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-background select-none"
+                                            aria-hidden="true"
+                                        >
+                                            +{{ extraParticipants(item.root) }}
+                                        </span>
+                                    </span>
+                                    <span
+                                        v-if="item.root.threadUnread"
+                                        data-test="thread-unread-dot"
+                                        aria-label="Unread replies"
+                                        class="size-2 shrink-0 rounded-full bg-rose-500"
+                                    ></span>
+                                    <span class="font-semibold text-primary">
+                                        {{ item.root.threadReplyCount }}
+                                        {{
+                                            item.root.threadReplyCount === 1
+                                                ? 'reply'
+                                                : 'replies'
+                                        }}
+                                    </span>
+                                </div>
+                            </div>
+                        </Link>
+                    </li>
+                </ul>
+            </InfiniteScroll>
+        </div>
+    </div>
+</template>

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -24,6 +24,7 @@ declare module '@inertiajs/core' {
             currentTeam: Team | null;
             teams: Team[];
             channels?: Channel[];
+            hasUnreadThreads?: boolean;
             pendingInvitations?: DashboardInvitation[];
             [key: string]: unknown;
         };

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -89,3 +89,25 @@ export type MessageSearchResult = {
     channelName: string;
     channelSlug: string;
 };
+
+/**
+ * A row in the Threads inbox. Mirrors the `ThreadInboxItemData` DTO: a followed
+ * thread's root message (carrying its reply count, participants, and per-viewer
+ * `threadUnread` state) plus the channel it lives in, for rendering the row and
+ * its jump-to-thread link.
+ */
+export type ThreadInboxItem = {
+    root: Message;
+    channelName: string;
+    channelSlug: string;
+};
+
+/**
+ * The paginated shape delivered by `Inertia::scroll()` for the Threads inbox.
+ * `data` arrives newest-activity first; older threads page in on scroll.
+ */
+export type ThreadInboxPage = {
+    data: ThreadInboxItem[];
+    next_cursor: string | null;
+    prev_cursor: string | null;
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Channels\ChannelMemberController;
 use App\Http\Controllers\Channels\ChannelPreferenceController;
 use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Channels\SearchController;
+use App\Http\Controllers\Channels\ThreadsController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Support\Facades\Route;
@@ -16,6 +17,7 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/channels', [ChannelController::class, 'store'])->name('channels.store');
     Route::get('t/{team}/channels/browse', [ChannelController::class, 'browse'])->name('channels.browse');
     Route::get('t/{team}/search', [SearchController::class, 'index'])->name('search');
+    Route::get('t/{team}/threads', [ThreadsController::class, 'index'])->name('channels.threads.index');
     Route::get('t/{team}/c/{channel}', [ChannelController::class, 'show'])
         ->scopeBindings()
         ->name('channels.show');

--- a/tests/Feature/Channels/ThreadsInboxTest.php
+++ b/tests/Feature/Channels/ThreadsInboxTest.php
@@ -1,0 +1,253 @@
+<?php
+
+use App\Actions\Channels\MarkThreadRead;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\NotificationLevel;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Carbon\CarbonInterface;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function inboxSetup(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and the given channel, returning them.
+ */
+function inboxMember(Team $team, Channel $channel): User
+{
+    $user = User::factory()->create();
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+/**
+ * Create a thread root carrying the denormalized reply aggregates the inbox
+ * filters and orders on, as PostMessage would maintain them in production.
+ */
+function inboxRoot(Channel $channel, User $author, ?CarbonInterface $lastReplyAt = null, array $attributes = []): Message
+{
+    return Message::factory()->for($channel)->for($author)->create(array_merge([
+        'reply_count' => 1,
+        'last_reply_at' => $lastReplyAt ?? now(),
+    ], $attributes));
+}
+
+/**
+ * Load the Threads inbox as the given user and return the `threads.data` rows.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function inboxRows(User $viewer, Team $team): array
+{
+    $captured = [];
+
+    test()->actingAs($viewer)
+        ->get(route('channels.threads.index', ['team' => $team->slug]))
+        ->assertInertia(function (Assert $page) use (&$captured) {
+            $page->component('channels/Threads');
+            $captured = $page->toArray()['props']['threads']['data'];
+        });
+
+    return $captured;
+}
+
+test('the inbox lists a thread the user authored the root of', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+
+    $root = inboxRoot($general, $owner);
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $rows = inboxRows($owner, $team);
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['root']['id'])->toBe($root->id)
+        ->and($rows[0]['channelName'])->toBe($general->name)
+        ->and($rows[0]['root']['threadUnread'])->toBeTrue();
+});
+
+test('the inbox lists a thread the user replied in', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+
+    $root = inboxRoot($general, $owner);
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    // Alice replied, so she follows; a reply by someone else would be unread,
+    // but here she is caught up (only her own reply exists).
+    $rows = inboxRows($alice, $team);
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['root']['id'])->toBe($root->id)
+        ->and($rows[0]['root']['threadUnread'])->toBeFalse();
+});
+
+test('the inbox lists a thread the user was mentioned in', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+    $bob = inboxMember($team, $general);
+
+    $root = inboxRoot($general, $owner);
+    $reply = Message::factory()->for($general)->for($alice)->inThread($root)->create();
+    $reply->mentionedUsers()->attach($bob->id);
+
+    $rows = inboxRows($bob, $team);
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['root']['id'])->toBe($root->id)
+        ->and($rows[0]['root']['threadUnread'])->toBeTrue();
+});
+
+test('the inbox excludes threads the user does not follow', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+    $bob = inboxMember($team, $general);
+
+    $root = inboxRoot($general, $owner);
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    // Bob never authored, replied, or was mentioned.
+    expect(inboxRows($bob, $team))->toBeEmpty();
+});
+
+test('the inbox excludes roots with no replies and deleted roots', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+
+    // A root the owner started but nobody has replied to yet.
+    Message::factory()->for($general)->for($owner)->create(['reply_count' => 0]);
+
+    // A deleted root, even with replies, should not surface.
+    $deleted = inboxRoot($general, $owner, attributes: ['deleted_at' => now()]);
+    Message::factory()->for($general)->for($alice)->inThread($deleted)->create();
+
+    expect(inboxRows($owner, $team))->toBeEmpty();
+});
+
+test('the inbox only lists threads in channels the user belongs to', function () {
+    [$owner, $team, $general] = inboxSetup();
+
+    // A private channel the owner is NOT a member of, with a thread they were
+    // even mentioned in — it must not leak into their inbox.
+    $secret = Channel::factory()->for($team)->create(['visibility' => 'private']);
+    $insider = inboxMember($team, $secret);
+    $root = inboxRoot($secret, $insider);
+    $reply = Message::factory()->for($secret)->for($insider)->inThread($root)->create();
+    $reply->mentionedUsers()->attach($owner->id);
+
+    expect(inboxRows($owner, $team))->toBeEmpty();
+});
+
+test('the inbox orders threads by most recent reply first', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+
+    $older = inboxRoot($general, $owner, now()->subHour());
+    Message::factory()->for($general)->for($alice)->inThread($older)->create();
+
+    $newer = inboxRoot($general, $owner, now());
+    Message::factory()->for($general)->for($alice)->inThread($newer)->create();
+
+    $rows = inboxRows($owner, $team);
+
+    expect($rows[0]['root']['id'])->toBe($newer->id)
+        ->and($rows[1]['root']['id'])->toBe($older->id);
+});
+
+test('a muted channel lists its threads without an unread dot', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+
+    $general->channelMembers()->where('user_id', $owner->id)->update(['muted' => true]);
+
+    $root = inboxRoot($general, $owner);
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $rows = inboxRows($owner, $team);
+
+    expect($rows)->toHaveCount(1)
+        ->and($rows[0]['root']['threadUnread'])->toBeFalse();
+});
+
+test('opening and reading a thread clears its unread dot in the inbox', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+
+    $root = inboxRoot($general, $owner);
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    expect(inboxRows($owner, $team)[0]['root']['threadUnread'])->toBeTrue();
+
+    app(MarkThreadRead::class)->handle($root, $owner);
+
+    expect(inboxRows($owner, $team)[0]['root']['threadUnread'])->toBeFalse();
+});
+
+test('the inbox is empty when the user follows no threads', function () {
+    [$owner, $team, $general] = inboxSetup();
+
+    expect(inboxRows($owner, $team))->toBeEmpty();
+});
+
+test('hasUnreadThreads flags an unread followed thread and clears when read', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+
+    $root = inboxRoot($general, $owner);
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $this->actingAs($owner)
+        ->get(route('channels.threads.index', ['team' => $team->slug]))
+        ->assertInertia(fn (Assert $page) => $page->where('hasUnreadThreads', true));
+
+    app(MarkThreadRead::class)->handle($root, $owner);
+
+    $this->actingAs($owner)
+        ->get(route('channels.threads.index', ['team' => $team->slug]))
+        ->assertInertia(fn (Assert $page) => $page->where('hasUnreadThreads', false));
+});
+
+test('hasUnreadThreads ignores threads the user does not follow', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+    $bob = inboxMember($team, $general);
+
+    $root = inboxRoot($general, $owner);
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $this->actingAs($bob)
+        ->get(route('channels.threads.index', ['team' => $team->slug]))
+        ->assertInertia(fn (Assert $page) => $page->where('hasUnreadThreads', false));
+});
+
+test('hasUnreadThreads respects channel mute', function () {
+    [$owner, $team, $general] = inboxSetup();
+    $alice = inboxMember($team, $general);
+
+    $general->channelMembers()->where('user_id', $owner->id)
+        ->update(['notification_level' => NotificationLevel::Mentions]);
+
+    $root = inboxRoot($general, $owner);
+    Message::factory()->for($general)->for($alice)->inThread($root)->create();
+
+    $this->actingAs($owner)
+        ->get(route('channels.threads.index', ['team' => $team->slug]))
+        ->assertInertia(fn (Assert $page) => $page->where('hasUnreadThreads', false));
+});


### PR DESCRIPTION
First of two focused PRs for #79. This one adds the **Threads inbox**; thread-panel reply pagination follows in a second PR (then #79 closes).

Part of #79. Builds on #71/#80's read-state foundation.

## What this does

A dedicated cross-channel view listing every thread the current user **follows** — Slack-style auto-follow (authored the root, replied, or was `@mentioned`) — newest activity first, with per-thread unread state. Reachable from a new **Threads** entry in the workspace sidebar that carries an aggregate unread dot.

### Backend
- **Promoted #80's derivation into reusable `Message` query scopes**, so the inbox and the channel view share one source of truth:
  - `scopeWithThreadReadState` — annotates `thread_followed` / `thread_has_unread`.
  - `scopeFollowedBy` — the *same* follow SQL as a filter (no drift).
  - `scopeWhereThreadUnreadFor` — unread existence filter.
  - The unread SQL now **self-suppresses per-channel mute/level**, so a cross-channel query gets correct per-channel muting for free. `ChannelController` no longer threads a `showUnread` flag through (net −82 lines there).
- **`ThreadsController@index`** (`channels.threads.index`) renders `channels/Threads` with an `Inertia::scroll` page of `ThreadInboxItemData`, ACL-scoped to the user's channels in the team (private-channel threads never leak). Older threads page in on scroll.
- **Shared `hasUnreadThreads` prop** drives the sidebar's Threads dot; `useSidebarBadges` refreshes it alongside the channel badges.

### Frontend
- `pages/channels/Threads.vue` — the inbox list (author, channel, body preview, participant avatars, reply count, unread dot); each row links into the channel with `?thread=` to open the thread. Empty state included.
- `Threads` sidebar nav entry with an aggregate unread dot bound to `hasUnreadThreads`.

### Notes
- Per-channel mute suppresses a thread's unread dot but does **not** remove it from the inbox — muted channels' followed threads still list, just without a dot (matches the #71 decision).
- The nav dot is authoritative on navigation and refreshes on the existing sidebar-badge reloads (channel messages / mentions / sent-to-channel replies); a thread-*only* reply updates the in-channel dot live (from #80) but not the aggregate nav dot until the next sidebar refresh. Fine as a soft signal; can be tightened later.

## Tests
- 13 Pest feature tests: follow derivation (author/reply/mention), non-follow exclusion, no-reply & deleted-root exclusion, cross-channel ACL, ordering, mute (row lists without dot), read-clears-dot, empty state, and the `hasUnreadThreads` flag (set / cleared / non-follow / muted).
- Existing #80 thread read-state tests stay green through the scope refactor.

## Quality gate
- Pint ✓ · PHPStan ✓ · **coverage 100.0%** ✓
- ESLint ✓ · Prettier ✓ · vue-tsc ✓ · build ✓ · Vitest ✓