### PR TITLE
feat(teams): team ownership transfer (Closes #101)

### DIFF
--- a/app/Actions/Teams/TransferTeamOwnership.php
+++ b/app/Actions/Teams/TransferTeamOwnership.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class TransferTeamOwnership
+{
+    /**
+     * Transfer ownership of the team from the current owner to a new owner.
+     *
+     * The demotion and promotion run in a single transaction so the single-owner
+     * invariant is never observable as broken: there is no committed window with
+     * zero or two owners.
+     */
+    public function handle(Team $team, User $currentOwner, User $newOwner): void
+    {
+        DB::transaction(function () use ($team, $currentOwner, $newOwner) {
+            $team->memberships()
+                ->where('user_id', $currentOwner->id)
+                ->update(['role' => TeamRole::Admin]);
+
+            $team->memberships()
+                ->where('user_id', $newOwner->id)
+                ->update(['role' => TeamRole::Owner]);
+        });
+    }
+}

--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -175,6 +175,7 @@ trait HasTeams
             canRemoveMember: $role?->hasPermission(TeamPermission::RemoveMember) ?? false,
             canCreateInvitation: $role?->hasPermission(TeamPermission::CreateInvitation) ?? false,
             canCancelInvitation: $role?->hasPermission(TeamPermission::CancelInvitation) ?? false,
+            canTransferOwnership: ! $team->is_personal && $role === TeamRole::Owner,
         );
     }
 

--- a/app/Data/TeamPermissions.php
+++ b/app/Data/TeamPermissions.php
@@ -12,6 +12,7 @@ readonly class TeamPermissions
         public bool $canRemoveMember,
         public bool $canCreateInvitation,
         public bool $canCancelInvitation,
+        public bool $canTransferOwnership,
     ) {
         //
     }

--- a/app/Http/Controllers/Teams/TeamMemberController.php
+++ b/app/Http/Controllers/Teams/TeamMemberController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers\Teams;
 
+use App\Actions\Teams\TransferTeamOwnership;
 use App\Data\UserProfileData;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Teams\TransferTeamOwnershipRequest;
 use App\Http\Requests\Teams\UpdateTeamMemberRequest;
 use App\Models\Membership;
 use App\Models\Team;
@@ -80,6 +82,28 @@ class TeamMemberController extends Controller
             ->update(['role' => $newRole]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member role updated.')]);
+
+        return to_route('teams.edit', ['team' => $team->slug]);
+    }
+
+    /**
+     * Transfer ownership of the team to the specified member.
+     *
+     * Only the current owner may initiate this, and the target must already be a
+     * member of the team. The outgoing owner is demoted to Admin and the new
+     * owner holds the sole Owner pivot row (see {@see TransferTeamOwnership}).
+     */
+    public function transferOwnership(TransferTeamOwnershipRequest $request, Team $team, User $user, TransferTeamOwnership $transferOwnership): RedirectResponse
+    {
+        Gate::authorize('transferOwnership', $team);
+
+        abort_if($request->user()->is($user), 403, __('You cannot transfer ownership to yourself.'));
+
+        abort_unless($user->belongsToTeam($team), 404);
+
+        $transferOwnership->handle($team, $request->user(), $user);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Team ownership transferred.')]);
 
         return to_route('teams.edit', ['team' => $team->slug]);
     }

--- a/app/Http/Requests/Teams/TransferTeamOwnershipRequest.php
+++ b/app/Http/Requests/Teams/TransferTeamOwnershipRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Teams;
+
+use App\Concerns\PasswordValidationRules;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class TransferTeamOwnershipRequest extends FormRequest
+{
+    use PasswordValidationRules;
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * Ownership is a consequential change, so the current owner must re-enter
+     * their password to confirm the transfer.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'password' => $this->currentPasswordRules(),
+        ];
+    }
+}

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -91,6 +91,17 @@ class TeamPolicy
     }
 
     /**
+     * Determine whether the user can transfer ownership of the team.
+     *
+     * Ownership is strictly the sole owner's to give away, so this is not a
+     * delegable {@see TeamPermission}: only the current owner may initiate it.
+     */
+    public function transferOwnership(User $user, Team $team): bool
+    {
+        return ! $team->is_personal && $user->ownsTeam($team);
+    }
+
+    /**
      * Determine whether the user can delete the model.
      */
     public function delete(User $user, Team $team): bool

