### PR TITLE
feat(navigation): custom user-defined sidebar sections with drag-ordering (#88)

### DIFF
--- a/app/Actions/Channels/SetChannelPlacement.php
+++ b/app/Actions/Channels/SetChannelPlacement.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+
+class SetChannelPlacement
+{
+    /**
+     * Place a channel within the sidebar: file it under a section and/or reorder
+     * the group it now lives in.
+     *
+     * `$orderedIds` is the full, ordered list of channel ids in the target group;
+     * each of the user's matching memberships takes its index as the new position,
+     * so a drag persists the whole group's order in one write. When `$moveSection`
+     * is true the dragged channel's `section_id` is set to `$sectionId` (null for
+     * the default "Channels" group); a pure within-group reorder leaves the
+     * assignment untouched.
+     *
+     * Only the user's own pivot rows in the team are written, so ids for channels
+     * they don't belong to — or in another team — are ignored.
+     *
+     * @param  list<string>  $orderedIds
+     */
+    public function handle(User $user, Team $team, Channel $channel, array $orderedIds, bool $moveSection, ?string $sectionId): void
+    {
+        $memberChannelIds = $user->channels()
+            ->where('channels.team_id', $team->id)
+            ->pluck('channels.id')
+            ->all();
+
+        foreach ($orderedIds as $index => $id) {
+            if (in_array($id, $memberChannelIds, true)) {
+                $user->channels()->updateExistingPivot($id, ['position' => $index]);
+            }
+        }
+
+        if ($moveSection) {
+            $user->channels()->updateExistingPivot($channel->id, ['section_id' => $sectionId]);
+        }
+    }
+}

--- a/app/Actions/Sidebar/CreateChannelSection.php
+++ b/app/Actions/Sidebar/CreateChannelSection.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions\Sidebar;
+
+use App\Models\ChannelSection;
+use App\Models\Team;
+use App\Models\User;
+
+class CreateChannelSection
+{
+    /**
+     * Create a custom sidebar section for the user in the team.
+     *
+     * The new section is appended after the user's existing sections in the team,
+     * so a freshly created section lands at the bottom of the custom groups.
+     */
+    public function handle(User $user, Team $team, string $name): ChannelSection
+    {
+        $nextPosition = (int) $user->channelSections()
+            ->where('team_id', $team->id)
+            ->max('position');
+
+        return $user->channelSections()->create([
+            'team_id' => $team->id,
+            'name' => $name,
+            'position' => $nextPosition + 1,
+            'collapsed' => false,
+        ]);
+    }
+}

--- a/app/Actions/Sidebar/DeleteChannelSection.php
+++ b/app/Actions/Sidebar/DeleteChannelSection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Actions\Sidebar;
+
+use App\Models\ChannelSection;
+
+class DeleteChannelSection
+{
+    /**
+     * Delete a custom sidebar section.
+     *
+     * Channels filed under the section keep their membership and fall back to the
+     * default "Channels" group: the `section_id` foreign key is defined
+     * `nullOnDelete`, so the database clears their assignment automatically.
+     */
+    public function handle(ChannelSection $section): void
+    {
+        $section->delete();
+    }
+}

--- a/app/Actions/Sidebar/ReorderChannelSections.php
+++ b/app/Actions/Sidebar/ReorderChannelSections.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Actions\Sidebar;
+
+use App\Models\Team;
+use App\Models\User;
+
+class ReorderChannelSections
+{
+    /**
+     * Persist the user's manual order of their custom sections in the team.
+     *
+     * Each id is assigned its index as the new position, so the sidebar renders
+     * the sections in exactly the order given. Scoped to the user's own sections
+     * in the team, so ids for other users or teams are ignored.
+     *
+     * @param  list<string>  $orderedIds
+     */
+    public function handle(User $user, Team $team, array $orderedIds): void
+    {
+        $sections = $user->channelSections()
+            ->where('team_id', $team->id)
+            ->pluck('id')
+            ->all();
+
+        foreach ($orderedIds as $index => $id) {
+            if (in_array($id, $sections, true)) {
+                $user->channelSections()->whereKey($id)->update(['position' => $index]);
+            }
+        }
+    }
+}

--- a/app/Actions/Sidebar/UpdateChannelSection.php
+++ b/app/Actions/Sidebar/UpdateChannelSection.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions\Sidebar;
+
+use App\Models\ChannelSection;
+
+class UpdateChannelSection
+{
+    /**
+     * Rename and/or collapse a custom sidebar section.
+     *
+     * Only the attributes present in `$attributes` are applied, so the endpoint
+     * can rename a section and toggle its collapse independently.
+     *
+     * @param  array{name?: string, collapsed?: bool}  $attributes
+     */
+    public function handle(ChannelSection $section, array $attributes): ChannelSection
+    {
+        $section->fill(array_intersect_key($attributes, array_flip(['name', 'collapsed'])));
+        $section->save();
+
+        return $section;
+    }
+}

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -25,6 +25,8 @@ class ChannelData extends Data
         public bool $hasDraft = false,
         public ?string $draft = null,
         public bool $starred = false,
+        public ?string $sectionId = null,
+        public int $position = 0,
     ) {}
 
     /**
@@ -47,6 +49,10 @@ class ChannelData extends Data
      *
      * `starred` is the viewer's own favorite flag, driving whether the channel is
      * pinned to the sidebar's "Starred" section.
+     *
+     * `sectionId` is the custom section the viewer has filed the channel under
+     * (null for the default "Channels" group), and `position` is its manual order
+     * within whichever group it renders in.
      */
     public static function fromChannel(Channel $channel): self
     {
@@ -65,6 +71,11 @@ class ChannelData extends Data
 
         $starred = (bool) ($channel->getAttribute('starred') ?? false);
 
+        $sectionId = $channel->getAttribute('section_id');
+        $sectionId = is_string($sectionId) ? $sectionId : null;
+
+        $position = (int) ($channel->getAttribute('position') ?? 0);
+
         return new self(
             id: $channel->id,
             name: $channel->name,
@@ -80,6 +91,8 @@ class ChannelData extends Data
             hasDraft: $hasDraft,
             draft: $draft,
             starred: $starred,
+            sectionId: $sectionId,
+            position: $position,
         );
     }
 }

