### PR TITLE
Star channels + collapsible sidebar sections (Phase 1 of #41)

### DIFF
--- a/app/Actions/Channels/SetChannelStar.php
+++ b/app/Actions/Channels/SetChannelStar.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Channel;
+use App\Models\User;
+
+class SetChannelStar
+{
+    /**
+     * Set the user's star (favorite) flag for the channel.
+     *
+     * Writes only the member's own pivot row; a non-member is a no-op because
+     * there is no membership to update.
+     */
+    public function handle(Channel $channel, User $user, bool $starred): void
+    {
+        $user->channels()->updateExistingPivot($channel->id, [
+            'starred' => $starred,
+        ]);
+    }
+}

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -24,6 +24,7 @@ class ChannelData extends Data
         public int $mentionCount = 0,
         public bool $hasDraft = false,
         public ?string $draft = null,
+        public bool $starred = false,
     ) {}
 
     /**
@@ -43,6 +44,9 @@ class ChannelData extends Data
      * (`Show`) carries the full `draft` so the composer restores it; the sidebar
      * ships only the `has_draft` boolean, so `draft` stays null there and only
      * the presence cue is exposed.
+     *
+     * `starred` is the viewer's own favorite flag, driving whether the channel is
+     * pinned to the sidebar's "Starred" section.
      */
     public static function fromChannel(Channel $channel): self
     {
@@ -59,6 +63,8 @@ class ChannelData extends Data
         $hasDraftAttribute = $channel->getAttribute('has_draft');
         $hasDraft = $hasDraftAttribute !== null ? (bool) $hasDraftAttribute : $draft !== null;
 
+        $starred = (bool) ($channel->getAttribute('starred') ?? false);
+
         return new self(
             id: $channel->id,
             name: $channel->name,
@@ -73,6 +79,7 @@ class ChannelData extends Data
             mentionCount: ! $muted && $level->alertsOnMention() ? $mentionCount : 0,
             hasDraft: $hasDraft,
             draft: $draft,
+            starred: $starred,
         );
     }
 }

--- a/app/Http/Controllers/Channels/ChannelStarController.php
+++ b/app/Http/Controllers/Channels/ChannelStarController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\SetChannelStar;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\UpdateChannelStarRequest;
+use App\Models\Channel;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+
+class ChannelStarController extends Controller
+{
+    /**
+     * Star or unstar the channel for the current user.
+     *
+     * Redirects back and lets Inertia recompute the shared `channels` prop so the
+     * sidebar's "Starred" section reflects the change without a full reload.
+     */
+    public function update(UpdateChannelStarRequest $request, Team $team, Channel $channel, SetChannelStar $setChannelStar): RedirectResponse
+    {
+        $setChannelStar->handle(
+            channel: $channel,
+            user: $request->user(),
+            starred: $request->boolean('starred'),
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/SidebarSectionController.php
+++ b/app/Http/Controllers/SidebarSectionController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\UpdateSidebarSectionsRequest;
+use Illuminate\Http\RedirectResponse;
+
+class SidebarSectionController extends Controller
+{
+    /**
+     * Persist which sidebar sections the current user has collapsed.
+     *
+     * Stored on the user so the collapsed layout follows them across reloads and
+     * devices. Redirects back and lets Inertia recompute the shared
+     * `collapsedChannelSections` prop.
+     */
+    public function update(UpdateSidebarSectionsRequest $request): RedirectResponse
+    {
+        $collapsed = array_values(array_unique($request->validated('collapsed')));
+
+        $request->user()->update(['collapsed_channel_sections' => $collapsed]);
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -54,6 +54,7 @@ class HandleInertiaRequests extends Middleware
             'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
             'teams' => fn () => $user?->toUserTeams(includeCurrent: true) ?? [],
             'channels' => fn () => $this->channelsForSidebar($request, $user),
+            'collapsedChannelSections' => fn () => $user->collapsed_channel_sections ?? [],
             'hasUnreadThreads' => fn () => $this->hasUnreadThreads($request, $user),
             'pendingInvitations' => Inertia::optional(fn () => $user ? $this->pendingInvitationsFor($user) : []),
         ];
@@ -76,7 +77,7 @@ class HandleInertiaRequests extends Middleware
             ->where('channels.team_id', $team->id)
             ->whereNull('channels.archived_at')
             ->select('channels.*')
-            ->addSelect(['channel_members.muted', 'channel_members.notification_level'])
+            ->addSelect(['channel_members.muted', 'channel_members.notification_level', 'channel_members.starred'])
             // Only the presence of a draft drives the sidebar cue; the draft text
             // itself is shipped solely to the open channel, so keep it out of the
             // sidebar payload and expose a 1/0 flag instead (an integer, not a

--- a/app/Http/Requests/Channels/UpdateChannelStarRequest.php
+++ b/app/Http/Requests/Channels/UpdateChannelStarRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class UpdateChannelStarRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('updateStar', $this->channel());
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'starred' => ['required', 'boolean'],
+        ];
+    }
+
+    /**
+     * Get the channel whose star flag is being toggled.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+}

--- a/app/Http/Requests/UpdateSidebarSectionsRequest.php
+++ b/app/Http/Requests/UpdateSidebarSectionsRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateSidebarSectionsRequest extends FormRequest
+{
+    /**
+     * The built-in sidebar sections whose collapsed state may be persisted.
+     *
+     * @var list<string>
+     */
+    public const SECTIONS = ['starred', 'channels'];
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Any authenticated user manages only their own sidebar layout, so the
+     * `auth` middleware on the route is sufficient.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * `collapsed` must be present (an empty array clears every collapse), and
+     * each entry is constrained to a known section key so the stored payload
+     * stays bounded and meaningful.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'collapsed' => ['present', 'array'],
+            'collapsed.*' => ['string', Rule::in(self::SECTIONS)],
+        ];
+    }
+}