--- a/resources/js/components/TransferOwnershipModal.vue
+++ b/resources/js/components/TransferOwnershipModal.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3';
+import { ref, useTemplateRef } from 'vue';
+import InputError from '@/components/InputError.vue';
+import PasswordInput from '@/components/PasswordInput.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { transferOwnership } from '@/routes/teams/members';
+import type { Team, TeamMember } from '@/types';
+
+type Props = {
+    team: Team;
+    member: TeamMember | null;
+    open: boolean;
+};
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+    'update:open': [value: boolean];
+}>();
+
+const passwordInput = useTemplateRef('passwordInput');
+const formKey = ref(0);
+
+const handleOpenChange = (nextOpen: boolean) => {
+    emit('update:open', nextOpen);
+
+    if (!nextOpen) {
+        formKey.value++;
+    }
+};
+</script>
+
+<template>
+    <Dialog :open="props.open" @update:open="handleOpenChange">
+        <DialogContent>
+            <Form
+                v-if="props.member"
+                :key="formKey"
+                v-bind="
+                    transferOwnership.form([props.team.slug, props.member.id])
+                "
+                reset-on-success
+                @error="() => passwordInput?.focus()"
+                @success="handleOpenChange(false)"
+                :options="{ preserveScroll: true }"
+                class="space-y-6"
+                v-slot="{ errors, processing }"
+            >
+                <DialogHeader class="space-y-3">
+                    <DialogTitle>Transfer team ownership</DialogTitle>
+                    <DialogDescription>
+                        Ownership of this team will be transferred to
+                        <strong>{{ props.member.name }}</strong
+                        >. You will be demoted to Admin and can no longer manage
+                        ownership. Enter your password to confirm.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div class="grid gap-2">
+                    <Label for="transfer-password" class="sr-only">
+                        Password
+                    </Label>
+                    <PasswordInput
+                        id="transfer-password"
+                        name="password"
+                        ref="passwordInput"
+                        data-test="transfer-ownership-password"
+                        placeholder="Password"
+                    />
+                    <InputError :message="errors.password" />
+                </div>
+
+                <DialogFooter class="gap-2">
+                    <DialogClose as-child>
+                        <Button variant="secondary"> Cancel </Button>
+                    </DialogClose>
+
+                    <Button
+                        type="submit"
+                        data-test="transfer-ownership-confirm"
+                        :disabled="processing"
+                    >
+                        Transfer ownership
+                    </Button>
+                </DialogFooter>
+            </Form>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Form, Head, Link, router } from '@inertiajs/vue3';
-import { ChevronDown, Mail, UserPlus, X } from '@lucide/vue';
+import { ChevronDown, Crown, Mail, UserPlus, X } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import CancelInvitationModal from '@/components/CancelInvitationModal.vue';
 import DeleteTeamModal from '@/components/DeleteTeamModal.vue';
@@ -8,6 +8,7 @@ import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import RemoveMemberModal from '@/components/RemoveMemberModal.vue';
+import TransferOwnershipModal from '@/components/TransferOwnershipModal.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -70,6 +71,8 @@ const inviteDialogOpen = ref(false);
 const deleteDialogOpen = ref(false);
 const removeMemberDialogOpen = ref(false);
 const memberToRemove = ref<TeamMember | null>(null);
+const transferOwnershipDialogOpen = ref(false);
+const memberToPromote = ref<TeamMember | null>(null);
 const cancelInvitationDialogOpen = ref(false);
 const invitationToCancel = ref<TeamInvitation | null>(null);
 