--- a/app/Data/ChannelSectionData.php
+++ b/app/Data/ChannelSectionData.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\ChannelSection;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class ChannelSectionData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public int $position,
+        public bool $collapsed,
+    ) {}
+
+    /**
+     * Build the DTO from a ChannelSection model for the sidebar prop.
+     */
+    public static function fromSection(ChannelSection $section): self
+    {
+        return new self(
+            id: $section->id,
+            name: $section->name,
+            position: $section->position,
+            collapsed: $section->collapsed,
+        );
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelPlacementController.php
+++ b/app/Http/Controllers/Channels/ChannelPlacementController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\SetChannelPlacement;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\UpdateChannelPlacementRequest;
+use App\Models\Channel;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+
+class ChannelPlacementController extends Controller
+{
+    /**
+     * Place the channel within the sidebar for the current user: file it under a
+     * section and/or reorder the group it now lives in.
+     *
+     * Redirects back and lets Inertia recompute the shared `channels` prop so the
+     * sidebar re-partitions without a full reload.
+     */
+    public function update(UpdateChannelPlacementRequest $request, Team $team, Channel $channel, SetChannelPlacement $setChannelPlacement): RedirectResponse
+    {
+        $setChannelPlacement->handle(
+            user: $request->user(),
+            team: $team,
+            channel: $channel,
+            orderedIds: $request->orderedIds(),
+            moveSection: $request->movesSection(),
+            sectionId: $request->input('section_id'),
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelSectionController.php
+++ b/app/Http/Controllers/Channels/ChannelSectionController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Sidebar\CreateChannelSection;
+use App\Actions\Sidebar\DeleteChannelSection;
+use App\Actions\Sidebar\ReorderChannelSections;
+use App\Actions\Sidebar\UpdateChannelSection;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Sidebar\DeleteChannelSectionRequest;
+use App\Http\Requests\Sidebar\ReorderChannelSectionsRequest;
+use App\Http\Requests\Sidebar\StoreChannelSectionRequest;
+use App\Http\Requests\Sidebar\UpdateChannelSectionRequest;
+use App\Models\ChannelSection;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+
+class ChannelSectionController extends Controller
+{
+    /**
+     * Create a custom sidebar section for the current user in the team.
+     *
+     * Redirects back and lets Inertia recompute the shared `channelSections` prop
+     * so the new section appears without a full reload.
+     */
+    public function store(StoreChannelSectionRequest $request, Team $team, CreateChannelSection $createChannelSection): RedirectResponse
+    {
+        $createChannelSection->handle($request->user(), $team, $request->validated('name'));
+
+        return back();
+    }
+
+    /**
+     * Rename and/or collapse a custom sidebar section.
+     */
+    public function update(UpdateChannelSectionRequest $request, Team $team, ChannelSection $section, UpdateChannelSection $updateChannelSection): RedirectResponse
+    {
+        $updateChannelSection->handle($section, $request->validated());
+
+        return back();
+    }
+
+    /**
+     * Delete a custom sidebar section, returning its channels to the default group.
+     */
+    public function destroy(DeleteChannelSectionRequest $request, Team $team, ChannelSection $section, DeleteChannelSection $deleteChannelSection): RedirectResponse
+    {
+        $deleteChannelSection->handle($section);
+
+        return back();
+    }
+
+    /**
+     * Persist the user's manual order of their custom sections in the team.
+     */
+    public function reorder(ReorderChannelSectionsRequest $request, Team $team, ReorderChannelSections $reorderChannelSections): RedirectResponse
+    {
+        $reorderChannelSections->handle($request->user(), $team, $request->validated('sections'));
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use App\Data\ChannelData;
+use App\Data\ChannelSectionData;
 use App\Models\Message;
 use App\Models\Team;
 use App\Models\TeamInvitation;
@@ -54,6 +55,7 @@ class HandleInertiaRequests extends Middleware
             'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
             'teams' => fn () => $user?->toUserTeams(includeCurrent: true) ?? [],
             'channels' => fn () => $this->channelsForSidebar($request, $user),
+            'channelSections' => fn () => $this->channelSectionsForSidebar($request, $user),
             'collapsedChannelSections' => fn () => $user->collapsed_channel_sections ?? [],
             'hasUnreadThreads' => fn () => $this->hasUnreadThreads($request, $user),
             'pendingInvitations' => Inertia::optional(fn () => $user ? $this->pendingInvitationsFor($user) : []),
@@ -77,7 +79,7 @@ class HandleInertiaRequests extends Middleware
             ->where('channels.team_id', $team->id)
             ->whereNull('channels.archived_at')
             ->select('channels.*')
-            ->addSelect(['channel_members.muted', 'channel_members.notification_level', 'channel_members.starred'])
+            ->addSelect(['channel_members.muted', 'channel_members.notification_level', 'channel_members.starred', 'channel_members.section_id', 'channel_members.position'])
             // Only the presence of a draft drives the sidebar cue; the draft text
             // itself is shipped solely to the open channel, so keep it out of the
             // sidebar payload and expose a 1/0 flag instead (an integer, not a
@@ -89,10 +91,39 @@ class HandleInertiaRequests extends Middleware
             ->selectSub($this->unreadMessages($user)
                 ->where(fn (Builder $query) => $query->whereNull('messages.thread_root_id')->orWhere('messages.sent_to_channel', true)), 'unread_count')
             ->selectSub($this->unreadMessages($user)->whereHas('mentionedUsers', fn ($query) => $query->whereKey($user->id)), 'mention_count')
-            ->orderBy('name')
+            // Manual order within each sidebar group first, then alphabetical as a
+            // stable tiebreak for channels the user has never reordered.
+            ->orderBy('channel_members.position')
+            ->orderBy('channels.name')
             ->get();
 
         return ChannelData::collect($channels, 'array');
+    }
+
+    /**
+     * The current user's custom sidebar sections for the team in the URL.
+     *
+     * Ordered by the user's manual section order, so the sidebar can render the
+     * custom groups between "Starred" and the default "Channels" list. Empty off
+     * the channel workspace, where the sidebar is absent.
+     *
+     * @return array<int, ChannelSectionData>
+     */
+    protected function channelSectionsForSidebar(Request $request, ?User $user): array
+    {
+        $team = $request->route('team');
+
+        if (! $user || ! $team instanceof Team || ! $request->routeIs('channels.*')) {
+            return [];
+        }
+
+        $sections = $user->channelSections()
+            ->where('team_id', $team->id)
+            ->orderBy('position')
+            ->orderBy('created_at')
+            ->get();
+
+        return ChannelSectionData::collect($sections, 'array');
     }
 
     /**

--- a/app/Http/Requests/Channels/UpdateChannelPlacementRequest.php
+++ b/app/Http/Requests/Channels/UpdateChannelPlacementRequest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use App\Models\Team;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+
+class UpdateChannelPlacementRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('place', $this->channel());
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * `ordered_ids` is the full order of the target group (channel ids the user
+     * belongs to). `section_id` is optional: omit it for a pure within-group
+     * reorder, send a section uuid (or null for the default group) to move the
+     * channel. A supplied uuid must be one of the user's own sections in the team.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'section_id' => [
+                'sometimes',
+                'nullable',
+                'uuid',
+                Rule::exists('channel_sections', 'id')
+                    ->where('user_id', $this->user()?->id)
+                    ->where('team_id', $this->team()->id),
+            ],
+            'ordered_ids' => ['present', 'array'],
+            'ordered_ids.*' => [
+                'uuid',
+                Rule::exists('channel_members', 'channel_id')->where('user_id', $this->user()?->id),
+            ],
+        ];
+    }
+
+    /**
+     * Whether the request moves the channel to a (possibly default) section, as
+     * opposed to only reordering within its current group.
+     */
+    public function movesSection(): bool
+    {
+        return $this->has('section_id');
+    }
+
+    /**
+     * Get the ids of the target group's channels in their new order.
+     *
+     * @return list<string>
+     */
+    public function orderedIds(): array
+    {
+        return array_values($this->validated('ordered_ids'));
+    }
+
+    /**
+     * Get the channel being placed.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+
+    /**
+     * Get the team the channel belongs to.
+     */
+    public function team(): Team
+    {
+        $team = $this->route('team');
+
+        abort_if(! $team instanceof Team, 404);
+
+        return $team;
+    }
+}

--- a/app/Http/Requests/Sidebar/DeleteChannelSectionRequest.php
+++ b/app/Http/Requests/Sidebar/DeleteChannelSectionRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests\Sidebar;
+
+use App\Models\ChannelSection;
+use App\Models\Team;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class DeleteChannelSectionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Only the section's owner may delete it, and it must belong to the team in
+     * the URL.
+     */
+    public function authorize(): bool
+    {
+        $section = $this->section();
+
+        return $section->team_id === $this->team()->id
+            && Gate::allows('delete', $section);
+    }
+
+    /**
+     * Get the section being deleted.
+     */
+    public function section(): ChannelSection
+    {
+        $section = $this->route('section');
+
+        abort_if(! $section instanceof ChannelSection, 404);
+
+        return $section;
+    }
+
+    /**
+     * Get the team the section belongs to.
+     */
+    public function team(): Team
+    {
+        $team = $this->route('team');
+
+        abort_if(! $team instanceof Team, 404);
+
+        return $team;
+    }
+}

--- a/app/Http/Requests/Sidebar/ReorderChannelSectionsRequest.php
+++ b/app/Http/Requests/Sidebar/ReorderChannelSectionsRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests\Sidebar;
+
+use App\Models\Team;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ReorderChannelSectionsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->belongsToTeam($this->team()) ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * Every id must be one of the user's own sections in the team, so the payload
+     * can only reorder sections they actually own.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'sections' => ['present', 'array'],
+            'sections.*' => [
+                'uuid',
+                Rule::exists('channel_sections', 'id')
+                    ->where('user_id', $this->user()?->id)
+                    ->where('team_id', $this->team()->id),
+            ],
+        ];
+    }
+
+    /**
+     * Get the team whose sections are being reordered.
+     */
+    public function team(): Team
+    {
+        $team = $this->route('team');
+
+        abort_if(! $team instanceof Team, 404);
+
+        return $team;
+    }
+}

--- a/app/Http/Requests/Sidebar/StoreChannelSectionRequest.php
+++ b/app/Http/Requests/Sidebar/StoreChannelSectionRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests\Sidebar;
+
+use App\Models\Team;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreChannelSectionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Sections are personal, so any member of the team in the URL may create one
+     * for themselves.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->belongsToTeam($this->team()) ?? false;
+    }
+
+    /**
+     * Trim surrounding whitespace from the section name before validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'name' => trim((string) $this->input('name')),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:50'],
+        ];
+    }
+
+    /**
+     * Get the team the section is being created in.
+     */
+    public function team(): Team
+    {
+        $team = $this->route('team');
+
+        abort_if(! $team instanceof Team, 404);
+
+        return $team;
+    }
+}

--- a/app/Http/Requests/Sidebar/UpdateChannelSectionRequest.php
+++ b/app/Http/Requests/Sidebar/UpdateChannelSectionRequest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Requests\Sidebar;
+
+use App\Models\ChannelSection;
+use App\Models\Team;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class UpdateChannelSectionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Only the section's owner may edit it, and it must belong to the team in the
+     * URL so the redirect re-renders the sidebar it lives in.
+     */
+    public function authorize(): bool
+    {
+        $section = $this->section();
+
+        return $section->team_id === $this->team()->id
+            && Gate::allows('update', $section);
+    }
+
+    /**
+     * Trim a supplied section name before validation, leaving it absent when the
+     * request only toggles the collapse state.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('name')) {
+            $this->merge(['name' => trim((string) $this->input('name'))]);
+        }
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * A rename and a collapse toggle are independent: either may be sent alone,
+     * but an empty payload (neither field) is rejected.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required_without:collapsed', 'string', 'max:50'],
+            'collapsed' => ['required_without:name', 'boolean'],
+        ];
+    }
+
+    /**
+     * Get the section being updated.
+     */
+    public function section(): ChannelSection
+    {
+        $section = $this->route('section');
+
+        abort_if(! $section instanceof ChannelSection, 404);
+
+        return $section;
+    }
+
+    /**
+     * Get the team the section belongs to.
+     */
+    public function team(): Team
+    {
+        $team = $this->route('team');
+
+        abort_if(! $team instanceof Team, 404);
+
+        return $team;
+    }
+}

--- a/app/Models/ChannelMember.php
+++ b/app/Models/ChannelMember.php
@@ -20,12 +20,15 @@ use Illuminate\Support\Carbon;
  * @property NotificationLevel $notification_level
  * @property string|null $draft
  * @property bool $starred
+ * @property string|null $section_id
+ * @property int $position
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Channel $channel
  * @property-read User $user
+ * @property-read ChannelSection|null $section
  */
