### PR TITLE
feat(messaging): message drafts — persist unsent composer text (#31)

### DIFF
--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -48,6 +48,10 @@ class PostMessage
 
             if ($threadRootId !== null) {
                 $this->bumpThreadRoot($channel, $threadRootId);
+            } else {
+                // A message sent from the main composer clears its channel draft;
+                // a thread reply leaves the channel draft alone (it isn't its text).
+                $author->channels()->updateExistingPivot($channel->id, ['draft' => null]);
             }
         }
 

--- a/app/Actions/Channels/SaveChannelDraft.php
+++ b/app/Actions/Channels/SaveChannelDraft.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Channel;
+use App\Models\User;
+
+class SaveChannelDraft
+{
+    /**
+     * Persist the user's unsent composer text for the channel.
+     *
+     * Writes only the member's own pivot row; a non-member is a no-op because
+     * there is no membership to update. A blank draft (empty or whitespace-only)
+     * is stored as null so it clears the pending-draft cue rather than lingering
+     * as an "empty" draft.
+     */
+    public function handle(Channel $channel, User $user, ?string $draft): void
+    {
+        $user->channels()->updateExistingPivot($channel->id, [
+            'draft' => $draft !== null && trim($draft) !== '' ? $draft : null,
+        ]);
+    }
+}

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -22,6 +22,8 @@ class ChannelData extends Data
         public string $notificationLevel = NotificationLevel::All->value,
         public int $unreadCount = 0,
         public int $mentionCount = 0,
+        public bool $hasDraft = false,
+        public ?string $draft = null,
     ) {}
 
     /**
@@ -36,6 +38,11 @@ class ChannelData extends Data
      * a muted channel or the "nothing" level shows no badge at all, and the
      * "mentions" level keeps only the mention badge (a direct @mention still
      * alerts while ordinary unread traffic is silenced).
+     *
+     * The draft is the viewer's own pending composer text. The open channel
+     * (`Show`) carries the full `draft` so the composer restores it; the sidebar
+     * ships only the `has_draft` boolean, so `draft` stays null there and only
+     * the presence cue is exposed.
      */
     public static function fromChannel(Channel $channel): self
     {
@@ -45,6 +52,12 @@ class ChannelData extends Data
 
         $unreadCount = (int) ($channel->getAttribute('unread_count') ?? 0);
         $mentionCount = (int) ($channel->getAttribute('mention_count') ?? 0);
+
+        $draftText = $channel->getAttribute('draft');
+        $draft = is_string($draftText) && trim($draftText) !== '' ? $draftText : null;
+
+        $hasDraftAttribute = $channel->getAttribute('has_draft');
+        $hasDraft = $hasDraftAttribute !== null ? (bool) $hasDraftAttribute : $draft !== null;
 
         return new self(
             id: $channel->id,
@@ -58,6 +71,8 @@ class ChannelData extends Data
             notificationLevel: $level->value,
             unreadCount: ! $muted && $level->alertsOnUnread() ? $unreadCount : 0,
             mentionCount: ! $muted && $level->alertsOnMention() ? $mentionCount : 0,
+            hasDraft: $hasDraft,
+            draft: $draft,
         );
     }
 }

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -95,6 +95,9 @@ class ChannelController extends Controller
         $membership = $channel->channelMembers()->where('user_id', $request->user()->id)->first();
         $channel->setAttribute('muted', $membership->muted ?? false);
         $channel->setAttribute('notification_level', $membership?->notification_level->value ?? NotificationLevel::All->value);
+        // Surface the member's saved draft so the composer restores it on open; a
+        // non-member has no pivot row, so the composer opens empty.
+        $channel->setAttribute('draft', $membership?->draft);
 
         // When arriving from a search result the URL carries the target message
         // id. If it belongs to this channel, cap the initial window a few messages

