### PR TITLE
feat(security): active sessions / device management (#47)

### DIFF
--- a/app/Data/SessionData.php
+++ b/app/Data/SessionData.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Data;
+
+use App\Support\UserAgentParser;
+use Illuminate\Support\Carbon;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class SessionData extends Data
+{
+    public function __construct(
+        public string $id,
+        public ?string $ipAddress,
+        public string $browser,
+        public string $platform,
+        public string $lastActive,
+        public bool $isCurrentDevice,
+    ) {}
+
+    /**
+     * Build the DTO from a raw `sessions` table row.
+     */
+    public static function fromSession(\stdClass $session, string $currentSessionId): self
+    {
+        $agent = UserAgentParser::parse($session->user_agent);
+
+        return new self(
+            id: $session->id,
+            ipAddress: $session->ip_address,
+            browser: $agent['browser'],
+            platform: $agent['platform'],
+            lastActive: Carbon::createFromTimestamp((int) $session->last_activity)->toIso8601String(),
+            isCurrentDevice: $session->id === $currentSessionId,
+        );
+    }
+}

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\Settings;
 
+use App\Data\SessionData;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\PasswordUpdateRequest;
 use App\Http\Requests\Settings\TwoFactorAuthenticationRequest;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -19,9 +21,29 @@ class SecurityController extends Controller
     {
         $props = [
             'passwordRules' => Password::defaults()->toPasswordRulesString(),
+            'sessions' => $this->activeSessions($request),
         ];
 
         return Inertia::render('settings/Security', $props);
+    }
+
+    /**
+     * List the user's active sessions, current session first, then most recent.
+     *
+     * @return array<int, SessionData>
+     */
+    private function activeSessions(TwoFactorAuthenticationRequest $request): array
+    {
+        $currentSessionId = $request->session()->getId();
+
+        return DB::table('sessions')
+            ->where('user_id', $request->user()->id)
+            ->orderByDesc('last_activity')
+            ->get()
+            ->map(fn (\stdClass $session): SessionData => SessionData::fromSession($session, $currentSessionId))
+            ->sortByDesc('isCurrentDevice')
+            ->values()
+            ->all();
     }
 
     /**

--- a/app/Http/Controllers/Settings/SessionController.php
+++ b/app/Http/Controllers/Settings/SessionController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\SessionRevokeRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+
+class SessionController extends Controller
+{
+    /**
+     * Revoke a single session, protecting the request's own session.
+     */
+    public function destroy(SessionRevokeRequest $request, string $session): RedirectResponse
+    {
+        DB::table('sessions')
+            ->where('user_id', $request->user()->id)
+            ->where('id', $session)
+            ->where('id', '!=', $request->session()->getId())
+            ->delete();
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Session revoked.')]);
+
+        return back();
+    }
+
+    /**
+     * Revoke every session for the user except the request's own session.
+     */
+    public function destroyOthers(SessionRevokeRequest $request): RedirectResponse
+    {
+        DB::table('sessions')
+            ->where('user_id', $request->user()->id)
+            ->where('id', '!=', $request->session()->getId())
+            ->delete();
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Logged out of your other devices.')]);
+
+        return back();
+    }
+}

--- a/app/Http/Requests/Settings/SessionRevokeRequest.php
+++ b/app/Http/Requests/Settings/SessionRevokeRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use App\Concerns\PasswordValidationRules;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SessionRevokeRequest extends FormRequest
+{
+    use PasswordValidationRules;
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'password' => $this->currentPasswordRules(),
+        ];
+    }
+}

