### PR TITLE
feat(identity): user profile pages (#44)

### DIFF
--- a/app/Data/UserProfileData.php
+++ b/app/Data/UserProfileData.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\Membership;
+use App\Models\User;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class UserProfileData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $email,
+        public ?string $role,
+        public ?string $roleLabel,
+        public ?string $memberSince,
+        public bool $isYou,
+    ) {}
+
+    /**
+     * Build the profile DTO for a member of a team as seen by the viewer.
+     *
+     * The role and join date are read from the member's team membership pivot,
+     * so it must belong to the team the profile is scoped to.
+     */
+    public static function forMember(User $member, Membership $membership, User $viewer): self
+    {
+        return new self(
+            id: $member->id,
+            name: $member->name,
+            email: $member->email,
+            role: $membership->role->value,
+            roleLabel: $membership->role->label(),
+            memberSince: $membership->created_at?->toIso8601String(),
+            isYou: $member->is($viewer),
+        );
+    }
+}

--- a/app/Http/Controllers/Teams/TeamMemberController.php
+++ b/app/Http/Controllers/Teams/TeamMemberController.php
@@ -2,17 +2,47 @@
 
 namespace App\Http\Controllers\Teams;
 
+use App\Data\UserProfileData;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\UpdateTeamMemberRequest;
+use App\Models\Membership;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class TeamMemberController extends Controller
 {
+    /**
+     * Show the profile page for a member of the team.
+     *
+     * Scoped to the team the viewer already belongs to (enforced by the route's
+     * membership middleware); a user who is not a member of that team resolves
+     * to a 404 so profiles never leak across team boundaries.
+     */
+    public function show(Request $request, Team $team, User $user): Response
+    {
+        /** @var Membership|null $membership */
+        $membership = $team->memberships()
+            ->where('user_id', $user->id)
+            ->first();
+
+        abort_if($membership === null, 404);
+
+        return Inertia::render('teams/MemberProfile', [
+            'team' => [
+                'id' => $team->id,
+                'name' => $team->name,
+                'slug' => $team->slug,
+            ],
+            'profile' => UserProfileData::forMember($user, $membership, $request->user()),
+        ]);
+    }
+
     /**
      * Update the specified team member's role.
      */

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Form, Head, router } from '@inertiajs/vue3';
+import { Form, Head, Link, router } from '@inertiajs/vue3';
 import { ChevronDown, Mail, UserPlus, X } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import CancelInvitationModal from '@/components/CancelInvitationModal.vue';
@@ -27,7 +27,10 @@ import {
 } from '@/components/ui/tooltip';
 import { useInitials } from '@/composables/useInitials';
 import { edit, index, update } from '@/routes/teams';
-import { update as updateMember } from '@/routes/teams/members';
+import {
+    show as showMember,
+    update as updateMember,
+} from '@/routes/teams/members';
 import type {
     RoleOption,
     Team,
@@ -182,9 +185,13 @@ const confirmCancelInvitation = (invitation: TeamInvitation) => {
                             }}</AvatarFallback>
                         </Avatar>
                         <div>
-                            <div class="font-medium">
+                            <Link
+                                :href="showMember([team.slug, member.id])"
+                                class="font-medium underline-offset-4 hover:underline"
+                                data-test="member-profile-link"
+                            >
                                 {{ member.name }}
-                            </div>
+                            </Link>
                             <div class="text-sm text-muted-foreground">
                                 {{ member.email }}
                             </div>

--- a/resources/js/pages/teams/MemberProfile.vue
+++ b/resources/js/pages/teams/MemberProfile.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import Heading from '@/components/Heading.vue';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { useInitials } from '@/composables/useInitials';
+import { edit, index } from '@/routes/teams';
+import type { Team, UserProfile } from '@/types';
+
+type Props = {
+    team: Pick<Team, 'id' | 'name' | 'slug'>;
+    profile: UserProfile;
+};
+
+const props = defineProps<Props>();
+
+const { getInitials } = useInitials();
+
+defineOptions({
+    layout: (props: {
+        team: Pick<Team, 'name' | 'slug'>;
+        profile: UserProfile;
+    }) => ({
+        breadcrumbs: [
+            {
+                title: 'Teams',
+                href: index(),
+            },
+            {
+                title: props.team.name,
+                href: edit(props.team.slug),
+            },
+            {
+                title: props.profile.name,
+            },
+        ],
+    }),
+});
+
+const memberSince = computed(() => {
+    if (!props.profile.memberSince) {
+        return null;
+    }
+
+    return new Date(props.profile.memberSince).toLocaleDateString(undefined, {
+        month: 'long',
+        year: 'numeric',
+    });
+});
+</script>
+
+<template>
+    <Head :title="profile.name" />
+
+    <div class="flex flex-col space-y-6">
+        <Heading
+            variant="small"
+            title="Profile"
+            :description="`Member of ${team.name}`"
+        />
+
+        <div class="flex items-start gap-4 rounded-lg border p-6">
+            <Avatar class="h-16 w-16 text-lg">
+                <AvatarFallback>{{ getInitials(profile.name) }}</AvatarFallback>
+            </Avatar>
+
+            <div class="min-w-0 flex-1 space-y-3">
+                <div class="flex flex-wrap items-center gap-2">
+                    <h3 class="text-lg font-semibold">{{ profile.name }}</h3>
+                    <Badge v-if="profile.isYou" variant="secondary">You</Badge>
+                    <Badge v-if="profile.roleLabel" variant="outline">
+                        {{ profile.roleLabel }}
+                    </Badge>
+                </div>
+
+                <dl class="grid gap-3 text-sm sm:grid-cols-2">
+                    <div>
+                        <dt class="text-muted-foreground">Email</dt>
+                        <dd class="mt-0.5">
+                            <a
+                                :href="`mailto:${profile.email}`"
+                                class="underline-offset-4 hover:underline"
+                                >{{ profile.email }}</a
+                            >
+                        </dd>
+                    </div>
+                    <div v-if="memberSince">
+                        <dt class="text-muted-foreground">Member since</dt>
+                        <dd class="mt-0.5">{{ memberSince }}</dd>
+                    </div>
+                </dl>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -19,6 +19,21 @@ export type TeamMember = {
     role_label: string;
 };
 
