### PR TITLE
Polish message-timeline scroll UX (jump-to-latest, new-message pill, styled scrollbar)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
                 "prettier-plugin-tailwindcss": "^0.6.11",
                 "pusher-js": "^8.5.0",
                 "shadcn-vue": "^2.7.4",
+                "tailwind-scrollbar": "^4.0.2",
                 "typescript": "^5.2.2",
                 "typescript-eslint": "^8.23.0",
                 "vite": "^8.0.0",
@@ -2052,6 +2053,13 @@
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
+        },
+        "node_modules/@types/prismjs": {
+            "version": "1.26.6",
+            "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+            "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/web-bluetooth": {
             "version": "0.0.21",
@@ -8795,6 +8803,20 @@
                 }
             }
         },
+        "node_modules/prism-react-renderer": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz",
+            "integrity": "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/prismjs": "^1.26.0",
+                "clsx": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.0.0"
+            }
+        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -8920,6 +8942,17 @@
             "dependencies": {
                 "defu": "^6.1.6",
                 "destr": "^2.0.5"
+            }
+        },
+        "node_modules/react": {
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/readdirp": {
@@ -10145,6 +10178,22 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/dcastil"
+            }
+        },
+        "node_modules/tailwind-scrollbar": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/tailwind-scrollbar/-/tailwind-scrollbar-4.0.2.tgz",
+            "integrity": "sha512-wAQiIxAPqk0MNTPptVe/xoyWi27y+NRGnTwvn4PQnbvB9kp8QUBiGl/wsfoVBHnQxTmhXJSNt9NHTmcz9EivFA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "prism-react-renderer": "^2.4.1"
+            },
+            "engines": {
+                "node": ">=12.13.0"
+            },
+            "peerDependencies": {
+                "tailwindcss": "4.x"
             }
         },
         "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "prettier-plugin-tailwindcss": "^0.6.11",
         "pusher-js": "^8.5.0",
         "shadcn-vue": "^2.7.4",
+        "tailwind-scrollbar": "^4.0.2",
         "typescript": "^5.2.2",
         "typescript-eslint": "^8.23.0",
         "vite": "^8.0.0",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -2,6 +2,8 @@
 
 @import 'tw-animate-css';
 