--- a/app/Support/UserAgentParser.php
+++ b/app/Support/UserAgentParser.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Support;
+
+class UserAgentParser
+{
+    /**
+     * Browser display names keyed by the pattern that identifies them.
+     *
+     * Order matters: derivative browsers (Edge, Opera) embed the tokens of the
+     * engines they are built on, so they must be matched before Chrome/Safari.
+     *
+     * @var array<string, string>
+     */
+    private const BROWSERS = [
+        'Edge' => '/\bEdg/i',
+        'Opera' => '/\bOPR\b|\bOpera\b/i',
+        'Firefox' => '/\bFirefox\b|\bFxiOS\b/i',
+        'Chrome' => '/\bChrome\b|\bCriOS\b/i',
+        'Safari' => '/\bSafari\b/i',
+    ];
+
+    /**
+     * Platform display names keyed by the pattern that identifies them.
+     *
+     * Order matters: Android user agents also contain "Linux", and iOS user
+     * agents can contain "Mac OS X", so the more specific tokens come first.
+     *
+     * @var array<string, string>
+     */
+    private const PLATFORMS = [
+        'Windows' => '/\bWindows\b/i',
+        'iOS' => '/\biPhone\b|\biPad\b|\biPod\b/i',
+        'Android' => '/\bAndroid\b/i',
+        'macOS' => '/\bMacintosh\b|\bMac OS X\b/i',
+        'Linux' => '/\bLinux\b/i',
+    ];
+
+    /**
+     * Parse a raw User-Agent header into a human-readable browser and platform.
+     *
+     * The matching is intentionally lightweight — it recognises the mainstream
+     * browsers and operating systems without pulling in a third-party dependency.
+     *
+     * @return array{browser: string, platform: string}
+     */
+    public static function parse(?string $userAgent): array
+    {
+        return [
+            'browser' => self::match($userAgent, self::BROWSERS, 'Unknown browser'),
+            'platform' => self::match($userAgent, self::PLATFORMS, 'Unknown platform'),
+        ];
+    }
+
+    /**
+     * Return the display name of the first pattern that matches the user agent.
+     *
+     * @param  array<string, string>  $patterns
+     */
+    private static function match(?string $userAgent, array $patterns, string $fallback): string
+    {
+        if ($userAgent === null || $userAgent === '') {
+            return $fallback;
+        }
+
+        foreach ($patterns as $name => $pattern) {
+            if (preg_match($pattern, $userAgent) === 1) {
+                return $name;
+            }
+        }
+
+        return $fallback;
+    }
+}

