### PR TITLE
feat(messaging): scheduled / send-later messages

### DIFF
--- a/app/Actions/Channels/CancelScheduledMessage.php
+++ b/app/Actions/Channels/CancelScheduledMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Enums\ScheduledMessageStatus;
+use App\Models\ScheduledMessage;
+
+class CancelScheduledMessage
+{
+    /**
+     * Cancel a pending scheduled message so the dispatcher never delivers it.
+     *
+     * The row is kept and flipped to Cancelled (rather than deleted) so the
+     * cancellation is observable and the per-minute scan — which only claims
+     * Pending rows — skips it for good.
+     */
+    public function handle(ScheduledMessage $scheduled): ScheduledMessage
+    {
+        $scheduled->update([
+            'status' => ScheduledMessageStatus::Cancelled,
+            'cancelled_at' => now(),
+        ]);
+
+        return $scheduled;
+    }
+}

--- a/app/Actions/Channels/DispatchDueScheduledMessages.php
+++ b/app/Actions/Channels/DispatchDueScheduledMessages.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Enums\ScheduledMessageStatus;
+use App\Models\ScheduledMessage;
+use Illuminate\Support\Facades\Gate;
+
+class DispatchDueScheduledMessages
+{
+    public function __construct(private PostMessage $postMessage) {}
+
+    /**
+     * Deliver every scheduled message whose send time has arrived.
+     *
+     * Runs once per minute. Only pending rows that are due are claimed, so a
+     * cancelled or already-sent row is never touched, and each is delivered
+     * through the normal send path so it broadcasts, resolves mentions, and
+     * unfurls links exactly like an immediate send.
+     */
+    public function handle(): void
+    {
+        ScheduledMessage::query()
+            ->due()
+            ->orderBy('send_at')
+            ->get()
+            ->each(fn (ScheduledMessage $scheduled) => $this->deliver($scheduled));
+    }
+
+    /**
+     * Deliver a single due row, or mark it failed when it can no longer be sent.
+     *
+     * When the author can no longer post to the channel — it was archived, or
+     * they were removed — the row is failed rather than delivered. A since-deleted
+     * reply target is dropped so the message still sends, just without its quote.
+     */
+    private function deliver(ScheduledMessage $scheduled): void
+    {
+        $channel = $scheduled->channel;
+        $author = $scheduled->user;
+
+        if (! Gate::forUser($author)->allows('postMessage', $channel)) {
+            $scheduled->update([
+                'status' => ScheduledMessageStatus::Failed,
+                'failed_at' => now(),
+                'failure_reason' => 'The author can no longer post to this channel.',
+            ]);
+
+            return;
+        }
+
+        $replyToId = $scheduled->reply_to_id;
+
+        if ($replyToId !== null && ! $channel->messages()->whereKey($replyToId)->exists()) {
+            $replyToId = null;
+        }
+
+        // PostMessage is keyed on the client uuid, so even if an overlapping tick
+        // delivered this row already the send resolves to the existing message
+        // without a duplicate or a second broadcast — at-most-once delivery.
+        $this->postMessage->handle(
+            channel: $channel,
+            author: $author,
+            body: $scheduled->body,
+            clientUuid: $scheduled->client_uuid,
+            replyToId: $replyToId,
+            clearDraft: false,
+        );
+
+        $scheduled->update([
+            'status' => ScheduledMessageStatus::Sent,
+            'sent_at' => now(),
+        ]);
+    }
+}

--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -31,8 +31,13 @@ class PostMessage
      * it stays out of the main timeline unless `$sentToChannel` is true, and it
      * bumps the root's denormalized reply count / last-reply time. The request
      * layer has already checked every reference points at a live, permitted message.
+     *
+     * A main-composer send clears the author's channel draft, since scheduling or
+     * sending consumes its text. A delayed delivery (the scheduler replaying a
+     * scheduled message) passes `$clearDraft: false` so it never wipes a draft the
+     * author has typed in the meantime.
      */
-    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null, ?string $forwardedFromId = null, ?string $threadRootId = null, bool $sentToChannel = false): Message
+    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null, ?string $forwardedFromId = null, ?string $threadRootId = null, bool $sentToChannel = false, bool $clearDraft = true): Message
     {
         $message = $channel->messages()->firstOrCreate(
             ['client_uuid' => $clientUuid],
@@ -55,9 +60,10 @@ class PostMessage
 
             if ($threadRootId !== null) {
                 $this->bumpThreadRoot($channel, $threadRootId);
-            } else {
+            } elseif ($clearDraft) {
                 // A message sent from the main composer clears its channel draft;
-                // a thread reply leaves the channel draft alone (it isn't its text).
+                // a thread reply leaves the channel draft alone (it isn't its text),
+                // and a delayed scheduled delivery leaves it alone too.
                 $author->channels()->updateExistingPivot($channel->id, ['draft' => null]);
             }
         }

--- a/app/Actions/Channels/ScheduleMessage.php
+++ b/app/Actions/Channels/ScheduleMessage.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\Channel;
+use App\Models\ScheduledMessage;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+class ScheduleMessage
+{
+    /**
+     * Schedule a message for future delivery to a channel on behalf of a user.
+     *
+     * Nothing is posted now: the row is stored pending and the per-minute
+     * dispatcher delivers it through the normal send path once `$sendAt` arrives.
+     * Scheduling consumes the composer's text like an immediate send, so the
+     * author's channel draft is cleared. The `$clientUuid` is carried through to
+     * delivery so the eventual send dedupes exactly like an immediate one.
+     */
+    public function handle(Channel $channel, User $author, string $body, string $clientUuid, Carbon $sendAt, ?string $replyToId = null): ScheduledMessage
+    {
+        $scheduled = $channel->scheduledMessages()->create([
+            'user_id' => $author->id,
+            'body' => $body,
+            'client_uuid' => $clientUuid,
+            'reply_to_id' => $replyToId,
+            'send_at' => $sendAt,
+        ]);
+
+        $author->channels()->updateExistingPivot($channel->id, ['draft' => null]);
+
+        return $scheduled;
+    }
+}

--- a/app/Actions/Channels/UpdateScheduledMessage.php
+++ b/app/Actions/Channels/UpdateScheduledMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Models\ScheduledMessage;
+use Illuminate\Support\Carbon;
+
+class UpdateScheduledMessage
+{
+    /**
+     * Revise a pending scheduled message's body and send time.
+     *
+     * v1 edits cover only the text and the moment of delivery; the target
+     * channel and reply reference are fixed at schedule time.
+     */
+    public function handle(ScheduledMessage $scheduled, string $body, Carbon $sendAt): ScheduledMessage
+    {
+        $scheduled->update([
+            'body' => $body,
+            'send_at' => $sendAt,
+        ]);
+
+        return $scheduled;
+    }
+}

--- a/app/Data/ScheduledMessageData.php
+++ b/app/Data/ScheduledMessageData.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\ScheduledMessage;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class ScheduledMessageData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $body,
+        public string $sendAt,
+        public string $createdAt,
+        public ?MessageReplyData $replyTo,
+    ) {}
+
+    /**
+     * Build the DTO from a ScheduledMessage model.
+     *
+     * `send_at` is serialized as a UTC ISO 8601 instant; the client renders it in
+     * the viewer's timezone. The `replyTo` relation (with its own `user` and
+     * `mentionedUsers`) should be eager-loaded when the message quotes a parent;
+     * a since-deleted parent still resolves so the quote can render a stub.
+     */
+    public static function fromScheduledMessage(ScheduledMessage $scheduled): self
+    {
+        return new self(
+            id: $scheduled->id,
+            body: $scheduled->body,
+            sendAt: $scheduled->send_at->toIso8601String(),
+            createdAt: $scheduled->created_at->toIso8601String(),
+            replyTo: $scheduled->replyTo !== null
+                ? MessageReplyData::fromMessage($scheduled->replyTo)
+                : null,
+        );
+    }
+}

--- a/app/Enums/ScheduledMessageStatus.php
+++ b/app/Enums/ScheduledMessageStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum ScheduledMessageStatus: string
+{
+    case Pending = 'pending';
+    case Sent = 'sent';
+    case Cancelled = 'cancelled';
+    case Failed = 'failed';
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -10,6 +10,7 @@ use App\Actions\Channels\MarkThreadRead;
 use App\Data\ChannelData;
 use App\Data\ChannelReaderData;
 use App\Data\MessageData;
+use App\Data\ScheduledMessageData;
 use App\Data\UserData;
 use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
@@ -154,6 +155,18 @@ class ChannelController extends Controller
             // independent of the main timeline's, and the client's reverse
             // InfiniteScroll pages older replies in above as it scrolls up.
             'threadReplies' => Inertia::scroll(fn () => $this->threadRepliesPage($request, $channel)),
+            // The viewer's own pending scheduled messages for this channel, soonest
+            // first, feeding the composer's "Scheduled" affordance. Only pending
+            // rows are listed — sent and cancelled ones drop off. The reply quote
+            // is eager-loaded so an inline-reply schedule renders its parent.
+            'scheduledMessages' => ScheduledMessageData::collect(
+                $channel->scheduledMessages()
+                    ->pending()
+                    ->where('user_id', $request->user()->id)
+                    ->with(['replyTo.user', 'replyTo.mentionedUsers'])
+                    ->orderBy('send_at')
+                    ->get()
+            ),
             // Team members feed the composer's @mention autocomplete; mentions are
             // scoped to the team, never limited to the current channel's members.
             'members' => UserData::collect($team->members()->orderBy('name')->get()),

--- a/app/Http/Controllers/Channels/ScheduledMessageController.php
+++ b/app/Http/Controllers/Channels/ScheduledMessageController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\CancelScheduledMessage;
+use App\Actions\Channels\ScheduleMessage;
+use App\Actions\Channels\UpdateScheduledMessage;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\CancelScheduledMessageRequest;
+use App\Http\Requests\Channels\ScheduleMessageRequest;
+use App\Http\Requests\Channels\UpdateScheduledMessageRequest;
+use App\Models\Channel;
+use App\Models\ScheduledMessage;
+use App\Models\Team;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Carbon;
+
+class ScheduledMessageController extends Controller
+{
+    /**
+     * Schedule a message for future delivery to the channel.
+     */
+    public function store(ScheduleMessageRequest $request, Team $team, Channel $channel, ScheduleMessage $scheduleMessage): RedirectResponse
+    {
+        $scheduleMessage->handle(
+            channel: $channel,
+            author: $request->user(),
+            body: $request->validated('body'),
+            clientUuid: $request->validated('client_uuid'),
+            sendAt: Carbon::parse($request->validated('send_at')),
+            replyToId: $request->validated('reply_to_id'),
+        );
+
+        return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+
+    /**
+     * Revise a pending scheduled message's body and send time.
+     */
+    public function update(UpdateScheduledMessageRequest $request, Team $team, Channel $channel, ScheduledMessage $scheduledMessage, UpdateScheduledMessage $updateScheduledMessage): RedirectResponse
+    {
+        $updateScheduledMessage->handle(
+            scheduled: $scheduledMessage,
+            body: $request->validated('body'),
+            sendAt: Carbon::parse($request->validated('send_at')),
+        );
+
+        return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+
+    /**
+     * Cancel a pending scheduled message so it is never delivered.
+     */
+    public function destroy(CancelScheduledMessageRequest $request, Team $team, Channel $channel, ScheduledMessage $scheduledMessage, CancelScheduledMessage $cancelScheduledMessage): RedirectResponse
+    {
+        $cancelScheduledMessage->handle($scheduledMessage);
+
+        return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+}

--- a/app/Http/Requests/Channels/CancelScheduledMessageRequest.php
+++ b/app/Http/Requests/Channels/CancelScheduledMessageRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\ScheduledMessage;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class CancelScheduledMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Only the author of a still-pending scheduled message may cancel it.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('delete', $this->scheduledMessage());
+    }
+
+    /**
+     * Get the scheduled message being cancelled.
+     */
+    public function scheduledMessage(): ScheduledMessage
+    {
+        $scheduled = $this->route('scheduledMessage');
+
+        abort_if(! $scheduled instanceof ScheduledMessage, 404);
+
+        return $scheduled;
+    }
+}

--- a/app/Http/Requests/Channels/ScheduleMessageRequest.php
+++ b/app/Http/Requests/Channels/ScheduleMessageRequest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+
+class ScheduleMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Scheduling requires the same gate as an immediate send, so an archived
+     * channel or a non-member is rejected before validation.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('postMessage', $this->channel());
+    }
+
+    /**
+     * Trim surrounding whitespace while preserving the message's inner newlines.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'body' => trim((string) $this->input('body')),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'max:8000'],
+            'client_uuid' => ['required', 'uuid'],
+            // The send time is stored UTC; the composer sends an ISO 8601 instant
+            // and the client enforces its own one-minute lead. The server only
+            // insists the moment is still in the future, so a stale request that
+            // has slipped into the past is rejected rather than firing instantly.
+            'send_at' => ['required', 'date', 'after:now'],
+            // An inline reply must quote a live (non-deleted) message in this same
+            // channel, exactly like an immediate reply.
+            'reply_to_id' => [
+                'nullable',
+                'uuid',
+                Rule::exists('messages', 'id')
+                    ->where('channel_id', $this->channel()->id)
+                    ->whereNull('deleted_at'),
+            ],
+        ];
+    }
+
+    /**
+     * Get the channel the message is being scheduled for.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+}

--- a/app/Http/Requests/Channels/UpdateScheduledMessageRequest.php
+++ b/app/Http/Requests/Channels/UpdateScheduledMessageRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\ScheduledMessage;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class UpdateScheduledMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * Only the author of a still-pending scheduled message may revise it.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('update', $this->scheduledMessage());
+    }
+
+    /**
+     * Trim surrounding whitespace while preserving the message's inner newlines.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'body' => trim((string) $this->input('body')),
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string', 'max:8000'],
+            'send_at' => ['required', 'date', 'after:now'],
+        ];
+    }
+
+    /**
+     * Get the scheduled message being edited.
+     */
+    public function scheduledMessage(): ScheduledMessage
+    {
+        $scheduled = $this->route('scheduledMessage');
+
+        abort_if(! $scheduled instanceof ScheduledMessage, 404);
+
+        return $scheduled;
+    }
+}

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -103,6 +103,16 @@ class Channel extends Model
     }
 
     /**
+     * Get the messages scheduled for future delivery to the channel.
+     *
+     * @return HasMany<ScheduledMessage, $this>
+     */
+    public function scheduledMessages(): HasMany
+    {
+        return $this->hasMany(ScheduledMessage::class);
+    }
+
+    /**
      * Get the users who are members of the channel.
      *
      * @return BelongsToMany<User, $this>

--- a/app/Models/ScheduledMessage.php
+++ b/app/Models/ScheduledMessage.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ScheduledMessageStatus;
+use Database\Factories\ScheduledMessageFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $channel_id
+ * @property string $user_id
+ * @property string $client_uuid
+ * @property string $body
+ * @property string|null $reply_to_id
+ * @property Carbon $send_at
+ * @property ScheduledMessageStatus $status
+ * @property Carbon|null $sent_at
+ * @property Carbon|null $cancelled_at
+ * @property Carbon|null $failed_at
+ * @property string|null $failure_reason
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Channel $channel
+ * @property-read User $user
+ * @property-read Message|null $replyTo
+ */
+#[Fillable(['channel_id', 'user_id', 'client_uuid', 'body', 'reply_to_id', 'send_at', 'status', 'sent_at', 'cancelled_at', 'failed_at', 'failure_reason'])]
+class ScheduledMessage extends Model
+{
+    /** @use HasFactory<ScheduledMessageFactory> */
+    use HasFactory, HasUuids;
+
+    /**
+     * The model's default attribute values.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'status' => ScheduledMessageStatus::Pending->value,
+    ];
+
+    /**
+     * Get the channel the message is scheduled for.
+     *
+     * @return BelongsTo<Channel, $this>
+     */
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class);
+    }
+
+    /**
+     * Get the user who scheduled the message.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the message this one will quote inline once delivered, if any.
+     *
+     * Resolved withTrashed so a since-deleted target can be recognised at
+     * delivery and its quote dropped rather than blocking the send.
+     *
+     * @return BelongsTo<Message, $this>
+     */
+    public function replyTo(): BelongsTo
+    {
+        return $this->belongsTo(Message::class, 'reply_to_id')->withTrashed();
+    }
+
+    /**
+     * Constrain the query to rows still awaiting delivery.
+     *
+     * @param  Builder<ScheduledMessage>  $query
+     */
+    public function scopePending(Builder $query): void
+    {
+        $query->where('status', ScheduledMessageStatus::Pending);
+    }
+
+    /**
+     * Constrain the query to pending rows whose send time has arrived.
+     *
+     * @param  Builder<ScheduledMessage>  $query
+     */
+    public function scopeDue(Builder $query): void
+    {
+        $query->pending()->where('send_at', '<=', now());
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'send_at' => 'datetime',
+            'sent_at' => 'datetime',
+            'cancelled_at' => 'datetime',
+            'failed_at' => 'datetime',
+            'status' => ScheduledMessageStatus::class,
+        ];
+    }
+}