@@ -94,6 +97,11 @@ const confirmRemoveMember = (member: TeamMember) => {
 const confirmCancelInvitation = (invitation: TeamInvitation) => {
     invitationToCancel.value = invitation;
     cancelInvitationDialogOpen.value = true;
+};
+
+const confirmTransferOwnership = (member: TeamMember) => {
+    memberToPromote.value = member;
+    transferOwnershipDialogOpen.value = true;
 };
 </script>
 
@@ -237,6 +245,31 @@ const confirmCancelInvitation = (invitation: TeamInvitation) => {
                         <TooltipProvider
                             v-if="
                                 member.role !== 'owner' &&
+                                permissions.canTransferOwnership
+                            "
+                        >
+                            <Tooltip>
+                                <TooltipTrigger as-child>
+                                    <Button
+                                        data-test="member-transfer-ownership-button"
+                                        variant="ghost"
+                                        size="sm"
+                                        @click="
+                                            confirmTransferOwnership(member)
+                                        "
+                                    >
+                                        <Crown class="h-4 w-4" />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>Transfer ownership</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
+
+                        <TooltipProvider
+                            v-if="
+                                member.role !== 'owner' &&
                                 permissions.canRemoveMember
                             "
                         >
@@ -357,6 +390,13 @@ const confirmCancelInvitation = (invitation: TeamInvitation) => {
         :member="memberToRemove"
         :open="removeMemberDialogOpen"
         @update:open="removeMemberDialogOpen = $event"
+    />
+
+    <TransferOwnershipModal
+        :team="team"
+        :member="memberToPromote"
+        :open="transferOwnershipDialogOpen"
+        @update:open="transferOwnershipDialogOpen = $event"
     />
 
     <CancelInvitationModal

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -68,6 +68,7 @@ export type TeamPermissions = {
     canRemoveMember: boolean;
     canCreateInvitation: boolean;
     canCancelInvitation: boolean;
+    canTransferOwnership: boolean;
 };
 
 export type RoleOption = {

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -60,6 +60,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'show'])->name('teams.members.show');
         Route::get('settings/teams/{team}/members/{user}/card', [TeamMemberController::class, 'card'])->name('teams.members.card');
         Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('teams.members.update');
+        Route::post('settings/teams/{team}/members/{user}/transfer-ownership', [TeamMemberController::class, 'transferOwnership'])->name('teams.members.transfer-ownership');
         Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');
 
         Route::post('settings/teams/{team}/invitations', [TeamInvitationController::class, 'store'])->name('teams.invitations.store');

--- a/tests/Feature/Settings/AccountDeletionTest.php
+++ b/tests/Feature/Settings/AccountDeletionTest.php
@@ -64,6 +64,25 @@ test('the sole owner of a shared team cannot delete their account', function () 
     expect(Team::find($team->id))->not->toBeNull();
 });
 
+test('a blocked sole owner can transfer ownership then delete their account', function () {
+    $user = User::factory()->create();
+    $member = User::factory()->create();
+    $team = attachToSharedTeam($user, TeamRole::Owner);
+    attachToSharedTeam($member, TeamRole::Member, $team);
+
+    $this->actingAs($user)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), ['password' => 'password'])
+        ->assertSessionHasNoErrors();
+
+    $this->actingAs($user)
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/');
+
+    expect($user->fresh())->toBeNull();
+    expect($team->fresh()->owner()->is($member))->toBeTrue();
+});
+
 test('a co-owned shared team does not block deletion', function () {
     $user = User::factory()->create();
     $coOwner = User::factory()->create();

--- a/tests/Feature/Teams/TeamOwnershipTransferTest.php
+++ b/tests/Feature/Teams/TeamOwnershipTransferTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+
+test('an owner can transfer ownership to another member', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $response = $this
+        ->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), [
+            'password' => 'password',
+        ]);
+
+    $response->assertRedirect(route('teams.edit', $team));
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Admin);
+    expect($member->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+});
+
+test('the single owner invariant is preserved after a transfer', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $this
+        ->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), [
+            'password' => 'password',
+        ]);
+
+    expect($team->members()->wherePivot('role', TeamRole::Owner->value)->count())->toBe(1);
+    expect($team->owner()->is($member))->toBeTrue();
+});
+
+test('a non owner cannot transfer ownership', function () {
+    $owner = User::factory()->create();
+    $admin = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($admin, ['role' => TeamRole::Admin->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $response = $this
+        ->actingAs($admin)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), [
+            'password' => 'password',
+        ]);
+
+    $response->assertForbidden();
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+});
+
+test('ownership cannot be transferred to a non member', function () {
+    $owner = User::factory()->create();
+    $stranger = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $response = $this
+        ->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $stranger]), [
+            'password' => 'password',
+        ]);
+
+    $response->assertNotFound();
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+});
+
+test('ownership cannot be transferred to yourself', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $response = $this
+        ->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $owner]), [
+            'password' => 'password',
+        ]);
+
+    $response->assertForbidden();
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+});
+
+test('transferring ownership requires the current password', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $response = $this
+        ->actingAs($owner)
+        ->from(route('teams.edit', $team))
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), [
+            'password' => 'wrong-password',
+        ]);
+
+    $response->assertSessionHasErrors('password');
+
+    expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
+    expect($member->fresh()->teamRole($team))->toBe(TeamRole::Member);
+});


### PR DESCRIPTION
## Summary

Adds the ability for a team owner to transfer ownership of a shared team to another existing member. This is the missing **escape hatch** for the #49 sole-owner deletion guard: a user blocked from deleting their account because they solely own a shared team can now transfer ownership, then delete.

Per issue #101, the single-owner invariant is preserved atomically — the outgoing owner is demoted to **Admin** and the new owner holds the sole `Owner` pivot row, with no committed window of zero or two owners.

Base branch is `feat/49-account-deletion-export` so the deletion guard and its escape hatch land together (#102).

## What changed

**Backend**
- `App\Actions\Teams\TransferTeamOwnership` — demote-then-promote inside a single `DB::transaction`.
- `TeamMemberController::transferOwnership` — authorizes via `TeamPolicy::transferOwnership` (owner-only), rejects self-transfer (403) and non-members (404).
- `TransferTeamOwnershipRequest` — requires the current password (ownership is consequential).
- New route `POST settings/teams/{team}/members/{user}/transfer-ownership` (`teams.members.transfer-ownership`) in the `EnsureTeamMembership` group.
- `TeamPermissions` DTO gains owner-only `canTransferOwnership`. `TeamRole::assignable()` / the member-role dropdown are left as-is — transfer is a separate, dedicated path.

**Frontend**
- `TransferOwnershipModal.vue` (password-confirm, mirrors the delete-account modal) + an owner-only per-member action on `teams/Edit.vue`.

## Tests
- Happy path (roles swap), single-owner invariant preserved, non-owner forbidden (403), target-not-a-member rejected (404), self-transfer rejected (403), wrong-password rejected.
- #49 end-to-end: a blocked sole owner transfers ownership, then deletes their account successfully.

Backend gate green (Pint + PHPStan + `--min=100` coverage); frontend gate green (lint, format, types, build).

Closes #101