### PR TITLE
fix(messaging): align message-list presence dots and avatar rhythm (#91)

### DIFF
--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -329,7 +329,7 @@ function confirmDelete(): void {
             </div>
 
             <div v-else class="mt-[18px] flex gap-3 first:mt-1">
-                <div class="relative size-9 shrink-0">
+                <div class="relative mt-0.5 size-9 shrink-0">
                     <div
                         class="flex size-9 items-center justify-center rounded-[10px] bg-primary/10 text-[12px] font-semibold text-primary select-none"
                         aria-hidden="true"
@@ -342,11 +342,11 @@ function confirmDelete(): void {
                         :aria-label="
                             isOnline(item.author.id) ? 'Online' : 'Offline'
                         "
-                        class="absolute -right-0.5 -bottom-0.5 size-2.5 rounded-full ring-2 ring-background"
+                        class="absolute right-0.5 bottom-0.5 size-2.5 rounded-full ring-2 ring-background"
                         :class="
                             isOnline(item.author.id)
                                 ? 'bg-emerald-500'
-                                : 'bg-transparent ring-muted-foreground/40 ring-inset'
+                                : 'bg-muted-foreground/60'
                         "
                     />
                 </div>


### PR DESCRIPTION
Closes #91.

Fixes the UI alignment issues in the channel message list (`resources/js/components/MessageList.vue`) around the avatar + presence-dot block. Frontend-only, verified visually against the issue screenshot.

## Acceptance criteria → changes

- [x] **Presence dot sits flush in the avatar corner (no floating gap).** The dot was `-right-0.5 -bottom-0.5`, pushing it *outside* the box so it perched on the corner tip of the `rounded-[10px]` (rounded-square) avatar with a visible diagonal gap. Changed to `right-0.5 bottom-0.5` so the dot overlaps *into* the rounded corner, with the existing `ring-2 ring-background` punching a clean cutout — it now reads as nestled into the corner.
- [x] **Online and offline indicators have consistent size/weight; offline is clearly legible.** Offline was `bg-transparent` + inset ring (barely visible). Replaced with a solid `bg-muted-foreground/60` dot — same `size-2.5` + `ring-2 ring-background` as the emerald online dot, differentiated only by fill color, so both states carry equal visual weight and the offline state is now easily readable.
- [x] **Avatar, author name, timestamp, and first message line are vertically aligned cleanly.** Added `mt-0.5` to the avatar wrapper so its vertical center aligns against the name/timestamp header and the first line of message text.
- [x] **No regression in message hover, thread affordances, or date dividers.** Changes are isolated to the avatar wrapper and presence-dot span; the `data-online` / aria-label hooks are unchanged. Verified in-browser that the hover row highlight + action bar, the "Today" divider, and thread/reply affordances are intact.

## Verification

- Visually confirmed before/after in the running app (logged in as the demo user, `#announcements`), including a zoomed crop of the avatar corners and a hover check.
- Frontend gate passes through Sail: `lint:check`, `format:check`, `types:check`, and `build`.