--- a/app/Http/Controllers/Channels/ChannelDraftController.php
+++ b/app/Http/Controllers/Channels/ChannelDraftController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\SaveChannelDraft;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\SaveChannelDraftRequest;
+use App\Models\Channel;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+
+class ChannelDraftController extends Controller
+{
+    /**
+     * Save (or clear) the current user's unsent composer text for the channel.
+     *
+     * Redirects back and lets Inertia recompute the shared `channels` prop so the
+     * sidebar's draft cue reflects the change without a full reload.
+     */
+    public function update(SaveChannelDraftRequest $request, Team $team, Channel $channel, SaveChannelDraft $saveChannelDraft): RedirectResponse
+    {
+        $saveChannelDraft->handle(
+            channel: $channel,
+            user: $request->user(),
+            draft: $request->validated('body'),
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -77,6 +77,11 @@ class HandleInertiaRequests extends Middleware
             ->whereNull('channels.archived_at')
             ->select('channels.*')
             ->addSelect(['channel_members.muted', 'channel_members.notification_level'])
+            // Only the presence of a draft drives the sidebar cue; the draft text
+            // itself is shipped solely to the open channel, so keep it out of the
+            // sidebar payload and expose a 1/0 flag instead (an integer, not a
+            // driver-specific boolean, so the DTO's cast reads it reliably).
+            ->selectRaw("case when channel_members.draft is not null and channel_members.draft != '' then 1 else 0 end as has_draft")
             // Thread-only replies stay out of the plain unread badge (they live
             // in the thread view), but a mention anywhere — including inside a
             // thread — still badges the channel.

--- a/app/Http/Requests/Channels/SaveChannelDraftRequest.php
+++ b/app/Http/Requests/Channels/SaveChannelDraftRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class SaveChannelDraftRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('saveDraft', $this->channel());
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * The body is stored verbatim (mention tokens and all) so it restores
+     * faithfully, so it is not trimmed here; a blank value clears the draft.
+     * The length cap mirrors {@see PostMessageRequest} so a draft can never hold
+     * more than a sendable message.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['nullable', 'string', 'max:8000'],
+        ];
+    }
+
+    /**
+     * Get the channel whose draft is being saved.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+}

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -110,7 +110,7 @@ class Channel extends Model
     public function members(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'channel_members')
-            ->withPivot(['last_read_message_id', 'muted', 'notification_level'])
+            ->withPivot(['last_read_message_id', 'muted', 'notification_level', 'draft'])
             ->withTimestamps();
     }
 

--- a/app/Models/ChannelMember.php
+++ b/app/Models/ChannelMember.php
@@ -18,12 +18,13 @@ use Illuminate\Support\Carbon;
  * @property string|null $last_read_message_id
  * @property bool $muted
  * @property NotificationLevel $notification_level
+ * @property string|null $draft
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Channel $channel
  * @property-read User $user
  */
-#[Fillable(['channel_id', 'user_id', 'last_read_message_id', 'muted', 'notification_level'])]
+#[Fillable(['channel_id', 'user_id', 'last_read_message_id', 'muted', 'notification_level', 'draft'])]
 class ChannelMember extends Model
 {
     /** @use HasFactory<ChannelMemberFactory> */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -65,7 +65,7 @@ class User extends Authenticatable
     public function channels(): BelongsToMany
     {
         return $this->belongsToMany(Channel::class, 'channel_members')
-            ->withPivot(['last_read_message_id', 'muted', 'notification_level'])
+            ->withPivot(['last_read_message_id', 'muted', 'notification_level', 'draft'])
             ->withTimestamps();
     }
 }

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -47,6 +47,19 @@ class ChannelPolicy
     }
 
     /**
+     * Determine whether the user can save their own composer draft for the channel.
+     *
+     * Drafts live on the membership pivot, so only a member of the channel
+     * (within the team) has one to save. Each member only ever touches their
+     * own row.
+     */
+    public function saveDraft(User $user, Channel $channel): bool
+    {
+        return $user->belongsToTeam($channel->team)
+            && $channel->members()->whereKey($user->id)->exists();
+    }
+
+    /**
      * Determine whether the user can post a message to the channel.
      *
      * Only members of a non-archived channel may post.

--- a/database/factories/ChannelMemberFactory.php
+++ b/database/factories/ChannelMemberFactory.php
@@ -26,6 +26,7 @@ class ChannelMemberFactory extends Factory
             'last_read_message_id' => null,
             'muted' => false,
             'notification_level' => NotificationLevel::All,
+            'draft' => null,
         ];
     }
 
@@ -35,6 +36,14 @@ class ChannelMemberFactory extends Factory
     public function muted(): static
     {
         return $this->state(fn (array $attributes): array => ['muted' => true]);
+    }
+
+    /**
+     * Indicate the membership has a pending composer draft.
+     */
+    public function draft(string $draft): static
+    {
+        return $this->state(fn (array $attributes): array => ['draft' => $draft]);
     }
 
     /**

--- a/database/migrations/2026_07_09_195709_add_draft_to_channel_members_table.php
+++ b/database/migrations/2026_07_09_195709_add_draft_to_channel_members_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channel_members', function (Blueprint $table) {
+            // The member's unsent composer text for the channel, persisted so it
+            // survives navigation, reloads and other devices. Null means no
+            // pending draft (the sidebar shows no draft cue).
+            $table->text('draft')->nullable()->after('notification_level');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channel_members', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+    }
+};

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -13,18 +13,42 @@ const props = defineProps<{
     placeholder?: string;
     allowSendToChannel?: boolean;
     autofocus?: boolean;
+    // Text to seed the composer with on mount, e.g. a persisted draft. Restored
+    // verbatim (mention tokens included) so it round-trips faithfully.
+    initialBody?: string;
 }>();
 
 const emit = defineEmits<{
     send: [body: string, mentions: Mention[], sendToChannel?: boolean];
     typing: [];
     cancelReply: [];
+    // The composer body changed (typed, restored-then-edited, or cleared on
+    // send). The parent decides whether to persist it as a draft.
+    draftChange: [body: string];
 }>();
 
 const { getInitials } = useInitials();
 
-const body = ref('');
+const body = ref(props.initialBody ?? '');
 const textarea = ref<HTMLTextAreaElement | null>(null);
+
+// When true, the next body change is a programmatic clear-on-send, not a user
+// edit, so it must not emit a draft change: sending already clears the draft
+// server-side, and re-emitting would fire a redundant save.
+let clearingAfterSend = false;
+
+// Surface every body change so the parent can persist (or clear) the draft.
+// Seeding `body` above happens before this watch is registered, so restoring a
+// draft doesn't echo back as a change.
+watch(body, (value) => {
+    if (clearingAfterSend) {
+        clearingAfterSend = false;
+
+        return;
+    }
+
+    emit('draftChange', value);
+});
 
 // In a thread composer, whether the reply is also surfaced in the main timeline.
 const sendToChannel = ref(false);
@@ -34,11 +58,16 @@ const composerPlaceholder = computed(
 );
 
 // Focus on mount when asked (e.g. the thread composer when a thread opens) so
-// the user can type straight away without clicking into the field.
+// the user can type straight away without clicking into the field. A restored
+// draft also needs a resize so a multi-line draft opens fully expanded.
 onMounted(() => {
-    if (props.autofocus) {
-        nextTick(() => textarea.value?.focus());
-    }
+    nextTick(() => {
+        resize();
+
+        if (props.autofocus) {
+            textarea.value?.focus();
+        }
+    });
 });
 
 // Focus the composer whenever a reply is started so the user can type straight
@@ -188,6 +217,7 @@ function submit(): void {
     }
 
     emit('send', trimmed, collectMentions(trimmed), sendToChannel.value);
+    clearingAfterSend = true;
     body.value = '';
     sendToChannel.value = false;
     menuOpen.value = false;

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
-import { MessageSquareText, MessagesSquare, Plus, Search } from '@lucide/vue';
+import {
+    MessageSquareText,
+    MessagesSquare,
+    Pencil,
+    Plus,
+    Search,
+} from '@lucide/vue';
 import { computed, onMounted, ref } from 'vue';
 import {
     browse,
@@ -262,7 +268,8 @@ onMounted(() => {
                                                     >{{ channel.name }}</span
                                                 >
                                                 <!-- A numeric badge for unread @mentions takes priority; -->
-                                                <!-- otherwise a plain dot marks the channel as unread. -->
+                                                <!-- then a "draft" cue for a pending unsent message on -->
+                                                <!-- another channel; otherwise a plain unread dot. -->
                                                 <span
                                                     v-if="
                                                         channel.mentionCount > 0
@@ -274,6 +281,19 @@ onMounted(() => {
                                                         channel.mentionCount
                                                     }}</span
                                                 >
+                                                <span
+                                                    v-else-if="
+                                                        channel.hasDraft &&
+                                                        channel.slug !==
+                                                            activeChannelSlug
+                                                    "
+                                                    data-test="draft-indicator"
+                                                    class="ml-auto inline-flex items-center gap-1 text-[10px] font-semibold tracking-[0.04em] text-amber-500 uppercase"
+                                                    aria-label="Draft saved"
+                                                >
+                                                    <Pencil class="size-3" />
+                                                    Draft
+                                                </span>
                                                 <span
                                                     v-else-if="
                                                         channel.unreadCount > 0

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -25,6 +25,7 @@ import {
     readThread as markThreadReadAction,
     show as showChannel,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
 import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
 import {
     destroy as destroyMessage,
@@ -477,6 +478,10 @@ watch(
 watch(
     () => props.channel.id,
     (newId, oldId) => {
+        // Persist the outgoing channel's draft before switching; `pendingDraft`
+        // still carries the old channel's slug, so it writes to the right place.
+        flushDraft();
+
         if (oldId) {
             unsubscribe(oldId);
         }
@@ -494,6 +499,9 @@ watch(
 );
 
 onBeforeUnmount(() => {
+    // Leaving the workspace (or a full navigation away) still persists a
+    // just-typed draft that the debounce hasn't written yet.
+    flushDraft();
     unsubscribe(props.channel.id);
     unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
@@ -523,7 +531,63 @@ function cancelReply(): void {
     replyTarget.value = null;
 }
 
+// The member's unsent composer text is persisted per channel so it survives
+// navigation, reloads and other devices. Saves are debounced — a burst of
+// keystrokes collapses to one request — and reload only the shared `channels`
+// prop so the sidebar's draft cue updates without disturbing the timeline. A
+// send clears the draft server-side, so only manual edits flow through here.
+const DRAFT_DEBOUNCE_MS = 700;
+
+let draftTimer: ReturnType<typeof setTimeout> | null = null;
+
+// The latest pending draft, tagged with the slug of the channel it belongs to,
+// so a flush triggered by switching channels still writes to the channel that
+// was actually being edited rather than the one just navigated to.
+let pendingDraft: { slug: string; body: string } | null = null;
+
+function persistDraft(slug: string, body: string): void {
+    router.patch(
+        saveChannelDraft({ team: props.team.slug, channel: slug }).url,
+        { body },
+        { preserveScroll: true, preserveState: true, only: ['channels'] },
+    );
+}
+
+// Write any pending draft immediately, cancelling the debounce. Called before
+// leaving the channel so a just-typed draft is never lost to an unfired timer.
+function flushDraft(): void {
+    if (draftTimer) {
+        clearTimeout(draftTimer);
+        draftTimer = null;
+    }
+
+    if (pendingDraft) {
+        persistDraft(pendingDraft.slug, pendingDraft.body);
+        pendingDraft = null;
+    }
+}
+
+// Debounce a draft save for the current channel; an empty body clears it.
+function onDraftChange(body: string): void {
+    pendingDraft = { slug: props.channel.slug, body };
+
+    if (draftTimer) {
+        clearTimeout(draftTimer);
+    }
+
+    draftTimer = setTimeout(flushDraft, DRAFT_DEBOUNCE_MS);
+}
+
 function send(body: string, mentions: Mention[]): void {
+    // Sending clears the draft server-side, so drop any debounced save still in
+    // flight; otherwise it would re-persist the just-sent text after the clear.
+    if (draftTimer) {
+        clearTimeout(draftTimer);
+        draftTimer = null;
+    }
+
+    pendingDraft = null;
+
     const clientUuid = crypto.randomUUID();
     const target = replyTarget.value;
 
@@ -1026,12 +1090,15 @@ function archive(): void {
                     />
 
                     <MessageComposer
+                        :key="props.channel.id"
                         :channel-name="props.channel.name"
                         :members="mentionableMembers"
                         :reply-target="replyTarget"
+                        :initial-body="props.channel.draft ?? ''"
                         @send="send"
                         @typing="onTyping"
                         @cancel-reply="cancelReply"
+                        @draft-change="onDraftChange"
                     />
                 </template>
             </div>

--- a/resources/js/types/channels.ts
+++ b/resources/js/types/channels.ts
@@ -17,4 +17,9 @@ export type Channel = {
     notificationLevel: NotificationLevel;
     unreadCount: number;
     mentionCount: number;
+    // Whether the viewer has unsent composer text saved for this channel; drives
+    // the sidebar's draft cue. The full `draft` text is only present on the open
+    // channel, so the composer can restore it.
+    hasDraft: boolean;
+    draft: string | null;
 };

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Channels\ChannelController;
+use App\Http\Controllers\Channels\ChannelDraftController;
 use App\Http\Controllers\Channels\ChannelMemberController;
 use App\Http\Controllers\Channels\ChannelPreferenceController;
 use App\Http\Controllers\Channels\MessageController;
@@ -35,6 +36,9 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::patch('t/{team}/c/{channel}/preferences', [ChannelPreferenceController::class, 'update'])
         ->scopeBindings()
         ->name('channels.preferences.update');
+    Route::patch('t/{team}/c/{channel}/draft', [ChannelDraftController::class, 'update'])
+        ->scopeBindings()
+        ->name('channels.draft.update');
     Route::post('t/{team}/c/{channel}/archive', [ChannelController::class, 'archive'])
         ->scopeBindings()
         ->name('channels.archive');

--- a/tests/Feature/Channels/ChannelDraftTest.php
+++ b/tests/Feature/Channels/ChannelDraftTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use App\Actions\Channels\PostMessage;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function draftTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and the given channel, returning them.
+ */
+function draftMember(Team $team, Channel $channel): User
+{
+    $user = User::factory()->create();
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+/**
+ * Resolve the sidebar `channels` prop entry for the channel as the acting user.
+ *
+ * @return array<string, mixed>
+ */
+function draftSidebarEntry(User $user, Team $team, Channel $channel): array
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]))->assertOk();
+
+    $channels = $response->viewData('page')['props']['channels'];
+
+    return collect($channels)->firstWhere('slug', $channel->slug);
+}
+
+/**
+ * Save the draft endpoint as the given user.
+ */
+function saveDraft(User $user, Team $team, Channel $channel, ?string $body): TestResponse
+{
+    return test()->actingAs($user)->patch(route('channels.draft.update', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]), ['body' => $body]);
+}
+
+test('a member can save a draft for a channel', function () {
+    [, $team, $general] = draftTeamWithGeneral();
+    $member = draftMember($team, $general);
+
+    saveDraft($member, $team, $general, 'a half-written thought')
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'draft' => 'a half-written thought',
+    ]);
+});
+
+test('saving a blank draft clears it', function () {
+    [, $team, $general] = draftTeamWithGeneral();
+    $member = draftMember($team, $general);
+    $member->channels()->updateExistingPivot($general->id, ['draft' => 'stale text']);
+
+    saveDraft($member, $team, $general, '   ')
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'draft' => null,
+    ]);
+})->with([
+    'whitespace only' => ['   '],
+    'null body' => [null],
+]);
+
+test('a non-member cannot save a draft for a channel', function () {
+    [$owner, $team] = draftTeamWithGeneral();
+    $private = Channel::factory()->for($team)->create([
+        'visibility' => ChannelVisibility::Private,
+        'created_by' => $owner->id,
+    ]);
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    saveDraft($stranger, $team, $private, 'let me in')
+        ->assertForbidden();
+
+    $this->assertDatabaseMissing('channel_members', [
+        'channel_id' => $private->id,
+        'user_id' => $stranger->id,
+    ]);
+});
+
+test('a draft cannot exceed the message length limit', function () {
+    [, $team, $general] = draftTeamWithGeneral();
+    $member = draftMember($team, $general);
+
+    saveDraft($member, $team, $general, str_repeat('a', 8001))
+        ->assertSessionHasErrors('body');
+});
+
+test('the channel view restores the members saved draft', function () {
+    [, $team, $general] = draftTeamWithGeneral();
+    $member = draftMember($team, $general);
+    $member->channels()->updateExistingPivot($general->id, ['draft' => 'unsent words']);
+
+    $response = $this->actingAs($member)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]))->assertOk();
+
+    expect($response->viewData('page')['props']['channel'])
+        ->toMatchArray(['draft' => 'unsent words', 'hasDraft' => true]);
+});
+
+test('a member without a draft opens the channel with an empty composer', function () {
+    [, $team, $general] = draftTeamWithGeneral();
+    $member = draftMember($team, $general);
+
+    $response = $this->actingAs($member)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]))->assertOk();
+
+    expect($response->viewData('page')['props']['channel'])
+        ->toMatchArray(['draft' => null, 'hasDraft' => false]);
+});
+
+test('the sidebar flags a channel with a draft without shipping the draft text', function () {
+    [, $team, $general] = draftTeamWithGeneral();
+    $member = draftMember($team, $general);
+    $member->channels()->updateExistingPivot($general->id, ['draft' => 'secret sauce']);
+
+    expect(draftSidebarEntry($member, $team, $general))
+        ->toMatchArray(['hasDraft' => true, 'draft' => null]);
+});
+
+test('the sidebar shows no draft cue when the channel has none', function () {
+    [, $team, $general] = draftTeamWithGeneral();
+    $member = draftMember($team, $general);
+
+    expect(draftSidebarEntry($member, $team, $general))
+        ->toMatchArray(['hasDraft' => false, 'draft' => null]);
+});
+
+test('posting a message from the main composer clears the channel draft', function () {
+    [, $team, $general] = draftTeamWithGeneral();
+    $member = draftMember($team, $general);
+    $member->channels()->updateExistingPivot($general->id, ['draft' => 'about to send this']);
+
+    app(PostMessage::class)->handle(
+        channel: $general,
+        author: $member,
+        body: 'sent it',
+        clientUuid: (string) Str::uuid(),
+    );
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'draft' => null,
+    ]);
+});