-#[Fillable(['channel_id', 'user_id', 'last_read_message_id', 'muted', 'notification_level', 'draft', 'starred'])]
+#[Fillable(['channel_id', 'user_id', 'last_read_message_id', 'muted', 'notification_level', 'draft', 'starred', 'section_id', 'position'])]
 class ChannelMember extends Model
 {
     /** @use HasFactory<ChannelMemberFactory> */
@@ -42,6 +45,7 @@ class ChannelMember extends Model
             'muted' => 'boolean',
             'notification_level' => NotificationLevel::class,
             'starred' => 'boolean',
+            'position' => 'integer',
         ];
     }
 
@@ -53,6 +57,16 @@ class ChannelMember extends Model
     public function channel(): BelongsTo
     {
         return $this->belongsTo(Channel::class);
+    }
+
+    /**
+     * Get the custom section the membership is filed under, if any.
+     *
+     * @return BelongsTo<ChannelSection, $this>
+     */
+    public function section(): BelongsTo
+    {
+        return $this->belongsTo(ChannelSection::class, 'section_id');
     }
 
     /**

--- a/app/Models/ChannelSection.php
+++ b/app/Models/ChannelSection.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\ChannelSectionFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $team_id
+ * @property string $name
+ * @property int $position
+ * @property bool $collapsed
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ * @property-read Team $team
+ * @property-read Collection<int, ChannelMember> $channelMembers
+ */
+#[Fillable(['user_id', 'team_id', 'name', 'position', 'collapsed'])]
+class ChannelSection extends Model
+{
+    /** @use HasFactory<ChannelSectionFactory> */
+    use HasFactory, HasUuids;
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+            'collapsed' => 'boolean',
+        ];
+    }
+
+    /**
+     * Get the user who owns the section.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the team the section belongs to.
+     *
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    /**
+     * Get the channel memberships filed under this section.
+     *
+     * @return HasMany<ChannelMember, $this>
+     */
+    public function channelMembers(): HasMany
+    {
+        return $this->hasMany(ChannelMember::class, 'section_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
@@ -36,6 +37,7 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, Membership> $teamMemberships
  * @property-read Collection<int, Team> $teams
  * @property-read Collection<int, Channel> $channels
+ * @property-read Collection<int, ChannelSection> $channelSections
  */
 #[Fillable(['name', 'email', 'password', 'current_team_id', 'chime_sound', 'collapsed_channel_sections'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
@@ -67,7 +69,17 @@ class User extends Authenticatable
     public function channels(): BelongsToMany
     {
         return $this->belongsToMany(Channel::class, 'channel_members')
-            ->withPivot(['last_read_message_id', 'muted', 'notification_level', 'draft', 'starred'])
+            ->withPivot(['last_read_message_id', 'muted', 'notification_level', 'draft', 'starred', 'section_id', 'position'])
             ->withTimestamps();
+    }
+
+    /**
+     * Get the user's custom sidebar sections across all their teams.
+     *
+     * @return HasMany<ChannelSection, $this>
+     */
+    public function channelSections(): HasMany
+    {
+        return $this->hasMany(ChannelSection::class);
     }
 }

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -60,6 +60,20 @@ class ChannelPolicy
     }
 
     /**
+     * Determine whether the user can place the channel in the sidebar (file it
+     * under a custom section or reorder it).
+     *
+     * The placement lives on the membership pivot, so only a member of the channel
+     * (within the team) has one to change, and each member only ever touches their
+     * own row.
+     */
+    public function place(User $user, Channel $channel): bool
+    {
+        return $user->belongsToTeam($channel->team)
+            && $channel->members()->whereKey($user->id)->exists();
+    }
+
+    /**
      * Determine whether the user can save their own composer draft for the channel.
      *
      * Drafts live on the membership pivot, so only a member of the channel

--- a/app/Policies/ChannelSectionPolicy.php
+++ b/app/Policies/ChannelSectionPolicy.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\ChannelSection;
+use App\Models\User;
+
+class ChannelSectionPolicy
+{
+    /**
+     * Determine whether the user can update (rename or collapse) the section.
+     *
+     * Sections are private to the user who created them, so only the owner may
+     * touch one.
+     */
+    public function update(User $user, ChannelSection $section): bool
+    {
+        return $section->user_id === $user->id;
+    }
+
+    /**
+     * Determine whether the user can delete the section.
+     */
+    public function delete(User $user, ChannelSection $section): bool
+    {
+        return $section->user_id === $user->id;
+    }
+}

--- a/database/factories/ChannelSectionFactory.php
+++ b/database/factories/ChannelSectionFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ChannelSection;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ChannelSection>
+ */
+class ChannelSectionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'team_id' => Team::factory(),
+            'name' => fake()->unique()->words(2, true),
+            'position' => 0,
+            'collapsed' => false,
+        ];
+    }
+
+    /**
+     * Indicate the section is collapsed.
+     */
+    public function collapsed(): static
+    {
+        return $this->state(fn (array $attributes): array => ['collapsed' => true]);
+    }
+
+    /**
+     * Place the section at the given position among the user's sections.
+     */
+    public function position(int $position): static
+    {
+        return $this->state(fn (array $attributes): array => ['position' => $position]);
+    }
+}

--- a/database/migrations/2026_07_09_205710_create_channel_sections_table.php
+++ b/database/migrations/2026_07_09_205710_create_channel_sections_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('channel_sections', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            // A custom section is owned by one user within one team, so each user
+            // curates their own sidebar grouping independently. Both cascade so a
+            // section is cleaned up when the user or team goes away.
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            // Order of the user's custom sections within the team, lowest first.
+            $table->integer('position')->default(0);
+            // Per-section collapse state. Built-in sections persist their collapse
+            // on `users.collapsed_channel_sections`; custom sections carry their own.
+            $table->boolean('collapsed')->default(false);
+            $table->timestamps();
+
+            $table->index(['user_id', 'team_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('channel_sections');
+    }
+};

--- a/database/migrations/2026_07_09_205711_add_section_to_channel_members_table.php
+++ b/database/migrations/2026_07_09_205711_add_section_to_channel_members_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channel_members', function (Blueprint $table) {
+            // The custom section the member has filed this channel under, or null
+            // for the default "Channels" group. Deleting the section returns the
+            // channel to the default group rather than dropping the membership.
+            $table->foreignUuid('section_id')->nullable()->after('starred')
+                ->constrained('channel_sections')->nullOnDelete();
+            // The channel's manual order within whichever group it renders in
+            // (Starred, a custom section, or the default list). Ties fall back to
+            // the alphabetical name order the sidebar query already applies.
+            $table->integer('position')->default(0)->after('section_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channel_members', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('section_id');
+            $table->dropColumn('position');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
                 "tailwindcss": "^4.1.1",
                 "tw-animate-css": "^1.2.5",
                 "vue": "^3.5.13",
-                "vue-sonner": "^2.0.0"
+                "vue-sonner": "^2.0.0",
+                "vuedraggable": "^4.1.0"
             },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
@@ -9669,6 +9670,12 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
+        "node_modules/sortablejs": {
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+            "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+            "license": "MIT"
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10981,6 +10988,18 @@
             },
             "peerDependencies": {
                 "typescript": ">=5.0.0"
+            }
+        },
+        "node_modules/vuedraggable": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+            "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+            "license": "MIT",
+            "dependencies": {
+                "sortablejs": "1.14.0"
+            },
+            "peerDependencies": {
+                "vue": "^3.0.1"
             }
         },
         "node_modules/web-worker": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
         "tailwindcss": "^4.1.1",
         "tw-animate-css": "^1.2.5",
         "vue": "^3.5.13",
-        "vue-sonner": "^2.0.0"
+        "vue-sonner": "^2.0.0",
+        "vuedraggable": "^4.1.0"
     },
     "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5",

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -1,17 +1,43 @@
 <script setup lang="ts">
 import { Link, router } from '@inertiajs/vue3';
-import { Pencil, Star } from '@lucide/vue';
+import { GripVertical, MoreVertical, Pencil, Star } from '@lucide/vue';
+import { ref } from 'vue';
 import { toast } from 'vue-sonner';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
-import type { Channel } from '@/types/channels';
+import type { Channel, ChannelSection } from '@/types/channels';
 
 const props = defineProps<{
     channel: Channel;
     teamSlug: string;
     activeChannelSlug: string | null;
+    /** The user's custom sections, offered as move targets in the kebab menu. */
+    sections?: ChannelSection[];
+    /** The section this row currently renders in (null for the default group). */
+    currentSectionId?: string | null;
 }>();
