### PR TITLE
feat(messaging): forward a message to another channel (#34)

### DIFF
--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -22,12 +22,14 @@ class PostMessage
      * path side-effect free.
      *
      * When `$replyToId` is set the message renders as an inline quote of that
-     * parent. When `$threadRootId` is set the message is a thread reply: it stays
-     * out of the main timeline unless `$sentToChannel` is true, and it bumps the
-     * root's denormalized reply count / last-reply time. The request layer has
-     * already checked both references point at live messages in this channel.
+     * parent. When `$forwardedFromId` is set the message forwards that (possibly
+     * cross-channel) source, rendered with its attribution and quote; the body is
+     * an optional note. When `$threadRootId` is set the message is a thread reply:
+     * it stays out of the main timeline unless `$sentToChannel` is true, and it
+     * bumps the root's denormalized reply count / last-reply time. The request
+     * layer has already checked every reference points at a live, permitted message.
      */
-    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null, ?string $threadRootId = null, bool $sentToChannel = false): Message
+    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null, ?string $forwardedFromId = null, ?string $threadRootId = null, bool $sentToChannel = false): Message
     {
         $message = $channel->messages()->firstOrCreate(
             ['client_uuid' => $clientUuid],
@@ -35,6 +37,7 @@ class PostMessage
                 'user_id' => $author->id,
                 'body' => $body,
                 'reply_to_id' => $replyToId,
+                'forwarded_from_id' => $forwardedFromId,
                 'thread_root_id' => $threadRootId,
                 'sent_to_channel' => $threadRootId !== null && $sentToChannel,
             ],
@@ -43,7 +46,7 @@ class PostMessage
         if ($message->wasRecentlyCreated) {
             $this->syncMentions->handle($channel, $message);
             $message->setRelation('user', $author);
-            $message->load(['mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers']);
+            $message->load(['mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
             MessageSent::dispatch($channel, MessageData::fromMessage($message));
 
             if ($threadRootId !== null) {

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -44,6 +44,6 @@ class SearchMessages
             ->whereIn('channel_id', $channelIds)
             ->take($limit)
             ->get()
-            ->load(['user', 'channel', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers']);
+            ->load(['user', 'channel', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
     }
 }

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -24,6 +24,7 @@ class MessageData extends Data
         public bool $isDeleted,
         public array $mentions,
         public ?MessageReplyData $replyTo,
+        public ?MessageForwardData $forwardedFrom,
         public ?string $threadRootId,
         public bool $sentToChannel,
         public int $threadReplyCount,
@@ -44,6 +45,9 @@ class MessageData extends Data
      * and `mentionedUsers`) when the message quotes a parent; a deleted parent
      * still resolves so the quote can render a stub. A tombstone carries no
      * quote of its own — a deleted message shows only its own placeholder.
+     *
+     * The `forwardedFrom` relation follows the same rules (eager-loaded with its
+     * `user`, `channel`, and `mentionedUsers`) for a forwarded message.
      *
      * Thread aggregates (`threadReplyCount`, `threadLastReplyAt`,
      * `threadParticipants`) are structural, so they survive a soft delete — a
@@ -74,6 +78,9 @@ class MessageData extends Data
             mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn (User $user) => MentionData::fromUser($user))->all(),
             replyTo: ! $isDeleted && $message->replyTo !== null
                 ? MessageReplyData::fromMessage($message->replyTo)
+                : null,
+            forwardedFrom: ! $isDeleted && $message->forwardedFrom !== null
+                ? MessageForwardData::fromMessage($message->forwardedFrom)
                 : null,
             threadRootId: $message->thread_root_id,
             sentToChannel: $message->sent_to_channel,

--- a/app/Data/MessageForwardData.php
+++ b/app/Data/MessageForwardData.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\Message;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class MessageForwardData extends Data
+{
+    /**
+     * @param  array<int, MentionData>  $mentions
+     */
+    public function __construct(
+        public string $id,
+        public string $body,
+        public string $authorName,
+        public string $channelName,
+        public bool $isDeleted,
+        public array $mentions,
+    ) {}
+
+    /**
+     * Build the compact quote of a forwarded source message.
+     *
+     * Like {@see MessageReplyData} this is intentionally flat — it carries no
+     * nested reference — but it also names the source channel so the forward can
+     * render its "Forwarded from #name" attribution. The `user` and `channel`
+     * relations are expected to be eager-loaded. A soft-deleted source blanks its
+     * body and mentions, leaving only the `isDeleted` flag so the client can
+     * render a "message deleted" stub.
+     */
+    public static function fromMessage(Message $message): self
+    {
+        $isDeleted = $message->trashed();
+
+        return new self(
+            id: $message->id,
+            body: $isDeleted ? '' : $message->body,
+            authorName: $message->user->name,
+            channelName: $message->channel->name,
+            isDeleted: $isDeleted,
+            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn ($user) => MentionData::fromUser($user))->all(),
+        );
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -153,7 +153,7 @@ class ChannelController extends Controller
             // "message deleted" tombstone in place; MessageData blanks their body.
             'messages' => Inertia::scroll(fn () => $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
                 ->withThreadReadState($request->user())
-                ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
+                ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
                 ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
                 ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
@@ -198,7 +198,7 @@ class ChannelController extends Controller
         $root = $this->resolveThreadRoot($request, $channel);
 
         $query = $root !== null
-            ? $root->threadReplies()->withTrashed()->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers'])
+            ? $root->threadReplies()->withTrashed()->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers'])
             : Message::query()->whereRaw('1 = 0');
 
         return $query
@@ -224,7 +224,7 @@ class ChannelController extends Controller
         return $channel->messages()
             ->whereNull('thread_root_id')
             ->withThreadReadState($request->user())
-            ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
+            ->with(['user', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
             ->find($rootId);
     }
 

--- a/app/Http/Controllers/Channels/ForwardMessageController.php
+++ b/app/Http/Controllers/Channels/ForwardMessageController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\PostMessage;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\ForwardMessageRequest;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+
+class ForwardMessageController extends Controller
+{
+    /**
+     * Forward a message into another channel.
+     *
+     * The route scopes `$message` to its source `$channel`; the destination is
+     * the validated `target_channel_id`. The forwarded copy carries an optional
+     * note as its body and enters the normal post + broadcast flow in the target
+     * channel. Redirecting back keeps the author on the source channel rather
+     * than navigating them to the destination.
+     */
+    public function store(ForwardMessageRequest $request, Team $team, Channel $channel, Message $message, PostMessage $postMessage): RedirectResponse
+    {
+        $target = Channel::query()->whereKey($request->validated('target_channel_id'))->firstOrFail();
+
+        $postMessage->handle(
+            channel: $target,
+            author: $request->user(),
+            body: (string) $request->validated('body'),
+            clientUuid: $request->validated('client_uuid'),
+            forwardedFromId: $message->id,
+        );
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Channels/ThreadsController.php
+++ b/app/Http/Controllers/Channels/ThreadsController.php
@@ -48,7 +48,7 @@ class ThreadsController extends Controller
                 ->where('reply_count', '>', 0)
                 ->followedBy($user)
                 ->withThreadReadState($user)
-                ->with(['user', 'channel', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants'])
+                ->with(['user', 'channel', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
                 ->orderByDesc('last_reply_at')
                 ->orderByDesc('id')
                 ->cursorPaginate(self::PAGE_SIZE)

--- a/app/Http/Requests/Channels/ForwardMessageRequest.php
+++ b/app/Http/Requests/Channels/ForwardMessageRequest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+
+class ForwardMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Forwarding is gated on being able to see the source message: the route
+     * scopes the message to the source channel, so viewing that channel is
+     * enough. Authorization to post into the chosen target channel is enforced
+     * separately by the `target_channel_id` rule.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('view', $this->sourceChannel());
+    }
+
+    /**
+     * Trim the optional note while preserving its inner newlines.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'body' => trim((string) $this->input('body')),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // The note is optional — the forwarded quote carries the content.
+            'body' => ['nullable', 'string', 'max:8000'],
+            'client_uuid' => ['required', 'uuid'],
+            // The destination must be a live (non-archived) channel in the same
+            // team that the author is a member of — the same constraint the
+            // `postMessage` gate applies, expressed as an existence check.
+            'target_channel_id' => [
+                'required',
+                'uuid',
+                Rule::exists('channels', 'id')
+                    ->where('team_id', $this->sourceChannel()->team_id)
+                    ->whereNull('archived_at')
+                    ->whereIn('id', $this->membershipChannelIds()),
+            ],
+        ];
+    }
+
+    /**
+     * Get the source channel the message is being forwarded from.
+     */
+    public function sourceChannel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+
+    /**
+     * The ids of channels the author belongs to, scoping the valid forward
+     * destinations to their own memberships.
+     *
+     * @return array<int, string>
+     */
+    protected function membershipChannelIds(): array
+    {
+        return $this->user()->channels()->pluck('channels.id')->all();
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -24,6 +24,7 @@ use Laravel\Scout\Searchable;
  * @property string $user_id
  * @property string $client_uuid
  * @property string|null $reply_to_id
+ * @property string|null $forwarded_from_id
  * @property string|null $thread_root_id
  * @property bool $sent_to_channel
  * @property int $reply_count
@@ -36,11 +37,12 @@ use Laravel\Scout\Searchable;
  * @property-read Channel $channel
  * @property-read User $user
  * @property-read Message|null $replyTo
+ * @property-read Message|null $forwardedFrom
  * @property-read Collection<int, Message> $threadReplies
  * @property-read Collection<int, User> $threadParticipants
  * @property-read Collection<int, User> $mentionedUsers
  */
-#[Fillable(['channel_id', 'user_id', 'client_uuid', 'reply_to_id', 'thread_root_id', 'sent_to_channel', 'body', 'edited_at'])]
+#[Fillable(['channel_id', 'user_id', 'client_uuid', 'reply_to_id', 'forwarded_from_id', 'thread_root_id', 'sent_to_channel', 'body', 'edited_at'])]
 class Message extends Model
 {
     /** @use HasFactory<MessageFactory> */
@@ -90,6 +92,21 @@ class Message extends Model
     public function replyTo(): BelongsTo
     {
         return $this->belongsTo(Message::class, 'reply_to_id')->withTrashed();
+    }
+
+    /**
+     * Get the source message this one forwards into its channel, if any.
+     *
+     * The source lives in another channel, so its `channel` relation carries the
+     * attribution ("Forwarded from #name"). A soft-deleted source is still
+     * resolved (withTrashed) so the client can render a "message deleted" stub in
+     * the forwarded quote rather than dropping it.
+     *
+     * @return BelongsTo<Message, $this>
+     */
+    public function forwardedFrom(): BelongsTo
+    {
+        return $this->belongsTo(Message::class, 'forwarded_from_id')->withTrashed();
     }
 
     /**

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -49,6 +49,16 @@ class MessageFactory extends Factory
     }
 
     /**
+     * Indicate that the message forwards another message into its channel.
+     */
+    public function forwardedFrom(Message $source): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'forwarded_from_id' => $source->id,
+        ]);
+    }
+
+    /**
      * Indicate that the message is a reply in another message's thread.
      *
      * The reply inherits the root's channel so it stays consistent with the

--- a/database/migrations/2026_07_09_213037_add_forwarded_from_id_to_messages_table.php
+++ b/database/migrations/2026_07_09_213037_add_forwarded_from_id_to_messages_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            // The message this one forwards into its channel, or null for a
+            // normal message. Unlike reply_to_id, the source lives in another
+            // channel (any the author belongs to). A force-deleted source nulls
+            // the reference; a soft-deleted source keeps it so the client renders
+            // a "message deleted" stub in the forwarded quote.
+            $table->foreignUuid('forwarded_from_id')
+                ->nullable()
+                ->after('reply_to_id')
+                ->constrained('messages')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('forwarded_from_id');
+        });
+    }
+};

--- a/resources/js/components/ForwardMessageDialog.vue
+++ b/resources/js/components/ForwardMessageDialog.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { Check, Hash, Search } from '@lucide/vue';
+import { computed, ref, watch } from 'vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { rankChannels } from '@/composables/quickSwitcher';
+import { messageBodyPreview } from '@/lib/messageBody';
+import type { Message } from '@/types';
+import type { Channel } from '@/types/channels';
+
+const props = defineProps<{
+    // The message being forwarded, driving the preview; null when the dialog is
+    // closed (nothing is being forwarded).
+    message: Message | null;
+    channels: Channel[];
+}>();
+
+const emit = defineEmits<{
+    submit: [payload: { channel: Channel; note: string }];
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+
+const query = ref('');
+const note = ref('');
+const selectedChannelId = ref<string | null>(null);
+
+// Fuzzy-ranked channel matches for the picker, reusing the quick switcher's
+// scorer so the ordering matches everywhere channels are searched.
+const rankedChannels = computed(() =>
+    rankChannels(props.channels, query.value),
+);
+
+const selectedChannel = computed(
+    () =>
+        props.channels.find(
+            (channel) => channel.id === selectedChannelId.value,
+        ) ?? null,
+);
+
+// A one-line snippet of the message being forwarded, empty for a deleted source.
+const preview = computed(() =>
+    props.message && !props.message.isDeleted
+        ? messageBodyPreview(props.message.body)
+        : '',
+);
+
+// Reset the picker every time it opens so it never reappears with a stale query,
+// note, or selection.
+watch(open, (isOpen) => {
+    if (isOpen) {
+        query.value = '';
+        note.value = '';
+        selectedChannelId.value = null;
+    }
+});
+
+function selectChannel(channel: Channel): void {
+    selectedChannelId.value = channel.id;
+}
+
+function submit(): void {
+    const channel = selectedChannel.value;
+
+    if (!channel) {
+        return;
+    }
+
+    emit('submit', { channel, note: note.value.trim() });
+    open.value = false;
+}
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent class="gap-4 sm:max-w-md">
+            <DialogHeader>
+                <DialogTitle>Forward message</DialogTitle>
+                <DialogDescription>
+                    Share this message to another channel you're in.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div
+                v-if="message"
+                class="rounded-md border-l-2 border-border bg-muted/30 px-3 py-2"
+            >
+                <p class="text-[12.5px] font-semibold text-foreground">
+                    {{ message.user.name }}
+                </p>
+                <p
+                    class="mt-0.5 line-clamp-2 text-[13px] text-foreground/80"
+                    :class="message.isDeleted ? 'italic' : ''"
+                >
+                    {{ message.isDeleted ? 'Message was deleted' : preview }}
+                </p>
+            </div>
+
+            <div>
+                <label
+                    class="mb-1 block text-[12px] font-medium text-muted-foreground"
+                >
+                    Channel
+                </label>
+                <div
+                    class="flex h-9 items-center gap-2 rounded-md border border-input px-2.5"
+                >
+                    <Search class="size-4 shrink-0 opacity-50" />
+                    <input
+                        v-model="query"
+                        type="text"
+                        placeholder="Search channels…"
+                        data-test="forward-channel-search"
+                        class="h-full w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
+                    />
+                </div>
+                <ul
+                    class="mt-1.5 max-h-44 space-y-0.5 overflow-y-auto"
+                    data-test="forward-channel-list"
+                >
+                    <li v-for="channel in rankedChannels" :key="channel.id">
+                        <button
+                            type="button"
+                            data-test="forward-channel-option"
+                            :aria-pressed="channel.id === selectedChannelId"
+                            class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted"
+                            :class="
+                                channel.id === selectedChannelId
+                                    ? 'bg-muted font-medium'
+                                    : ''
+                            "
+                            @click="selectChannel(channel)"
+                        >
+                            <Hash class="size-4 shrink-0 opacity-60" />
+                            <span class="truncate">{{ channel.name }}</span>
+                            <Check
+                                v-if="channel.id === selectedChannelId"
+                                class="ml-auto size-4 shrink-0 text-primary"
+                            />
+                        </button>
+                    </li>
+                    <li
+                        v-if="rankedChannels.length === 0"
+                        class="px-2 py-2 text-xs text-muted-foreground"
+                    >
+                        No channels match “{{ query }}”.
+                    </li>
+                </ul>
+            </div>
+
+            <div>
+                <label
+                    class="mb-1 block text-[12px] font-medium text-muted-foreground"
+                >
+                    Add a note
+                    <span class="font-normal text-muted-foreground/70"
+                        >(optional)</span
+                    >
+                </label>
+                <textarea
+                    v-model="note"
+                    rows="2"
+                    placeholder="Say something about this…"
+                    data-test="forward-note"
+                    class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-sm leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                ></textarea>
+            </div>
+
+            <DialogFooter class="gap-2">
+                <Button variant="secondary" @click="open = false">
+                    Cancel
+                </Button>
+                <Button
+                    data-test="forward-submit"
+                    :disabled="!selectedChannel"
+                    @click="submit"
+                >
+                    Forward
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/MessageForward.vue
+++ b/resources/js/components/MessageForward.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { Forward } from '@lucide/vue';
+import { computed } from 'vue';
+import { renderMessageBody } from '@/lib/messageBody';
+import type { Mention } from '@/types';
+
+const props = defineProps<{
+    authorName: string;
+    channelName: string;
+    body: string;
+    isDeleted: boolean;
+    mentions: Mention[];
+}>();
+
+// The forwarded body, rendered with its own mentions; empty for a deleted
+// source, whose body is never sent to the client.
+const rendered = computed(() =>
+    props.isDeleted ? '' : renderMessageBody(props.body, props.mentions),
+);
+</script>
+
+<template>
+    <div class="mt-1 max-w-full">
+        <p
+            class="flex items-center gap-1.5 text-[11.5px] font-medium text-muted-foreground"
+        >
+            <Forward class="size-3 shrink-0" aria-hidden="true" />
+            <span>
+                Forwarded from
+                <span class="text-muted-foreground/70">#</span>{{ channelName }}
+            </span>
+        </p>
+        <div
+            class="mt-1 rounded-md border-l-2 border-border bg-muted/30 py-1.5 pr-2 pl-2.5"
+        >
+            <p
+                v-if="isDeleted"
+                data-test="forward-deleted"
+                class="text-[13px] text-muted-foreground/70 italic"
+            >
+                Original message was deleted
+            </p>
+            <template v-else>
+                <p class="text-[12.5px] font-semibold text-foreground">
+                    {{ authorName }}
+                </p>
+                <p
+                    class="mt-0.5 text-[13.5px] leading-[1.5] break-words whitespace-pre-wrap text-foreground/85"
+                >
+                    <span v-html="rendered"></span>
+                </p>
+            </template>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
-import { CornerUpLeft, MessageSquareText, Pencil, Trash2 } from '@lucide/vue';
+import {
+    CornerUpLeft,
+    Forward,
+    MessageSquareText,
+    Pencil,
+    Trash2,
+} from '@lucide/vue';
 import { computed, nextTick, ref } from 'vue';
+import MessageForward from '@/components/MessageForward.vue';
 import MessageQuote from '@/components/MessageQuote.vue';
 import { Button } from '@/components/ui/button';
 import {
@@ -37,6 +44,7 @@ const emit = defineEmits<{
     edit: [message: Message, body: string];
     delete: [message: Message];
     reply: [message: Message];
+    forward: [message: Message];
     openThread: [messageId: string];
     jump: [messageId: string];
 }>();
@@ -211,6 +219,12 @@ function canDelete(message: Message): boolean {
 // thread the composer answers the root, so it's suppressed.
 function canReply(message: Message): boolean {
     return !props.inThread && !message.isDeleted && !isPending(message);
+}
+
+// Any live message can be forwarded to another channel — including from inside a
+// thread panel. A pending or deleted row has no stable target to forward yet.
+function canForward(message: Message): boolean {
+    return !message.isDeleted && !isPending(message);
 }
 
 // The hover "reply in thread" action shows on live root messages in the main
@@ -421,7 +435,7 @@ function confirmDelete(): void {
                         </div>
 
                         <p
-                            v-else
+                            v-else-if="message.body !== ''"
                             :data-test="'message-body'"
                             class="py-0.5 text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90"
                             :class="isPending(message) ? 'opacity-60' : ''"
@@ -441,6 +455,20 @@ function confirmDelete(): void {
                                 >(edited)</span
                             >
                         </p>
+
+                        <MessageForward
+                            v-if="
+                                message.forwardedFrom &&
+                                !message.isDeleted &&
+                                editingId !== message.id
+                            "
+                            data-test="forwarded-message"
+                            :author-name="message.forwardedFrom.authorName"
+                            :channel-name="message.forwardedFrom.channelName"
+                            :body="message.forwardedFrom.body"
+                            :is-deleted="message.forwardedFrom.isDeleted"
+                            :mentions="message.forwardedFrom.mentions"
+                        />
 
                         <button
                             v-if="showThreadSummary(message)"
@@ -499,6 +527,7 @@ function confirmDelete(): void {
                                 editingId !== message.id &&
                                 (canReply(message) ||
                                     canStartThread(message) ||
+                                    canForward(message) ||
                                     canEdit(message) ||
                                     canDelete(message))
                             "
@@ -523,6 +552,16 @@ function confirmDelete(): void {
                                 @click="emit('reply', message)"
                             >
                                 <CornerUpLeft class="size-3.5" />
+                            </button>
+                            <button
+                                v-if="canForward(message)"
+                                type="button"
+                                :data-test="'message-forward'"
+                                aria-label="Forward message"
+                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                @click="emit('forward', message)"
+                            >
+                                <Forward class="size-3.5" />
                             </button>
                             <button
                                 v-if="canEdit(message)"

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -29,6 +29,7 @@ const emit = defineEmits<{
     send: [body: string, mentions: Mention[], sendToChannel?: boolean];
     edit: [message: Message, body: string];
     delete: [message: Message];
+    forward: [message: Message];
     typing: [];
     jump: [messageId: string];
 }>();
@@ -150,6 +151,7 @@ watch(
                     in-thread
                     @edit="(message, body) => emit('edit', message, body)"
                     @delete="(message) => emit('delete', message)"
+                    @forward="(message) => emit('forward', message)"
                     @jump="(id) => emit('jump', id)"
                 />
             </InfiniteScroll>

--- a/resources/js/composables/useMessageStream.ts
+++ b/resources/js/composables/useMessageStream.ts
@@ -1,6 +1,6 @@
 import { computed, ref, watch } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
-import type { Mention, Message } from '@/types';
+import type { Mention, Message, MessageForward } from '@/types';
 
 /**
  * The reactive merge engine behind a message list.
@@ -191,6 +191,7 @@ export function optimisticMessage(params: {
     author: Mention;
     mentions: Mention[];
     replyTo?: Message | null;
+    forwardedFrom?: MessageForward | null;
     threadRootId?: string | null;
     sentToChannel?: boolean;
 }): Message {
@@ -214,6 +215,7 @@ export function optimisticMessage(params: {
                   mentions: target.mentions,
               }
             : null,
+        forwardedFrom: params.forwardedFrom ?? null,
         threadRootId: params.threadRootId ?? null,
         sentToChannel: params.sentToChannel ?? false,
         threadReplyCount: 0,

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -29,11 +29,13 @@ import {
 import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
 import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
 import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
+import { store as forwardMessageAction } from '@/actions/App/Http/Controllers/Channels/ForwardMessageController';
 import {
     destroy as destroyMessage,
     store as storeMessage,
     update as updateMessage,
 } from '@/actions/App/Http/Controllers/Channels/MessageController';
+import ForwardMessageDialog from '@/components/ForwardMessageDialog.vue';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
 import ThreadPanel from '@/components/ThreadPanel.vue';
@@ -532,6 +534,89 @@ function startReply(message: Message): void {
 
 function cancelReply(): void {
     replyTarget.value = null;
+}
+
+// The message being forwarded and whether the forward dialog is open. The dialog
+// picks a target channel (from the sidebar list — the channels the viewer can
+// post to) and an optional note.
+const forwardTarget = ref<Message | null>(null);
+const forwardDialogOpen = ref(false);
+
+const forwardableChannels = computed<Channel[]>(
+    () => page.props.channels ?? [],
+);
+
+function openForward(message: Message): void {
+    forwardTarget.value = message;
+    forwardDialogOpen.value = true;
+}
+
+// Forward the selected message into `channel` with an optional note. The source
+// always lives in the current channel (the action originates from its timeline
+// or thread), so a forward back into it renders optimistically and dedups
+// against the broadcast echo; a forward elsewhere just confirms with a toast.
+function forwardMessage({
+    channel,
+    note,
+}: {
+    channel: Channel;
+    note: string;
+}): void {
+    const source = forwardTarget.value;
+
+    if (!source) {
+        return;
+    }
+
+    const clientUuid = crypto.randomUUID();
+    const toCurrentChannel = channel.id === props.channel.id;
+
+    if (toCurrentChannel) {
+        appendPendingMain(
+            optimisticMessage({
+                clientUuid,
+                body: note,
+                author: currentUser.value,
+                mentions: [],
+                forwardedFrom: {
+                    id: source.id,
+                    body: source.body,
+                    authorName: source.user.name,
+                    channelName: props.channel.name,
+                    isDeleted: source.isDeleted,
+                    mentions: source.mentions,
+                },
+            }),
+        );
+    }
+
+    router.post(
+        forwardMessageAction({
+            team: props.team.slug,
+            channel: props.channel.slug,
+            message: source.id,
+        }).url,
+        { body: note, client_uuid: clientUuid, target_channel_id: channel.id },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channels'],
+            onSuccess: () => {
+                if (!toCurrentChannel) {
+                    toast.success(`Message forwarded to #${channel.name}.`);
+                }
+            },
+            onError: () => {
+                if (toCurrentChannel) {
+                    mainStream.removePending(clientUuid);
+                }
+
+                toast.error('Failed to forward the message. Please try again.');
+            },
+        },
+    );
+
+    forwardTarget.value = null;
 }
 
 // The member's unsent composer text is persisted per channel so it survives
@@ -1098,6 +1183,7 @@ function archive(): void {
                             @edit="editMessage"
                             @delete="deleteMessage"
                             @reply="startReply"
+                            @forward="openForward"
                             @open-thread="openThread"
                             @jump="jumpToMessage"
                         />
@@ -1180,11 +1266,19 @@ function archive(): void {
                 @send="sendThreadReply"
                 @edit="editMessage"
                 @delete="deleteMessage"
+                @forward="openForward"
                 @typing="onTyping"
                 @jump="jumpToMessage"
             />
         </Transition>
     </div>
+
+    <ForwardMessageDialog
+        v-model:open="forwardDialogOpen"
+        :message="forwardTarget"
+        :channels="forwardableChannels"
+        @submit="forwardMessage"
+    />
 
     <Dialog v-model:open="confirmingArchive">
         <DialogContent>

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -25,6 +25,22 @@ export type MessageReply = {
     mentions: Mention[];
 };
 
+/**
+ * A compact quote of a forwarded source message. Mirrors the
+ * `MessageForwardData` DTO: like `MessageReply` but also names the source
+ * channel so the forward can render its "Forwarded from #name" attribution.
+ * Flat (never nested), with the body and mentions blanked when the source has
+ * been deleted.
+ */
+export type MessageForward = {
+    id: string;
+    body: string;
+    authorName: string;
+    channelName: string;
+    isDeleted: boolean;
+    mentions: Mention[];
+};
+
 export type Message = {
     id: string;
     clientUuid: string;
@@ -35,6 +51,11 @@ export type Message = {
     isDeleted: boolean;
     mentions: Mention[];
     replyTo: MessageReply | null;
+    /**
+     * A compact quote of the message this one forwards into the channel, or null
+     * for a normal message. Mirrors the `MessageData` DTO's `forwardedFrom`.
+     */
+    forwardedFrom: MessageForward | null;
     /**
      * Threading fields (mirror the `MessageData` DTO). `threadRootId` is set on a
      * thread reply and names its root; null on a root/normal message. The

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Channels\ChannelPlacementController;
 use App\Http\Controllers\Channels\ChannelPreferenceController;
 use App\Http\Controllers\Channels\ChannelSectionController;
 use App\Http\Controllers\Channels\ChannelStarController;
+use App\Http\Controllers\Channels\ForwardMessageController;
 use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Channels\SearchController;
 use App\Http\Controllers\Channels\ThreadsController;
@@ -65,6 +66,9 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::delete('t/{team}/c/{channel}/messages/{message}', [MessageController::class, 'destroy'])
         ->scopeBindings()
         ->name('channels.messages.destroy');
+    Route::post('t/{team}/c/{channel}/messages/{message}/forward', [ForwardMessageController::class, 'store'])
+        ->scopeBindings()
+        ->name('channels.messages.forward');
     Route::post('t/{team}/c/{channel}/members', [ChannelMemberController::class, 'store'])
         ->scopeBindings()
         ->name('channels.members.store');

--- a/tests/Feature/Channels/ForwardMessageTest.php
+++ b/tests/Feature/Channels/ForwardMessageTest.php
@@ -1,0 +1,241 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Events\MessageSent;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team whose owner is a member of #general plus a second channel, with
+ * a message sitting in #general ready to forward.
+ *
+ * @return array{0: User, 1: Team, 2: Channel, 3: Channel, 4: Message}
+ */
+function forwardFixture(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    $target = Channel::factory()->for($team)->create(['name' => 'random']);
+    $target->members()->attach($owner->id);
+
+    $source = Message::factory()->for($general)->for($owner)->create(['body' => 'the original']);
+
+    return [$owner, $team, $general, $target, $source];
+}
+
+function forwardRoute(Team $team, Channel $source, Message $message): string
+{
+    return route('channels.messages.forward', [
+        'team' => $team->slug,
+        'channel' => $source->slug,
+        'message' => $message->id,
+    ]);
+}
+
+test('a message can be forwarded into another channel with a note', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)
+        ->from(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->post(forwardRoute($team, $general, $source), [
+            'body' => 'check this out',
+            'client_uuid' => $clientUuid,
+            'target_channel_id' => $target->id,
+        ])
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $this->assertDatabaseHas('messages', [
+        'client_uuid' => $clientUuid,
+        'channel_id' => $target->id,
+        'body' => 'check this out',
+        'forwarded_from_id' => $source->id,
+    ]);
+});
+
+test('a message can be forwarded with no note, leaving an empty body', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)->post(forwardRoute($team, $general, $source), [
+        'client_uuid' => $clientUuid,
+        'target_channel_id' => $target->id,
+    ]);
+
+    $this->assertDatabaseHas('messages', [
+        'client_uuid' => $clientUuid,
+        'channel_id' => $target->id,
+        'body' => '',
+        'forwarded_from_id' => $source->id,
+    ]);
+});
+
+test('the target channel renders a forwarded message with source attribution', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+
+    // A mention on the source rides along in the forwarded quote's mentions.
+    $mentioned = User::factory()->create();
+    $team->memberships()->create(['user_id' => $mentioned->id, 'role' => TeamRole::Member]);
+    $source->mentionedUsers()->attach($mentioned->id);
+
+    Message::factory()->for($target)->for($owner)->forwardedFrom($source)->create(['body' => 'fyi']);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $target->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('messages.data.0.body', 'fyi')
+            ->where('messages.data.0.forwardedFrom.id', $source->id)
+            ->where('messages.data.0.forwardedFrom.body', 'the original')
+            ->where('messages.data.0.forwardedFrom.authorName', $owner->name)
+            ->where('messages.data.0.forwardedFrom.channelName', $general->name)
+            ->where('messages.data.0.forwardedFrom.isDeleted', false)
+            ->where('messages.data.0.forwardedFrom.mentions.0.id', $mentioned->id)
+        );
+});
+
+test('a forward whose source was later deleted renders a deleted stub', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+
+    Message::factory()->for($target)->for($owner)->forwardedFrom($source)->create(['body' => 'fyi']);
+    $source->delete();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $target->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('messages.data.0.forwardedFrom.id', $source->id)
+            ->where('messages.data.0.forwardedFrom.isDeleted', true)
+            ->where('messages.data.0.forwardedFrom.body', '')
+        );
+});
+
+test('a deleted forwarded message carries no source reference', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+
+    $forward = Message::factory()->for($target)->for($owner)->forwardedFrom($source)->create(['body' => 'fyi']);
+    $forward->delete();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $target->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('messages.data.0.isDeleted', true)
+            ->where('messages.data.0.forwardedFrom', null)
+        );
+});
+
+test('forwarding broadcasts the source quote in the target channel payload', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+
+    $this->actingAs($owner)->post(forwardRoute($team, $general, $source), [
+        'body' => 'broadcast forward',
+        'client_uuid' => (string) Str::uuid7(),
+        'target_channel_id' => $target->id,
+    ]);
+
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($target, $source, $general) {
+        $payload = $event->message->toArray();
+
+        return $event->channel->is($target)
+            && $payload['forwardedFrom']['id'] === $source->id
+            && $payload['forwardedFrom']['body'] === 'the original'
+            && $payload['forwardedFrom']['channelName'] === $general->name;
+    });
+});
+
+test('a message cannot be forwarded to a channel the user is not a member of', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+    $stranger = Channel::factory()->for($team)->create();
+
+    $this->actingAs($owner)->post(forwardRoute($team, $general, $source), [
+        'body' => 'sneaky',
+        'client_uuid' => (string) Str::uuid7(),
+        'target_channel_id' => $stranger->id,
+    ])->assertInvalid(['target_channel_id']);
+
+    expect(Message::where('channel_id', $stranger->id)->count())->toBe(0);
+});
+
+test('a message cannot be forwarded to an archived channel', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+    $archived = Channel::factory()->for($team)->archived()->create();
+    $archived->members()->attach($owner->id);
+
+    $this->actingAs($owner)->post(forwardRoute($team, $general, $source), [
+        'body' => 'to the vault',
+        'client_uuid' => (string) Str::uuid7(),
+        'target_channel_id' => $archived->id,
+    ])->assertInvalid(['target_channel_id']);
+});
+
+test('a message cannot be forwarded to a channel in another team', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+
+    $otherOwner = User::factory()->create();
+    $otherTeam = app(CreateTeam::class)->handle($otherOwner, 'Other');
+    $otherGeneral = Channel::where('team_id', $otherTeam->id)->where('slug', 'general')->firstOrFail();
+    $team->memberships()->create(['user_id' => $otherOwner->id, 'role' => TeamRole::Member]);
+
+    // The author belongs to the other team's channel too, but it lives in a
+    // different team than the source, so it is not a valid destination.
+    $otherGeneral->members()->attach($owner->id);
+
+    $this->actingAs($owner)->post(forwardRoute($team, $general, $source), [
+        'body' => 'cross-team',
+        'client_uuid' => (string) Str::uuid7(),
+        'target_channel_id' => $otherGeneral->id,
+    ])->assertInvalid(['target_channel_id']);
+});
+
+test('a user cannot forward a message from a private channel they cannot view', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+
+    $private = Channel::factory()->for($team)->create(['visibility' => ChannelVisibility::Private]);
+    $secret = Message::factory()->for($private)->for($owner)->create();
+
+    $outsider = User::factory()->create();
+    $team->memberships()->create(['user_id' => $outsider->id, 'role' => TeamRole::Member]);
+    $target->members()->attach($outsider->id);
+
+    $this->actingAs($outsider)->post(forwardRoute($team, $private, $secret), [
+        'body' => 'leak',
+        'client_uuid' => (string) Str::uuid7(),
+        'target_channel_id' => $target->id,
+    ])->assertForbidden();
+});
+
+test('a deleted source message cannot be forwarded', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+    $source->delete();
+
+    $this->actingAs($owner)->post(forwardRoute($team, $general, $source), [
+        'body' => 'ghost',
+        'client_uuid' => (string) Str::uuid7(),
+        'target_channel_id' => $target->id,
+    ])->assertNotFound();
+});
+
+test('forwarding is idempotent on a resent client uuid', function () {
+    [$owner, $team, $general, $target, $source] = forwardFixture();
+    $clientUuid = (string) Str::uuid7();
+
+    $payload = [
+        'body' => 'once',
+        'client_uuid' => $clientUuid,
+        'target_channel_id' => $target->id,
+    ];
+
+    $this->actingAs($owner)->post(forwardRoute($team, $general, $source), $payload);
+    $this->actingAs($owner)->post(forwardRoute($team, $general, $source), $payload);
+
+    expect(Message::where('client_uuid', $clientUuid)->count())->toBe(1);
+});