--- a/app/Models/ChannelMember.php
+++ b/app/Models/ChannelMember.php
@@ -19,12 +19,13 @@ use Illuminate\Support\Carbon;
  * @property bool $muted
  * @property NotificationLevel $notification_level
  * @property string|null $draft
+ * @property bool $starred
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Channel $channel
  * @property-read User $user
  */
-#[Fillable(['channel_id', 'user_id', 'last_read_message_id', 'muted', 'notification_level', 'draft'])]
+#[Fillable(['channel_id', 'user_id', 'last_read_message_id', 'muted', 'notification_level', 'draft', 'starred'])]
 class ChannelMember extends Model
 {
     /** @use HasFactory<ChannelMemberFactory> */
@@ -40,6 +41,7 @@ class ChannelMember extends Model
         return [
             'muted' => 'boolean',
             'notification_level' => NotificationLevel::class,
+            'starred' => 'boolean',
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,6 +28,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $remember_token
  * @property string|null $current_team_id
  * @property ChimeSound $chime_sound
+ * @property array<int, string>|null $collapsed_channel_sections
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Team|null $currentTeam
@@ -36,7 +37,7 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, Team> $teams
  * @property-read Collection<int, Channel> $channels
  */
-#[Fillable(['name', 'email', 'password', 'current_team_id', 'chime_sound'])]
+#[Fillable(['name', 'email', 'password', 'current_team_id', 'chime_sound', 'collapsed_channel_sections'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable
 {
@@ -54,6 +55,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'chime_sound' => ChimeSound::class,
+            'collapsed_channel_sections' => 'array',
         ];
     }
 
@@ -65,7 +67,7 @@ class User extends Authenticatable
     public function channels(): BelongsToMany
     {
         return $this->belongsToMany(Channel::class, 'channel_members')
-            ->withPivot(['last_read_message_id', 'muted', 'notification_level', 'draft'])
+            ->withPivot(['last_read_message_id', 'muted', 'notification_level', 'draft', 'starred'])
             ->withTimestamps();
     }
 }

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -47,6 +47,19 @@ class ChannelPolicy
     }
 
     /**
+     * Determine whether the user can star (favorite) the channel for themselves.
+     *
+     * The star flag lives on the membership pivot, so only a member of the channel
+     * (within the team) has one to toggle, and each member only ever touches their
+     * own row.
+     */
+    public function updateStar(User $user, Channel $channel): bool
+    {
+        return $user->belongsToTeam($channel->team)
+            && $channel->members()->whereKey($user->id)->exists();
+    }
+
+    /**
      * Determine whether the user can save their own composer draft for the channel.
      *
      * Drafts live on the membership pivot, so only a member of the channel

--- a/database/factories/ChannelMemberFactory.php
+++ b/database/factories/ChannelMemberFactory.php
@@ -27,6 +27,7 @@ class ChannelMemberFactory extends Factory
             'muted' => false,
             'notification_level' => NotificationLevel::All,
             'draft' => null,
+            'starred' => false,
         ];
     }
 
@@ -36,6 +37,14 @@ class ChannelMemberFactory extends Factory
     public function muted(): static
     {
         return $this->state(fn (array $attributes): array => ['muted' => true]);
+    }
+
+    /**
+     * Indicate the membership is starred (favorited).
+     */
+    public function starred(): static
+    {
+        return $this->state(fn (array $attributes): array => ['starred' => true]);
     }
 
     /**

--- a/database/migrations/2026_07_09_202754_add_starred_to_channel_members_table.php
+++ b/database/migrations/2026_07_09_202754_add_starred_to_channel_members_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channel_members', function (Blueprint $table) {
+            // Whether the member has starred (favorited) the channel, pinning it to
+            // the sidebar's "Starred" section. Per member, so each user curates
+            // their own favorites independently.
+            $table->boolean('starred')->default(false)->after('draft');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channel_members', function (Blueprint $table) {
+            $table->dropColumn('starred');
+        });
+    }
+};

--- a/database/migrations/2026_07_09_202755_add_collapsed_channel_sections_to_users_table.php
+++ b/database/migrations/2026_07_09_202755_add_collapsed_channel_sections_to_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // The sidebar section keys the user has collapsed (e.g. ["starred"]),
+            // persisted so the collapsed/expanded layout follows them across
+            // reloads and devices. Null is treated as "nothing collapsed".
+            //
+            // `jsonb`, not `json`: Postgres cannot apply the `SELECT DISTINCT
+            // users.*` used by the thread-participants query to a `json` column
+            // (it has no equality operator), whereas `jsonb` does.
+            $table->jsonb('collapsed_channel_sections')->nullable()->after('chime_sound');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('collapsed_channel_sections');
+        });
+    }
+};

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { Link, router } from '@inertiajs/vue3';
+import { Pencil, Star } from '@lucide/vue';
+import { toast } from 'vue-sonner';
+import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
+import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import type { Channel } from '@/types/channels';
+
+const props = defineProps<{
+    channel: Channel;
+    teamSlug: string;
+    activeChannelSlug: string | null;
+}>();
+
+/**
+ * Star or unstar the channel, reloading only the shared `channels` prop so the
+ * sidebar re-partitions between the "Starred" and "Channels" sections.
+ */
+function toggleStar(): void {
+    router.patch(
+        updateChannelStar({
+            team: props.teamSlug,
+            channel: props.channel.slug,
+        }).url,
+        { starred: !props.channel.starred },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channels'],
+            onError: () => {
+                toast.error('Failed to update the channel. Please try again.');
+            },
+        },
+    );
+}
+</script>
+
+<template>
+    <SidebarMenuItem>
+        <SidebarMenuButton
+            as-child
+            :is-active="channel.slug === activeChannelSlug"
+            :data-muted="channel.muted"
+            class="h-[30px] gap-1.5 rounded-md py-0 pr-2 pl-7 text-[13.5px] text-sidebar-foreground/80 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground data-[active=true]:relative data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100"
+        >
+            <Link
+                :href="
+                    show({
+                        team: teamSlug,
+                        channel: channel.slug,
+                    }).url
+                "
+            >
+                <span
+                    v-if="channel.slug === activeChannelSlug"
+                    aria-hidden="true"
+                    class="absolute top-[7px] bottom-[7px] left-0 w-[3px] rounded-full bg-primary"
+                />
+                <span
+                    class="font-medium"
+                    :class="
+                        channel.slug === activeChannelSlug
+                            ? 'text-sidebar-foreground/70'
+                            : 'text-muted-foreground/80'
+                    "
+                    >#</span
+                >
+                <span
+                    class="truncate"
+                    :class="
+                        channel.unreadCount > 0
+                            ? 'font-semibold text-sidebar-foreground'
+                            : ''
+                    "
+                    >{{ channel.name }}</span
+                >
+                <!-- A numeric badge for unread @mentions takes priority; -->
+                <!-- then a "draft" cue for a pending unsent message on -->
+                <!-- another channel; otherwise a plain unread dot. -->
+                <span
+                    v-if="channel.mentionCount > 0"
+                    data-test="mention-badge"
+                    class="ml-auto flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary px-1 text-[11px] font-semibold text-primary-foreground tabular-nums"
+                    :aria-label="`${channel.mentionCount} unread mentions`"
+                    >{{ channel.mentionCount }}</span
+                >
+                <span
+                    v-else-if="
+                        channel.hasDraft && channel.slug !== activeChannelSlug
+                    "
+                    data-test="draft-indicator"
+                    class="ml-auto inline-flex items-center gap-1 text-[10px] font-semibold tracking-[0.04em] text-amber-500 uppercase"
+                    aria-label="Draft saved"
+                >
+                    <Pencil class="size-3" />
+                    Draft
+                </span>
+                <span
+                    v-else-if="channel.unreadCount > 0"
+                    data-test="unread-dot"
+                    aria-hidden="true"
+                    class="ml-auto size-1.5 rounded-full bg-primary"
+                />
+            </Link>
+        </SidebarMenuButton>
+        <!-- Star toggle to the left of the channel name. A separate button
+             (outside the navigation link, so the anchor stays valid) overlaid on
+             the row's reserved left padding: filled amber when starred, hollow and
+             dimmed otherwise, brightening on hover. -->
+        <button
+            type="button"
+            :data-test="`star-toggle-${channel.slug}`"
+            :data-starred="channel.starred"
+            :aria-pressed="channel.starred"
+            :aria-label="
+                channel.starred
+                    ? `Unstar ${channel.name}`
+                    : `Star ${channel.name}`
+            "
+            :title="channel.starred ? 'Unstar channel' : 'Star channel'"
+            class="absolute top-1/2 left-1 z-10 flex size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/60 opacity-70 transition hover:text-amber-500 hover:opacity-100 data-[starred=true]:text-amber-500 data-[starred=true]:opacity-100"
+            @click="toggleStar"
+        >
+            <Star
+                class="size-3.5"
+                :class="channel.starred ? 'fill-current' : ''"
+            />
+        </button>
+    </SidebarMenuItem>
+</template>

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -1,19 +1,22 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
 import {
+    ChevronRight,
     MessageSquareText,
     MessagesSquare,
-    Pencil,
     Plus,
     Search,
 } from '@lucide/vue';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
