### PR TITLE
feat(security): account deletion policy & GDPR data export (#49)

### DIFF
--- a/app/Actions/Teams/TransferTeamOwnership.php
+++ b/app/Actions/Teams/TransferTeamOwnership.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class TransferTeamOwnership
+{
+    /**
+     * Transfer ownership of the team from the current owner to a new owner.
+     *
+     * The demotion and promotion run in a single transaction so the single-owner
+     * invariant is never observable as broken: there is no committed window with
+     * zero or two owners.
+     */
+    public function handle(Team $team, User $currentOwner, User $newOwner): void
+    {
+        DB::transaction(function () use ($team, $currentOwner, $newOwner) {
+            $team->memberships()
+                ->where('user_id', $currentOwner->id)
+                ->update(['role' => TeamRole::Admin]);
+
+            $team->memberships()
+                ->where('user_id', $newOwner->id)
+                ->update(['role' => TeamRole::Owner]);
+        });
+    }
+}

--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -175,6 +175,7 @@ trait HasTeams
             canRemoveMember: $role?->hasPermission(TeamPermission::RemoveMember) ?? false,
             canCreateInvitation: $role?->hasPermission(TeamPermission::CreateInvitation) ?? false,
             canCancelInvitation: $role?->hasPermission(TeamPermission::CancelInvitation) ?? false,
+            canTransferOwnership: ! $team->is_personal && $role === TeamRole::Owner,
         );
     }
 

--- a/app/Data/DataExportData.php
+++ b/app/Data/DataExportData.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\DataExport;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class DataExportData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $status,
+        public string $statusLabel,
+        public bool $isReady,
+        public string $requestedAt,
+        public ?string $expiresAt,
+    ) {}
+
+    /**
+     * Build the DTO from a data export record.
+     */
+    public static function fromExport(DataExport $export): self
+    {
+        return new self(
+            id: $export->id,
+            status: $export->status->value,
+            statusLabel: $export->status->label(),
+            isReady: $export->isReady() && ! $export->isExpired(),
+            requestedAt: $export->created_at->toIso8601String(),
+            expiresAt: $export->expires_at?->toIso8601String(),
+        );
+    }
+}

--- a/app/Data/TeamPermissions.php
+++ b/app/Data/TeamPermissions.php
@@ -12,6 +12,7 @@ readonly class TeamPermissions
         public bool $canRemoveMember,
         public bool $canCreateInvitation,
         public bool $canCancelInvitation,
+        public bool $canTransferOwnership,
     ) {
         //
     }

--- a/app/Enums/DataExportStatus.php
+++ b/app/Enums/DataExportStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum DataExportStatus: string
+{
+    case Pending = 'pending';
+    case Ready = 'ready';
+    case Failed = 'failed';
+
+    /**
+     * Get the human-readable label shown on the Data & privacy panel.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Pending => 'Preparing',
+            self::Ready => 'Ready to download',
+            self::Failed => 'Failed',
+        };
+    }
+}

--- a/app/Http/Controllers/Settings/DataExportController.php
+++ b/app/Http/Controllers/Settings/DataExportController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Enums\DataExportStatus;
+use App\Http\Controllers\Controller;
+use App\Jobs\ExportUserData;
+use App\Models\DataExport;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class DataExportController extends Controller
+{
+    /**
+     * Queue a fresh export of the authenticated user's personal data.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $export = $request->user()->dataExports()->create([
+            'status' => DataExportStatus::Pending,
+        ]);
+
+        ExportUserData::dispatch($export->id);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __("Preparing your data export. We'll email you when it's ready.")]);
+
+        return back();
+    }
+
+    /**
+     * Download a ready export archive.
+     *
+     * Guards ownership and the download window: another user's export is
+     * forbidden, and one that is still pending, failed, or expired is a 404.
+     */
+    public function download(Request $request, DataExport $dataExport): StreamedResponse
+    {
+        abort_unless($dataExport->user_id === $request->user()->id, 403);
+        abort_unless($dataExport->isReady() && ! $dataExport->isExpired(), 404);
+
+        return Storage::disk(ExportUserData::DISK)->download($dataExport->path, 'data-export.zip');
+    }
+}

--- a/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/Http/Controllers/Settings/ProfileController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers\Settings;
 
+use App\Data\DataExportData;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\ProfileDeleteRequest;
 use App\Http\Requests\Settings\ProfileUpdateRequest;
+use App\Support\AccountDeleter;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -19,9 +21,12 @@ class ProfileController extends Controller
      */
     public function edit(Request $request): Response
     {
+        $latestExport = $request->user()->dataExports()->first();
+
         return Inertia::render('settings/Profile', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => $request->session()->get('status'),
+            'dataExport' => $latestExport === null ? null : DataExportData::fromExport($latestExport),
         ]);
     }
 
@@ -46,13 +51,13 @@ class ProfileController extends Controller
     /**
      * Delete the user's profile.
      */
