### PR TITLE
feat(messaging): read receipts / "seen by" (#36)

### DIFF
--- a/app/Actions/Channels/MarkChannelRead.php
+++ b/app/Actions/Channels/MarkChannelRead.php
@@ -2,6 +2,8 @@
 
 namespace App\Actions\Channels;
 
+use App\Data\UserData;
+use App\Events\MessageRead;
 use App\Models\Channel;
 use App\Models\User;
 
@@ -14,6 +16,11 @@ class MarkChannelRead
      * pointer never lags behind a deleted tail) zeroes the sidebar's unread and
      * mention badges. A channel with no messages leaves the pointer untouched,
      * and a non-member is a no-op because there is no pivot row to update.
+     *
+     * When the pointer actually advances and the user shares read receipts, a
+     * {@see MessageRead} event is broadcast so peers can update their "Seen by"
+     * affordance. The advance guard also avoids re-broadcasting on the frequent
+     * no-op calls the client fires on every incoming message and window focus.
      */
     public function handle(Channel $channel, User $user): void
     {
@@ -23,8 +30,16 @@ class MarkChannelRead
             return;
         }
 
-        $user->channels()->updateExistingPivot($channel->id, [
-            'last_read_message_id' => $latestMessageId,
-        ]);
+        $member = $channel->channelMembers()->where('user_id', $user->id)->first();
+
+        if ($member === null || $member->last_read_message_id === $latestMessageId) {
+            return;
+        }
+
+        $member->update(['last_read_message_id' => $latestMessageId]);
+
+        if ($user->share_read_receipts) {
+            MessageRead::dispatch($channel, UserData::fromUser($user), $latestMessageId);
+        }
     }
 }

--- a/app/Data/ChannelReaderData.php
+++ b/app/Data/ChannelReaderData.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\ChannelMember;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class ChannelReaderData extends Data
+{
+    public function __construct(
+        public UserData $user,
+        public ?string $lastReadMessageId,
+    ) {}
+
+    /**
+     * Build the DTO from a channel membership row.
+     *
+     * `lastReadMessageId` is the member's read pointer, powering how far the
+     * "Seen by" affordance places their avatar. The membership's `user` relation
+     * is expected to be eager-loaded by the caller.
+     */
+    public static function fromMember(ChannelMember $member): self
+    {
+        return new self(
+            user: UserData::fromUser($member->user),
+            lastReadMessageId: $member->last_read_message_id !== null ? (string) $member->last_read_message_id : null,
+        );
+    }
+}

--- a/app/Events/MessageRead.php
+++ b/app/Events/MessageRead.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Events;
+
+use App\Data\UserData;
+use App\Models\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageRead implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * Announces that `reader` has advanced their read pointer in the channel to
+     * `lastReadMessageId`, so peers can update the "Seen by" affordance in
+     * realtime. Only dispatched for users who share read receipts.
+     */
+    public function __construct(
+        public Channel $channel,
+        public UserData $reader,
+        public string $lastReadMessageId,
+    ) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel.'.$this->channel->id),
+        ];
+    }
+
+    /**
+     * Get the data to broadcast: who read, and how far.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'reader' => $this->reader->toArray(),
+            'lastReadMessageId' => $this->lastReadMessageId,
+        ];
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -8,6 +8,7 @@ use App\Actions\Channels\JoinChannel;
 use App\Actions\Channels\MarkChannelRead;
 use App\Actions\Channels\MarkThreadRead;
 use App\Data\ChannelData;
+use App\Data\ChannelReaderData;
 use App\Data\MessageData;
 use App\Data\UserData;
 use App\Enums\ChannelVisibility;
@@ -147,6 +148,16 @@ class ChannelController extends Controller
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),
+            // Read pointers of the channel's other members who share read receipts,
+            // seeding the "Seen by" affordance at open; later advances arrive via the
+            // MessageRead broadcast. The viewer and opted-out members are excluded.
+            'channelReaders' => ChannelReaderData::collect(
+                $channel->channelMembers()
+                    ->where('user_id', '!=', $request->user()->id)
+                    ->whereRelation('user', 'share_read_receipts', true)
+                    ->with('user')
+                    ->get()
+            ),
             // Newest 50 first; the InfiniteScroll composer runs in reverse mode, so
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a

--- a/app/Http/Controllers/Settings/ReadReceiptsController.php
+++ b/app/Http/Controllers/Settings/ReadReceiptsController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ReadReceiptsController extends Controller
+{
+    /**
+     * Toggle whether the current user shares their read position with peers.
+     *
+     * Stored on the user so it follows them across devices; redirects back and
+     * lets Inertia recompute the shared `auth.user` prop. When off, the user
+     * neither broadcasts nor exposes where they've read up to.
+     */
+    public function update(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'share_read_receipts' => ['required', 'boolean'],
+        ]);
+
+        $request->user()->update($validated);
+
+        return back();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -29,6 +29,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $remember_token
  * @property string|null $current_team_id
  * @property ChimeSound $chime_sound