+import { toast } from 'vue-sonner';
 import {
     browse,
     show,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { index as searchMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
 import { index as threadsInbox } from '@/actions/App/Http/Controllers/Channels/ThreadsController';
+import { update as updateSidebarSections } from '@/actions/App/Http/Controllers/SidebarSectionController';
+import ChannelListItem from '@/components/ChannelListItem.vue';
 import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import KeyboardShortcutsModal from '@/components/KeyboardShortcutsModal.vue';
@@ -29,7 +32,6 @@ import {
     SidebarGroup,
     SidebarGroupAction,
     SidebarGroupContent,
-    SidebarGroupLabel,
     SidebarHeader,
     SidebarInset,
     SidebarMenu,
@@ -49,6 +51,11 @@ import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
 import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
+import {
+    partitionChannels,
+    toggleCollapsedSection,
+} from '@/lib/channelSections';
+import type { SidebarSectionKey } from '@/lib/channelSections';
 
 const page = usePage();
 
@@ -67,6 +74,59 @@ const activeChannelSlug = computed(
 );
 const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
 const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
+
+// Split the flat channel list into the pinned "Starred" section and the main
+// list, re-derived whenever the shared `channels` prop changes (a star toggle or
+// a live badge update).
+const sections = computed(() => partitionChannels(channels.value));
+const starredChannels = computed(() => sections.value.starred);
+const otherChannels = computed(() => sections.value.others);
+
+// Which sidebar sections the user has collapsed, seeded from the shared prop and
+// kept in sync when the server recomputes it (e.g. after a reload on another
+// device). A local ref lets the header toggle feel instant before the persisted
+// state round-trips.
+const collapsedSections = ref<string[]>([
+    ...(page.props.collapsedChannelSections ?? []),
+]);
+
+watch(
+    () => page.props.collapsedChannelSections,
+    (value) => {
+        collapsedSections.value = [...(value ?? [])];
+    },
+);
+
+function isSectionCollapsed(section: SidebarSectionKey): boolean {
+    return collapsedSections.value.includes(section);
+}
+
+/**
+ * Collapse or expand a sidebar section, persisting the new set so the layout
+ * follows the user across reloads and devices. The toggle is optimistic and
+ * rolls back if the request fails.
+ */
+function toggleSection(section: SidebarSectionKey): void {
+    const previous = collapsedSections.value;
+    const next = toggleCollapsedSection(previous, section);
+    collapsedSections.value = next;
+
+    router.patch(
+        updateSidebarSections().url,
+        { collapsed: next },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['collapsedChannelSections'],
+            onError: () => {
+                collapsedSections.value = previous;
+                toast.error(
+                    'Failed to save the sidebar layout. Please try again.',
+                );
+            },
+        },
+    );
+}
 
 const { getInitials } = useInitials();
 const { switchTeam } = useTeamSwitch();
@@ -197,12 +257,64 @@ onMounted(() => {
                                 >
                             </button>
                         </div>
-                        <SidebarGroup>
-                            <SidebarGroupLabel
-                                class="h-7 px-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
+                        <!-- Starred channels, pinned above the main list; the
+                             whole section is hidden until the user stars one. -->
+                        <SidebarGroup
+                            v-if="starredChannels.length > 0"
+                            class="pb-0"
+                        >
+                            <button
+                                type="button"
+                                data-test="section-toggle-starred"
+                                :aria-expanded="!isSectionCollapsed('starred')"
+                                class="flex h-7 w-full items-center gap-1 rounded-md px-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                                @click="toggleSection('starred')"
                             >
+                                <ChevronRight
+                                    class="size-3 shrink-0 transition-transform"
+                                    :class="
+                                        isSectionCollapsed('starred')
+                                            ? ''
+                                            : 'rotate-90'
+                                    "
+                                />
+                                Starred
+                            </button>
+                            <SidebarGroupContent
+                                v-show="!isSectionCollapsed('starred')"
+                                data-test="section-content-starred"
+                            >
+                                <SidebarMenu>
+                                    <ChannelListItem
+                                        v-for="channel in starredChannels"
+                                        :key="channel.id"
+                                        :channel="channel"
+                                        :team-slug="currentTeam?.slug ?? ''"
+                                        :active-channel-slug="activeChannelSlug"
+                                    />
+                                </SidebarMenu>
+                            </SidebarGroupContent>
+                        </SidebarGroup>
+
+                        <!-- The main channel list. -->
+                        <SidebarGroup>
+                            <button
+                                type="button"
+                                data-test="section-toggle-channels"
+                                :aria-expanded="!isSectionCollapsed('channels')"
+                                class="flex h-7 w-full items-center gap-1 rounded-md px-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                                @click="toggleSection('channels')"
+                            >
+                                <ChevronRight
+                                    class="size-3 shrink-0 transition-transform"
+                                    :class="
+                                        isSectionCollapsed('channels')
+                                            ? ''
+                                            : 'rotate-90'
+                                    "
+                                />
                                 Channels
-                            </SidebarGroupLabel>
+                            </button>
                             <CreateChannelModal
                                 v-if="currentTeam"
                                 :team-slug="currentTeam.slug"
@@ -216,99 +328,31 @@ onMounted(() => {
                                     <span class="sr-only">Create channel</span>
                                 </SidebarGroupAction>
                             </CreateChannelModal>
+                            <SidebarGroupContent
+                                v-show="!isSectionCollapsed('channels')"
+                                data-test="section-content-channels"
+                            >
+                                <SidebarMenu>
+                                    <ChannelListItem
+                                        v-for="channel in otherChannels"
+                                        :key="channel.id"
+                                        :channel="channel"
+                                        :team-slug="currentTeam?.slug ?? ''"
+                                        :active-channel-slug="activeChannelSlug"
+                                    />
+                                </SidebarMenu>
+                            </SidebarGroupContent>
+                        </SidebarGroup>
+
+                        <!-- Workspace navigation, always visible regardless of
+                             which channel sections are collapsed. -->
+                        <SidebarGroup class="pt-0">
                             <SidebarGroupContent>
                                 <SidebarMenu>
-                                    <SidebarMenuItem
-                                        v-for="channel in channels"
-                                        :key="channel.id"
-                                    >
-                                        <SidebarMenuButton
-                                            as-child
-                                            :is-active="
-                                                channel.slug ===
-                                                activeChannelSlug
-                                            "
-                                            :data-muted="channel.muted"
-                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13.5px] text-sidebar-foreground/80 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground data-[active=true]:relative data-[active=true]:bg-sidebar-accent data-[active=true]:pl-3.5 data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100"
-                                        >
-                                            <Link
-                                                v-if="currentTeam"
-                                                :href="
-                                                    show({
-                                                        team: currentTeam.slug,
-                                                        channel: channel.slug,
-                                                    }).url
-                                                "
-                                            >
-                                                <span
-                                                    v-if="
-                                                        channel.slug ===
-                                                        activeChannelSlug
-                                                    "
-                                                    aria-hidden="true"
-                                                    class="absolute top-[7px] bottom-[7px] left-0 w-[3px] rounded-full bg-primary"
-                                                />
-                                                <span
-                                                    class="font-medium"
-                                                    :class="
-                                                        channel.slug ===
-                                                        activeChannelSlug
-                                                            ? 'text-sidebar-foreground/70'
-                                                            : 'text-muted-foreground/80'
-                                                    "
-                                                    >#</span
-                                                >
-                                                <span
-                                                    class="truncate"
-                                                    :class="
-                                                        channel.unreadCount > 0
-                                                            ? 'font-semibold text-sidebar-foreground'
-                                                            : ''
-                                                    "
-                                                    >{{ channel.name }}</span
-                                                >
-                                                <!-- A numeric badge for unread @mentions takes priority; -->
-                                                <!-- then a "draft" cue for a pending unsent message on -->
-                                                <!-- another channel; otherwise a plain unread dot. -->
-                                                <span
-                                                    v-if="
-                                                        channel.mentionCount > 0
-                                                    "
-                                                    data-test="mention-badge"
-                                                    class="ml-auto flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary px-1 text-[11px] font-semibold text-primary-foreground tabular-nums"
-                                                    :aria-label="`${channel.mentionCount} unread mentions`"
-                                                    >{{
-                                                        channel.mentionCount
-                                                    }}</span
-                                                >
-                                                <span
-                                                    v-else-if="
-                                                        channel.hasDraft &&
-                                                        channel.slug !==
-                                                            activeChannelSlug
-                                                    "
-                                                    data-test="draft-indicator"
-                                                    class="ml-auto inline-flex items-center gap-1 text-[10px] font-semibold tracking-[0.04em] text-amber-500 uppercase"
-                                                    aria-label="Draft saved"
-                                                >
-                                                    <Pencil class="size-3" />
-                                                    Draft
-                                                </span>
-                                                <span
-                                                    v-else-if="
-                                                        channel.unreadCount > 0
-                                                    "
-                                                    data-test="unread-dot"
-                                                    aria-hidden="true"
-                                                    class="ml-auto size-1.5 rounded-full bg-primary"
-                                                />
-                                            </Link>
-                                        </SidebarMenuButton>
-                                    </SidebarMenuItem>
                                     <SidebarMenuItem>
                                         <SidebarMenuButton
                                             as-child
-                                            class="mt-1.5 h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
                                         >
                                             <Link
                                                 v-if="currentTeam"

--- a/resources/js/lib/channelSections.test.ts
+++ b/resources/js/lib/channelSections.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+    partitionChannels,
+    toggleCollapsedSection,
+} from '@/lib/channelSections';
+import type { Channel } from '@/types/channels';
+
+/**
+ * A minimal channel with only the fields the section helpers read; `starred`
+ * defaults to false and is overridden per case.
+ */
+function channel(overrides: Partial<Channel> = {}): Channel {
+    return {
+        id: overrides.id ?? overrides.slug ?? 'id',
+        name: overrides.name ?? 'General',
+        slug: overrides.slug ?? 'general',
+        visibility: 'public',
+        topic: null,
+        isGeneral: false,
+        isArchived: false,
+        muted: false,
+        notificationLevel: 'all',
+        unreadCount: 0,
+        mentionCount: 0,
+        hasDraft: false,
+        draft: null,
+        starred: false,
+        ...overrides,
+    };
+}
+
+describe('partitionChannels', () => {
+    it('splits starred channels from the rest', () => {
+        const alpha = channel({ slug: 'alpha', starred: true });
+        const beta = channel({ slug: 'beta' });
+        const gamma = channel({ slug: 'gamma', starred: true });
+
+        const { starred, others } = partitionChannels([alpha, beta, gamma]);
+
+        expect(starred.map((c) => c.slug)).toEqual(['alpha', 'gamma']);
+        expect(others.map((c) => c.slug)).toEqual(['beta']);
+    });
+
+    it('preserves the incoming order within each group', () => {
+        const channels = [
+            channel({ slug: 'zebra', starred: true }),
+            channel({ slug: 'apple', starred: true }),
+        ];
+
+        expect(partitionChannels(channels).starred.map((c) => c.slug)).toEqual([
+            'zebra',
+            'apple',
+        ]);
+    });
+
+    it('returns empty groups for an empty list', () => {
+        expect(partitionChannels([])).toEqual({ starred: [], others: [] });
+    });
+
+    it('puts everything in others when nothing is starred', () => {
+        const { starred, others } = partitionChannels([
+            channel({ slug: 'a' }),
+            channel({ slug: 'b' }),
+        ]);
+
+        expect(starred).toEqual([]);
+        expect(others.map((c) => c.slug)).toEqual(['a', 'b']);
+    });
+});
+
+describe('toggleCollapsedSection', () => {
+    it('collapses a section that was expanded', () => {
+        expect(toggleCollapsedSection([], 'starred')).toEqual(['starred']);
+    });
+
+    it('expands a section that was collapsed', () => {
+        expect(
+            toggleCollapsedSection(['starred', 'channels'], 'starred'),
+        ).toEqual(['channels']);
+    });
+
+    it('does not mutate the input array', () => {
+        const collapsed = ['channels'];
+        toggleCollapsedSection(collapsed, 'starred');
+        expect(collapsed).toEqual(['channels']);
+    });
+});

--- a/resources/js/lib/channelSections.ts
+++ b/resources/js/lib/channelSections.ts
@@ -1,0 +1,50 @@
+import type { Channel } from '@/types/channels';
+
+/**
+ * The built-in sidebar sections whose collapsed state is persisted per user.
+ * Keys must match `App\Http\Requests\UpdateSidebarSectionsRequest::SECTIONS`.
+ */
+export const SIDEBAR_SECTIONS = ['starred', 'channels'] as const;
+
+export type SidebarSectionKey = (typeof SIDEBAR_SECTIONS)[number];
+
+export type ChannelSections = {
+    /** Channels the viewer has starred, pinned above the main list. */
+    starred: Channel[];
+    /** Every remaining channel the viewer belongs to. */
+    others: Channel[];
+};
+
+/**
+ * Split the sidebar's channels into the pinned "Starred" section and the main
+ * "Channels" list, preserving the incoming order within each group (the server
+ * already sorts alphabetically).
+ */
+export function partitionChannels(channels: Channel[]): ChannelSections {
+    const starred: Channel[] = [];
+    const others: Channel[] = [];
+
+    for (const channel of channels) {
+        if (channel.starred) {
+            starred.push(channel);
+        } else {
+            others.push(channel);
+        }
+    }
+
+    return { starred, others };
+}
+
+/**
+ * Toggle a section key within the collapsed set, returning a new array. Adding a
+ * key collapses the section; removing it expands the section. Unknown keys are
+ * left untouched so a stale value never blocks the toggle.
+ */
+export function toggleCollapsedSection(
+    collapsed: readonly string[],
+    key: SidebarSectionKey,
+): string[] {
+    return collapsed.includes(key)
+        ? collapsed.filter((section) => section !== key)
+        : [...collapsed, key];
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -8,6 +8,7 @@ import {
     BellMinus,
     BellOff,
     EllipsisVertical,
+    Star,
 } from '@lucide/vue';
 import type { AcceptableValue } from 'reka-ui';
 import {
@@ -27,6 +28,7 @@ import {
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
 import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
+import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
 import {
     destroy as destroyMessage,
     store as storeMessage,
@@ -492,6 +494,7 @@ watch(
         typing.reset();
         notificationLevel.value = props.channel.notificationLevel;
         muted.value = props.channel.muted;
+        starred.value = props.channel.starred;
         subscribe(newId);
         computeUnreadDivider();
         markRead();
@@ -816,6 +819,33 @@ const notificationLevel = ref<NotificationLevel>(
     props.channel.notificationLevel,
 );
 const muted = ref<boolean>(props.channel.muted);
+const starred = ref<boolean>(props.channel.starred);
+
+/**
+ * Star or unstar this channel, reloading only the shared `channels` prop so the
+ * sidebar re-partitions its "Starred" section. Optimistic, rolled back on error.
+ */
+function toggleStar(): void {
+    const previous = starred.value;
+    starred.value = !previous;
+
+    router.patch(
+        updateChannelStar({
+            team: props.team.slug,
+            channel: props.channel.slug,
+        }).url,
+        { starred: starred.value },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channels'],
+            onError: () => {
+                starred.value = previous;
+                toast.error('Failed to update the channel. Please try again.');
+            },
+        },
+    );
+}
 
 // Thread-unread dots are silenced under the same rule as the sidebar's unread
 // badge: a muted channel or any level below "all". Mirrors the server's
@@ -956,6 +986,28 @@ function archive(): void {
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" class="w-56">
                         <template v-if="props.canManagePreferences">
+                            <DropdownMenuItem
+                                data-test="star-channel"
+                                :aria-pressed="starred"
+                                @select="
+                                    (event: Event) => {
+                                        event.preventDefault();
+                                        toggleStar();
+                                    }
+                                "
+                            >
+                                <Star
+                                    :class="
+                                        starred
+                                            ? 'fill-current text-amber-500'
+                                            : ''
+                                    "
+                                />
+                                {{
+                                    starred ? 'Unstar channel' : 'Star channel'
+                                }}
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
                             <DropdownMenuLabel
                                 class="text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
                             >

--- a/resources/js/types/channels.ts
+++ b/resources/js/types/channels.ts
@@ -22,4 +22,7 @@ export type Channel = {
     // channel, so the composer can restore it.
     hasDraft: boolean;
     draft: string | null;
+    // Whether the viewer has starred (favorited) this channel, pinning it to the
+    // sidebar's "Starred" section.
+    starred: boolean;
 };

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -24,6 +24,7 @@ declare module '@inertiajs/core' {
             currentTeam: Team | null;
             teams: Team[];
             channels?: Channel[];
+            collapsedChannelSections?: string[];
             hasUnreadThreads?: boolean;
             pendingInvitations?: DashboardInvitation[];
             [key: string]: unknown;

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,9 +4,11 @@ use App\Http\Controllers\Channels\ChannelController;
 use App\Http\Controllers\Channels\ChannelDraftController;
 use App\Http\Controllers\Channels\ChannelMemberController;
 use App\Http\Controllers\Channels\ChannelPreferenceController;
+use App\Http\Controllers\Channels\ChannelStarController;
 use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Channels\SearchController;
 use App\Http\Controllers\Channels\ThreadsController;
+use App\Http\Controllers\SidebarSectionController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Support\Facades\Route;
@@ -39,6 +41,9 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::patch('t/{team}/c/{channel}/draft', [ChannelDraftController::class, 'update'])
         ->scopeBindings()
         ->name('channels.draft.update');
+    Route::patch('t/{team}/c/{channel}/star', [ChannelStarController::class, 'update'])
+        ->scopeBindings()
+        ->name('channels.star.update');
     Route::post('t/{team}/c/{channel}/archive', [ChannelController::class, 'archive'])
         ->scopeBindings()
         ->name('channels.archive');
@@ -60,6 +65,8 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
 });
 
 Route::middleware(['auth'])->group(function () {
+    Route::patch('sidebar/sections', [SidebarSectionController::class, 'update'])->name('sidebar.sections.update');
+
     Route::get('invitations/{invitation}/accept', [TeamInvitationController::class, 'accept'])->name('invitations.accept');
     Route::delete('invitations/{invitation}', [TeamInvitationController::class, 'decline'])->name('invitations.decline');
 });

--- a/tests/Feature/Channels/ChannelStarTest.php
+++ b/tests/Feature/Channels/ChannelStarTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function starTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and the given channel, returning them.
+ */
+function starMember(Team $team, Channel $channel): User
+{
+    $user = User::factory()->create();
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+/**
+ * Resolve the sidebar `channels` prop entry for the channel as the acting user.
+ *
+ * @return array<string, mixed>
+ */
+function starSidebarEntry(User $user, Team $team, Channel $channel): array
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]))->assertOk();
+
+    $channels = $response->viewData('page')['props']['channels'];
+
+    return collect($channels)->firstWhere('slug', $channel->slug);
+}
+
+/**
+ * Hit the star endpoint as the given user.
+ */
+function setStar(User $user, Team $team, Channel $channel, bool $starred): TestResponse
+{
+    return test()->actingAs($user)->patch(route('channels.star.update', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]), ['starred' => $starred]);
+}
+
+test('a member can star a channel', function () {
+    [, $team, $general] = starTeamWithGeneral();
+    $member = starMember($team, $general);
+
+    setStar($member, $team, $general, true)->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'starred' => true,
+    ]);
+});
+
+test('a member can unstar a channel', function () {
+    [, $team, $general] = starTeamWithGeneral();
+    $member = starMember($team, $general);
+    $member->channels()->updateExistingPivot($general->id, ['starred' => true]);
+
+    setStar($member, $team, $general, false)->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'starred' => false,
+    ]);
+});
+
+test('the sidebar reflects a channel star flag', function () {
+    [, $team, $general] = starTeamWithGeneral();
+    $member = starMember($team, $general);
+
+    expect(starSidebarEntry($member, $team, $general))
+        ->toMatchArray(['starred' => false]);
+
+    $member->channels()->updateExistingPivot($general->id, ['starred' => true]);
+
+    expect(starSidebarEntry($member, $team, $general))
+        ->toMatchArray(['starred' => true]);
+});
+
+test('one member starring a channel does not star it for another', function () {
+    [$owner, $team, $general] = starTeamWithGeneral();
+    $member = starMember($team, $general);
+
+    setStar($member, $team, $general, true)->assertRedirect();
+
+    expect(starSidebarEntry($owner, $team, $general))->toMatchArray(['starred' => false]);
+    expect(starSidebarEntry($member, $team, $general))->toMatchArray(['starred' => true]);
+});
+
+test('a non-member cannot star a channel', function () {
+    [$owner, $team] = starTeamWithGeneral();
+    $private = Channel::factory()->for($team)->create([
+        'visibility' => ChannelVisibility::Private,
+        'created_by' => $owner->id,
+    ]);
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    setStar($stranger, $team, $private, true)->assertForbidden();
+
+    $this->assertDatabaseMissing('channel_members', [
+        'channel_id' => $private->id,
+        'user_id' => $stranger->id,
+    ]);
+});
+
+test('starring requires a boolean flag', function () {
+    [, $team, $general] = starTeamWithGeneral();
+    $member = starMember($team, $general);
+
+    test()->actingAs($member)->patch(route('channels.star.update', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]), ['starred' => 'nope'])->assertSessionHasErrors('starred');
+});