-    public function destroy(ProfileDeleteRequest $request): RedirectResponse
+    public function destroy(ProfileDeleteRequest $request, AccountDeleter $deleter): RedirectResponse
     {
         $user = $request->user();
 
         Auth::logout();
 
-        $user->delete();
+        $deleter->delete($user);
 
         $request->session()->invalidate();
         $request->session()->regenerateToken();

--- a/app/Http/Controllers/Teams/TeamMemberController.php
+++ b/app/Http/Controllers/Teams/TeamMemberController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers\Teams;
 
+use App\Actions\Teams\TransferTeamOwnership;
 use App\Data\UserProfileData;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Teams\TransferTeamOwnershipRequest;
 use App\Http\Requests\Teams\UpdateTeamMemberRequest;
 use App\Models\Membership;
 use App\Models\Team;
@@ -80,6 +82,28 @@ class TeamMemberController extends Controller
             ->update(['role' => $newRole]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member role updated.')]);
+
+        return to_route('teams.edit', ['team' => $team->slug]);
+    }
+
+    /**
+     * Transfer ownership of the team to the specified member.
+     *
+     * Only the current owner may initiate this, and the target must already be a
+     * member of the team. The outgoing owner is demoted to Admin and the new
+     * owner holds the sole Owner pivot row (see {@see TransferTeamOwnership}).
+     */
+    public function transferOwnership(TransferTeamOwnershipRequest $request, Team $team, User $user, TransferTeamOwnership $transferOwnership): RedirectResponse
+    {
+        Gate::authorize('transferOwnership', $team);
+
+        abort_if($request->user()->is($user), 403, __('You cannot transfer ownership to yourself.'));
+
+        abort_unless($user->belongsToTeam($team), 404);
+
+        $transferOwnership->handle($team, $request->user(), $user);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Team ownership transferred.')]);
 
         return to_route('teams.edit', ['team' => $team->slug]);
     }

--- a/app/Http/Requests/Settings/ProfileDeleteRequest.php
+++ b/app/Http/Requests/Settings/ProfileDeleteRequest.php
@@ -3,7 +3,9 @@
 namespace App\Http\Requests\Settings;
 
 use App\Concerns\PasswordValidationRules;
+use App\Models\Team;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ProfileDeleteRequest extends FormRequest
@@ -19,6 +21,35 @@ class ProfileDeleteRequest extends FormRequest
     {
         return [
             'password' => $this->currentPasswordRules(),
+        ];
+    }
+
+    /**
+     * Get the "after" validation callables.
+     *
+     * Block deletion while the user is the only owner of a shared team, which
+     * would otherwise leave that team ownerless. The error names the teams so the
+     * user knows exactly which ownerships to transfer first.
+     *
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                $teams = $this->user()->soleOwnedSharedTeams();
+
+                if ($teams->isEmpty()) {
+                    return;
+                }
+
+                $names = $teams->map(fn (Team $team): string => $team->name)->join(', ', ' and ');
+
+                $validator->errors()->add('team', __(
+                    'You are the only owner of :teams. Transfer ownership or delete :teamWord before deleting your account.',
+                    ['teams' => $names, 'teamWord' => $teams->count() === 1 ? 'it' : 'them'],
+                ));
+            },
         ];
     }
 }

--- a/app/Http/Requests/Teams/TransferTeamOwnershipRequest.php
+++ b/app/Http/Requests/Teams/TransferTeamOwnershipRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Teams;
+
+use App\Concerns\PasswordValidationRules;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class TransferTeamOwnershipRequest extends FormRequest
+{
+    use PasswordValidationRules;
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * Ownership is a consequential change, so the current owner must re-enter
+     * their password to confirm the transfer.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'password' => $this->currentPasswordRules(),
+        ];
+    }
+}

--- a/app/Jobs/ExportUserData.php
+++ b/app/Jobs/ExportUserData.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\DataExportStatus;
+use App\Mail\DataExportReady;
+use App\Models\DataExport;
+use App\Models\Membership;
+use App\Models\Message;
+use App\Models\SecurityEvent;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+use ZipArchive;
+
+class ExportUserData implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * The private disk the archive is written to.
+     */
+    public const string DISK = 'local';
+
+    /**
+     * How many days the built archive stays downloadable before it is purged.
+     */
+    private const int RETENTION_DAYS = 7;
+
+    public function __construct(private string $dataExportId) {}
+
+    /**
+     * Assemble the user's personal data into a zip of JSON files on the private
+     * disk, then mark the export ready and email them the download link.
+     *
+     * Re-fetches by id and bails quietly when the export is gone (the account may
+     * have been deleted since the job was queued).
+     */
+    public function handle(): void
+    {
+        $export = DataExport::with('user')->find($this->dataExportId);
+
+        if ($export === null) {
+            return;
+        }
+
+        $path = 'exports/'.$export->id.'.zip';
+        $disk = Storage::disk(self::DISK);
+        $disk->makeDirectory('exports');
+
+        $zip = new ZipArchive;
+        $zip->open($disk->path($path), ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+        foreach ($this->archiveContents($export->user) as $filename => $contents) {
+            $zip->addFromString($filename, (string) json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        }
+
+        $zip->close();
+
+        $export->update([
+            'status' => DataExportStatus::Ready,
+            'path' => $path,
+            'expires_at' => now()->addDays(self::RETENTION_DAYS),
+        ]);
+
+        Mail::to($export->user)->send(new DataExportReady($export));
+    }
+
+    /**
+     * Mark the export failed so the panel can offer a retry.
+     */
+    public function failed(Throwable $exception): void
+    {
+        DataExport::whereKey($this->dataExportId)->update(['status' => DataExportStatus::Failed]);
+    }
+
+    /**
+     * Build the named JSON documents that make up the archive.
+     *
+     * @return array<string, mixed>
+     */
+    private function archiveContents(User $user): array
+    {
+        return [
+            'profile.json' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'pronouns' => $user->pronouns,
+                'title' => $user->title,
+                'phone' => $user->phone,
+                'timezone' => $user->timezone,
+                'created_at' => $user->created_at?->toIso8601String(),
+            ],
+            'teams.json' => $user->teamMemberships()->with('team')->get()->map(fn (Membership $membership): array => [
+                'id' => $membership->team->id,
+                'name' => $membership->team->name,
+                'slug' => $membership->team->slug,
+                'is_personal' => $membership->team->is_personal,
+                'role' => $membership->role->value,
+            ])->all(),
+            'messages.json' => Message::withTrashed()
+                ->where('user_id', $user->id)
+                ->get()
+                ->map(fn (Message $message): array => [
+                    'id' => $message->id,
+                    'channel_id' => $message->channel_id,
+                    'body' => $message->body,
+                    'created_at' => $message->created_at?->toIso8601String(),
+                    'deleted_at' => $message->deleted_at?->toIso8601String(),
+                ])->all(),
+            'security-events.json' => $user->securityEvents()->get()->map(fn (SecurityEvent $event): array => [
+                'type' => $event->type->value,
+                'ip_address' => $event->ip_address,
+                'user_agent' => $event->user_agent,
+                'created_at' => $event->created_at?->toIso8601String(),
+            ])->all(),
+        ];
+    }
+}

--- a/app/Mail/DataExportReady.php
+++ b/app/Mail/DataExportReady.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\DataExport;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class DataExportReady extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(public DataExport $export) {}
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Your data export is ready',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.data-export-ready',
+            with: [
+                'url' => route('data-export.download', $this->export),
+                'expiresAt' => $this->export->expires_at,
+            ],
+        );
+    }
+}