--- a/resources/js/components/ManageSessions.vue
+++ b/resources/js/components/ManageSessions.vue
@@ -1,0 +1,222 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3';
+import { Monitor, Smartphone } from '@lucide/vue';
+import { computed, useTemplateRef } from 'vue';
+import SessionController from '@/actions/App/Http/Controllers/Settings/SessionController';
+import Heading from '@/components/Heading.vue';
+import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { useTimezone } from '@/composables/useTimezone';
+import { formatDateTime } from '@/lib/datetime';
+
+type Props = {
+    sessions: App.Data.SessionData[];
+};
+
+const props = defineProps<Props>();
+
+const { timezone } = useTimezone();
+const revokeInput = useTemplateRef('revokeInput');
+const revokeOthersInput = useTemplateRef('revokeOthersInput');
+
+const hasOtherSessions = computed(() =>
+    props.sessions.some((session) => !session.isCurrentDevice),
+);
+
+function isMobile(platform: string): boolean {
+    return platform === 'iOS' || platform === 'Android';
+}
+
+function lastActive(iso: string): string {
+    return formatDateTime(iso, timezone.value ?? undefined);
+}
+</script>
+
+<template>
+    <div class="space-y-6">
+        <Heading
+            variant="small"
+            title="Active sessions"
+            description="Manage and log out your active sessions on other browsers and devices"
+        />
+
+        <ul class="space-y-3" role="list" data-test="sessions-list">
+            <li
+                v-for="session in props.sessions"
+                :key="session.id"
+                class="flex items-center gap-4 rounded-lg border border-border p-4"
+                :data-test="`session-${session.id}`"
+            >
+                <component
+                    :is="isMobile(session.platform) ? Smartphone : Monitor"
+                    class="size-5 shrink-0 text-muted-foreground"
+                />
+
+                <div class="min-w-0 flex-1 space-y-0.5">
+                    <div class="flex items-center gap-2">
+                        <p class="truncate text-sm font-medium">
+                            {{ session.browser }} on {{ session.platform }}
+                        </p>
+                        <Badge
+                            v-if="session.isCurrentDevice"
+                            variant="secondary"
+                            data-test="current-device-badge"
+                        >
+                            This device
+                        </Badge>
+                    </div>
+                    <p class="truncate text-xs text-muted-foreground">
+                        {{ session.ipAddress ?? 'Unknown IP' }} &middot; Last
+                        active {{ lastActive(session.lastActive) }}
+                    </p>
+                </div>
+
+                <Dialog v-if="!session.isCurrentDevice">
+                    <DialogTrigger as-child>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            :data-test="`revoke-session-${session.id}`"
+                        >
+                            Revoke
+                        </Button>
+                    </DialogTrigger>
+                    <DialogContent>
+                        <Form
+                            v-bind="SessionController.destroy.form(session.id)"
+                            reset-on-success
+                            @error="() => revokeInput?.focus()"
+                            :options="{ preserveScroll: true }"
+                            class="space-y-6"
+                            v-slot="{ errors, processing, reset, clearErrors }"
+                        >
+                            <DialogHeader class="space-y-3">
+                                <DialogTitle>Revoke this session?</DialogTitle>
+                                <DialogDescription>
+                                    The device signed in with this session will
+                                    be logged out. Enter your password to
+                                    confirm.
+                                </DialogDescription>
+                            </DialogHeader>
+
+                            <div class="grid gap-2">
+                                <Label for="revoke_password" class="sr-only">
+                                    Password
+                                </Label>
+                                <PasswordInput
+                                    id="revoke_password"
+                                    name="password"
+                                    ref="revokeInput"
+                                    placeholder="Password"
+                                />
+                                <InputError :message="errors.password" />
+                            </div>
+
+                            <DialogFooter class="gap-2">
+                                <DialogClose as-child>
+                                    <Button
+                                        variant="secondary"
+                                        @click="
+                                            () => {
+                                                clearErrors();
+                                                reset();
+                                            }
+                                        "
+                                    >
+                                        Cancel
+                                    </Button>
+                                </DialogClose>
+
+                                <Button
+                                    type="submit"
+                                    variant="destructive"
+                                    :disabled="processing"
+                                    :data-test="`confirm-revoke-${session.id}`"
+                                >
+                                    Revoke
+                                </Button>
+                            </DialogFooter>
+                        </Form>
+                    </DialogContent>
+                </Dialog>
+            </li>
+        </ul>
+
+        <Dialog v-if="hasOtherSessions">
+            <DialogTrigger as-child>
+                <Button variant="outline" data-test="revoke-others-button">
+                    Log out other devices
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <Form
+                    v-bind="SessionController.destroyOthers.form()"
+                    reset-on-success
+                    @error="() => revokeOthersInput?.focus()"
+                    :options="{ preserveScroll: true }"
+                    class="space-y-6"
+                    v-slot="{ errors, processing, reset, clearErrors }"
+                >
+                    <DialogHeader class="space-y-3">
+                        <DialogTitle>Log out other devices?</DialogTitle>
+                        <DialogDescription>
+                            This logs out every session except the one you are
+                            using now. Enter your password to confirm.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div class="grid gap-2">
+                        <Label for="revoke_others_password" class="sr-only">
+                            Password
+                        </Label>
+                        <PasswordInput
+                            id="revoke_others_password"
+                            name="password"
+                            ref="revokeOthersInput"
+                            placeholder="Password"
+                        />
+                        <InputError :message="errors.password" />
+                    </div>
+
+                    <DialogFooter class="gap-2">
+                        <DialogClose as-child>
+                            <Button
+                                variant="secondary"
+                                @click="
+                                    () => {
+                                        clearErrors();
+                                        reset();
+                                    }
+                                "
+                            >
+                                Cancel
+                            </Button>
+                        </DialogClose>
+
+                        <Button
+                            type="submit"
+                            variant="destructive"
+                            :disabled="processing"
+                            data-test="confirm-revoke-others"
+                        >
+                            Log out other devices
+                        </Button>
+                    </DialogFooter>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    </div>
+</template>

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -3,13 +3,16 @@ import { Form, Head } from '@inertiajs/vue3';
 import SecurityController from '@/actions/App/Http/Controllers/Settings/SecurityController';
 import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
+import ManageSessions from '@/components/ManageSessions.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
 import { edit } from '@/routes/security';
 
 type Props = {
     passwordRules: string;
+    sessions: App.Data.SessionData[];
 };
 
 const props = defineProps<Props>();