+@plugin 'tailwind-scrollbar';
+
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 @source '../../storage/framework/views/*.php';
 

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { InfiniteScroll } from '@inertiajs/vue3';
-import { X } from '@lucide/vue';
+import { ChevronDown, X } from '@lucide/vue';
 import { computed, nextTick, ref, watch } from 'vue';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useScrollPin } from '@/composables/useScrollPin';
 import type { Mention, Message } from '@/types';
 
 const props = defineProps<{
@@ -47,31 +48,18 @@ const hasRoot = computed(() => root.value !== undefined);
 const replyCount = computed(() => root.value?.threadReplyCount ?? 0);
 const showSkeleton = computed(() => props.loading || !hasRoot.value);
 
-// Distance (px) from the bottom within which the panel stays pinned to newest,
-// matching the main timeline's behaviour.
-const NEAR_BOTTOM_THRESHOLD = 120;
+// Shared scroll/pin bookkeeping, identical to the main timeline's: the
+// pinned-to-newest flag, the "N new replies" count while scrolled up, and the
+// smooth jump back to the bottom.
 const scrollContainer = ref<HTMLElement | null>(null);
-
-function isNearBottom(): boolean {
-    const el = scrollContainer.value;
-
-    if (!el) {
-        return true;
-    }
-
-    return (
-        el.scrollHeight - el.scrollTop - el.clientHeight <=
-        NEAR_BOTTOM_THRESHOLD
-    );
-}
-
-function scrollToBottom(): void {
-    const el = scrollContainer.value;
-
-    if (el) {
-        el.scrollTop = el.scrollHeight;
-    }
-}
+const {
+    pinnedToBottom,
+    newMessageCount,
+    isNearBottom,
+    scrollToBottom,
+    notifyAppended,
+    onScroll,
+} = useScrollPin(scrollContainer);
 
 // The thread reply composer, so a hover card on a thread message can drop a
 // mention into it rather than the main channel composer.
@@ -81,14 +69,33 @@ function mentionInThread(member: { id: string; name: string }): void {
     threadComposer.value?.insertMention(member);
 }
 
-// Keep the panel pinned to the newest reply as the conversation grows, unless
-// the reader has scrolled up to older replies.
+// The id of the newest reply currently shown, so a reply appended at the bottom
+// (which should follow the reader or raise the count) can be told apart from
+// older replies paging in at the top, which must leave the viewport anchored.
+const newestMessageId = ref<string | null>(null);
+
+// Keep the panel pinned to the newest reply as the conversation grows: the
+// initial load lands at the bottom, a later reply appended at the bottom follows
+// the reader down (or raises the "new replies" count while they're scrolled up),
+// and older replies paging in above are left in place. `isNearBottom()` is read
+// pre-flush, so it reflects the position before the new row grows the panel.
 watch(
-    () => props.messages.length,
-    () => {
-        if (isNearBottom()) {
-            nextTick(scrollToBottom);
+    () => props.messages,
+    (messages, previous) => {
+        const newestId = messages[messages.length - 1]?.id ?? null;
+        const previousLength = previous?.length ?? 0;
+
+        if (messages.length > previousLength) {
+            const wasNearBottom = isNearBottom();
+
+            if (previousLength === 0) {
+                nextTick(() => scrollToBottom());
+            } else if (newestId !== newestMessageId.value) {
+                notifyAppended(wasNearBottom);
+            }
         }
+
+        newestMessageId.value = newestId;
     },
 );
 </script>
@@ -125,51 +132,93 @@ watch(
             </button>
         </header>
 
-        <div ref="scrollContainer" class="min-h-0 flex-1 overflow-y-auto">
-            <div v-if="showSkeleton" class="space-y-4 p-5">
-                <div class="flex gap-3">
-                    <Skeleton class="size-9 rounded-[10px]" />
-                    <div class="flex-1 space-y-2">
-                        <Skeleton class="h-3 w-24" />
-                        <Skeleton class="h-3 w-3/4" />
+        <div class="relative flex min-h-0 flex-1 flex-col">
+            <div
+                ref="scrollContainer"
+                class="scrollbar-thin min-h-0 flex-1 scrollbar-thumb-border scrollbar-track-transparent overflow-y-auto overscroll-contain"
+                @scroll.passive="onScroll"
+            >
+                <div v-if="showSkeleton" class="space-y-4 p-5">
+                    <div class="flex gap-3">
+                        <Skeleton class="size-9 rounded-[10px]" />
+                        <div class="flex-1 space-y-2">
+                            <Skeleton class="h-3 w-24" />
+                            <Skeleton class="h-3 w-3/4" />
+                        </div>
+                    </div>
+                    <div class="flex gap-3">
+                        <Skeleton class="size-9 rounded-[10px]" />
+                        <div class="flex-1 space-y-2">
+                            <Skeleton class="h-3 w-20" />
+                            <Skeleton class="h-3 w-1/2" />
+                        </div>
                     </div>
                 </div>
-                <div class="flex gap-3">
-                    <Skeleton class="size-9 rounded-[10px]" />
-                    <div class="flex-1 space-y-2">
-                        <Skeleton class="h-3 w-20" />
-                        <Skeleton class="h-3 w-1/2" />
-                    </div>
-                </div>
+
+                <!-- Older replies page in on scroll-up; keyed by root so switching
+                     threads mounts a fresh, bottom-anchored list. `preserve-url`
+                     keeps the cursor out of the URL, matching the main timeline. -->
+                <InfiniteScroll
+                    v-else
+                    :key="props.rootId"
+                    data="threadReplies"
+                    reverse
+                    preserve-url
+                >
+                    <MessageList
+                        :messages="props.messages"
+                        :team-slug="props.teamSlug"
+                        :pending-uuids="props.pendingUuids"
+                        :current-user-id="props.currentUserId"
+                        :can-moderate="props.canModerate"
+                        :can-react="props.canReact"
+                        :online-ids="props.onlineIds"
+                        in-thread
+                        @edit="(message, body) => emit('edit', message, body)"
+                        @delete="(message) => emit('delete', message)"
+                        @forward="(message) => emit('forward', message)"
+                        @react="
+                            (message, emoji) => emit('react', message, emoji)
+                        "
+                        @jump="(id) => emit('jump', id)"
+                        @mention="mentionInThread"
+                    />
+                </InfiniteScroll>
             </div>
 
-            <!-- Older replies page in on scroll-up; keyed by root so switching
-                 threads mounts a fresh, bottom-anchored list. `preserve-url`
-                 keeps the cursor out of the URL, matching the main timeline. -->
-            <InfiniteScroll
-                v-else
-                :key="props.rootId"
-                data="threadReplies"
-                reverse
-                preserve-url
+            <Transition
+                enter-active-class="transition duration-150 ease-out"
+                enter-from-class="translate-y-1 opacity-0"
+                enter-to-class="translate-y-0 opacity-100"
+                leave-active-class="transition duration-100 ease-in"
+                leave-from-class="translate-y-0 opacity-100"
+                leave-to-class="translate-y-1 opacity-0"
             >
-                <MessageList
-                    :messages="props.messages"
-                    :team-slug="props.teamSlug"
-                    :pending-uuids="props.pendingUuids"
-                    :current-user-id="props.currentUserId"
-                    :can-moderate="props.canModerate"
-                    :can-react="props.canReact"
-                    :online-ids="props.onlineIds"
-                    in-thread
-                    @edit="(message, body) => emit('edit', message, body)"
-                    @delete="(message) => emit('delete', message)"
-                    @forward="(message) => emit('forward', message)"
-                    @react="(message, emoji) => emit('react', message, emoji)"
-                    @jump="(id) => emit('jump', id)"
-                    @mention="mentionInThread"
-                />
-            </InfiniteScroll>
+                <button
+                    v-if="!pinnedToBottom"
+                    type="button"
+                    data-test="jump-to-latest-thread"
+                    :data-new-count="newMessageCount"
+                    :aria-label="
+                        newMessageCount > 0
+                            ? `${newMessageCount} new replies, jump to latest`
+                            : 'Jump to latest reply'
+                    "
+                    class="absolute right-4 bottom-4 z-10 inline-flex items-center gap-1.5 rounded-full shadow-md transition-colors"
+                    :class="
+                        newMessageCount > 0
+                            ? 'bg-primary px-3 py-1.5 text-[12px] font-semibold text-primary-foreground hover:opacity-90'
+                            : 'size-9 justify-center bg-card text-muted-foreground ring-1 ring-border hover:bg-muted hover:text-foreground'
+                    "
+                    @click="scrollToBottom(true)"
+                >
+                    <ChevronDown class="size-4 shrink-0" />
+                    <span v-if="newMessageCount > 0">
+                        {{ newMessageCount }} new
+                        {{ newMessageCount === 1 ? 'reply' : 'replies' }}
+                    </span>
+                </button>
+            </Transition>
         </div>
 
         <MessageComposer

--- a/resources/js/composables/useScrollPin.test.ts
+++ b/resources/js/composables/useScrollPin.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from 'vitest';
+import { nextTick, ref } from 'vue';
+import {
+    NEAR_BOTTOM_THRESHOLD,
+    useScrollPin,
+} from '@/composables/useScrollPin';
+
+/**
+ * A stand-in for the scroll container, exposing just the geometry the composable
+ * reads plus a `scrollTo` spy. `scrollTo` moves the element to the bottom so a
+ * subsequent `isNearBottom()` reflects the pinned position, mirroring the DOM.
+ */
+function fakeElement(geometry: {
+    scrollHeight: number;
+    scrollTop: number;
+    clientHeight: number;
+}): HTMLElement {
+    const el = {
+        ...geometry,
+        scrollTo: vi.fn((options: ScrollToOptions) => {
+            el.scrollTop = (options.top ?? 0) as number;
+        }),
+    };
+
+    return el as unknown as HTMLElement;
+}
+
+describe('useScrollPin', () => {
+    it('treats a missing container as pinned to the bottom', () => {
+        const { isNearBottom } = useScrollPin(ref(null));
+
+        expect(isNearBottom()).toBe(true);
+    });
+
+    it('reports near-bottom at and within the threshold, but not beyond it', () => {
+        const el = fakeElement({
+            scrollHeight: 1000,
+            clientHeight: 100,
+            // Exactly NEAR_BOTTOM_THRESHOLD from the bottom.
+            scrollTop: 1000 - 100 - NEAR_BOTTOM_THRESHOLD,
+        });
+        const { isNearBottom } = useScrollPin(ref(el));
+
+        expect(isNearBottom()).toBe(true);
+
+        // One pixel further up crosses the threshold.
+        el.scrollTop -= 1;
+        expect(isNearBottom()).toBe(false);
+    });
+
+    it('counts appends that arrive while scrolled up, without moving the view', () => {
+        const el = fakeElement({
+            scrollHeight: 1000,
+            clientHeight: 100,
+            scrollTop: 0,
+        });
+        const { newMessageCount, notifyAppended } = useScrollPin(ref(el));
+
+        notifyAppended(false);
+        notifyAppended(false);
+
+        expect(newMessageCount.value).toBe(2);
+        expect(el.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('scrolls to the bottom instead of counting when the reader was near it', async () => {
+        const el = fakeElement({
+            scrollHeight: 1000,
+            clientHeight: 100,
+            scrollTop: 900,
+        });
+        const { newMessageCount, notifyAppended } = useScrollPin(ref(el));
+
+        notifyAppended(true);
+        await nextTick();
+
+        expect(newMessageCount.value).toBe(0);
+        expect(el.scrollTo).toHaveBeenCalledWith({
+            top: 1000,
+            behavior: 'auto',
+        });
+    });
+
+    it('scrolls smoothly and clears the unread count on an explicit jump', () => {
+        const el = fakeElement({
+            scrollHeight: 1000,
+            clientHeight: 100,
+            scrollTop: 0,
+        });
+        const {
+            newMessageCount,
+            pinnedToBottom,
+            notifyAppended,
+            scrollToBottom,
+        } = useScrollPin(ref(el));
+
+        notifyAppended(false);
+        expect(newMessageCount.value).toBe(1);
+
+        scrollToBottom(true);
+
+        expect(el.scrollTo).toHaveBeenCalledWith({
+            top: 1000,
+            behavior: 'smooth',
+        });
+        expect(newMessageCount.value).toBe(0);
+        expect(pinnedToBottom.value).toBe(true);
+    });
+
+    it('re-pins and clears the count once the reader scrolls back to the bottom', () => {
+        const el = fakeElement({
+            scrollHeight: 1000,
+            clientHeight: 100,
+            scrollTop: 0,
+        });
+        const { newMessageCount, pinnedToBottom, notifyAppended, onScroll } =
+            useScrollPin(ref(el));
+
+        // Scrolled up: a new arrival is counted and the view is unpinned.
+        notifyAppended(false);
+        onScroll();
+        expect(pinnedToBottom.value).toBe(false);
+        expect(newMessageCount.value).toBe(1);
+
+        // The reader drags back to the bottom.
+        el.scrollTop = 900;
+        onScroll();
+        expect(pinnedToBottom.value).toBe(true);
+        expect(newMessageCount.value).toBe(0);
+    });
+
+    it('reset returns to the pinned, zero-count baseline', () => {
+        const el = fakeElement({
+            scrollHeight: 1000,
+            clientHeight: 100,
+            scrollTop: 0,
+        });
+        const {
+            newMessageCount,
+            pinnedToBottom,
+            notifyAppended,
+            onScroll,
+            reset,
+        } = useScrollPin(ref(el));
+
+        notifyAppended(false);
+        onScroll();
+        expect(pinnedToBottom.value).toBe(false);
+        expect(newMessageCount.value).toBe(1);
+
+        reset();
+
+        expect(pinnedToBottom.value).toBe(true);
+        expect(newMessageCount.value).toBe(0);
+    });
+});

--- a/resources/js/composables/useScrollPin.ts
+++ b/resources/js/composables/useScrollPin.ts
@@ -1,0 +1,116 @@
+import { nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+
+/**
+ * Distance (px) from the bottom within which the timeline stays pinned to the
+ * newest message, so an incoming message never yanks a reader who has scrolled
+ * up into older history.
+ */
+export const NEAR_BOTTOM_THRESHOLD = 120;
+
+/**
+ * Shared scroll/pin bookkeeping for a message timeline.
+ *
+ * Owns the "near the bottom?" threshold, the pinned-to-newest flag, and the
+ * count of messages that have arrived while the reader is scrolled up. Both the
+ * main channel timeline and the thread panel drive their floating
+ * "jump to latest / N new messages" control from this single source of truth so
+ * the two can't drift apart.
+ *
+ * The composable never attaches its own listeners: the consumer binds `onScroll`
+ * to the container's `@scroll` event, keeping this lifecycle-free and unit
+ * testable.
+ */
+export function useScrollPin(container: Ref<HTMLElement | null>) {
+    // Whether the view is currently anchored to the newest message. Optimistic
+    // on mount (reverse InfiniteScroll lands at the bottom) until the first
+    // scroll event corrects it.
+    const pinnedToBottom = ref(true);
+
+    // Messages that have arrived while the reader is scrolled up, surfaced as the
+    // "N new messages" state on the jump-to-latest control.
+    const newMessageCount = ref(0);
+
+    /**
+     * Whether the container is scrolled to within `NEAR_BOTTOM_THRESHOLD` of the
+     * bottom. A missing element counts as pinned, matching the mount-time state.
+     */
+    function isNearBottom(): boolean {
+        const el = container.value;
+
+        if (!el) {
+            return true;
+        }
+
+        return (
+            el.scrollHeight - el.scrollTop - el.clientHeight <=
+            NEAR_BOTTOM_THRESHOLD
+        );
+    }
+
+    /**
+     * Anchor the view to the newest message, clearing the pinned flag and the
+     * unread count. `smooth` animates the jump for user-initiated returns; the
+     * automatic pin on a live append passes it falsy for an instant snap.
+     */
+    function scrollToBottom(smooth = false): void {
+        const el = container.value;
+
+        if (el) {
+            el.scrollTo({
+                top: el.scrollHeight,
+                behavior: smooth ? 'smooth' : 'auto',
+            });
+        }
+
+        pinnedToBottom.value = true;
+        newMessageCount.value = 0;
+    }
+
+    /**
+     * React to a freshly appended message. `wasNearBottom` is captured by the
+     * caller *before* the DOM grows: when true the view follows the message to
+     * the bottom; otherwise the arrival is counted so the control can offer a
+     * jump. The scroll is deferred a tick so the new row is laid out first.
+     */
+    function notifyAppended(wasNearBottom: boolean): void {
+        if (wasNearBottom) {
+            nextTick(() => scrollToBottom());
+
+            return;
+        }
+
+        newMessageCount.value += 1;
+    }
+
+    /**
+     * Recompute the pinned flag from the live scroll position, clearing the
+     * unread count once the reader reaches the bottom under their own steam.
+     */
+    function onScroll(): void {
+        const near = isNearBottom();
+        pinnedToBottom.value = near;
+
+        if (near) {
+            newMessageCount.value = 0;
+        }
+    }
+
+    /**
+     * Return to the pinned, zero-count baseline, e.g. when switching channels.
+     */
+    function reset(): void {
+        pinnedToBottom.value = true;
+        newMessageCount.value = 0;
+    }
+
+    return {
+        pinnedToBottom,
+        newMessageCount,
+        isNearBottom,
+        scrollToBottom,
+        notifyAppended,
+        onScroll,
+        reset,
+    };
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -7,6 +7,7 @@ import {
     AtSign,
     BellMinus,
     BellOff,
+    ChevronDown,
     EllipsisVertical,
     Star,
 } from '@lucide/vue';
@@ -68,6 +69,7 @@ import {
     useMessageStream,
     optimisticMessage,
 } from '@/composables/useMessageStream';
+import { useScrollPin } from '@/composables/useScrollPin';
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
@@ -158,11 +160,20 @@ const canModerate = computed(() =>
     ['admin', 'owner'].includes(page.props.currentTeam?.role ?? ''),
 );
 
-// Distance (px) from the bottom within which the view stays pinned to newest,
-// so an incoming message never yanks a user who is reading older history.
-const NEAR_BOTTOM_THRESHOLD = 120;
-
 const scrollContainer = ref<HTMLElement | null>(null);
+
+// Shared scroll/pin bookkeeping: the pinned-to-newest flag, the "N new messages"
+// count while scrolled up, and the smooth jump back to the bottom. The thread
+// panel runs its own instance of the same composable.
+const {
+    pinnedToBottom,
+    newMessageCount,
+    isNearBottom,
+    scrollToBottom,
+    notifyAppended,
+    onScroll,
+    reset: resetScrollPin,
+} = useScrollPin(scrollContainer);
 
 // `Inertia::scroll` delivers messages newest-first; reverse for display.
 const serverMessages = computed<Message[]>(() =>
@@ -199,27 +210,6 @@ const threadServerMessages = computed<Message[]>(() =>
 const threadStream = useMessageStream(threadServerMessages);
 const threadMessages = threadStream.displayMessages;
 const threadPendingUuids = threadStream.pendingUuids;
-
-function isNearBottom(): boolean {
-    const el = scrollContainer.value;
-
-    if (!el) {
-        return true;
-    }
-
-    return (
-        el.scrollHeight - el.scrollTop - el.clientHeight <=
-        NEAR_BOTTOM_THRESHOLD
-    );
-}
-
-function scrollToBottom(): void {
-    const el = scrollContainer.value;
-
-    if (el) {
-        el.scrollTop = el.scrollHeight;
-    }
-}
 
 // The message to briefly highlight after a search jump. The server windows the
 // initial page so the target is loaded; we scroll it into view and clear the
@@ -304,13 +294,14 @@ function scrollToUnread(): void {
         ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
 }
 
-// Append a message to the main timeline, keeping the view pinned to newest only
-// when the reader was already near the bottom.
+// Append a message to the main timeline. When the reader was near the bottom the
+// view follows it down; otherwise the arrival raises the "new messages" count on
+// the jump-to-latest control instead of scrolling silently.
 function appendLiveMain(message: Message): void {
-    const pinned = isNearBottom();
+    const wasNearBottom = isNearBottom();
 
-    if (mainStream.appendLive(message) && pinned) {
-        nextTick(scrollToBottom);
+    if (mainStream.appendLive(message)) {
+        notifyAppended(wasNearBottom);
     }
 }
 
@@ -542,6 +533,7 @@ watch(
         }
 
         mainStream.reset();
+        resetScrollPin();
         resetThreadPanel();
         replyTarget.value = null;
         typing.reset();
@@ -752,7 +744,7 @@ function send(body: string, mentions: Mention[]): void {
     );
 
     cancelReply();
-    nextTick(scrollToBottom);
+    nextTick(() => scrollToBottom());
 
     router.post(
         storeMessage({ team: props.team.slug, channel: props.channel.slug })
@@ -830,12 +822,14 @@ function sendThreadReply(
 }
 
 // Add an optimistic row to the main timeline, keeping the pinned-to-bottom rule.
+// This is the viewer's own message (a forward or sent-to-channel reply), so it
+// follows them down when near the bottom but never inflates the unread count.
 function appendPendingMain(message: Message): void {
     const pinned = isNearBottom();
     mainStream.addPending(message);
 
     if (pinned) {
-        nextTick(scrollToBottom);
+        nextTick(() => scrollToBottom());
     }
 }
 
@@ -1233,80 +1227,121 @@ function archive(): void {
             </header>
 
             <div class="relative flex min-h-0 flex-1 flex-col">
-                <Transition
-                    enter-active-class="transition duration-150 ease-out"
-                    enter-from-class="-translate-y-1 opacity-0"
-                    enter-to-class="translate-y-0 opacity-100"
-                    leave-active-class="transition duration-100 ease-in"
-                    leave-from-class="translate-y-0 opacity-100"
-                    leave-to-class="-translate-y-1 opacity-0"
-                >
-                    <button
-                        v-if="showJumpToUnread"
-                        type="button"
-                        data-test="jump-to-unread"
-                        class="absolute top-2.5 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-rose-500 px-3 py-1 text-[12px] font-semibold text-white shadow-md hover:bg-rose-600"
-                        @click="scrollToUnread"
+                <div class="relative flex min-h-0 flex-1 flex-col">
+                    <Transition
+                        enter-active-class="transition duration-150 ease-out"
+                        enter-from-class="-translate-y-1 opacity-0"
+                        enter-to-class="translate-y-0 opacity-100"
+                        leave-active-class="transition duration-100 ease-in"
+                        leave-from-class="translate-y-0 opacity-100"
+                        leave-to-class="-translate-y-1 opacity-0"
                     >
-                        <ArrowUp class="size-3.5" />
-                        New messages
-                    </button>
-                </Transition>
-
-                <div
-                    ref="scrollContainer"
-                    class="min-h-0 flex-1 overflow-y-auto"
-                >
-                    <InfiniteScroll
-                        v-if="hasMessages"
-                        data="messages"
-                        reverse
-                        preserve-url
-                    >
-                        <MessageList
-                            :messages="displayMessages"
-                            :team-slug="props.team.slug"
-                            :pending-uuids="pendingUuids"
-                            :current-user-id="currentUser.id"
-                            :can-moderate="canModerate"
-                            :can-react="props.canReact"
-                            :online-ids="onlineIds"
-                            :readers="channelReadersList"
-                            :highlight-message-id="highlightedMessageId"
-                            :unread-divider-id="unreadDividerId"
-                            :active-thread-root-id="activeThreadRootId"
-                            @edit="editMessage"
-                            @delete="deleteMessage"
-                            @reply="startReply"
-                            @forward="openForward"
-                            @react="reactToMessage"
-                            @open-thread="openThread"
-                            @jump="jumpToMessage"
-                            @mention="mentionInChannel"
-                        />
-                    </InfiniteScroll>
+                        <button
+                            v-if="showJumpToUnread"
+                            type="button"
+                            data-test="jump-to-unread"
+                            class="absolute top-2.5 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-rose-500 px-3 py-1 text-[12px] font-semibold text-white shadow-md hover:bg-rose-600"
+                            @click="scrollToUnread"
+                        >
+                            <ArrowUp class="size-3.5" />
+                            New messages
+                        </button>
+                    </Transition>
 
                     <div
-                        v-else
-                        class="flex h-full flex-col items-center justify-center gap-1"
+                        ref="scrollContainer"
+                        class="scrollbar-thin min-h-0 flex-1 scrollbar-thumb-border scrollbar-track-transparent overflow-y-auto overscroll-contain"
+                        @scroll.passive="onScroll"
                     >
+                        <InfiniteScroll
+                            v-if="hasMessages"
+                            data="messages"
+                            reverse
+                            preserve-url
+                        >
+                            <MessageList
+                                :messages="displayMessages"
+                                :team-slug="props.team.slug"
+                                :pending-uuids="pendingUuids"
+                                :current-user-id="currentUser.id"
+                                :can-moderate="canModerate"
+                                :can-react="props.canReact"
+                                :online-ids="onlineIds"
+                                :readers="channelReadersList"
+                                :highlight-message-id="highlightedMessageId"
+                                :unread-divider-id="unreadDividerId"
+                                :active-thread-root-id="activeThreadRootId"
+                                @edit="editMessage"
+                                @delete="deleteMessage"
+                                @reply="startReply"
+                                @forward="openForward"
+                                @react="reactToMessage"
+                                @open-thread="openThread"
+                                @jump="jumpToMessage"
+                                @mention="mentionInChannel"
+                            />
+                        </InfiniteScroll>
+
                         <div
-                            class="flex size-14 items-center justify-center rounded-2xl border border-border bg-muted text-2xl font-semibold text-muted-foreground"
-                            aria-hidden="true"
+                            v-else
+                            class="flex h-full flex-col items-center justify-center gap-1"
                         >
-                            #
+                            <div
+                                class="flex size-14 items-center justify-center rounded-2xl border border-border bg-muted text-2xl font-semibold text-muted-foreground"
+                                aria-hidden="true"
+                            >
+                                #
+                            </div>
+                            <p
+                                class="mt-2.5 text-[15px] font-semibold text-foreground"
+                            >
+                                No messages yet
+                            </p>
+                            <p class="text-[13.5px] text-muted-foreground">
+                                Be the first to say something in #{{
+                                    props.channel.name
+                                }}.
+                            </p>
                         </div>
-                        <p
-                            class="mt-2.5 text-[15px] font-semibold text-foreground"
-                        >
-                            No messages yet
-                        </p>
-                        <p class="text-[13.5px] text-muted-foreground">
-                            Be the first to say something in #{{
-                                props.channel.name
-                            }}.
-                        </p>
                     </div>
+
+                    <Transition
+                        enter-active-class="transition duration-150 ease-out"
+                        enter-from-class="translate-y-1 opacity-0"
+                        enter-to-class="translate-y-0 opacity-100"
+                        leave-active-class="transition duration-100 ease-in"
+                        leave-from-class="translate-y-0 opacity-100"
+                        leave-to-class="translate-y-1 opacity-0"
+                    >
+                        <button
+                            v-if="!pinnedToBottom"
+                            type="button"
+                            data-test="jump-to-latest"
+                            :data-new-count="newMessageCount"
+                            :aria-label="
+                                newMessageCount > 0
+                                    ? `${newMessageCount} new messages, jump to latest`
+                                    : 'Jump to latest message'
+                            "
+                            class="absolute right-4 bottom-4 z-10 inline-flex items-center gap-1.5 rounded-full shadow-md transition-colors"
+                            :class="
+                                newMessageCount > 0
+                                    ? 'bg-primary px-3 py-1.5 text-[12px] font-semibold text-primary-foreground hover:opacity-90'
+                                    : 'size-9 justify-center bg-card text-muted-foreground ring-1 ring-border hover:bg-muted hover:text-foreground'
+                            "
+                            @click="scrollToBottom(true)"
+                        >
+                            <ChevronDown class="size-4 shrink-0" />
+                            <span v-if="newMessageCount > 0">
+                                {{ newMessageCount }} new
+                                {{
+                                    newMessageCount === 1
+                                        ? 'message'
+                                        : 'messages'
+                                }}
+                            </span>
+                        </button>
+                    </Transition>
                 </div>
 
                 <div


### PR DESCRIPTION
Closes #106.

Brings the message-timeline scrolling up to a polished chat-client standard on both the main channel timeline (`Show.vue`) and the thread panel (`ThreadPanel.vue`).

## What changed

- **Shared `useScrollPin` composable** (`resources/js/composables/useScrollPin.ts`) — single source of truth for near-bottom detection, the pinned-to-newest flag, the "new messages" count, and the smooth jump back to the bottom. Replaces the near-identical scroll helpers that `Show.vue` and `ThreadPanel.vue` each carried, so behaviour can't drift. Lifecycle-free (the template wires `@scroll.passive="onScroll"`), matching the sibling `useMessageSearch` style, with co-located Vitest unit tests.
- **Jump-to-latest control** on both timelines — a chevron when scrolled up and caught up, expanding to a primary-coloured "N new message(s)" / "N new repl(y/ies)" pill when live messages arrive while scrolled up. Clicking scrolls **smoothly** to the newest message.
- **Thin, theme-aware scrollbar** via the `tailwind-scrollbar` plugin (`scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent`); the thumb tracks `var(--border)`, so it flips with light/dark automatically.
- **`overscroll-contain`** on both scroll containers so momentum doesn't chain to the page/adjacent panels.
- The existing top-centre **jump-to-unread** pill is untouched; the two controls coexist (bottom-right vs. top-centre).

## New dependency

Adds `tailwind-scrollbar` (dev). Approved in the design discussion for the scrollbar styling (over hand-rolled CSS).

## Testing

- 7 new Vitest tests for `useScrollPin` (near-bottom threshold, count increments only while scrolled up, reset on scroll-to-bottom, pinned-vs-not-pinned append, smooth jump clears count).
- Full frontend gate green: `lint:check`, `format:check`, `types:check`, `build`, `test:js` (148 tests).
- No PHP touched — backend coverage unaffected.
- Verified in the running app: initial channel open anchors to the newest message (caught and fixed a regression here — an early `h-full` change broke InfiniteScroll's mount-time bottom-anchor; restored the container's original `flex-1 min-h-0` sizing); jump-to-latest appears on scroll-up; real broadcast messages surface the count with correct pluralisation; clicking smooth-scrolls to the bottom and hides the control; scrollbar renders thin in dark mode.
