### PR TITLE
feat: self-hosting with Docker (prod image, compose, CI build check)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Rebuilt inside the image (Composer/Node stages) — never copy the host copies.
+node_modules
+vendor
+
+# VCS, CI, IDE, OS cruft.
+.git
+.gitattributes
+.github
+.idea
+.vscode
+.fleet
+.nova
+.zed
+.DS_Store
+
+# Secrets and local environment. .env.prod.example stays out of the image too;
+# it is only a template for the operator's .env.
+.env
+.env.*
+
+# Build artifacts generated inside the image.
+public/build
+public/hot
+public/storage
+bootstrap/ssr
+resources/js/actions
+resources/js/routes
+resources/js/wayfinder
+resources/js/generated
+
+# Local runtime state.
+storage/*.key
+storage/pail
+storage/logs/*
+# Host-generated compiled caches (would leak dev providers like Boost into the
+# --no-dev image); Laravel regenerates these at boot / via the entrypoint.
+bootstrap/cache/*.php
+.phpunit.cache
+.phpunit.result.cache
+
+# Dev-only / not needed in the production image.
+tests
+compose.yaml
+docker-compose.prod.yml
+*.md

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,91 @@
+# =============================================================================
+# Production environment template for the Docker self-hosting stack.
+#
+#   cp .env.prod.example .env
+#   docker run --rm laravel-slack-clone:latest php artisan key:generate --show
+#   # paste the value into APP_KEY below, fill in the rest, then:
+#   docker compose -f docker-compose.prod.yml up -d --build
+#
+# Values consumed at BUILD time (VITE_*) are compiled into the browser bundle,
+# so they must be correct before `--build`. Change one → rebuild the image.
+# =============================================================================
+
+APP_NAME="Laravel Slack Clone"
+APP_ENV=production
+# Generate once with: docker run --rm laravel-slack-clone:latest php artisan key:generate --show
+APP_KEY=
+APP_DEBUG=false
+# Public URL your reverse proxy serves the app on.
+APP_URL=https://chat.example.com
+
+APP_LOCALE=en
+APP_FALLBACK_LOCALE=en
+APP_FAKER_LOCALE=en_US
+
+APP_MAINTENANCE_DRIVER=file
+
+LOG_CHANNEL=stack
+LOG_STACK=single
+LOG_LEVEL=warning
+
+# --- Database (pgsql service) ------------------------------------------------
+DB_CONNECTION=pgsql
+DB_HOST=pgsql
+DB_PORT=5432
+DB_DATABASE=laravel
+DB_USERNAME=laravel
+# Required — used by both the app and the Postgres container.
+DB_PASSWORD=
+
+# --- Cache / session / queue (all on the database, no Redis needed) ----------
+SESSION_DRIVER=database
+SESSION_LIFETIME=120
+SESSION_ENCRYPT=false
+SESSION_PATH=/
+SESSION_DOMAIN=null
+
+BROADCAST_CONNECTION=reverb
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION=database
+CACHE_STORE=database
+
+# --- Mail (external SMTP, operator-provided) ---------------------------------
+MAIL_MAILER=smtp
+MAIL_SCHEME=null
+MAIL_HOST=smtp.example.com
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_FROM_NAME="${APP_NAME}"
+
+# --- Search (meilisearch service) --------------------------------------------
+SCOUT_DRIVER=meilisearch
+MEILISEARCH_HOST=http://meilisearch:7700
+# Required — master key for the Meilisearch container. Use a long random string.
+MEILISEARCH_KEY=
+MEILISEARCH_NO_ANALYTICS=true
+
+# --- Broadcasting (reverb service) -------------------------------------------
+# Required — generate with: docker run --rm laravel-slack-clone:latest php artisan reverb:secret
+REVERB_APP_ID=
+REVERB_APP_KEY=
+REVERB_APP_SECRET=
+# Server-side host the app broadcasts to: the reverb container on the compose network.
+REVERB_HOST=reverb
+REVERB_PORT=8080
+REVERB_SCHEME=http
+
+# Browser-side values (through your TLS proxy). BUILD-time — compiled into the
+# frontend bundle, so set them before `--build`. Use your public domain and
+# wss/https in production. VITE_REVERB_APP_KEY must equal REVERB_APP_KEY above
+# (gen-secrets.sh keeps them in sync).
+VITE_REVERB_APP_KEY=
+VITE_REVERB_HOST=chat.example.com
+VITE_REVERB_PORT=443
+VITE_REVERB_SCHEME=https
+
+# --- Container port mapping (host side) --------------------------------------
+# Host port the app is published on (proxy sits in front of this). Defaults to 80.
+# APP_PORT=80
+# REVERB_PORT above doubles as the host port the reverb service is published on.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+      - master
+      - workos
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+      - workos
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Validate that the production image builds. Build-only: nothing is pushed
+      # to a registry.
+      - name: Build production image
+        run: docker build --tag laravel-slack-clone:ci --file Dockerfile .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,129 @@
+# syntax=docker/dockerfile:1
+
+# =============================================================================
+# Production image for self-hosting (build-from-source at a release tag).
+#
+#   git checkout vX.Y.Z
+#   docker compose -f docker-compose.prod.yml up -d --build
+#
+# Development still uses Laravel Sail (compose.yaml); this image is a separate
+# production path and does not replace it. Served with FrankenPHP (Caddy + a
+# built-in PHP SAPI) in classic mode: one process per container, no nginx +
+# PHP-FPM + supervisor juggling, and no extra Composer dependency (unlike
+# Laravel Octane).
+# =============================================================================
+
+ARG PHP_VERSION=8.5
+
+# -----------------------------------------------------------------------------
+# Stage 1 — Composer: production PHP dependencies only, optimized autoloader.
+# -----------------------------------------------------------------------------
+FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS vendor
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+
+# Cache the dependency layer on the manifest alone.
+COPY composer.json composer.lock ./
+
+# --no-scripts: the post-autoload-dump `artisan package:discover` boots the full
+# app, which is deferred to the runtime entrypoint (config:cache) instead.
+RUN composer install \
+        --no-dev \
+        --no-scripts \
+        --no-autoloader \
+        --prefer-dist \
+        --no-interaction \
+        --no-progress
+
+# Add the source and build an authoritative, optimized autoloader.
+COPY . .
+RUN composer dump-autoload --no-dev --optimize --classmap-authoritative
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Assets: compile the Vite/Inertia frontend (`npm ci && npm run build`).
+#
+# Built on the PHP base rather than a plain Node image because the Wayfinder
+# Vite plugin shells out to `php artisan wayfinder:generate` during the build,
+# so PHP + the vendor directory must be available here.
+# -----------------------------------------------------------------------------
+FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS assets
+
+RUN apk add --no-cache nodejs npm
+
+WORKDIR /app
+
+# Cache the npm layer on the lockfile alone.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Vendor (for Wayfinder codegen) + full source.
+COPY --from=vendor /app/vendor ./vendor
+COPY . .
+
+# VITE_* values are compiled into the browser bundle at build time, so the
+# operator's real Reverb/app settings must be passed as build args. These are
+# wired up from the .env file in docker-compose.prod.yml.
+ARG VITE_APP_NAME=Laravel
+ARG VITE_REVERB_APP_KEY
+ARG VITE_REVERB_HOST=localhost
+ARG VITE_REVERB_PORT=8080
+ARG VITE_REVERB_SCHEME=https
+ENV VITE_APP_NAME=${VITE_APP_NAME} \
+    VITE_REVERB_APP_KEY=${VITE_REVERB_APP_KEY} \
+    VITE_REVERB_HOST=${VITE_REVERB_HOST} \
+    VITE_REVERB_PORT=${VITE_REVERB_PORT} \
+    VITE_REVERB_SCHEME=${VITE_REVERB_SCHEME}
+
+RUN npm run build
+
+# -----------------------------------------------------------------------------
+# Stage 3 — Runtime: slim FrankenPHP image with only what production needs.
+# -----------------------------------------------------------------------------
+FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS runtime
+
+# pdo_pgsql: Postgres. pcntl/posix: queue worker + Reverb signal handling.
+# intl/zip/opcache: framework recommendations + performance.
+RUN install-php-extensions \
+        pdo_pgsql \
+        pcntl \
+        posix \
+        intl \
+        zip \
+        opcache \
+    && apk add --no-cache curl
+
+# Production PHP/OPcache tuning.
+COPY docker/php/production.ini $PHP_INI_DIR/conf.d/zz-production.ini
+
+WORKDIR /app
+
+# App source, production vendor, compiled assets.
+COPY . .
+COPY --from=vendor /app/vendor ./vendor
+COPY --from=assets /app/public/build ./public/build
+
+# Non-root runtime user. FrankenPHP listens on 8080 (>1024), so no extra
+# capabilities are required to bind the port.
+RUN set -eux; \
+    addgroup -g 1000 -S www; \
+    adduser -u 1000 -S -G www www; \
+    mkdir -p \
+        storage/framework/cache \
+        storage/framework/sessions \
+        storage/framework/views \
+        storage/app/public \
+        bootstrap/cache; \
+    chown -R www:www storage bootstrap/cache public /data /config; \
+    chmod +x docker/entrypoint.sh
+
+ENV SERVER_NAME=:8080 \
+    SERVER_ROOT=/app/public
+
+USER www
+
+EXPOSE 8080
+
+ENTRYPOINT ["docker/entrypoint.sh"]
+CMD ["frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,121 @@
+# Laravel Slack Clone
+
+A real-time team chat application — workspaces, channels, threads, reactions,
+search, and scheduled messages — built with Laravel 13, Inertia + Vue 3, Laravel
+Reverb (WebSockets), and Meilisearch.
+
+## Development
+
+Local development uses [Laravel Sail](https://laravel.com/docs/sail):
+
+```bash
+git clone git@github.com:emmpaul/laravel-slack-clone.git
+cd laravel-slack-clone
+cp .env.example .env
+composer install
+./vendor/bin/sail up -d
+./vendor/bin/sail composer setup
+```
+
+Run the quality gate before pushing:
+
+```bash
+./vendor/bin/sail composer test        # Pint, PHPStan, and tests at 100% coverage
+./vendor/bin/sail npm run lint:check    # ESLint / Prettier / vue-tsc / build
+```
+
+## Self-Hosting with Docker
+
+The production stack is built **from source at a release tag** and orchestrated
+with `docker-compose.prod.yml`. There is no prebuilt image to pull; you clone the
+repo, check out a tagged release, and bring the stack up. The app is served with
+[FrankenPHP](https://frankenphp.dev/); Postgres, Meilisearch, Reverb, a queue
+worker, and the scheduler all run as containers.
+
+### Prerequisites
+
+- Docker Engine 24+ and the Docker Compose plugin.
+- A domain and a TLS-terminating reverse proxy (nginx, Caddy, Traefik, …) in
+  front of the stack. **TLS/HTTPS is your responsibility** — the containers speak
+  plain HTTP. Your proxy must also forward WebSocket upgrade requests to the
+  `reverb` service.
+
+### First install
+
+```bash
+# 1. Clone and check out the latest release tag.
+git clone git@github.com:emmpaul/laravel-slack-clone.git
+cd laravel-slack-clone
+git fetch --tags
+git checkout v0.1.0                                   # the desired release tag
+
+# 2. Generate .env with all required secrets filled in.
+#    Creates .env from the template and fills APP_KEY, DB_PASSWORD,
+#    MEILISEARCH_KEY, and the REVERB_* keys with fresh random values.
+#    Safe to re-run — it never overwrites values you have already set.
+./docker/gen-secrets.sh
+
+# 3. Edit .env and set the non-secret settings the script can't guess:
+#    APP_URL, SMTP mail credentials, and the browser-side VITE_REVERB_HOST /
+#    VITE_REVERB_PORT / VITE_REVERB_SCHEME (your public domain + wss/https).
+#    VITE_* values are compiled into the frontend at build time, so set them
+#    before building.
+
+# 4. Build the images and start the stack.
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+Migrations run automatically on start (the `app` container's entrypoint runs
+`php artisan migrate --force`). The app is published on `APP_PORT` (default `80`)
+and Reverb on `REVERB_PORT` (default `8080`); point your reverse proxy at them.
+
+> **Required secrets.** `APP_KEY`, `DB_PASSWORD`, and `MEILISEARCH_KEY` have no
+> defaults — the stack refuses to start without them. `gen-secrets.sh` generates
+> all of these for you; prefer it over setting them by hand. If you would rather
+> generate `APP_KEY` yourself, any `base64:`-encoded 32-byte value works, e.g.
+> `docker run --rm dunglas/frankenphp:1-php8.5-alpine php -r "echo 'base64:'.base64_encode(random_bytes(32)).PHP_EOL;"`.
+
+### Create the first user and workspace
+
+Registration is open, so onboarding is self-service:
+
+1. Visit your `APP_URL` and go to **/register** to create the first account.
+2. Email verification is enabled — make sure your SMTP settings work so the
+   verification email is delivered, then verify.
+3. Create your first workspace from **Settings → Teams**, then invite teammates.
+
+### Upgrading
+
+Upgrades follow the same tag-based flow. Check out the newer release tag and
+rebuild:
+
+```bash
+git fetch --tags
+git checkout v1.4.0                                   # the desired release tag
+docker compose -f docker-compose.prod.yml down
+docker compose -f docker-compose.prod.yml up -d --build
+# migrations run automatically via the entrypoint
+```
+
+Your data persists across `down`/`up` in named volumes (`pgsql-data`,
+`meili-data`, `storage-app`).
+
+> **MAJOR version upgrades may contain breaking changes.** Before upgrading
+> across a major version, read the [CHANGELOG](CHANGELOG.md) and the
+> corresponding [GitHub Release notes](https://github.com/emmpaul/laravel-slack-clone/releases)
+> for required manual steps.
+
+### What runs, and why no Redis
+
+| Service       | Role                                             |
+| ------------- | ------------------------------------------------ |
+| `app`         | FrankenPHP web server (HTTP + migrations on boot)|
+| `reverb`      | WebSocket server for real-time broadcasting      |
+| `queue`       | Queue worker (`queue:work`)                      |
+| `scheduler`   | Scheduled tasks (`schedule:work`)                |
+| `pgsql`       | PostgreSQL database (named volume)               |
+| `meilisearch` | Full-text search index (named volume)            |
+
+Cache, session, and queue all use the **database** driver and broadcasting uses
+**Reverb**, so nothing resolves to Redis — there is no Redis service in the
+production stack.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,111 @@
+# Production stack for self-hosting. Build-from-source at a release tag:
+#
+#   git fetch --tags && git checkout vX.Y.Z
+#   docker compose -f docker-compose.prod.yml up -d --build
+#
+# Development uses Laravel Sail (compose.yaml) — this file does not replace it.
+#
+# TLS/HTTPS is the operator's responsibility: put a reverse proxy in front of
+# `app` (published on APP_PORT) and `reverb` (published on REVERB_PORT). The
+# proxy must forward WebSocket upgrade requests to the reverb service.
+#
+# No Redis service: cache, session, and queue all use the `database` driver, and
+# broadcasting uses Reverb — nothing resolves to Redis.
+
+x-app: &app
+  build:
+    context: .
+    args:
+      VITE_APP_NAME: ${APP_NAME:-Laravel}
+      VITE_REVERB_APP_KEY: ${REVERB_APP_KEY}
+      VITE_REVERB_HOST: ${VITE_REVERB_HOST}
+      VITE_REVERB_PORT: ${VITE_REVERB_PORT:-8080}
+      VITE_REVERB_SCHEME: ${VITE_REVERB_SCHEME:-https}
+  image: laravel-slack-clone:latest
+  env_file:
+    - .env
+  restart: unless-stopped
+  volumes:
+    - storage-app:/app/storage/app
+  depends_on:
+    pgsql:
+      condition: service_healthy
+    meilisearch:
+      condition: service_healthy
+  networks:
+    - app
+
+services:
+  # Web app (FrankenPHP). Runs migrations on start and serves HTTP on 8080.
+  app:
+    <<: *app
+    environment:
+      AUTORUN_MIGRATIONS: 'true'
+    ports:
+      - '${APP_PORT:-80}:8080'
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:8080/up']
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+  # WebSocket server for broadcasting.
+  reverb:
+    <<: *app
+    command: ['php', 'artisan', 'reverb:start', '--host=0.0.0.0', '--port=8080']
+    ports:
+      - '${REVERB_PORT:-8080}:8080'
+
+  # Queue worker (queue connection is `database`).
+  queue:
+    <<: *app
+    command: ['php', 'artisan', 'queue:work', '--tries=3']
+
+  # Scheduler (delivers due scheduled messages, prunes expired invitations).
+  scheduler:
+    <<: *app
+    command: ['php', 'artisan', 'schedule:work']
+
+  pgsql:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_DB: ${DB_DATABASE:-laravel}
+      POSTGRES_USER: ${DB_USERNAME:-laravel}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+    volumes:
+      - pgsql-data:/var/lib/postgresql/data
+    restart: unless-stopped
+    networks:
+      - app
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-q', '-d', '${DB_DATABASE:-laravel}', '-U', '${DB_USERNAME:-laravel}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.16
+    environment:
+      MEILI_MASTER_KEY: ${MEILISEARCH_KEY:?MEILISEARCH_KEY is required}
+      MEILI_ENV: production
+      MEILI_NO_ANALYTICS: ${MEILISEARCH_NO_ANALYTICS:-true}
+    volumes:
+      - meili-data:/meili_data
+    restart: unless-stopped
+    networks:
+      - app
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--spider', 'http://127.0.0.1:7700/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+networks:
+  app:
+    driver: bridge
+
+volumes:
+  pgsql-data:
+  meili-data:
+  storage-app:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# Named volumes mount in empty, so ensure the writable runtime directories exist
+# before caching or linking anything.
+mkdir -p \
+    storage/framework/cache \
+    storage/framework/sessions \
+    storage/framework/views \
+    storage/app/public \
+    bootstrap/cache
+
+# Run migrations automatically on start. Only the `app` service sets
+# AUTORUN_MIGRATIONS=true; the reverb/queue/scheduler services leave it unset so
+# four containers don't race to migrate the same database.
+if [ "${AUTORUN_MIGRATIONS:-false}" = "true" ]; then
+    echo "Running database migrations..."
+    php artisan migrate --force
+fi
+
+# Cache config/routes/events against the runtime environment (compose injects it
+# at container start, so this must happen here, not at build time) and link
+# public storage. All idempotent and per-container.
+php artisan config:cache
+php artisan route:cache
+php artisan event:cache
+php artisan storage:link
+
+exec "$@"

--- a/docker/gen-secrets.sh
+++ b/docker/gen-secrets.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# Bootstrap a production .env for the Docker self-hosting stack.
+#
+#   ./docker/gen-secrets.sh
+#
+# Creates .env from .env.prod.example (if missing) and fills any EMPTY required
+# secret with a freshly generated value. Existing values are never overwritten,
+# so the script is safe to re-run. After it finishes, fill in the non-secret
+# settings (APP_URL, mail, VITE_REVERB_HOST, …) before building the stack.
+set -eu
+
+EXAMPLE_FILE=".env.prod.example"
+ENV_FILE=".env"
+
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "Error: openssl is required to generate secrets." >&2
+    exit 1
+fi
+
+if [ ! -f "$EXAMPLE_FILE" ]; then
+    echo "Error: $EXAMPLE_FILE not found. Run this from the project root." >&2
+    exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+    cp "$EXAMPLE_FILE" "$ENV_FILE"
+    echo "Created $ENV_FILE from $EXAMPLE_FILE."
+fi
+
+# Set KEY=VALUE only when KEY is currently empty (matches "KEY=" at end of line).
+set_if_empty() {
+    key="$1"
+    value="$2"
+    if grep -Eq "^${key}=$" "$ENV_FILE"; then
+        # Use a non-/ delimiter since values may contain / or +.
+        tmp="$(mktemp)"
+        sed "s#^${key}=\$#${key}=${value}#" "$ENV_FILE" >"$tmp"
+        mv "$tmp" "$ENV_FILE"
+        echo "  set ${key}"
+    else
+        echo "  kept ${key} (already set)"
+    fi
+}
+
+echo "Generating missing secrets in $ENV_FILE:"
+set_if_empty "APP_KEY"         "base64:$(openssl rand -base64 32)"
+set_if_empty "DB_PASSWORD"     "$(openssl rand -hex 24)"
+set_if_empty "MEILISEARCH_KEY" "$(openssl rand -hex 32)"
+set_if_empty "REVERB_APP_ID"   "$(openssl rand 4 | od -An -tu4 | tr -d ' ')"
+
+# The browser (VITE_REVERB_APP_KEY) and server (REVERB_APP_KEY) must share the
+# same app key, so generate it once and set both when they are empty.
+reverb_key="$(openssl rand -hex 16)"
+set_if_empty "REVERB_APP_KEY"      "$reverb_key"
+set_if_empty "VITE_REVERB_APP_KEY" "$reverb_key"
+set_if_empty "REVERB_APP_SECRET"   "$(openssl rand -hex 16)"
+
+echo
+echo "Done. Review $ENV_FILE and set APP_URL, mail credentials, and the"
+echo "browser-side VITE_REVERB_* values before running:"
+echo "  docker compose -f docker-compose.prod.yml up -d --build"

--- a/docker/php/production.ini
+++ b/docker/php/production.ini
@@ -1,0 +1,14 @@
+; Production PHP settings baked into the image.
+expose_php = Off
+memory_limit = 256M
+upload_max_filesize = 20M
+post_max_size = 21M
+
+; OPcache tuning. Timestamp validation is disabled because the code is immutable
+; inside the image; rebuild the image to ship new code.
+opcache.enable = 1
+opcache.enable_cli = 0
+opcache.memory_consumption = 128
+opcache.interned_strings_buffer = 16
+opcache.max_accelerated_files = 20000
+opcache.validate_timestamps = 0


### PR DESCRIPTION
Closes #111.

Adds a **production Docker path** for self-hosting, alongside (not replacing) the existing Sail dev workflow. Distribution model is build-from-source at a release tag — no registry image is published.

## What's included
- **`Dockerfile`** — multi-stage, served with **FrankenPHP in classic mode**:
  1. Composer stage — `composer install --no-dev --optimize-autoloader` + authoritative autoloader.
  2. Asset stage — `npm ci && npm run build`.
  3. Slim non-root PHP 8.5 runtime (`pdo_pgsql`, `pcntl`/`posix`, `intl`, `zip`, `opcache`), assets + vendor copied in.
  - **Entrypoint** runs `migrate --force`, `config:cache`, `route:cache`, `event:cache`, `storage:link`, then execs the role command.
- **`.dockerignore`** — excludes `node_modules`, `vendor`, `.git`, `.env`, and host-generated `bootstrap/cache/*.php`.
- **`docker-compose.prod.yml`** — `app` / `reverb` / `queue` / `scheduler` share `build: .`; `pgsql` + `meilisearch` with healthchecks and `depends_on: healthy`; named volumes for Postgres, Meilisearch, and `storage/app`.
- **`.env.prod.example`** + **`docker/gen-secrets.sh`** — documents required keys and generates the secrets (`APP_KEY`, `DB_PASSWORD`, `MEILISEARCH_KEY`, `REVERB_APP_*`) into `.env`.
- **`.github/workflows/docker.yml`** — `docker build` validation on PR + push to `master`. **Build-only — no image is published.**
- **`README.md`** — "Self-Hosting with Docker" section with first-install, first-user/workspace onboarding, and the verbatim tag-based upgrade flow.

## Key decisions
- **App server: FrankenPHP (classic mode).** One process per container, no nginx+PHP-FPM+supervisor to juggle, and **no new Composer dependency** (unlike Laravel Octane, which classic mode does not require). The `reverb`/`queue`/`scheduler` roles reuse the same image with an overridden command.
- **The asset stage runs on the PHP base, not a plain Node image**, because the Wayfinder Vite plugin shells out to `php artisan wayfinder:generate` during `npm run build` — PHP + vendor must be present.
- **No Redis service.** `.env.example` puts cache, session, and queue all on the `database` driver and broadcasting on Reverb, so nothing resolves to Redis.
- **`migrate --force` is gated to the `app` role** (`AUTORUN_MIGRATIONS`) so four containers don't race the same database; the entrypoint still runs it by default for a bare `docker run`.
- **`VITE_REVERB_*` are build args** (compiled into the browser bundle); `gen-secrets.sh` keeps `VITE_REVERB_APP_KEY` in sync with `REVERB_APP_KEY`.

## Verification (local)
- `docker build` of the production image succeeds.
- Booted the image against a Postgres container: migrations ran, `config`/`route`/`event:cache` + `storage:link` succeeded, FrankenPHP served, and both `/up` (healthcheck) and `/` returned **HTTP 200**.
- `docker compose -f docker-compose.prod.yml config` validates; all six services resolve and build args interpolate.
- `docker/gen-secrets.sh` fills empty secrets, keeps the two Reverb keys in sync, and is idempotent on re-run.

No PHP/JS application code changed (health uses the existing `/up` route), so the Pest suite and 100% coverage gate are unaffected; infra behavior was verified end-to-end against a live container instead.

## Notes
- The `docker build` emits two `SecretsUsedInArgOrEnv` warnings for `VITE_REVERB_APP_KEY`. These are benign — the Reverb *app key* is a public client-side identifier shipped to browsers by design, not a secret. Warnings do not fail the build.
- CI is build-only; publishing a prebuilt image to GHCR/Docker Hub is intentionally out of scope (see #111).