### PR DESCRIPTION
Closes #34.

## What
Forward an existing message into another channel you belong to, preserving the original author + a compact quote, with an optional note.

## How it works
- **Data model** — a self-referencing `forwarded_from_id` on `messages` (`nullOnDelete`, mirrors `reply_to_id`) and a `forwardedFrom` relation that resolves soft-deleted sources so a "message deleted" stub can render in the quote.
- **Dedicated endpoint** — `POST t/{team}/c/{channel}/messages/{message}/forward` (`ForwardMessageController`). It resolves the chosen target channel and reuses `PostMessage`, so a forward enters the normal post + `MessageSent` broadcast flow. It returns `back()` so forwarding into *another* channel doesn't navigate you away from the source.
- **Authorization** (`ForwardMessageRequest`) — you must be able to **view** the source channel, and the destination must be a **live, non-archived channel in the same team that you're a member of** — the same constraint the `postMessage` gate applies.
- **DTO** — `MessageForwardData` carries the source author, **source channel name**, quote, and mentions. Wired into `MessageData` and eager-loaded alongside `replyTo` in every path that builds message DTOs (timeline, threads, search, inbox) to avoid N+1.
- **Frontend** — a `Forward` hover action (timeline + thread panel) opens `ForwardMessageDialog`: a fuzzy channel picker over the sidebar channels (reusing the quick-switcher scorer) plus an optional note. Forwarded messages render via a new `MessageForward` card ("Forwarded from #channel", author, quoted body). Forwarding back into the current channel renders optimistically and dedups against the broadcast echo; forwarding elsewhere confirms with a toast.

## Acceptance criteria
- [x] Forward action on a message opens a channel picker + optional note
- [x] Forwarded message renders with original author attribution and quote
- [x] Only channels the user is a member of are targetable (authorization enforced)
- [x] Enters the normal realtime + optimistic flow
- [x] Test coverage for authorization and rendering

## Testing
- `tests/Feature/Channels/ForwardMessageTest.php` — 12 tests covering happy path (with/without note), rendering + attribution + mentions, deleted-source stub, deleted-forward carries no reference, broadcast payload, and authorization (non-member / archived / cross-team target, non-viewable private source, deleted source, idempotent resend).
- Full backend gate green at **100.0%** coverage (Pint + PHPStan + `--min=100`).
- Frontend gate green: `lint:check`, `format:check`, `types:check`, `build`.