### PR TITLE
feat(security): login history / security activity log (#48)

### DIFF
--- a/app/Data/SecurityEventData.php
+++ b/app/Data/SecurityEventData.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\SecurityEvent;
+use App\Support\UserAgentParser;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class SecurityEventData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $type,
+        public string $label,
+        public ?string $ipAddress,
+        public string $browser,
+        public string $platform,
+        public bool $isNewDevice,
+        public string $occurredAt,
+    ) {}
+
+    /**
+     * Build the DTO from a recorded security event.
+     */
+    public static function fromEvent(SecurityEvent $event): self
+    {
+        $agent = UserAgentParser::parse($event->user_agent);
+
+        return new self(
+            id: $event->id,
+            type: $event->type->value,
+            label: $event->type->label(),
+            ipAddress: $event->ip_address,
+            browser: $agent['browser'],
+            platform: $agent['platform'],
+            isNewDevice: $event->is_new_device,
+            occurredAt: $event->created_at->toIso8601String(),
+        );
+    }
+}

--- a/app/Enums/SecurityEventType.php
+++ b/app/Enums/SecurityEventType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Enums;
+
+enum SecurityEventType: string
+{
+    case LoggedIn = 'logged_in';
+    case LoggedOut = 'logged_out';
+    case PasswordChanged = 'password_changed';
+    case PasswordReset = 'password_reset';
+    case TwoFactorEnabled = 'two_factor_enabled';
+    case TwoFactorDisabled = 'two_factor_disabled';
+    case TwoFactorConfirmed = 'two_factor_confirmed';
+    case RecoveryCodesGenerated = 'recovery_codes_generated';
+
+    /**
+     * Get the human-readable label shown in the activity log.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::LoggedIn => 'Signed in',
+            self::LoggedOut => 'Signed out',
+            self::PasswordChanged => 'Password changed',
+            self::PasswordReset => 'Password reset',
+            self::TwoFactorEnabled => 'Two-factor authentication enabled',
+            self::TwoFactorDisabled => 'Two-factor authentication disabled',
+            self::TwoFactorConfirmed => 'Two-factor authentication confirmed',
+            self::RecoveryCodesGenerated => 'Recovery codes generated',
+        };
+    }
+}

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -2,10 +2,14 @@
 
 namespace App\Http\Controllers\Settings;
 
+use App\Data\SecurityEventData;
 use App\Data\SessionData;
+use App\Enums\SecurityEventType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\PasswordUpdateRequest;
 use App\Http\Requests\Settings\TwoFactorAuthenticationRequest;
+use App\Models\SecurityEvent;
+use App\Support\SecurityEventRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rules\Password;
@@ -15,6 +19,11 @@ use Inertia\Response;
 class SecurityController extends Controller
 {
     /**
+     * The number of recent security events to surface on the settings page.
+     */
+    private const RECENT_ACTIVITY_LIMIT = 20;
+
+    /**
      * Show the user's security settings page.
      */
     public function edit(TwoFactorAuthenticationRequest $request): Response
@@ -22,9 +31,25 @@ class SecurityController extends Controller
         $props = [
             'passwordRules' => Password::defaults()->toPasswordRulesString(),
             'sessions' => $this->activeSessions($request),
+            'securityEvents' => $this->recentSecurityEvents($request),
         ];
 
         return Inertia::render('settings/Security', $props);
+    }
+
+    /**
+     * List the user's most recent security activity, newest first.
+     *
+     * @return array<int, SecurityEventData>
+     */
+    private function recentSecurityEvents(TwoFactorAuthenticationRequest $request): array
+    {
+        return $request->user()
+            ->securityEvents()
+            ->limit(self::RECENT_ACTIVITY_LIMIT)
+            ->get()
+            ->map(fn (SecurityEvent $event): SecurityEventData => SecurityEventData::fromEvent($event))
+            ->all();
     }
 
     /**
@@ -48,12 +73,19 @@ class SecurityController extends Controller
 
     /**
      * Update the user's password.
+     *
+     * The in-app password change fires no framework event, so the security
+     * activity is recorded explicitly here.
      */