--- a/app/Policies/ScheduledMessagePolicy.php
+++ b/app/Policies/ScheduledMessagePolicy.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\ScheduledMessageStatus;
+use App\Models\ScheduledMessage;
+use App\Models\User;
+
+class ScheduledMessagePolicy
+{
+    /**
+     * Determine whether the user can edit the scheduled message.
+     *
+     * Only the author may edit their own, and only while it is still pending —
+     * a delivered or cancelled row is immutable.
+     */
+    public function update(User $user, ScheduledMessage $scheduledMessage): bool
+    {
+        return $this->managesPending($user, $scheduledMessage);
+    }
+
+    /**
+     * Determine whether the user can cancel the scheduled message.
+     *
+     * Only the author may cancel their own, and only while it is still pending.
+     */
+    public function delete(User $user, ScheduledMessage $scheduledMessage): bool
+    {
+        return $this->managesPending($user, $scheduledMessage);
+    }
+
+    /**
+     * Shared rule: the actor authored the row and it is still awaiting delivery.
+     */
+    private function managesPending(User $user, ScheduledMessage $scheduledMessage): bool
+    {
+        return $scheduledMessage->user_id === $user->id
+            && $scheduledMessage->status === ScheduledMessageStatus::Pending;
+    }
+}

--- a/database/factories/ScheduledMessageFactory.php
+++ b/database/factories/ScheduledMessageFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ScheduledMessageStatus;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\ScheduledMessage;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ScheduledMessage>
+ */
+class ScheduledMessageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'channel_id' => Channel::factory(),
+            'user_id' => User::factory(),
+            'client_uuid' => fake()->uuid(),
+            'body' => fake()->realText(120),
+            'reply_to_id' => null,
+            'send_at' => now()->addHour(),
+            'status' => ScheduledMessageStatus::Pending,
+            'sent_at' => null,
+            'cancelled_at' => null,
+            'failed_at' => null,
+            'failure_reason' => null,
+        ];
+    }
+
+    /**
+     * Indicate that the scheduled message quotes another message inline.
+     */
+    public function replyTo(Message $parent): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'reply_to_id' => $parent->id,
+        ]);
+    }
+
+    /**
+     * Indicate that the scheduled message has already been delivered.
+     */
+    public function sent(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => ScheduledMessageStatus::Sent,
+            'sent_at' => now(),
+        ]);
+    }
+
+    /**
+     * Indicate that the scheduled message has been cancelled by its author.
+     */
+    public function cancelled(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => ScheduledMessageStatus::Cancelled,
+            'cancelled_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_07_10_154701_create_scheduled_messages_table.php
+++ b/database/migrations/2026_07_10_154701_create_scheduled_messages_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Enums\ScheduledMessageStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('scheduled_messages', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            $table->foreignUuid('channel_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            // Generated when the message is scheduled and handed to PostMessage at
+            // delivery, so the eventual send dedupes against the messages table's
+            // unique (channel_id, client_uuid) exactly like an immediate send.
+            $table->uuid('client_uuid');
+            $table->text('body');
+            // The inline quote target, resolved against the channel at delivery; a
+            // since-deleted target is dropped rather than blocking the send.
+            $table->foreignUuid('reply_to_id')->nullable()->constrained('messages')->nullOnDelete();
+            $table->timestamp('send_at');
+            $table->string('status')->default(ScheduledMessageStatus::Pending->value);
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            // Why a due row could not be delivered (archived channel, author removed),
+            // surfaced for observability; null while pending or once sent.
+            $table->string('failure_reason')->nullable();
+            $table->timestamps();
+
+            // The per-minute dispatcher scans WHERE status = ? AND send_at <= ?.
+            $table->index(['status', 'send_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('scheduled_messages');
+    }
+};

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ArrowUp, Plus, X } from '@lucide/vue';
+import { ArrowUp, CalendarClock, Plus, X } from '@lucide/vue';
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import MessageQuote from '@/components/MessageQuote.vue';
+import ScheduleMessageDialog from '@/components/ScheduleMessageDialog.vue';
 import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
 import type { Mention, Message } from '@/types';
@@ -16,6 +17,10 @@ const props = defineProps<{
     // Text to seed the composer with on mount, e.g. a persisted draft. Restored
     // verbatim (mention tokens included) so it round-trips faithfully.
     initialBody?: string;
+    // Whether to offer the "schedule for later" affordance (main channel
+    // composer only). The viewer's zone drives the picker's presets.
+    allowSchedule?: boolean;
+    timezone?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -25,6 +30,8 @@ const emit = defineEmits<{
     // The composer body changed (typed, restored-then-edited, or cleared on
     // send). The parent decides whether to persist it as a draft.
     draftChange: [body: string];
+    // The composer text should be delivered later, at the chosen UTC instant.
+    schedule: [body: string, mentions: Mention[], sendAt: string];
 }>();
 
 const { getInitials } = useInitials();
@@ -241,6 +248,16 @@ function insertMention(member: Mention): void {
 
 defineExpose({ insertMention });
 
+// Clear the composer after the text has been handed off (an immediate send or a
+// scheduled one), flagging the wipe so it doesn't re-persist as a draft.
+function clearAfterHandoff(): void {
+    clearingAfterSend = true;
+    body.value = '';
+    sendToChannel.value = false;
+    menuOpen.value = false;
+    nextTick(resize);
+}
+
 function submit(): void {
     const trimmed = body.value.trim();
 
@@ -249,11 +266,30 @@ function submit(): void {
     }
 
     emit('send', trimmed, collectMentions(trimmed), sendToChannel.value);
-    clearingAfterSend = true;
-    body.value = '';
-    sendToChannel.value = false;
-    menuOpen.value = false;
-    nextTick(resize);
+    clearAfterHandoff();
+}
+
+// Whether the schedule picker is open. Opening requires some text — an empty
+// composer has nothing to schedule.
+const scheduling = ref(false);
+
+function openSchedule(): void {
+    if (body.value.trim() === '') {
+        return;
+    }
+
+    scheduling.value = true;
+}
+
+function onScheduleConfirm(sendAt: string): void {
+    const trimmed = body.value.trim();
+
+    if (trimmed === '') {
+        return;
+    }
+
+    emit('schedule', trimmed, collectMentions(trimmed), sendAt);
+    clearAfterHandoff();
 }
 
 function onKeydown(event: KeyboardEvent): void {
@@ -404,18 +440,40 @@ function onKeydown(event: KeyboardEvent): void {
                             Also send to #{{ props.channelName }}
                         </label>
                     </div>
-                    <Button
-                        size="icon"
-                        :disabled="body.trim() === ''"
-                        data-test="message-composer-send"
-                        class="size-7 rounded-lg"
-                        aria-label="Send message"
-                        @click="submit"
-                    >
-                        <ArrowUp class="size-3.5" />
-                    </Button>
+                    <div class="flex items-center gap-1.5">
+                        <Button
+                            v-if="props.allowSchedule"
+                            variant="ghost"
+                            size="icon"
+                            :disabled="body.trim() === ''"
+                            data-test="message-composer-schedule"
+                            class="size-7 rounded-lg text-muted-foreground"
+                            aria-label="Schedule for later"
+                            title="Schedule for later"
+                            @click="openSchedule"
+                        >
+                            <CalendarClock class="size-3.5" />
+                        </Button>
+                        <Button
+                            size="icon"
+                            :disabled="body.trim() === ''"
+                            data-test="message-composer-send"
+                            class="size-7 rounded-lg"
+                            aria-label="Send message"
+                            @click="submit"
+                        >
+                            <ArrowUp class="size-3.5" />
+                        </Button>
+                    </div>
                 </div>
             </div>
         </div>
+
+        <ScheduleMessageDialog
+            v-if="props.allowSchedule"
+            v-model:open="scheduling"
+            :timezone="props.timezone ?? null"
+            @confirm="onScheduleConfirm"
+        />
     </div>
 </template>

--- a/resources/js/components/ScheduleMessageDialog.vue
+++ b/resources/js/components/ScheduleMessageDialog.vue
@@ -1,0 +1,300 @@
+<script setup lang="ts">
+import { CalendarDate, today } from '@internationalized/date';
+import { Check, Clock } from '@lucide/vue';
+import type { DateValue } from 'reka-ui';
+import { computed, ref, watch } from 'vue';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    formatScheduledFor,
+    isSendAtInFuture,
+    schedulePresets,
+    to12Hour,
+    to24Hour,
+    wallTimeToInstant,
+    zonedWallTime,
+} from '@/lib/scheduleTime';
+import type { SchedulePreset } from '@/lib/scheduleTime';
+
+const props = withDefaults(
+    defineProps<{
+        // The viewer's stored IANA zone; falls back to the runtime zone when null
+        // so presets and the picker are always resolved in a real zone.
+        timezone: string | null;
+        // When editing an existing scheduled message, the instant to open on.
+        initialSendAt?: string | null;
+        title?: string;
+        confirmLabel?: string;
+    }>(),
+    {
+        initialSendAt: null,
+        title: 'Schedule message',
+        confirmLabel: 'Schedule',
+    },
+);
+
+const emit = defineEmits<{
+    confirm: [sendAt: string];
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+
+const effectiveZone = computed(
+    () => props.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+);
+
+const HOURS = Array.from({ length: 12 }, (_, index) => index + 1);
+const MINUTES = Array.from({ length: 12 }, (_, index) => index * 5);
+const PERIODS = ['AM', 'PM'] as const;
+
+// The calendar + time selects are the single source of truth; a preset is just a
+// shortcut that fills them in, so the "Sends…" preview always agrees with what
+// the controls show.
+const presets = ref<SchedulePreset[]>([]);
+const dateValue = ref<DateValue>();
+const minDate = ref<DateValue>();
+const hour = ref(9);
+const minute = ref(0);
+const period = ref<'AM' | 'PM'>('AM');
+
+/**
+ * Point the controls at a UTC instant, expressed in the viewer's zone. Minutes
+ * snap down to the 5-minute grid the selects offer.
+ */
+function applyInstant(iso: string): void {
+    const wall = zonedWallTime(effectiveZone.value, new Date(iso));
+    dateValue.value = new CalendarDate(wall.year, wall.month, wall.day);
+    const clock = to12Hour(wall.hour);
+    hour.value = clock.hour;
+    period.value = clock.period;
+    minute.value = Math.floor(wall.minute / 5) * 5;
+}
+
+function reset(): void {
+    presets.value = schedulePresets(effectiveZone.value);
+    minDate.value = today(effectiveZone.value);
+    // Seed from the edited instant, else from the first preset ("In 1 hour") so
+    // it opens highlighted with a valid, future default.
+    applyInstant(props.initialSendAt ?? presets.value[0].sendAt);
+}
+
+watch(open, (isOpen) => {
+    if (isOpen) {
+        reset();
+    }
+});
+
+function choosePreset(preset: SchedulePreset): void {
+    applyInstant(preset.sendAt);
+}
+
+// The chosen instant as a UTC ISO string, derived from the controls.
+const selectedSendAt = computed<string | null>(() => {
+    if (!dateValue.value) {
+        return null;
+    }
+
+    return wallTimeToInstant(
+        {
+            year: dateValue.value.year,
+            month: dateValue.value.month,
+            day: dateValue.value.day,
+            hour: to24Hour(hour.value, period.value),
+            minute: minute.value,
+        },
+        effectiveZone.value,
+    ).toISOString();
+});
+
+// Highlight the preset whose (grid-snapped) time the controls currently match,
+// so choosing one lights it up and nudging a select clears it.
+const activePresetKey = computed(() => {
+    const current = selectedSendAt.value;
+
+    if (current === null) {
+        return null;
+    }
+
+    const zone = effectiveZone.value;
+
+    return (
+        presets.value.find((preset) => {
+            const wall = zonedWallTime(zone, new Date(preset.sendAt));
+
+            return (
+                wallTimeToInstant(
+                    { ...wall, minute: Math.floor(wall.minute / 5) * 5 },
+                    zone,
+                ).toISOString() === current
+            );
+        })?.key ?? null
+    );
+});
+
+const preview = computed(() =>
+    selectedSendAt.value
+        ? formatScheduledFor(selectedSendAt.value, effectiveZone.value)
+        : null,
+);
+
+// The chosen time can still be in the past (an earlier time today), so guard the
+// submit and surface why it's disabled. The server enforces the same rule.
+const isFuture = computed(
+    () =>
+        selectedSendAt.value !== null && isSendAtInFuture(selectedSendAt.value),
+);
+
+function confirm(): void {
+    if (!selectedSendAt.value || !isFuture.value) {
+        return;
+    }
+
+    emit('confirm', selectedSendAt.value);
+    open.value = false;
+}
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent class="max-h-[85dvh] gap-3 overflow-y-auto sm:max-w-md">
+            <DialogHeader>
+                <DialogTitle>{{ props.title }}</DialogTitle>
+                <DialogDescription>
+                    Pick when this message should be sent. Times are in your
+                    timezone.
+                </DialogDescription>
+            </DialogHeader>
+
+            <div class="grid grid-cols-2 gap-2" data-test="schedule-presets">
+                <button
+                    v-for="preset in presets"
+                    :key="preset.key"
+                    type="button"
+                    data-test="schedule-preset"
+                    :data-preset="preset.key"
+                    :aria-pressed="preset.key === activePresetKey"
+                    class="flex items-center justify-between gap-2 rounded-md border px-3 py-1.5 text-left text-[13px] transition-colors"
+                    :class="
+                        preset.key === activePresetKey
+                            ? 'border-primary bg-primary/5 font-medium text-foreground'
+                            : 'border-input hover:bg-muted'
+                    "
+                    @click="choosePreset(preset)"
+                >
+                    <span class="truncate">{{ preset.label }}</span>
+                    <Check
+                        v-if="preset.key === activePresetKey"
+                        class="size-4 shrink-0 text-primary"
+                    />
+                </button>
+            </div>
+
+            <div class="rounded-lg border border-border">
+                <p
+                    class="border-b border-border px-3 py-1.5 text-[12px] font-medium text-muted-foreground"
+                >
+                    Or pick a date &amp; time
+                </p>
+                <Calendar
+                    v-model="dateValue"
+                    :min-value="minDate"
+                    weekday-format="short"
+                    data-test="schedule-calendar"
+                    class="p-2"
+                />
+                <div
+                    class="flex items-center gap-2 border-t border-border px-3 py-2"
+                >
+                    <Clock class="size-4 shrink-0 text-muted-foreground" />
+                    <Select v-model="hour" data-test="schedule-hour">
+                        <SelectTrigger class="h-8 w-20">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem
+                                v-for="value in HOURS"
+                                :key="value"
+                                :value="value"
+                            >
+                                {{ value }}
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <span class="text-muted-foreground">:</span>
+                    <Select v-model="minute" data-test="schedule-minute">
+                        <SelectTrigger class="h-8 w-20">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem
+                                v-for="value in MINUTES"
+                                :key="value"
+                                :value="value"
+                            >
+                                {{ String(value).padStart(2, '0') }}
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <Select v-model="period" data-test="schedule-period">
+                        <SelectTrigger class="h-8 w-20">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem
+                                v-for="value in PERIODS"
+                                :key="value"
+                                :value="value"
+                            >
+                                {{ value }}
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                </div>
+            </div>
+
+            <p
+                v-if="preview && isFuture"
+                data-test="schedule-preview"
+                class="flex items-center gap-1.5 text-[13px] text-muted-foreground"
+            >
+                <Clock class="size-3.5 shrink-0" />
+                Sends {{ preview }}
+            </p>
+            <p
+                v-else-if="preview"
+                data-test="schedule-past"
+                class="text-[13px] text-destructive"
+            >
+                Pick a time in the future.
+            </p>
+
+            <DialogFooter class="gap-2">
+                <Button variant="secondary" @click="open = false">
+                    Cancel
+                </Button>
+                <Button
+                    data-test="schedule-confirm"
+                    :disabled="!isFuture"
+                    @click="confirm"
+                >
+                    {{ props.confirmLabel }}
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/ScheduledMessagesDialog.vue
+++ b/resources/js/components/ScheduledMessagesDialog.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { CalendarClock, Clock, Pencil, Trash2 } from '@lucide/vue';
+import { computed, ref, watch } from 'vue';
+import MessageQuote from '@/components/MessageQuote.vue';
+import ScheduleMessageDialog from '@/components/ScheduleMessageDialog.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { messageBodyPreview } from '@/lib/messageBody';
+import { formatScheduledFor } from '@/lib/scheduleTime';
+import type { ScheduledMessage } from '@/types';
+
+const props = defineProps<{
+    scheduledMessages: ScheduledMessage[];
+    timezone: string | null;
+}>();
+
+const emit = defineEmits<{
+    update: [payload: { id: string; body: string; sendAt: string }];
+    cancel: [id: string];
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+
+// The row being edited, plus its working copy of the body and send time. Null
+// when the list is just being browsed.
+const editingId = ref<string | null>(null);
+const editBody = ref('');
+const editSendAt = ref('');
+const rescheduling = ref(false);
+
+// Closing the dialog abandons any in-progress edit so it never reopens stale.
+watch(open, (isOpen) => {
+    if (!isOpen) {
+        editingId.value = null;
+    }
+});
+
+// If the row being edited is delivered or cancelled out from under us (the prop
+// refreshes after a dispatch), drop back to the list.
+watch(
+    () => props.scheduledMessages,
+    (messages) => {
+        if (
+            editingId.value !== null &&
+            !messages.some((message) => message.id === editingId.value)
+        ) {
+            editingId.value = null;
+        }
+    },
+);
+
+function startEdit(scheduled: ScheduledMessage): void {
+    editingId.value = scheduled.id;
+    editBody.value = scheduled.body;
+    editSendAt.value = scheduled.sendAt;
+}
+
+function cancelEdit(): void {
+    editingId.value = null;
+}
+
+function onRescheduled(sendAt: string): void {
+    editSendAt.value = sendAt;
+}
+
+const canSave = computed(() => editBody.value.trim() !== '');
+
+function saveEdit(): void {
+    if (editingId.value === null || !canSave.value) {
+        return;
+    }
+
+    emit('update', {
+        id: editingId.value,
+        body: editBody.value.trim(),
+        sendAt: editSendAt.value,
+    });
+    editingId.value = null;
+}
+
+function cancelSend(scheduled: ScheduledMessage): void {
+    emit('cancel', scheduled.id);
+}
+
+function whenLabel(iso: string): string {
+    return formatScheduledFor(
+        iso,
+        props.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+    );
+}
+
+function bodyPreview(body: string): string {
+    return messageBodyPreview(body);
+}
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent class="gap-4 sm:max-w-lg">
+            <DialogHeader>
+                <DialogTitle>Scheduled messages</DialogTitle>
+                <DialogDescription>
+                    Messages waiting to be sent to this channel. Edit or cancel
+                    any that haven't gone out yet.
+                </DialogDescription>
+            </DialogHeader>
+
+            <ul
+                v-if="props.scheduledMessages.length > 0"
+                class="max-h-96 space-y-2 overflow-y-auto"
+                data-test="scheduled-list"
+            >
+                <li
+                    v-for="scheduled in props.scheduledMessages"
+                    :key="scheduled.id"
+                    data-test="scheduled-item"
+                    class="rounded-lg border border-border p-3"
+                >
+                    <template v-if="editingId === scheduled.id">
+                        <textarea
+                            v-model="editBody"
+                            rows="2"
+                            data-test="scheduled-edit-body"
+                            class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-sm leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                        ></textarea>
+                        <div
+                            class="mt-2 flex items-center justify-between gap-2"
+                        >
+                            <button
+                                type="button"
+                                data-test="scheduled-reschedule"
+                                class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[13px] text-muted-foreground hover:bg-muted hover:text-foreground"
+                                @click="rescheduling = true"
+                            >
+                                <CalendarClock class="size-3.5" />
+                                {{ whenLabel(editSendAt) }}
+                            </button>
+                            <div class="flex items-center gap-1.5">
+                                <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    class="h-7"
+                                    @click="cancelEdit"
+                                >
+                                    Discard
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    class="h-7"
+                                    data-test="scheduled-save"
+                                    :disabled="!canSave"
+                                    @click="saveEdit"
+                                >
+                                    Save
+                                </Button>
+                            </div>
+                        </div>
+                    </template>
+
+                    <template v-else>
+                        <MessageQuote
+                            v-if="scheduled.replyTo"
+                            :author-name="scheduled.replyTo.authorName"
+                            :body="scheduled.replyTo.body"
+                            :is-deleted="scheduled.replyTo.isDeleted"
+                            class="mb-1"
+                        />
+                        <p class="line-clamp-3 text-sm text-foreground">
+                            {{ bodyPreview(scheduled.body) }}
+                        </p>
+                        <div
+                            class="mt-1.5 flex items-center justify-between gap-2"
+                        >
+                            <span
+                                class="inline-flex items-center gap-1.5 text-[12.5px] text-muted-foreground"
+                                data-test="scheduled-when"
+                            >
+                                <Clock class="size-3.5" />
+                                {{ whenLabel(scheduled.sendAt) }}
+                            </span>
+                            <div class="flex items-center gap-1">
+                                <button
+                                    type="button"
+                                    aria-label="Edit scheduled message"
+                                    data-test="scheduled-edit"
+                                    class="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                    @click="startEdit(scheduled)"
+                                >
+                                    <Pencil class="size-4" />
+                                </button>
+                                <button
+                                    type="button"
+                                    aria-label="Cancel scheduled message"
+                                    data-test="scheduled-cancel"
+                                    class="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive"
+                                    @click="cancelSend(scheduled)"
+                                >
+                                    <Trash2 class="size-4" />
+                                </button>
+                            </div>
+                        </div>
+                    </template>
+                </li>
+            </ul>
+
+            <p
+                v-else
+                data-test="scheduled-empty"
+                class="py-6 text-center text-[13px] text-muted-foreground"
+            >
+                You have no messages scheduled for this channel.
+            </p>
+        </DialogContent>
+    </Dialog>
+
+    <ScheduleMessageDialog
+        v-model:open="rescheduling"
+        :timezone="props.timezone"
+        :initial-send-at="editSendAt"
+        title="Reschedule message"
+        confirm-label="Reschedule"
+        @confirm="onRescheduled"
+    />
+</template>

--- a/resources/js/components/ui/calendar/Calendar.vue
+++ b/resources/js/components/ui/calendar/Calendar.vue
@@ -1,0 +1,162 @@
+<script lang="ts" setup>
+import type { CalendarRootEmits, CalendarRootProps, DateValue } from "reka-ui"
+import type { HTMLAttributes, Ref } from "vue"
+import type { LayoutTypes } from "."
+import { getLocalTimeZone, today } from "@internationalized/date"
+import { createReusableTemplate, reactiveOmit, useVModel } from "@vueuse/core"
+import { CalendarRoot, useDateFormatter, useForwardPropsEmits } from "reka-ui"
+import { createYear, createYearRange, toDate } from "reka-ui/date"
+import { computed, toRaw } from "vue"
+import { cn } from "@/lib/utils"
+import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select'
+import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, CalendarGridHead, CalendarGridRow, CalendarHeadCell, CalendarHeader, CalendarHeading, CalendarNextButton, CalendarPrevButton } from "."
+
+const props = withDefaults(defineProps<CalendarRootProps & { class?: HTMLAttributes["class"], layout?: LayoutTypes, yearRange?: DateValue[] }>(), {
+  modelValue: undefined,
+  layout: undefined,
+})
+const emits = defineEmits<CalendarRootEmits>()
+
+const delegatedProps = reactiveOmit(props, "class", "layout", "placeholder")
+
+const placeholder = useVModel(props, "placeholder", emits, {
+  passive: true,
+  defaultValue: props.defaultPlaceholder ?? today(getLocalTimeZone()),
+}) as Ref<DateValue>
+
+const formatter = useDateFormatter(props.locale ?? "en")
+
+const yearRange = computed(() => {
+  return props.yearRange ?? createYearRange({
+    start: props?.minValue ?? (toRaw(props.placeholder) ?? props.defaultPlaceholder ?? today(getLocalTimeZone()))
+      .cycle("year", -100),
+
+    end: props?.maxValue ?? (toRaw(props.placeholder) ?? props.defaultPlaceholder ?? today(getLocalTimeZone()))
+      .cycle("year", 10),
+  })
+})
+
+const [DefineMonthTemplate, ReuseMonthTemplate] = createReusableTemplate<{ date: DateValue }>()
+const [DefineYearTemplate, ReuseYearTemplate] = createReusableTemplate<{ date: DateValue }>()
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <DefineMonthTemplate v-slot="{ date }">
+    <div class="**:data-[slot=native-select-icon]:right-1">
+      <div class="relative">
+        <div class="absolute inset-0 flex h-full items-center text-sm pl-2 pointer-events-none">
+          {{ formatter.custom(toDate(date), { month: 'short' }) }}
+        </div>
+        <NativeSelect
+          class="text-xs h-8 pr-6 pl-2 text-transparent relative"
+          :model-value="date.month"
+          @change="(e: Event) => {
+            placeholder = placeholder.set({
+              month: Number((e?.target as any)?.value),
+            })
+          }"
+        >
+          <NativeSelectOption v-for="(month) in createYear({ dateObj: date })" :key="month.toString()" :value="month.month" :selected="date.month === month.month">
+            {{ formatter.custom(toDate(month), { month: 'short' }) }}
+          </NativeSelectOption>
+        </NativeSelect>
+      </div>
+    </div>
+  </DefineMonthTemplate>
+
+  <DefineYearTemplate v-slot="{ date }">
+    <div class="**:data-[slot=native-select-icon]:right-1">
+      <div class="relative">
+        <div class="absolute inset-0 flex h-full items-center text-sm pl-2 pointer-events-none">
+          {{ formatter.custom(toDate(date), { year: 'numeric' }) }}
+        </div>
+        <NativeSelect
+          class="text-xs h-8 pr-6 pl-2 text-transparent relative"
+          :model-value="date.year"
+          @change="(e: Event) => {
+            placeholder = placeholder.set({
+              year: Number((e?.target as any)?.value),
+            })
+          }"
+        >
+          <NativeSelectOption v-for="(year) in yearRange" :key="year.toString()" :value="year.year" :selected="date.year === year.year">
+            {{ formatter.custom(toDate(year), { year: 'numeric' }) }}
+          </NativeSelectOption>
+        </NativeSelect>
+      </div>
+    </div>
+  </DefineYearTemplate>
+
+  <CalendarRoot
+    v-slot="{ grid, weekDays, date }"
+    v-bind="forwarded"
+    v-model:placeholder="placeholder"
+    data-slot="calendar"
+    :class="cn('p-3', props.class)"
+  >
+    <CalendarHeader class="pt-0">
+      <nav class="flex items-center gap-1 absolute top-0 inset-x-0 justify-between">
+        <CalendarPrevButton>
+          <slot name="calendar-prev-icon" />
+        </CalendarPrevButton>
+        <CalendarNextButton>
+          <slot name="calendar-next-icon" />
+        </CalendarNextButton>
+      </nav>
+
+      <slot name="calendar-heading" :date="date" :month="ReuseMonthTemplate" :year="ReuseYearTemplate">
+        <template v-if="layout === 'month-and-year'">
+          <div class="flex items-center justify-center gap-1">
+            <ReuseMonthTemplate :date="date" />
+            <ReuseYearTemplate :date="date" />
+          </div>
+        </template>
+        <template v-else-if="layout === 'month-only'">
+          <div class="flex items-center justify-center gap-1">
+            <ReuseMonthTemplate :date="date" />
+            {{ formatter.custom(toDate(date), { year: 'numeric' }) }}
+          </div>
+        </template>
+        <template v-else-if="layout === 'year-only'">
+          <div class="flex items-center justify-center gap-1">
+            {{ formatter.custom(toDate(date), { month: 'short' }) }}
+            <ReuseYearTemplate :date="date" />
+          </div>
+        </template>
+        <template v-else>
+          <CalendarHeading />
+        </template>
+      </slot>
+    </CalendarHeader>
+
+    <div class="flex flex-col gap-y-4 mt-4 sm:flex-row sm:gap-x-4 sm:gap-y-0">
+      <CalendarGrid v-for="month in grid" :key="month.value.toString()">
+        <CalendarGridHead>
+          <CalendarGridRow>
+            <CalendarHeadCell
+              v-for="day in weekDays" :key="day"
+            >
+              {{ day }}
+            </CalendarHeadCell>
+          </CalendarGridRow>
+        </CalendarGridHead>
+        <CalendarGridBody>
+          <CalendarGridRow v-for="(weekDates, index) in month.rows" :key="`weekDate-${index}`" class="mt-2 w-full">
+            <CalendarCell
+              v-for="weekDate in weekDates"
+              :key="weekDate.toString()"
+              :date="weekDate"
+            >
+              <CalendarCellTrigger
+                :day="weekDate"
+                :month="month.value"
+              />
+            </CalendarCell>
+          </CalendarGridRow>
+        </CalendarGridBody>
+      </CalendarGrid>
+    </div>
+  </CalendarRoot>
+</template>

--- a/resources/js/components/ui/calendar/CalendarCell.vue
+++ b/resources/js/components/ui/calendar/CalendarCell.vue
@@ -1,0 +1,23 @@
+<script lang="ts" setup>
+import type { CalendarCellProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarCell, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<CalendarCellProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarCell
+    data-slot="calendar-cell"
+    :class="cn('relative p-0 text-center text-sm focus-within:relative focus-within:z-20 flex-1 [&:has([data-selected])]:rounded-md [&:has([data-selected])]:bg-accent', props.class)"
+    v-bind="forwardedProps"
+  >
+    <slot />
+  </CalendarCell>
+</template>

--- a/resources/js/components/ui/calendar/CalendarCellTrigger.vue
+++ b/resources/js/components/ui/calendar/CalendarCellTrigger.vue
@@ -1,0 +1,39 @@
+<script lang="ts" setup>
+import type { CalendarCellTriggerProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarCellTrigger, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+import { buttonVariants } from '@/components/ui/button'
+
+const props = withDefaults(defineProps<CalendarCellTriggerProps & { class?: HTMLAttributes["class"] }>(), {
+  as: "button",
+})
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarCellTrigger
+    data-slot="calendar-cell-trigger"
+    :class="cn(
+      buttonVariants({ variant: 'ghost' }),
+      'size-8 p-0 font-normal aria-selected:opacity-100 cursor-default',
+      '[&[data-today]:not([data-selected])]:bg-accent [&[data-today]:not([data-selected])]:text-accent-foreground',
+      // Selected
+      'data-[selected]:bg-primary data-[selected]:text-primary-foreground data-[selected]:opacity-100 [&[data-selected]:hover]:bg-primary data-[selected]:hover:text-primary-foreground data-[selected]:focus:bg-primary data-[selected]:focus:text-primary-foreground',
+      // Disabled
+      'data-[disabled]:text-muted-foreground data-[disabled]:opacity-50',
+      // Unavailable
+      'data-[unavailable]:text-destructive-foreground data-[unavailable]:line-through',
+      // Outside months
+      'data-[outside-view]:text-muted-foreground',
+      props.class,
+    )"
+    v-bind="forwardedProps"
+  >
+    <slot />
+  </CalendarCellTrigger>
+</template>

--- a/resources/js/components/ui/calendar/CalendarGrid.vue
+++ b/resources/js/components/ui/calendar/CalendarGrid.vue
@@ -1,0 +1,23 @@
+<script lang="ts" setup>
+import type { CalendarGridProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarGrid, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<CalendarGridProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarGrid
+    data-slot="calendar-grid"
+    :class="cn('w-full border-collapse space-x-1', props.class)"
+    v-bind="forwardedProps"
+  >
+    <slot />
+  </CalendarGrid>
+</template>

--- a/resources/js/components/ui/calendar/CalendarGridBody.vue
+++ b/resources/js/components/ui/calendar/CalendarGridBody.vue
@@ -1,0 +1,15 @@
+<script lang="ts" setup>
+import type { CalendarGridBodyProps } from "reka-ui"
+import { CalendarGridBody } from "reka-ui"
+
+const props = defineProps<CalendarGridBodyProps>()
+</script>
+
+<template>
+  <CalendarGridBody
+    data-slot="calendar-grid-body"
+    v-bind="props"
+  >
+    <slot />
+  </CalendarGridBody>
+</template>

--- a/resources/js/components/ui/calendar/CalendarGridHead.vue
+++ b/resources/js/components/ui/calendar/CalendarGridHead.vue
@@ -1,0 +1,16 @@
+<script lang="ts" setup>
+import type { CalendarGridHeadProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { CalendarGridHead } from "reka-ui"
+
+const props = defineProps<CalendarGridHeadProps & { class?: HTMLAttributes["class"] }>()
+</script>
+
+<template>
+  <CalendarGridHead
+    data-slot="calendar-grid-head"
+    v-bind="props"
+  >
+    <slot />
+  </CalendarGridHead>
+</template>

--- a/resources/js/components/ui/calendar/CalendarGridRow.vue
+++ b/resources/js/components/ui/calendar/CalendarGridRow.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import type { CalendarGridRowProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarGridRow, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<CalendarGridRowProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarGridRow
+    data-slot="calendar-grid-row"
+    :class="cn('flex', props.class)" v-bind="forwardedProps"
+  >
+    <slot />
+  </CalendarGridRow>
+</template>

--- a/resources/js/components/ui/calendar/CalendarHeadCell.vue
+++ b/resources/js/components/ui/calendar/CalendarHeadCell.vue
@@ -1,0 +1,23 @@
+<script lang="ts" setup>
+import type { CalendarHeadCellProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarHeadCell, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<CalendarHeadCellProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarHeadCell
+    data-slot="calendar-head-cell"
+    :class="cn('text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem]', props.class)"
+    v-bind="forwardedProps"
+  >
+    <slot />
+  </CalendarHeadCell>
+</template>

--- a/resources/js/components/ui/calendar/CalendarHeader.vue
+++ b/resources/js/components/ui/calendar/CalendarHeader.vue
@@ -1,0 +1,23 @@
+<script lang="ts" setup>
+import type { CalendarHeaderProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarHeader, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<CalendarHeaderProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarHeader
+    data-slot="calendar-header"
+    :class="cn('flex justify-center pt-1 relative items-center w-full px-8', props.class)"
+    v-bind="forwardedProps"
+  >
+    <slot />
+  </CalendarHeader>
+</template>

--- a/resources/js/components/ui/calendar/CalendarHeading.vue
+++ b/resources/js/components/ui/calendar/CalendarHeading.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import type { CalendarHeadingProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarHeading, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<CalendarHeadingProps & { class?: HTMLAttributes["class"] }>()
+
+defineSlots<{
+  default: (props: { headingValue: string }) => any
+}>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarHeading
+    v-slot="{ headingValue }"
+    data-slot="calendar-heading"
+    :class="cn('text-sm font-medium', props.class)"
+    v-bind="forwardedProps"
+  >
+    <slot :heading-value>
+      {{ headingValue }}
+    </slot>
+  </CalendarHeading>
+</template>

--- a/resources/js/components/ui/calendar/CalendarNextButton.vue
+++ b/resources/js/components/ui/calendar/CalendarNextButton.vue
@@ -1,0 +1,31 @@
+<script lang="ts" setup>
+import type { CalendarNextProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { ChevronRight } from "@lucide/vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarNext, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+import { buttonVariants } from '@/components/ui/button'
+
+const props = defineProps<CalendarNextProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarNext
+    data-slot="calendar-next-button"
+    :class="cn(
+      buttonVariants({ variant: 'outline' }),
+      'size-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+      props.class,
+    )"
+    v-bind="forwardedProps"
+  >
+    <slot>
+      <ChevronRight class="size-4" />
+    </slot>
+  </CalendarNext>
+</template>

--- a/resources/js/components/ui/calendar/CalendarPrevButton.vue
+++ b/resources/js/components/ui/calendar/CalendarPrevButton.vue
@@ -1,0 +1,31 @@
+<script lang="ts" setup>
+import type { CalendarPrevProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { ChevronLeft } from "@lucide/vue"
+import { reactiveOmit } from "@vueuse/core"
+import { CalendarPrev, useForwardProps } from "reka-ui"
+import { cn } from "@/lib/utils"
+import { buttonVariants } from '@/components/ui/button'
+
+const props = defineProps<CalendarPrevProps & { class?: HTMLAttributes["class"] }>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <CalendarPrev
+    data-slot="calendar-prev-button"
+    :class="cn(
+      buttonVariants({ variant: 'outline' }),
+      'size-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+      props.class,
+    )"
+    v-bind="forwardedProps"
+  >
+    <slot>
+      <ChevronLeft class="size-4" />
+    </slot>
+  </CalendarPrev>
+</template>

--- a/resources/js/components/ui/calendar/index.ts
+++ b/resources/js/components/ui/calendar/index.ts
@@ -1,0 +1,14 @@
+export { default as Calendar } from "./Calendar.vue"
+export { default as CalendarCell } from "./CalendarCell.vue"
+export { default as CalendarCellTrigger } from "./CalendarCellTrigger.vue"
+export { default as CalendarGrid } from "./CalendarGrid.vue"
+export { default as CalendarGridBody } from "./CalendarGridBody.vue"
+export { default as CalendarGridHead } from "./CalendarGridHead.vue"
+export { default as CalendarGridRow } from "./CalendarGridRow.vue"
+export { default as CalendarHeadCell } from "./CalendarHeadCell.vue"
+export { default as CalendarHeader } from "./CalendarHeader.vue"
+export { default as CalendarHeading } from "./CalendarHeading.vue"
+export { default as CalendarNextButton } from "./CalendarNextButton.vue"
+export { default as CalendarPrevButton } from "./CalendarPrevButton.vue"
+
+export type LayoutTypes = "month-and-year" | "month-only" | "year-only" | undefined

--- a/resources/js/components/ui/native-select/NativeSelect.vue
+++ b/resources/js/components/ui/native-select/NativeSelect.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { AcceptableValue } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { ChevronDownIcon } from "@lucide/vue"
+import { reactiveOmit, useVModel } from "@vueuse/core"
+import { cn } from "@/lib/utils"
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = defineProps<{ modelValue?: AcceptableValue | AcceptableValue[], class?: HTMLAttributes["class"] }>()
+
+const emit = defineEmits<{
+  "update:modelValue": AcceptableValue
+}>()
+
+const modelValue = useVModel(props, "modelValue", emit, {
+  passive: true,
+  defaultValue: "",
+})
+
+const delegatedProps = reactiveOmit(props, "class")
+</script>
+
+<template>
+  <div
+    class="group/native-select relative w-fit has-[select:disabled]:opacity-50"
+    data-slot="native-select-wrapper"
+  >
+    <select
+      v-bind="{ ...$attrs, ...delegatedProps }"
+      v-model="modelValue"
+      data-slot="native-select"
+      :class="cn(
+        'border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        props.class,
+      )"
+    >
+      <slot />
+    </select>
+    <ChevronDownIcon
+      class="text-muted-foreground pointer-events-none absolute top-1/2 right-3.5 size-4 -translate-y-1/2 opacity-50 select-none"
+      aria-hidden="true"
+      data-slot="native-select-icon"
+    />
+  </div>
+</template>

--- a/resources/js/components/ui/native-select/NativeSelectOptGroup.vue
+++ b/resources/js/components/ui/native-select/NativeSelectOptGroup.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from "vue"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<{ class?: HTMLAttributes["class"] }>()
+</script>
+
+<template>
+  <optgroup data-slot="native-select-optgroup" :class="cn('bg-popover text-popover-foreground', props.class)">
+    <slot />
+  </optgroup>
+</template>

--- a/resources/js/components/ui/native-select/NativeSelectOption.vue
+++ b/resources/js/components/ui/native-select/NativeSelectOption.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from "vue"
+import { cn } from "@/lib/utils"
+
+const props = defineProps<{ class?: HTMLAttributes["class"] }>()
+</script>
+
+<template>
+  <option data-slot="native-select-option" :class="cn('bg-popover text-popover-foreground', props.class)">
+    <slot />
+  </option>
+</template>

--- a/resources/js/components/ui/native-select/index.ts
+++ b/resources/js/components/ui/native-select/index.ts
@@ -1,0 +1,3 @@
+export { default as NativeSelect } from "./NativeSelect.vue"
+export { default as NativeSelectOptGroup } from "./NativeSelectOptGroup.vue"
+export { default as NativeSelectOption } from "./NativeSelectOption.vue"

--- a/resources/js/lib/scheduleTime.test.ts
+++ b/resources/js/lib/scheduleTime.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+    formatScheduledFor,
+    isSendAtInFuture,
+    schedulePresets,
+    to12Hour,
+    to24Hour,
+    wallTimeToInstant,
+    zonedWallTime,
+} from '@/lib/scheduleTime';
+
+// A fixed reference instant: Tuesday 14 Jul 2026, 15:30 UTC.
+const NOW = new Date('2026-07-14T15:30:00.000Z');
+
+describe('zonedWallTime', () => {
+    it('reads the wall clock a zone shows at an instant', () => {
+        expect(zonedWallTime('UTC', NOW)).toEqual({
+            year: 2026,
+            month: 7,
+            day: 14,
+            hour: 15,
+            minute: 30,
+        });
+
+        // America/New_York is UTC-4 in July (EDT).
+        expect(zonedWallTime('America/New_York', NOW)).toEqual({
+            year: 2026,
+            month: 7,
+            day: 14,
+            hour: 11,
+            minute: 30,
+        });
+    });
+});
+
+describe('wallTimeToInstant', () => {
+    it('resolves a wall-clock time in UTC to the same instant', () => {
+        const instant = wallTimeToInstant(
+            { year: 2026, month: 7, day: 14, hour: 9, minute: 0 },
+            'UTC',
+        );
+
+        expect(instant.toISOString()).toBe('2026-07-14T09:00:00.000Z');
+    });
+
+    it('resolves a wall-clock time in an offset zone by correcting for the offset', () => {
+        // 9:00 AM in New York (UTC-4) is 13:00 UTC.
+        const instant = wallTimeToInstant(
+            { year: 2026, month: 7, day: 14, hour: 9, minute: 0 },
+            'America/New_York',
+        );
+
+        expect(instant.toISOString()).toBe('2026-07-14T13:00:00.000Z');
+    });
+});
+
+describe('schedulePresets', () => {
+    it('offers in-an-hour, this-evening, tomorrow and next-monday in the afternoon', () => {
+        const presets = schedulePresets('UTC', NOW);
+        const byKey = Object.fromEntries(presets.map((p) => [p.key, p.sendAt]));
+
+        expect(presets.map((p) => p.key)).toEqual([
+            'in-an-hour',
+            'this-evening',
+            'tomorrow-morning',
+            'next-monday',
+        ]);
+        expect(byKey['in-an-hour']).toBe('2026-07-14T16:30:00.000Z');
+        expect(byKey['this-evening']).toBe('2026-07-14T18:00:00.000Z');
+        expect(byKey['tomorrow-morning']).toBe('2026-07-15T09:00:00.000Z');
+        // Tuesday 14 Jul → next Monday is 20 Jul.
+        expect(byKey['next-monday']).toBe('2026-07-20T09:00:00.000Z');
+    });
+
+    it('drops the evening option once it is too late in the day', () => {
+        const evening = new Date('2026-07-14T20:00:00.000Z');
+        const keys = schedulePresets('UTC', evening).map((p) => p.key);
+
+        expect(keys).not.toContain('this-evening');
+        expect(keys).toContain('tomorrow-morning');
+    });
+
+    it('resolves the next Monday to the following week when today is Monday', () => {
+        const monday = new Date('2026-07-20T09:00:00.000Z');
+        const byKey = Object.fromEntries(
+            schedulePresets('UTC', monday).map((p) => [p.key, p.sendAt]),
+        );
+
+        expect(byKey['next-monday']).toBe('2026-07-27T09:00:00.000Z');
+    });
+});
+
+describe('to24Hour', () => {
+    it('maps a 12-hour clock and meridiem onto a 24-hour hour', () => {
+        expect(to24Hour(12, 'AM')).toBe(0);
+        expect(to24Hour(9, 'AM')).toBe(9);
+        expect(to24Hour(12, 'PM')).toBe(12);
+        expect(to24Hour(1, 'PM')).toBe(13);
+        expect(to24Hour(11, 'PM')).toBe(23);
+    });
+});
+
+describe('to12Hour', () => {
+    it('splits a 24-hour hour back into a 12-hour hour and meridiem', () => {
+        expect(to12Hour(0)).toEqual({ hour: 12, period: 'AM' });
+        expect(to12Hour(9)).toEqual({ hour: 9, period: 'AM' });
+        expect(to12Hour(12)).toEqual({ hour: 12, period: 'PM' });
+        expect(to12Hour(13)).toEqual({ hour: 1, period: 'PM' });
+        expect(to12Hour(23)).toEqual({ hour: 11, period: 'PM' });
+    });
+});
+
+describe('isSendAtInFuture', () => {
+    it('accepts an instant at least the lead ahead', () => {
+        expect(isSendAtInFuture('2026-07-14T15:32:00.000Z', NOW, 1)).toBe(true);
+    });
+
+    it('rejects an instant inside the lead window or in the past', () => {
+        expect(isSendAtInFuture('2026-07-14T15:30:30.000Z', NOW, 1)).toBe(
+            false,
+        );
+        expect(isSendAtInFuture('2026-07-14T15:00:00.000Z', NOW, 1)).toBe(
+            false,
+        );
+    });
+
+    it('rejects an unparseable instant', () => {
+        expect(isSendAtInFuture('nonsense', NOW, 1)).toBe(false);
+    });
+});
+
+describe('formatScheduledFor', () => {
+    it('labels today and tomorrow by name', () => {
+        expect(
+            formatScheduledFor('2026-07-14T18:00:00.000Z', 'UTC', NOW),
+        ).toMatch(/^Today at /);
+        expect(
+            formatScheduledFor('2026-07-15T09:00:00.000Z', 'UTC', NOW),
+        ).toMatch(/^Tomorrow at /);
+    });
+
+    it('labels a further day by its weekday and date', () => {
+        const label = formatScheduledFor(
+            '2026-07-20T09:00:00.000Z',
+            'UTC',
+            NOW,
+        );
+
+        expect(label).toMatch(/Jul 20/);
+        expect(label).not.toMatch(/^Today/);
+        expect(label).not.toMatch(/^Tomorrow/);
+    });
+});

--- a/resources/js/lib/scheduleTime.ts
+++ b/resources/js/lib/scheduleTime.ts
@@ -1,0 +1,259 @@
+/**
+ * Pure time math for the "schedule / send later" composer. Every value the user
+ * picks is a wall-clock time in *their* stored IANA zone; this module converts
+ * between that wall clock and the UTC instant stored on the server, computes the
+ * quick presets, and formats a stored instant back for display. Kept free of Vue
+ * and DOM so it can be unit-tested in isolation.
+ *
+ * `now` is always injectable so tests are deterministic.
+ */
+
+/** Wall-clock components, as read off a clock on the wall in some zone. */
+export type WallTime = {
+    year: number;
+    month: number; // 1-12
+    day: number;
+    hour: number; // 0-23
+    minute: number;
+};
+
+/** A quick-pick option offered in the schedule dialog. */
+export type SchedulePreset = {
+    key: string;
+    label: string;
+    /** The chosen instant as a UTC ISO 8601 string. */
+    sendAt: string;
+};
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 3_600_000;
+
+/**
+ * Read the wall-clock components a zone shows at a given instant.
+ */
+export function zonedWallTime(timeZone: string, at: Date): WallTime {
+    const parts = new Intl.DateTimeFormat('en-US', {
+        timeZone,
+        hourCycle: 'h23',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+    }).formatToParts(at);
+
+    const read = (type: string): number =>
+        Number(parts.find((part) => part.type === type)?.value);
+
+    return {
+        year: read('year'),
+        month: read('month'),
+        day: read('day'),
+        hour: read('hour'),
+        minute: read('minute'),
+    };
+}
+
+/**
+ * The instant a wall-clock time names in a given zone.
+ *
+ * Reads the zone's offset at the candidate instant and corrects for it. A single
+ * correction is exact everywhere except within the ~1h window of a DST shift,
+ * which the presets (morning/evening) never land in.
+ */
+export function wallTimeToInstant(wall: WallTime, timeZone: string): Date {
+    const naiveUtc = Date.UTC(
+        wall.year,
+        wall.month - 1,
+        wall.day,
+        wall.hour,
+        wall.minute,
+    );
+
+    const shown = zonedWallTime(timeZone, new Date(naiveUtc));
+    const shownUtc = Date.UTC(
+        shown.year,
+        shown.month - 1,
+        shown.day,
+        shown.hour,
+        shown.minute,
+    );
+
+    // How far the zone's wall clock ran ahead of UTC at the candidate instant.
+    const offset = shownUtc - naiveUtc;
+
+    return new Date(naiveUtc - offset);
+}
+
+/**
+ * Shift a civil date (calendar day, no zone) by whole days, wrapping months and
+ * years correctly. Used to name "tomorrow" and "next Monday" as calendar days.
+ */
+function addCivilDays(
+    date: Pick<WallTime, 'year' | 'month' | 'day'>,
+    days: number,
+): Pick<WallTime, 'year' | 'month' | 'day'> {
+    const shifted = new Date(Date.UTC(date.year, date.month - 1, date.day));
+    shifted.setUTCDate(shifted.getUTCDate() + days);
+
+    return {
+        year: shifted.getUTCFullYear(),
+        month: shifted.getUTCMonth() + 1,
+        day: shifted.getUTCDate(),
+    };
+}
+
+/**
+ * The day-of-week (0 = Sunday … 6 = Saturday) of a civil date.
+ */
+function civilWeekday(date: Pick<WallTime, 'year' | 'month' | 'day'>): number {
+    return new Date(Date.UTC(date.year, date.month - 1, date.day)).getUTCDay();
+}
+
+/**
+ * The quick-pick presets to offer, computed against the viewer's zone and the
+ * current instant. "In 1 hour" is a pure offset; the rest are wall-clock times
+ * (this evening 6pm, tomorrow & next Monday at 9am) resolved to instants. The
+ * evening option is dropped once it's too late in the day for it to be future.
+ */
+export function schedulePresets(
+    timeZone: string,
+    now: Date = new Date(),
+): SchedulePreset[] {
+    const presets: SchedulePreset[] = [
+        {
+            key: 'in-an-hour',
+            label: 'In 1 hour',
+            sendAt: new Date(now.getTime() + MS_PER_HOUR).toISOString(),
+        },
+    ];
+
+    const wall = zonedWallTime(timeZone, now);
+
+    // "This evening" (6pm) only while it's still comfortably ahead.
+    if (wall.hour < 17) {
+        presets.push({
+            key: 'this-evening',
+            label: 'This evening',
+            sendAt: wallTimeToInstant(
+                {
+                    year: wall.year,
+                    month: wall.month,
+                    day: wall.day,
+                    hour: 18,
+                    minute: 0,
+                },
+                timeZone,
+            ).toISOString(),
+        });
+    }
+
+    const tomorrow = addCivilDays(wall, 1);
+    presets.push({
+        key: 'tomorrow-morning',
+        label: 'Tomorrow morning',
+        sendAt: wallTimeToInstant(
+            { ...tomorrow, hour: 9, minute: 0 },
+            timeZone,
+        ).toISOString(),
+    });
+
+    // Next Monday (1). `|| 7` makes "on a Monday" resolve to the following one.
+    const daysUntilMonday = (((1 - civilWeekday(wall)) % 7) + 7) % 7 || 7;
+    const nextMonday = addCivilDays(wall, daysUntilMonday);
+    presets.push({
+        key: 'next-monday',
+        label: 'Next Monday',
+        sendAt: wallTimeToInstant(
+            { ...nextMonday, hour: 9, minute: 0 },
+            timeZone,
+        ).toISOString(),
+    });
+
+    return presets;
+}
+
+/**
+ * Combine a 12-hour clock hour with its meridiem into a 24-hour hour, the way
+ * the time selects express what the viewer picked.
+ */
+export function to24Hour(hour12: number, period: 'AM' | 'PM'): number {
+    const base = hour12 % 12;
+
+    return period === 'PM' ? base + 12 : base;
+}
+
+/**
+ * Split a 24-hour clock hour into a 12-hour hour and meridiem, for seeding the
+ * time selects when editing an existing scheduled message.
+ */
+export function to12Hour(hour24: number): {
+    hour: number;
+    period: 'AM' | 'PM';
+} {
+    const period: 'AM' | 'PM' = hour24 < 12 ? 'AM' : 'PM';
+    const hour = hour24 % 12 === 0 ? 12 : hour24 % 12;
+
+    return { hour, period };
+}
+
+/**
+ * Whether a chosen instant is far enough in the future to schedule. Mirrors the
+ * server's "must be in the future" rule with a small lead so a value the user
+ * just picked hasn't already lapsed by the time they confirm.
+ */
+export function isSendAtInFuture(
+    iso: string,
+    now: Date = new Date(),
+    leadMinutes = 1,
+): boolean {
+    const target = new Date(iso).getTime();
+
+    return (
+        Number.isFinite(target) &&
+        target - now.getTime() >= leadMinutes * MS_PER_MINUTE
+    );
+}
+
+/**
+ * Format a stored instant for display in the viewer's zone, e.g.
+ * "Today at 3:45 PM", "Tomorrow at 9:00 AM", or "Mon, Jul 14 at 9:00 AM".
+ */
+export function formatScheduledFor(
+    iso: string,
+    timeZone: string,
+    now: Date = new Date(),
+): string {
+    const target = new Date(iso);
+    const time = target.toLocaleTimeString(undefined, {
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone,
+    });
+
+    const targetDay = zonedWallTime(timeZone, target);
+    const nowDay = zonedWallTime(timeZone, now);
+
+    const dayDiff = Math.round(
+        (Date.UTC(targetDay.year, targetDay.month - 1, targetDay.day) -
+            Date.UTC(nowDay.year, nowDay.month - 1, nowDay.day)) /
+            (24 * MS_PER_HOUR),
+    );
+
+    if (dayDiff === 0) {
+        return `Today at ${time}`;
+    }
+
+    if (dayDiff === 1) {
+        return `Tomorrow at ${time}`;
+    }
+
+    const date = target.toLocaleDateString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        timeZone,
+    });
+
+    return `${date} at ${time}`;
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -7,6 +7,7 @@ import {
     AtSign,
     BellMinus,
     BellOff,
+    CalendarClock,
     ChevronDown,
     EllipsisVertical,
     Star,
@@ -37,9 +38,15 @@ import {
     update as updateMessage,
 } from '@/actions/App/Http/Controllers/Channels/MessageController';
 import { store as toggleReactionAction } from '@/actions/App/Http/Controllers/Channels/ReactionController';
+import {
+    destroy as destroyScheduledMessage,
+    store as storeScheduledMessage,
+    update as updateScheduledMessage,
+} from '@/actions/App/Http/Controllers/Channels/ScheduledMessageController';
 import ForwardMessageDialog from '@/components/ForwardMessageDialog.vue';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
+import ScheduledMessagesDialog from '@/components/ScheduledMessagesDialog.vue';
 import ThreadPanel from '@/components/ThreadPanel.vue';
 import TypingIndicator from '@/components/TypingIndicator.vue';
 import { Button } from '@/components/ui/button';
@@ -71,6 +78,7 @@ import {
 } from '@/composables/useMessageStream';
 import { useScrollPin } from '@/composables/useScrollPin';
 import { useTeamPresence } from '@/composables/useTeamPresence';
+import { useTimezone } from '@/composables/useTimezone';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
 import { toggleReaction } from '@/lib/reactions';
@@ -86,6 +94,7 @@ import type {
     NotificationLevel,
     NotificationLevelOption,
     Reaction,
+    ScheduledMessage,
     Thread,
 } from '@/types';
 
@@ -112,6 +121,9 @@ const props = defineProps<{
     // The open thread's replies, a reverse-infinite-scroll page that grows as
     // older replies load. Empty when no thread is open.
     threadReplies: MessagePage;
+    // The viewer's own pending scheduled messages for this channel, soonest
+    // first, feeding the composer's "Scheduled" affordance.
+    scheduledMessages: ScheduledMessage[];
 }>();
 
 const page = usePage();
@@ -761,6 +773,107 @@ function send(body: string, mentions: Mention[]): void {
     );
 }
 
+// The viewer's stored timezone, driving the schedule picker's presets and the
+// list's "sends at" labels so a scheduled time always reads in their own zone.
+const { timezone } = useTimezone();
+
+// Whether the "Scheduled messages" management dialog is open.
+const scheduledDialogOpen = ref(false);
+
+// Schedule the composer's text for later delivery. Unlike a send it renders
+// nothing in the timeline (it isn't posted yet) — it only lands in the
+// "Scheduled" surface. Scheduling consumes the composer text like a send, so any
+// debounced draft save in flight is dropped and the server clears the draft.
+function scheduleMessage(
+    body: string,
+    _mentions: Mention[],
+    sendAt: string,
+): void {
+    if (draftTimer) {
+        clearTimeout(draftTimer);
+        draftTimer = null;
+    }
+
+    pendingDraft = null;
+
+    const target = replyTarget.value;
+
+    router.post(
+        storeScheduledMessage({
+            team: props.team.slug,
+            channel: props.channel.slug,
+        }).url,
+        {
+            body,
+            client_uuid: crypto.randomUUID(),
+            reply_to_id: target?.id ?? null,
+            send_at: sendAt,
+        },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['scheduledMessages', 'channels'],
+            onSuccess: () => toast.success('Message scheduled.'),
+            onError: () =>
+                toast.error(
+                    'Failed to schedule your message. Please try again.',
+                ),
+        },
+    );
+
+    cancelReply();
+}
+
+// Save an edit to a pending scheduled message's body and send time.
+function updateScheduled({
+    id,
+    body,
+    sendAt,
+}: {
+    id: string;
+    body: string;
+    sendAt: string;
+}): void {
+    router.patch(
+        updateScheduledMessage({
+            team: props.team.slug,
+            channel: props.channel.slug,
+            scheduledMessage: id,
+        }).url,
+        { body, send_at: sendAt },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['scheduledMessages'],
+            onError: () =>
+                toast.error(
+                    'Failed to update the scheduled message. Please try again.',
+                ),
+        },
+    );
+}
+
+// Cancel a pending scheduled message so it is never delivered.
+function cancelScheduled(id: string): void {
+    router.delete(
+        destroyScheduledMessage({
+            team: props.team.slug,
+            channel: props.channel.slug,
+            scheduledMessage: id,
+        }).url,
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['scheduledMessages'],
+            onSuccess: () => toast.success('Scheduled message cancelled.'),
+            onError: () =>
+                toast.error(
+                    'Failed to cancel the scheduled message. Please try again.',
+                ),
+        },
+    );
+}
+
 // Post a reply into the open thread. It renders optimistically in the panel and,
 // when "also send to channel" is checked, in the main timeline too.
 function sendThreadReply(
@@ -1359,6 +1472,22 @@ function archive(): void {
                         class="mx-5 shrink-0"
                     />
 
+                    <button
+                        v-if="props.scheduledMessages.length > 0"
+                        type="button"
+                        data-test="scheduled-trigger"
+                        class="mx-5 mb-1 inline-flex w-fit items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-[12px] font-medium text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+                        @click="scheduledDialogOpen = true"
+                    >
+                        <CalendarClock class="size-3.5" />
+                        {{ props.scheduledMessages.length }}
+                        {{
+                            props.scheduledMessages.length === 1
+                                ? 'scheduled message'
+                                : 'scheduled messages'
+                        }}
+                    </button>
+
                     <MessageComposer
                         ref="channelComposer"
                         :key="props.channel.id"
@@ -1366,7 +1495,10 @@ function archive(): void {
                         :members="mentionableMembers"
                         :reply-target="replyTarget"
                         :initial-body="props.channel.draft ?? ''"
+                        allow-schedule
+                        :timezone="timezone"
                         @send="send"
+                        @schedule="scheduleMessage"
                         @typing="onTyping"
                         @cancel-reply="cancelReply"
                         @draft-change="onDraftChange"
@@ -1414,6 +1546,14 @@ function archive(): void {
         :message="forwardTarget"
         :channels="forwardableChannels"
         @submit="forwardMessage"
+    />
+
+    <ScheduledMessagesDialog
+        v-model:open="scheduledDialogOpen"
+        :scheduled-messages="props.scheduledMessages"
+        :timezone="timezone"
+        @update="updateScheduled"
+        @cancel="cancelScheduled"
     />
 
     <Dialog v-model:open="confirmingArchive">

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -136,6 +136,21 @@ export type Message = {
 };
 
 /**
+ * A message the viewer has scheduled for future delivery to the channel. Mirrors
+ * the `ScheduledMessageData` DTO: the pending body, the UTC `sendAt` instant (the
+ * client renders it in the viewer's zone), and the inline reply quote it will
+ * carry once delivered. The channel page lists the viewer's own pending rows in
+ * the `scheduledMessages` prop.
+ */
+export type ScheduledMessage = {
+    id: string;
+    body: string;
+    sendAt: string;
+    createdAt: string;
+    replyTo: MessageReply | null;
+};
+
+/**
  * An open thread's root message. Mirrors the `thread` prop the channel page
  * loads on demand from `?thread=`; the replies ride a separate, paginated
  * `threadReplies` scroll prop (a `MessagePage`).

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\Channels\DispatchDueScheduledMessages;
 use App\Models\TeamInvitation;
 use Illuminate\Support\Facades\Schedule;
 
@@ -9,3 +10,9 @@ Schedule::call(function () {
         ->where('expires_at', '<', now())
         ->delete();
 })->daily()->description('Delete expired team invitations');
+
+Schedule::call(fn (DispatchDueScheduledMessages $dispatch) => $dispatch->handle())
+    ->name('deliver-due-scheduled-messages')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->description('Deliver due scheduled messages');

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Channels\ChannelStarController;
 use App\Http\Controllers\Channels\ForwardMessageController;
 use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Channels\ReactionController;
+use App\Http\Controllers\Channels\ScheduledMessageController;
 use App\Http\Controllers\Channels\SearchController;
 use App\Http\Controllers\Channels\ThreadsController;
 use App\Http\Controllers\SidebarSectionController;
@@ -70,6 +71,15 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/messages/{message}/forward', [ForwardMessageController::class, 'store'])
         ->scopeBindings()
         ->name('channels.messages.forward');
+    Route::post('t/{team}/c/{channel}/scheduled-messages', [ScheduledMessageController::class, 'store'])
+        ->scopeBindings()
+        ->name('channels.scheduled-messages.store');
+    Route::patch('t/{team}/c/{channel}/scheduled-messages/{scheduledMessage}', [ScheduledMessageController::class, 'update'])
+        ->scopeBindings()
+        ->name('channels.scheduled-messages.update');
+    Route::delete('t/{team}/c/{channel}/scheduled-messages/{scheduledMessage}', [ScheduledMessageController::class, 'destroy'])
+        ->scopeBindings()
+        ->name('channels.scheduled-messages.destroy');
     Route::post('t/{team}/c/{channel}/messages/{message}/reactions', [ReactionController::class, 'store'])
         ->scopeBindings()
         ->name('channels.messages.reactions.store');

--- a/tests/Feature/Channels/DispatchScheduledMessageTest.php
+++ b/tests/Feature/Channels/DispatchScheduledMessageTest.php
@@ -1,0 +1,204 @@
+<?php
+
+use App\Actions\Channels\DispatchDueScheduledMessages;
+use App\Actions\Teams\CreateTeam;
+use App\Data\MessageData;
+use App\Enums\ScheduledMessageStatus;
+use App\Enums\TeamRole;
+use App\Events\MessageSent;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\ScheduledMessage;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function dispatchTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/** Run the per-minute dispatch scan. */
+function dispatchDue(): void
+{
+    app(DispatchDueScheduledMessages::class)->handle();
+}
+
+test('a due scheduled message is delivered through the normal send path and broadcasts', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create([
+        'body' => 'from the past',
+        'send_at' => now()->subMinute(),
+    ]);
+
+    dispatchDue();
+
+    $message = Message::where('client_uuid', $scheduled->client_uuid)->firstOrFail();
+
+    expect($message->body)->toBe('from the past')
+        ->and($message->user_id)->toBe($owner->id)
+        ->and($message->channel_id)->toBe($general->id)
+        ->and($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Sent)
+        ->and($scheduled->fresh()->sent_at)->not->toBeNull();
+
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($general, $message) {
+        return $event->broadcastOn()[0]->name === 'private-channel.'.$general->id
+            && $event->broadcastWith() === MessageData::fromMessage($message->fresh()->load('user'))->toArray();
+    });
+});
+
+test('a scheduled message not yet due is left pending', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create([
+        'send_at' => now()->addHour(),
+    ]);
+
+    dispatchDue();
+
+    expect($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Pending)
+        ->and(Message::count())->toBe(0);
+    Event::assertNotDispatched(MessageSent::class);
+});
+
+test('a cancelled scheduled message is never delivered', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ScheduledMessage::factory()->for($general)->for($owner)->cancelled()->create([
+        'send_at' => now()->subMinute(),
+    ]);
+
+    dispatchDue();
+
+    expect(Message::count())->toBe(0);
+    Event::assertNotDispatched(MessageSent::class);
+});
+
+test('a due message is delivered at most once across overlapping runs', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    ScheduledMessage::factory()->for($general)->for($owner)->create([
+        'send_at' => now()->subMinute(),
+    ]);
+
+    dispatchDue();
+    dispatchDue();
+
+    expect(Message::count())->toBe(1);
+    Event::assertDispatchedTimes(MessageSent::class, 1);
+});
+
+test('a due message preserves the inline reply quote when its target is still live', function () {
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create([
+        'send_at' => now()->subMinute(),
+    ]);
+
+    dispatchDue();
+
+    $message = Message::where('client_uuid', $scheduled->client_uuid)->firstOrFail();
+
+    expect($message->reply_to_id)->toBe($parent->id)
+        ->and($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Sent);
+});
+
+test('a due message drops a since-deleted reply target but still sends', function () {
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create([
+        'body' => 'still worth sending',
+        'send_at' => now()->subMinute(),
+    ]);
+    $parent->delete();
+
+    dispatchDue();
+
+    $message = Message::where('client_uuid', $scheduled->client_uuid)->firstOrFail();
+
+    expect($message->reply_to_id)->toBeNull()
+        ->and($message->body)->toBe('still worth sending')
+        ->and($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Sent);
+});
+
+test('a due message for an archived channel fails instead of delivering', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team] = dispatchTeamWithGeneral();
+    $channel = Channel::factory()->for($team)->create();
+    $channel->channelMembers()->create(['user_id' => $owner->id]);
+    $scheduled = ScheduledMessage::factory()->for($channel)->for($owner)->create([
+        'send_at' => now()->subMinute(),
+    ]);
+    $channel->update(['archived_at' => now()]);
+
+    dispatchDue();
+
+    expect(Message::count())->toBe(0)
+        ->and($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Failed)
+        ->and($scheduled->fresh()->failed_at)->not->toBeNull()
+        ->and($scheduled->fresh()->failure_reason)->not->toBeNull();
+    Event::assertNotDispatched(MessageSent::class);
+});
+
+test('a due message fails when its author is no longer a channel member', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    $author = User::factory()->create();
+    $team->memberships()->create(['user_id' => $author->id, 'role' => TeamRole::Member]);
+    $general->channelMembers()->firstOrCreate(['user_id' => $author->id]);
+    $scheduled = ScheduledMessage::factory()->for($general)->for($author)->create([
+        'send_at' => now()->subMinute(),
+    ]);
+    $general->channelMembers()->where('user_id', $author->id)->delete();
+
+    dispatchDue();
+
+    expect(Message::count())->toBe(0)
+        ->and($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Failed);
+    Event::assertNotDispatched(MessageSent::class);
+});
+
+test('delivering a scheduled message leaves the author current draft untouched', function () {
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    $owner->channels()->updateExistingPivot($general->id, ['draft' => 'a fresh draft']);
+    ScheduledMessage::factory()->for($general)->for($owner)->create([
+        'send_at' => now()->subMinute(),
+    ]);
+
+    dispatchDue();
+
+    expect($owner->channels()->where('channels.id', $general->id)->first()->pivot->draft)
+        ->toBe('a fresh draft');
+});
+
+test('the send time is honored as a UTC instant regardless of when the scan runs', function () {
+    [$owner, $team, $general] = dispatchTeamWithGeneral();
+    $sendAt = now()->addMinutes(30);
+    ScheduledMessage::factory()->for($general)->for($owner)->create(['send_at' => $sendAt]);
+
+    // A scan a minute before the instant leaves it pending.
+    $this->travelTo($sendAt->copy()->subMinute());
+    dispatchDue();
+    expect(Message::count())->toBe(0);
+
+    // A scan once the instant has arrived delivers it.
+    $this->travelTo($sendAt->copy()->addSecond());
+    dispatchDue();
+    expect(Message::count())->toBe(1);
+});

--- a/tests/Feature/Channels/ScheduleMessageTest.php
+++ b/tests/Feature/Channels/ScheduleMessageTest.php
@@ -1,0 +1,188 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ScheduledMessageStatus;
+use App\Enums\TeamRole;
+use App\Events\MessageSent;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\ScheduledMessage;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function scheduleTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+test('a member can schedule a message for a future time', function () {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    $clientUuid = (string) Str::uuid7();
+    $sendAt = now()->addHour();
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'send me later',
+            'client_uuid' => $clientUuid,
+            'send_at' => $sendAt->toIso8601String(),
+        ])
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $scheduled = ScheduledMessage::firstOrFail();
+
+    expect($scheduled->body)->toBe('send me later')
+        ->and($scheduled->client_uuid)->toBe($clientUuid)
+        ->and($scheduled->user_id)->toBe($owner->id)
+        ->and($scheduled->channel_id)->toBe($general->id)
+        ->and($scheduled->status)->toBe(ScheduledMessageStatus::Pending)
+        ->and($scheduled->send_at->toIso8601String())->toBe($sendAt->toIso8601String());
+
+    // Scheduling posts nothing yet: no message row and no broadcast.
+    expect(Message::count())->toBe(0);
+    Event::assertNotDispatched(MessageSent::class);
+});
+
+test('scheduling clears the author composer draft for the channel', function () {
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    $owner->channels()->updateExistingPivot($general->id, ['draft' => 'half-typed']);
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'send me later',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->addHour()->toIso8601String(),
+        ]);
+
+    expect($owner->channels()->where('channels.id', $general->id)->first()->pivot->draft)->toBeNull();
+});
+
+test('a scheduled message can quote a live message in the same channel', function () {
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'a scheduled reply',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->addHour()->toIso8601String(),
+            'reply_to_id' => $parent->id,
+        ]);
+
+    expect(ScheduledMessage::firstOrFail()->reply_to_id)->toBe($parent->id);
+});
+
+test('a non-future send time is rejected', function () {
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'too late',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->subMinute()->toIso8601String(),
+        ])
+        ->assertInvalid(['send_at']);
+
+    expect(ScheduledMessage::count())->toBe(0);
+});
+
+test('a missing send time is rejected', function () {
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'when though',
+            'client_uuid' => (string) Str::uuid7(),
+        ])
+        ->assertInvalid(['send_at']);
+});
+
+test('an empty body is rejected', function () {
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => '   ',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->addHour()->toIso8601String(),
+        ])
+        ->assertInvalid(['body']);
+});
+
+test('the reply target must belong to the same channel', function () {
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    $other = Channel::factory()->for($team)->create();
+    $other->channelMembers()->create(['user_id' => $owner->id]);
+    $foreign = Message::factory()->for($other)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'cross-channel reply',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->addHour()->toIso8601String(),
+            'reply_to_id' => $foreign->id,
+        ])
+        ->assertInvalid(['reply_to_id']);
+});
+
+test('the reply target cannot be a deleted message', function () {
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create();
+    $parent->delete();
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'reply to a ghost',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->addHour()->toIso8601String(),
+            'reply_to_id' => $parent->id,
+        ])
+        ->assertInvalid(['reply_to_id']);
+});
+
+test('a non-member cannot schedule a message', function () {
+    [$owner, $team] = scheduleTeamWithGeneral();
+    // A private channel the team member is not a member of: the postMessage gate
+    // rejects scheduling just as it would an immediate send.
+    $private = Channel::factory()->for($team)->private()->create();
+    $private->channelMembers()->create(['user_id' => $owner->id]);
+
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+
+    $this->actingAs($stranger)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $private->slug]), [
+            'body' => 'let me in',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->addHour()->toIso8601String(),
+        ])
+        ->assertForbidden();
+
+    expect(ScheduledMessage::count())->toBe(0);
+});
+
+test('a message cannot be scheduled to an archived channel', function () {
+    [$owner, $team, $general] = scheduleTeamWithGeneral();
+    $channel = Channel::factory()->for($team)->archived()->create();
+    $channel->channelMembers()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($owner)
+        ->post(route('channels.scheduled-messages.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
+            'body' => 'to the archive',
+            'client_uuid' => (string) Str::uuid7(),
+            'send_at' => now()->addHour()->toIso8601String(),
+        ])
+        ->assertForbidden();
+});