@@ -99,5 +102,9 @@ defineOptions({
                 </Button>
             </div>
         </Form>
+
+        <Separator />
+
+        <ManageSessions :sessions="props.sessions" />
     </div>
 </template>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Settings\NotificationController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\ReadReceiptsController;
 use App\Http\Controllers\Settings\SecurityController;
+use App\Http\Controllers\Settings\SessionController;
 use App\Http\Controllers\Settings\TimezoneController;
 use App\Http\Controllers\Teams\TeamController;
 use App\Http\Controllers\Teams\TeamInvitationController;
@@ -31,6 +32,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::put('settings/password', [SecurityController::class, 'update'])
         ->middleware('throttle:6,1')
         ->name('user-password.update');
+
+    Route::delete('settings/sessions', [SessionController::class, 'destroyOthers'])->name('sessions.destroy-others');
+    Route::delete('settings/sessions/{session}', [SessionController::class, 'destroy'])->name('sessions.destroy');
 
     Route::inertia('settings/appearance', 'settings/Appearance')->name('appearance.edit');
 

--- a/tests/Feature/Settings/SessionManagementTest.php
+++ b/tests/Feature/Settings/SessionManagementTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Insert a row into the `sessions` table for the given user.
+ */
+function seedSession(User $user, string $id, string $userAgent = 'Mozilla/5.0 (Windows NT 10.0) Chrome/120.0.0.0 Safari/537.36', string $ip = '203.0.113.10', ?int $lastActivity = null): void
+{
+    DB::table('sessions')->insert([
+        'id' => $id,
+        'user_id' => $user->id,
+        'ip_address' => $ip,
+        'user_agent' => $userAgent,
+        'payload' => '',
+        'last_activity' => $lastActivity ?? now()->timestamp,
+    ]);
+}
+
+test('active sessions are listed on the security page with the current device flagged', function () {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+    $otherId = Str::random(40);
+
+    seedSession($user, $currentId, ip: '198.51.100.5', lastActivity: now()->subMinute()->timestamp);
+    seedSession($user, $otherId, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) Version/17.2 Mobile Safari/604.1', ip: '203.0.113.10', lastActivity: now()->subHour()->timestamp);
+
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->withCookie(config('session.cookie'), $currentId)
+        ->get(route('security.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/Security')
+            ->has('sessions', 2)
+            ->where('sessions.0.id', $currentId)
+            ->where('sessions.0.isCurrentDevice', true)
+            ->where('sessions.0.browser', 'Chrome')
+            ->where('sessions.0.platform', 'Windows')
+            ->where('sessions.0.ipAddress', '198.51.100.5')
+            ->where('sessions.1.id', $otherId)
+            ->where('sessions.1.isCurrentDevice', false),
+        );
+});
+
+test('a single session can be revoked', function () {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+    $otherId = Str::random(40);
+
+    seedSession($user, $currentId);
+    seedSession($user, $otherId);
+
+    $this->actingAs($user)
+        ->withCookie(config('session.cookie'), $currentId)
+        ->from(route('security.edit'))
+        ->delete(route('sessions.destroy', $otherId), ['password' => 'password'])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('security.edit'));
+
+    $this->assertDatabaseMissing('sessions', ['id' => $otherId]);
+    $this->assertDatabaseHas('sessions', ['id' => $currentId]);
+});
+
+test('the current session cannot be revoked through the single-session route', function () {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+
+    seedSession($user, $currentId);
+
+    $this->actingAs($user)
+        ->withCookie(config('session.cookie'), $currentId)
+        ->from(route('security.edit'))
+        ->delete(route('sessions.destroy', $currentId), ['password' => 'password'])
+        ->assertRedirect(route('security.edit'));
+
+    $this->assertDatabaseHas('sessions', ['id' => $currentId]);
+});
+
+test('a session belonging to another user cannot be revoked', function () {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $currentId = Str::random(40);
+    $victimId = Str::random(40);
+
+    seedSession($user, $currentId);
+    seedSession($otherUser, $victimId);
+
+    $this->actingAs($user)
+        ->withCookie(config('session.cookie'), $currentId)
+        ->from(route('security.edit'))
+        ->delete(route('sessions.destroy', $victimId), ['password' => 'password'])
+        ->assertRedirect(route('security.edit'));
+
+    $this->assertDatabaseHas('sessions', ['id' => $victimId]);
+});
+
+test('logging out other devices removes other sessions but keeps the current one', function () {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+    $otherId = Str::random(40);
+    $anotherId = Str::random(40);
+
+    seedSession($user, $currentId);
+    seedSession($user, $otherId);
+    seedSession($user, $anotherId);
+
+    $this->actingAs($user)
+        ->withCookie(config('session.cookie'), $currentId)
+        ->from(route('security.edit'))
+        ->delete(route('sessions.destroy-others'), ['password' => 'password'])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('security.edit'));
+
+    $this->assertDatabaseHas('sessions', ['id' => $currentId]);
+    $this->assertDatabaseMissing('sessions', ['id' => $otherId]);
+    $this->assertDatabaseMissing('sessions', ['id' => $anotherId]);
+});
+
+test('revoking a session requires the correct password', function () {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+    $otherId = Str::random(40);
+
+    seedSession($user, $currentId);
+    seedSession($user, $otherId);
+
+    $this->actingAs($user)
+        ->withCookie(config('session.cookie'), $currentId)
+        ->from(route('security.edit'))
+        ->delete(route('sessions.destroy', $otherId), ['password' => 'wrong-password'])
+        ->assertSessionHasErrors('password')
+        ->assertRedirect(route('security.edit'));
+
+    $this->assertDatabaseHas('sessions', ['id' => $otherId]);
+});
+
+test('logging out other devices requires the correct password', function () {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+    $otherId = Str::random(40);
+
+    seedSession($user, $currentId);
+    seedSession($user, $otherId);
+
+    $this->actingAs($user)
+        ->withCookie(config('session.cookie'), $currentId)
+        ->from(route('security.edit'))
+        ->delete(route('sessions.destroy-others'), ['password' => 'wrong-password'])
+        ->assertSessionHasErrors('password')
+        ->assertRedirect(route('security.edit'));
+
+    $this->assertDatabaseHas('sessions', ['id' => $otherId]);
+});

