### PR TITLE
feat(admin): audit log for workspace moderation & admin actions (Close #50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,10 @@ Vue components must have a single root element.
 
 <!-- Custom project guidance below is preserved across `boost:update` runs. -->
 
+## Implementing Issues (TDD)
+
+- **Always activate the `tdd` skill when implementing an issue or building a feature.** Drive the work test-first (red → green → refactor): write a failing test that captures the acceptance criterion, make it pass with the minimal change, then refactor. This pairs with the non-negotiable 100% coverage gate below.
+
 ## Frontend Tooling (run through Sail)
 
 - **Always run Node/npm tooling through Sail** — `./vendor/bin/sail npm run <script>`, never bare `npm` on the host. `node_modules` is installed inside the Linux container, so its native bindings (`@unrs/resolver-*`, `@rolldown/binding-*`) are Linux-only. Running `npm run build`, `lint`, etc. directly on macOS fails with `Cannot find native binding` (the npm optional-dependencies bug); Sail runs them in the matching Linux environment where the bindings exist.

--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -176,6 +176,7 @@ trait HasTeams
             canCreateInvitation: $role?->hasPermission(TeamPermission::CreateInvitation) ?? false,
             canCancelInvitation: $role?->hasPermission(TeamPermission::CancelInvitation) ?? false,
             canTransferOwnership: ! $team->is_personal && $role === TeamRole::Owner,
+            canViewAudit: ! $team->is_personal && ($role?->isAtLeast(TeamRole::Admin) ?? false),
         );
     }
 

--- a/app/Data/AuditEventData.php
+++ b/app/Data/AuditEventData.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Data;
+
+use App\Enums\AuditAction;
+use App\Models\AuditActivity;
+use App\Models\User;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class AuditEventData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $action,
+        public string $label,
+        public ?string $actorName,
+        public string $description,
+        public string $occurredAt,
+    ) {}
+
+    /**
+     * Build the DTO from a recorded audit entry.
+     */
+    public static function fromActivity(AuditActivity $activity): self
+    {
+        $action = AuditAction::from((string) $activity->event);
+
+        /** @var array<string, mixed> $context */
+        $context = $activity->properties?->toArray() ?? [];
+
+        /** @var User|null $actor */
+        $actor = $activity->causer;
+
+        return new self(
+            id: $activity->id,
+            action: $action->value,
+            label: $action->label(),
+            actorName: $actor?->name,
+            description: $action->describe($context),
+            occurredAt: $activity->created_at->toIso8601String(),
+        );
+    }
+}

--- a/app/Data/TeamPermissions.php
+++ b/app/Data/TeamPermissions.php
@@ -13,6 +13,7 @@ readonly class TeamPermissions
         public bool $canCreateInvitation,
         public bool $canCancelInvitation,
         public bool $canTransferOwnership,
+        public bool $canViewAudit,
     ) {
         //
     }