--- a/tests/Feature/Channels/ScheduledMessageListTest.php
+++ b/tests/Feature/Channels/ScheduledMessageListTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\ScheduledMessage;
+use App\Models\Team;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function scheduledListTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+test('the channel page lists the viewer own pending scheduled messages, soonest first', function () {
+    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+
+    $later = ScheduledMessage::factory()->for($general)->for($owner)->create([
+        'body' => 'the later one',
+        'send_at' => now()->addHours(3),
+    ]);
+    $sooner = ScheduledMessage::factory()->for($general)->for($owner)->create([
+        'body' => 'the sooner one',
+        'send_at' => now()->addHour(),
+    ]);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('scheduledMessages', 2)
+            ->where('scheduledMessages.0.id', $sooner->id)
+            ->where('scheduledMessages.0.body', 'the sooner one')
+            ->where('scheduledMessages.1.id', $later->id)
+        );
+});
+
+test('the list excludes other members scheduled messages', function () {
+    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+
+    ScheduledMessage::factory()->for($general)->for($owner)->create(['body' => 'mine']);
+    ScheduledMessage::factory()->for($general)->for($other)->create(['body' => 'theirs']);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('scheduledMessages', 1)
+            ->where('scheduledMessages.0.body', 'mine')
+        );
+});
+
+test('the list excludes sent and cancelled scheduled messages', function () {
+    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+
+    ScheduledMessage::factory()->for($general)->for($owner)->create(['body' => 'still pending']);
+    ScheduledMessage::factory()->for($general)->for($owner)->sent()->create(['body' => 'already sent']);
+    ScheduledMessage::factory()->for($general)->for($owner)->cancelled()->create(['body' => 'was cancelled']);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('scheduledMessages', 1)
+            ->where('scheduledMessages.0.body', 'still pending')
+        );
+});
+
+test('the list is scoped to the current channel', function () {
+    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+    $other = Channel::factory()->for($team)->create();
+    $other->channelMembers()->create(['user_id' => $owner->id]);
+
+    ScheduledMessage::factory()->for($general)->for($owner)->create(['body' => 'in general']);
+    ScheduledMessage::factory()->for($other)->for($owner)->create(['body' => 'in other']);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('scheduledMessages', 1)
+            ->where('scheduledMessages.0.body', 'in general')
+        );
+});
+
+test('a scheduled message carries its inline reply quote', function () {
+    [$owner, $team, $general] = scheduledListTeamWithGeneral();
+    $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'the original']);
+    ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'scheduled answer']);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('scheduledMessages.0.replyTo.id', $parent->id)
+            ->where('scheduledMessages.0.replyTo.body', 'the original')
+            ->where('scheduledMessages.0.replyTo.authorName', $owner->name)
+        );
+});