-    public function update(PasswordUpdateRequest $request): RedirectResponse
+    public function update(PasswordUpdateRequest $request, SecurityEventRecorder $recorder): RedirectResponse
     {
-        $request->user()->update([
+        $user = $request->user();
+
+        $user->update([
             'password' => $request->password,
         ]);
+
+        $recorder->record($user, SecurityEventType::PasswordChanged);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Password updated.')]);
 

--- a/app/Listeners/RecordSecurityEvents.php
+++ b/app/Listeners/RecordSecurityEvents.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Enums\SecurityEventType;
+use App\Support\SecurityEventRecorder;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Auth\Events\PasswordReset;
+use Laravel\Fortify\Events\RecoveryCodesGenerated;
+use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
+use Laravel\Fortify\Events\TwoFactorAuthenticationDisabled;
+use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
+
+/**
+ * Records framework and Fortify authentication events into the security
+ * activity log. Each `handle*` method is wired to its event by Laravel's event
+ * discovery. Runs synchronously (never queued) so the live request's IP and
+ * User-Agent are available when the event is captured.
+ */
+class RecordSecurityEvents
+{
+    public function __construct(private SecurityEventRecorder $recorder) {}
+
+    /**
+     * Handle a successful sign in.
+     */
+    public function handleLogin(Login $event): void
+    {
+        $this->recorder->record($event->user, SecurityEventType::LoggedIn);
+    }
+
+    /**
+     * Handle a sign out, ignoring guests without an authenticated user.
+     */
+    public function handleLogout(Logout $event): void
+    {
+        if ($event->user === null) {
+            return;
+        }
+
+        $this->recorder->record($event->user, SecurityEventType::LoggedOut);
+    }
+
+    /**
+     * Handle a password reset completed via the forgot-password flow.
+     */
+    public function handlePasswordReset(PasswordReset $event): void
+    {
+        $this->recorder->record($event->user, SecurityEventType::PasswordReset);
+    }
+
+    /**
+     * Handle two-factor authentication being enabled.
+     */
+    public function handleTwoFactorEnabled(TwoFactorAuthenticationEnabled $event): void
+    {
+        $this->recorder->record($event->user, SecurityEventType::TwoFactorEnabled);
+    }
+
+    /**
+     * Handle two-factor authentication being disabled.
+     */
+    public function handleTwoFactorDisabled(TwoFactorAuthenticationDisabled $event): void
+    {
+        $this->recorder->record($event->user, SecurityEventType::TwoFactorDisabled);
+    }
+
+    /**
+     * Handle two-factor authentication being confirmed.
+     */
+    public function handleTwoFactorConfirmed(TwoFactorAuthenticationConfirmed $event): void
+    {
+        $this->recorder->record($event->user, SecurityEventType::TwoFactorConfirmed);
+    }
+
+    /**
+     * Handle a fresh set of recovery codes being generated.
+     */
+    public function handleRecoveryCodesGenerated(RecoveryCodesGenerated $event): void
+    {
+        $this->recorder->record($event->user, SecurityEventType::RecoveryCodesGenerated);
+    }
+}

--- a/app/Models/SecurityEvent.php
+++ b/app/Models/SecurityEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\SecurityEventType;
+use Database\Factories\SecurityEventFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * A record of a security-relevant account action (sign in/out, credential and
+ * two-factor changes), captured with the request's IP and User-Agent so users
+ * can review recent activity and spot unfamiliar access.
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property SecurityEventType $type
+ * @property string|null $ip_address
+ * @property string|null $user_agent
+ * @property bool $is_new_device
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ */
+#[Fillable(['user_id', 'type', 'ip_address', 'user_agent', 'is_new_device'])]
+class SecurityEvent extends Model
+{
+    /** @use HasFactory<SecurityEventFactory> */
+    use HasFactory, HasUuids;
+
+    /**
+     * Get the user the security event belongs to.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'type' => SecurityEventType::class,
+            'is_new_device' => 'boolean',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -88,4 +88,14 @@ class User extends Authenticatable
     {
         return $this->hasMany(ChannelSection::class);
     }
+
+    /**
+     * Get the user's recorded security activity, newest first.
+     *
+     * @return HasMany<SecurityEvent, $this>
+     */
+    public function securityEvents(): HasMany
+    {
+        return $this->hasMany(SecurityEvent::class)->latest();
+    }
 }

--- a/app/Support/SecurityEventRecorder.php
+++ b/app/Support/SecurityEventRecorder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Support;
+
+use App\Enums\SecurityEventType;
+use App\Models\SecurityEvent;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+
+/**
+ * Persists security-relevant account events, capturing the live request's IP
+ * and User-Agent. Must be resolved during a real request so the request context
+ * is available — never from a queued job.
+ */
+class SecurityEventRecorder
+{
+    public function __construct(private Request $request) {}
+
+    /**
+     * Record a security event for the given user against the current request.
+     */
+    public function record(Authenticatable $user, SecurityEventType $type): SecurityEvent
+    {
+        $userId = $user->getAuthIdentifier();
+        $ipAddress = $this->request->ip();
+        $userAgent = $this->request->userAgent();
+
+        return SecurityEvent::create([
+            'user_id' => $userId,
+            'type' => $type,
+            'ip_address' => $ipAddress,
+            'user_agent' => $userAgent,
+            'is_new_device' => $type === SecurityEventType::LoggedIn
+                && $this->isNewDevice($userId, $ipAddress, $userAgent),
+        ]);
+    }
+
+    /**
+     * Determine whether this IP and User-Agent are new for the user's sign-ins.
+     */
+    private function isNewDevice(mixed $userId, ?string $ipAddress, ?string $userAgent): bool
+    {
+        return ! SecurityEvent::query()
+            ->where('user_id', $userId)
+            ->where('type', SecurityEventType::LoggedIn)
+            ->where('ip_address', $ipAddress)
+            ->where('user_agent', $userAgent)
+            ->exists();
+    }
+}

--- a/database/factories/SecurityEventFactory.php
+++ b/database/factories/SecurityEventFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SecurityEventType;
+use App\Models\SecurityEvent;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SecurityEvent>
+ */
+class SecurityEventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'type' => fake()->randomElement(SecurityEventType::cases()),
+            'ip_address' => fake()->ipv4(),
+            'user_agent' => fake()->userAgent(),
+            'is_new_device' => false,
+        ];
+    }
+
+    /**
+     * Record the event as a specific type.
+     */
+    public function ofType(SecurityEventType $type): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'type' => $type,
+        ]);
+    }
+
+    /**
+     * Flag the event as coming from an unfamiliar device.
+     */
+    public function newDevice(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'type' => SecurityEventType::LoggedIn,
+            'is_new_device' => true,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_10_123909_create_security_events_table.php
+++ b/database/migrations/2026_07_10_123909_create_security_events_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('security_events', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            // The kind of security-relevant action (see App\Enums\SecurityEventType).
+            $table->string('type');
+            // Nullable, sized for IPv6; the request IP is not always resolvable.
+            $table->string('ip_address', 45)->nullable();
+            // The raw User-Agent header, parsed for display into browser/platform.
+            $table->text('user_agent')->nullable();
+            // Only meaningful for sign-in events: the IP+User-Agent combination
+            // had not been seen on a prior sign-in, flagging unfamiliar access.
+            $table->boolean('is_new_device')->default(false);
+            $table->timestamps();
+
+            // The activity log is always read newest-first for a single user.
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('security_events');
+    }
+};