+/**
+ * A team member's profile as shown on their dedicated profile page. Mirrors the
+ * `App\Data\UserProfileData` DTO. `role`/`roleLabel`/`memberSince` come from the
+ * membership pivot; `isYou` marks the viewer's own profile.
+ */
+export type UserProfile = {
+    id: string;
+    name: string;
+    email: string;
+    role: TeamRole | null;
+    roleLabel: string | null;
+    memberSince: string | null;
+    isYou: boolean;
+};
+
 export type TeamInvitation = {
     code: string;
     email: string;

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -46,6 +46,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('settings/teams/{team}/switch', [TeamController::class, 'switch'])->name('teams.switch');
         Route::delete('settings/teams/{team}/leave', [TeamController::class, 'leave'])->name('teams.leave');
 
+        Route::get('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'show'])->name('teams.members.show');
         Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('teams.members.update');
         Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');
 

--- a/tests/Feature/Teams/MemberProfileTest.php
+++ b/tests/Feature/Teams/MemberProfileTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('a team member can view another member profile', function () {
+    $viewer = User::factory()->create();
+    $member = User::factory()->create(['name' => 'Ada Lovelace', 'email' => 'ada@example.com']);
+    $team = Team::factory()->create();
+
+    $team->members()->attach($viewer, ['role' => TeamRole::Member->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Admin->value]);
+
+    $this->actingAs($viewer)
+        ->get(route('teams.members.show', [$team, $member]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('teams/MemberProfile')
+            ->where('team.slug', $team->slug)
+            ->where('profile.id', $member->id)
+            ->where('profile.name', 'Ada Lovelace')
+            ->where('profile.email', 'ada@example.com')
+            ->where('profile.role', TeamRole::Admin->value)
+            ->where('profile.roleLabel', 'Admin')
+            ->where('profile.isYou', false)
+            ->whereNot('profile.memberSince', null)
+        );
+});
+
+test('a member viewing their own profile is flagged as you', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($user, ['role' => TeamRole::Owner->value]);
+
+    $this->actingAs($user)
+        ->get(route('teams.members.show', [$team, $user]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->where('profile.isYou', true));
+});
+
+test('viewing a user who does not belong to the team returns 404', function () {
+    $viewer = User::factory()->create();
+    $outsider = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($viewer, ['role' => TeamRole::Member->value]);
+
+    $this->actingAs($viewer)
+        ->get(route('teams.members.show', [$team, $outsider]))
+        ->assertNotFound();
+});
+
+test('a user who is not a team member cannot view profiles in that team', function () {
+    $outsider = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $this->actingAs($outsider)
+        ->get(route('teams.members.show', [$team, $member]))
+        ->assertForbidden();
+});
+
+test('guests cannot view member profiles', function () {
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $this->get(route('teams.members.show', [$team, $member]))
+        ->assertRedirect(route('login'));
+});


### PR DESCRIPTION
## Summary

Partial delivery of #44 — builds the **profile-page half**; the hover-card half is deferred (see the note on the issue). Refs #44.

A dedicated per-user profile page, scoped to a team and reachable from the team members list. Introduces a tested `UserProfileData` provider that maps a member + membership pivot to name, email, team role, and join date.

## What's included

| Layer | Change |
|---|---|
| Data provider | `app/Data/UserProfileData.php` — `forMember()` → `{ id, name, email, role, roleLabel, memberSince, isYou }` |
| Controller | `TeamMemberController::show()` — 404s a target who isn't in the team, renders the page |
| Route | `GET settings/teams/{team}/members/{user}` → `teams.members.show` |
| Page | `resources/js/pages/teams/MemberProfile.vue` — avatar, name, You/role badges, email, member-since |
| Entry point | Member names in `teams/Edit.vue` link to their profile |
| Tests | `tests/Feature/Teams/MemberProfileTest.php` |

## Visibility

Enforced on two axes: `EnsureTeamMembership` blocks viewers who don't belong to the team (403), and a target who isn't a member of the scoped team resolves to a 404 — profiles never leak across teams.

## Deferred to follow-ups

- Hover card on names/avatars + quick actions (the `HoverCard` primitive from #35 is not yet wired to users)
- Message-list author linking (needs the team slug threaded into `MessageList.vue`)
- Richer fields: title/pronouns (#46) and local time (#45)
- "Message" quick action — blocked until a DM feature exists

## Testing

- `./vendor/bin/sail composer test` — full suite at **100.0% coverage**
- Pint, PHPStan, `types:check`, `lint:check`, `format:check`, `build` — all green