+ * @property bool $share_read_receipts
  * @property array<int, string>|null $collapsed_channel_sections
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -39,7 +40,7 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, Channel> $channels
  * @property-read Collection<int, ChannelSection> $channelSections
  */
-#[Fillable(['name', 'email', 'password', 'current_team_id', 'chime_sound', 'collapsed_channel_sections'])]
+#[Fillable(['name', 'email', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'collapsed_channel_sections'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable
 {
@@ -57,6 +58,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'chime_sound' => ChimeSound::class,
+            'share_read_receipts' => 'boolean',
             'collapsed_channel_sections' => 'array',
         ];
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -37,6 +37,7 @@ class UserFactory extends Factory
             'two_factor_recovery_codes' => null,
             'two_factor_confirmed_at' => null,
             'chime_sound' => ChimeSound::Ping->value,
+            'share_read_receipts' => true,
         ];
     }
 
@@ -65,6 +66,16 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the user has opted out of sharing read receipts.
+     */
+    public function withoutReadReceipts(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'share_read_receipts' => false,
         ]);
     }
 

--- a/database/migrations/2026_07_09_233832_add_share_read_receipts_to_users_table.php
+++ b/database/migrations/2026_07_09_233832_add_share_read_receipts_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Whether the user shares their read position with channel peers, powering
+            // the "Seen by" affordance. Default on; turning it off stops the user from
+            // broadcasting or exposing where they've read up to (they can still see others').
+            $table->boolean('share_read_receipts')->default(true)->after('chime_sound');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('share_read_receipts');
+        });
+    }
+};

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -21,7 +21,8 @@ import {
 } from '@/components/ui/dialog';
 import { useInitials } from '@/composables/useInitials';
 import { renderMessageBody } from '@/lib/messageBody';