--- a/app/Models/DataExport.php
+++ b/app/Models/DataExport.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DataExportStatus;
+use App\Jobs\ExportUserData;
+use Database\Factories\DataExportFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * A user-requested archive of their personal data, assembled asynchronously by
+ * {@see ExportUserData} and served, once ready, from a private disk
+ * for a limited window (GDPR self-service export).
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property DataExportStatus $status
+ * @property string|null $path
+ * @property Carbon|null $expires_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ */
+#[Fillable(['user_id', 'status', 'path', 'expires_at'])]
+class DataExport extends Model
+{
+    /** @use HasFactory<DataExportFactory> */
+    use HasFactory, HasUuids;
+
+    /**
+     * Get the user the export belongs to.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Determine if the archive has been built and is ready to download.
+     */
+    public function isReady(): bool
+    {
+        return $this->status === DataExportStatus::Ready && $this->path !== null;
+    }
+
+    /**
+     * Determine if the download window has closed.
+     */
+    public function isExpired(): bool
+    {
+        return $this->expires_at !== null && $this->expires_at->isPast();
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => DataExportStatus::class,
+            'expires_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Concerns\HasTeams;
 use App\Enums\ChimeSound;
+use App\Enums\TeamRole;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 
 /**
  * @property string $id
@@ -34,6 +37,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $current_team_id
  * @property ChimeSound $chime_sound
  * @property bool $share_read_receipts
+ * @property bool $is_tombstone
  * @property array<int, string>|null $collapsed_channel_sections
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -43,8 +47,9 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, Team> $teams
  * @property-read Collection<int, Channel> $channels
  * @property-read Collection<int, ChannelSection> $channelSections
+ * @property-read Collection<int, DataExport> $dataExports
  */
-#[Fillable(['name', 'email', 'pronouns', 'title', 'phone', 'timezone', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'collapsed_channel_sections'])]
+#[Fillable(['name', 'email', 'pronouns', 'title', 'phone', 'timezone', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'collapsed_channel_sections', 'is_tombstone'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable
 {
@@ -63,8 +68,51 @@ class User extends Authenticatable
             'password' => 'hashed',
             'chime_sound' => ChimeSound::class,
             'share_read_receipts' => 'boolean',
+            'is_tombstone' => 'boolean',
             'collapsed_channel_sections' => 'array',
         ];
+    }
+
+    /**
+     * Get the retained "Deleted User" tombstone account, creating it on first use.
+     *
+     * Authored messages are reassigned to this account when their real author
+     * deletes their profile, so channel history reads coherently instead of
+     * collapsing into gaps. It is never attached to a team and cannot be signed
+     * into (its password is random and discarded).
+     */
+    public static function tombstone(): self
+    {
+        return static::firstOrCreate(
+            ['is_tombstone' => true],
+            [
+                'name' => 'Deleted User',
+                'email' => 'deleted-user@deleted.invalid',
+                'password' => Hash::make(Str::random(40)),
+            ],
+        );
+    }
+
+    /**
+     * Get the shared (non-personal) teams this user is the only owner of.
+     *
+     * Deleting the account would leave these teams ownerless, so the deletion
+     * flow blocks until the user transfers ownership (see App\Http\Requests\
+     * Settings\ProfileDeleteRequest).
+     *
+     * @return Collection<int, Team>
+     */
+    public function soleOwnedSharedTeams(): Collection
+    {
+        return $this->teams()
+            ->where('is_personal', false)
+            ->wherePivot('role', TeamRole::Owner->value)
+            ->get()
+            ->filter(fn (Team $team): bool => $team->members()
+                ->wherePivot('role', TeamRole::Owner->value)
+                ->where('users.id', '!=', $this->id)
+                ->doesntExist())
+            ->values();
     }
 
     /**
@@ -97,5 +145,15 @@ class User extends Authenticatable
     public function securityEvents(): HasMany
     {
         return $this->hasMany(SecurityEvent::class)->latest();
+    }
+
+    /**
+     * Get the user's requested data exports, newest first.
+     *
+     * @return HasMany<DataExport, $this>
+     */
+    public function dataExports(): HasMany
+    {
+        return $this->hasMany(DataExport::class)->latest();
     }
 }

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -91,6 +91,17 @@ class TeamPolicy
     }
 
     /**
+     * Determine whether the user can transfer ownership of the team.
+     *
+     * Ownership is strictly the sole owner's to give away, so this is not a
+     * delegable {@see TeamPermission}: only the current owner may initiate it.
+     */
+    public function transferOwnership(User $user, Team $team): bool
+    {
+        return ! $team->is_personal && $user->ownsTeam($team);
+    }
+
+    /**
      * Determine whether the user can delete the model.
      */
     public function delete(User $user, Team $team): bool

