### PR TITLE
fix(messaging): opt message composer out of password-manager autofill

### DIFF
--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -335,6 +335,14 @@ function onKeydown(event: KeyboardEvent): void {
                     rows="1"
                     :placeholder="composerPlaceholder"
                     data-test="message-composer-input"
+                    autocomplete="off"
+                    autocorrect="off"
+                    autocapitalize="sentences"
+                    spellcheck="true"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    data-bwignore
+                    data-form-type="other"
                     class="max-h-[200px] w-full resize-none bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
                     @input="(resize(), refreshSuggestions(), emit('typing'))"
                     @click="refreshSuggestions"


### PR DESCRIPTION
## What & why

Adds autocomplete / opt-out hints to the message composer `<textarea>` (shared by the channel and thread-reply composers) so password managers don't treat a plain message field as a credential input:

- `autocomplete="off"`
- `data-1p-ignore` (1Password), `data-lpignore="true"` (LastPass), `data-bwignore` (Bitwarden), `data-form-type="other"`
- `spellcheck` and sentence `autocapitalize` left on so normal typing is unaffected

## Scope — please read

This is **defensive hardening for third-party password-manager extensions** (1Password, LastPass, Bitwarden).

It does **not** resolve the specific popup in #85. That banner is Apple's **iCloud Passwords browser extension** (seen in Arc/Chromium), whose "Enable Password AutoFill" onboarding nag fires on *any* editable field and is driven by the user's extension / system AutoFill state — **not the page markup**. There is no reliable HTML/attribute opt-out for it; every documented remedy is client-side (extension options or macOS System Settings). So #85's acceptance criteria can't be met from code and the issue is being handled separately as environment-specific.

## Verification
- `lint:check`, `format:check`, `types:check`, and `build` all pass.

Refs #85