--- a/resources/js/components/SecurityActivity.vue
+++ b/resources/js/components/SecurityActivity.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { Monitor, Smartphone } from '@lucide/vue';
+import Heading from '@/components/Heading.vue';
+import { Badge } from '@/components/ui/badge';
+import { useTimezone } from '@/composables/useTimezone';
+import { formatDateTime } from '@/lib/datetime';
+import type { SecurityActivityEvent } from '@/types';
+
+type Props = {
+    events: SecurityActivityEvent[];
+};
+
+const props = defineProps<Props>();
+
+const { timezone } = useTimezone();
+
+function isMobile(platform: string): boolean {
+    return platform === 'iOS' || platform === 'Android';
+}
+
+function occurredAt(iso: string): string {
+    return formatDateTime(iso, timezone.value ?? undefined);
+}
+</script>
+
+<template>
+    <div class="space-y-6">
+        <Heading
+            variant="small"
+            title="Recent activity"
+            description="Review recent security activity on your account to spot anything unfamiliar"
+        />
+
+        <p
+            v-if="props.events.length === 0"
+            class="text-sm text-muted-foreground"
+            data-test="security-activity-empty"
+        >
+            No recent activity to show yet.
+        </p>
+
+        <ul
+            v-else
+            class="space-y-3"
+            role="list"
+            data-test="security-activity-list"
+        >
+            <li
+                v-for="event in props.events"
+                :key="event.id"
+                class="flex items-center gap-4 rounded-lg border border-border p-4"
+                :data-test="`security-event-${event.id}`"
+            >
+                <component
+                    :is="isMobile(event.platform) ? Smartphone : Monitor"
+                    class="size-5 shrink-0 text-muted-foreground"
+                />
+
+                <div class="min-w-0 flex-1 space-y-0.5">
+                    <div class="flex items-center gap-2">
+                        <p class="truncate text-sm font-medium">
+                            {{ event.label }}
+                        </p>
+                        <Badge
+                            v-if="event.isNewDevice"
+                            variant="destructive"
+                            data-test="new-device-badge"
+                        >
+                            New device
+                        </Badge>
+                    </div>
+                    <p class="truncate text-xs text-muted-foreground">
+                        {{ event.browser }} on {{ event.platform }} &middot;
+                        {{ event.ipAddress ?? 'Unknown IP' }} &middot;
+                        {{ occurredAt(event.occurredAt) }}
+                    </p>
+                </div>
+            </li>
+        </ul>
+    </div>
+</template>

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -5,15 +5,17 @@ import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
 import ManageSessions from '@/components/ManageSessions.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