--- a/app/Support/AccountDeleter.php
+++ b/app/Support/AccountDeleter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Support;
+
+use App\Http\Requests\Settings\ProfileDeleteRequest;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class AccountDeleter
+{
+    /**
+     * Permanently delete a user's account, enforcing the content and ownership
+     * policy rather than relying on the raw foreign-key cascades.
+     *
+     * Authored messages are reassigned to the retained "Deleted User" tombstone
+     * so channel history stays coherent (anonymize, not remove). The user's
+     * personal teams are torn down with them, while their memberships of shared
+     * teams simply drop via the cascade — the sole-owner-of-a-shared-team case is
+     * blocked upstream in {@see ProfileDeleteRequest}.
+     */
+    public function delete(User $user): void
+    {
+        DB::transaction(function () use ($user): void {
+            $tombstone = User::tombstone();
+
+            Message::withTrashed()
+                ->where('user_id', $user->id)
+                ->update(['user_id' => $tombstone->id]);
+
+            $user->teams()
+                ->where('is_personal', true)
+                ->get()
+                ->each(fn (Team $team) => $team->delete());
+
+            $user->delete();
+        });
+    }
+}

--- a/database/factories/DataExportFactory.php
+++ b/database/factories/DataExportFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DataExportStatus;
+use App\Models\DataExport;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DataExport>
+ */
+class DataExportFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'status' => DataExportStatus::Pending,
+            'path' => null,
+            'expires_at' => null,
+        ];
+    }
+
+    /**
+     * Mark the export as built and ready to download.
+     */
+    public function ready(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => DataExportStatus::Ready,
+            'path' => 'exports/'.fake()->uuid().'.zip',
+            'expires_at' => now()->addDays(7),
+        ]);
+    }
+
+    /**
+     * Mark the export as expired (ready, but past its download window).
+     */
+    public function expired(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => DataExportStatus::Ready,
+            'path' => 'exports/'.fake()->uuid().'.zip',
+            'expires_at' => now()->subDay(),
+        ]);
+    }
+
+    /**
+     * Mark the export as failed to build.
+     */
+    public function failed(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'status' => DataExportStatus::Failed,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_10_130825_create_data_exports_table.php
+++ b/database/migrations/2026_07_10_130825_create_data_exports_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('data_exports', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            // The lifecycle state of the export (see App\Enums\DataExportStatus).
+            $table->string('status');
+            // Path on the private disk once the archive is built; null while pending or failed.
+            $table->string('path')->nullable();
+            // When the archive is purged and the download link stops working.
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            // The Data & privacy panel reads the user's latest export.
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('data_exports');
+    }
+};

--- a/database/migrations/2026_07_10_130828_add_is_tombstone_to_users_table.php
+++ b/database/migrations/2026_07_10_130828_add_is_tombstone_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Marks the single retained "Deleted User" account that authored
+            // messages are reassigned to when their real author deletes their
+            // account, so channel history stays coherent (see App\Support\AccountDeleter).
+            $table->boolean('is_tombstone')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_tombstone');
+        });
+    }
+};

--- a/resources/js/components/DataPrivacy.vue
+++ b/resources/js/components/DataPrivacy.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3';
+import { Download } from '@lucide/vue';
+import { computed } from 'vue';
+import DataExportController from '@/actions/App/Http/Controllers/Settings/DataExportController';
+import Heading from '@/components/Heading.vue';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useTimezone } from '@/composables/useTimezone';
+import { formatDateTime } from '@/lib/datetime';
+import type { DataExport } from '@/types';
+
+type Props = {
+    dataExport: DataExport | null;
+};
+
+const props = defineProps<Props>();
+
+const { timezone } = useTimezone();
+
+const isPending = computed(() => props.dataExport?.status === 'pending');
+const isReady = computed(() => props.dataExport?.isReady ?? false);
+const hasFailed = computed(() => props.dataExport?.status === 'failed');
+
+const downloadUrl = computed(() =>
+    props.dataExport
+        ? DataExportController.download(props.dataExport.id).url
+        : '#',
+);
+
+const requestLabel = computed(() =>
+    props.dataExport ? 'Request a new export' : 'Request export',
+);
+
+function formatExpiry(iso: string): string {
+    return formatDateTime(iso, timezone.value ?? undefined);
+}
+</script>
+
+<template>
+    <div class="space-y-6">
+        <Heading
+            variant="small"
+            title="Data & privacy"
+            description="Download a copy of your personal data"
+        />
+
+        <div class="space-y-4 rounded-lg border border-border p-4">
+            <p class="text-sm text-muted-foreground">
+                Request an export and we'll assemble an archive of your profile,
+                teams, messages, and security activity. It's prepared in the
+                background — we'll email you a download link when it's ready.
+            </p>
+
+            <div
+                v-if="isReady && dataExport"
+                class="flex flex-wrap items-center gap-3"
+                data-test="data-export-ready"
+            >
+                <Button as="a" :href="downloadUrl" download>
+                    <Download class="size-4" />
+                    Download your data
+                </Button>
+                <span
+                    v-if="dataExport.expiresAt"
+                    class="text-sm text-muted-foreground"
+                >
+                    Link expires {{ formatExpiry(dataExport.expiresAt) }}
+                </span>
+            </div>
+
+            <p
+                v-else-if="isPending"
+                class="flex items-center gap-2 text-sm text-muted-foreground"
+                data-test="data-export-pending"
+            >
+                <Badge variant="secondary">Preparing</Badge>
+                Your export is being prepared. We'll email you when it's ready.
+            </p>
+
+            <p
+                v-else-if="hasFailed"
+                class="text-sm text-red-600 dark:text-red-400"
+                data-test="data-export-failed"
+            >
+                We couldn't prepare your last export. Please try again.
+            </p>
+
+            <Form
+                v-bind="DataExportController.store.form()"
+                :options="{ preserveScroll: true }"
+                v-slot="{ processing }"
+            >
+                <Button
+                    type="submit"
+                    variant="outline"
+                    :disabled="processing || isPending"
+                    data-test="request-data-export-button"
+                >
+                    {{ requestLabel }}
+                </Button>
+            </Form>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/TransferOwnershipModal.vue
+++ b/resources/js/components/TransferOwnershipModal.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3';
+import { ref, useTemplateRef } from 'vue';
+import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { transferOwnership } from '@/routes/teams/members';
+import type { Team, TeamMember } from '@/types';
+
+type Props = {
+    team: Team;
+    member: TeamMember | null;
+    open: boolean;
+};
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+    'update:open': [value: boolean];
+}>();
+
+const passwordInput = useTemplateRef('passwordInput');
+const formKey = ref(0);
+
+const handleOpenChange = (nextOpen: boolean) => {
+    emit('update:open', nextOpen);
+
+    if (!nextOpen) {
+        formKey.value++;
+    }
+};
+</script>
+
+<template>
+    <Dialog :open="props.open" @update:open="handleOpenChange">
+        <DialogContent>
+            <Form
+                v-if="props.member"
+                :key="formKey"
+                v-bind="
+                    transferOwnership.form([props.team.slug, props.member.id])
+                "
+                reset-on-success
+                @error="() => passwordInput?.focus()"
+                @success="handleOpenChange(false)"
+                :options="{ preserveScroll: true }"
+                class="space-y-6"
+                v-slot="{ errors, processing }"
+            >
+                <DialogHeader class="space-y-3">
+                    <DialogTitle>Transfer team ownership</DialogTitle>
+                    <DialogDescription>
+                        Ownership of this team will be transferred to
+                        <strong>{{ props.member.name }}</strong
+                        >. You will be demoted to Admin and can no longer manage
+                        ownership. Enter your password to confirm.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div class="grid gap-2">
+                    <Label for="transfer-password" class="sr-only">
+                        Password
+                    </Label>
+                    <PasswordInput
+                        id="transfer-password"
+                        name="password"
+                        ref="passwordInput"
+                        data-test="transfer-ownership-password"
+                        placeholder="Password"
+                    />
+                    <InputError :message="errors.password" />
+                </div>
+
+                <DialogFooter class="gap-2">
+                    <DialogClose as-child>
+                        <Button variant="secondary"> Cancel </Button>
+                    </DialogClose>
+
+                    <Button
+                        type="submit"
+                        data-test="transfer-ownership-confirm"
+                        :disabled="processing"
+                    >
+                        Transfer ownership
+                    </Button>
+                </DialogFooter>
+            </Form>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -3,6 +3,7 @@ import { Form, Head, usePage } from '@inertiajs/vue3';
 import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