-import type { Mention, Message, MessageAuthor } from '@/types';
+import { readersForMessage } from '@/lib/readReceipts';
+import type { ChannelReader, Mention, Message, MessageAuthor } from '@/types';
 
 const props = defineProps<{
     messages: Message[];
@@ -38,6 +39,9 @@ const props = defineProps<{
     inThread?: boolean;
     // The root of the currently-open thread, highlighted in the main timeline.
     activeThreadRootId?: string | null;
+    // Read positions of channel members who share read receipts, driving the
+    // "Seen by" affordance under the newest message. Omitted inside a thread.
+    readers?: ChannelReader[];
 }>();
 
 const emit = defineEmits<{
@@ -59,6 +63,57 @@ function threadAvatars(message: Message): Mention[] {
 function extraThreadParticipants(message: Message): number {
     return Math.max(0, message.threadParticipants.length - MAX_THREAD_AVATARS);
 }
+
+// How many reader avatars to preview on the "Seen by" row before collapsing the
+// rest into a "+N" overflow chip.
+const MAX_SEEN_AVATARS = 3;
+
+// The members who have read up to the newest message, driving the "Seen by" row.
+// Empty inside a thread panel and on an empty timeline.
+const seenByReaders = computed<MessageAuthor[]>(() => {
+    if (props.inThread || props.messages.length === 0) {
+        return [];
+    }
+
+    const lastMessageId = props.messages[props.messages.length - 1].id;
+
+    return readersForMessage(
+        props.readers ?? [],
+        lastMessageId,
+        props.currentUserId,
+    );
+});
+
+const seenByAvatars = computed(() =>
+    seenByReaders.value.slice(0, MAX_SEEN_AVATARS),
+);
+
+const extraSeenBy = computed(() =>
+    Math.max(0, seenByReaders.value.length - MAX_SEEN_AVATARS),
+);
+
+// A full, human-readable roster ("Seen by Alice, Bob and 3 others") used as the
+// row's accessible label and hover title, so the compact avatars still name who.
+const seenByLabel = computed(() => {
+    const names = seenByReaders.value.map((reader) => reader.name);
+
+    if (names.length === 0) {
+        return '';
+    }
+
+    if (names.length === 1) {
+        return `Seen by ${names[0]}`;
+    }
+
+    if (names.length <= MAX_SEEN_AVATARS) {
+        return `Seen by ${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+    }
+
+    const shown = names.slice(0, MAX_SEEN_AVATARS).join(', ');
+    const others = names.length - MAX_SEEN_AVATARS;
+
+    return `Seen by ${shown} and ${others} ${others === 1 ? 'other' : 'others'}`;
+});
 
 const { getInitials } = useInitials();
 
@@ -588,6 +643,35 @@ function confirmDelete(): void {
                 </div>
             </div>
         </template>
+
+        <div
+            v-if="seenByReaders.length > 0"
+            data-test="seen-by"
+            class="mt-1.5 flex items-center justify-end gap-1.5 pr-1"
+            :title="seenByLabel"
+        >
+            <span class="text-[11px] font-medium text-muted-foreground">
+                Seen by
+            </span>
+            <span class="flex -space-x-1">
+                <span
+                    v-for="reader in seenByAvatars"
+                    :key="reader.id"
+                    class="flex size-4 items-center justify-center rounded-[5px] bg-primary/10 text-[8px] font-semibold text-primary ring-2 ring-background select-none"
+                    aria-hidden="true"
+                >
+                    {{ getInitials(reader.name) }}
+                </span>
+                <span
+                    v-if="extraSeenBy > 0"
+                    class="flex size-4 items-center justify-center rounded-[5px] bg-muted text-[8px] font-semibold text-muted-foreground ring-2 ring-background select-none"
+                    aria-hidden="true"
+                >
+                    +{{ extraSeenBy }}
+                </span>
+            </span>
+            <span class="sr-only">{{ seenByLabel }}</span>
+        </div>
 
         <Dialog :open="pendingDelete !== null" @update:open="setDeleteOpen">
             <DialogContent>

--- a/resources/js/components/ui/switch/Switch.vue
+++ b/resources/js/components/ui/switch/Switch.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { SwitchRootEmits, SwitchRootProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import {
+  SwitchRoot,
+  SwitchThumb,
+  useForwardPropsEmits,
+} from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<SwitchRootProps & { class?: HTMLAttributes["class"] }>()
+
+const emits = defineEmits<SwitchRootEmits>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <SwitchRoot
+    v-slot="slotProps"
+    data-slot="switch"
+    v-bind="forwarded"
+    :class="cn(
+      'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-3 disabled:cursor-not-allowed disabled:opacity-50',
+      props.class,
+    )"
+  >
+    <SwitchThumb
+      data-slot="switch-thumb"
+      :class="cn('bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0')"
+    >
+      <slot name="thumb" v-bind="slotProps" />
+    </SwitchThumb>
+  </SwitchRoot>
+</template>

--- a/resources/js/components/ui/switch/index.ts
+++ b/resources/js/components/ui/switch/index.ts
@@ -1,0 +1,1 @@
+export { default as Switch } from "./Switch.vue"

--- a/resources/js/composables/useReadReceipts.ts
+++ b/resources/js/composables/useReadReceipts.ts
@@ -1,0 +1,30 @@
+import { router, usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import { update } from '@/routes/read-receipts';
+
+/**
+ * Read and mutate the current user's "share read receipts" preference. The value
+ * is the shared `auth.user.share_read_receipts` prop, so every consumer stays in
+ * sync; the shared prop refreshes from the redirect, so no optimistic state is
+ * needed. When off, the user neither broadcasts nor exposes their read position.
+ */
+export function useReadReceipts() {
+    const page = usePage();
+
+    const shareReadReceipts = computed<boolean>(
+        () => page.props.auth.user.share_read_receipts ?? true,
+    );
+
+    /**
+     * Persist a new sharing choice.
+     */
+    function updateShareReadReceipts(share: boolean): void {
+        router.patch(
+            update().url,
+            { share_read_receipts: share },
+            { preserveScroll: true, preserveState: true },
+        );
+    }
+
+    return { shareReadReceipts, updateShareReadReceipts };
+}

--- a/resources/js/lib/readReceipts.test.ts
+++ b/resources/js/lib/readReceipts.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { readersForMessage } from '@/lib/readReceipts';
+import type { ChannelReader } from '@/types';
+
+/**
+ * A time-ordered, uuid-shaped id for a given sequence number. Zero-padded to a
+ * fixed width so the ids sort chronologically under a lexicographic comparison,
+ * mirroring the ordered UUIDs the server assigns to real messages.
+ */
+function id(seq: number): string {
+    return `019f44c7-0000-7000-8000-${String(seq).padStart(12, '0')}`;
+}
+
+/**
+ * A reader row: the member and how far they have read.
+ */
+function reader(
+    userId: string,
+    name: string,
+    lastReadMessageId: string | null,
+): ChannelReader {
+    return { user: { id: userId, name }, lastReadMessageId };
+}
+
+const ME = 'me';
+
+describe('readersForMessage', () => {
+    it('includes members whose pointer sits at or after the message', () => {
+        const readers = [
+            reader('a', 'Alice', id(5)), // read past it
+            reader('b', 'Bob', id(3)), // read exactly it
+            reader('c', 'Carol', id(2)), // has not reached it
+        ];
+
+        expect(readersForMessage(readers, id(3), ME)).toEqual([
+            { id: 'a', name: 'Alice' },
+            { id: 'b', name: 'Bob' },
+        ]);
+    });
+
+    it('excludes a member who has never read the channel (null pointer)', () => {
+        const readers = [reader('a', 'Alice', null)];
+
+        expect(readersForMessage(readers, id(1), ME)).toEqual([]);
+    });
+
+    it('excludes the current user defensively', () => {
+        const readers = [reader(ME, 'Me', id(9)), reader('a', 'Alice', id(9))];
+
+        expect(readersForMessage(readers, id(3), ME)).toEqual([
+            { id: 'a', name: 'Alice' },
+        ]);
+    });
+
+    it('sorts the roster by name for stable avatar order', () => {
+        const readers = [
+            reader('c', 'Carol', id(9)),
+            reader('a', 'Alice', id(9)),
+            reader('b', 'Bob', id(9)),
+        ];
+
+        expect(
+            readersForMessage(readers, id(3), ME).map((member) => member.name),
+        ).toEqual(['Alice', 'Bob', 'Carol']);
+    });
+
+    it('returns an empty roster when nobody has read that far', () => {
+        const readers = [
+            reader('a', 'Alice', id(1)),
+            reader('b', 'Bob', id(2)),
+        ];
+
+        expect(readersForMessage(readers, id(5), ME)).toEqual([]);
+    });
+
+    it('returns an empty roster when there are no readers', () => {
+        expect(readersForMessage([], id(1), ME)).toEqual([]);
+    });
+});

--- a/resources/js/lib/readReceipts.ts
+++ b/resources/js/lib/readReceipts.ts
@@ -1,0 +1,29 @@
+import type { ChannelReader, MessageAuthor } from '@/types';
+
+/**
+ * The members who have read up to (or past) a given message — the "Seen by"
+ * roster for that message.
+ *
+ * A member has seen the message when their `lastReadMessageId` sorts at or after
+ * the message's id. Message ids are time-ordered UUIDs, so they compare
+ * chronologically under a plain lexicographic string comparison — no numeric
+ * coercion (a UUID is `NaN` as a number). A null pointer means the member has
+ * never read the channel, so they have seen nothing. The current user is dropped
+ * defensively (the server already excludes them), and the result is sorted by
+ * name so avatar order is stable across realtime updates.
+ */
+export function readersForMessage(
+    readers: ChannelReader[],
+    messageId: string,
+    currentUserId: string,
+): MessageAuthor[] {
+    return readers
+        .filter(
+            (reader) =>
+                reader.user.id !== currentUserId &&
+                reader.lastReadMessageId !== null &&
+                reader.lastReadMessageId >= messageId,
+        )
+        .map((reader) => reader.user)
+        .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -74,8 +74,10 @@ import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
 import { unreadDividerMessageId } from '@/lib/unreadDivider';
 import type {
     Channel,
+    ChannelReader,
     Mention,
     Message,
+    MessageAuthor,
     MessagePage,
     NotificationLevel,
     NotificationLevelOption,
@@ -94,6 +96,9 @@ const props = defineProps<{
     // The viewer's read pointer at load time, used to place the "New messages"
     // divider; null when the channel has never been read.
     lastReadMessageId?: string | null;
+    // Read positions of the channel's other members who share read receipts,
+    // seeding the "Seen by" affordance; later advances arrive via MessageRead.
+    channelReaders: ChannelReader[];
     // The open thread's root, loaded on demand keyed by `?thread=`.
     thread?: Thread | null;
     // The open thread's replies, a reverse-infinite-scroll page that grows as
@@ -119,6 +124,19 @@ const typingNames = typing.typingNames;
 // Live roster of team members currently online, driving the presence dots on
 // message avatars. Follows the team across channel switches.
 const { onlineIds } = useTeamPresence(() => props.team.id);
+
+// Read positions of the channel's other members who share read receipts, keyed
+// by user id. Seeded from the server prop and kept current from the MessageRead
+// broadcast, driving the "Seen by" affordance under the newest message.
+const readers = ref(new Map<string, ChannelReader>());
+
+function seedReaders(): void {
+    readers.value = new Map(
+        props.channelReaders.map((reader) => [reader.user.id, reader]),
+    );
+}
+
+const channelReadersList = computed(() => Array.from(readers.value.values()));
 
 function onTyping(): void {
     typing.signalTyping(currentUser.value);
@@ -398,6 +416,23 @@ function subscribe(id: string): void {
         .listen('MessageDeleted', (message: Message) => {
             applyPatch(message);
         })
+        .listen(
+            'MessageRead',
+            (event: { reader: MessageAuthor; lastReadMessageId: string }) => {
+                // Our own advance echoes back on the shared private channel; the
+                // "Seen by" row never shows the viewer, so drop it here.
+                if (event.reader.id === currentUser.value.id) {
+                    return;
+                }
+
+                const next = new Map(readers.value);
+                next.set(event.reader.id, {
+                    user: event.reader,
+                    lastReadMessageId: event.lastReadMessageId,
+                });
+                readers.value = next;
+            },
+        )
         .listenForWhisper('typing', (user: TypingUser) => {
             typing.receiveTyping(user);
         });
@@ -436,6 +471,7 @@ function markRead(): void {
 
 onMounted(() => {
     subscribe(props.channel.id);
+    seedReaders();
     computeUnreadDivider();
     markRead();
     window.addEventListener('focus', markRead);
@@ -498,6 +534,7 @@ watch(
         muted.value = props.channel.muted;
         starred.value = props.channel.starred;
         subscribe(newId);
+        seedReaders();
         computeUnreadDivider();
         markRead();
     },
@@ -1177,6 +1214,7 @@ function archive(): void {
                             :current-user-id="currentUser.id"
                             :can-moderate="canModerate"
                             :online-ids="onlineIds"
+                            :readers="channelReadersList"
                             :highlight-message-id="highlightedMessageId"
                             :unread-divider-id="unreadDividerId"
                             :active-thread-root-id="activeThreadRootId"

--- a/resources/js/pages/settings/Notifications.vue
+++ b/resources/js/pages/settings/Notifications.vue
@@ -12,7 +12,9 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import { useChimes } from '@/composables/useChimes';
+import { useReadReceipts } from '@/composables/useReadReceipts';
 import { edit } from '@/routes/notifications';
 import type { ChimeSound, ChimeSoundOption } from '@/types';
 
@@ -43,6 +45,8 @@ function onSelect(value: unknown): void {
     selected.value = value as ChimeSound;
     updateChimeSound(selected.value);
 }
+
+const { shareReadReceipts, updateShareReadReceipts } = useReadReceipts();
 </script>
 
 <template>
@@ -93,6 +97,25 @@ function onSelect(value: unknown): void {
                 Chimes never play for your own messages, for muted channels, or
                 for the channel you're actively viewing. Choose
                 <span class="font-medium">Off</span> to silence them entirely.
+            </p>
+        </div>
+
+        <div class="grid max-w-md gap-2">
+            <div class="flex items-center justify-between gap-4">
+                <Label for="share-read-receipts">Share read receipts</Label>
+
+                <Switch
+                    id="share-read-receipts"
+                    data-test="share-read-receipts"
+                    :model-value="shareReadReceipts"
+                    @update:model-value="updateShareReadReceipts"
+                />
+            </div>
+
+            <p class="text-sm text-muted-foreground">
+                When on, channel members can see when you've read their
+                messages. Turn this off to keep your read position private —
+                you'll still see when others have read yours.
             </p>
         </div>
     </div>

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -9,6 +9,7 @@ export type User = {
     created_at: string;
     updated_at: string;
     chime_sound: ChimeSound;
+    share_read_receipts: boolean;
     [key: string]: unknown;
 };
 

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -13,6 +13,17 @@ export type Mention = {
 };
 
 /**
+ * A channel member's read position, powering the "Seen by" affordance. Mirrors
+ * the `ChannelReaderData` DTO: the member and the id of the last message they
+ * have read (null when they have never read the channel). The channel page seeds
+ * these from a prop and keeps them current from the `MessageRead` broadcast.
+ */
+export type ChannelReader = {
+    user: MessageAuthor;
+    lastReadMessageId: string | null;
+};
+
+/**
  * A compact quote of the parent message an inline reply answers. Mirrors the
  * `MessageReplyData` DTO: flat (never nested) so a quote can't recurse, with
  * the body and mentions blanked when the parent has been deleted.

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Settings\NotificationController;
 use App\Http\Controllers\Settings\ProfileController;
+use App\Http\Controllers\Settings\ReadReceiptsController;
 use App\Http\Controllers\Settings\SecurityController;
 use App\Http\Controllers\Teams\TeamController;
 use App\Http\Controllers\Teams\TeamInvitationController;
@@ -32,6 +33,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::get('settings/notifications', [NotificationController::class, 'edit'])->name('notifications.edit');
     Route::patch('settings/notifications', [NotificationController::class, 'update'])->name('notifications.update');
+
+    Route::patch('settings/read-receipts', [ReadReceiptsController::class, 'update'])->name('read-receipts.update');
 
     Route::get('settings/teams', [TeamController::class, 'index'])->name('teams.index');
     Route::post('settings/teams', [TeamController::class, 'store'])->name('teams.store');

--- a/tests/Feature/Channels/ReadReceiptsTest.php
+++ b/tests/Feature/Channels/ReadReceiptsTest.php
@@ -1,0 +1,176 @@
+<?php
+
+use App\Actions\Channels\MarkChannelRead;
+use App\Actions\Teams\CreateTeam;
+use App\Data\UserData;
+use App\Enums\TeamRole;
+use App\Events\MessageRead;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Support\Facades\Event;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function receiptsTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and #general, returning them.
+ */
+function receiptsMember(Team $team, Channel $channel, User $user): User
+{
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+test('MarkChannelRead broadcasts the advance for a user who shares read receipts', function () {
+    Event::fake([MessageRead::class]);
+
+    [$owner, $team, $general] = receiptsTeamWithGeneral();
+    $member = receiptsMember($team, $general, User::factory()->create(['name' => 'Ada Lovelace']));
+
+    Message::factory()->for($general)->for($owner)->create();
+    $latest = Message::factory()->for($general)->for($owner)->create();
+
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    Event::assertDispatched(MessageRead::class, function (MessageRead $event) use ($general, $member, $latest) {
+        return $event->channel->is($general)
+            && $event->reader->id === $member->id
+            && $event->reader->name === 'Ada Lovelace'
+            && $event->lastReadMessageId === $latest->id;
+    });
+});
+
+test('MarkChannelRead does not broadcast for a user who opted out of read receipts', function () {
+    Event::fake([MessageRead::class]);
+
+    [$owner, $team, $general] = receiptsTeamWithGeneral();
+    $member = receiptsMember($team, $general, User::factory()->withoutReadReceipts()->create());
+
+    $latest = Message::factory()->for($general)->for($owner)->create();
+
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    // The pointer still advances so their own badges clear...
+    $this->assertDatabaseHas('channel_members', [
+        'channel_id' => $general->id,
+        'user_id' => $member->id,
+        'last_read_message_id' => $latest->id,
+    ]);
+
+    // ...but nothing is shared with peers.
+    Event::assertNotDispatched(MessageRead::class);
+});
+
+test('MarkChannelRead does not re-broadcast when the pointer is already at the tail', function () {
+    Event::fake([MessageRead::class]);
+
+    [$owner, $team, $general] = receiptsTeamWithGeneral();
+    $member = receiptsMember($team, $general, User::factory()->create());
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    // First read advances and broadcasts.
+    app(MarkChannelRead::class)->handle($general, $member);
+    // Second read with no new messages is a no-op.
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    Event::assertDispatchedTimes(MessageRead::class, 1);
+});
+
+test('MarkChannelRead does not broadcast on an empty channel', function () {
+    Event::fake([MessageRead::class]);
+
+    [, $team, $general] = receiptsTeamWithGeneral();
+    $member = receiptsMember($team, $general, User::factory()->create());
+
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    Event::assertNotDispatched(MessageRead::class);
+});
+
+test('MarkChannelRead does not broadcast for a non-member', function () {
+    Event::fake([MessageRead::class]);
+
+    [$owner, $team, $general] = receiptsTeamWithGeneral();
+    $outsider = User::factory()->create();
+    $team->memberships()->create(['user_id' => $outsider->id, 'role' => TeamRole::Member]);
+    $general->channelMembers()->where('user_id', $outsider->id)->delete();
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    app(MarkChannelRead::class)->handle($general, $outsider);
+
+    Event::assertNotDispatched(MessageRead::class);
+});
+
+test('the read endpoint broadcasts the advance for a sharing member', function () {
+    Event::fake([MessageRead::class]);
+
+    [$owner, $team, $general] = receiptsTeamWithGeneral();
+    $member = receiptsMember($team, $general, User::factory()->create());
+
+    $latest = Message::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($member)
+        ->post(route('channels.read', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertRedirect();
+
+    Event::assertDispatched(MessageRead::class, fn (MessageRead $event) => $event->lastReadMessageId === $latest->id);
+});
+
+test('MessageRead broadcasts on the channel private channel with the reader and pointer', function () {
+    [$owner, $team, $general] = receiptsTeamWithGeneral();
+
+    $message = Message::factory()->for($general)->for($owner)->create();
+    $event = new MessageRead($general, UserData::fromUser($owner), $message->id);
+
+    expect($event->broadcastOn())->toEqual([new PrivateChannel('channel.'.$general->id)]);
+    expect($event->broadcastWith())->toEqual([
+        'reader' => ['id' => $owner->id, 'name' => $owner->name],
+        'lastReadMessageId' => $message->id,
+    ]);
+});
+
+test('the channel page seeds channelReaders with sharing members, excluding the viewer and opt-outs', function () {
+    [$owner, $team, $general] = receiptsTeamWithGeneral();
+    $viewer = receiptsMember($team, $general, User::factory()->create(['name' => 'Viewer']));
+    $sharer = receiptsMember($team, $general, User::factory()->create(['name' => 'Sharer']));
+    $optedOut = receiptsMember($team, $general, User::factory()->withoutReadReceipts()->create(['name' => 'Quiet']));
+
+    $message = Message::factory()->for($general)->for($owner)->create();
+    $sharer->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $message->id]);
+
+    $response = $this->actingAs($viewer)->get(route('channels.show', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]))->assertOk();
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->has('channelReaders')
+        ->where('channelReaders', fn ($readers) => collect($readers)->pluck('user.id')->contains($sharer->id)
+            && ! collect($readers)->pluck('user.id')->contains($viewer->id)
+            && ! collect($readers)->pluck('user.id')->contains($optedOut->id))
+    );
+
+    $entry = collect($response->viewData('page')['props']['channelReaders'])
+        ->firstWhere('user.id', $sharer->id);
+
+    expect($entry['lastReadMessageId'])->toBe($message->id);
+});

--- a/tests/Feature/Settings/ReadReceiptsSettingsTest.php
+++ b/tests/Feature/Settings/ReadReceiptsSettingsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\User;
+
+test('read receipt sharing can be turned off', function () {
+    $user = User::factory()->create(['share_read_receipts' => true]);
+
+    $this
+        ->actingAs($user)
+        ->from(route('notifications.edit'))
+        ->patch(route('read-receipts.update'), ['share_read_receipts' => false])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('notifications.edit'));
+
+    expect($user->refresh()->share_read_receipts)->toBeFalse();
+});
+
+test('read receipt sharing can be turned back on', function () {
+    $user = User::factory()->withoutReadReceipts()->create();
+
+    $this
+        ->actingAs($user)
+        ->patch(route('read-receipts.update'), ['share_read_receipts' => true])
+        ->assertSessionHasNoErrors();
+
+    expect($user->refresh()->share_read_receipts)->toBeTrue();
+});
+
+test('the share_read_receipts value is required', function () {
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->from(route('notifications.edit'))
+        ->patch(route('read-receipts.update'), [])
+        ->assertSessionHasErrors('share_read_receipts');
+});
+
+test('the share_read_receipts value must be a boolean', function () {
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->patch(route('read-receipts.update'), ['share_read_receipts' => 'maybe'])
+        ->assertSessionHasErrors('share_read_receipts');
+});
+
+test('guests cannot update read receipt sharing', function () {
+    $this->patch(route('read-receipts.update'), ['share_read_receipts' => false])
+        ->assertRedirect(route('login'));
+});


### PR DESCRIPTION
Closes #36.

## What & why

Track and show **who has read a message** — distinct from the viewer's own unread badges (#10) — synced in realtime, with a per-user opt-out.

The per-member read pointer already existed (`channel_members.last_read_message_id`, driving the viewer's own unread counts). Because messages use ordered UUIDs, `messages.id > last_read_message_id` already works as a "has read up to" comparison. So this PR mostly **exposes** that pointer to other members, broadcasts its advance, and gates it behind an opt-out.

## Approach

**Backend**
- New `MessageRead` event broadcasts on the existing private `channel.{id}` when a member's pointer advances **and** they share receipts. `MarkChannelRead` reads the current pointer first and only writes + dispatches on a real advance, so the frequent no-op client calls (fired on every incoming message and window focus) don't spam broadcasts.
- `ChannelReaderData` DTO + a `channelReaders` prop on `ChannelController::show()` seed the roster at open, excluding the viewer and opted-out members.
- `share_read_receipts` boolean on `users` (default on), following the `chime_sound` pattern. Persisted via a dedicated `read-receipts.update` endpoint (kept off `notifications.update`, which requires `chime_sound` and would have coupled the two toggles).

**Frontend**
- `readReceipts.ts` pure helper (`readersForMessage`) with Vitest coverage.
- A compact "Seen by" avatar row (initials + `+N` overflow, accessible label) under the newest message in `MessageList.vue`.
- `Show.vue` keeps a reactive readers map seeded from the prop and updated live from a new `.listen('MessageRead')`, ignoring the viewer's own echo.
- A shadcn `Switch` on the Notifications settings page via a small `useReadReceipts` composable.

## Product decisions
- **Surface:** aggregate "Seen by" row under the **newest message only** (Slack-style; one query, cheap to update) rather than per-message avatar placement.
- **Opt-out:** default **on**; turning it off stops you broadcasting/exposing your read position (you still see others').

## Acceptance criteria
- [x] Per-member read position tracked and synced in realtime
- [x] Messages can show who has read them
- [x] Respects an opt-out setting
- [x] Test coverage for read-position updates

## Testing
- Backend: Pint ✓, PHPStan 0 errors ✓, 430 tests pass, **100.0%** coverage ✓ (`sail composer test`)
- Frontend: format / lint / types / build ✓, Vitest 104 pass ✓

## Notes
- Reverted the `reka-ui` / `@lucide/vue` minor bumps the shadcn CLI attempted when adding the Switch (it only needs already-installed exports).
- Generated TS-transformer and Wayfinder files are gitignored (regenerated at build), so they're absent from the diff by design.

## Out of scope (possible follow-ups)
- Per-message avatar placement across the timeline.
- Read receipts inside the thread panel (thread pointers live in `thread_reads`).