### PR TITLE
feat(navigation): quick switcher command palette (#39)

### DIFF
--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -27,7 +27,7 @@ class SearchMessages
      *
      * @return Collection<int, Message>
      */
-    public function handle(User $user, Team $team, string $query): Collection
+    public function handle(User $user, Team $team, string $query, int $limit = self::RESULT_LIMIT): Collection
     {
         $query = trim($query);
 
@@ -42,7 +42,7 @@ class SearchMessages
 
         return Message::search($query)
             ->whereIn('channel_id', $channelIds)
-            ->take(self::RESULT_LIMIT)
+            ->take($limit)
             ->get()
             ->load(['user', 'channel', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers']);
     }

--- a/app/Http/Controllers/Channels/SearchController.php
+++ b/app/Http/Controllers/Channels/SearchController.php
@@ -8,11 +8,18 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\SearchMessagesRequest;
 use App\Models\Message;
 use App\Models\Team;
+use Illuminate\Http\JsonResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class SearchController extends Controller
 {
+    /**
+     * The number of message matches surfaced inline in the quick switcher, kept
+     * small so the palette stays a preview; the full page shows the rest.
+     */
+    private const SUGGEST_LIMIT = 5;
+
     /**
      * Search messages in the current team, scoped to the user's channels.
      *
@@ -37,5 +44,23 @@ class SearchController extends Controller
             'query' => $query,
             'results' => $results,
         ]);
+    }
+
+    /**
+     * A JSON preview of the top message matches for the quick switcher.
+     *
+     * Shares the ACL-filtered SearchMessages action with {@see self::index()},
+     * capped at {@see self::SUGGEST_LIMIT} so the palette shows only a handful
+     * of hits; users open the full page for the complete result set.
+     */
+    public function suggest(SearchMessagesRequest $request, Team $team, SearchMessages $searchMessages): JsonResponse
+    {
+        $query = trim((string) $request->validated('q'));
+
+        $results = $searchMessages->handle($request->user(), $team, $query, self::SUGGEST_LIMIT)
+            ->map(fn (Message $message) => MessageSearchResultData::fromMessage($message))
+            ->all();
+
+        return response()->json(['results' => $results]);
     }
 }

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3';
+import { CornerDownLeft, Hash, Search } from '@lucide/vue';
+import { ListboxFilter } from 'reka-ui';
+import { computed, ref, watch } from 'vue';
+import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import {
+    index as searchPage,
+    suggest as suggestMessages,
+} from '@/actions/App/Http/Controllers/Channels/SearchController';
+import {
+    CommandDialog,
+    CommandGroup,
+    CommandItem,
+    CommandList,
+} from '@/components/ui/command';
+import { rankChannels } from '@/composables/quickSwitcher';
+import { getInitials } from '@/composables/useInitials';
+import { useMessageSearch } from '@/composables/useMessageSearch';
+import { renderMessageBody } from '@/lib/messageBody';
+import type { MessageSearchResult } from '@/types';
+import type { Channel } from '@/types/channels';
+
+const props = defineProps<{
+    channels: Channel[];
+    teamSlug: string;
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+
+// Our own query drives the fuzzy channel ranking. The Command's internal filter
+// state is deliberately left untouched (empty) so it never hides a subsequence
+// match that `rankChannels` chose to surface — the ranked list is the single
+// source of truth for what shows and in what order.
+const query = ref('');
+
+const trimmedQuery = computed(() => query.value.trim().replace(/^#+/, ''));
+
+const channelResults = computed(() =>
+    rankChannels(props.channels, query.value),
+);
+
+// Live message search: a debounced JSON call to the suggest endpoint, with the
+// in-flight request cancelled whenever the query changes so late responses
+// never overwrite newer ones.
+const {
+    results: messageResults,
+    isSearching: isSearchingMessages,
+    search: searchMessages,
+    reset: resetMessages,
+} = useMessageSearch(
+    (term) => suggestMessages(props.teamSlug, { query: { q: term } }).url,
+);
+
+watch(trimmedQuery, (term) => {
+    searchMessages(term);
+});
+
+// Reset everything on dismiss so the palette always reopens blank.
+watch(open, (isOpen) => {
+    if (!isOpen) {
+        query.value = '';
+        resetMessages();
+    }
+});
+
+function formatTimestamp(iso: string): string {
+    return new Date(iso).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+}
+
+function selectChannel(channel: Channel): void {
+    open.value = false;
+    router.visit(show({ team: props.teamSlug, channel: channel.slug }).url);
+}
+
+function selectMessage(result: MessageSearchResult): void {
+    open.value = false;
+    router.visit(
+        show(
+            { team: props.teamSlug, channel: result.channelSlug },
+            { query: { message: result.message.id } },
+        ).url,
+    );
+}
+
+function seeAllResults(): void {
+    open.value = false;
+    router.visit(
+        searchPage(props.teamSlug, { query: { q: trimmedQuery.value } }).url,
+    );
+}
+</script>
+
+<template>
+    <CommandDialog
+        v-model:open="open"
+        title="Quick switcher"
+        description="Jump to a channel or search messages"
+    >
+        <div class="flex h-11 items-center gap-2 border-b px-3">
+            <Search class="size-4 shrink-0 opacity-50" />
+            <ListboxFilter
+                v-model="query"
+                auto-focus
+                placeholder="Jump to a channel or search messages…"
+                data-test="quick-switcher-input"
+                class="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            />
+        </div>
+        <CommandList>
+            <CommandGroup v-if="channelResults.length > 0" heading="Channels">
+                <CommandItem
+                    v-for="channel in channelResults"
+                    :key="channel.id"
+                    :value="`channel:${channel.id}`"
+                    data-test="quick-switcher-channel"
+                    class="gap-2"
+                    @select="selectChannel(channel)"
+                >
+                    <Hash class="size-4 shrink-0 opacity-60" />
+                    <span class="truncate">{{ channel.name }}</span>
+                </CommandItem>
+            </CommandGroup>
+
+            <CommandGroup v-if="trimmedQuery !== ''" heading="Messages">
+                <p
+                    v-if="isSearchingMessages && messageResults.length === 0"
+                    class="px-2 py-2 text-xs text-muted-foreground"
+                >
+                    Searching…
+                </p>
+                <p
+                    v-else-if="messageResults.length === 0"
+                    data-test="quick-switcher-no-messages"
+                    class="px-2 py-2 text-xs text-muted-foreground"
+                >
+                    No messages match &ldquo;{{ trimmedQuery }}&rdquo;.
+                </p>
+
+                <CommandItem
+                    v-for="result in messageResults"
+                    :key="result.message.id"
+                    :value="`message:${result.message.id}`"
+                    data-test="quick-switcher-message"
+                    class="items-start gap-2.5"
+                    @select="selectMessage(result)"
+                >
+                    <div
+                        class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-semibold text-primary select-none"
+                        aria-hidden="true"
+                    >
+                        {{ getInitials(result.message.user.name) }}
+                    </div>
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-baseline gap-1.5 text-xs">
+                            <span class="font-medium text-foreground">{{
+                                result.message.user.name
+                            }}</span>
+                            <span class="text-muted-foreground/70"
+                                ><span class="text-muted-foreground/50">#</span
+                                >{{ result.channelName }}</span
+                            >
+                            <span
+                                class="ml-auto shrink-0 text-[10px] text-muted-foreground/60"
+                                >{{
+                                    formatTimestamp(result.message.createdAt)
+                                }}</span
+                            >
+                        </div>
+                        <p
+                            class="mt-0.5 line-clamp-1 text-[13px] text-foreground/80"
+                        >
+                            <span
+                                v-html="
+                                    renderMessageBody(
+                                        result.message.body,
+                                        result.message.mentions,
+                                    )
+                                "
+                            ></span>
+                        </p>
+                    </div>
+                </CommandItem>
+
+                <CommandItem
+                    value="see-all-results"
+                    data-test="quick-switcher-see-all"
+                    class="gap-2 text-muted-foreground"
+                    @select="seeAllResults"
+                >
+                    <CornerDownLeft class="size-4 shrink-0 opacity-60" />
+                    <span class="truncate"
+                        >See all results for &ldquo;{{
+                            trimmedQuery
+                        }}&rdquo;</span
+                    >
+                </CommandItem>
+            </CommandGroup>
+        </CommandList>
+    </CommandDialog>
+</template>

--- a/resources/js/components/ui/command/Command.vue
+++ b/resources/js/components/ui/command/Command.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import type { ListboxRootEmits, ListboxRootProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { ListboxRoot, useFilter, useForwardPropsEmits } from "reka-ui"
+import { reactive, ref, watch } from "vue"
+import { cn } from "@/lib/utils"
+import { provideCommandContext } from "."
+
+const props = withDefaults(defineProps<ListboxRootProps & { class?: HTMLAttributes["class"] }>(), {
+  modelValue: "",
+  highlightOnHover: true,
+})
+
+const emits = defineEmits<ListboxRootEmits>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+
+const allItems = ref<Map<string, string>>(new Map())
+const allGroups = ref<Map<string, Set<string>>>(new Map())
+
+const { contains } = useFilter({ sensitivity: "base" })
+const filterState = reactive({
+  search: "",
+  filtered: {
+    /** The count of all visible items. */
+    count: 0,
+    /** Map from visible item id to its search score. */
+    items: new Map() as Map<string, number>,
+    /** Set of groups with at least one visible item. */
+    groups: new Set() as Set<string>,
+  },
+})
+
+function filterItems() {
+  if (!filterState.search) {
+    filterState.filtered.count = allItems.value.size
+    // Do nothing, each item will know to show itself because search is empty
+    return
+  }
+
+  // Reset the groups
+  filterState.filtered.groups = new Set()
+  let itemCount = 0
+
+  // Check which items should be included
+  for (const [id, value] of allItems.value) {
+    const score = contains(value, filterState.search)
+    filterState.filtered.items.set(id, score ? 1 : 0)
+    if (score)
+      itemCount++
+  }
+
+  // Check which groups have at least 1 item shown
+  for (const [groupId, group] of allGroups.value) {
+    for (const itemId of group) {
+      if (filterState.filtered.items.get(itemId)! > 0) {
+        filterState.filtered.groups.add(groupId)
+        break
+      }
+    }
+  }
+
+  filterState.filtered.count = itemCount
+}
+
+watch(() => filterState.search, () => {
+  filterItems()
+})
+
+provideCommandContext({
+  allItems,
+  allGroups,
+  filterState,
+})
+</script>
+
+<template>
+  <ListboxRoot
+    data-slot="command"
+    v-bind="forwarded"
+    :class="cn('bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md', props.class)"
+  >
+    <slot />
+  </ListboxRoot>
+</template>

--- a/resources/js/components/ui/command/CommandDialog.vue
+++ b/resources/js/components/ui/command/CommandDialog.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import type { DialogRootEmits, DialogRootProps } from "reka-ui"
+import { useForwardPropsEmits } from "reka-ui"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import Command from "./Command.vue"
+
+const props = withDefaults(defineProps<DialogRootProps & {
+  title?: string
+  description?: string
+}>(), {
+  title: "Command Palette",
+  description: "Search for a command to run...",
+})
+const emits = defineEmits<DialogRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <Dialog v-slot="slotProps" v-bind="forwarded">
+    <DialogContent class="overflow-hidden p-0 ">
+      <DialogHeader class="sr-only">
+        <DialogTitle>{{ title }}</DialogTitle>
+        <DialogDescription>{{ description }}</DialogDescription>
+      </DialogHeader>
+      <Command>
+        <slot v-bind="slotProps" />
+      </Command>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/resources/js/components/ui/command/CommandEmpty.vue
+++ b/resources/js/components/ui/command/CommandEmpty.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { PrimitiveProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { Primitive } from "reka-ui"
+import { computed } from "vue"
+import { cn } from "@/lib/utils"
+import { useCommand } from "."
+
+const props = defineProps<PrimitiveProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const { filterState } = useCommand()
+const isRender = computed(() => !!filterState.search && filterState.filtered.count === 0,
+)
+</script>
+
+<template>
+  <Primitive
+    v-if="isRender"
+    data-slot="command-empty"
+    v-bind="delegatedProps" :class="cn('py-6 text-center text-sm', props.class)"
+  >
+    <slot />
+  </Primitive>
+</template>

--- a/resources/js/components/ui/command/CommandGroup.vue
+++ b/resources/js/components/ui/command/CommandGroup.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { ListboxGroupProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { ListboxGroup, ListboxGroupLabel, useId } from "reka-ui"
+import { computed, onMounted, onUnmounted } from "vue"
+import { cn } from "@/lib/utils"
+import { provideCommandGroupContext, useCommand } from "."
+
+const props = defineProps<ListboxGroupProps & {
+  class?: HTMLAttributes["class"]
+  heading?: string
+}>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const { allGroups, filterState } = useCommand()
+const id = useId()
+
+const isRender = computed(() => !filterState.search ? true : filterState.filtered.groups.has(id))
+
+provideCommandGroupContext({ id })
+onMounted(() => {
+  if (!allGroups.value.has(id))
+    allGroups.value.set(id, new Set())
+})
+onUnmounted(() => {
+  allGroups.value.delete(id)
+})
+</script>
+
+<template>
+  <ListboxGroup
+    v-bind="delegatedProps"
+    :id="id"
+    data-slot="command-group"
+    :class="cn('text-foreground overflow-hidden p-1', props.class)"
+    :hidden="isRender ? undefined : true"
+  >
+    <ListboxGroupLabel v-if="heading" data-slot="command-group-heading" class="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+      {{ heading }}
+    </ListboxGroupLabel>
+    <slot />
+  </ListboxGroup>
+</template>

--- a/resources/js/components/ui/command/CommandInput.vue
+++ b/resources/js/components/ui/command/CommandInput.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import type { ListboxFilterProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { Search } from "@lucide/vue"
+import { reactiveOmit } from "@vueuse/core"
+import { ListboxFilter, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+import { useCommand } from "."
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = defineProps<ListboxFilterProps & {
+  class?: HTMLAttributes["class"]
+}>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+
+const { filterState } = useCommand()
+</script>
+
+<template>
+  <div
+    data-slot="command-input-wrapper"
+    class="flex h-9 items-center gap-2 border-b px-3"
+  >
+    <Search class="size-4 shrink-0 opacity-50" />
+    <ListboxFilter
+      v-bind="{ ...forwardedProps, ...$attrs }"
+      v-model="filterState.search"
+      data-slot="command-input"
+      auto-focus
+      :class="cn('placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50', props.class)"
+    />
+  </div>
+</template>

--- a/resources/js/components/ui/command/CommandItem.vue
+++ b/resources/js/components/ui/command/CommandItem.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import type { ListboxItemEmits, ListboxItemProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit, useCurrentElement } from "@vueuse/core"
+import { ListboxItem, useForwardPropsEmits, useId } from "reka-ui"
+import { computed, onMounted, onUnmounted, ref } from "vue"
+import { cn } from "@/lib/utils"
+import { useCommand, useCommandGroup } from "."
+
+const props = defineProps<ListboxItemProps & { class?: HTMLAttributes["class"] }>()
+const emits = defineEmits<ListboxItemEmits>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+
+const id = useId()
+const { filterState, allItems, allGroups } = useCommand()
+const groupContext = useCommandGroup()
+
+const isRender = computed(() => {
+  if (!filterState.search) {
+    return true
+  }
+  else {
+    const filteredCurrentItem = filterState.filtered.items.get(id)
+    // If the filtered items is undefined means not in the all times map yet
+    // Do the first render to add into the map
+    if (filteredCurrentItem === undefined) {
+      return true
+    }
+
+    // Check with filter
+    return filteredCurrentItem > 0
+  }
+})
+
+const itemRef = ref()
+const currentElement = useCurrentElement(itemRef)
+onMounted(() => {
+  if (!(currentElement.value instanceof HTMLElement))
+    return
+
+  // textValue to perform filter
+  allItems.value.set(id, currentElement.value.textContent ?? (props.value?.toString() ?? ""))
+
+  const groupId = groupContext?.id
+  if (groupId) {
+    if (!allGroups.value.has(groupId)) {
+      allGroups.value.set(groupId, new Set([id]))
+    }
+    else {
+      allGroups.value.get(groupId)?.add(id)
+    }
+  }
+})
+onUnmounted(() => {
+  allItems.value.delete(id)
+})
+</script>
+
+<template>
+  <ListboxItem
+    v-if="isRender"
+    v-bind="forwarded"
+    :id="id"
+    ref="itemRef"
+    data-slot="command-item"
+    :class="cn('data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground [&_svg:not([class*=\'text-\'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4', props.class)"
+    @select="() => {
+      filterState.search = ''
+    }"
+  >
+    <slot />
+  </ListboxItem>
+</template>

--- a/resources/js/components/ui/command/CommandList.vue
+++ b/resources/js/components/ui/command/CommandList.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { ListboxContentProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { ListboxContent, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<ListboxContentProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwarded = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <ListboxContent
+    data-slot="command-list"
+    v-bind="forwarded"
+    :class="cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', props.class)"
+  >
+    <div role="presentation">
+      <slot />
+    </div>
+  </ListboxContent>
+</template>

--- a/resources/js/components/ui/command/CommandSeparator.vue
+++ b/resources/js/components/ui/command/CommandSeparator.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import type { SeparatorProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { Separator } from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<SeparatorProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+</script>
+
+<template>
+  <Separator
+    data-slot="command-separator"
+    v-bind="delegatedProps"
+    :class="cn('bg-border -mx-1 h-px', props.class)"
+  >
+    <slot />
+  </Separator>
+</template>

--- a/resources/js/components/ui/command/CommandShortcut.vue
+++ b/resources/js/components/ui/command/CommandShortcut.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from "vue"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<{
+  class?: HTMLAttributes["class"]
+}>()
+</script>
+
+<template>
+  <span
+    data-slot="command-shortcut"
+    :class="cn('text-muted-foreground ml-auto text-xs tracking-widest', props.class)"
+  >
+    <slot />
+  </span>
+</template>

--- a/resources/js/components/ui/command/index.ts
+++ b/resources/js/components/ui/command/index.ts
@@ -1,0 +1,25 @@
+import type { Ref } from "vue"
+import { createContext } from "reka-ui"
+
+export { default as Command } from "./Command.vue"
+export { default as CommandDialog } from "./CommandDialog.vue"
+export { default as CommandEmpty } from "./CommandEmpty.vue"
+export { default as CommandGroup } from "./CommandGroup.vue"
+export { default as CommandInput } from "./CommandInput.vue"
+export { default as CommandItem } from "./CommandItem.vue"
+export { default as CommandList } from "./CommandList.vue"
+export { default as CommandSeparator } from "./CommandSeparator.vue"
+export { default as CommandShortcut } from "./CommandShortcut.vue"
+
+export const [useCommand, provideCommandContext] = createContext<{
+  allItems: Ref<Map<string, string>>
+  allGroups: Ref<Map<string, Set<string>>>
+  filterState: {
+    search: string
+    filtered: { count: number, items: Map<string, number>, groups: Set<string> }
+  }
+}>("Command")
+
+export const [useCommandGroup, provideCommandGroupContext] = createContext<{
+  id?: string
+}>("CommandGroup")

--- a/resources/js/composables/quickSwitcher.test.ts
+++ b/resources/js/composables/quickSwitcher.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { rankChannels, scoreChannelName } from '@/composables/quickSwitcher';
+
+describe('scoreChannelName', () => {
+    it('scores an empty query as a neutral match for every name', () => {
+        expect(scoreChannelName('general', '')).toBe(0);
+    });
+
+    it('ranks tiers from best to worst: exact > prefix > word-boundary > substring > subsequence', () => {
+        const exact = scoreChannelName('gen', 'gen')!;
+        const prefix = scoreChannelName('general', 'gen')!;
+        const wordBoundary = scoreChannelName('team-general', 'gen')!;
+        const substring = scoreChannelName('regeneration', 'gen')!;
+        const subsequence = scoreChannelName('gardening', 'gen')!;
+
+        expect(exact).toBeGreaterThan(prefix);
+        expect(prefix).toBeGreaterThan(wordBoundary);
+        expect(wordBoundary).toBeGreaterThan(substring);
+        expect(substring).toBeGreaterThan(subsequence);
+    });
+
+    it('is case-insensitive', () => {
+        expect(scoreChannelName('General', 'GEN')).toBe(
+            scoreChannelName('general', 'gen'),
+        );
+    });
+
+    it('prefers shorter remainders within the prefix tier', () => {
+        expect(scoreChannelName('gen', 'gen')).toBeGreaterThan(
+            scoreChannelName('generalities', 'gen')!,
+        );
+        expect(scoreChannelName('general', 'gen')).toBeGreaterThan(
+            scoreChannelName('generalities', 'gen')!,
+        );
+    });
+
+    it('prefers earlier substring positions', () => {
+        expect(scoreChannelName('xgen', 'gen')).toBeGreaterThan(
+            scoreChannelName('xxgen', 'gen')!,
+        );
+    });
+
+    it('prefers tighter subsequences', () => {
+        // Both are subsequence-only matches for "gen" (no substring): the
+        // characters sit closer together in "green" than in "gardening".
+        expect(scoreChannelName('green', 'gen')).toBeGreaterThan(
+            scoreChannelName('gardening', 'gen')!,
+        );
+    });
+
+    it('returns null when the characters are out of order', () => {
+        expect(scoreChannelName('general', 'neg')).toBeNull();
+    });
+
+    it('returns null when a needle character is missing', () => {
+        expect(scoreChannelName('general', 'genx')).toBeNull();
+    });
+});
+
+describe('rankChannels', () => {
+    const channel = (name: string) => ({ name });
+
+    it('returns every channel alphabetically for an empty query', () => {
+        const result = rankChannels(
+            [channel('random'), channel('general'), channel('announce')],
+            '',
+        );
+
+        expect(result.map((c) => c.name)).toEqual([
+            'announce',
+            'general',
+            'random',
+        ]);
+    });
+
+    it('filters out non-matches', () => {
+        const result = rankChannels(
+            [channel('general'), channel('random'), channel('marketing')],
+            'gen',
+        );
+
+        expect(result.map((c) => c.name)).toEqual(['general']);
+    });
+
+    it('orders matches by score, best first', () => {
+        const result = rankChannels(
+            [
+                channel('regeneration'), // substring
+                channel('gardening'), // subsequence
+                channel('general'), // prefix
+                channel('gen'), // exact
+            ],
+            'gen',
+        );
+
+        expect(result.map((c) => c.name)).toEqual([
+            'gen',
+            'general',
+            'regeneration',
+            'gardening',
+        ]);
+    });
+
+    it('breaks score ties alphabetically', () => {
+        const result = rankChannels(
+            [channel('general-updates'), channel('general-chat')],
+            'general',
+        );
+
+        expect(result.map((c) => c.name)).toEqual([
+            'general-chat',
+            'general-updates',
+        ]);
+    });
+
+    it('ignores a leading # and surrounding whitespace', () => {
+        const result = rankChannels(
+            [channel('general'), channel('random')],
+            '  #gen  ',
+        );
+
+        expect(result.map((c) => c.name)).toEqual(['general']);
+    });
+});

--- a/resources/js/composables/quickSwitcher.ts
+++ b/resources/js/composables/quickSwitcher.ts
@@ -1,0 +1,109 @@
+import type { Channel } from '@/types/channels';
+
+/**
+ * The minimal shape the ranking cares about. Keeping it structural lets the
+ * scorer be unit-tested with plain objects while the component passes real
+ * {@link Channel} records.
+ */
+export type RankableChannel = Pick<Channel, 'name'>;
+
+const WORD_BOUNDARY = /[^a-z0-9]+/;
+
+/**
+ * Measure how tightly `needle` appears as an in-order subsequence of
+ * `haystack`, returning the number of characters skipped between the first and
+ * last matched positions (0 = contiguous). Returns `null` when `haystack` does
+ * not contain the subsequence at all.
+ */
+function subsequenceSpread(haystack: string, needle: string): number | null {
+    let firstIndex = -1;
+    let lastIndex = -1;
+    let cursor = 0;
+
+    for (let i = 0; i < haystack.length && cursor < needle.length; i++) {
+        if (haystack[i] === needle[cursor]) {
+            if (firstIndex === -1) {
+                firstIndex = i;
+            }
+
+            lastIndex = i;
+            cursor++;
+        }
+    }
+
+    if (cursor < needle.length) {
+        return null;
+    }
+
+    return lastIndex - firstIndex - (needle.length - 1);
+}
+
+/**
+ * Score a channel name against a query. Higher is a better match; `null` means
+ * no match at all. Tiers, best to worst: exact, prefix, word-boundary prefix,
+ * contiguous substring, in-order subsequence. Within the prefix and substring
+ * tiers, tighter matches (shorter remainder / earlier position) score higher.
+ */
+export function scoreChannelName(name: string, query: string): number | null {
+    const haystack = name.toLowerCase();
+    const needle = query.toLowerCase();
+
+    if (needle === '') {
+        return 0;
+    }
+
+    if (haystack === needle) {
+        return 1000;
+    }
+
+    if (haystack.startsWith(needle)) {
+        return 800 - (haystack.length - needle.length);
+    }
+
+    if (haystack.split(WORD_BOUNDARY).some((word) => word.startsWith(needle))) {
+        return 600;
+    }
+
+    const substringIndex = haystack.indexOf(needle);
+
+    if (substringIndex !== -1) {
+        return 400 - substringIndex;
+    }
+
+    const spread = subsequenceSpread(haystack, needle);
+
+    if (spread !== null) {
+        return 200 - spread;
+    }
+
+    return null;
+}
+
+/**
+ * Filter and rank channels for the quick switcher. A leading `#` and
+ * surrounding whitespace are stripped so typing `#gen` behaves like `gen`. An
+ * empty query returns every channel in alphabetical order; otherwise only
+ * matches are returned, best score first, ties broken alphabetically.
+ */
+export function rankChannels<T extends RankableChannel>(
+    channels: readonly T[],
+    query: string,
+): T[] {
+    const normalizedQuery = query.trim().replace(/^#+/, '');
+
+    return channels
+        .map((channel) => ({
+            channel,
+            score: scoreChannelName(channel.name, normalizedQuery),
+        }))
+        .filter(
+            (scored): scored is { channel: T; score: number } =>
+                scored.score !== null,
+        )
+        .sort(
+            (a, b) =>
+                b.score - a.score ||
+                a.channel.name.localeCompare(b.channel.name),
+        )
+        .map((scored) => scored.channel);
+}

--- a/resources/js/composables/useMessageSearch.test.ts
+++ b/resources/js/composables/useMessageSearch.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMessageSearch } from '@/composables/useMessageSearch';
+import type { MessageSearchResult } from '@/types';
+
+function makeResult(id: string): MessageSearchResult {
+    return {
+        message: { id },
+        channelName: 'general',
+        channelSlug: 'general',
+    } as unknown as MessageSearchResult;
+}
+
+function jsonResponse(results: MessageSearchResult[], ok = true): Response {
+    return { ok, json: async () => ({ results }) } as unknown as Response;
+}
+
+const ids = (results: MessageSearchResult[]): string[] =>
+    results.map((result) => result.message.id);
+
+// Drain the microtask queue so an already-resolved fetch chain settles.
+const flush = async (): Promise<void> => {
+    await vi.advanceTimersByTimeAsync(0);
+};
+
+describe('useMessageSearch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.useRealTimers();
+    });
+
+    it('debounces the request, then populates results', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(jsonResponse([makeResult('hi')]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = useMessageSearch((term) => `/s?q=${term}`, 200);
+        search.search('hi');
+
+        expect(search.isSearching.value).toBe(true);
+        expect(fetchMock).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(200);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            '/s?q=hi',
+            expect.objectContaining({
+                headers: { Accept: 'application/json' },
+            }),
+        );
+        expect(ids(search.results.value)).toEqual(['hi']);
+        expect(search.isSearching.value).toBe(false);
+    });
+
+    it('collapses rapid keystrokes into a single request', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(jsonResponse([makeResult('abc')]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = useMessageSearch((term) => `/s?q=${term}`, 200);
+        search.search('a');
+        await vi.advanceTimersByTimeAsync(100);
+        search.search('ab');
+        await vi.advanceTimersByTimeAsync(100);
+        search.search('abc');
+        await vi.advanceTimersByTimeAsync(200);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock).toHaveBeenCalledWith('/s?q=abc', expect.anything());
+    });
+
+    it('clears results without hitting the network for an empty term', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = useMessageSearch((term) => `/s?q=${term}`, 200);
+        search.search('');
+        await vi.advanceTimersByTimeAsync(200);
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(search.results.value).toEqual([]);
+        expect(search.isSearching.value).toBe(false);
+    });
+
+    it('clears results when the response is not ok', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse([makeResult('a')]))
+            .mockResolvedValueOnce(jsonResponse([], false));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = useMessageSearch((term) => `/s?q=${term}`, 200);
+        search.search('a');
+        await vi.advanceTimersByTimeAsync(200);
+        expect(ids(search.results.value)).toEqual(['a']);
+
+        search.search('b');
+        await vi.advanceTimersByTimeAsync(200);
+        expect(search.results.value).toEqual([]);
+        expect(search.isSearching.value).toBe(false);
+    });
+
+    it('clears results when the request throws', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse([makeResult('a')]))
+            .mockRejectedValueOnce(new Error('network'));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = useMessageSearch((term) => `/s?q=${term}`, 200);
+        search.search('a');
+        await vi.advanceTimersByTimeAsync(200);
+        expect(ids(search.results.value)).toEqual(['a']);
+
+        search.search('b');
+        await vi.advanceTimersByTimeAsync(200);
+        expect(search.results.value).toEqual([]);
+    });
+
+    it('ignores a stale in-flight response when a newer query supersedes it', async () => {
+        const resolvers: Record<string, (value: Response) => void> = {};
+        const fetchMock = vi.fn(
+            (url: string) =>
+                new Promise<Response>((resolve) => {
+                    resolvers[url] = resolve;
+                }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = useMessageSearch((term) => `/s?q=${term}`, 200);
+
+        search.search('old');
+        await vi.advanceTimersByTimeAsync(200); // 'old' request now in flight
+        search.search('new');
+        await vi.advanceTimersByTimeAsync(200); // 'old' aborted, 'new' in flight
+
+        // Resolve the stale request first — it must not land.
+        resolvers['/s?q=old'](jsonResponse([makeResult('old')]));
+        await flush();
+        expect(search.results.value).toEqual([]);
+
+        resolvers['/s?q=new'](jsonResponse([makeResult('new')]));
+        await flush();
+        expect(ids(search.results.value)).toEqual(['new']);
+        expect(search.isSearching.value).toBe(false);
+    });
+
+    it('reset clears results and cancels a pending request', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(jsonResponse([makeResult('a')]));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const search = useMessageSearch((term) => `/s?q=${term}`, 200);
+        search.search('a');
+        await vi.advanceTimersByTimeAsync(200);
+        expect(ids(search.results.value)).toEqual(['a']);
+
+        // A pending (debouncing) request is dropped by reset without firing.
+        search.search('b');
+        search.reset();
+        await vi.advanceTimersByTimeAsync(200);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1); // only the first 'a' request
+        expect(search.results.value).toEqual([]);
+        expect(search.isSearching.value).toBe(false);
+    });
+});

--- a/resources/js/composables/useMessageSearch.ts
+++ b/resources/js/composables/useMessageSearch.ts
@@ -1,0 +1,103 @@
+import { ref } from 'vue';
+import type { Ref } from 'vue';
+import type { MessageSearchResult } from '@/types';
+
+export type UseMessageSearch = {
+    results: Ref<MessageSearchResult[]>;
+    isSearching: Ref<boolean>;
+    search: (term: string) => void;
+    reset: () => void;
+};
+
+/**
+ * Debounced live message search for the quick switcher.
+ *
+ * `search()` debounces keystrokes into a single JSON request built by
+ * `buildUrl`. The previous request — whether still waiting out the debounce or
+ * already in flight — is always cancelled first, and an aborted request never
+ * writes its (stale) response, so the visible results only ever reflect the
+ * latest query. An empty term clears results without hitting the network.
+ *
+ * @param buildUrl   Maps a (trimmed, non-empty) term to the request URL.
+ * @param debounceMs Idle delay before a term is sent.
+ */
+export function useMessageSearch(
+    buildUrl: (term: string) => string,
+    debounceMs = 250,
+): UseMessageSearch {
+    const results = ref<MessageSearchResult[]>([]);
+    const isSearching = ref(false);
+    let debounceHandle: ReturnType<typeof setTimeout> | null = null;
+    let inFlight: AbortController | null = null;
+
+    function cancelPending(): void {
+        if (debounceHandle) {
+            clearTimeout(debounceHandle);
+            debounceHandle = null;
+        }
+
+        inFlight?.abort();
+        inFlight = null;
+    }
+
+    async function fetchResults(term: string): Promise<void> {
+        const controller = new AbortController();
+        inFlight = controller;
+
+        try {
+            const response = await fetch(buildUrl(term), {
+                headers: { Accept: 'application/json' },
+                signal: controller.signal,
+            });
+
+            if (!response.ok) {
+                throw new Error('Message search failed');
+            }
+
+            const data = (await response.json()) as {
+                results: MessageSearchResult[];
+            };
+
+            if (controller.signal.aborted) {
+                return;
+            }
+
+            results.value = data.results;
+        } catch {
+            if (controller.signal.aborted) {
+                return;
+            }
+
+            results.value = [];
+        } finally {
+            if (inFlight === controller) {
+                isSearching.value = false;
+                inFlight = null;
+            }
+        }
+    }
+
+    function search(term: string): void {
+        cancelPending();
+
+        if (term === '') {
+            results.value = [];
+            isSearching.value = false;
+
+            return;
+        }
+
+        isSearching.value = true;
+        debounceHandle = setTimeout(() => {
+            void fetchResults(term);
+        }, debounceMs);
+    }
+
+    function reset(): void {
+        cancelPending();
+        results.value = [];
+        isSearching.value = false;
+    }
+
+    return { results, isSearching, search, reset };
+}

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
 import { MessageSquareText, MessagesSquare, Plus, Search } from '@lucide/vue';
-import { computed, onMounted } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import {
     browse,
     show,
@@ -12,6 +12,7 @@ import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import NavUser from '@/components/NavUser.vue';
 import PendingInvitationsModal from '@/components/PendingInvitationsModal.vue';
+import QuickSwitcher from '@/components/QuickSwitcher.vue';
 import TeamSwitcher from '@/components/TeamSwitcher.vue';
 import { Separator } from '@/components/ui/separator';
 import {
@@ -60,9 +61,24 @@ const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
 const { getInitials } = useInitials();
 const { switchTeam } = useTeamSwitch();
 
+// Cmd/Ctrl+K toggles the quick switcher from anywhere in the workspace.
+const quickSwitcherOpen = ref(false);
+
+function handleQuickSwitcherShortcut(event: KeyboardEvent): void {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        quickSwitcherOpen.value = !quickSwitcherOpen.value;
+    }
+}
+
 onMounted(() => {
     // Lazily pull the (optional) shared invitations so the post-login prompt appears.
     router.reload({ only: ['pendingInvitations'] });
+    window.addEventListener('keydown', handleQuickSwitcherShortcut);
+});
+
+onUnmounted(() => {
+    window.removeEventListener('keydown', handleQuickSwitcherShortcut);
 });
 </script>
 
@@ -139,6 +155,21 @@ onMounted(() => {
                     </SidebarHeader>
 
                     <SidebarContent>
+                        <div class="px-2 pt-2">
+                            <button
+                                type="button"
+                                data-test="quick-switcher-trigger"
+                                class="flex w-full items-center gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/40 px-2.5 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                                @click="quickSwitcherOpen = true"
+                            >
+                                <Search class="size-[15px] shrink-0" />
+                                <span>Jump to…</span>
+                                <kbd
+                                    class="ml-auto rounded border border-sidebar-border bg-sidebar px-1.5 py-0.5 font-mono text-[10px] tracking-wide text-muted-foreground"
+                                    >⌘K</kbd
+                                >
+                            </button>
+                        </div>
                         <SidebarGroup>
                             <SidebarGroupLabel
                                 class="h-7 px-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
@@ -317,6 +348,13 @@ onMounted(() => {
         <PendingInvitationsModal
             v-if="pendingInvitations.length > 0"
             :invitations="pendingInvitations"
+        />
+
+        <QuickSwitcher
+            v-if="currentTeam"
+            v-model:open="quickSwitcherOpen"
+            :channels="channels"
+            :team-slug="currentTeam.slug"
         />
     </SidebarProvider>
 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/channels', [ChannelController::class, 'store'])->name('channels.store');
     Route::get('t/{team}/channels/browse', [ChannelController::class, 'browse'])->name('channels.browse');
     Route::get('t/{team}/search', [SearchController::class, 'index'])->name('search');
+    Route::get('t/{team}/search/suggest', [SearchController::class, 'suggest'])->name('search.suggest');
     Route::get('t/{team}/threads', [ThreadsController::class, 'index'])->name('channels.threads.index');
     Route::get('t/{team}/c/{channel}', [ChannelController::class, 'show'])
         ->scopeBindings()

--- a/tests/Feature/Channels/MessageSearchTest.php
+++ b/tests/Feature/Channels/MessageSearchTest.php
@@ -43,6 +43,14 @@ function performSearch(User $user, Team $team, string $query): TestResponse
     return test()->actingAs($user)->get(route('search', ['team' => $team->slug, 'q' => $query]));
 }
 
+/**
+ * Hit the quick-switcher JSON suggest endpoint for a team as the given user.
+ */
+function performSuggest(User $user, Team $team, string $query): TestResponse
+{
+    return test()->actingAs($user)->getJson(route('search.suggest', ['team' => $team->slug, 'q' => $query]));
+}
+
 test('a member searches messages in their channels', function () {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general, 'Ada Lovelace');
@@ -206,6 +214,69 @@ test('a message param from another channel is ignored', function () {
         ->where('jumpToMessageId', null)
         ->has('messages.data', 1)
     );
+});
+
+test('the suggest endpoint returns matching messages as JSON', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general, 'Ada Lovelace');
+    Message::factory()->for($general)->for($member)->create(['body' => 'the quokka danced at dawn']);
+    Message::factory()->for($general)->for($owner)->create(['body' => 'totally unrelated chatter']);
+
+    performSuggest($member, $team, 'quokka')
+        ->assertOk()
+        ->assertJsonCount(1, 'results')
+        ->assertJsonPath('results.0.message.body', 'the quokka danced at dawn')
+        ->assertJsonPath('results.0.message.user.name', 'Ada Lovelace')
+        ->assertJsonPath('results.0.channelName', $general->name)
+        ->assertJsonPath('results.0.channelSlug', $general->slug);
+});
+
+test('the suggest endpoint caps results at the preview limit', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+    collect(range(1, 8))->each(
+        fn (int $i) => Message::factory()->for($general)->for($owner)->create(['body' => "zephyr note {$i}"])
+    );
+
+    performSuggest($member, $team, 'zephyr')
+        ->assertOk()
+        ->assertJsonCount(5, 'results');
+});
+
+test('the suggest endpoint is ACL-filtered to the user channels', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+    $private = Channel::factory()->for($team)->private()->create(['created_by' => $owner->id]);
+    Message::factory()->for($private)->for($owner)->create(['body' => 'secret zephyr plans']);
+
+    performSuggest($member, $team, 'zephyr')
+        ->assertOk()
+        ->assertJsonCount(0, 'results');
+});
+
+test('an empty suggest query returns no results without touching the engine', function () {
+    [$owner, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+    Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr']);
+
+    performSuggest($member, $team, '')
+        ->assertOk()
+        ->assertJsonCount(0, 'results');
+});
+
+test('a non-member of the team cannot use suggest', function () {
+    [, $team] = searchTeamWithGeneral();
+    $outsider = User::factory()->create();
+
+    performSuggest($outsider, $team, 'zephyr')->assertForbidden();
+});
+
+test('the suggest query cannot exceed 255 characters', function () {
+    [, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general);
+
+    performSuggest($member, $team, str_repeat('a', 256))
+        ->assertJsonValidationErrorFor('q');
 });
 
 test('soft-deleted messages report that they should not be searchable', function () {


### PR DESCRIPTION
## Summary

Implements #39 — a **⌘K / Ctrl+K command palette** for fast navigation across the workspace, with Meilisearch message search folded in.

Two ways to open it: the **⌘K/Ctrl+K** shortcut, or the new **"Jump to…"** input at the top of the sidebar. (The "Search messages" sidebar item still links to the full search page.)

### Channels — fuzzy jump
- Client-side fuzzy ranking over the user's channels: exact › prefix › word-boundary › substring › in-order subsequence, alphabetical tie-break, leading `#` ignored.
- Ranking is a pure helper (`rankChannels`) so it's fully unit-tested.

### Messages — live search
- New JSON endpoint `GET t/{team}/search/suggest` returns the top 5 **ACL-filtered** Meilisearch hits, reusing the existing `SearchMessages` action (now takes an optional `$limit`).
- Rendered inline in the palette (author · #channel · snippet); selecting jumps to the message (`channels.show?message=…`). A **"See all results"** row opens the existing full `/search` page — which is left untouched for deep-links and the complete result set.
- The debounce / abort / stale-response-guard logic lives in a dedicated `useMessageSearch` composable so late responses can never overwrite newer queries.

Built on the shadcn-vue `command` component (added via the shadcn-vue MCP). Driven by reka-ui's `ListboxFilter` bound to our own query ref, leaving the component's internal substring filter untouched so subsequence matches aren't hidden — `rankChannels` is the single source of truth.

## Scope note
Scoped to **channels + messages**. People/DMs are intentionally excluded — there's no navigable destination for a person yet (profile pages #44 / DMs don't exist). Easy to add later.

## Testing
- **PHP:** 7 new feature tests on the `suggest` endpoint (JSON shape, 5-result cap, ACL scoping, empty query, non-member 403, 255-char validation). `composer test` green at **100.0%** coverage.
- **Vitest (61 total):** 13 for channel ranking + 7 for `useMessageSearch` (debounce, keystroke collapse, empty-term clear, non-ok/network handling, stale-response ignore, reset).
- Frontend gate green: ESLint, Prettier, vue-tsc, Vite build.

## No dependency changes
The shadcn-vue CLI tried to bump `@lucide/vue`/`reka-ui`; those bumps were reverted — `package.json`/lock are untouched.

Closes #39