+import DataPrivacy from '@/components/DataPrivacy.vue';
 import DeleteUser from '@/components/DeleteUser.vue';
 import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
@@ -19,6 +20,13 @@ import {
 import { useTimezone } from '@/composables/useTimezone';
 import { edit } from '@/routes/profile';
 import { send } from '@/routes/verification';
+import type { DataExport } from '@/types';
+
+type Props = {
+    dataExport: DataExport | null;
+};
+
+defineProps<Props>();
 
 defineOptions({
     layout: {
@@ -194,6 +202,8 @@ function onTimezoneSelect(value: unknown): void {
             </p>
         </div>
     </div>
+
+    <DataPrivacy :data-export="dataExport" />
 
     <DeleteUser />
 </template>

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Form, Head, Link, router } from '@inertiajs/vue3';
-import { ChevronDown, Mail, UserPlus, X } from '@lucide/vue';
+import { ChevronDown, Crown, Mail, UserPlus, X } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import CancelInvitationModal from '@/components/CancelInvitationModal.vue';
 import DeleteTeamModal from '@/components/DeleteTeamModal.vue';
@@ -8,6 +8,7 @@ import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import RemoveMemberModal from '@/components/RemoveMemberModal.vue';
+import TransferOwnershipModal from '@/components/TransferOwnershipModal.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -70,6 +71,8 @@ const inviteDialogOpen = ref(false);
 const deleteDialogOpen = ref(false);
 const removeMemberDialogOpen = ref(false);
 const memberToRemove = ref<TeamMember | null>(null);
+const transferOwnershipDialogOpen = ref(false);
+const memberToPromote = ref<TeamMember | null>(null);
 const cancelInvitationDialogOpen = ref(false);
 const invitationToCancel = ref<TeamInvitation | null>(null);
 
@@ -94,6 +97,11 @@ const confirmRemoveMember = (member: TeamMember) => {
 const confirmCancelInvitation = (invitation: TeamInvitation) => {
     invitationToCancel.value = invitation;
     cancelInvitationDialogOpen.value = true;
+};
+
+const confirmTransferOwnership = (member: TeamMember) => {
+    memberToPromote.value = member;
+    transferOwnershipDialogOpen.value = true;
 };
 </script>
 
@@ -237,6 +245,31 @@ const confirmCancelInvitation = (invitation: TeamInvitation) => {
                         <TooltipProvider
                             v-if="
                                 member.role !== 'owner' &&
+                                permissions.canTransferOwnership
+                            "
+                        >
+                            <Tooltip>
+                                <TooltipTrigger as-child>
+                                    <Button
+                                        data-test="member-transfer-ownership-button"
+                                        variant="ghost"
+                                        size="sm"
+                                        @click="
+                                            confirmTransferOwnership(member)
+                                        "
+                                    >
+                                        <Crown class="h-4 w-4" />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>Transfer ownership</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
+
+                        <TooltipProvider
+                            v-if="
+                                member.role !== 'owner' &&
                                 permissions.canRemoveMember
                             "
                         >
@@ -357,6 +390,13 @@ const confirmCancelInvitation = (invitation: TeamInvitation) => {
         :member="memberToRemove"
         :open="removeMemberDialogOpen"
         @update:open="removeMemberDialogOpen = $event"
+    />
+
+    <TransferOwnershipModal
+        :team="team"
+        :member="memberToPromote"
+        :open="transferOwnershipDialogOpen"
+        @update:open="transferOwnershipDialogOpen = $event"
     />
 
     <CancelInvitationModal

--- a/resources/js/types/dataExport.ts
+++ b/resources/js/types/dataExport.ts
@@ -1,0 +1,14 @@
+/**
+ * The authenticated user's most recent personal-data export, as shown in the
+ * "Data & privacy" section of the profile settings page. Mirrors the
+ * `App\Data\DataExportData` DTO. `isReady` is true only while the archive is
+ * built and still inside its download window.
+ */
+export type DataExport = {
+    id: string;
+    status: string;
+    statusLabel: string;
+    isReady: boolean;
+    requestedAt: string;
+    expiresAt: string | null;
+};

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -1,6 +1,7 @@
 export * from './auth';
 export * from './channels';
 export * from './chimes';
+export * from './dataExport';
 export * from './messages';
 export * from './navigation';
 export * from './security';

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -68,6 +68,7 @@ export type TeamPermissions = {
     canRemoveMember: boolean;
     canCreateInvitation: boolean;
     canCancelInvitation: boolean;
+    canTransferOwnership: boolean;
 };
 
 export type RoleOption = {

--- a/resources/views/mail/data-export-ready.blade.php
+++ b/resources/views/mail/data-export-ready.blade.php
@@ -1,0 +1,18 @@
+<x-mail::message>
+# Your data export is ready
+
+We've finished assembling a copy of your {{ config('app.name') }} data. Use the button below to download the archive.
+
+<x-mail::button :url="$url">
+Download your data
+</x-mail::button>
+
+@isset($expiresAt)
+This link expires on {{ $expiresAt->toFormattedDayDateString() }}. You can request a fresh export any time from your profile settings.
+@endisset
+
+If you didn't request this export, you can safely ignore this email.
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -60,6 +60,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'show'])->name('teams.members.show');
         Route::get('settings/teams/{team}/members/{user}/card', [TeamMemberController::class, 'card'])->name('teams.members.card');
         Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('teams.members.update');
+        Route::post('settings/teams/{team}/members/{user}/transfer-ownership', [TeamMemberController::class, 'transferOwnership'])->name('teams.members.transfer-ownership');
         Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');
 
         Route::post('settings/teams/{team}/invitations', [TeamInvitationController::class, 'store'])->name('teams.invitations.store');

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Settings\DataExportController;
 use App\Http\Controllers\Settings\NotificationController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\ReadReceiptsController;
@@ -24,6 +25,9 @@ Route::middleware(['auth'])->group(function () {
 
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('settings/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::post('settings/data-export', [DataExportController::class, 'store'])->name('data-export.store');
+    Route::get('settings/data-export/{dataExport}/download', [DataExportController::class, 'download'])->name('data-export.download');
 
     Route::get('settings/security', [SecurityController::class, 'edit'])
         ->middleware(RequirePassword::class)

--- a/tests/Feature/Settings/AccountDeletionTest.php
+++ b/tests/Feature/Settings/AccountDeletionTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Attach the user to a fresh shared (non-personal) team with the given role.
+ */
+function attachToSharedTeam(User $user, TeamRole $role, ?Team $team = null): Team
+{
+    $team ??= Team::factory()->create();
+
+    $team->members()->attach($user, ['role' => $role->value]);
+
+    return $team;
+}
+
+test('authored messages are reassigned to the deleted-user tombstone', function () {
+    $user = User::factory()->create();
+    $channel = Channel::factory()->create();
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $user->id,
+    ]);
+
+    $this->actingAs($user)
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/');
+
+    $tombstone = User::where('is_tombstone', true)->firstOrFail();
+
+    expect($user->fresh())->toBeNull();
+    expect(Message::find($message->id)->user_id)->toBe($tombstone->id);
+    expect($tombstone->name)->toBe('Deleted User');
+});
+
+test('the personal team is soft-deleted with the account', function () {
+    $user = User::factory()->create();
+    $personalTeam = $user->personalTeam();
+
+    $this->actingAs($user)
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertSessionHasNoErrors();
+
+    expect(Team::find($personalTeam->id))->toBeNull();
+    expect(Team::withTrashed()->find($personalTeam->id)->trashed())->toBeTrue();
+});
+
+test('the sole owner of a shared team cannot delete their account', function () {
+    $user = User::factory()->create();
+    $team = attachToSharedTeam($user, TeamRole::Owner);
+
+    $this->actingAs($user)
+        ->from(route('profile.edit'))
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertSessionHasErrors('team')
+        ->assertRedirect(route('profile.edit'));
+
+    expect($user->fresh())->not->toBeNull();
+    expect(Team::find($team->id))->not->toBeNull();
+});
+
+test('a co-owned shared team does not block deletion', function () {
+    $user = User::factory()->create();
+    $coOwner = User::factory()->create();
+    $team = attachToSharedTeam($user, TeamRole::Owner);
+    attachToSharedTeam($coOwner, TeamRole::Owner, $team);
+
+    $this->actingAs($user)
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertSessionHasNoErrors();
+
+    expect($user->fresh())->toBeNull();
+    expect(Team::find($team->id))->not->toBeNull();
+    expect($team->fresh()->owner()->is($coOwner))->toBeTrue();
+});
+
+test('membership of a shared team is dropped when the account is deleted', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = attachToSharedTeam($owner, TeamRole::Owner);
+    attachToSharedTeam($member, TeamRole::Member, $team);
+
+    $this->actingAs($member)
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertSessionHasNoErrors();
+
+    expect($member->fresh())->toBeNull();
+    expect(Team::find($team->id))->not->toBeNull();
+    expect($team->fresh()->members()->whereKey($member->id)->exists())->toBeFalse();
+});
+
+test('the deleted-user tombstone is a reused singleton', function () {
+    $first = User::tombstone();
+    $second = User::tombstone();
+
+    expect($second->id)->toBe($first->id);
+    expect($first->name)->toBe('Deleted User');
+    expect($first->is_tombstone)->toBeTrue();
+});

--- a/tests/Feature/Settings/AccountDeletionTest.php
+++ b/tests/Feature/Settings/AccountDeletionTest.php
@@ -64,6 +64,25 @@ test('the sole owner of a shared team cannot delete their account', function () 
     expect(Team::find($team->id))->not->toBeNull();
 });
 
+test('a blocked sole owner can transfer ownership then delete their account', function () {
+    $user = User::factory()->create();
+    $member = User::factory()->create();
+    $team = attachToSharedTeam($user, TeamRole::Owner);
+    attachToSharedTeam($member, TeamRole::Member, $team);
+
+    $this->actingAs($user)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), ['password' => 'password'])
+        ->assertSessionHasNoErrors();
+
+    $this->actingAs($user)
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/');
+
+    expect($user->fresh())->toBeNull();
+    expect($team->fresh()->owner()->is($member))->toBeTrue();
+});
+
 test('a co-owned shared team does not block deletion', function () {
     $user = User::factory()->create();
     $coOwner = User::factory()->create();

--- a/tests/Feature/Settings/DataExportTest.php
+++ b/tests/Feature/Settings/DataExportTest.php
@@ -1,0 +1,190 @@
+<?php
+
+use App\Data\DataExportData;
+use App\Enums\DataExportStatus;
+use App\Jobs\ExportUserData;
+use App\Mail\DataExportReady;
+use App\Models\Channel;
+use App\Models\DataExport;
+use App\Models\Message;
+use App\Models\SecurityEvent;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('requesting an export queues the job and records a pending export', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from(route('profile.edit'))
+        ->post(route('data-export.store'))
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('profile.edit'));
+
+    Queue::assertPushed(ExportUserData::class);
+
+    $export = $user->dataExports()->first();
+
+    expect($export)->not->toBeNull();
+    expect($export->status)->toBe(DataExportStatus::Pending);
+});
+
+test('the export job builds a downloadable archive and emails the user', function () {
+    Storage::fake('local');
+    Mail::fake();
+
+    $user = User::factory()->create();
+    $channel = Channel::factory()->create();
+    Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $user->id,
+        'body' => 'Hello from the archive',
+    ]);
+    SecurityEvent::factory()->for($user)->create();
+
+    $export = DataExport::factory()->for($user)->create();
+
+    (new ExportUserData($export->id))->handle();
+
+    $export->refresh();
+
+    expect($export->status)->toBe(DataExportStatus::Ready);
+    expect($export->path)->not->toBeNull();
+    expect($export->expires_at)->not->toBeNull();
+    Storage::disk('local')->assertExists($export->path);
+
+    $zip = new ZipArchive;
+    $zip->open(Storage::disk('local')->path($export->path));
+    $profile = json_decode((string) $zip->getFromName('profile.json'), true);
+    $messages = json_decode((string) $zip->getFromName('messages.json'), true);
+    $zip->close();
+
+    expect($profile['email'])->toBe($user->email);
+    expect($messages)->toHaveCount(1);
+    expect($messages[0]['body'])->toBe('Hello from the archive');
+
+    Mail::assertSent(DataExportReady::class, fn (DataExportReady $mail): bool => $mail->hasTo($user->email));
+});
+
+test('the job bails quietly when the export no longer exists', function () {
+    Mail::fake();
+
+    $export = DataExport::factory()->create();
+    $id = $export->id;
+    $export->delete();
+
+    (new ExportUserData($id))->handle();
+
+    Mail::assertNothingSent();
+});
+
+test('the failed hook marks the export failed', function () {
+    $export = DataExport::factory()->create();
+
+    (new ExportUserData($export->id))->failed(new RuntimeException('boom'));
+
+    expect($export->refresh()->status)->toBe(DataExportStatus::Failed);
+});
+
+test('the owner can download a ready export', function () {
+    Storage::fake('local');
+
+    $user = User::factory()->create();
+    $export = DataExport::factory()->for($user)->ready()->create();
+    Storage::disk('local')->put($export->path, 'zip-bytes');
+
+    $this->actingAs($user)
+        ->get(route('data-export.download', $export))
+        ->assertOk()
+        ->assertDownload('data-export.zip');
+});
+
+test('another user cannot download an export', function () {
+    Storage::fake('local');
+
+    $export = DataExport::factory()->ready()->create();
+    Storage::disk('local')->put($export->path, 'zip-bytes');
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('data-export.download', $export))
+        ->assertForbidden();
+});
+
+test('a pending export cannot be downloaded', function () {
+    $user = User::factory()->create();
+    $export = DataExport::factory()->for($user)->create();
+
+    $this->actingAs($user)
+        ->get(route('data-export.download', $export))
+        ->assertNotFound();
+});
+
+test('an expired export cannot be downloaded', function () {
+    Storage::fake('local');
+
+    $user = User::factory()->create();
+    $export = DataExport::factory()->for($user)->expired()->create();
+    Storage::disk('local')->put($export->path, 'zip-bytes');
+
+    $this->actingAs($user)
+        ->get(route('data-export.download', $export))
+        ->assertNotFound();
+});
+
+test('the profile page carries the latest export', function () {
+    $user = User::factory()->create();
+    DataExport::factory()->for($user)->ready()->create();
+
+    $this->actingAs($user)
+        ->get(route('profile.edit'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/Profile')
+            ->where('dataExport.status', 'ready')
+            ->where('dataExport.isReady', true));
+});
+
+test('the profile page carries a null export when none has been requested', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('profile.edit'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/Profile')
+            ->where('dataExport', null));
+});
+
+test('the DTO maps a ready export', function () {
+    $export = DataExport::factory()->ready()->create();
+
+    $data = DataExportData::fromExport($export);
+
+    expect($data->status)->toBe('ready');
+    expect($data->statusLabel)->toBe('Ready to download');
+    expect($data->isReady)->toBeTrue();
+    expect($data->expiresAt)->not->toBeNull();
+    expect($data->requestedAt)->not->toBeNull();
+});
+
+test('the DTO maps a pending export', function () {
+    $export = DataExport::factory()->create();
+
+    $data = DataExportData::fromExport($export);
+
+    expect($data->status)->toBe('pending');
+    expect($data->statusLabel)->toBe('Preparing');
+    expect($data->isReady)->toBeFalse();
+    expect($data->expiresAt)->toBeNull();
+});
+
+test('the ready-export mail renders the download link', function () {
+    $export = DataExport::factory()->ready()->create();
+
+    $mail = new DataExportReady($export);
+
+    $mail->assertHasSubject('Your data export is ready');
+    $mail->assertSeeInHtml('Download your data');
+});

