### PR TITLE
Emoji reactions on messages

### DIFF
--- a/app/Actions/Channels/DeleteMessage.php
+++ b/app/Actions/Channels/DeleteMessage.php
@@ -18,6 +18,11 @@ class DeleteMessage
      */
     public function handle(Channel $channel, Message $message): void
     {
+        // A soft delete leaves the row (and its FK-cascading children) in place,
+        // so drop the reactions explicitly — a tombstone shows none, and they
+        // would otherwise linger unreachable behind the deleted message.
+        $message->reactions()->delete();
+
         $message->delete();
 
         $message->loadMissing('user');

--- a/app/Actions/Channels/EditMessage.php
+++ b/app/Actions/Channels/EditMessage.php
@@ -32,7 +32,7 @@ class EditMessage
         $this->syncLinkPreviews->handle($message);
 
         $message->loadMissing('user');
-        $message->load(['mentionedUsers', 'linkPreviews']);
+        $message->load(['mentionedUsers', 'linkPreviews', 'reactions.user']);
         MessageUpdated::dispatch($channel, MessageData::fromMessage($message));
 
         return $message;

--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -50,7 +50,7 @@ class PostMessage
             $this->syncMentions->handle($channel, $message);
             $this->syncLinkPreviews->handle($message);
             $message->setRelation('user', $author);
-            $message->load(['mentionedUsers', 'linkPreviews', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
+            $message->load(['mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
             MessageSent::dispatch($channel, MessageData::fromMessage($message));
 
             if ($threadRootId !== null) {
@@ -74,7 +74,7 @@ class PostMessage
         $root = $channel->messages()->withTrashed()->findOrFail($threadRootId);
         $root->forceFill(['reply_count' => $root->reply_count + 1, 'last_reply_at' => now()])->save();
 
-        $root->load(['user', 'mentionedUsers', 'linkPreviews', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants']);
+        $root->load(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants']);
         MessageUpdated::dispatch($channel, MessageData::fromMessage($root));
     }
 }

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -44,6 +44,6 @@ class SearchMessages
             ->whereIn('channel_id', $channelIds)
             ->take($limit)
             ->get()
-            ->load(['user', 'channel', 'mentionedUsers', 'linkPreviews', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
+            ->load(['user', 'channel', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
     }
 }

--- a/app/Actions/Channels/ToggleReaction.php
+++ b/app/Actions/Channels/ToggleReaction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Data\ReactionData;
+use App\Events\MessageReactionChanged;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+
+class ToggleReaction
+{
+    /**
+     * Toggle a user's emoji reaction on a message, then broadcast the new summary.
+     *
+     * Flips the single `(message, user, emoji)` row on or off — a first tap adds
+     * it, a second removes it — so a user reacts at most once per distinct emoji,
+     * enforced by the table's unique constraint. Either way the message's
+     * reactions are re-aggregated and broadcast so every open timeline and thread
+     * patches the row's pills live, mirroring how message edits sync.
+     */
+    public function handle(Channel $channel, Message $message, User $user, string $emoji): void
+    {
+        $existing = $message->reactions()
+            ->where('user_id', $user->id)
+            ->where('emoji', $emoji)
+            ->first();
+
+        if ($existing !== null) {
+            $existing->delete();
+        } else {
+            $message->reactions()->create([
+                'user_id' => $user->id,
+                'emoji' => $emoji,
+            ]);
+        }
+
+        $message->load('reactions.user');
+
+        MessageReactionChanged::dispatch($channel, $message->id, ReactionData::forMessage($message));
+    }
+}

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -15,6 +15,7 @@ class MessageData extends Data
     /**
      * @param  array<int, MentionData>  $mentions
      * @param  array<int, LinkPreviewData>  $linkPreviews
+     * @param  array<int, ReactionData>  $reactions
      * @param  array<int, MentionData>  $threadParticipants
      */
     public function __construct(
@@ -27,6 +28,7 @@ class MessageData extends Data
         public bool $isDeleted,
         public array $mentions,
         public array $linkPreviews,
+        public array $reactions,
         public ?MessageReplyData $replyTo,
         public ?MessageForwardData $forwardedFrom,
         public ?string $threadRootId,
@@ -85,6 +87,9 @@ class MessageData extends Data
                 ->map(fn (MessageLinkPreview $preview) => LinkPreviewData::fromModel($preview))
                 ->values()
                 ->all(),
+            // A tombstone carries no reactions; DeleteMessage also hard-deletes
+            // the rows, so a deleted message aggregates to an empty set either way.
+            reactions: $isDeleted ? [] : ReactionData::forMessage($message),
             replyTo: ! $isDeleted && $message->replyTo !== null
                 ? MessageReplyData::fromMessage($message->replyTo)
                 : null,

--- a/app/Data/ReactionData.php
+++ b/app/Data/ReactionData.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\Message;
+use App\Models\MessageReaction;
+use Illuminate\Support\Collection;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class ReactionData extends Data
+{
+    /**
+     * @param  array<int, MentionData>  $reactors
+     */
+    public function __construct(
+        public string $emoji,
+        public int $count,
+        public array $reactors,
+    ) {}
+
+    /**
+     * Aggregate a message's reactions into one entry per distinct emoji.
+     *
+     * The `reactions` relation (with each row's `user`) should be eager-loaded.
+     * Rows are grouped by emoji, preserving the first-reacted order the relation
+     * already sorts by, so the client renders stable pills. Each entry carries
+     * the emoji, its total count, and the reactor set (`MentionData`) — the
+     * client derives "did I react" from whether its own id appears among them,
+     * so the summary stays viewer-free and rides the broadcast unchanged.
+     *
+     * @return array<int, self>
+     */
+    public static function forMessage(Message $message): array
+    {
+        return $message->reactions
+            ->groupBy('emoji')
+            ->map(fn (Collection $group, string $emoji) => new self(
+                emoji: $emoji,
+                count: $group->count(),
+                reactors: $group->map(fn (MessageReaction $reaction) => MentionData::fromUser($reaction->user))->all(),
+            ))
+            ->values()
+            ->all();
+    }
+}

--- a/app/Events/MessageReactionChanged.php
+++ b/app/Events/MessageReactionChanged.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Events;
+
+use App\Data\MessageData;
+use App\Data\ReactionData;
+use App\Models\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageReactionChanged implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * A slim payload carrying just the message id and its freshly aggregated
+     * reaction summary — the client merges it into the row it already renders,
+     * matched by id, rather than rebuilding the whole {@see MessageData}.
+     * The summary is viewer-free (each entry lists its reactors), so a single
+     * broadcast serves every subscriber and each derives its own "did I react".
+     *
+     * @param  array<int, ReactionData>  $reactions
+     */
+    public function __construct(
+        public Channel $channel,
+        public string $messageId,
+        public array $reactions,
+    ) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel.'.$this->channel->id),
+        ];
+    }
+
+    /**
+     * Get the data to broadcast: the target message id and its reaction summary.
+     *
+     * @return array{messageId: string, reactions: array<int, array<string, mixed>>}
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'messageId' => $this->messageId,
+            'reactions' => array_map(fn (ReactionData $reaction) => $reaction->toArray(), $this->reactions),
+        ];
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -131,6 +131,9 @@ class ChannelController extends Controller
             // Gates the notification settings menu; only a member of the channel
             // has preferences to manage.
             'canManagePreferences' => Gate::allows('updatePreference', $channel),
+            // Gates the reaction affordances; only a member of a non-archived
+            // channel may react, matching the server-side `postMessage` rule.
+            'canReact' => Gate::allows('postMessage', $channel),
             // Selectable notification levels for the settings menu.
             'notificationLevels' => NotificationLevel::options(),
             // The message the client should scroll to and highlight on load, or
@@ -170,7 +173,7 @@ class ChannelController extends Controller
             // "message deleted" tombstone in place; MessageData blanks their body.
             'messages' => Inertia::scroll(fn () => $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
                 ->withThreadReadState($request->user())
-                ->with(['user', 'mentionedUsers', 'linkPreviews', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
+                ->with(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
                 ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
                 ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
@@ -215,7 +218,7 @@ class ChannelController extends Controller
         $root = $this->resolveThreadRoot($request, $channel);
 
         $query = $root !== null
-            ? $root->threadReplies()->withTrashed()->with(['user', 'mentionedUsers', 'linkPreviews', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers'])
+            ? $root->threadReplies()->withTrashed()->with(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers'])
             : Message::query()->whereRaw('1 = 0');
 
         return $query

--- a/app/Http/Controllers/Channels/ReactionController.php
+++ b/app/Http/Controllers/Channels/ReactionController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\ToggleReaction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\ReactionRequest;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+
+class ReactionController extends Controller
+{
+    /**
+     * Toggle the current user's emoji reaction on a message.
+     *
+     * A single endpoint flips the reaction on or off; the action re-aggregates
+     * and broadcasts the message's reactions so every viewer patches it live.
+     * Redirecting back keeps the user in the channel — the pill update arrives
+     * over the broadcast, not the response.
+     */
+    public function store(ReactionRequest $request, Team $team, Channel $channel, Message $message, ToggleReaction $toggleReaction): RedirectResponse
+    {
+        $toggleReaction->handle($channel, $message, $request->user(), $request->validated('emoji'));
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Channels/ThreadsController.php
+++ b/app/Http/Controllers/Channels/ThreadsController.php
@@ -48,7 +48,7 @@ class ThreadsController extends Controller
                 ->where('reply_count', '>', 0)
                 ->followedBy($user)
                 ->withThreadReadState($user)
-                ->with(['user', 'channel', 'mentionedUsers', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
+                ->with(['user', 'channel', 'mentionedUsers', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
                 ->orderByDesc('last_reply_at')
                 ->orderByDesc('id')
                 ->cursorPaginate(self::PAGE_SIZE)

--- a/app/Http/Requests/Channels/ReactionRequest.php
+++ b/app/Http/Requests/Channels/ReactionRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class ReactionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Reacting reuses the `postMessage` rule: only a member of the (non-archived)
+     * channel may react, so an archived channel stays read-only for reactions too.
+     * The route scopes `{message}` to the channel and excludes soft-deleted rows,
+     * so a tombstone can't be reacted to.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('postMessage', $this->channel());
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // The literal unicode emoji character to toggle; capped so a stray
+            // payload can't bloat the row while still fitting multi-codepoint
+            // emoji (skin-tone and ZWJ sequences run several code points).
+            'emoji' => ['required', 'string', 'max:32'],
+        ];
+    }
+
+    /**
+     * Get the channel the reaction is being toggled in.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+}

--- a/app/Jobs/UnfurlMessageLinks.php
+++ b/app/Jobs/UnfurlMessageLinks.php
@@ -20,7 +20,7 @@ class UnfurlMessageLinks implements ShouldQueue
      * @var array<int, string>
      */
     private const array MESSAGE_RELATIONS = [
-        'user', 'mentionedUsers', 'linkPreviews',
+        'user', 'mentionedUsers', 'linkPreviews', 'reactions.user',
         'replyTo.user', 'replyTo.mentionedUsers',
         'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers',
     ];

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -41,6 +41,7 @@ use Laravel\Scout\Searchable;
  * @property-read Collection<int, Message> $threadReplies
  * @property-read Collection<int, User> $threadParticipants
  * @property-read Collection<int, User> $mentionedUsers
+ * @property-read Collection<int, MessageReaction> $reactions
  */
 #[Fillable(['channel_id', 'user_id', 'client_uuid', 'reply_to_id', 'forwarded_from_id', 'thread_root_id', 'sent_to_channel', 'body', 'edited_at'])]
 class Message extends Model
@@ -162,6 +163,20 @@ class Message extends Model
     public function linkPreviews(): HasMany
     {
         return $this->hasMany(MessageLinkPreview::class)->orderBy('position');
+    }
+
+    /**
+     * Get the emoji reactions added to this message.
+     *
+     * Ordered by when each reaction was first added so the aggregated pills keep
+     * a stable, first-reacted-first order. Each row's `user` is eager-loaded when
+     * building the reaction summary so the reactor tooltip avoids an N+1.
+     *
+     * @return HasMany<MessageReaction, $this>
+     */
+    public function reactions(): HasMany
+    {
+        return $this->hasMany(MessageReaction::class)->orderBy('created_at')->orderBy('id');
     }
 
     /**

--- a/app/Models/MessageReaction.php
+++ b/app/Models/MessageReaction.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\MessageReactionFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $message_id
+ * @property string $user_id
+ * @property string $emoji
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Message $message
+ * @property-read User $user
+ */
+#[Fillable(['message_id', 'user_id', 'emoji'])]
+class MessageReaction extends Model
+{
+    /** @use HasFactory<MessageReactionFactory> */
+    use HasFactory, HasUuids;
+
+    /**
+     * Get the message this reaction was added to.
+     *
+     * @return BelongsTo<Message, $this>
+     */
+    public function message(): BelongsTo
+    {
+        return $this->belongsTo(Message::class);
+    }
+
+    /**
+     * Get the user who added the reaction.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/factories/MessageReactionFactory.php
+++ b/database/factories/MessageReactionFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Message;
+use App\Models\MessageReaction;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<MessageReaction>
+ */
+class MessageReactionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'message_id' => Message::factory(),
+            'user_id' => User::factory(),
+            'emoji' => fake()->randomElement(['👍', '❤️', '😂', '🎉', '👀', '🙌']),
+        ];
+    }
+
+    /**
+     * Indicate the reaction uses a specific emoji.
+     */
+    public function emoji(string $emoji): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'emoji' => $emoji,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_10_142309_create_message_reactions_table.php
+++ b/database/migrations/2026_07_10_142309_create_message_reactions_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('message_reactions', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            $table->foreignUuid('message_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            $table->string('emoji');
+            $table->timestamps();
+
+            // A user reacts at most once per distinct emoji on a message; the
+            // toggle endpoint flips the row on and off against this constraint.
+            $table->unique(['message_id', 'user_id', 'emoji']);
+            // Aggregating a message's reactions loads the whole set by message.
+            $table->index('message_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('message_reactions');
+    }
+};

--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -11,6 +11,7 @@ use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Message;
+use App\Models\MessageReaction;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
@@ -119,10 +120,11 @@ class WorkspaceSeeder extends Seeder
         $members = [$demo, $admin, $member1, $member2, $twoFactor];
 
         // A busy channel: enough backfill to make infinite scroll meaningful.
-        $this->seedMessages($general, $members, 60);
+        $generalMessages = $this->seedMessages($general, $members, 60);
         $this->seedEditedMessage($general, $admin);
         $this->seedDeletedMessage($general, $member1);
         $this->seedMentionMessage($general, $member2, $demo);
+        $this->seedReactions($generalMessages, [$demo, $admin, $member1]);
 
         // Extra public channels — one with a topic, one without.
         $announcements = $this->createChannel->handle($acme, 'announcements', ChannelVisibility::Public, $demo, 'Company-wide news');
@@ -308,6 +310,36 @@ class WorkspaceSeeder extends Seeder
         }
 
         return $messages;
+    }
+
+    /**
+     * Attach a spread of emoji reactions to a few messages so the reaction pills,
+     * multi-reactor aggregation, and the "You and N others" tooltip all have data
+     * on load — including reactions by the demo user so its own pills highlight.
+     *
+     * @param  list<Message>  $messages
+     * @param  array{0: User, 1: User, 2: User}  $reactors
+     */
+    private function seedReactions(array $messages, array $reactors): void
+    {
+        if (count($messages) < 5) {
+            return;
+        }
+
+        [$demo, $admin, $member] = $reactors;
+
+        // A popular message: three reactors share one emoji, with a second emoji
+        // alongside — the viewer reads "You and 2 others" on the first pill.
+        $popular = $messages[count($messages) - 2];
+
+        foreach ([$demo, $admin, $member] as $reactor) {
+            MessageReaction::factory()->for($popular)->for($reactor)->emoji('👍')->create();
+        }
+
+        MessageReaction::factory()->for($popular)->for($demo)->emoji('🎉')->create();
+
+        // A lightly-reacted message: a single emoji from one other member.
+        MessageReaction::factory()->for($messages[count($messages) - 5])->for($admin)->emoji('❤️')->create();
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "tw-animate-css": "^1.2.5",
                 "vue": "^3.5.13",
                 "vue-sonner": "^2.0.0",
+                "vue3-emoji-picker": "^1.1.8",
                 "vuedraggable": "^4.1.0"
             },
             "devDependencies": {
@@ -1324,6 +1325,16 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
@@ -6258,6 +6269,12 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/idb": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+            "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+            "license": "ISC"
+        },
         "node_modules/identifier-regex": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.1.0.tgz",
@@ -10988,6 +11005,20 @@
             },
             "peerDependencies": {
                 "typescript": ">=5.0.0"
+            }
+        },
+        "node_modules/vue3-emoji-picker": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/vue3-emoji-picker/-/vue3-emoji-picker-1.1.8.tgz",
+            "integrity": "sha512-k9tVHeQEBVLzVCLYAkFaI1nib3FJFQwdPhWD5khJkhks3ktg3g12z5wPGOSDpIuSLNtelRGvq1qdmZuJu5khfA==",
+            "license": "MIT",
+            "dependencies": {
+                "@popperjs/core": "^2.11.0",
+                "idb": "^7.1.0",
+                "vue": "^3.2.23"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/vuedraggable": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "tw-animate-css": "^1.2.5",
         "vue": "^3.5.13",
         "vue-sonner": "^2.0.0",
+        "vue3-emoji-picker": "^1.1.8",
         "vuedraggable": "^4.1.0"
     },
     "optionalDependencies": {

--- a/resources/js/components/EmojiPickerPopover.vue
+++ b/resources/js/components/EmojiPickerPopover.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import {
+    PopoverContent,
+    PopoverPortal,
+    PopoverRoot,
+    PopoverTrigger,
+} from 'reka-ui';
+import { defineAsyncComponent, ref } from 'vue';
+
+// The emoji picker touches `indexedDB` at module load, which doesn't exist under
+// Node SSR, so import it lazily on the client only — its loader runs when the
+// popover first opens (a client-only interaction), never during server render.
+const EmojiPicker = defineAsyncComponent(async () => {
+    await import('vue3-emoji-picker/css');
+
+    return (await import('vue3-emoji-picker')).default;
+});
+
+const emit = defineEmits<{
+    select: [emoji: string];
+}>();
+
+// The popover's open state, closed after a pick.
+const open = ref(false);
+
+/**
+ * The picker's `select` event carries the chosen emoji as `.i`; surface it and
+ * close the popover.
+ */
+function onPick(payload: { i: string }): void {
+    emit('select', payload.i);
+    open.value = false;
+}
+</script>
+
+<template>
+    <PopoverRoot v-model:open="open">
+        <PopoverTrigger as-child>
+            <slot :open="open" />
+        </PopoverTrigger>
+        <PopoverPortal>
+            <PopoverContent
+                align="start"
+                :side-offset="6"
+                :collision-padding="8"
+                class="z-50 outline-none"
+            >
+                <EmojiPicker
+                    :native="true"
+                    :hide-search="false"
+                    theme="auto"
+                    @select="onPick"
+                />
+            </PopoverContent>
+        </PopoverPortal>
+    </PopoverRoot>
+</template>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -5,12 +5,15 @@ import {
     Forward,
     MessageSquareText,
     Pencil,
+    SmilePlus,
     Trash2,
 } from '@lucide/vue';
 import { computed, nextTick, ref } from 'vue';
+import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
 import LinkPreview from '@/components/LinkPreview.vue';
 import MessageForward from '@/components/MessageForward.vue';
 import MessageQuote from '@/components/MessageQuote.vue';
+import MessageReactions from '@/components/MessageReactions.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -48,6 +51,9 @@ const props = defineProps<{
     pendingUuids?: string[];
     currentUserId: string;
     canModerate?: boolean;
+    // Whether the viewer may add/remove reactions (member of a non-archived
+    // channel); existing reaction pills still render read-only when false.
+    canReact?: boolean;
     onlineIds?: Set<string>;
     highlightMessageId?: string | null;
     // The message the "New messages" divider sits above — the first unread on
@@ -68,6 +74,7 @@ const emit = defineEmits<{
     delete: [message: Message];
     reply: [message: Message];
     forward: [message: Message];
+    react: [message: Message, emoji: string];
     openThread: [messageId: string];
     jump: [messageId: string];
     mention: [member: { id: string; name: string }];
@@ -324,6 +331,12 @@ function canReply(message: Message): boolean {
 // thread panel. A pending or deleted row has no stable target to forward yet.
 function canForward(message: Message): boolean {
     return !message.isDeleted && !isPending(message);
+}
+
+// The viewer may react to any live, confirmed message when they're a member of
+// the (non-archived) channel; a pending or deleted row has no stable target yet.
+function canReactTo(message: Message): boolean {
+    return Boolean(props.canReact) && !message.isDeleted && !isPending(message);
 }
 
 // The hover "reply in thread" action shows on live root messages in the main
@@ -641,6 +654,16 @@ function confirmDelete(): void {
                             :mentions="message.forwardedFrom.mentions"
                         />
 
+                        <MessageReactions
+                            v-if="
+                                !message.isDeleted && editingId !== message.id
+                            "
+                            :reactions="message.reactions"
+                            :current-user-id="props.currentUserId"
+                            :can-react="canReactTo(message)"
+                            @toggle="(emoji) => emit('react', message, emoji)"
+                        />
+
                         <button
                             v-if="showThreadSummary(message)"
                             type="button"
@@ -696,14 +719,30 @@ function confirmDelete(): void {
                         <div
                             v-if="
                                 editingId !== message.id &&
-                                (canReply(message) ||
+                                (canReactTo(message) ||
+                                    canReply(message) ||
                                     canStartThread(message) ||
                                     canForward(message) ||
                                     canEdit(message) ||
                                     canDelete(message))
                             "
-                            class="absolute -top-3 right-2 hidden items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm group-hover/message:flex"
+                            class="absolute -top-3 right-2 hidden items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm group-hover/message:flex has-[[data-state=open]]:flex"
                         >
+                            <EmojiPickerPopover
+                                v-if="canReactTo(message)"
+                                @select="
+                                    (emoji) => emit('react', message, emoji)
+                                "
+                            >
+                                <button
+                                    type="button"
+                                    data-test="message-react"
+                                    aria-label="Add reaction"
+                                    class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                >
+                                    <SmilePlus class="size-3.5" />
+                                </button>
+                            </EmojiPickerPopover>
                             <button
                                 v-if="canStartThread(message)"
                                 type="button"

--- a/resources/js/components/MessageReactions.vue
+++ b/resources/js/components/MessageReactions.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import { SmilePlus } from '@lucide/vue';
+import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
+import {
+    HoverCard,
+    HoverCardContent,
+    HoverCardTrigger,
+} from '@/components/ui/hover-card';
+import { hasReacted, reactionRoster } from '@/lib/reactions';
+import type { Reaction } from '@/types';
+
+const props = defineProps<{
+    reactions: Reaction[];
+    currentUserId: string;
+    // Whether the viewer may add/remove reactions (channel member, non-archived);
+    // when false the existing pills still render read-only.
+    canReact: boolean;
+}>();
+
+const emit = defineEmits<{
+    toggle: [emoji: string];
+}>();
+
+/**
+ * Whether the viewer has reacted with a given emoji, driving the pill's
+ * highlighted (own-reaction) styling.
+ */
+function reacted(reaction: Reaction): boolean {
+    return hasReacted(reaction, props.currentUserId);
+}
+
+/**
+ * The full roster of who reacted with an emoji ("You, Alice and Bob"), shown in
+ * the pill's hover card and used as its accessible label.
+ */
+function roster(reaction: Reaction): string {
+    return reactionRoster(reaction, props.currentUserId);
+}
+
+function toggle(emoji: string): void {
+    if (!props.canReact) {
+        return;
+    }
+
+    emit('toggle', emoji);
+}
+</script>
+
+<template>
+    <!-- Rendered only when reactions exist, so an empty message reserves no
+         vertical space — the add-reaction affordance for a message with no
+         reactions lives in the floating hover toolbar, which never reflows the
+         timeline. Once reactions exist this row keeps a stable height. -->
+    <div
+        v-if="props.reactions.length > 0"
+        data-test="message-reactions"
+        class="mt-1 flex flex-wrap items-center gap-1"
+    >
+        <HoverCard
+            v-for="reaction in props.reactions"
+            :key="reaction.emoji"
+            :open-delay="200"
+            :close-delay="100"
+        >
+            <HoverCardTrigger as-child>
+                <button
+                    type="button"
+                    data-test="reaction-pill"
+                    :data-emoji="reaction.emoji"
+                    :data-reacted="reacted(reaction)"
+                    :disabled="!props.canReact"
+                    :aria-label="`${reaction.emoji} ${roster(reaction)}`"
+                    :aria-pressed="reacted(reaction)"
+                    class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[12px] leading-none transition-colors"
+                    :class="
+                        reacted(reaction)
+                            ? 'border-primary/40 bg-primary/10 text-primary'
+                            : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted'
+                    "
+                    @click="toggle(reaction.emoji)"
+                >
+                    <span aria-hidden="true">{{ reaction.emoji }}</span>
+                    <span class="font-medium tabular-nums">{{
+                        reaction.count
+                    }}</span>
+                </button>
+            </HoverCardTrigger>
+            <HoverCardContent
+                data-test="reaction-reactors"
+                class="w-auto max-w-60 p-2.5"
+            >
+                <div class="flex items-center gap-2.5">
+                    <span class="text-2xl leading-none" aria-hidden="true">{{
+                        reaction.emoji
+                    }}</span>
+                    <p class="text-[12.5px] leading-snug text-foreground">
+                        <span class="font-medium">{{ roster(reaction) }}</span>
+                        <span class="text-muted-foreground"> reacted</span>
+                    </p>
+                </div>
+            </HoverCardContent>
+        </HoverCard>
+
+        <EmojiPickerPopover
+            v-if="props.canReact"
+            @select="(emoji) => emit('toggle', emoji)"
+        >
+            <button
+                type="button"
+                data-test="add-reaction"
+                aria-label="Add reaction"
+                class="inline-flex items-center rounded-full border border-border bg-muted/40 p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+                <SmilePlus class="size-3.5" />
+            </button>
+        </EmojiPickerPopover>
+    </div>
+</template>

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
     members: Mention[];
     currentUserId: string;
     canModerate?: boolean;
+    canReact?: boolean;
     onlineIds?: Set<string>;
     loading?: boolean;
     readOnly?: boolean;
@@ -31,6 +32,7 @@ const emit = defineEmits<{
     edit: [message: Message, body: string];
     delete: [message: Message];
     forward: [message: Message];
+    react: [message: Message, emoji: string];
     typing: [];
     jump: [messageId: string];
 }>();
@@ -157,11 +159,13 @@ watch(
                     :pending-uuids="props.pendingUuids"
                     :current-user-id="props.currentUserId"
                     :can-moderate="props.canModerate"
+                    :can-react="props.canReact"
                     :online-ids="props.onlineIds"
                     in-thread
                     @edit="(message, body) => emit('edit', message, body)"
                     @delete="(message) => emit('delete', message)"
                     @forward="(message) => emit('forward', message)"
+                    @react="(message, emoji) => emit('react', message, emoji)"
                     @jump="(id) => emit('jump', id)"
                     @mention="mentionInThread"
                 />

--- a/resources/js/composables/useMessageStream.ts
+++ b/resources/js/composables/useMessageStream.ts
@@ -1,6 +1,6 @@
 import { computed, ref, watch } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
-import type { Mention, Message, MessageForward } from '@/types';
+import type { Mention, Message, MessageForward, Reaction } from '@/types';
 
 /**
  * The reactive merge engine behind a message list.
@@ -136,6 +136,15 @@ export function useMessageStream(
         patches.value.set(current.clientUuid, { ...current, ...partial });
     }
 
+    /**
+     * Replace a rendered message's reactions in place, found by its message id
+     * (the id the `MessageReactionChanged` broadcast carries). Used to patch the
+     * pills live as reactions are toggled, keeping every other field intact.
+     */
+    function patchReactions(id: string, reactions: Reaction[]): void {
+        patchThreadState(id, { reactions });
+    }
+
     function getPatch(clientUuid: string): Message | undefined {
         return patches.value.get(clientUuid);
     }
@@ -173,6 +182,7 @@ export function useMessageStream(
         appendLive,
         applyPatch,
         patchThreadState,
+        patchReactions,
         getPatch,
         restorePatch,
         addPending,
@@ -209,6 +219,8 @@ export function optimisticMessage(params: {
         // Previews resolve server-side; the echo replaces this optimistic copy
         // with one carrying any pending skeletons.
         linkPreviews: [],
+        // A just-sent message has no reactions yet.
+        reactions: [],
         replyTo: target
             ? {
                   id: target.id,

--- a/resources/js/lib/reactions.test.ts
+++ b/resources/js/lib/reactions.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { hasReacted, reactionRoster, toggleReaction } from '@/lib/reactions';
+import type { Mention, Reaction } from '@/types';
+
+const ME: Mention = { id: 'me', name: 'Me' };
+const ALICE: Mention = { id: 'a', name: 'Alice' };
+const BOB: Mention = { id: 'b', name: 'Bob' };
+const CAROL: Mention = { id: 'c', name: 'Carol' };
+
+/**
+ * A reaction entry for `emoji` reacted to by the given members, in order.
+ */
+function reaction(emoji: string, reactors: Mention[]): Reaction {
+    return { emoji, count: reactors.length, reactors };
+}
+
+describe('hasReacted', () => {
+    it('is true when the user is among the reactors', () => {
+        expect(hasReacted(reaction('👍', [ALICE, ME]), ME.id)).toBe(true);
+    });
+
+    it('is false when the user is not among the reactors', () => {
+        expect(hasReacted(reaction('👍', [ALICE]), ME.id)).toBe(false);
+    });
+});
+
+describe('toggleReaction', () => {
+    it('adds a brand-new emoji to the end', () => {
+        const result = toggleReaction([reaction('👍', [ALICE])], '🎉', ME);
+
+        expect(result).toEqual([reaction('👍', [ALICE]), reaction('🎉', [ME])]);
+    });
+
+    it('appends the user to an existing emoji they had not used', () => {
+        const result = toggleReaction([reaction('👍', [ALICE])], '👍', ME);
+
+        expect(result).toEqual([reaction('👍', [ALICE, ME])]);
+    });
+
+    it('removes the user from an emoji they already used', () => {
+        const result = toggleReaction([reaction('👍', [ALICE, ME])], '👍', ME);
+
+        expect(result).toEqual([reaction('👍', [ALICE])]);
+    });
+
+    it('drops the entry entirely when the last reactor toggles off', () => {
+        const result = toggleReaction([reaction('👍', [ME])], '👍', ME);
+
+        expect(result).toEqual([]);
+    });
+
+    it('does not mutate the input array or its entries', () => {
+        const input = [reaction('👍', [ALICE])];
+        const snapshot = structuredClone(input);
+
+        toggleReaction(input, '👍', ME);
+
+        expect(input).toEqual(snapshot);
+    });
+});
+
+describe('reactionRoster', () => {
+    it('names a single other reactor', () => {
+        expect(reactionRoster(reaction('👍', [ALICE]), ME.id)).toBe('Alice');
+    });
+
+    it('surfaces the viewer as "You"', () => {
+        expect(reactionRoster(reaction('👍', [ME]), ME.id)).toBe('You');
+    });
+
+    it('puts "You" first when the viewer reacted alongside others', () => {
+        expect(reactionRoster(reaction('👍', [ALICE, ME]), ME.id)).toBe(
+            'You and Alice',
+        );
+    });
+
+    it('joins two names with "and"', () => {
+        expect(reactionRoster(reaction('👍', [ALICE, BOB]), ME.id)).toBe(
+            'Alice and Bob',
+        );
+    });
+
+    it('names every reactor, without collapsing beyond two', () => {
+        expect(reactionRoster(reaction('👍', [ALICE, BOB, CAROL]), ME.id)).toBe(
+            'Alice, Bob and Carol',
+        );
+    });
+
+    it('keeps "You" first across a longer full roster', () => {
+        expect(
+            reactionRoster(reaction('👍', [ALICE, BOB, CAROL, ME]), ME.id),
+        ).toBe('You, Alice, Bob and Carol');
+    });
+});

--- a/resources/js/lib/reactions.ts
+++ b/resources/js/lib/reactions.ts
@@ -1,0 +1,85 @@
+import type { Mention, Reaction } from '@/types';
+
+/**
+ * Whether the given user is among a reaction's reactors — i.e. the viewer has
+ * this emoji reaction on the message. The reaction summary is viewer-free, so
+ * "did I react" is derived here rather than sent from the server.
+ */
+export function hasReacted(reaction: Reaction, userId: string): boolean {
+    return reaction.reactors.some((reactor) => reactor.id === userId);
+}
+
+/**
+ * Apply an optimistic toggle of `user`'s reaction with `emoji` to a message's
+ * reaction summary, returning a new array (the input is never mutated).
+ *
+ * Mirrors the server's toggle: if the user already reacts with this emoji they
+ * are removed — dropping the whole entry when they were the last reactor —
+ * otherwise they are appended. A brand-new emoji is added to the end, keeping
+ * the first-reacted-first order the server also produces; the broadcast echo
+ * later replaces this optimistic copy with the authoritative one.
+ */
+export function toggleReaction(
+    reactions: Reaction[],
+    emoji: string,
+    user: Mention,
+): Reaction[] {
+    const existing = reactions.find((reaction) => reaction.emoji === emoji);
+
+    if (!existing) {
+        return [...reactions, { emoji, count: 1, reactors: [user] }];
+    }
+
+    if (hasReacted(existing, user.id)) {
+        const reactors = existing.reactors.filter(
+            (reactor) => reactor.id !== user.id,
+        );
+
+        if (reactors.length === 0) {
+            return reactions.filter((reaction) => reaction.emoji !== emoji);
+        }
+
+        return reactions.map((reaction) =>
+            reaction.emoji === emoji
+                ? { ...reaction, count: reactors.length, reactors }
+                : reaction,
+        );
+    }
+
+    const reactors = [...existing.reactors, user];
+
+    return reactions.map((reaction) =>
+        reaction.emoji === emoji
+            ? { ...reaction, count: reactors.length, reactors }
+            : reaction,
+    );
+}
+
+/**
+ * The full, human-readable roster of who reacted with an emoji, for the pill's
+ * hover card, with the viewer surfaced as "You" first: "You", "You and Alice",
+ * "You, Alice and Bob", "Alice", "Alice and Bob", "Alice, Bob and Carol".
+ *
+ * Every reactor is named (the card exists to show exactly who reacted), so —
+ * unlike a compact tooltip — no names are collapsed into an "N others" tail.
+ */
+export function reactionRoster(reaction: Reaction, userId: string): string {
+    const names = reaction.reactors.map((reactor) =>
+        reactor.id === userId ? 'You' : reactor.name,
+    );
+
+    // Keep "You" first so the viewer always reads as the leading reactor.
+    names.sort((a, b) => (a === 'You' ? -1 : b === 'You' ? 1 : 0));
+
+    if (names.length === 1) {
+        return names[0];
+    }
+
+    if (names.length === 2) {
+        return `${names[0]} and ${names[1]}`;
+    }
+
+    const head = names.slice(0, -1).join(', ');
+
+    return `${head} and ${names[names.length - 1]}`;
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -35,6 +35,7 @@ import {
     store as storeMessage,
     update as updateMessage,
 } from '@/actions/App/Http/Controllers/Channels/MessageController';
+import { store as toggleReactionAction } from '@/actions/App/Http/Controllers/Channels/ReactionController';
 import ForwardMessageDialog from '@/components/ForwardMessageDialog.vue';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
@@ -70,6 +71,7 @@ import {
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
+import { toggleReaction } from '@/lib/reactions';
 import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
 import { unreadDividerMessageId } from '@/lib/unreadDivider';
 import type {
@@ -81,6 +83,7 @@ import type {
     MessagePage,
     NotificationLevel,
     NotificationLevelOption,
+    Reaction,
     Thread,
 } from '@/types';
 
@@ -91,6 +94,9 @@ const props = defineProps<{
     members: Mention[];
     canArchive: boolean;
     canManagePreferences: boolean;
+    // Whether the viewer may react (member of a non-archived channel); read-only
+    // reaction pills still render for a non-member browsing a public channel.
+    canReact: boolean;
     notificationLevels: NotificationLevelOption[];
     jumpToMessageId?: string | null;
     // The viewer's read pointer at load time, used to place the "New messages"
@@ -416,6 +422,15 @@ function subscribe(id: string): void {
         .listen('MessageDeleted', (message: Message) => {
             applyPatch(message);
         })
+        .listen(
+            'MessageReactionChanged',
+            (event: { messageId: string; reactions: Reaction[] }) => {
+                // The authoritative, viewer-free summary; patch it into whichever
+                // timeline renders the message (the patch is a no-op elsewhere).
+                mainStream.patchReactions(event.messageId, event.reactions);
+                threadStream.patchReactions(event.messageId, event.reactions);
+            },
+        )
         .listen(
             'MessageRead',
             (event: { reader: MessageAuthor; lastReadMessageId: string }) => {
@@ -873,6 +888,38 @@ function deleteMessage(message: Message): void {
     );
 }
 
+// Toggle the viewer's emoji reaction on a message. The pills update
+// optimistically in whichever timeline renders it; the authoritative summary
+// arrives over the MessageReactionChanged broadcast (including the viewer's own
+// echo), and a failed request rolls the optimistic patch back.
+function reactToMessage(message: Message, emoji: string): void {
+    const previousMain = mainStream.getPatch(message.clientUuid);
+    const previousThread = threadStream.getPatch(message.clientUuid);
+
+    const next = toggleReaction(message.reactions, emoji, currentUser.value);
+    mainStream.patchReactions(message.id, next);
+    threadStream.patchReactions(message.id, next);
+
+    router.post(
+        toggleReactionAction({
+            team: props.team.slug,
+            channel: props.channel.slug,
+            message: message.id,
+        }).url,
+        { emoji },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['channels'],
+            onError: () => {
+                mainStream.restorePatch(message.clientUuid, previousMain);
+                threadStream.restorePatch(message.clientUuid, previousThread);
+                toast.error('Failed to update the reaction. Please try again.');
+            },
+        },
+    );
+}
+
 // Reset the panel's client state without navigating. Used when switching
 // channels, where the URL has already moved off any open thread.
 function resetThreadPanel(): void {
@@ -1222,6 +1269,7 @@ function archive(): void {
                             :pending-uuids="pendingUuids"
                             :current-user-id="currentUser.id"
                             :can-moderate="canModerate"
+                            :can-react="props.canReact"
                             :online-ids="onlineIds"
                             :readers="channelReadersList"
                             :highlight-message-id="highlightedMessageId"
@@ -1231,6 +1279,7 @@ function archive(): void {
                             @delete="deleteMessage"
                             @reply="startReply"
                             @forward="openForward"
+                            @react="reactToMessage"
                             @open-thread="openThread"
                             @jump="jumpToMessage"
                             @mention="mentionInChannel"
@@ -1309,6 +1358,7 @@ function archive(): void {
                 :members="mentionableMembers"
                 :current-user-id="currentUser.id"
                 :can-moderate="canModerate"
+                :can-react="props.canReact"
                 :online-ids="onlineIds"
                 :loading="threadLoading"
                 :read-only="props.channel.isArchived"
@@ -1317,6 +1367,7 @@ function archive(): void {
                 @edit="editMessage"
                 @delete="deleteMessage"
                 @forward="openForward"
+                @react="reactToMessage"
                 @typing="onTyping"
                 @jump="jumpToMessage"
             />

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -68,6 +68,20 @@ export type MessagePreview = {
     siteName: string | null;
 };
 
+/**
+ * A message's reactions for a single emoji. Mirrors the `ReactionData` DTO: the
+ * emoji, its total count, and the reactor set (id + name, for the "you and 3
+ * others" tooltip). The summary is viewer-free — the client derives whether it
+ * reacted by checking its own id against `reactors` — so it rides the
+ * `MessageReactionChanged` broadcast unchanged and every viewer merges the same
+ * payload. Ordered first-reacted first, matching the server's aggregation.
+ */
+export type Reaction = {
+    emoji: string;
+    count: number;
+    reactors: Mention[];
+};
+
 export type Message = {
     id: string;
     clientUuid: string;
@@ -77,6 +91,12 @@ export type Message = {
     editedAt: string | null;
     isDeleted: boolean;
     mentions: Mention[];
+    /**
+     * Aggregated emoji reactions (mirrors the `MessageData` DTO's `reactions`),
+     * one entry per distinct emoji. Empty when nobody has reacted and always
+     * empty on a tombstone. Patched live in place from `MessageReactionChanged`.
+     */
+    reactions: Reaction[];
     /**
      * Open Graph preview cards for the URLs in the body (mirrors the
      * `MessageData` DTO's `linkPreviews`), in order of appearance. Empty when the

--- a/resources/js/types/vue-shims.d.ts
+++ b/resources/js/types/vue-shims.d.ts
@@ -3,3 +3,8 @@ declare module '*.vue' {
     const component: DefineComponent;
     export default component;
 }
+
+// The emoji picker ships its stylesheet under a bare `/css` subpath (not a
+// `*.css` file path), which has no bundled type declaration; it's imported for
+// its side effect only.
+declare module 'vue3-emoji-picker/css';

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Channels\ChannelSectionController;
 use App\Http\Controllers\Channels\ChannelStarController;
 use App\Http\Controllers\Channels\ForwardMessageController;
 use App\Http\Controllers\Channels\MessageController;
+use App\Http\Controllers\Channels\ReactionController;
 use App\Http\Controllers\Channels\SearchController;
 use App\Http\Controllers\Channels\ThreadsController;
 use App\Http\Controllers\SidebarSectionController;
@@ -69,6 +70,9 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/messages/{message}/forward', [ForwardMessageController::class, 'store'])
         ->scopeBindings()
         ->name('channels.messages.forward');
+    Route::post('t/{team}/c/{channel}/messages/{message}/reactions', [ReactionController::class, 'store'])
+        ->scopeBindings()
+        ->name('channels.messages.reactions.store');
     Route::post('t/{team}/c/{channel}/members', [ChannelMemberController::class, 'store'])
         ->scopeBindings()
         ->name('channels.members.store');

--- a/tests/Feature/Channels/MessageReactionTest.php
+++ b/tests/Feature/Channels/MessageReactionTest.php
@@ -1,0 +1,191 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Data\MessageData;
+use App\Enums\TeamRole;
+use App\Events\MessageReactionChanged;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\MessageReaction;
+use App\Models\User;
+use App\Support\AccountDeleter;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function reactionTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * POST the toggle-reaction endpoint for the given actor.
+ */
+function toggleReaction($actor, $team, $channel, $message, string $emoji)
+{
+    return test()->actingAs($actor)->post(route('channels.messages.reactions.store', [
+        'team' => $team->slug,
+        'channel' => $channel->slug,
+        'message' => $message->id,
+    ]), ['emoji' => $emoji]);
+}
+
+test('reacting adds the reaction, and reacting again with the same emoji removes it', function () {
+    [$owner, $team, $general] = reactionTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create();
+
+    toggleReaction($owner, $team, $general, $message, '👍')->assertRedirect();
+
+    expect(MessageReaction::where('message_id', $message->id)->where('user_id', $owner->id)->where('emoji', '👍')->exists())->toBeTrue();
+
+    toggleReaction($owner, $team, $general, $message, '👍')->assertRedirect();
+
+    expect(MessageReaction::where('message_id', $message->id)->exists())->toBeFalse();
+});
+
+test('a user holds at most one row per distinct emoji and can react with several emoji', function () {
+    [$owner, $team, $general] = reactionTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create();
+
+    toggleReaction($owner, $team, $general, $message, '👍');
+    toggleReaction($owner, $team, $general, $message, '🎉');
+
+    expect(MessageReaction::where('message_id', $message->id)->where('user_id', $owner->id)->count())->toBe(2);
+
+    // Toggling one emoji off leaves the other untouched — no duplicate rows.
+    toggleReaction($owner, $team, $general, $message, '👍');
+
+    $remaining = MessageReaction::where('message_id', $message->id)->where('user_id', $owner->id)->get();
+
+    expect($remaining)->toHaveCount(1)
+        ->and($remaining->first()->emoji)->toBe('🎉');
+});
+
+test('a non-member of a private channel cannot react', function () {
+    [$owner, $team] = reactionTeamWithGeneral();
+
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    $private = Channel::factory()->for($team)->private()->create();
+    $private->channelMembers()->create(['user_id' => $owner->id]);
+    $message = Message::factory()->for($private)->for($owner)->create();
+
+    toggleReaction($stranger, $team, $private, $message, '👍')->assertForbidden();
+
+    expect(MessageReaction::where('message_id', $message->id)->exists())->toBeFalse();
+});
+
+test('reactions cannot be added in an archived channel', function () {
+    [$owner, $team, $general] = reactionTeamWithGeneral();
+    $channel = Channel::factory()->for($team)->create(['archived_at' => now()]);
+    $channel->channelMembers()->create(['user_id' => $owner->id]);
+    $message = Message::factory()->for($channel)->for($owner)->create();
+
+    toggleReaction($owner, $team, $channel, $message, '👍')->assertForbidden();
+
+    expect(MessageReaction::where('message_id', $message->id)->exists())->toBeFalse();
+});
+
+test('the emoji is required', function () {
+    [$owner, $team, $general] = reactionTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($owner)->post(route('channels.messages.reactions.store', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+        'message' => $message->id,
+    ]), [])->assertInvalid(['emoji']);
+});
+
+test('a message aggregates its reactions per emoji with reactor sets', function () {
+    [$owner, $team, $general] = reactionTeamWithGeneral();
+    $alice = User::factory()->create(['name' => 'Alice']);
+    $team->memberships()->create(['user_id' => $alice->id, 'role' => TeamRole::Member]);
+
+    $message = Message::factory()->for($general)->for($owner)->create();
+
+    MessageReaction::factory()->for($message)->for($owner)->emoji('👍')->create();
+    MessageReaction::factory()->for($message)->for($alice)->emoji('👍')->create();
+    MessageReaction::factory()->for($message)->for($alice)->emoji('🎉')->create();
+
+    $message->load('reactions.user');
+    $reactions = MessageData::fromMessage($message)->reactions;
+
+    expect($reactions)->toHaveCount(2);
+
+    $thumbs = collect($reactions)->firstWhere('emoji', '👍');
+    $party = collect($reactions)->firstWhere('emoji', '🎉');
+
+    expect($thumbs->count)->toBe(2)
+        ->and(collect($thumbs->reactors)->pluck('name')->all())->toEqualCanonicalizing(['Alice', $owner->name])
+        ->and($party->count)->toBe(1)
+        ->and($party->reactors[0]->name)->toBe('Alice');
+});
+
+test('toggling a reaction broadcasts MessageReactionChanged on the channel with the fresh summary', function () {
+    Event::fake([MessageReactionChanged::class]);
+
+    [$owner, $team, $general] = reactionTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create();
+
+    // Add.
+    toggleReaction($owner, $team, $general, $message, '👍');
+
+    Event::assertDispatched(MessageReactionChanged::class, function (MessageReactionChanged $event) use ($general, $message) {
+        $target = $event->broadcastOn()[0];
+        $payload = $event->broadcastWith();
+
+        expect($target)->toBeInstanceOf(PrivateChannel::class)
+            ->and($target->name)->toBe('private-channel.'.$general->id);
+
+        return $payload['messageId'] === $message->id
+            && count($payload['reactions']) === 1
+            && $payload['reactions'][0]['emoji'] === '👍'
+            && $payload['reactions'][0]['count'] === 1;
+    });
+
+    // Remove — still broadcasts, now with an empty summary.
+    toggleReaction($owner, $team, $general, $message, '👍');
+
+    Event::assertDispatchedTimes(MessageReactionChanged::class, 2);
+    Event::assertDispatched(MessageReactionChanged::class, fn (MessageReactionChanged $event) => $event->broadcastWith()['reactions'] === []);
+});
+
+test('deleting a message removes its reactions and emits none in the tombstone payload', function () {
+    [$owner, $team, $general] = reactionTeamWithGeneral();
+    $message = Message::factory()->for($general)->for($owner)->create();
+    MessageReaction::factory()->for($message)->for($owner)->emoji('👍')->create();
+
+    $this->actingAs($owner)->delete(route('channels.messages.destroy', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+        'message' => $message->id,
+    ]))->assertRedirect();
+
+    expect(MessageReaction::where('message_id', $message->id)->exists())->toBeFalse();
+
+    $message->refresh()->loadMissing('user');
+    expect(MessageData::fromMessage($message)->reactions)->toBe([]);
+});
+
+test('deleting a reacting user drops their reactions via the cascade', function () {
+    [$owner, $team, $general] = reactionTeamWithGeneral();
+    $alice = User::factory()->create();
+    $team->memberships()->create(['user_id' => $alice->id, 'role' => TeamRole::Member]);
+
+    $message = Message::factory()->for($general)->for($owner)->create();
+    MessageReaction::factory()->for($message)->for($alice)->emoji('👍')->create();
+
+    app(AccountDeleter::class)->delete($alice);
+
+    expect(MessageReaction::where('message_id', $message->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
Closes #104.

Lets channel members react to a message with emoji. Each reaction is a `(message, user, emoji)` tuple: toggled on/off per user, aggregated per emoji under the message, and synced in real time to everyone viewing the channel or thread.

## What's included
- **Schema/model** — `message_reactions` table with `unique(message_id, user_id, emoji)` and both FKs `cascadeOnDelete`; `MessageReaction` model + `reactions()` relation on `Message` (ordered first-reacted first).
- **Aggregation** — `ReactionData::forMessage()` groups reactions per emoji into `{ emoji, count, reactors[] }` and rides on `MessageData`. The summary is **viewer-free**: the client derives "did I react" from the reactor ids, so the same payload broadcasts to everyone (mirrors the existing thread-state pattern) and `MessageData::fromMessage` needs no viewer.
- **Toggle endpoint** — `POST .../messages/{message}/reactions` gated by `ReactionRequest`, which reuses the `postMessage` rule (members only; archived channels stay read-only). `ToggleReaction` flips the single row and broadcasts a slim `MessageReactionChanged { messageId, reactions[] }` the client merges into the row it already renders, matched by id.
- **No N+1 / cleanup** — `reactions.user` eager-loaded at every message-loading site; rows hard-deleted when a message is soft-deleted (tombstone shows none) and dropped via the `user_id` cascade on account deletion.
- **Frontend** — reaction pills + an add-reaction affordance. To avoid layout reflow on hover, the add button for a message with no reactions lives in the **floating** hover toolbar (absolute-positioned), and the in-flow pills row only renders once reactions exist. A **hover card lists who reacted** ("You, Alice and Bob reacted"). The emoji picker (`vue3-emoji-picker`) is **lazy-loaded client-only** (it touches `indexedDB` at import, absent under SSR). Toggling is optimistic and reconciled by the broadcast echo.
- **Seeder** — `WorkspaceSeeder` seeds a popular message (👍 from three incl. the demo user, plus 🎉) and a lightly-reacted one.

## Decisions (confirmed with product before building)
- Emoji picker: `vue3-emoji-picker` (approved dependency add).
- Endpoint: single toggle POST (not store/destroy).
- Broadcast: slim `MessageReactionChanged` (not re-broadcasting full `MessageData`).
- Storage: unicode emoji char, unique per `(message, user, emoji)`.

## Tests
- **Backend** (`tests/Feature/Channels/MessageReactionTest.php`, 9 tests): toggle add→remove, the one-row-per-emoji invariant, non-member 403, archived 403, emoji required, aggregation shape, `MessageReactionChanged` dispatched on add **and** remove, cleanup on message soft-delete and on reacting-user deletion.
- **Frontend** (`resources/js/lib/reactions.test.ts`, 13 tests): `toggleReaction` (add/append/remove/drop, non-mutation), `hasReacted`, `reactionRoster`.

## Gates
- Backend `composer test` (Pint + PHPStan + coverage): **Total: 100.0 %**.
- Frontend: `lint:check`, `format:check`, `types:check`, `build`, and `test:js` all pass.