--- a/tests/Feature/Channels/UpdateScheduledMessageTest.php
+++ b/tests/Feature/Channels/UpdateScheduledMessageTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ScheduledMessageStatus;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\ScheduledMessage;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function updateScheduledTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+test('the author can edit the body and send time of a pending scheduled message', function () {
+    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create([
+        'body' => 'first draft',
+        'send_at' => now()->addHour(),
+    ]);
+    $newTime = now()->addDay();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.scheduled-messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'scheduledMessage' => $scheduled->id,
+        ]), [
+            'body' => 'revised draft',
+            'send_at' => $newTime->toIso8601String(),
+        ])
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $scheduled->refresh();
+
+    expect($scheduled->body)->toBe('revised draft')
+        ->and($scheduled->send_at->toIso8601String())->toBe($newTime->toIso8601String())
+        ->and($scheduled->status)->toBe(ScheduledMessageStatus::Pending);
+});
+
+test('editing rejects a non-future send time', function () {
+    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.scheduled-messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'scheduledMessage' => $scheduled->id,
+        ]), [
+            'body' => 'revised',
+            'send_at' => now()->subMinute()->toIso8601String(),
+        ])
+        ->assertInvalid(['send_at']);
+});
+
+test('editing rejects an empty body', function () {
+    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.scheduled-messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'scheduledMessage' => $scheduled->id,
+        ]), [
+            'body' => '   ',
+            'send_at' => now()->addHour()->toIso8601String(),
+        ])
+        ->assertInvalid(['body']);
+});
+
+test('a non-author cannot edit a scheduled message', function () {
+    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create(['body' => 'not yours']);
+
+    $this->actingAs($other)
+        ->patch(route('channels.scheduled-messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'scheduledMessage' => $scheduled->id,
+        ]), [
+            'body' => 'hijacked',
+            'send_at' => now()->addHour()->toIso8601String(),
+        ])
+        ->assertForbidden();
+
+    expect($scheduled->fresh()->body)->toBe('not yours');
+});
+
+test('an already-sent scheduled message cannot be edited', function () {
+    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->sent()->create();
+
+    $this->actingAs($owner)
+        ->patch(route('channels.scheduled-messages.update', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'scheduledMessage' => $scheduled->id,
+        ]), [
+            'body' => 'too late to change',
+            'send_at' => now()->addHour()->toIso8601String(),
+        ])
+        ->assertForbidden();
+});
+
+test('the author can cancel a pending scheduled message', function () {
+    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->delete(route('channels.scheduled-messages.destroy', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'scheduledMessage' => $scheduled->id,
+        ]))
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $scheduled->refresh();
+
+    expect($scheduled->status)->toBe(ScheduledMessageStatus::Cancelled)
+        ->and($scheduled->cancelled_at)->not->toBeNull();
+});
+
+test('a non-author cannot cancel a scheduled message', function () {
+    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+    $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($other)
+        ->delete(route('channels.scheduled-messages.destroy', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'scheduledMessage' => $scheduled->id,
+        ]))
+        ->assertForbidden();
+
+    expect($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Pending);
+});
+
+test('a scheduled message id from another channel is not resolvable', function () {
+    [$owner, $team, $general] = updateScheduledTeamWithGeneral();
+    $other = Channel::factory()->for($team)->create();
+    $other->channelMembers()->create(['user_id' => $owner->id]);
+    $scheduled = ScheduledMessage::factory()->for($other)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->delete(route('channels.scheduled-messages.destroy', [
+            'team' => $team->slug,
+            'channel' => $general->slug,
+            'scheduledMessage' => $scheduled->id,
+        ]))
+        ->assertNotFound();
+});