--- a/tests/Feature/Teams/TeamOwnershipTransferTest.php
+++ b/tests/Feature/Teams/TeamOwnershipTransferTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+
+test('an owner can transfer ownership to another member', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $response = $this
+        ->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), [
+            'password' => 'password',
+        ]);
+
+    $response->assertRedirect(route('teams.edit', $team));
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Admin);
+    expect($member->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+});
+
+test('the single owner invariant is preserved after a transfer', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $this
+        ->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), [
+            'password' => 'password',
+        ]);
+
+    expect($team->members()->wherePivot('role', TeamRole::Owner->value)->count())->toBe(1);
+    expect($team->owner()->is($member))->toBeTrue();
+});
+
+test('a non owner cannot transfer ownership', function () {
+    $owner = User::factory()->create();
+    $admin = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($admin, ['role' => TeamRole::Admin->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $response = $this
+        ->actingAs($admin)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), [
+            'password' => 'password',
+        ]);
+
+    $response->assertForbidden();
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+});
+
+test('ownership cannot be transferred to a non member', function () {
+    $owner = User::factory()->create();
+    $stranger = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $response = $this
+        ->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $stranger]), [
+            'password' => 'password',
+        ]);
+
+    $response->assertNotFound();
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+});
+
+test('ownership cannot be transferred to yourself', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $response = $this
+        ->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $owner]), [
+            'password' => 'password',
+        ]);
+
+    $response->assertForbidden();
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+});
+
+test('transferring ownership requires the current password', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $response = $this
+        ->actingAs($owner)
+        ->from(route('teams.edit', $team))
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), [
+            'password' => 'wrong-password',
+        ]);
+
+    $response->assertSessionHasErrors('password');
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+    expect($member->fresh()->teamRole($team))->toBe(TeamRole::Member);
+});