+
+/**
+ * Ask the parent to file this channel under a different section (null moves it
+ * back to the default "Channels" group). The parent owns the placement request
+ * because it knows the target group's full order.
+ */
+const emit = defineEmits<{
+    move: [sectionId: string | null];
+}>();
+
+// Keep the hover controls visible while the move menu is open, so a click on a
+// menu item doesn't dismiss the row's actions mid-interaction.
+const menuOpen = ref(false);
 
 /**
  * Star or unstar the channel, reloading only the shared `channels` prop so the
@@ -37,7 +63,7 @@ function toggleStar(): void {
 </script>
 
 <template>
-    <SidebarMenuItem>
+    <SidebarMenuItem class="group/row relative">
         <SidebarMenuButton
             as-child
             :is-active="channel.slug === activeChannelSlug"
@@ -127,5 +153,59 @@ function toggleStar(): void {
                 :class="channel.starred ? 'fill-current' : ''"
             />
         </button>
+        <!-- Hover controls on the right: a drag handle (the SortableJS handle for
+             reordering rows) and a kebab menu to file the channel under a custom
+             section. Revealed on hover or focus, and pinned open while the menu
+             is; a solid background masks any unread badge underneath. -->
+        <div
+            class="absolute top-1/2 right-1 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md bg-sidebar pl-1 opacity-0 transition group-hover/row:opacity-100 group-data-[active=true]/row:bg-sidebar-accent focus-within:opacity-100"
+            :class="menuOpen ? 'opacity-100' : ''"
+        >
+            <button
+                type="button"
+                :data-test="`channel-drag-handle-${channel.slug}`"
+                :aria-label="`Reorder ${channel.name}`"
+                title="Drag to reorder"
+                class="channel-drag-handle flex size-5 cursor-grab items-center justify-center rounded text-muted-foreground/60 transition hover:text-sidebar-foreground active:cursor-grabbing"
+            >
+                <GripVertical class="size-3.5" />
+            </button>
+            <DropdownMenu
+                v-if="(sections?.length ?? 0) > 0"
+                v-model:open="menuOpen"
+            >
+                <DropdownMenuTrigger as-child>
+                    <button
+                        type="button"
+                        :data-test="`channel-menu-${channel.slug}`"
+                        :aria-label="`Channel options for ${channel.name}`"
+                        title="More options"
+                        class="flex size-5 items-center justify-center rounded text-muted-foreground/60 transition hover:text-sidebar-foreground data-[state=open]:text-sidebar-foreground"
+                    >
+                        <MoreVertical class="size-3.5" />
+                    </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" class="w-52">
+                    <DropdownMenuLabel>Move to</DropdownMenuLabel>
+                    <DropdownMenuItem
+                        v-for="section in sections"
+                        :key="section.id"
+                        :disabled="section.id === (currentSectionId ?? null)"
+                        :data-test="`move-to-${section.id}`"
+                        @select="emit('move', section.id)"
+                    >
+                        <span class="truncate">{{ section.name }}</span>
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                        :disabled="(currentSectionId ?? null) === null"
+                        data-test="move-to-default"
+                        @select="emit('move', null)"
+                    >
+                        Channels
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
     </SidebarMenuItem>
 </template>

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -2,17 +2,30 @@
 import { Link, router, usePage } from '@inertiajs/vue3';
 import {
     ChevronRight,
+    FolderPlus,
+    GripVertical,
     MessageSquareText,
     MessagesSquare,
+    MoreVertical,
+    Pencil,
     Plus,
     Search,
+    Trash2,
 } from '@lucide/vue';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { toast } from 'vue-sonner';
+import draggable from 'vuedraggable';
 import {
     browse,
     show,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { update as updateChannelPlacement } from '@/actions/App/Http/Controllers/Channels/ChannelPlacementController';
+import {
+    destroy as destroySection,
+    reorder as reorderSections,
+    store as storeSection,
+    update as updateSection,
+} from '@/actions/App/Http/Controllers/Channels/ChannelSectionController';
 import { index as searchMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
 import { index as threadsInbox } from '@/actions/App/Http/Controllers/Channels/ThreadsController';
 import { update as updateSidebarSections } from '@/actions/App/Http/Controllers/SidebarSectionController';
@@ -24,6 +37,12 @@ import NavUser from '@/components/NavUser.vue';
 import PendingInvitationsModal from '@/components/PendingInvitationsModal.vue';
 import QuickSwitcher from '@/components/QuickSwitcher.vue';
 import TeamSwitcher from '@/components/TeamSwitcher.vue';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import {
     Sidebar,
@@ -56,6 +75,7 @@ import {
     toggleCollapsedSection,
 } from '@/lib/channelSections';
 import type { SidebarSectionKey } from '@/lib/channelSections';
+import type { Channel, ChannelSection } from '@/types/channels';
 
 const page = usePage();
 
@@ -75,12 +95,295 @@ const activeChannelSlug = computed(
 const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
 const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
 
-// Split the flat channel list into the pinned "Starred" section and the main
-// list, re-derived whenever the shared `channels` prop changes (a star toggle or
-// a live badge update).
-const sections = computed(() => partitionChannels(channels.value));
-const starredChannels = computed(() => sections.value.starred);
-const otherChannels = computed(() => sections.value.others);
+// The user's custom sidebar sections for the current team, kept in their
+// persisted order.
+const customSections = computed<ChannelSection[]>(
+    () => page.props.channelSections ?? [],
+);
+
+// Local, drag-mutable copies of each sidebar group. vuedraggable writes to these
+// arrays as the user drags; they are re-seeded from the shared props whenever the
+// server recomputes them (a star toggle, a live badge update, or a persisted
+// reorder round-tripping), so the layout follows the user across devices.
+const starredList = ref<Channel[]>([]);
+const defaultList = ref<Channel[]>([]);
+const customGroups = ref<{ section: ChannelSection; channels: Channel[] }[]>(
+    [],
+);
+
+function syncSidebarGroups(): void {
+    const partitioned = partitionChannels(channels.value, customSections.value);
+    starredList.value = [...partitioned.starred];
+    defaultList.value = [...partitioned.others];
+    customGroups.value = partitioned.custom.map((group) => ({
+        section: group.section,
+        channels: [...group.channels],
+    }));
+}
+
+watch([channels, customSections], syncSidebarGroups, { immediate: true });
+
+/**
+ * Persist a channel's placement: reorder the group it now lives in, and — when
+ * `sectionId` is provided — file it under that section (null for the default
+ * "Channels" group). Only the shared `channels` prop is reloaded so the sidebar
+ * re-partitions in place.
+ */
+function persistPlacement(
+    channel: Channel,
+    orderedList: Channel[],
+    sectionId: string | null | undefined,
+): void {
+    const payload: { ordered_ids: string[]; section_id?: string | null } = {
+        ordered_ids: orderedList.map((entry) => entry.id),
+    };
+
+    if (sectionId !== undefined) {
+        payload.section_id = sectionId;
+    }
+
+    router.patch(
+        updateChannelPlacement({
+            team: currentTeam.value?.slug ?? '',
+            channel: channel.slug,
+        }).url,
+        payload,
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channels'],
+            onError: () => {
+                syncSidebarGroups();
+                toast.error(
+                    'Failed to save the sidebar layout. Please try again.',
+                );
+            },
+        },
+    );
+}
+
+/**
+ * Handle a vuedraggable change within one channel group. A `moved` event is a
+ * pure reorder (the assignment is left untouched); an `added` event means the
+ * channel was dragged in from another group, so it is filed under this group's
+ * section as well.
+ */
+type ChannelDragChange = {
+    moved?: { element: Channel };
+    added?: { element: Channel };
+};
+
+function onChannelChange(
+    change: ChannelDragChange,
+    list: Channel[],
+    sectionId: string | null,
+): void {
+    if (change.added) {
+        persistPlacement(change.added.element, list, sectionId);
+    } else if (change.moved) {
+        persistPlacement(change.moved.element, list, undefined);
+    }
+}
+
+/**
+ * A reorder within the "Starred" group. Starred channels keep any section
+ * assignment, so only their order is persisted.
+ */
+function onStarredChange(change: ChannelDragChange): void {
+    if (change.moved) {
+        persistPlacement(change.moved.element, starredList.value, undefined);
+    }
+}
+
+/**
+ * File a channel under a section (or the default group) from its kebab menu,
+ * appending it to the end of the target group's current order.
+ */
+function moveChannelToSection(
+    channel: Channel,
+    sectionId: string | null,
+): void {
+    const target =
+        sectionId === null
+            ? defaultList.value
+            : (customGroups.value.find(
+                  (group) => group.section.id === sectionId,
+              )?.channels ?? []);
+
+    persistPlacement(channel, [...target, channel], sectionId);
+}
+
+/**
+ * Persist the manual order of the custom sections after a drag.
+ */
+type ChannelGroup = { section: ChannelSection; channels: Channel[] };
+
+/**
+ * The vuedraggable item key for a custom section row.
+ */
+function sectionKey(group: ChannelGroup): string {
+    return group.section.id;
+}
+
+function onSectionReorder(): void {
+    router.patch(
+        reorderSections({ team: currentTeam.value?.slug ?? '' }).url,
+        { sections: customGroups.value.map((group) => group.section.id) },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channelSections'],
+            onError: () => {
+                syncSidebarGroups();
+                toast.error(
+                    'Failed to save the section order. Please try again.',
+                );
+            },
+        },
+    );
+}
+
+// Creating a new section from the inline form under the "Channels" header.
+const sectionFormOpen = ref(false);
+const newSectionName = ref('');
+const sectionNameInput = ref<HTMLInputElement | null>(null);
+
+async function openSectionForm(): Promise<void> {
+    sectionFormOpen.value = true;
+    await nextTick();
+    sectionNameInput.value?.focus();
+}
+
+function cancelSectionForm(): void {
+    sectionFormOpen.value = false;
+    newSectionName.value = '';
+}
+
+function createSection(): void {
+    const name = newSectionName.value.trim();
+
+    if (name === '') {
+        cancelSectionForm();
+
+        return;
+    }
+
+    router.post(
+        storeSection({ team: currentTeam.value?.slug ?? '' }).url,
+        { name },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channelSections'],
+            onSuccess: () => cancelSectionForm(),
+            onError: () => {
+                toast.error('Failed to create the section. Please try again.');
+            },
+        },
+    );
+}
+
+// Inline renaming of an existing section. The input lives inside the sections
+// v-for, so a function ref captures the single mounted instance rather than the
+// array a string ref would collect.
+const renamingSectionId = ref<string | null>(null);
+const renameValue = ref('');
+const renameInput = ref<HTMLInputElement | null>(null);
+
+function setRenameInput(el: unknown): void {
+    if (el instanceof HTMLInputElement) {
+        renameInput.value = el;
+    }
+}
+
+async function startRename(section: ChannelSection): Promise<void> {
+    renamingSectionId.value = section.id;
+    renameValue.value = section.name;
+    await nextTick();
+    renameInput.value?.focus();
+    renameInput.value?.select();
+}
+
+function cancelRename(): void {
+    renamingSectionId.value = null;
+    renameValue.value = '';
+}
+
+function submitRename(section: ChannelSection): void {
+    const name = renameValue.value.trim();
+
+    if (name === '' || name === section.name) {
+        cancelRename();
+
+        return;
+    }
+
+    router.patch(
+        updateSection({
+            team: currentTeam.value?.slug ?? '',
+            section: section.id,
+        }).url,
+        { name },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channelSections'],
+            onSuccess: () => cancelRename(),
+            onError: () => {
+                toast.error('Failed to rename the section. Please try again.');
+            },
+        },
+    );
+}
+
+function deleteSection(section: ChannelSection): void {
+    router.delete(
+        destroySection({
+            team: currentTeam.value?.slug ?? '',
+            section: section.id,
+        }).url,
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channels', 'channelSections'],
+            onError: () => {
+                toast.error('Failed to delete the section. Please try again.');
+            },
+        },
+    );
+}
+
+/**
+ * Collapse or expand a custom section, persisting the flag (the custom sections
+ * carry their own collapse state, unlike the built-in ones). Optimistic, rolling
+ * back if the request fails.
+ */
+function toggleCustomSection(group: {
+    section: ChannelSection;
+    channels: Channel[];
+}): void {
+    const previous = group.section.collapsed;
+    group.section.collapsed = !previous;
+
+    router.patch(
+        updateSection({
+            team: currentTeam.value?.slug ?? '',
+            section: group.section.id,
+        }).url,
+        { collapsed: group.section.collapsed },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channelSections'],
+            onError: () => {
+                group.section.collapsed = previous;
+                toast.error(
+                    'Failed to save the sidebar layout. Please try again.',
+                );
+            },
+        },
+    );
+}
 
 // Which sidebar sections the user has collapsed, seeded from the shared prop and
 // kept in sync when the server recomputes it (e.g. after a reload on another
