### PR TITLE
ci: pin first release to 0.1.0 and keep pre-1.0 breaking bumps in minor

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bump-minor-pre-major": true,
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
Follow-up to #112.

The first release-please PR came out as **1.0.0** instead of the intended **0.1.0**, for two reasons:

1. **A stray magic token.** The commit body in #112 contained the literal `BREAKING CHANGE:` string (in prose describing the feature), which release-please parsed as a real breaking-change footer and used to force a MAJOR bump.
2. **Missing pre-1.0 config.** Per #110's versioning decision, pre-1.0 semver-major changes should stay in a **minor** bump (`0.1.x`), not roll to `1.0.0`. That requires `bump-minor-pre-major`, which the original config sketch omitted.

## Changes

- `release-please-config.json`: add `"bump-minor-pre-major": true` so breaking changes bump the minor while the app is pre-1.0.
- Carry a `Release-As: 0.1.0` footer on this commit so the **initial** cut is pinned to the bootstrapped `0.1.0` (the manifest baseline would otherwise bump past it). This is a one-shot; subsequent releases compute normally from `0.1.0`.

Once this merges, the release-please PR (#113) updates from `1.0.0` to `0.1.0`.

Note: the `0.1.0` changelog will still list one nonsensical "BREAKING CHANGES" line sourced from #112's commit body. Removing it cleanly would require rewriting that commit on `master`; happy to do that as a separate step if a pristine first changelog is wanted.