--- a/tests/Unit/DataExportStatusTest.php
+++ b/tests/Unit/DataExportStatusTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Enums\DataExportStatus;
+
+test('every status has a non-empty label', function (DataExportStatus $status) {
+    expect($status->label())->toBeString()->not->toBeEmpty();
+})->with(DataExportStatus::cases());
+
+test('labels describe the status', function () {
+    expect(DataExportStatus::Pending->label())->toBe('Preparing');
+    expect(DataExportStatus::Ready->label())->toBe('Ready to download');
+    expect(DataExportStatus::Failed->label())->toBe('Failed');
+});


### PR DESCRIPTION
> [!WARNING]
> **🚫 Do not merge — blocked by #101.** This PR must not merge until team ownership transfer (#101) lands, via a PR **branched from `feat/49-account-deletion-export`**. Kept as a draft until then.

Closes #49.
Blocked by #101.

## What this does

Hardens the account-deletion flow and adds self-service GDPR data export.

### Account deletion (was `Auth::logout(); $user->delete();` relying on FK cascades)
- **Anonymize authored content** — `AccountDeleter` runs in a transaction and reassigns the user's messages (including soft-deleted) to a retained **"Deleted User" tombstone** so channel history stays coherent instead of collapsing into gaps.
- **Personal team teardown** — the user's personal team(s) are soft-deleted with them; shared-team memberships drop via the existing cascade.
- **Sole-owner guard** — deletion is blocked when the user is the only owner of a shared team, with an error naming the teams to hand off first (`ProfileDeleteRequest::after()`). Current-password confirmation still guards the route.

