### PR TITLE
fix(security): hand-written type for active sessions prop (fixes CI)

### DIFF
--- a/resources/js/components/ManageSessions.vue
+++ b/resources/js/components/ManageSessions.vue
@@ -21,9 +21,10 @@ import {
 import { Label } from '@/components/ui/label';
 import { useTimezone } from '@/composables/useTimezone';
 import { formatDateTime } from '@/lib/datetime';
+import type { ActiveSession } from '@/types';
 
 type Props = {
-    sessions: App.Data.SessionData[];
+    sessions: ActiveSession[];
 };
 
 const props = defineProps<Props>();

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -9,10 +9,11 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { edit } from '@/routes/security';
+import type { ActiveSession } from '@/types';
 
 type Props = {
     passwordRules: string;
-    sessions: App.Data.SessionData[];
+    sessions: ActiveSession[];
 };
 
 const props = defineProps<Props>();

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -3,5 +3,6 @@ export * from './channels';
 export * from './chimes';
 export * from './messages';
 export * from './navigation';
+export * from './sessions';
 export * from './teams';
 export * from './ui';

--- a/resources/js/types/sessions.ts
+++ b/resources/js/types/sessions.ts
@@ -1,0 +1,13 @@
+/**
+ * An active browser/device session as shown on the Security settings page.
+ * Mirrors the `App\Data\SessionData` DTO. `isCurrentDevice` marks the session
+ * the request is being made from, which cannot be revoked.
+ */
+export type ActiveSession = {
+    id: string;
+    ipAddress: string | null;
+    browser: string;
+    platform: string;
+    lastActive: string;
+    isCurrentDevice: boolean;
+};


### PR DESCRIPTION
## Problem

The `tests` workflow is red on `master` after #98. CI fails at **Check Frontend Types**:

```
resources/js/components/ManageSessions.vue(26,15): error TS2503: Cannot find namespace 'App'.
resources/js/pages/settings/Security.vue(15,15): error TS2503: Cannot find namespace 'App'.
```

## Root cause

#98 typed the `sessions` prop as `App.Data.SessionData[]`. The `App` ambient namespace is declared in `resources/js/generated/generated.d.ts`, which is **gitignored** and only produced by `php artisan typescript:transform`. CI never runs that command — `npm run build` regenerates the Wayfinder `@/actions`/`@/routes` (vite plugin) but nothing regenerates the spatie type file — so the namespace is absent on CI. It passed locally only because the generated file was present.

This is why the codebase hand-writes local types (e.g. `resources/js/types/teams.ts` mirrors `UserProfileData`) rather than importing `App.Data.*`.

## Fix

- Add `resources/js/types/sessions.ts` with a hand-written `ActiveSession` type mirroring the `SessionData` DTO, exported via `types/index.ts`.
- Switch `ManageSessions.vue` and `Security.vue` to `import type { ActiveSession }`.

## Verification

Reproduced CI by moving `generated.d.ts` aside — `types:check` now passes **without** it. `lint:check`, `format:check`, and `build` all pass. No PHP changed.

## Follow-up

CI would have caught this pre-merge if the workflow committed the generated types or ran `typescript:transform` before `types:check`. Worth a separate `tech-debt` issue.