@@ -258,9 +561,12 @@ onMounted(() => {
                             </button>
                         </div>
                         <!-- Starred channels, pinned above the main list; the
-                             whole section is hidden until the user stars one. -->
+                             whole section is hidden until the user stars one.
+                             Reorderable within itself (its own drag group), but a
+                             starred row can't be dragged into a custom section —
+                             starring wins, so its move menu stays hidden. -->
                         <SidebarGroup
-                            v-if="starredChannels.length > 0"
+                            v-if="starredList.length > 0"
                             class="pb-0"
                         >
                             <button
@@ -284,19 +590,215 @@ onMounted(() => {
                                 v-show="!isSectionCollapsed('starred')"
                                 data-test="section-content-starred"
                             >
-                                <SidebarMenu>
-                                    <ChannelListItem
-                                        v-for="channel in starredChannels"
-                                        :key="channel.id"
-                                        :channel="channel"
-                                        :team-slug="currentTeam?.slug ?? ''"
-                                        :active-channel-slug="activeChannelSlug"
-                                    />
-                                </SidebarMenu>
+                                <draggable
+                                    v-model="starredList"
+                                    :group="{ name: 'starred' }"
+                                    handle=".channel-drag-handle"
+                                    item-key="id"
+                                    tag="ul"
+                                    class="flex w-full min-w-0 flex-col gap-1"
+                                    :animation="150"
+                                    @change="onStarredChange"
+                                >
+                                    <template #item="{ element }">
+                                        <ChannelListItem
+                                            :channel="element"
+                                            :team-slug="currentTeam?.slug ?? ''"
+                                            :active-channel-slug="
+                                                activeChannelSlug
+                                            "
+                                        />
+                                    </template>
+                                </draggable>
                             </SidebarGroupContent>
                         </SidebarGroup>
 
-                        <!-- The main channel list. -->
+                        <!-- The user's custom sections, drag-reorderable amongst
+                             themselves; each holds a channel list that shares a
+                             drag group with the default "Channels" list below, so
+                             channels can be dragged across them. -->
+                        <draggable
+                            v-if="customGroups.length > 0"
+                            v-model="customGroups"
+                            :group="{ name: 'sections' }"
+                            handle=".section-drag-handle"
+                            :item-key="sectionKey"
+                            tag="div"
+                            :animation="150"
+                            @change="onSectionReorder"
+                        >
+                            <template #item="{ element: group }">
+                                <SidebarGroup
+                                    class="pb-0"
+                                    :data-test="`section-custom-${group.section.id}`"
+                                >
+                                    <div
+                                        class="group/section flex h-7 w-full items-center gap-1 rounded-md pr-1 pl-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                                    >
+                                        <button
+                                            type="button"
+                                            :data-test="`section-drag-${group.section.id}`"
+                                            :aria-label="`Reorder ${group.section.name}`"
+                                            title="Drag to reorder section"
+                                            class="section-drag-handle flex size-4 shrink-0 cursor-grab items-center justify-center rounded text-muted-foreground/50 opacity-0 transition group-hover/section:opacity-100 hover:text-sidebar-foreground active:cursor-grabbing"
+                                        >
+                                            <GripVertical class="size-3" />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            :data-test="`section-toggle-custom-${group.section.id}`"
+                                            :aria-expanded="
+                                                !group.section.collapsed
+                                            "
+                                            class="flex min-w-0 flex-1 items-center gap-1"
+                                            @click="toggleCustomSection(group)"
+                                        >
+                                            <ChevronRight
+                                                class="size-3 shrink-0 transition-transform"
+                                                :class="
+                                                    group.section.collapsed
+                                                        ? ''
+                                                        : 'rotate-90'
+                                                "
+                                            />
+                                            <input
+                                                v-if="
+                                                    renamingSectionId ===
+                                                    group.section.id
+                                                "
+                                                :ref="setRenameInput"
+                                                v-model="renameValue"
+                                                :data-test="`section-rename-input-${group.section.id}`"
+                                                class="w-full min-w-0 rounded-sm border border-sidebar-border bg-sidebar px-1 py-0.5 text-[11px] tracking-normal text-sidebar-foreground normal-case focus:outline-none"
+                                                type="text"
+                                                maxlength="50"
+                                                @click.stop
+                                                @keydown.enter.prevent="
+                                                    renameInput?.blur()
+                                                "
+                                                @keydown.esc="cancelRename"
+                                                @blur="
+                                                    submitRename(group.section)
+                                                "
+                                            />
+                                            <span
+                                                v-else
+                                                class="truncate"
+                                                @dblclick.stop="
+                                                    startRename(group.section)
+                                                "
+                                                >{{ group.section.name }}</span
+                                            >
+                                        </button>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger as-child>
+                                                <button
+                                                    type="button"
+                                                    :data-test="`section-menu-${group.section.id}`"
+                                                    :aria-label="`Options for ${group.section.name}`"
+                                                    title="Section options"
+                                                    class="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition group-hover/section:opacity-100 hover:text-sidebar-foreground focus-visible:opacity-100 data-[state=open]:opacity-100"
+                                                >
+                                                    <MoreVertical
+                                                        class="size-3.5"
+                                                    />
+                                                </button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent
+                                                align="end"
+                                                class="w-40"
+                                            >
+                                                <DropdownMenuItem
+                                                    :data-test="`section-rename-${group.section.id}`"
+                                                    @select="
+                                                        startRename(
+                                                            group.section,
+                                                        )
+                                                    "
+                                                >
+                                                    <Pencil class="size-3.5" />
+                                                    Rename
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem
+                                                    variant="destructive"
+                                                    :data-test="`section-delete-${group.section.id}`"
+                                                    @select="
+                                                        deleteSection(
+                                                            group.section,
+                                                        )
+                                                    "
+                                                >
+                                                    <Trash2 class="size-3.5" />
+                                                    Delete
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </div>
+                                    <SidebarGroupContent
+                                        v-show="!group.section.collapsed"
+                                        :data-test="`section-content-custom-${group.section.id}`"
+                                    >
+                                        <draggable
+                                            v-model="group.channels"
+                                            :group="{
+                                                name: 'sidebar-channels',
+                                            }"
+                                            handle=".channel-drag-handle"
+                                            item-key="id"
+                                            tag="ul"
+                                            class="flex w-full min-w-0 flex-col gap-1"
+                                            :class="
+                                                group.channels.length === 0
+                                                    ? 'min-h-6'
+                                                    : ''
+                                            "
+                                            :animation="150"
+                                            @change="
+                                                (change) =>
+                                                    onChannelChange(
+                                                        change,
+                                                        group.channels,
+                                                        group.section.id,
+                                                    )
+                                            "
+                                        >
+                                            <template #item="{ element }">
+                                                <ChannelListItem
+                                                    :channel="element"
+                                                    :team-slug="
+                                                        currentTeam?.slug ?? ''
+                                                    "
+                                                    :active-channel-slug="
+                                                        activeChannelSlug
+                                                    "
+                                                    :sections="customSections"
+                                                    :current-section-id="
+                                                        group.section.id
+                                                    "
+                                                    @move="
+                                                        (sectionId) =>
+                                                            moveChannelToSection(
+                                                                element,
+                                                                sectionId,
+                                                            )
+                                                    "
+                                                />
+                                            </template>
+                                        </draggable>
+                                        <p
+                                            v-if="group.channels.length === 0"
+                                            class="px-7 pb-1 text-[12px] text-muted-foreground/50 normal-case"
+                                        >
+                                            Drag channels here
+                                        </p>
+                                    </SidebarGroupContent>
+                                </SidebarGroup>
+                            </template>
+                        </draggable>
+
+                        <!-- The default "Channels" list: unstarred, unassigned
+                             channels. Shares a drag group with the custom sections
+                             so channels can be dragged in and out. -->
                         <SidebarGroup>
                             <button
                                 type="button"
@@ -332,15 +834,74 @@ onMounted(() => {
                                 v-show="!isSectionCollapsed('channels')"
                                 data-test="section-content-channels"
                             >
-                                <SidebarMenu>
-                                    <ChannelListItem
-                                        v-for="channel in otherChannels"
-                                        :key="channel.id"
-                                        :channel="channel"
-                                        :team-slug="currentTeam?.slug ?? ''"
-                                        :active-channel-slug="activeChannelSlug"
+                                <draggable
+                                    v-model="defaultList"
+                                    :group="{ name: 'sidebar-channels' }"
+                                    handle=".channel-drag-handle"
+                                    item-key="id"
+                                    tag="ul"
+                                    class="flex w-full min-w-0 flex-col gap-1"
+                                    :animation="150"
+                                    @change="
+                                        (change) =>
+                                            onChannelChange(
+                                                change,
+                                                defaultList,
+                                                null,
+                                            )
+                                    "
+                                >
+                                    <template #item="{ element }">
+                                        <ChannelListItem
+                                            :channel="element"
+                                            :team-slug="currentTeam?.slug ?? ''"
+                                            :active-channel-slug="
+                                                activeChannelSlug
+                                            "
+                                            :sections="customSections"
+                                            :current-section-id="null"
+                                            @move="
+                                                (sectionId) =>
+                                                    moveChannelToSection(
+                                                        element,
+                                                        sectionId,
+                                                    )
+                                            "
+                                        />
+                                    </template>
+                                </draggable>
+                            </SidebarGroupContent>
+                        </SidebarGroup>
+
+                        <!-- Create a new custom section. -->
+                        <SidebarGroup class="py-0">
+                            <SidebarGroupContent>
+                                <div v-if="sectionFormOpen" class="px-2">
+                                    <input
+                                        ref="sectionNameInput"
+                                        v-model="newSectionName"
+                                        data-test="create-section-input"
+                                        class="w-full rounded-md border border-sidebar-border bg-sidebar px-2 py-1 text-[13px] text-sidebar-foreground focus:outline-none"
+                                        type="text"
+                                        maxlength="50"
+                                        placeholder="New section name"
+                                        @keydown.enter.prevent="
+                                            sectionNameInput?.blur()
+                                        "
+                                        @keydown.esc="cancelSectionForm"
+                                        @blur="createSection"
                                     />
-                                </SidebarMenu>
+                                </div>
+                                <button
+                                    v-else
+                                    type="button"
+                                    data-test="create-section-trigger"
+                                    class="flex h-7 w-full items-center gap-1.5 rounded-md px-2 text-[12px] text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
+                                    @click="openSectionForm"
+                                >
+                                    <FolderPlus class="size-3.5" />
+                                    New section
+                                </button>
                             </SidebarGroupContent>
                         </SidebarGroup>
 

--- a/resources/js/lib/channelSections.test.ts
+++ b/resources/js/lib/channelSections.test.ts
@@ -3,7 +3,7 @@ import {
     partitionChannels,
     toggleCollapsedSection,
 } from '@/lib/channelSections';
-import type { Channel } from '@/types/channels';
+import type { Channel, ChannelSection } from '@/types/channels';
 
 /**
  * A minimal channel with only the fields the section helpers read; `starred`
@@ -25,6 +25,19 @@ function channel(overrides: Partial<Channel> = {}): Channel {
         hasDraft: false,
         draft: null,
         starred: false,
+        sectionId: null,
+        position: 0,
+        ...overrides,
+    };
+}
+
+/** A minimal custom section. */
+function section(overrides: Partial<ChannelSection> = {}): ChannelSection {
+    return {
+        id: overrides.id ?? 'section',
+        name: overrides.name ?? 'Section',
+        position: 0,
+        collapsed: false,
         ...overrides,
     };
 }
@@ -54,17 +67,73 @@ describe('partitionChannels', () => {
     });
 
     it('returns empty groups for an empty list', () => {
-        expect(partitionChannels([])).toEqual({ starred: [], others: [] });
+        expect(partitionChannels([])).toEqual({
+            starred: [],
+            custom: [],
+            others: [],
+        });
     });
 
-    it('puts everything in others when nothing is starred', () => {
-        const { starred, others } = partitionChannels([
+    it('puts everything in others when nothing is starred or assigned', () => {
+        const { starred, custom, others } = partitionChannels([
             channel({ slug: 'a' }),
             channel({ slug: 'b' }),
         ]);
 
         expect(starred).toEqual([]);
+        expect(custom).toEqual([]);
         expect(others.map((c) => c.slug)).toEqual(['a', 'b']);
+    });
+
+    it('files assigned channels under their custom section', () => {
+        const projects = section({ id: 's1', name: 'Projects' });
+        const clients = section({ id: 's2', name: 'Clients', position: 1 });
+
+        const { custom, others } = partitionChannels(
+            [
+                channel({ slug: 'api', sectionId: 's1' }),
+                channel({ slug: 'random' }),
+                channel({ slug: 'acme', sectionId: 's2' }),
+            ],
+            [projects, clients],
+        );
+
+        expect(custom.map((g) => g.section.name)).toEqual([
+            'Projects',
+            'Clients',
+        ]);
+        expect(custom[0].channels.map((c) => c.slug)).toEqual(['api']);
+        expect(custom[1].channels.map((c) => c.slug)).toEqual(['acme']);
+        expect(others.map((c) => c.slug)).toEqual(['random']);
+    });
+
+    it('keeps starred channels in Starred even when assigned to a section', () => {
+        const projects = section({ id: 's1', name: 'Projects' });
+
+        const { starred, custom } = partitionChannels(
+            [channel({ slug: 'api', sectionId: 's1', starred: true })],
+            [projects],
+        );
+
+        expect(starred.map((c) => c.slug)).toEqual(['api']);
+        expect(custom[0].channels).toEqual([]);
+    });
+
+    it('falls back to others when the assigned section no longer exists', () => {
+        const { custom, others } = partitionChannels(
+            [channel({ slug: 'orphan', sectionId: 'gone' })],
+            [section({ id: 's1' })],
+        );
+
+        expect(custom[0].channels).toEqual([]);
+        expect(others.map((c) => c.slug)).toEqual(['orphan']);
+    });
+
+    it('renders an empty custom section with no channels', () => {
+        const { custom } = partitionChannels([], [section({ id: 's1' })]);
+
+        expect(custom).toHaveLength(1);
+        expect(custom[0].channels).toEqual([]);
     });
 });
 

--- a/resources/js/lib/channelSections.ts
+++ b/resources/js/lib/channelSections.ts
@@ -1,4 +1,4 @@
-import type { Channel } from '@/types/channels';
+import type { Channel, ChannelSection } from '@/types/channels';
 
 /**
  * The built-in sidebar sections whose collapsed state is persisted per user.
@@ -8,31 +8,64 @@ export const SIDEBAR_SECTIONS = ['starred', 'channels'] as const;
 
 export type SidebarSectionKey = (typeof SIDEBAR_SECTIONS)[number];
 
+/** A custom section paired with the channels the viewer filed under it. */
+export type ChannelSectionGroup = {
+    section: ChannelSection;
+    channels: Channel[];
+};
+
 export type ChannelSections = {
-    /** Channels the viewer has starred, pinned above the main list. */
+    /** Channels the viewer has starred, pinned above every other group. */
     starred: Channel[];
-    /** Every remaining channel the viewer belongs to. */
+    /** The viewer's custom sections, in their persisted order. */
+    custom: ChannelSectionGroup[];
+    /** Unstarred, unassigned channels — the default "Channels" group. */
     others: Channel[];
 };
 
 /**
- * Split the sidebar's channels into the pinned "Starred" section and the main
- * "Channels" list, preserving the incoming order within each group (the server
- * already sorts alphabetically).
+ * Split the sidebar's channels into the pinned "Starred" section, the viewer's
+ * custom sections, and the default "Channels" list, preserving the incoming
+ * order within each group (the server already sorts by position then name).
+ *
+ * Starring wins over section assignment: a starred channel always renders in
+ * "Starred", even when it also carries a `sectionId`. A channel assigned to a
+ * section that no longer exists falls back to the default group.
  */
-export function partitionChannels(channels: Channel[]): ChannelSections {
+export function partitionChannels(
+    channels: Channel[],
+    sections: ChannelSection[] = [],
+): ChannelSections {
     const starred: Channel[] = [];
     const others: Channel[] = [];
+    const bySection = new Map<string, Channel[]>(
+        sections.map((section) => [section.id, []]),
+    );
 
     for (const channel of channels) {
         if (channel.starred) {
             starred.push(channel);
+            continue;
+        }
+
+        const bucket =
+            channel.sectionId != null
+                ? bySection.get(channel.sectionId)
+                : undefined;
+
+        if (bucket) {
+            bucket.push(channel);
         } else {
             others.push(channel);
         }
     }
 
-    return { starred, others };
+    const custom = sections.map((section) => ({
+        section,
+        channels: bySection.get(section.id) ?? [],
+    }));
+
+    return { starred, custom, others };
 }
 
 /**

--- a/resources/js/types/channels.ts
+++ b/resources/js/types/channels.ts
@@ -25,4 +25,19 @@ export type Channel = {
     // Whether the viewer has starred (favorited) this channel, pinning it to the
     // sidebar's "Starred" section.
     starred: boolean;
+    // The custom section the viewer has filed this channel under, or null for the
+    // default "Channels" group. Starred channels render in "Starred" regardless.
+    sectionId: string | null;
+    // The channel's manual order within whichever sidebar group it renders in;
+    // ties fall back to the alphabetical order the server applies.
+    position: number;
+};
+
+// A user-created sidebar section, rendered between "Starred" and the default
+// "Channels" group. Mirrors `App\Data\ChannelSectionData`.
+export type ChannelSection = {
+    id: string;
+    name: string;
+    position: number;
+    collapsed: boolean;
 };

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -1,5 +1,5 @@
 import type { Auth } from '@/types/auth';
-import type { Channel } from '@/types/channels';
+import type { Channel, ChannelSection } from '@/types/channels';
 import type { DashboardInvitation, Team } from '@/types/teams';
 
 // Extend ImportMeta interface for Vite...
@@ -24,6 +24,7 @@ declare module '@inertiajs/core' {
             currentTeam: Team | null;
             teams: Team[];
             channels?: Channel[];
+            channelSections?: ChannelSection[];
             collapsedChannelSections?: string[];
             hasUnreadThreads?: boolean;
             pendingInvitations?: DashboardInvitation[];

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,9 @@
 use App\Http\Controllers\Channels\ChannelController;
 use App\Http\Controllers\Channels\ChannelDraftController;
 use App\Http\Controllers\Channels\ChannelMemberController;
+use App\Http\Controllers\Channels\ChannelPlacementController;
 use App\Http\Controllers\Channels\ChannelPreferenceController;
+use App\Http\Controllers\Channels\ChannelSectionController;
 use App\Http\Controllers\Channels\ChannelStarController;
 use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Channels\SearchController;
@@ -44,6 +46,13 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::patch('t/{team}/c/{channel}/star', [ChannelStarController::class, 'update'])
         ->scopeBindings()
         ->name('channels.star.update');
+    Route::patch('t/{team}/c/{channel}/placement', [ChannelPlacementController::class, 'update'])
+        ->scopeBindings()
+        ->name('channels.placement.update');
+    Route::post('t/{team}/sidebar/sections', [ChannelSectionController::class, 'store'])->name('channels.sections.store');
+    Route::patch('t/{team}/sidebar/sections/reorder', [ChannelSectionController::class, 'reorder'])->name('channels.sections.reorder');
+    Route::patch('t/{team}/sidebar/sections/{section}', [ChannelSectionController::class, 'update'])->name('channels.sections.update');
+    Route::delete('t/{team}/sidebar/sections/{section}', [ChannelSectionController::class, 'destroy'])->name('channels.sections.destroy');
     Route::post('t/{team}/c/{channel}/archive', [ChannelController::class, 'archive'])
         ->scopeBindings()
         ->name('channels.archive');

--- a/tests/Feature/Channels/ChannelPlacementTest.php
+++ b/tests/Feature/Channels/ChannelPlacementTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\ChannelSection;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function placementTeam(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Create a public channel in the team the user is a member of.
+ */
+function placementChannel(User $user, Team $team, string $name): Channel
+{
+    $channel = Channel::factory()->for($team)->create([
+        'name' => $name,
+        'slug' => Str::slug($name),
+        'visibility' => ChannelVisibility::Public,
+        'created_by' => $user->id,
+    ]);
+    $channel->channelMembers()->create(['user_id' => $user->id]);
+
+    return $channel;
+}
+
+/**
+ * Hit the placement endpoint for the channel.
+ *
+ * @param  array<string, mixed>  $payload
+ */
+function placeChannel(User $user, Team $team, Channel $channel, array $payload): TestResponse
+{
+    return test()->actingAs($user)->patch(route('channels.placement.update', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]), $payload);
+}
+
+/**
+ * The acting user's sidebar `channels` prop, keyed by slug.
+ *
+ * @return Collection<string, array<string, mixed>>
+ */
+function placementSidebar(User $user, Team $team, Channel $channel): Collection
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]))->assertOk();
+
+    return collect($response->viewData('page')['props']['channels'])->keyBy('slug');
+}
+
+test('a member can move a channel into a custom section', function () {
+    [$owner, $team, $general] = placementTeam();
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+
+    placeChannel($owner, $team, $general, [
+        'section_id' => $section->id,
+        'ordered_ids' => [$general->id],
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $owner->id,
+        'section_id' => $section->id,
+        'position' => 0,
+    ]);
+
+    expect(placementSidebar($owner, $team, $general)[$general->slug])
+        ->toMatchArray(['sectionId' => $section->id, 'position' => 0]);
+});
+
+test('a member can move a channel back to the default group with a null section', function () {
+    [$owner, $team, $general] = placementTeam();
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+    $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
+
+    placeChannel($owner, $team, $general, [
+        'section_id' => null,
+        'ordered_ids' => [$general->id],
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $owner->id,
+        'section_id' => null,
+    ]);
+});
+
+test('a pure reorder leaves the section assignment untouched', function () {
+    [$owner, $team, $general] = placementTeam();
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+    $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
+
+    // No section_id key -> reorder only.
+    placeChannel($owner, $team, $general, [
+        'ordered_ids' => [$general->id],
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $owner->id,
+        'section_id' => $section->id,
+    ]);
+});
+
+test('reordering persists channel positions and drives the sidebar order', function () {
+    [$owner, $team, $general] = placementTeam();
+    $alpha = placementChannel($owner, $team, 'Alpha');
+    $beta = placementChannel($owner, $team, 'Beta');
+
+    // Default alphabetical order is general, alpha, beta (all position 0). Flip it.
+    placeChannel($owner, $team, $general, [
+        'ordered_ids' => [$beta->id, $alpha->id, $general->id],
+    ])->assertRedirect();
+
+    expect($beta->fresh()->channelMembers()->where('user_id', $owner->id)->value('position'))->toBe(0)
+        ->and($alpha->fresh()->channelMembers()->where('user_id', $owner->id)->value('position'))->toBe(1)
+        ->and($general->fresh()->channelMembers()->where('user_id', $owner->id)->value('position'))->toBe(2);
+
+    $order = placementSidebar($owner, $team, $general)->keys()->all();
+    expect($order)->toBe(['beta', 'alpha', 'general']);
+});
+
+test('placement only touches the acting user own rows', function () {
+    [$owner, $team, $general] = placementTeam();
+    $member = User::factory()->create();
+    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+    $general->channelMembers()->firstOrCreate(['user_id' => $member->id]);
+
+    placeChannel($owner, $team, $general, [
+        'ordered_ids' => [$general->id],
+        'section_id' => null,
+    ])->assertRedirect();
+
+    // The other member's position stays at its default.
+    expect($general->channelMembers()->where('user_id', $member->id)->value('position'))->toBe(0);
+});
+
+test('a member cannot place a channel into another user section', function () {
+    [$owner, $team, $general] = placementTeam();
+    $other = User::factory()->create();
+    $theirs = ChannelSection::factory()->for($other)->for($team)->create();
+
+    placeChannel($owner, $team, $general, [
+        'section_id' => $theirs->id,
+        'ordered_ids' => [$general->id],
+    ])->assertSessionHasErrors('section_id');
+});
+
+test('a non-member cannot place a channel', function () {
+    [$owner, $team] = placementTeam();
+    $private = Channel::factory()->for($team)->create([
+        'visibility' => ChannelVisibility::Private,
+        'created_by' => $owner->id,
+    ]);
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    placeChannel($stranger, $team, $private, [
+        'ordered_ids' => [$private->id],
+    ])->assertForbidden();
+});
+
+test('placement requires the ordered ids payload', function () {
+    [$owner, $team, $general] = placementTeam();
+
+    placeChannel($owner, $team, $general, [])->assertSessionHasErrors('ordered_ids');
+});
+
+test('placement rejects a channel id the user does not belong to', function () {
+    [$owner, $team, $general] = placementTeam();
+    $foreign = Channel::factory()->for($team)->create();
+
+    placeChannel($owner, $team, $general, [
+        'ordered_ids' => [$foreign->id],
+    ])->assertSessionHasErrors('ordered_ids.0');
+});
+
+test('a guest cannot place a channel', function () {
+    [$owner, $team, $general] = placementTeam();
+
+    $this->patch(route('channels.placement.update', ['team' => $team->slug, 'channel' => $general->slug]), [
+        'ordered_ids' => [$general->id],
+    ])->assertRedirect(route('login'));
+});

--- a/tests/Feature/Sidebar/ChannelSectionTest.php
+++ b/tests/Feature/Sidebar/ChannelSectionTest.php
@@ -1,0 +1,256 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\ChannelMember;
+use App\Models\ChannelSection;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function sectionCrudTeam(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Read the shared `channelSections` prop for the acting user off a channel page.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function sidebarSectionsProp(User $user, Team $team, Channel $channel): array
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+    ]))->assertOk();
+
+    return $response->viewData('page')['props']['channelSections'];
+}
+
+/**
+ * Create a section for the user via the endpoint.
+ */
+function createSection(User $user, Team $team, string $name): TestResponse
+{
+    return test()->actingAs($user)->post(route('channels.sections.store', ['team' => $team->slug]), [
+        'name' => $name,
+    ]);
+}
+
+test('a member can create a custom section', function () {
+    [$owner, $team, $general] = sectionCrudTeam();
+
+    createSection($owner, $team, 'My Projects')->assertRedirect();
+
+    $this->assertDatabaseHas('channel_sections', [
+        'user_id' => $owner->id,
+        'team_id' => $team->id,
+        'name' => 'My Projects',
+        'collapsed' => false,
+    ]);
+
+    expect(sidebarSectionsProp($owner, $team, $general))
+        ->toHaveCount(1)
+        ->and(sidebarSectionsProp($owner, $team, $general)[0])
+        ->toMatchArray(['name' => 'My Projects', 'collapsed' => false]);
+});
+
+test('new sections are appended after existing ones', function () {
+    [$owner, $team] = sectionCrudTeam();
+
+    createSection($owner, $team, 'First')->assertRedirect();
+    createSection($owner, $team, 'Second')->assertRedirect();
+
+    $positions = $owner->channelSections()->where('team_id', $team->id)->orderBy('position')->pluck('name', 'position');
+
+    expect($positions[1] ?? null)->toBe('First')
+        ->and($positions[2] ?? null)->toBe('Second');
+});
+
+test('the section name is trimmed and required', function () {
+    [$owner, $team] = sectionCrudTeam();
+
+    createSection($owner, $team, '   Trimmed   ')->assertRedirect();
+    $this->assertDatabaseHas('channel_sections', ['name' => 'Trimmed']);
+
+    createSection($owner, $team, '   ')->assertSessionHasErrors('name');
+});
+
+test('a section name is capped at 50 characters', function () {
+    [$owner, $team] = sectionCrudTeam();
+
+    createSection($owner, $team, str_repeat('a', 51))->assertSessionHasErrors('name');
+});
+
+test('a non-member cannot create a section in the team', function () {
+    [, $team] = sectionCrudTeam();
+    $stranger = User::factory()->create();
+
+    createSection($stranger, $team, 'Nope')->assertForbidden();
+
+    $this->assertDatabaseMissing('channel_sections', ['user_id' => $stranger->id]);
+});
+
+test('a member can rename their section', function () {
+    [$owner, $team] = sectionCrudTeam();
+    $section = ChannelSection::factory()->for($owner)->for($team)->create(['name' => 'Old']);
+
+    $this->actingAs($owner)
+        ->patch(route('channels.sections.update', ['team' => $team->slug, 'section' => $section->id]), ['name' => 'New'])
+        ->assertRedirect();
+
+    expect($section->refresh()->name)->toBe('New');
+});
+
+test('a member can collapse their section', function () {
+    [$owner, $team] = sectionCrudTeam();
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.sections.update', ['team' => $team->slug, 'section' => $section->id]), ['collapsed' => true])
+        ->assertRedirect();
+
+    expect($section->refresh()->collapsed)->toBeTrue();
+});
+
+test('an empty section update is rejected', function () {
+    [$owner, $team] = sectionCrudTeam();
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.sections.update', ['team' => $team->slug, 'section' => $section->id]), [])
+        ->assertSessionHasErrors(['name', 'collapsed']);
+});
+
+test('a member cannot update another user section', function () {
+    [$owner, $team] = sectionCrudTeam();
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+
+    $this->actingAs($other)
+        ->patch(route('channels.sections.update', ['team' => $team->slug, 'section' => $section->id]), ['name' => 'Hijacked'])
+        ->assertForbidden();
+
+    expect($section->refresh()->name)->not->toBe('Hijacked');
+});
+
+test('a section from another team cannot be updated through this team', function () {
+    [$owner, $team] = sectionCrudTeam();
+    $otherTeam = app(CreateTeam::class)->handle($owner, 'Other');
+    $section = ChannelSection::factory()->for($owner)->for($otherTeam)->create();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.sections.update', ['team' => $team->slug, 'section' => $section->id]), ['name' => 'X'])
+        ->assertForbidden();
+});
+
+test('a member can delete their section and its channels fall back to the default group', function () {
+    [$owner, $team, $general] = sectionCrudTeam();
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+    $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
+
+    $this->actingAs($owner)
+        ->delete(route('channels.sections.destroy', ['team' => $team->slug, 'section' => $section->id]))
+        ->assertRedirect();
+
+    $this->assertDatabaseMissing('channel_sections', ['id' => $section->id]);
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $owner->id,
+        'section_id' => null,
+    ]);
+});
+
+test('a member cannot delete another user section', function () {
+    [$owner, $team] = sectionCrudTeam();
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+
+    $this->actingAs($other)
+        ->delete(route('channels.sections.destroy', ['team' => $team->slug, 'section' => $section->id]))
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('channel_sections', ['id' => $section->id]);
+});
+
+test('a member can reorder their sections', function () {
+    [$owner, $team] = sectionCrudTeam();
+    $a = ChannelSection::factory()->for($owner)->for($team)->position(0)->create(['name' => 'A']);
+    $b = ChannelSection::factory()->for($owner)->for($team)->position(1)->create(['name' => 'B']);
+    $c = ChannelSection::factory()->for($owner)->for($team)->position(2)->create(['name' => 'C']);
+
+    $this->actingAs($owner)
+        ->patch(route('channels.sections.reorder', ['team' => $team->slug]), [
+            'sections' => [$c->id, $a->id, $b->id],
+        ])
+        ->assertRedirect();
+
+    expect($c->refresh()->position)->toBe(0)
+        ->and($a->refresh()->position)->toBe(1)
+        ->and($b->refresh()->position)->toBe(2);
+});
+
+test('reordering rejects a section the user does not own', function () {
+    [$owner, $team] = sectionCrudTeam();
+    $mine = ChannelSection::factory()->for($owner)->for($team)->create();
+    $other = User::factory()->create();
+    $theirs = ChannelSection::factory()->for($other)->for($team)->create();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.sections.reorder', ['team' => $team->slug]), [
+            'sections' => [$mine->id, $theirs->id],
+        ])
+        ->assertSessionHasErrors('sections.1');
+});
+
+test('the sections payload must be present to reorder', function () {
+    [$owner, $team] = sectionCrudTeam();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.sections.reorder', ['team' => $team->slug]), [])
+        ->assertSessionHasErrors('sections');
+});
+
+test('sections are scoped per user in the sidebar prop', function () {
+    [$owner, $team, $general] = sectionCrudTeam();
+    ChannelSection::factory()->for($owner)->for($team)->create(['name' => 'Mine']);
+    $other = User::factory()->create();
+    ChannelSection::factory()->for($other)->for($team)->create(['name' => 'Theirs']);
+
+    $names = collect(sidebarSectionsProp($owner, $team, $general))->pluck('name');
+
+    expect($names)->toContain('Mine')->not->toContain('Theirs');
+});
+
+test('a section and its channel memberships relate both ways', function () {
+    [$owner, $team, $general] = sectionCrudTeam();
+    $section = ChannelSection::factory()->for($owner)->for($team)->create();
+    $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
+
+    $membership = ChannelMember::where('channel_id', $general->id)
+        ->where('user_id', $owner->id)
+        ->firstOrFail();
+
+    expect($membership->section->is($section))->toBeTrue()
+        ->and($section->channelMembers->pluck('id')->all())->toContain($membership->id);
+});
+
+test('a guest cannot manage sections', function () {
+    [, $team] = sectionCrudTeam();
+
+    $this->post(route('channels.sections.store', ['team' => $team->slug]), ['name' => 'X'])
+        ->assertRedirect(route('login'));
+});