--- a/app/Enums/AuditAction.php
+++ b/app/Enums/AuditAction.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * The admin and moderation actions recorded in a workspace's audit log. The
+ * value is stored in the activity log's `event` column and is the primary
+ * filter dimension for the viewer.
+ */
+enum AuditAction: string
+{
+    case TeamRenamed = 'team_renamed';
+    case MemberRoleChanged = 'member_role_changed';
+    case MemberRemoved = 'member_removed';
+    case OwnershipTransferred = 'ownership_transferred';
+    case ChannelCreated = 'channel_created';
+    case ChannelArchived = 'channel_archived';
+    case ChannelMemberAdded = 'channel_member_added';
+    case ChannelMemberRemoved = 'channel_member_removed';
+    case MessageDeleted = 'message_deleted';
+
+    /**
+     * Get the short human-readable label used in the action filter and headers.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::TeamRenamed => 'Workspace renamed',
+            self::MemberRoleChanged => 'Member role changed',
+            self::MemberRemoved => 'Member removed',
+            self::OwnershipTransferred => 'Ownership transferred',
+            self::ChannelCreated => 'Channel created',
+            self::ChannelArchived => 'Channel archived',
+            self::ChannelMemberAdded => 'Channel member added',
+            self::ChannelMemberRemoved => 'Channel member removed',
+            self::MessageDeleted => 'Message deleted',
+        };
+    }
+
+    /**
+     * Build the full human sentence describing the action, from the entry's
+     * recorded context. The acting user is shown separately, so this reads as
+     * the predicate (e.g. "Removed Dana from #general").
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function describe(array $context): string
+    {
+        return match ($this) {
+            self::TeamRenamed => sprintf('Renamed the workspace from “%s” to “%s”', $this->text($context, 'old_name'), $this->text($context, 'new_name')),
+            self::MemberRoleChanged => sprintf('Changed %s’s role from %s to %s', $this->text($context, 'member_name'), $this->text($context, 'old_role'), $this->text($context, 'new_role')),
+            self::MemberRemoved => sprintf('Removed %s from the workspace', $this->text($context, 'member_name')),
+            self::OwnershipTransferred => sprintf('Transferred ownership to %s', $this->text($context, 'new_owner_name')),
+            self::ChannelCreated => sprintf('Created #%s', $this->text($context, 'channel_name')),
+            self::ChannelArchived => sprintf('Archived #%s', $this->text($context, 'channel_name')),
+            self::ChannelMemberAdded => sprintf('Added %s to #%s', $this->text($context, 'member_name'), $this->text($context, 'channel_name')),
+            self::ChannelMemberRemoved => sprintf('Removed %s from #%s', $this->text($context, 'member_name'), $this->text($context, 'channel_name')),
+            self::MessageDeleted => sprintf('Deleted a message from %s in #%s', $this->text($context, 'author_name'), $this->text($context, 'channel_name')),
+        };
+    }
+
+    /**
+     * Get the selectable action options for the viewer's filter dropdown.
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public static function options(): array
+    {
+        return array_map(
+            fn (self $action): array => ['value' => $action->value, 'label' => $action->label()],
+            self::cases(),
+        );
+    }
+
+    /**
+     * Read a context value as a display string, falling back for missing or
+     * non-scalar values so a sentence always renders.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    private function text(array $context, string $key): string
+    {
+        $value = $context[$key] ?? null;
+
+        return is_scalar($value) ? (string) $value : '—';
+    }
+}

--- a/app/Exceptions/AuditLogImmutableException.php
+++ b/app/Exceptions/AuditLogImmutableException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when code attempts to update or delete an audit log entry. The log is
+ * append-only, so entries can only ever be created.
+ */
+class AuditLogImmutableException extends RuntimeException
+{
+    //
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -11,6 +11,7 @@ use App\Data\ChannelData;
 use App\Data\ChannelReaderData;
 use App\Data\MessageData;
 use App\Data\UserData;
+use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
 use App\Enums\NotificationLevel;
 use App\Http\Controllers\Controller;
@@ -18,6 +19,7 @@ use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
+use App\Support\AuditRecorder;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
@@ -68,7 +70,7 @@ class ChannelController extends Controller
     /**
      * Store a newly created channel and redirect to it.
      */
-    public function store(CreateChannelRequest $request, Team $team, CreateChannel $createChannel): RedirectResponse
+    public function store(CreateChannelRequest $request, Team $team, CreateChannel $createChannel, AuditRecorder $recorder): RedirectResponse
     {
         $channel = $createChannel->handle(
             team: $team,
@@ -77,6 +79,10 @@ class ChannelController extends Controller
             creator: $request->user(),
             topic: $request->validated('topic'),
         );
+
+        $recorder->record($team, $request->user(), AuditAction::ChannelCreated, $channel, [
+            'channel_name' => $channel->name,
+        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Channel created.')]);
 
@@ -413,11 +419,17 @@ class ChannelController extends Controller
      * sidebar, so we send the user back to #general rather than to a channel
      * that no longer appears in their list.
      */
-    public function archive(Request $request, Team $team, Channel $channel, ArchiveChannel $archiveChannel): RedirectResponse
+    public function archive(Request $request, Team $team, Channel $channel, ArchiveChannel $archiveChannel, AuditRecorder $recorder): RedirectResponse
     {
+        // The policy rejects archiving #general or an already-archived channel,
+        // so reaching here always represents a fresh archive worth recording.
         Gate::authorize('archive', $channel);
 
         $archiveChannel->handle($channel);
+
+        $recorder->record($team, $request->user(), AuditAction::ChannelArchived, $channel, [
+            'channel_name' => $channel->name,
+        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Archived #:channel.', ['channel' => $channel->name])]);
 

--- a/app/Http/Controllers/Channels/ChannelMemberController.php
+++ b/app/Http/Controllers/Channels/ChannelMemberController.php
@@ -4,12 +4,14 @@ namespace App\Http\Controllers\Channels;
 
 use App\Actions\Channels\JoinChannel;
 use App\Actions\Channels\RemoveChannelMember;
+use App\Enums\AuditAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\AddChannelMemberRequest;
 use App\Http\Requests\Channels\RemoveChannelMemberRequest;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 
@@ -18,11 +20,16 @@ class ChannelMemberController extends Controller
     /**
      * Add a team member to a private channel.
      */
-    public function store(AddChannelMemberRequest $request, Team $team, Channel $channel, JoinChannel $joinChannel): RedirectResponse
+    public function store(AddChannelMemberRequest $request, Team $team, Channel $channel, JoinChannel $joinChannel, AuditRecorder $recorder): RedirectResponse
     {
         $user = User::findOrFail((string) $request->validated('user_id'));
 
         $joinChannel->handle($channel, $user);
+
+        $recorder->record($team, $request->user(), AuditAction::ChannelMemberAdded, $channel, [
+            'channel_name' => $channel->name,
+            'member_name' => $user->name,
+        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member added.')]);
 
@@ -32,11 +39,16 @@ class ChannelMemberController extends Controller
     /**
      * Remove a member from a private channel.
      */
-    public function destroy(RemoveChannelMemberRequest $request, Team $team, Channel $channel, RemoveChannelMember $removeChannelMember): RedirectResponse
+    public function destroy(RemoveChannelMemberRequest $request, Team $team, Channel $channel, RemoveChannelMember $removeChannelMember, AuditRecorder $recorder): RedirectResponse
     {
         $user = User::findOrFail((string) $request->validated('user_id'));
 
         $removeChannelMember->handle($channel, $user);
+
+        $recorder->record($team, $request->user(), AuditAction::ChannelMemberRemoved, $channel, [
+            'channel_name' => $channel->name,
+            'member_name' => $user->name,
+        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member removed.')]);
 

--- a/app/Http/Controllers/Channels/MessageController.php
+++ b/app/Http/Controllers/Channels/MessageController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Channels;
 use App\Actions\Channels\DeleteMessage;
 use App\Actions\Channels\EditMessage;
 use App\Actions\Channels\PostMessage;
+use App\Enums\AuditAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\DeleteMessageRequest;
 use App\Http\Requests\Channels\EditMessageRequest;
@@ -12,6 +13,7 @@ use App\Http\Requests\Channels\PostMessageRequest;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
+use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 
 class MessageController extends Controller
@@ -47,9 +49,22 @@ class MessageController extends Controller
     /**
      * Soft-delete a message, leaving a tombstone in its place.
      */
-    public function destroy(DeleteMessageRequest $request, Team $team, Channel $channel, Message $message, DeleteMessage $deleteMessage): RedirectResponse
+    public function destroy(DeleteMessageRequest $request, Team $team, Channel $channel, Message $message, DeleteMessage $deleteMessage, AuditRecorder $recorder): RedirectResponse
     {
+        $message->loadMissing('user');
+        $author = $message->user;
+        $isModeration = ! $request->user()->is($author);
+
         $deleteMessage->handle($channel, $message);
+
+        // Only moderation deletions (an admin removing another member's message)
+        // are audited; a member deleting their own message is not an admin action.
+        if ($isModeration) {
+            $recorder->record($team, $request->user(), AuditAction::MessageDeleted, $message, [
+                'channel_name' => $channel->name,
+                'author_name' => $author->name,
+            ]);
+        }
 
         return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
     }

--- a/app/Http/Controllers/Teams/AuditController.php
+++ b/app/Http/Controllers/Teams/AuditController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Teams;
+
+use App\Data\AuditEventData;
+use App\Enums\AuditAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Teams\ViewAuditLogRequest;
+use App\Models\AuditActivity;
+use App\Models\Team;
+use App\Models\User;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AuditController extends Controller
+{
+    /**
+     * The number of audit entries shown per page.
+     */
+    private const int PER_PAGE = 30;
+
+    /**
+     * Show the workspace's audit log, newest first, filterable by action and actor.
+     */
+    public function index(ViewAuditLogRequest $request, Team $team): Response
+    {
+        $action = $request->validated('action');
+        $actorId = $request->validated('actor');
+
+        $entries = AuditActivity::query()
+            ->where('team_id', $team->id)
+            ->when($action, fn ($query) => $query->where('event', $action))
+            ->when($actorId, fn ($query) => $query->where('causer_id', $actorId))
+            ->with('causer')
+            ->orderByDesc('created_at')
+            ->orderByDesc('id')
+            ->simplePaginate(self::PER_PAGE)
+            ->withQueryString();
+
+        return Inertia::render('teams/Audit', [
+            'team' => [
+                'id' => $team->id,
+                'name' => $team->name,
+                'slug' => $team->slug,
+            ],
+            'entries' => [
+                'data' => collect($entries->items())
+                    ->map(fn (AuditActivity $entry): AuditEventData => AuditEventData::fromActivity($entry))
+                    ->all(),
+                'prevPageUrl' => $entries->previousPageUrl(),
+                'nextPageUrl' => $entries->nextPageUrl(),
+            ],
+            'filters' => [
+                'action' => $action,
+                'actor' => $actorId,
+            ],
+            'actionOptions' => AuditAction::options(),
+            'actors' => $this->actors($team),
+        ]);
+    }
+
+    /**
+     * List the distinct actors who appear in the team's audit log, for the
+     * actor filter dropdown.
+     *
+     * @return array<int, array{id: string, name: string}>
+     */
+    private function actors(Team $team): array
+    {
+        $actorIds = AuditActivity::query()
+            ->where('team_id', $team->id)
+            ->whereNotNull('causer_id')
+            ->distinct()
+            ->pluck('causer_id');
+
+        return User::query()
+            ->whereIn('id', $actorIds)
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (User $user): array => ['id' => $user->id, 'name' => $user->name])
+            ->all();
+    }
+}

--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Teams;
 
 use App\Actions\Teams\CreateTeam;
+use App\Enums\AuditAction;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\DeleteTeamRequest;
@@ -10,6 +11,7 @@ use App\Http\Requests\Teams\SaveTeamRequest;
 use App\Models\Membership;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -88,17 +90,27 @@ class TeamController extends Controller
     /**
      * Update the specified team.
      */
-    public function update(SaveTeamRequest $request, Team $team): RedirectResponse
+    public function update(SaveTeamRequest $request, Team $team, AuditRecorder $recorder): RedirectResponse
     {
         Gate::authorize('update', $team);
 
-        $team = DB::transaction(function () use ($request, $team) {
+        $oldName = $team->name;
+        $newName = $request->validated('name');
+
+        $team = DB::transaction(function () use ($newName, $team) {
             $team = Team::whereKey($team->id)->lockForUpdate()->firstOrFail();
 
-            $team->update(['name' => $request->validated('name')]);
+            $team->update(['name' => $newName]);
 
             return $team;
         });
+
+        if ($newName !== $oldName) {
+            $recorder->record($team, $request->user(), AuditAction::TeamRenamed, $team, [
+                'old_name' => $oldName,
+                'new_name' => $newName,
+            ]);
+        }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Team updated.')]);
 

--- a/app/Http/Controllers/Teams/TeamMemberController.php
+++ b/app/Http/Controllers/Teams/TeamMemberController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Teams;
 
 use App\Actions\Teams\TransferTeamOwnership;
 use App\Data\UserProfileData;
+use App\Enums\AuditAction;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\TransferTeamOwnershipRequest;
@@ -11,6 +12,7 @@ use App\Http\Requests\Teams\UpdateTeamMemberRequest;
 use App\Models\Membership;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -70,16 +72,27 @@ class TeamMemberController extends Controller
     /**
      * Update the specified team member's role.
      */
-    public function update(UpdateTeamMemberRequest $request, Team $team, User $user): RedirectResponse
+    public function update(UpdateTeamMemberRequest $request, Team $team, User $user, AuditRecorder $recorder): RedirectResponse
     {
         Gate::authorize('updateMember', $team);
 
         $newRole = TeamRole::from($request->validated('role'));
 
-        $team->memberships()
+        $membership = $team->memberships()
             ->where('user_id', $user->id)
-            ->firstOrFail()
-            ->update(['role' => $newRole]);
+            ->firstOrFail();
+
+        $oldRole = $membership->role;
+
+        $membership->update(['role' => $newRole]);
+
+        if ($newRole !== $oldRole) {
+            $recorder->record($team, $request->user(), AuditAction::MemberRoleChanged, $user, [
+                'member_name' => $user->name,
+                'old_role' => $oldRole->label(),
+                'new_role' => $newRole->label(),
+            ]);
+        }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member role updated.')]);
 
@@ -93,7 +106,7 @@ class TeamMemberController extends Controller
      * member of the team. The outgoing owner is demoted to Admin and the new
      * owner holds the sole Owner pivot row (see {@see TransferTeamOwnership}).
      */
-    public function transferOwnership(TransferTeamOwnershipRequest $request, Team $team, User $user, TransferTeamOwnership $transferOwnership): RedirectResponse
+    public function transferOwnership(TransferTeamOwnershipRequest $request, Team $team, User $user, TransferTeamOwnership $transferOwnership, AuditRecorder $recorder): RedirectResponse
     {
         Gate::authorize('transferOwnership', $team);
 
@@ -103,6 +116,10 @@ class TeamMemberController extends Controller
 
         $transferOwnership->handle($team, $request->user(), $user);
 
+        $recorder->record($team, $request->user(), AuditAction::OwnershipTransferred, $user, [
+            'new_owner_name' => $user->name,
+        ]);
+
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Team ownership transferred.')]);
 
         return to_route('teams.edit', ['team' => $team->slug]);
@@ -111,7 +128,7 @@ class TeamMemberController extends Controller
     /**
      * Remove the specified team member.
      */
-    public function destroy(Team $team, User $user): RedirectResponse
+    public function destroy(Request $request, Team $team, User $user, AuditRecorder $recorder): RedirectResponse
     {
         Gate::authorize('removeMember', $team);
 
@@ -124,6 +141,10 @@ class TeamMemberController extends Controller
         if ($user->isCurrentTeam($team)) {
             $user->switchTeam($user->personalTeam());
         }
+
+        $recorder->record($team, $request->user(), AuditAction::MemberRemoved, $user, [
+            'member_name' => $user->name,
+        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member removed.')]);
 

--- a/app/Http/Requests/Teams/ViewAuditLogRequest.php
+++ b/app/Http/Requests/Teams/ViewAuditLogRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Teams;
+
+use App\Enums\AuditAction;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+
+class ViewAuditLogRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to view the workspace's audit log.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('viewAudit', $this->route('team'));
+    }
+
+    /**
+     * Get the validation rules that apply to the audit log filters.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'action' => ['nullable', Rule::enum(AuditAction::class)],
+            'actor' => ['nullable', 'uuid'],
+        ];
+    }
+}

--- a/app/Models/AuditActivity.php
+++ b/app/Models/AuditActivity.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Exceptions\AuditLogImmutableException;
+use Database\Factories\AuditActivityFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * An append-only record of an admin or moderation action within a workspace.
+ *
+ * Extends Spatie's activity model to carry the app's UUID keys and a `team_id`
+ * for workspace scoping. Immutability is enforced here at the model layer:
+ * once created, an entry can never be updated or deleted.
+ *
+ * @property string $id
+ * @property string $team_id
+ * @property-read Team $team
+ */
+class AuditActivity extends Activity
+{
+    /** @use HasFactory<AuditActivityFactory> */
+    use HasFactory, HasUuids;
+
+    /**
+     * Guard against any mutation after creation so the log stays append-only.
+     */
+    protected static function booted(): void
+    {
+        static::updating(function (): never {
+            throw new AuditLogImmutableException('Audit log entries cannot be updated.');
+        });
+
+        static::deleting(function (): never {
+            throw new AuditLogImmutableException('Audit log entries cannot be deleted.');
+        });
+    }
+
+    /**
+     * Get the workspace the audit entry belongs to.
+     *
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+}

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Enums\TeamPermission;
+use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 
@@ -107,5 +108,17 @@ class TeamPolicy
     public function delete(User $user, Team $team): bool
     {
         return ! $team->is_personal && $user->hasTeamPermission($team, TeamPermission::DeleteTeam);
+    }
+
+    /**
+     * Determine whether the user can view the team's audit log.
+     *
+     * The log surfaces moderation and admin actions, so it is scoped to admins
+     * and the owner of a real (non-personal) workspace.
+     */
+    public function viewAudit(User $user, Team $team): bool
+    {
+        return ! $team->is_personal
+            && ($user->teamRole($team)?->isAtLeast(TeamRole::Admin) ?? false);
     }
 }

--- a/app/Support/AuditRecorder.php
+++ b/app/Support/AuditRecorder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Support;
+
+use App\Enums\AuditAction;
+use App\Models\AuditActivity;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Writes append-only audit entries for admin and moderation actions. The actor,
+ * target, and context are always passed explicitly (the acting user differs
+ * from the affected entity), so this is safe to resolve anywhere a request has
+ * an authenticated actor in hand.
+ */
+class AuditRecorder
+{
+    /**
+     * Record a single audit entry for an action performed within a workspace.
+     *
+     * @param  Model|null  $target  The entity acted upon (channel, message, or
+     *                              the affected member), stored as the subject.
+     * @param  array<string, mixed>  $context  Extra detail needed to render a
+     *                                         human sentence (names, old->new role).
+     */
+    public function record(
+        Team $team,
+        User $actor,
+        AuditAction $action,
+        ?Model $target = null,
+        array $context = [],
+    ): AuditActivity {
+        $logger = activity()
+            ->useLog('audit')
+            ->causedBy($actor)
+            ->event($action->value)
+            ->withProperties($context)
+            ->tap(function (AuditActivity $activity) use ($team): void {
+                $activity->team_id = $team->id;
+            });
+
+        if ($target !== null) {
+            $logger->performedOn($target);
+        }
+
+        $activity = $logger->log($action->label());
+
+        assert($activity instanceof AuditActivity);
+
+        return $activity;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",
         "meilisearch/meilisearch-php": "^1.16",
+        "spatie/laravel-activitylog": "^5.0",
         "spatie/laravel-data": "^4.23",
         "spatie/laravel-typescript-transformer": "^3.3",
         "symfony/dom-crawler": "^8.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f8440562c9fe83b93ce57afd7200762",
+    "content-hash": "2e740ffe5227e1614568bf09db995630",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5433,6 +5433,99 @@
                 }
             ],
             "time": "2025-11-26T10:41:42+00:00"
+        },
+        {
+            "name": "spatie/laravel-activitylog",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-activitylog.git",
+                "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-activitylog/zipball/0e00fe74fd071cc572a045459f6d4c9de33130bd",
+                "reference": "0e00fe74fd071cc572a045459f6d4c9de33130bd",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "^12.0 || ^13.0",
+                "illuminate/database": "^12.0 || ^13.0",
+                "illuminate/support": "^12.0 || ^13.0",
+                "php": "^8.4",
+                "spatie/laravel-package-tools": "^1.6.3"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "larastan/larastan": "^3.0",
+                "laravel/pint": "^1.29",
+                "orchestra/testbench": "^10.0 || ^11.0",
+                "pestphp/pest": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Activitylog\\ActivitylogServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Activitylog\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev.gummibeer@gmail.com",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A very simple activity logger to monitor the users of your website or application",
+            "homepage": "https://github.com/spatie/activitylog",
+            "keywords": [
+                "activity",
+                "laravel",
+                "log",
+                "spatie",
+                "user"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-activitylog/issues",
+                "source": "https://github.com/spatie/laravel-activitylog/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-25T10:04:54+00:00"
         },
         {
             "name": "spatie/laravel-data",

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\AuditActivity;
+use Spatie\Activitylog\Actions\CleanActivityLogAction;
+use Spatie\Activitylog\Actions\LogActivityAction;
+
+return [
+
+    /*
+     * If set to false, no activities will be saved to the database.
+     */
+    'enabled' => env('ACTIVITYLOG_ENABLED', true),
+
+    /*
+     * When the clean command is executed, all recording activities older than
+     * the number of days specified here will be deleted.
+     */
+    'clean_after_days' => 365,
+
+    /*
+     * If no log name is passed to the activity() helper
+     * we use this default log name.
+     */
+    'default_log_name' => 'audit',
+
+    /*
+     * You can specify an auth driver here that gets user models.
+     * If this is null we'll use the current Laravel auth driver.
+     */
+    'default_auth_driver' => null,
+
+    /*
+     * If set to true, the subject relationship on activities
+     * will include soft deleted models.
+     */
+    'include_soft_deleted_subjects' => false,
+
+    /*
+     * This model will be used to log activity.
+     * It should implement the Spatie\Activitylog\Contracts\Activity interface
+     * and extend Illuminate\Database\Eloquent\Model.
+     */
+    'activity_model' => AuditActivity::class,
+
+    /*
+     * These attributes will be excluded from logging for all models.
+     * Model-specific exclusions via logExcept() are merged with these.
+     */
+    'default_except_attributes' => [],
+
+    /*
+     * When enabled, activities are buffered in memory and inserted in a
+     * single bulk query after the response has been sent to the client.
+     * This can significantly reduce the number of database queries when
+     * many activities are logged during a single request.
+     *
+     * Only enable this if your application logs a high volume of activities
+     * per request. Buffered activities will not have an ID until the
+     * buffer is flushed.
+     */
+    'buffer' => [
+        'enabled' => env('ACTIVITYLOG_BUFFER_ENABLED', false),
+    ],
+
+    /*
+     * These action classes can be overridden to customize how activities
+     * are logged and cleaned. Your custom classes must extend the originals.
+     */
+    'actions' => [
+        'log_activity' => LogActivityAction::class,
+        'clean_log' => CleanActivityLogAction::class,
+    ],
+];

--- a/database/factories/AuditActivityFactory.php
+++ b/database/factories/AuditActivityFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AuditAction;
+use App\Models\AuditActivity;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AuditActivity>
+ */
+class AuditActivityFactory extends Factory
+{
+    protected $model = AuditActivity::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $action = fake()->randomElement(AuditAction::cases());
+
+        return [
+            'log_name' => 'audit',
+            'event' => $action->value,
+            'description' => $action->label(),
+            'properties' => [],
+            'causer_type' => (new User)->getMorphClass(),
+            'causer_id' => User::factory(),
+            'team_id' => Team::factory(),
+        ];
+    }
+
+    /**
+     * Record the entry for a specific action.
+     */
+    public function ofAction(AuditAction $action): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'event' => $action->value,
+            'description' => $action->label(),
+        ]);
+    }
+
+    /**
+     * Record the entry within the given workspace.
+     */
+    public function forTeam(Team $team): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'team_id' => $team->id,
+        ]);
+    }
+
+    /**
+     * Attribute the entry to a specific actor.
+     */
+    public function causedBy(User $user): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'causer_type' => $user->getMorphClass(),
+            'causer_id' => $user->id,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_10_140000_create_activity_log_table.php
+++ b/database/migrations/2026_07_10_140000_create_activity_log_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Backs Spatie's activity log with the app's UUID conventions and a
+     * `team_id` so the log can be scoped to a single workspace. The table is
+     * treated as append-only at the model layer (see App\Models\AuditActivity).
+     */
+    public function up(): void
+    {
+        Schema::create('activity_log', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            // Groups entries by feature; always 'audit' for this application.
+            $table->string('log_name')->nullable();
+            // A human-readable label for the action (see App\Enums\AuditAction).
+            $table->text('description');
+            // The entity acted upon (channel, message, or target user).
+            $table->nullableUuidMorphs('subject');
+            // The admin/moderator who performed the action.
+            $table->nullableUuidMorphs('causer');
+            // The App\Enums\AuditAction value; the primary filter dimension.
+            $table->string('event')->nullable();
+            // Structured context to render a human sentence (names, old->new role).
+            $table->json('properties')->nullable();
+            // Spatie's attribute diff column; unused by the audit recorder.
+            $table->json('attribute_changes')->nullable();
+            // Present for Spatie batch logging; unused by the audit recorder.
+            $table->uuid('batch_uuid')->nullable();
+            // The workspace the action belongs to; the log is always team-scoped.
+            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            // The viewer reads one team's log newest-first, optionally filtered by
+            // action type or actor.
+            $table->index(['team_id', 'created_at']);
+            $table->index(['team_id', 'event']);
+            $table->index(['team_id', 'causer_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_log');
+    }
+};

--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -6,6 +6,7 @@ use App\Actions\Channels\CreateChannel;
 use App\Actions\Channels\JoinChannel;
 use App\Actions\Channels\SyncMentions;
 use App\Actions\Teams\CreateTeam;
+use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
 use App\Models\Channel;
@@ -13,6 +14,7 @@ use App\Models\Message;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Support\AuditRecorder;
 use Illuminate\Database\Seeder;
 
 /**
@@ -37,6 +39,7 @@ class WorkspaceSeeder extends Seeder
         private readonly CreateChannel $createChannel,
         private readonly JoinChannel $joinChannel,
         private readonly SyncMentions $syncMentions,
+        private readonly AuditRecorder $auditRecorder,
     ) {}
 
     /**
@@ -157,8 +160,53 @@ class WorkspaceSeeder extends Seeder
 
         $this->seedUnreadState($demo, $general, $announcements, $leadership);
         $this->seedInvitations($acme, $demo);
+        $this->seedAuditLog($acme, $demo, $admin, $member1, $announcements, $archived, $secret);
 
         return $acme;
+    }
+
+    /**
+     * Populate the workspace's append-only audit log with a representative set
+     * of admin and moderation actions across two actors, so the admin-only
+     * audit viewer (and its action/actor filters) has data to show.
+     */
+    private function seedAuditLog(
+        Team $team,
+        User $owner,
+        User $admin,
+        User $member,
+        Channel $announcements,
+        Channel $archived,
+        Channel $secret,
+    ): void {
+        $this->auditRecorder->record($team, $owner, AuditAction::TeamRenamed, $team, [
+            'old_name' => 'Acme',
+            'new_name' => $team->name,
+        ]);
+
+        $this->auditRecorder->record($team, $owner, AuditAction::MemberRoleChanged, $admin, [
+            'member_name' => $admin->name,
+            'old_role' => TeamRole::Member->label(),
+            'new_role' => TeamRole::Admin->label(),
+        ]);
+
+        $this->auditRecorder->record($team, $owner, AuditAction::ChannelCreated, $announcements, [
+            'channel_name' => $announcements->name,
+        ]);
+
+        $this->auditRecorder->record($team, $admin, AuditAction::ChannelMemberAdded, $secret, [
+            'channel_name' => $secret->name,
+            'member_name' => $member->name,
+        ]);
+
+        $this->auditRecorder->record($team, $admin, AuditAction::MessageDeleted, null, [
+            'channel_name' => Channel::GENERAL_SLUG,
+            'author_name' => $member->name,
+        ]);
+
+        $this->auditRecorder->record($team, $owner, AuditAction::ChannelArchived, $archived, [
+            'channel_name' => $archived->name,
+        ]);
     }
 
     /**

--- a/resources/js/pages/teams/Audit.vue
+++ b/resources/js/pages/teams/Audit.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import { Head, Link, router } from '@inertiajs/vue3';
+import { ChevronLeft, ChevronRight } from '@lucide/vue';
+import { ref, watch } from 'vue';
+import Heading from '@/components/Heading.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { useTimezone } from '@/composables/useTimezone';
+import { formatDateTime } from '@/lib/datetime';
+import { edit, index } from '@/routes/teams';
+import { index as auditIndex } from '@/routes/teams/audit';
+import type {
+    AuditActionOption,
+    AuditActor,
+    AuditEntriesPage,
+    Team,
+} from '@/types';
+
+type Props = {
+    team: Team;
+    entries: AuditEntriesPage;
+    filters: {
+        action: string | null;
+        actor: string | null;
+    };
+    actionOptions: AuditActionOption[];
+    actors: AuditActor[];
+};
+
+const props = defineProps<Props>();
+
+defineOptions({
+    layout: (props: { team: Team }) => ({
+        breadcrumbs: [
+            {
+                title: 'Teams',
+                href: index(),
+            },
+            {
+                title: props.team.name,
+                href: edit(props.team.slug),
+            },
+            {
+                title: 'Audit log',
+                href: auditIndex(props.team.slug),
+            },
+        ],
+    }),
+});
+
+const ALL = 'all';
+
+const { timezone } = useTimezone();
+
+const actionFilter = ref(props.filters.action ?? ALL);
+const actorFilter = ref(props.filters.actor ?? ALL);
+
+watch([actionFilter, actorFilter], ([action, actor]) => {
+    router.get(
+        auditIndex(props.team.slug).url,
+        {
+            action: action === ALL ? undefined : action,
+            actor: actor === ALL ? undefined : actor,
+        },
+        {
+            preserveState: true,
+            preserveScroll: true,
+            replace: true,
+        },
+    );
+});
+
+function occurredAt(iso: string): string {
+    return formatDateTime(iso, timezone.value ?? undefined);
+}
+</script>
+
+<template>
+    <Head title="Audit log" />
+
+    <div class="flex flex-col space-y-6">
+        <Heading
+            variant="small"
+            title="Audit log"
+            description="A record of moderation and admin actions in this workspace"
+        />
+
+        <div class="flex flex-wrap items-center gap-3">
+            <Select v-model="actionFilter">
+                <SelectTrigger class="w-56" data-test="audit-action-filter">
+                    <SelectValue placeholder="All actions" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem :value="ALL">All actions</SelectItem>
+                    <SelectItem
+                        v-for="option in actionOptions"
+                        :key="option.value"
+                        :value="option.value"
+                    >
+                        {{ option.label }}
+                    </SelectItem>
+                </SelectContent>
+            </Select>
+
+            <Select v-model="actorFilter">
+                <SelectTrigger class="w-56" data-test="audit-actor-filter">
+                    <SelectValue placeholder="All members" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem :value="ALL">All members</SelectItem>
+                    <SelectItem
+                        v-for="actor in actors"
+                        :key="actor.id"
+                        :value="actor.id"
+                    >
+                        {{ actor.name }}
+                    </SelectItem>
+                </SelectContent>
+            </Select>
+        </div>
+
+        <p
+            v-if="entries.data.length === 0"
+            class="text-sm text-muted-foreground"
+            data-test="audit-empty"
+        >
+            No audit activity to show.
+        </p>
+
+        <ul v-else class="space-y-3" role="list" data-test="audit-list">
+            <li
+                v-for="entry in entries.data"
+                :key="entry.id"
+                class="flex flex-col gap-1 rounded-lg border border-border p-4 sm:flex-row sm:items-center sm:justify-between"
+                :data-test="`audit-entry-${entry.id}`"
+            >
+                <div class="min-w-0 space-y-0.5">
+                    <p class="text-sm font-medium">
+                        {{ entry.actorName ?? 'Unknown member' }}
+                    </p>
+                    <p class="text-sm text-muted-foreground">
+                        {{ entry.description }}
+                    </p>
+                </div>
+                <time
+                    class="shrink-0 text-xs text-muted-foreground"
+                    :datetime="entry.occurredAt"
+                >
+                    {{ occurredAt(entry.occurredAt) }}
+                </time>
+            </li>
+        </ul>
+
+        <div
+            v-if="entries.prevPageUrl || entries.nextPageUrl"
+            class="flex items-center justify-between"
+        >
+            <Button
+                v-if="entries.prevPageUrl"
+                as-child
+                variant="outline"
+                size="sm"
+                data-test="audit-prev-page"
+            >
+                <Link :href="entries.prevPageUrl" preserve-scroll>
+                    <ChevronLeft class="h-4 w-4" /> Newer
+                </Link>
+            </Button>
+            <span v-else></span>
+
+            <Button
+                v-if="entries.nextPageUrl"
+                as-child
+                variant="outline"
+                size="sm"
+                data-test="audit-next-page"
+            >
+                <Link :href="entries.nextPageUrl" preserve-scroll>
+                    Older <ChevronRight class="h-4 w-4" />
+                </Link>
+            </Button>
+            <span v-else></span>
+        </div>
+    </div>
+</template>

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -28,6 +28,7 @@ import {
 } from '@/components/ui/tooltip';
 import { useInitials } from '@/composables/useInitials';
 import { edit, index, update } from '@/routes/teams';
+import { index as auditIndex } from '@/routes/teams/audit';
 import {
     show as showMember,
     update as updateMember,
@@ -344,6 +345,18 @@ const confirmTransferOwnership = (member: TeamMember) => {
                     </TooltipProvider>
                 </div>
             </div>
+        </div>
+
+        <!-- Audit Log -->
+        <div v-if="permissions.canViewAudit" class="space-y-6">
+            <Heading
+                variant="small"
+                title="Audit log"
+                description="Review moderation and admin actions in this workspace"
+            />
+            <Button as-child variant="outline" data-test="view-audit-log-link">
+                <Link :href="auditIndex(team.slug)">View audit log</Link>
+            </Button>
         </div>
 
         <!-- Danger Zone -->

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -69,9 +69,44 @@ export type TeamPermissions = {
     canCreateInvitation: boolean;
     canCancelInvitation: boolean;
     canTransferOwnership: boolean;
+    canViewAudit: boolean;
 };
 
 export type RoleOption = {
     value: TeamRole;
     label: string;
+};
+
+/**
+ * A recorded admin/moderation action shown in a workspace's audit log. Mirrors
+ * the `App\Data\AuditEventData` DTO. `actorName` is null when the acting user no
+ * longer exists; `description` is a ready-to-render human sentence.
+ */
+export type AuditEntry = {
+    id: string;
+    action: string;
+    label: string;
+    actorName: string | null;
+    description: string;
+    occurredAt: string;
+};
+
+export type AuditActionOption = {
+    value: string;
+    label: string;
+};
+
+export type AuditActor = {
+    id: string;
+    name: string;
+};
+
+/**
+ * One page of audit entries. Uses simple (prev/next) pagination so the log can
+ * be paged through in full without a bounded cap.
+ */
+export type AuditEntriesPage = {
+    data: AuditEntry[];
+    prevPageUrl: string | null;
+    nextPageUrl: string | null;
 };

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Settings\ReadReceiptsController;
 use App\Http\Controllers\Settings\SecurityController;
 use App\Http\Controllers\Settings\SessionController;
 use App\Http\Controllers\Settings\TimezoneController;
+use App\Http\Controllers\Teams\AuditController;
 use App\Http\Controllers\Teams\TeamController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Controllers\Teams\TeamMemberController;
@@ -56,6 +57,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
         Route::post('settings/teams/{team}/switch', [TeamController::class, 'switch'])->name('teams.switch');
         Route::delete('settings/teams/{team}/leave', [TeamController::class, 'leave'])->name('teams.leave');
+
+        Route::get('settings/teams/{team}/audit', [AuditController::class, 'index'])->name('teams.audit.index');
 
         Route::get('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'show'])->name('teams.members.show');
         Route::get('settings/teams/{team}/members/{user}/card', [TeamMemberController::class, 'card'])->name('teams.members.card');

--- a/tests/Feature/Teams/AuditLogTest.php
+++ b/tests/Feature/Teams/AuditLogTest.php
@@ -1,0 +1,347 @@
+<?php
+
+use App\Actions\Channels\JoinChannel;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\AuditAction;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Exceptions\AuditLogImmutableException;
+use App\Models\AuditActivity;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team (with its #general channel) owned by a fresh user.
+ *
+ * @return array{0: User, 1: Team}
+ */
+function auditTeam(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    return [$owner, $team];
+}
+
+/**
+ * Attach a member to a team with the given role.
+ */
+function auditMember(Team $team, TeamRole $role = TeamRole::Member): User
+{
+    $member = User::factory()->create();
+    $team->members()->attach($member, ['role' => $role->value]);
+
+    return $member;
+}
+
+/**
+ * Fetch the single audit entry of the given action for a team.
+ */
+function auditEntry(Team $team, AuditAction $action): AuditActivity
+{
+    return AuditActivity::query()
+        ->where('team_id', $team->id)
+        ->where('event', $action->value)
+        ->sole();
+}
+
+test('renaming a team records an audit entry with old and new names', function () {
+    [$owner, $team] = auditTeam();
+
+    $this->actingAs($owner)
+        ->patch(route('teams.update', $team), ['name' => 'Acme Corp'])
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::TeamRenamed);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->properties['old_name'])->toBe('Acme');
+    expect($entry->properties['new_name'])->toBe('Acme Corp');
+});
+
+test('renaming a team to the same name records nothing', function () {
+    [$owner, $team] = auditTeam();
+
+    $this->actingAs($owner)
+        ->patch(route('teams.update', $team), ['name' => 'Acme'])
+        ->assertRedirect();
+
+    expect(AuditActivity::query()->where('team_id', $team->id)->count())->toBe(0);
+});
+
+test('changing a member role records an audit entry with old and new roles', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team);
+
+    $this->actingAs($owner)
+        ->patch(route('teams.members.update', [$team, $member]), ['role' => TeamRole::Admin->value])
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::MemberRoleChanged);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->subject_id)->toBe($member->id);
+    expect($entry->properties['old_role'])->toBe(TeamRole::Member->label());
+    expect($entry->properties['new_role'])->toBe(TeamRole::Admin->label());
+});
+
+test('changing a member role to the same role records nothing', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team);
+
+    $this->actingAs($owner)
+        ->patch(route('teams.members.update', [$team, $member]), ['role' => TeamRole::Member->value])
+        ->assertRedirect();
+
+    expect(AuditActivity::query()->where('team_id', $team->id)->count())->toBe(0);
+});
+
+test('removing a member records an audit entry', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team);
+
+    $this->actingAs($owner)
+        ->delete(route('teams.members.destroy', [$team, $member]))
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::MemberRemoved);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->properties['member_name'])->toBe($member->name);
+});
+
+test('transferring ownership records an audit entry', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team, TeamRole::Admin);
+
+    $this->actingAs($owner)
+        ->post(route('teams.members.transfer-ownership', [$team, $member]), ['password' => 'password'])
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::OwnershipTransferred);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->properties['new_owner_name'])->toBe($member->name);
+});
+
+test('creating a channel records an audit entry', function () {
+    [$owner, $team] = auditTeam();
+
+    $this->actingAs($owner)
+        ->post(route('channels.store', $team), [
+            'name' => 'marketing',
+            'visibility' => ChannelVisibility::Public->value,
+        ])
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::ChannelCreated);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->properties['channel_name'])->toBe('marketing');
+});
+
+test('archiving a channel records an audit entry', function () {
+    [$owner, $team] = auditTeam();
+    $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
+
+    $this->actingAs($owner)
+        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::ChannelArchived);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->properties['channel_name'])->toBe($channel->name);
+});
+
+test('adding a channel member records an audit entry', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team);
+    $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
+    app(JoinChannel::class)->handle($channel, $owner);
+
+    $this->actingAs($owner)
+        ->post(route('channels.members.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
+            'user_id' => $member->id,
+        ])
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::ChannelMemberAdded);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->properties['channel_name'])->toBe($channel->name);
+    expect($entry->properties['member_name'])->toBe($member->name);
+});
+
+test('removing a channel member records an audit entry', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team);
+    $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
+    app(JoinChannel::class)->handle($channel, $owner);
+    app(JoinChannel::class)->handle($channel, $member);
+
+    $this->actingAs($owner)
+        ->delete(route('channels.members.destroy', ['team' => $team->slug, 'channel' => $channel->slug]), [
+            'user_id' => $member->id,
+        ])
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::ChannelMemberRemoved);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->properties['member_name'])->toBe($member->name);
+});
+
+test('a moderator deleting another members message records an audit entry', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team);
+    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+    $message = Message::factory()->for($general)->for($member)->create();
+
+    $this->actingAs($owner)
+        ->delete(route('channels.messages.destroy', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]))
+        ->assertRedirect();
+
+    $entry = auditEntry($team, AuditAction::MessageDeleted);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->properties['author_name'])->toBe($member->name);
+});
+
+test('a member deleting their own message records nothing', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team);
+    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+    $message = Message::factory()->for($general)->for($member)->create();
+
+    $this->actingAs($member)
+        ->delete(route('channels.messages.destroy', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'message' => $message->id,
+        ]))
+        ->assertRedirect();
+
+    expect(AuditActivity::query()->where('event', AuditAction::MessageDeleted->value)->count())->toBe(0);
+});
+
+test('an audit entry belongs to its team', function () {
+    [$owner, $team] = auditTeam();
+    $entry = AuditActivity::factory()->forTeam($team)->causedBy($owner)->create();
+
+    expect($entry->team->id)->toBe($team->id);
+});
+
+test('an audit entry cannot be updated', function () {
+    $entry = AuditActivity::factory()->create();
+
+    expect(fn () => $entry->update(['description' => 'tampered']))
+        ->toThrow(AuditLogImmutableException::class);
+
+    expect($entry->fresh()->description)->not->toBe('tampered');
+});
+
+test('an audit entry cannot be deleted', function () {
+    $entry = AuditActivity::factory()->create();
+
+    expect(fn () => $entry->delete())
+        ->toThrow(AuditLogImmutableException::class);
+
+    expect(AuditActivity::query()->whereKey($entry->id)->exists())->toBeTrue();
+});
+
+test('an admin can view the audit log', function () {
+    [$owner, $team] = auditTeam();
+    $admin = auditMember($team, TeamRole::Admin);
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
+
+    $this->actingAs($admin)
+        ->get(route('teams.audit.index', $team))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('teams/Audit')
+            ->has('entries.data', 1)
+            ->where('entries.data.0.action', AuditAction::ChannelCreated->value)
+        );
+});
+
+test('a plain member cannot view the audit log', function () {
+    [$owner, $team] = auditTeam();
+    $member = auditMember($team);
+
+    $this->actingAs($member)
+        ->get(route('teams.audit.index', $team))
+        ->assertForbidden();
+});
+
+test('a non member cannot view the audit log', function () {
+    [$owner, $team] = auditTeam();
+    $stranger = User::factory()->create();
+
+    $this->actingAs($stranger)
+        ->get(route('teams.audit.index', $team))
+        ->assertForbidden();
+});
+
+test('the audit log is not available for a personal team', function () {
+    $user = User::factory()->create();
+    $personal = $user->personalTeam();
+
+    $this->actingAs($user)
+        ->get(route('teams.audit.index', $personal))
+        ->assertForbidden();
+});
+
+test('the audit log only shows the current teams entries', function () {
+    [$owner, $team] = auditTeam();
+    $otherTeam = Team::factory()->create();
+
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
+    AuditActivity::factory()->forTeam($otherTeam)->ofAction(AuditAction::TeamRenamed)->create();
+
+    $this->actingAs($owner)
+        ->get(route('teams.audit.index', $team))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('entries.data', 1)
+            ->where('entries.data.0.action', AuditAction::ChannelCreated->value)
+        );
+});
+
+test('the audit log can be filtered by action', function () {
+    [$owner, $team] = auditTeam();
+
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::MemberRemoved)->create();
+
+    $this->actingAs($owner)
+        ->get(route('teams.audit.index', ['team' => $team, 'action' => AuditAction::ChannelCreated->value]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('entries.data', 1)
+            ->where('entries.data.0.action', AuditAction::ChannelCreated->value)
+        );
+});
+
+test('the audit log can be filtered by actor', function () {
+    [$owner, $team] = auditTeam();
+    $admin = auditMember($team, TeamRole::Admin);
+
+    AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
+    AuditActivity::factory()->forTeam($team)->causedBy($admin)->ofAction(AuditAction::MemberRemoved)->create();
+
+    $this->actingAs($owner)
+        ->get(route('teams.audit.index', ['team' => $team, 'actor' => $admin->id]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('entries.data', 1)
+            ->where('entries.data.0.action', AuditAction::MemberRemoved->value)
+        );
+});

--- a/tests/Unit/AuditActionTest.php
+++ b/tests/Unit/AuditActionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Enums\AuditAction;
+
+test('every action describes itself from context', function (AuditAction $action) {
+    $context = [
+        'old_name' => 'Acme',
+        'new_name' => 'Acme Corp',
+        'member_name' => 'Dana',
+        'old_role' => 'Member',
+        'new_role' => 'Admin',
+        'new_owner_name' => 'Dana',
+        'channel_name' => 'general',
+        'author_name' => 'Ravi',
+    ];
+
+    expect($action->describe($context))->toBeString()->not->toBe('');
+})->with(AuditAction::cases());
+
+test('a missing context value falls back to a placeholder', function () {
+    expect(AuditAction::ChannelCreated->describe([]))->toContain('—');
+});
+
+test('the action options expose a value and label for every case', function () {
+    $options = AuditAction::options();
+
+    expect($options)->toHaveCount(count(AuditAction::cases()));
+    expect($options[0])->toHaveKeys(['value', 'label']);
+});


### PR DESCRIPTION
Closes #50.

## What
An immutable, team-scoped audit trail of admin/moderation actions, plus an admin-only viewer with filtering.

## Storage — spatie/laravel-activitylog (adapted)
Uses the package (approved as a dependency add), adapted to this codebase:
- Custom `activity_log` migration with the app's UUID keys + an indexed `team_id` for workspace scoping.
- `App\Models\AuditActivity` extends Spatie's `Activity` with `HasUuids`, a `team()` relation, and **model-layer append-only guards** — `updating`/`deleting` throw `AuditLogImmutableException`.
- `App\Enums\AuditAction` (typed events, `label()`, `describe()`), `App\Support\AuditRecorder`, and `App\Data\AuditEventData` (`#[TypeScript]` DTO) mirror the existing SecurityEvent typed/enum/DTO conventions.

## Recorded actions (at the controller seam, where the actor is known)
Team rename, member role change, member removal, ownership transfer, channel create, channel archive, channel member add/remove, and **moderator** message deletion (recorded only when actor ≠ author).

## Viewer
`GET settings/teams/{team}/audit` → `AuditController`, gated by `TeamPolicy::viewAudit` (Admin+, non-personal) via `ViewAuditLogRequest`. Filter by action and actor, simple-paginated newest-first. `canViewAudit` added to `TeamPermissions`; a link surfaces on the team Edit page. New `teams/Audit.vue` page with committed TS types.

## Scope notes
- **Channel rename** omitted — the app has no channel-rename endpoint, so there is no seam.
- **Team delete** omitted — a per-team viewer cannot show a "team deleted" entry (the `team_id` cascade removes the log with the team). Recorded team **rename** instead; straightforward to add once a cross-team/global audit surface exists.

## Tests
- Entry creation per recorded action (correct actor/target/context).
- Append-only immutability (update and delete rejected).
- Authorization: plain member and non-member get 403; admin/owner can view; personal team blocked.
- Team scoping (no cross-team leakage) and filtering by action and actor.

## Also
- `WorkspaceSeeder` seeds a representative audit trail across two actors so the viewer/filters have demo data.
- CLAUDE.md: added an "Implementing Issues (TDD)" convention.

## Gates
- Backend `sail composer test`: Pint + PHPStan + **Total: 100.0%** coverage (full suite 589 passed, 4 skipped, 0 failed).
- Frontend: `lint:check`, `format:check`, `types:check`, `build` all pass.