--- a/tests/Unit/UserAgentParserTest.php
+++ b/tests/Unit/UserAgentParserTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Support\UserAgentParser;
+
+test('it detects the browser', function (string $userAgent, string $browser) {
+    expect(UserAgentParser::parse($userAgent)['browser'])->toBe($browser);
+})->with([
+    'Edge' => ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0', 'Edge'],
+    'Opera' => ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0', 'Opera'],
+    'Firefox' => ['Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0', 'Firefox'],
+    'Chrome' => ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36', 'Chrome'],
+    'Safari' => ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/605.1.15', 'Safari'],
+    'unknown browser' => ['curl/8.4.0', 'Unknown browser'],
+]);
+
+test('it detects the platform', function (string $userAgent, string $platform) {
+    expect(UserAgentParser::parse($userAgent)['platform'])->toBe($platform);
+})->with([
+    'Windows' => ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36', 'Windows'],
+    'iOS' => ['Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 Version/17.2 Mobile/15E148 Safari/604.1', 'iOS'],
+    'Android' => ['Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36', 'Android'],
+    'macOS' => ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.2 Safari/605.1.15', 'macOS'],
+    'Linux' => ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36', 'Linux'],
+    'unknown platform' => ['curl/8.4.0', 'Unknown platform'],
+]);
+
+test('it falls back to unknowns for a missing user agent', function (?string $userAgent) {
+    expect(UserAgentParser::parse($userAgent))->toBe([
+        'browser' => 'Unknown browser',
+        'platform' => 'Unknown platform',
+    ]);
+})->with([
+    'null' => [null],
+    'empty string' => [''],
+]);


### PR DESCRIPTION
Closes #47

## What

A security settings panel listing the current user's active sessions/devices, with the ability to revoke an individual session and log out all other devices.

- **List** DB-backed sessions with device (browser + platform), IP and last-active metadata, current device first.
- **Revoke** a single session, or **log out all other devices** in one action.
- The **current session is clearly flagged "This device"**, has no Revoke button, and is excluded in SQL — it can never be revoked by either action.
- Both destructive actions are **gated behind password confirmation**; the listing itself sits behind the Security page's existing `RequirePassword` middleware.

## How

- `app/Support/UserAgentParser.php` — dependency-free helper turning `user_agent` into a browser + platform name (mirrors `HostResolver`).
- `app/Data/SessionData.php` — `#[TypeScript]` DTO with a `fromSession()` factory; flags the current device via `session()->getId()`.
- `app/Http/Controllers/Settings/SessionController.php` — `destroy` (single) and `destroyOthers`, both scoped to the user and excluding the current session id.
- `app/Http/Requests/Settings/SessionRevokeRequest.php` — requires `current_password` (reuses `PasswordValidationRules`).
- `SecurityController::edit` passes the `sessions` prop; new named routes in `routes/settings.php`.
- `resources/js/components/ManageSessions.vue` — device rows, per-row revoke dialog and a "log out other devices" dialog, each with password confirmation via Wayfinder `.form()` helpers; wired into `Security.vue`.

## Tests

- `tests/Unit/UserAgentParserTest.php` — every browser/platform branch plus null/empty fallbacks.
- `tests/Feature/Settings/SessionManagementTest.php` — listing with the current-device flag, single revoke, current-session protection, cross-user protection, log-out-others keeping the current session, and password enforcement on both actions. The request's session id is pinned via the encrypted session cookie so the "current device" logic is genuinely exercised.

## Verification

- `./vendor/bin/sail composer test` → **Total: 100.0 %** (Pint, PHPStan, coverage).
- Frontend: `lint:check`, `format:check`, `types:check`, `build` all pass.
- Verified in the browser: panel renders, current device flagged, revoke/log-out-others controls present.

## Notes

Rather than wiring `AuthenticateSession` + `Auth::logoutOtherDevices`, this deletes the other session rows directly and requires password confirmation in the request — the alternative called out as acceptable in the issue — keeping the current session row intact.