### PR DESCRIPTION
## Summary

**Phase 2 of #41** (follow-up to Phase 1, PR #89). Lets users organize the channel sidebar into their own **named, collapsible sections** with **manual drag-ordering**, persisted per user and team so the layout follows them across reloads and devices.

Builds directly on the Phase 1 extension points rather than reworking the sidebar:
- extends the pure `partitionChannels()` helper (`resources/js/lib/channelSections.ts`),
- reuses `ChannelListItem.vue` for rows inside custom sections,
- threads section/position data through `ChannelData` + `HandleInertiaRequests` (`channelsForSidebar`),
- mirrors the `ChannelStarController → SetChannelStar → FormRequest → Policy → route` pattern for every new endpoint.

## Decisions (confirmed with the maintainer)

- **Starring wins**: a starred channel always renders in "Starred", even when assigned to a custom section — every channel appears in exactly one group.
- **Layout order**: Starred (top) → custom sections (drag order) → default "Channels" (unassigned, bottom).
- **Assignment UX**: drag-and-drop **plus** a per-row kebab "Move to section →" menu (accessible/testable path alongside drag).
- **Reorder scope**: manual order persists in every group; each `channel_member` carries a `position`, tie-broken by name.

## Data model

- New `channel_sections` table: `user_id`, `team_id`, `name`, `position`, `collapsed`. Custom sections carry their own collapse flag (Phase 1's built-in collapse state stays a jsonb array on `users`).
- `channel_members`: adds `section_id` (nullable FK, `nullOnDelete` so deleting a section returns its channels to the default group) and `position`.

## Endpoints

- `POST/PATCH/DELETE t/{team}/sidebar/sections[/{section}]` — create / rename+collapse / delete (`channels.sections.*`).
- `PATCH t/{team}/sidebar/sections/reorder` — reorder sections.
- `PATCH t/{team}/c/{channel}/placement` — file a channel under a section and/or reorder its group in one write (never clobbers other channels' assignments).

New drag-and-drop dep: **vuedraggable** (sortablejs) — the maintainer pre-approved adding it for this work.

## Testing

- Pest feature tests for section CRUD, reorder, channel placement, ordering, starred precedence, per-user scoping, authorization, and validation — **100% backend coverage** (`sail composer test`).
- Vitest coverage for the extended `partitionChannels()` (custom sections, starred precedence, orphaned-section fallback).
- Frontend gate green: `lint:check`, `format:check`, `types:check`, `build`.
- Verified end-to-end against the running app: SSR renders cleanly and creating a section places it between Starred and Channels.

## Acceptance criteria (#88)

- [x] Create, rename, and delete custom sections
- [x] Assign/move channels between sections
- [x] Drag-reorder sections and channels, persisted per user
- [x] Persists across reloads/devices
- [x] Test coverage for persistence and ordering

Closes #88. Part of #41. Implements the Phase 2 handoff.