--- a/tests/Feature/SidebarSectionTest.php
+++ b/tests/Feature/SidebarSectionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function sectionTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Read the shared `collapsedChannelSections` prop for the acting user off a
+ * channel page (where the workspace sidebar is rendered).
+ *
+ * @return array<int, string>
+ */
+function sidebarCollapsedProp(User $user, Team $team, Channel $channel): array
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]))->assertOk();
+
+    return $response->viewData('page')['props']['collapsedChannelSections'];
+}
+
+test('a user can collapse a sidebar section', function () {
+    [$owner, $team, $general] = sectionTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->patch(route('sidebar.sections.update'), ['collapsed' => ['starred']])
+        ->assertRedirect();
+
+    expect($owner->refresh()->collapsed_channel_sections)->toBe(['starred']);
+    expect(sidebarCollapsedProp($owner, $team, $general))->toBe(['starred']);
+});
+
+test('an empty payload clears every collapsed section', function () {
+    [$owner, $team, $general] = sectionTeamWithGeneral();
+    $owner->update(['collapsed_channel_sections' => ['starred', 'channels']]);
+
+    $this->actingAs($owner)
+        ->patch(route('sidebar.sections.update'), ['collapsed' => []])
+        ->assertRedirect();
+
+    expect($owner->refresh()->collapsed_channel_sections)->toBe([]);
+    expect(sidebarCollapsedProp($owner, $team, $general))->toBe([]);
+});
+
+test('collapsed sections default to empty for a fresh user', function () {
+    [$owner, $team, $general] = sectionTeamWithGeneral();
+
+    expect($owner->collapsed_channel_sections)->toBeNull();
+    expect(sidebarCollapsedProp($owner, $team, $general))->toBe([]);
+});
+
+test('duplicate section keys are stored once', function () {
+    [$owner] = sectionTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->patch(route('sidebar.sections.update'), ['collapsed' => ['channels', 'channels']])
+        ->assertRedirect();
+
+    expect($owner->refresh()->collapsed_channel_sections)->toBe(['channels']);
+});
+
+test('unknown section keys are rejected', function () {
+    [$owner] = sectionTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->patch(route('sidebar.sections.update'), ['collapsed' => ['bogus']])
+        ->assertSessionHasErrors('collapsed.0');
+
+    expect($owner->refresh()->collapsed_channel_sections)->toBeNull();
+});
+
+test('the collapsed payload must be present', function () {
+    [$owner] = sectionTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->patch(route('sidebar.sections.update'), [])
+        ->assertSessionHasErrors('collapsed');
+});
+
+test('a guest cannot persist sidebar sections', function () {
+    $this->patch(route('sidebar.sections.update'), ['collapsed' => ['starred']])
+        ->assertRedirect(route('login'));
+});