+import SecurityActivity from '@/components/SecurityActivity.vue';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { edit } from '@/routes/security';
-import type { ActiveSession } from '@/types';
+import type { ActiveSession, SecurityActivityEvent } from '@/types';
 
 type Props = {
     passwordRules: string;
     sessions: ActiveSession[];
+    securityEvents: SecurityActivityEvent[];
 };
 
 const props = defineProps<Props>();
@@ -107,5 +109,9 @@ defineOptions({
         <Separator />
 
         <ManageSessions :sessions="props.sessions" />
+
+        <Separator />
+
+        <SecurityActivity :events="props.securityEvents" />
     </div>
 </template>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -3,6 +3,7 @@ export * from './channels';
 export * from './chimes';
 export * from './messages';
 export * from './navigation';
+export * from './security';
 export * from './sessions';
 export * from './teams';
 export * from './ui';

--- a/resources/js/types/security.ts
+++ b/resources/js/types/security.ts
@@ -1,0 +1,15 @@
+/**
+ * A recorded security-relevant account event as shown on the Security settings
+ * page. Mirrors the `App\Data\SecurityEventData` DTO. `isNewDevice` flags a
+ * sign-in from an IP and browser not seen on a prior sign-in.
+ */
+export type SecurityActivityEvent = {
+    id: string;
+    type: string;
+    label: string;
+    ipAddress: string | null;
+    browser: string;
+    platform: string;
+    isNewDevice: boolean;
+    occurredAt: string;
+};

--- a/tests/Feature/Settings/SecurityActivityTest.php
+++ b/tests/Feature/Settings/SecurityActivityTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Enums\SecurityEventType;
+use App\Models\SecurityEvent;
+use App\Models\User;
+use Illuminate\Auth\Events\Logout;
+use Illuminate\Auth\Events\PasswordReset;
+use Inertia\Testing\AssertableInertia as Assert;
+use Laravel\Fortify\Events\RecoveryCodesGenerated;
+use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
+use Laravel\Fortify\Events\TwoFactorAuthenticationDisabled;
+use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
+
+test('signing in records a security event with request context', function () {
+    $user = User::factory()->create();
+
+    $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $event = SecurityEvent::query()
+        ->where('user_id', $user->id)
+        ->where('type', SecurityEventType::LoggedIn)
+        ->sole();
+
+    expect($event->ip_address)->toBe('127.0.0.1');
+    expect($event->is_new_device)->toBeTrue();
+});
+
+test('a repeat sign in from the same device is not flagged as new', function () {
+    $user = User::factory()->create();
+
+    $credentials = ['email' => $user->email, 'password' => 'password'];
+
+    $this->post(route('login.store'), $credentials);
+    $this->post(route('logout'));
+    $this->post(route('login.store'), $credentials);
+
+    $logins = SecurityEvent::query()
+        ->where('user_id', $user->id)
+        ->where('type', SecurityEventType::LoggedIn);
+
+    expect($logins->count())->toBe(2);
+    expect((clone $logins)->where('is_new_device', true)->count())->toBe(1);
+});
+
+test('signing out records a security event', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->post(route('logout'));
+
+    expect(SecurityEvent::query()
+        ->where('user_id', $user->id)
+        ->where('type', SecurityEventType::LoggedOut)
+        ->exists())->toBeTrue();
+});
+
+test('signing out as a guest records nothing', function () {
+    event(new Logout('web', null));
+
+    expect(SecurityEvent::query()->count())->toBe(0);
+});
+
+test('changing the password records a security event', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from(route('security.edit'))
+        ->put(route('user-password.update'), [
+            'current_password' => 'password',
+            'password' => 'new-password',
+            'password_confirmation' => 'new-password',
+        ])
+        ->assertRedirect(route('security.edit'));
+
+    expect(SecurityEvent::query()
+        ->where('user_id', $user->id)
+        ->where('type', SecurityEventType::PasswordChanged)
+        ->exists())->toBeTrue();
+});
+
+test('resetting the password records a security event', function () {
+    $user = User::factory()->create();
+
+    event(new PasswordReset($user));
+
+    expect(SecurityEvent::query()
+        ->where('user_id', $user->id)
+        ->where('type', SecurityEventType::PasswordReset)
+        ->exists())->toBeTrue();
+});
+
+test('two factor changes are recorded', function () {
+    $user = User::factory()->create();
+
+    event(new TwoFactorAuthenticationEnabled($user));
+    event(new TwoFactorAuthenticationConfirmed($user));
+    event(new RecoveryCodesGenerated($user));
+    event(new TwoFactorAuthenticationDisabled($user));
+
+    $recorded = SecurityEvent::query()
+        ->where('user_id', $user->id)
+        ->pluck('type')
+        ->all();
+
+    expect($recorded)->toContain(
+        SecurityEventType::TwoFactorEnabled,
+        SecurityEventType::TwoFactorConfirmed,
+        SecurityEventType::RecoveryCodesGenerated,
+        SecurityEventType::TwoFactorDisabled,
+    );
+});
+
+test('the security page lists recent activity newest first', function () {
+    $user = User::factory()->create();
+
+    SecurityEvent::factory()->for($user)->ofType(SecurityEventType::PasswordChanged)->create(['created_at' => now()->subMinute()]);
+    SecurityEvent::factory()->for($user)->newDevice()->create();
+
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->get(route('security.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/Security')
+            ->has('securityEvents', 2)
+            ->has('securityEvents.0', fn (Assert $event) => $event
+                ->where('isNewDevice', true)
+                ->where('label', SecurityEventType::LoggedIn->label())
+                ->hasAll(['id', 'type', 'ipAddress', 'browser', 'platform', 'occurredAt']),
+            ),
+        );
+});
+
+test('the activity log is scoped to the authenticated user', function () {
+    $user = User::factory()->create();
+    SecurityEvent::factory()->for(User::factory())->create();
+
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->get(route('security.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->where('securityEvents', []));
+});

--- a/tests/Unit/SecurityEventTypeTest.php
+++ b/tests/Unit/SecurityEventTypeTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Enums\SecurityEventType;
+
+test('every event type has a non-empty label', function (SecurityEventType $type) {
+    expect($type->label())->toBeString()->not->toBeEmpty();
+})->with(SecurityEventType::cases());
+
+test('labels describe the action', function () {
+    expect(SecurityEventType::LoggedIn->label())->toBe('Signed in');
+    expect(SecurityEventType::TwoFactorEnabled->label())->toBe('Two-factor authentication enabled');
+});


### PR DESCRIPTION
## Summary

Implements issue #48 — records security-relevant account events (timestamp, IP, device) and surfaces a read-only **Recent activity** list on the Security settings page so users can spot unfamiliar access. Direct follow-on to #47 (active sessions), reusing its patterns.

Covers **login, logout, password change, password reset, and 2FA changes**.

## Backend

- **`SecurityEventType` enum** — TitleCase cases for login/logout, password changed/reset, and the four Fortify 2FA events, each with a `label()`.
- **`SecurityEvent` model + migration + factory** — UUID key, `foreignUuid user_id`, `type` cast to the enum, nullable `ip_address` (45) / `user_agent`, an `is_new_device` flag, and a `[user_id, created_at]` index.
- **`SecurityEventRecorder`** — captures the live request's IP/User-Agent; flags first-seen IP+User-Agent sign-ins as new devices.
- **`RecordSecurityEvents` listener** — one `handle*` method per framework/Fortify event, wired via Laravel's event auto-discovery. Synchronous (never queued) so request context is available; the logout handler guards the guest-`null` case.
- **`SecurityController`** — records the in-app password change explicitly (no stock event fires there) and passes the 20 most recent events to the page; `User::securityEvents()` relation added.
- **`SecurityEventData`** DTO (`#[TypeScript]`, `fromEvent()` factory) reusing `UserAgentParser` from #47.

## Frontend

- **`SecurityActivity.vue`** — Monitor/Smartphone icons, viewer-timezone timestamps, a "New device" badge, and an empty state — rendered below `ManageSessions` on `Security.vue`. Hand-written `SecurityActivityEvent` type, matching the settled #47 convention.

## Tests

18 new tests (feature + unit): sign-in/out, password change, password reset, all four 2FA events, new-device detection (both branches), page-prop rendering, and user scoping.

## Design note

The issue suggested wiring listeners via `Event::subscribe` in `AppServiceProvider::boot`. Laravel 13 has event auto-discovery enabled by default, which already registers the `handle*` methods — adding `Event::subscribe` on top recorded every event **twice**. I removed the manual subscription and rely on auto-discovery (the idiomatic path), documented in the listener's docblock.

## Gates

- `composer test` → **Total: 100.0 %** (Pint + PHPStan + coverage).
- Frontend `lint:check`, `format:check`, `types:check`, `build` → all pass.

Closes #48