### PR DESCRIPTION
Closes #32.

Let a member schedule a message to a channel for a future time; a queued per-minute scheduler posts it at the chosen moment, and the author can list, edit, and cancel their pending scheduled messages.

## What's included
- **Compose → schedule.** A "schedule for later" affordance on the main composer opens a picker (presets — in 1 hour / this evening / tomorrow morning / next Monday — plus a shadcn **Calendar + hour/minute/AM-PM selects**). Times are chosen in the viewer's timezone and stored UTC; a scheduled send does **not** render optimistically in the timeline.
- **Storage + dispatch.** A `scheduled_messages` table + `ScheduledMessage` model/enum/factory. `DispatchDueScheduledMessages` runs every minute (`routes/console.php`) and delivers each due, pending row through the existing `PostMessage->handle`, so a delivered message **enters the identical realtime flow** — broadcasts, mentions, and link previews — as an immediate send, then flips the row to `sent`.
- **Manage.** A per-channel "N scheduled messages" affordance opens a manager to edit (body + send time) or cancel pending rows. Only the author of a still-pending row may edit/cancel it (`ScheduledMessagePolicy`).

## Edge cases handled (and tested)
- Delivery-time validity: an **archived channel** or an author **removed** from the channel marks the row `failed` (no crash to the batch); a **since-deleted reply target** is dropped and the message still sends.
- **At-most-once**: delivery carries the scheduled `client_uuid` into `PostMessage`, whose `firstOrCreate` dedup means an overlapping tick can't double-send or double-broadcast (scheduler also runs `withoutOverlapping`).
- **Timezone correctness**: stored UTC, validated as future server-side, rendered/edited in the viewer's zone. `PostMessage` gained a `clearDraft` flag so a delayed delivery never wipes a draft typed in the meantime.

## Tests / gates
- Pest feature tests for schedule/list/edit/cancel + dispatch (delivery, broadcast, skip-cancelled, no-double-send, archived / removed-author / deleted-reply, tz-as-UTC-instant). `composer test` reports **Total: 100.0%** (Pint + PHPStan clean).
- Vitest for the pure `scheduleTime` logic (presets → instant, tz conversion, 12/24h, future-guard, formatting). Frontend lint/format/types/build all green.
- Verified end-to-end in the running app: schedule a message, see it in the manager, edit its time, cancel, and let one fire live.

## Notes
- The shadcn Calendar imports `@internationalized/date`, already present transitively via `reka-ui` — `package.json` is unchanged (no new dependency).