### PR DESCRIPTION
Closes #31.

## What
Persists the message composer's unsent text **per user, per channel** so it survives navigation, reloads and other devices, and cues channels with a pending draft in the sidebar.

## Behavior
- **Save** — composer text is saved (debounced) to the `channel_members` pivot as you type.
- **Restore** — opening a channel seeds the composer from its saved draft (mention tokens and all).
- **Clear** — sending a message clears the draft server-side; emptying the composer clears it too. A whitespace-only draft is stored as `null` so it doesn't leave a phantom cue.
- **Sidebar cue** — channels with a pending draft show a small "Draft" indicator (hidden on the channel you're currently in). Mention badges still take priority.
- **No loss on navigation** — a pending debounced save is flushed on channel switch and on unmount, tagged with the originating channel's slug so it always lands on the right channel.

## Implementation
- **Backend:** nullable `draft` column on `channel_members`; `SaveChannelDraft` action, `ChannelDraftController` + `SaveChannelDraftRequest` gated by a new `saveDraft` policy ability (channel members only); `PATCH t/{team}/c/{channel}/draft` route. `ChannelData` exposes `hasDraft` (sidebar, from a `has_draft` 1/0 flag) and the full `draft` (open channel only). `PostMessage` clears the draft when a top-level message is sent.
- **Frontend:** `MessageComposer` seeds from an `initialBody` prop and emits `draftChange`; `Show.vue` debounces persistence and flushes on switch/unmount; `Layout.vue` renders the sidebar draft cue.

## Tests
- New `ChannelDraftTest` covers save, blank-clears-to-null, non-member forbidden, length validation, restore on channel open, sidebar flag (without shipping draft text), empty-state, and send-clears-draft.
- Full gate green: Pint, PHPStan, `--min=100` coverage (Total: 100.0%), and frontend lint/format/types/build.

## Discovered while working (not fixed here)
The composer triggers the macOS "Enable Password AutoFill" popup — pre-existing, filed as #85 and left out of this PR's scope.