### Data export
- `DataExport` model + `DataExportStatus` enum (Pending/Ready/Failed), migration, factory.
- `ExportUserData` queued job assembles a **zip of JSON files** (profile, teams, messages, security events) on the private disk, sets a 7-day expiry, and emails a `DataExportReady` download link; `failed()` marks the export Failed.
- `DataExportController@store` / `@download` (owner + not-expired guards); the Profile page gains a **"Data & privacy"** section (`DataPrivacy.vue`).

## Decisions (confirmed with maintainer)
- Authored messages → **anonymize to a tombstone** (not hard-delete).
- Sole owner of a shared team → **block** until ownership is transferred.
- Export → **zip of JSON files** on a private disk, expiring download, **email on ready**, surfaced on the **Profile** page.

## Why the block on #101
The sole-owner guard tells the user to *transfer ownership or delete the team*, but **team ownership transfer does not exist yet** (`TeamRole::assignable()` excludes `Owner`; no transfer endpoint) — so a sole owner currently has no escape hatch. #101 is that missing capability and must ship alongside this. Discovered while implementing #49.

## Testing
- Deletion: anonymize, personal-team teardown, sole-owner block, co-owned allowed, member-leaves, password guard, tombstone singleton.
- Export: dispatch, archive contents, download auth/expiry/pending, failed hook, mail render, Profile prop, DTO mapping.
- Backend gate `Total: 100.0 %` (Pint + PHPStan + coverage); frontend lint/format/types/build all green.