### PR TITLE
feat(threads): paginate thread panel replies (#79)

### DIFF
--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -17,6 +17,7 @@ use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
+use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -38,6 +39,12 @@ class ChannelController extends Controller
      * feeds the read-boundary window math.
      */
     private const int MESSAGE_PAGE_SIZE = 50;
+
+    /**
+     * How many replies a thread page loads. The panel pages older replies in on
+     * scroll-up, mirroring the main timeline.
+     */
+    private const int THREAD_PAGE_SIZE = 50;
 
     /**
      * How many already-read messages to keep loaded above the "New messages"
@@ -124,11 +131,16 @@ class ChannelController extends Controller
             // "New messages" divider so it lands at the last-read boundary on
             // open; null when the channel has never been read.
             'lastReadMessageId' => $membership?->last_read_message_id !== null ? (string) $membership->last_read_message_id : null,
-            // The open thread (root + its replies), resolved from the `?thread=`
-            // query param, or null for a normal visit. The client opens a thread
-            // with a partial reload of just this prop; on a full visit the closure
-            // returns null cheaply when no thread is requested.
+            // The open thread's root message, resolved from the `?thread=` query
+            // param, or null for a normal visit. The client opens a thread by
+            // visiting `?thread=<root>`, which also drives the paginated replies
+            // below; the closure returns null cheaply when no thread is requested.
             'thread' => fn () => $this->threadPayload($request, $channel),
+            // The open thread's replies, oldest last, paginated so a very long
+            // thread doesn't ship in one payload. Its own cursor name keeps it
+            // independent of the main timeline's, and the client's reverse
+            // InfiniteScroll pages older replies in above as it scrolls up.
+            'threadReplies' => Inertia::scroll(fn () => $this->threadRepliesPage($request, $channel)),
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),
@@ -147,16 +159,58 @@ class ChannelController extends Controller
     }
 
     /**
-     * Resolve the open thread from the `?thread=` query param.
+     * Resolve the open thread's root from the `?thread=` query param.
      *
-     * Returns the root message plus its replies (oldest first, tombstones
-     * included) when the param names a live root in this channel, or null when
-     * it is absent or points elsewhere. The eager-load set mirrors the main
-     * timeline so replies render quotes and thread affordances identically.
+     * Returns the root message (annotated with the viewer's thread read-state)
+     * when the param names a live root in this channel, or null when it is absent
+     * or points elsewhere. The replies are delivered separately and paginated by
+     * {@see self::threadRepliesPage()}.
      *
-     * @return array{root: MessageData, replies: array<int, MessageData>}|null
+     * @return array{root: MessageData}|null
      */
     private function threadPayload(Request $request, Channel $channel): ?array
+    {
+        $root = $this->resolveThreadRoot($request, $channel);
+
+        if ($root === null) {
+            return null;
+        }
+
+        return ['root' => MessageData::fromMessage($root)];
+    }
+
+    /**
+     * The open thread's replies as a cursor-paginated page for infinite scroll.
+     *
+     * Ordered newest first (the client reverses for display and pages older
+     * replies in on scroll-up), tombstones included so deletions render in place.
+     * Its own cursor name keeps the pagination independent of the main timeline's.
+     * Falls back to an empty page when no live root is named, so the scroll prop
+     * always has a well-formed shape even on a normal channel visit.
+     *
+     * @return CursorPaginator<int, MessageData>
+     */
+    private function threadRepliesPage(Request $request, Channel $channel): CursorPaginator
+    {
+        $root = $this->resolveThreadRoot($request, $channel);
+
+        $query = $root !== null
+            ? $root->threadReplies()->withTrashed()->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers'])
+            : Message::query()->whereRaw('1 = 0');
+
+        return $query
+            ->orderByDesc('id')
+            ->cursorPaginate(self::THREAD_PAGE_SIZE, ['*'], 'thread_cursor')
+            ->through(fn (Message $message) => MessageData::fromMessage($message));
+    }
+
+    /**
+     * Resolve the live root message named by the `?thread=` query param, or null.
+     *
+     * The eager-load set mirrors the main timeline so the root renders its quote
+     * and thread affordances identically.
+     */
+    private function resolveThreadRoot(Request $request, Channel $channel): ?Message
     {
         $rootId = $request->query('thread');
 
@@ -164,28 +218,11 @@ class ChannelController extends Controller
             return null;
         }
 
-        $root = $channel->messages()
+        return $channel->messages()
             ->whereNull('thread_root_id')
             ->withThreadReadState($request->user())
             ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
             ->find($rootId);
-
-        if ($root === null) {
-            return null;
-        }
-
-        $replies = $root->threadReplies()
-            ->withTrashed()
-            ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers'])
-            ->orderBy('id')
-            ->get()
-            ->map(fn (Message $message) => MessageData::fromMessage($message))
-            ->all();
-
-        return [
-            'root' => MessageData::fromMessage($root),
-            'replies' => $replies,
-        ];
     }
 
     /**

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { InfiniteScroll } from '@inertiajs/vue3';
 import { X } from '@lucide/vue';
 import { computed, nextTick, ref, watch } from 'vue';
 import MessageComposer from '@/components/MessageComposer.vue';
@@ -7,6 +8,9 @@ import { Skeleton } from '@/components/ui/skeleton';
 import type { Mention, Message } from '@/types';
 
 const props = defineProps<{
+    // The open thread's root id, used to key the reply scroll so switching
+    // threads mounts a fresh, bottom-anchored list.
+    rootId: string;
     channelName: string;
     // The root followed by its replies (oldest first), merged and deduped by the
     // parent's thread stream; empty while the thread is still loading.
@@ -29,9 +33,14 @@ const emit = defineEmits<{
     jump: [messageId: string];
 }>();
 
-// The first message is the root; everything after it is a reply.
-const hasRoot = computed(() => props.messages.length > 0);
-const replyCount = computed(() => Math.max(0, props.messages.length - 1));
+// The root is the thread's only top-level message; everything else is a reply.
+const root = computed(() =>
+    props.messages.find((message) => message.threadRootId === null),
+);
+const hasRoot = computed(() => root.value !== undefined);
+// The header shows the thread's total reply count (denormalized on the root),
+// not just the replies currently paged into view.
+const replyCount = computed(() => root.value?.threadReplyCount ?? 0);
 const showSkeleton = computed(() => props.loading || !hasRoot.value);
 
 // Distance (px) from the bottom within which the panel stays pinned to newest,
@@ -122,23 +131,33 @@ watch(
                 </div>
             </div>
 
-            <MessageList
+            <!-- Older replies page in on scroll-up; keyed by root so switching
+                 threads mounts a fresh, bottom-anchored list. `preserve-url`
+                 keeps the cursor out of the URL, matching the main timeline. -->
+            <InfiniteScroll
                 v-else
-                :messages="props.messages"
-                :pending-uuids="props.pendingUuids"
-                :current-user-id="props.currentUserId"
-                :can-moderate="props.canModerate"
-                :online-ids="props.onlineIds"
-                in-thread
-                @edit="(message, body) => emit('edit', message, body)"
-                @delete="(message) => emit('delete', message)"
-                @jump="(id) => emit('jump', id)"
-            />
+                :key="props.rootId"
+                data="threadReplies"
+                reverse
+                preserve-url
+            >
+                <MessageList
+                    :messages="props.messages"
+                    :pending-uuids="props.pendingUuids"
+                    :current-user-id="props.currentUserId"
+                    :can-moderate="props.canModerate"
+                    :online-ids="props.onlineIds"
+                    in-thread
+                    @edit="(message, body) => emit('edit', message, body)"
+                    @delete="(message) => emit('delete', message)"
+                    @jump="(id) => emit('jump', id)"
+                />
+            </InfiniteScroll>
         </div>
 
         <MessageComposer
             v-if="hasRoot && !props.readOnly"
-            :key="props.messages[0]?.id"
+            :key="root?.id"
             :channel-name="props.channelName"
             :members="props.members"
             placeholder="Reply…"

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -23,6 +23,7 @@ import {
     archive as archiveChannel,
     read as markChannelRead,
     readThread as markThreadReadAction,
+    show as showChannel,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
 import {
@@ -88,8 +89,11 @@ const props = defineProps<{
     // The viewer's read pointer at load time, used to place the "New messages"
     // divider; null when the channel has never been read.
     lastReadMessageId?: string | null;
-    // The open thread, loaded on demand as an optional prop keyed by `?thread=`.
+    // The open thread's root, loaded on demand keyed by `?thread=`.
     thread?: Thread | null;
+    // The open thread's replies, a reverse-infinite-scroll page that grows as
+    // older replies load. Empty when no thread is open.
+    threadReplies: MessagePage;
 }>();
 
 const page = usePage();
@@ -144,16 +148,22 @@ const pendingUuids = mainStream.pendingUuids;
 
 const hasMessages = computed(() => displayMessages.value.length > 0);
 
-// The open thread (root + replies), loaded on demand and kept client-side so a
-// later full-page visit that omits the optional prop can't drop it. The thread
-// panel runs its own stream instance over the root + its replies.
+// The open thread's root, kept client-side so a partial reload that omits the
+// optional `thread` prop can't drop it. The panel runs its own stream instance
+// over the root plus its paginated replies.
 const activeThreadRootId = ref<string | null>(null);
 const threadData = ref<Thread | null>(null);
 const threadLoading = ref(false);
 
+// The reply page arrives newest-first (older replies page in on scroll-up); the
+// root is the thread's oldest message, so it leads the reversed list. The stream
+// then re-sorts by timestamp, keeping the root pinned to the top.
 const threadServerMessages = computed<Message[]>(() =>
     threadData.value
-        ? [threadData.value.root, ...threadData.value.replies]
+        ? [
+              threadData.value.root,
+              ...[...(props.threadReplies?.data ?? [])].reverse(),
+          ]
         : [],
 );
 
@@ -472,7 +482,7 @@ watch(
         }
 
         mainStream.reset();
-        closeThread();
+        resetThreadPanel();
         replyTarget.value = null;
         typing.reset();
         notificationLevel.value = props.channel.notificationLevel;
@@ -666,9 +676,19 @@ function deleteMessage(message: Message): void {
     );
 }
 
-// Open the thread rooted at a message. The root's replies load as the optional
-// `thread` prop (a partial reload keyed by `?thread=`), shown as a skeleton
-// until they arrive.
+// Reset the panel's client state without navigating. Used when switching
+// channels, where the URL has already moved off any open thread.
+function resetThreadPanel(): void {
+    activeThreadRootId.value = null;
+    threadData.value = null;
+    threadLoading.value = false;
+    threadStream.reset();
+}
+
+// Open the thread rooted at a message by putting `?thread=<root>` in the URL, so
+// the root (`thread`) and the first page of replies (`threadReplies`) load and
+// the reply InfiniteScroll's paging requests carry the root. `reset` clears any
+// previous thread's merged replies; a skeleton shows until the root arrives.
 function openThread(rootId: string): void {
     if (activeThreadRootId.value === rootId) {
         return;
@@ -683,21 +703,45 @@ function openThread(rootId: string): void {
     // once the replies load (and again on focus / as new replies stream in).
     mainStream.patchThreadState(rootId, { threadUnread: false });
 
-    router.reload({
-        only: ['thread'],
-        data: { thread: rootId },
-        onFinish: () => {
-            threadLoading.value = false;
-            markThreadRead();
+    router.get(
+        showChannel(
+            { team: props.team.slug, channel: props.channel.slug },
+            { query: { thread: rootId } },
+        ).url,
+        {},
+        {
+            only: ['thread', 'threadReplies'],
+            reset: ['threadReplies'],
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+            onFinish: () => {
+                threadLoading.value = false;
+                markThreadRead();
+            },
         },
-    });
+    );
 }
 
+// Close the thread: drop `?thread=` from the URL and reset the panel.
 function closeThread(): void {
-    activeThreadRootId.value = null;
-    threadData.value = null;
-    threadLoading.value = false;
-    threadStream.reset();
+    if (activeThreadRootId.value === null) {
+        return;
+    }
+
+    resetThreadPanel();
+
+    router.get(
+        showChannel({ team: props.team.slug, channel: props.channel.slug }).url,
+        {},
+        {
+            only: ['thread', 'threadReplies'],
+            reset: ['threadReplies'],
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        },
+    );
 }
 
 // The member's own notification preferences for this channel, seeded from the
@@ -1003,6 +1047,7 @@ function archive(): void {
         >
             <ThreadPanel
                 v-if="activeThreadRootId"
+                :root-id="activeThreadRootId"
                 :channel-name="props.channel.name"
                 :messages="threadMessages"
                 :pending-uuids="threadPendingUuids"

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -61,12 +61,12 @@ export type Message = {
 };
 
 /**
- * An open thread: its root message plus every reply (oldest first, tombstones
- * included). Mirrors the `thread` prop the channel page loads on demand.
+ * An open thread's root message. Mirrors the `thread` prop the channel page
+ * loads on demand from `?thread=`; the replies ride a separate, paginated
+ * `threadReplies` scroll prop (a `MessagePage`).
  */
 export type Thread = {
     root: Message;
-    replies: Message[];
 };
 
 /**

--- a/tests/Feature/Channels/ThreadTest.php
+++ b/tests/Feature/Channels/ThreadTest.php
@@ -153,30 +153,49 @@ test('the main timeline hides thread-only replies but keeps sent-to-channel repl
         );
 });
 
-test('the thread prop returns the root and its replies oldest-first, tombstones included', function () {
+test('the thread prop returns the root and paginated replies newest-first, tombstones included', function () {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
     Message::factory()->for($owner)->inThread($root)->create(['body' => 'first reply']);
     $second = Message::factory()->for($owner)->inThread($root)->create(['body' => 'second reply']);
     $second->delete();
 
+    // Replies ride a separate paginated `threadReplies` scroll prop, newest
+    // first (the client reverses for display); the root stays on `thread`.
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $root->id]))
         ->assertInertia(fn (Assert $page) => $page
             ->where('thread.root.id', $root->id)
-            ->has('thread.replies', 2)
-            ->where('thread.replies.0.body', 'first reply')
-            ->where('thread.replies.1.isDeleted', true)
-            ->where('thread.replies.1.body', '')
+            ->has('threadReplies.data', 2)
+            ->where('threadReplies.data.0.isDeleted', true)
+            ->where('threadReplies.data.0.body', '')
+            ->where('threadReplies.data.1.body', 'first reply')
         );
 });
 
-test('the thread prop is null for a normal visit', function () {
+test('the thread prop is null and replies are empty for a normal visit', function () {
     [$owner, $team, $general] = threadTeamWithGeneral();
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page->where('thread', null));
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('thread', null)
+            ->has('threadReplies.data', 0));
+});
+
+test('a long thread caps the first page of replies and offers more', function () {
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->for($general)->for($owner)->create();
+    Message::factory()->count(51)->for($owner)->inThread($root)->create();
+
+    // The first page holds the newest 50 of 51 replies; the 51st (oldest) pages
+    // in on scroll, so the cursor to fetch it is present.
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $root->id]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('threadReplies.data', 50)
+            ->where('threadReplies.next_cursor', fn (?string $cursor) => $cursor !== null)
+            ->etc());
 });
 
 test('the thread prop is null when the param is blank or points elsewhere', function () {


### PR DESCRIPTION
Second and final PR for #79 (follows the Threads inbox in #81). **Closes #79.**

## What this does

Very long threads no longer ship every reply in one payload. The thread panel loads the newest 50 replies and pages older ones in on scroll-up, mirroring the main timeline's reverse infinite scroll.

### Backend
- Split the on-demand `thread` prop into the **root** (`thread`) plus a **cursor-paginated `threadReplies`** scroll prop (`Inertia::scroll`, its own cursor name so it's independent of the main timeline's). Falls back to an empty page on a normal visit.
- `resolveThreadRoot()` is shared by both so the root lookup isn't duplicated.

### Frontend
- Opening a thread now puts `?thread=<root>` in the URL (a `replace` visit that `reset`s `threadReplies`), so the reply `InfiniteScroll`'s paging requests carry the root — and threads become **link-addressable**. Closing drops the param; channel switches reset the panel without navigating.
- `ThreadPanel` wraps its reply list in a **reverse, root-keyed `InfiniteScroll`** (`preserve-url`) and shows the root's denormalized **total** reply count in the header rather than the loaded count.
- The parent thread stream still merges root + replies + live + optimistic, so realtime broadcasts and optimistic sends are unchanged; the root stays pinned at the top.

## Tests
- `ThreadTest` updated for the new prop shape, plus new cases: the first page **caps at 50** with a `next_cursor` for the rest, and a normal visit yields an **empty** `threadReplies`.
- #80/#81 thread read-state + inbox tests stay green.

## Live verification
Drove the running app (headless Chrome via CDP) end-to-end on a seeded 55-reply thread:
- Opening the thread → URL gains `?thread=`, header shows **55 replies**, **50 of 55** replies load (#6–#55), root shown.
- Scrolling up → the earliest replies **#1–#5 page in** (all 56 rows incl. root).
- Closing → URL param removed, panel gone, main timeline intact.

## Quality gate
- Pint ✓ · PHPStan ✓ · **coverage 100.0%** ✓
- ESLint ✓ · Prettier ✓ · vue-tsc ✓ · build ✓ · Vitest ✓