### PR TITLE
feat(navigation): keyboard shortcuts + help modal (#40)

### DIFF
--- a/resources/js/components/KeyboardShortcutsModal.vue
+++ b/resources/js/components/KeyboardShortcutsModal.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { shortcutsByCategory } from '@/composables/keyboardShortcuts';
+
+const open = defineModel<boolean>('open', { default: false });
+
+const groups = shortcutsByCategory();
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent data-test="keyboard-shortcuts-modal" class="sm:max-w-md">
+            <DialogHeader>
+                <DialogTitle>Keyboard shortcuts</DialogTitle>
+                <DialogDescription>
+                    Speed up navigation without reaching for the mouse.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div class="grid gap-5">
+                <div v-for="group in groups" :key="group.category">
+                    <p
+                        class="mb-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
+                    >
+                        {{ group.category }}
+                    </p>
+                    <ul class="grid gap-1.5">
+                        <li
+                            v-for="shortcut in group.shortcuts"
+                            :key="shortcut.id"
+                            data-test="shortcut-row"
+                            class="flex items-center justify-between gap-4 text-sm"
+                        >
+                            <span class="text-foreground/90">{{
+                                shortcut.description
+                            }}</span>
+                            <span class="flex shrink-0 items-center gap-1">
+                                <kbd
+                                    v-for="key in shortcut.keys"
+                                    :key="key"
+                                    class="flex h-6 min-w-6 items-center justify-center rounded border border-border bg-muted px-1.5 font-mono text-[11px] font-medium text-muted-foreground"
+                                    >{{ key }}</kbd
+                                >
+                            </span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { Link, router } from '@inertiajs/vue3';
-import { LogOut, Settings } from '@lucide/vue';
+import { Keyboard, LogOut, Settings } from '@lucide/vue';
 import {
     DropdownMenuGroup,
     DropdownMenuItem,
     DropdownMenuLabel,
     DropdownMenuSeparator,
+    DropdownMenuShortcut,
 } from '@/components/ui/dropdown-menu';
 import UserInfo from '@/components/UserInfo.vue';
+import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
 import { logout } from '@/routes';
 import { edit } from '@/routes/profile';
 import type { User } from '@/types';
@@ -15,6 +17,8 @@ import type { User } from '@/types';
 type Props = {
     user: User;
 };
+
+const { open: openKeyboardShortcuts } = useKeyboardShortcutsModal();
 
 const handleLogout = () => {
     router.flushAll();
@@ -36,6 +40,15 @@ defineProps<Props>();
                 <Settings class="mr-2 h-4 w-4" />
                 Settings
             </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+            class="cursor-pointer"
+            data-test="keyboard-shortcuts-menu-item"
+            @select="openKeyboardShortcuts"
+        >
+            <Keyboard class="mr-2 h-4 w-4" />
+            Keyboard shortcuts
+            <DropdownMenuShortcut>?</DropdownMenuShortcut>
         </DropdownMenuItem>
     </DropdownMenuGroup>
     <DropdownMenuSeparator />

--- a/resources/js/composables/keyboardShortcuts.test.ts
+++ b/resources/js/composables/keyboardShortcuts.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    adjacentSlug,
+    dispatchKeydown,
+    eventMatchesShortcut,
+    isEditableTarget,
+    matchShortcut,
+    SHORTCUTS,
+    shortcutsByCategory,
+} from '@/composables/keyboardShortcuts';
+import type {
+    DispatchableEvent,
+    ShortcutMatch,
+} from '@/composables/keyboardShortcuts';
+
+/**
+ * Build a fake keydown event with sensible defaults so each test only states
+ * the modifiers it cares about.
+ */
+function keydown(
+    overrides: Partial<DispatchableEvent> = {},
+): DispatchableEvent {
+    return {
+        key: 'a',
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        target: null,
+        preventDefault: vi.fn(),
+        ...overrides,
+    };
+}
+
+describe('eventMatchesShortcut', () => {
+    it('matches on key case-insensitively', () => {
+        const match: ShortcutMatch = { key: 'k', mod: true };
+
+        expect(
+            eventMatchesShortcut(keydown({ key: 'K', metaKey: true }), match),
+        ).toBe(true);
+    });
+
+    it('treats meta and ctrl as the same command key', () => {
+        const match: ShortcutMatch = { key: 'k', mod: true };
+
+        expect(
+            eventMatchesShortcut(keydown({ key: 'k', metaKey: true }), match),
+        ).toBe(true);
+        expect(
+            eventMatchesShortcut(keydown({ key: 'k', ctrlKey: true }), match),
+        ).toBe(true);
+    });
+
+    it('requires the command key when mod is set', () => {
+        expect(
+            eventMatchesShortcut(keydown({ key: 'k' }), {
+                key: 'k',
+                mod: true,
+            }),
+        ).toBe(false);
+    });
+
+    it('rejects the command key when mod is not set', () => {
+        expect(
+            eventMatchesShortcut(
+                keydown({ key: 'ArrowDown', altKey: true, ctrlKey: true }),
+                {
+                    key: 'ArrowDown',
+                    alt: true,
+                },
+            ),
+        ).toBe(false);
+    });
+
+    it('enforces alt exactly', () => {
+        expect(
+            eventMatchesShortcut(keydown({ key: 'ArrowUp', altKey: true }), {
+                key: 'ArrowUp',
+                alt: true,
+            }),
+        ).toBe(true);
+        expect(
+            eventMatchesShortcut(keydown({ key: 'ArrowUp' }), {
+                key: 'ArrowUp',
+                alt: true,
+            }),
+        ).toBe(false);
+    });
+
+    it('ignores shift when the match leaves it unspecified', () => {
+        expect(
+            eventMatchesShortcut(keydown({ key: '?', shiftKey: true }), {
+                key: '?',
+            }),
+        ).toBe(true);
+        expect(
+            eventMatchesShortcut(keydown({ key: '?', shiftKey: false }), {
+                key: '?',
+            }),
+        ).toBe(true);
+    });
+
+    it('enforces shift when the match specifies it', () => {
+        expect(
+            eventMatchesShortcut(keydown({ key: 'a', shiftKey: true }), {
+                key: 'a',
+                shift: false,
+            }),
+        ).toBe(false);
+    });
+});
+
+describe('matchShortcut', () => {
+    it('returns the matching definition', () => {
+        expect(matchShortcut(keydown({ key: 'k', metaKey: true }))?.id).toBe(
+            'quick-switcher',
+        );
+        expect(
+            matchShortcut(keydown({ key: 'ArrowDown', altKey: true }))?.id,
+        ).toBe('next-channel');
+        expect(
+            matchShortcut(keydown({ key: 'ArrowUp', altKey: true }))?.id,
+        ).toBe('previous-channel');
+        expect(matchShortcut(keydown({ key: '?' }))?.id).toBe('show-shortcuts');
+    });
+
+    it('returns null when nothing matches', () => {
+        expect(matchShortcut(keydown({ key: 'z' }))).toBeNull();
+    });
+});
+
+describe('isEditableTarget', () => {
+    it.each(['INPUT', 'TEXTAREA', 'SELECT', 'input', 'textarea'])(
+        'treats <%s> as editable',
+        (tagName) => {
+            expect(
+                isEditableTarget({ tagName } as unknown as EventTarget),
+            ).toBe(true);
+        },
+    );
+
+    it('treats a contenteditable element as editable', () => {
+        expect(
+            isEditableTarget({
+                tagName: 'DIV',
+                isContentEditable: true,
+            } as unknown as EventTarget),
+        ).toBe(true);
+    });
+
+    it('treats a plain element as not editable', () => {
+        expect(
+            isEditableTarget({
+                tagName: 'DIV',
+                isContentEditable: false,
+            } as unknown as EventTarget),
+        ).toBe(false);
+    });
+
+    it('treats null and non-elements as not editable', () => {
+        expect(isEditableTarget(null)).toBe(false);
+        expect(isEditableTarget({} as EventTarget)).toBe(false);
+    });
+});
+
+describe('dispatchKeydown', () => {
+    it('runs the handler and prevents default for a matched shortcut', () => {
+        const event = keydown({ key: '?' });
+        const run = vi.fn();
+
+        expect(dispatchKeydown(event, SHORTCUTS, run)).toBe(true);
+        expect(run).toHaveBeenCalledWith('show-shortcuts');
+        expect(event.preventDefault).toHaveBeenCalledOnce();
+    });
+
+    it('does nothing when no shortcut matches', () => {
+        const event = keydown({ key: 'z' });
+        const run = vi.fn();
+
+        expect(dispatchKeydown(event, SHORTCUTS, run)).toBe(false);
+        expect(run).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('suppresses non-modifier shortcuts while typing in a field', () => {
+        const event = keydown({
+            key: '?',
+            target: { tagName: 'TEXTAREA' } as unknown as EventTarget,
+        });
+        const run = vi.fn();
+
+        expect(dispatchKeydown(event, SHORTCUTS, run)).toBe(false);
+        expect(run).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('still fires command-key shortcuts while typing in a field', () => {
+        const event = keydown({
+            key: 'k',
+            metaKey: true,
+            target: { tagName: 'TEXTAREA' } as unknown as EventTarget,
+        });
+        const run = vi.fn();
+
+        expect(dispatchKeydown(event, SHORTCUTS, run)).toBe(true);
+        expect(run).toHaveBeenCalledWith('quick-switcher');
+    });
+});
+
+describe('adjacentSlug', () => {
+    const slugs = ['general', 'random', 'design'];
+
+    it('returns null for an empty list', () => {
+        expect(adjacentSlug([], 'general', 1)).toBeNull();
+    });
+
+    it('steps forward and wraps past the end', () => {
+        expect(adjacentSlug(slugs, 'general', 1)).toBe('random');
+        expect(adjacentSlug(slugs, 'design', 1)).toBe('general');
+    });
+
+    it('steps backward and wraps past the start', () => {
+        expect(adjacentSlug(slugs, 'random', -1)).toBe('general');
+        expect(adjacentSlug(slugs, 'general', -1)).toBe('design');
+    });
+
+    it('falls back to an end of the list when the active slug is unknown', () => {
+        expect(adjacentSlug(slugs, null, 1)).toBe('general');
+        expect(adjacentSlug(slugs, 'missing', -1)).toBe('design');
+    });
+});
+
+describe('shortcutsByCategory', () => {
+    it('groups definitions by category in first-seen order', () => {
+        const groups = shortcutsByCategory();
+
+        expect(groups.map((group) => group.category)).toEqual([
+            'Navigation',
+            'Help',
+        ]);
+        expect(groups[0].shortcuts.map((shortcut) => shortcut.id)).toEqual([
+            'quick-switcher',
+            'previous-channel',
+            'next-channel',
+        ]);
+    });
+});

--- a/resources/js/composables/keyboardShortcuts.ts
+++ b/resources/js/composables/keyboardShortcuts.ts
@@ -1,0 +1,210 @@
+/**
+ * App-wide keyboard shortcuts. The definitions here are the single source of
+ * truth shared by the dispatcher ({@link dispatchKeydown}) and the help modal,
+ * so a shortcut can never appear in one without the other.
+ */
+export type ShortcutId =
+    'quick-switcher' | 'previous-channel' | 'next-channel' | 'show-shortcuts';
+
+/**
+ * How a {@link KeyboardEvent} is matched to a shortcut. `mod` means the
+ * platform command key (⌘ on macOS, Ctrl elsewhere). `alt` and `shift`, when
+ * omitted, must be absent — except `shift`, which is left unconstrained when
+ * omitted because printable keys such as `?` already imply it on many layouts.
+ */
+export interface ShortcutMatch {
+    key: string;
+    mod?: boolean;
+    alt?: boolean;
+    shift?: boolean;
+}
+
+export interface ShortcutDefinition {
+    id: ShortcutId;
+    category: string;
+    description: string;
+    /** Display tokens for the help modal, e.g. `['⌘', 'K']`. */
+    keys: string[];
+    match: ShortcutMatch;
+}
+
+/**
+ * The minimal event surface the dispatcher reads, so callers (and tests) can
+ * pass either a real {@link KeyboardEvent} or a plain object.
+ */
+export type DispatchableEvent = Pick<
+    KeyboardEvent,
+    'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey' | 'target'
+> & { preventDefault(): void };
+
+export const SHORTCUTS: readonly ShortcutDefinition[] = [
+    {
+        id: 'quick-switcher',
+        category: 'Navigation',
+        description: 'Open the quick switcher',
+        keys: ['⌘', 'K'],
+        match: { key: 'k', mod: true },
+    },
+    {
+        id: 'previous-channel',
+        category: 'Navigation',
+        description: 'Previous channel',
+        keys: ['⌥', '↑'],
+        match: { key: 'ArrowUp', alt: true },
+    },
+    {
+        id: 'next-channel',
+        category: 'Navigation',
+        description: 'Next channel',
+        keys: ['⌥', '↓'],
+        match: { key: 'ArrowDown', alt: true },
+    },
+    {
+        id: 'show-shortcuts',
+        category: 'Help',
+        description: 'Show this shortcut list',
+        keys: ['?'],
+        match: { key: '?' },
+    },
+];
+
+/**
+ * Whether `target` is a field the user is typing into. Non-modifier shortcuts
+ * are suppressed for these so they never hijack a keystroke mid-word. Duck-typed
+ * rather than using `instanceof HTMLElement` so it works without a global DOM.
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+    const element = target as {
+        tagName?: string;
+        isContentEditable?: boolean;
+    } | null;
+
+    if (!element || typeof element.tagName !== 'string') {
+        return false;
+    }
+
+    const tag = element.tagName.toUpperCase();
+
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+        return true;
+    }
+
+    return element.isContentEditable === true;
+}
+
+/**
+ * Whether `event` satisfies `match`. The command key is treated as
+ * meta-or-ctrl so a single definition covers both macOS and other platforms.
+ */
+export function eventMatchesShortcut(
+    event: DispatchableEvent,
+    match: ShortcutMatch,
+): boolean {
+    if (event.key.toLowerCase() !== match.key.toLowerCase()) {
+        return false;
+    }
+
+    const modActive = event.metaKey || event.ctrlKey;
+
+    if (Boolean(match.mod) !== modActive) {
+        return false;
+    }
+
+    if (Boolean(match.alt) !== event.altKey) {
+        return false;
+    }
+
+    if (match.shift !== undefined && match.shift !== event.shiftKey) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * The first shortcut `event` matches, or `null` when none do.
+ */
+export function matchShortcut(
+    event: DispatchableEvent,
+    shortcuts: readonly ShortcutDefinition[] = SHORTCUTS,
+): ShortcutDefinition | null {
+    return (
+        shortcuts.find((shortcut) =>
+            eventMatchesShortcut(event, shortcut.match),
+        ) ?? null
+    );
+}
+
+/**
+ * Resolve `event` against `shortcuts` and, when one fires, prevent the default
+ * and invoke `run` with its id. Non-modifier shortcuts are ignored while the
+ * user is typing in a field; command-key shortcuts (like ⌘K) still fire there.
+ * Returns whether a shortcut was dispatched.
+ */
+export function dispatchKeydown(
+    event: DispatchableEvent,
+    shortcuts: readonly ShortcutDefinition[],
+    run: (id: ShortcutId) => void,
+): boolean {
+    const shortcut = matchShortcut(event, shortcuts);
+
+    if (!shortcut) {
+        return false;
+    }
+
+    if (isEditableTarget(event.target) && !shortcut.match.mod) {
+        return false;
+    }
+
+    event.preventDefault();
+    run(shortcut.id);
+
+    return true;
+}
+
+/**
+ * The slug `delta` steps away from `activeSlug` in `slugs`, wrapping at either
+ * end. Returns `null` for an empty list; falls back to the first (or last) slug
+ * when `activeSlug` is not present.
+ */
+export function adjacentSlug(
+    slugs: readonly string[],
+    activeSlug: string | null,
+    delta: number,
+): string | null {
+    if (slugs.length === 0) {
+        return null;
+    }
+
+    const index = slugs.indexOf(activeSlug ?? '');
+
+    if (index === -1) {
+        return delta > 0 ? slugs[0] : slugs[slugs.length - 1];
+    }
+
+    return slugs[(index + delta + slugs.length) % slugs.length];
+}
+
+/**
+ * Group the shortcut definitions by category, preserving first-seen order, for
+ * rendering in the help modal.
+ */
+export function shortcutsByCategory(
+    shortcuts: readonly ShortcutDefinition[] = SHORTCUTS,
+): { category: string; shortcuts: ShortcutDefinition[] }[] {
+    const groups: { category: string; shortcuts: ShortcutDefinition[] }[] = [];
+
+    for (const shortcut of shortcuts) {
+        const group = groups.find(
+            (candidate) => candidate.category === shortcut.category,
+        );
+
+        if (group) {
+            group.shortcuts.push(shortcut);
+        } else {
+            groups.push({ category: shortcut.category, shortcuts: [shortcut] });
+        }
+    }
+
+    return groups;
+}

--- a/resources/js/composables/useKeyboardShortcuts.ts
+++ b/resources/js/composables/useKeyboardShortcuts.ts
@@ -1,0 +1,19 @@
+import { onMounted, onUnmounted } from 'vue';
+import { dispatchKeydown, SHORTCUTS } from '@/composables/keyboardShortcuts';
+import type { ShortcutId } from '@/composables/keyboardShortcuts';
+
+/**
+ * Wire the app-wide keyboard shortcuts to a window `keydown` listener for the
+ * lifetime of the calling component. `handlers` maps a {@link ShortcutId} to
+ * the action it runs; unmapped shortcuts are simply ignored.
+ */
+export function useKeyboardShortcuts(
+    handlers: Partial<Record<ShortcutId, () => void>>,
+): void {
+    function onKeydown(event: KeyboardEvent): void {
+        dispatchKeydown(event, SHORTCUTS, (id) => handlers[id]?.());
+    }
+
+    onMounted(() => window.addEventListener('keydown', onKeydown));
+    onUnmounted(() => window.removeEventListener('keydown', onKeydown));
+}

--- a/resources/js/composables/useKeyboardShortcutsModal.ts
+++ b/resources/js/composables/useKeyboardShortcutsModal.ts
@@ -1,0 +1,16 @@
+import { ref } from 'vue';
+
+/**
+ * Shared open-state for the keyboard shortcuts help modal. The modal is mounted
+ * once in the channels layout, but it can be opened from anywhere (the `?`
+ * shortcut, the user menu) without prop-drilling through the component tree.
+ */
+const isOpen = ref(false);
+
+export function useKeyboardShortcutsModal() {
+    return {
+        isOpen,
+        open: () => (isOpen.value = true),
+        toggle: () => (isOpen.value = !isOpen.value),
+    };
+}

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -40,6 +40,7 @@ import { adjacentSlug } from '@/composables/keyboardShortcuts';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useInitials } from '@/composables/useInitials';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
+import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
 
@@ -65,7 +66,8 @@ const { getInitials } = useInitials();
 const { switchTeam } = useTeamSwitch();
 
 const quickSwitcherOpen = ref(false);
-const shortcutsOpen = ref(false);
+const { isOpen: shortcutsOpen, toggle: toggleShortcuts } =
+    useKeyboardShortcutsModal();
 
 /**
  * Jump `delta` channels along the sidebar list from the active one, wrapping at
@@ -92,7 +94,7 @@ useKeyboardShortcuts({
         (quickSwitcherOpen.value = !quickSwitcherOpen.value),
     'previous-channel': () => moveChannel(-1),
     'next-channel': () => moveChannel(1),
-    'show-shortcuts': () => (shortcutsOpen.value = !shortcutsOpen.value),
+    'show-shortcuts': () => toggleShortcuts(),
 });
 
 onMounted(() => {

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
 import { MessageSquareText, MessagesSquare, Plus, Search } from '@lucide/vue';
-import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import {
     browse,
     show,
@@ -10,6 +10,7 @@ import { index as searchMessages } from '@/actions/App/Http/Controllers/Channels
 import { index as threadsInbox } from '@/actions/App/Http/Controllers/Channels/ThreadsController';
 import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
+import KeyboardShortcutsModal from '@/components/KeyboardShortcutsModal.vue';
 import NavUser from '@/components/NavUser.vue';
 import PendingInvitationsModal from '@/components/PendingInvitationsModal.vue';
 import QuickSwitcher from '@/components/QuickSwitcher.vue';
@@ -35,8 +36,10 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { adjacentSlug } from '@/composables/keyboardShortcuts';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useInitials } from '@/composables/useInitials';
+import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
 
@@ -61,24 +64,40 @@ const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
 const { getInitials } = useInitials();
 const { switchTeam } = useTeamSwitch();
 
-// Cmd/Ctrl+K toggles the quick switcher from anywhere in the workspace.
 const quickSwitcherOpen = ref(false);
+const shortcutsOpen = ref(false);
 
-function handleQuickSwitcherShortcut(event: KeyboardEvent): void {
-    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
-        event.preventDefault();
-        quickSwitcherOpen.value = !quickSwitcherOpen.value;
+/**
+ * Jump `delta` channels along the sidebar list from the active one, wrapping at
+ * either end. Does nothing until a team and its channels are loaded.
+ */
+function moveChannel(delta: number): void {
+    if (!currentTeam.value) {
+        return;
+    }
+
+    const slug = adjacentSlug(
+        channels.value.map((channel) => channel.slug),
+        activeChannelSlug.value,
+        delta,
+    );
+
+    if (slug) {
+        router.visit(show({ team: currentTeam.value.slug, channel: slug }).url);
     }
 }
+
+useKeyboardShortcuts({
+    'quick-switcher': () =>
+        (quickSwitcherOpen.value = !quickSwitcherOpen.value),
+    'previous-channel': () => moveChannel(-1),
+    'next-channel': () => moveChannel(1),
+    'show-shortcuts': () => (shortcutsOpen.value = !shortcutsOpen.value),
+});
 
 onMounted(() => {
     // Lazily pull the (optional) shared invitations so the post-login prompt appears.
     router.reload({ only: ['pendingInvitations'] });
-    window.addEventListener('keydown', handleQuickSwitcherShortcut);
-});
-
-onUnmounted(() => {
-    window.removeEventListener('keydown', handleQuickSwitcherShortcut);
 });
 </script>
 
@@ -356,5 +375,7 @@ onUnmounted(() => {
             :channels="channels"
             :team-slug="currentTeam.slug"
         />
+
+        <KeyboardShortcutsModal v-model:open="shortcutsOpen" />
     </SidebarProvider>
 </template>


### PR DESCRIPTION
Closes #40.

## What

App-wide keyboard shortcuts with a discoverable **"?" help modal**. A single shortcut registry drives both the dispatcher and the modal, so a shortcut can never appear in one without the other.

### Shortcuts
| Keys | Action |
|---|---|
| ⌘ / Ctrl + K | Open the quick switcher |
| ⌥ ↑ / ⌥ ↓ | Previous / next channel (wraps) |
| ? | Show the shortcut list |

### Discoverability
- Press **?** anywhere in the workspace.
- **User menu → Keyboard shortcuts** (with a `?` hint), the conventional home for it.

## How
- `composables/keyboardShortcuts.ts` — pure registry + dispatcher (`matchShortcut`, `dispatchKeydown`, `isEditableTarget`, `adjacentSlug`). No DOM globals, so it's fully unit-testable.
- `composables/useKeyboardShortcuts.ts` — thin Vue composable that binds the window `keydown` listener over the component lifetime.
- `composables/useKeyboardShortcutsModal.ts` — shared open-state so the `?` shortcut and the user-menu item both drive the single modal mounted in the layout, without prop-drilling.
- `components/KeyboardShortcutsModal.vue` — groups shortcuts by category with `<kbd>` chips.
- Replaces the ad-hoc ⌘K listener in the channels layout with the dispatcher.

### Behaviour notes
- Non-modifier shortcuts (`?`, `⌥↑/↓`) are **suppressed while typing** in an input/textarea/contenteditable.
- Command-key shortcuts (⌘K) intentionally still fire while typing — matches the previous behaviour and Slack.
- Cross-platform: `mod` matches ⌘ **or** Ctrl from one definition.

## Acceptance criteria
- [x] Core navigation shortcuts wired up
- [x] "?" opens a modal documenting all shortcuts
- [x] Shortcuts don't fire while typing in inputs (except command-key ones, by design)
- [x] Test coverage for the shortcut dispatcher

## Testing
- 26 new unit tests for the dispatcher; full JS suite **87 passing**.
- `lint:check`, `format:check`, `types:check`, `build` all green.
- No PHP touched.

## Scope note
Kept to navigation + help. "Focus composer" / "mark read" (the issue's `etc.`) are trivial follow-ups now that the dispatcher exists — the composer lives inside a page slot with no clean, conflict-free default binding, so I left it out rather than invent one.