### PR DESCRIPTION
Implements **Phase 1** of #41: starred/favorite channels and collapsible sidebar sections, persisted per user across reloads and devices. Custom user-defined sections and drag-reordering are deferred to #88.

## What's included

**Star / favorite channels**
- `channel_members.starred` (per-user) surfaced on the shared `channels` prop via `ChannelData`.
- `PATCH channels.star.update` → `ChannelStarController` → `SetChannelStar`, gated by a new `updateStar` policy ability (members only).
- Starred channels pin into a new **Starred** section above the main list. A star toggle sits to the left of each channel name, and a Star/Unstar item is added to the channel header menu.

**Collapsible sections (persisted per user)**
- `users.collapsed_channel_sections` (`jsonb`) stores which built-in sections are collapsed.
- `PATCH sidebar/sections` → `SidebarSectionController`, validated against known section keys.
- Starred and Channels sections collapse via chevrons; workspace nav (Threads/Search/Browse) stays always-visible.
- `jsonb` (not `json`) so the existing `SELECT DISTINCT users.*` thread-participants query keeps working on Postgres.

## Acceptance criteria (from #41)
- [x] Star/unstar a channel; starred appear in a pinned section
- [x] Persists across reloads/devices (DB-backed)
- [x] Collapsible sections, collapse state persisted per user
- [x] Test coverage for persistence and ordering
- [ ] User-defined sections with drag-ordering → deferred to #88

## Testing
- `ChannelStarTest`, `SidebarSectionTest` (feature) + `channelSections` vitest specs.
- Full gate green: Pint, PHPStan, **377 tests at 100.0% coverage**; frontend lint/format/types/build all pass.

Closes #41 (Phase 1). Follow-up: #88.