### PR TITLE
refactor(architecture): land the architecture-hardening epic (#131)

### DIFF
--- a/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -1,0 +1,123 @@
+# HTML Report Format
+
+The architectural review is rendered as a single self-contained HTML file in the OS temp directory. Tailwind and Mermaid both come from CDNs. Mermaid handles graph-shaped diagrams reliably; hand-built divs and inline SVG handle the more editorial visuals (mass diagrams, cross-sections). Mix the two — don't lean on Mermaid for everything, it'll start to look generic.
+
+## Scaffold
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Architecture review — {{repo name}}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+    </script>
+    <style>
+      /* small custom layer for things Tailwind doesn't cover cleanly:
+         dashed seam lines, hand-drawn-feeling arrow heads, etc. */
+      .seam { stroke-dasharray: 4 4; }
+      .leak { stroke: #dc2626; }
+      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+    </style>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+      <header>...</header>
+      <section id="candidates" class="space-y-10">...</section>
+      <section id="top-recommendation">...</section>
+    </main>
+  </body>
+</html>
+```
+
+## Header
+
+Repo name, date, and a compact legend: solid box = module, dashed line = seam, red arrow = leakage, thick dark box = deep module. No introduction paragraph — straight into the candidates.
+
+## Candidate card
+
+The diagrams carry the weight. Prose is sparse, plain, and uses the glossary terms (from the `/codebase-design` skill) without ceremony.
+
+Each candidate is one `<article>`:
+
+- **Title** — short, names the deepening (e.g. "Collapse the Order intake pipeline").
+- **Badge row** — recommendation strength (`Strong` = emerald, `Worth exploring` = amber, `Speculative` = slate), plus a tag for the dependency category (`in-process`, `local-substitutable`, `ports & adapters`, `mock`).
+- **Files** — monospaced list, `font-mono text-sm`.
+- **Before / After diagram** — the centrepiece. Two columns, side by side. See patterns below.
+- **Problem** — one sentence. What hurts.
+- **Solution** — one sentence. What changes.
+- **Wins** — bullets, ≤6 words each. e.g. "Tests hit one interface", "Pricing logic stops leaking", "Delete 4 shallow wrappers".
+- **ADR callout** (if applicable) — one line in an amber-tinted box.
+
+No paragraphs of explanation. If the diagram needs a paragraph to be understood, redraw the diagram.
+
+## Diagram patterns
+
+Pick the pattern that fits the candidate. Mix them. Don't make every diagram look the same — variety is part of the point.
+
+### Mermaid graph (the workhorse for dependencies / call flow)
+
+Use a Mermaid `flowchart` or `graph` when the point is "X calls Y calls Z, and look at the mess." Wrap it in a Tailwind-styled card so it doesn't feel parachuted in. Style with classDef to colour leakage edges red and the deep module dark. Sequence diagrams work well for "before: 6 round-trips; after: 1."
+
+```html
+<div class="rounded-lg border border-slate-200 bg-white p-4">
+  <pre class="mermaid">
+    flowchart LR
+      A[OrderHandler] --> B[OrderValidator]
+      B --> C[OrderRepo]
+      C -.leak.-> D[PricingClient]
+      classDef leak stroke:#dc2626,stroke-width:2px;
+      class C,D leak
+  </pre>
+</div>
+```
+
+### Hand-built boxes-and-arrows (when Mermaid's layout fights you)
+
+Modules as `<div>`s with borders and labels. Arrows as inline SVG `<line>` or `<path>` elements positioned absolutely over a relative container. Reach for this when you want the "after" diagram to feel like one thick-bordered deep module with greyed-out internals — Mermaid won't render that with the right weight.
+
+### Cross-section (good for layered shallowness)
+
+Stack horizontal bands (`h-12 border-l-4`) to show layers a call passes through. Before: 6 thin layers each doing nothing. After: 1 thick band labelled with the consolidated responsibility.
+
+### Mass diagram (good for "interface as wide as implementation")
+
+Two rectangles per module — one for interface surface area, one for implementation. Before: interface rectangle is nearly as tall as the implementation rectangle (shallow). After: interface rectangle is short, implementation rectangle is tall (deep).
+
+### Call-graph collapse
+
+Before: a tree of function calls rendered as nested boxes. After: the same tree collapsed into one box, with the now-internal calls shown faded inside it.
+
+## Style guidance
+
+- Lean editorial, not corporate-dashboard. Generous whitespace. Serif optional for headings (`font-serif` works well with stone/slate).
+- Colour sparingly: one accent (emerald or indigo) plus red for leakage and amber for warnings.
+- Keep diagrams ~320px tall so before/after sits comfortably side by side without scrolling.
+- Use `text-xs uppercase tracking-wider` for module labels inside diagrams — they should read as schematic, not as UI.
+- The only scripts are the Tailwind CDN and the Mermaid ESM import. The report is otherwise static — no app code, no interactivity beyond Mermaid's own rendering.
+
+## Top recommendation section
+
+One larger card. Candidate name, one sentence on why, anchor link to its card. That's it.
+
+## Tone
+
+Plain English, concise — but the architectural nouns and verbs come straight from the `/codebase-design` skill. Concision is not an excuse to drift.
+
+**Use exactly:** module, interface, implementation, depth, deep, shallow, seam, adapter, leverage, locality.
+
+**Never substitute:** component, service, unit (for module) · API, signature (for interface) · boundary (for seam) · layer, wrapper (for module, when you mean module).
+
+**Phrasings that fit the style:**
+
+- "Order intake module is shallow — interface nearly matches the implementation."
+- "Pricing leaks across the seam."
+- "Deepen: one interface, one place to test."
+- "Two adapters justify the seam: HTTP in prod, in-memory in tests."
+
+**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+
+No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in the `/codebase-design` glossary, reach for one that is before inventing a new one.

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: improve-codebase-architecture
+description: Scan a codebase for deepening opportunities, present them as a visual HTML report, then grill through whichever one you pick.
+disable-model-invocation: true
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+This command is _informed_ by the project's domain model and built on a shared design vocabulary:
+
+- Run the `/codebase-design` skill for the architecture vocabulary (**module**, **interface**, **depth**, **seam**, **adapter**, **leverage**, **locality**) and its principles (the deletion test, "the interface is the test surface", "one adapter = hypothetical seam, two = real"). Use these terms exactly in every suggestion — don't drift into "component," "service," "API," or "boundary."
+- The domain language in `CONTEXT.md` gives names to good seams; ADRs in `docs/adr/` record decisions this command should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary (`CONTEXT.md`) and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates as an HTML report
+
+Write a self-contained HTML file to the OS temp directory so nothing lands in the repo. Resolve the temp dir from `$TMPDIR`, falling back to `/tmp` (or `%TEMP%` on Windows), and write to `<tmpdir>/architecture-review-<timestamp>.html` so each run gets a fresh file. Open it for the user — `xdg-open <path>` on Linux, `open <path>` on macOS, `start <path>` on Windows — and tell them the absolute path.
+
+The report uses **Tailwind via CDN** for layout and styling, and **Mermaid via CDN** for diagrams where a graph/flow/sequence reliably communicates the structure. Mix Mermaid with hand-crafted CSS/SVG visuals — use Mermaid when relationships are graph-shaped (call graphs, dependencies, sequences), and hand-built divs/SVG when you want something more editorial (mass diagrams, cross-sections, collapse animations). Each candidate gets a **before/after visualisation**. Be visual.
+
+For each candidate, render a card with:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and how tests would improve
+- **Before / After diagram** — side-by-side, custom-drawn, illustrating the shallowness and the deepening
+- **Recommendation strength** — one of `Strong`, `Worth exploring`, `Speculative`, rendered as a badge
+
+End the report with a **Top recommendation** section: which candidate you'd tackle first and why.
+
+**Use CONTEXT.md vocabulary for the domain, and the `/codebase-design` vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly in the card (e.g. a warning callout: _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+See [HTML-REPORT.md](HTML-REPORT.md) for the full HTML scaffold, diagram patterns, and styling guidance.
+
+Do NOT propose interfaces yet. After the file is written, ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, run the `/grilling` skill to walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize — run the `/domain-modeling` skill to keep the domain model current as you go:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md`. Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones.
+- **Want to explore alternative interfaces for the deepened module?** Run the `/codebase-design` skill and use its design-it-twice parallel sub-agent pattern.

--- a/.claude/skills/improve-codebase-architecture
+++ b/.claude/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/improve-codebase-architecture

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,19 +59,19 @@ The nouns the product is built from.
 
 These are the deep modules that carry the codebase's real weight. **When new work
 touches one of these concerns, route through the named module — do not re-inline
-the logic.** Items marked _(planned)_ are being introduced by the
-architecture-hardening epic; build them once, then reuse.
+the logic.** Items still marked _(planned)_ are deferred follow-ups not yet
+built; build them once, then reuse.
 
 ### Backend (`app/`)
 
-- **Message load-set scope** _(planned — ADR-0002)_ — the single query scope that
+- **Message load-set scope** _(ADR-0002)_ — the single query scope that
   eager-loads exactly the relations `MessageData::fromMessage()` reads. Every
   timeline / thread / search / broadcast / edit payload goes through it, so the
   N+1 contract has one home. Never hand-write the `with([...])` relation list.
-- **Visible-channels ACL** _(planned — ADR-0003)_ — one scope on `User` returning
+- **Visible-channels ACL** _(ADR-0003)_ — one scope on `User` returning
   the channel ids a user may see in a team. This *is* the authorization boundary
   for search, the thread inbox, unread dots, and forwarding. Never re-`pluck` it.
-- **Channel timeline window** _(planned — ADR-0004)_ — the read-model/query object
+- **Channel timeline window** _(ADR-0004)_ — the read-model/query object
   that resolves where a channel's initial message window opens (unread anchoring,
   jump context, paging). Takes explicit params; the controller keeps HTTP glue.
 - **Domain-event recording** _(ADR-0005)_ — audit and security events are recorded
@@ -94,14 +94,14 @@ architecture-hardening epic; build them once, then reuse.
   `unreadDivider`, `readReceipts`, `scheduleTime`.
 - **`useMessageStream`** — deep composable: a simple `appendLive`/`applyPatch`
   interface hiding a three-source merge engine. The model for composables.
-- **`useChannelRealtime`** _(planned — ADR-0006)_ — owns the channel's Echo
+- **`useChannelRealtime`** _(ADR-0006)_ — owns the channel's Echo
   subscribe/route/teardown and feeds the message streams; its placement decisions
   push into a pure `lib/` helper. Realtime wiring never lives inline in a page.
-- **`useChannelFleetSubscription`** _(planned — ADR-0006)_ — one engine for
+- **`useChannelFleetSubscription`** _(ADR-0006)_ — one engine for
   subscribing to a set of channels (sidebar badges, chimes, and the active
   channel all share it). One tested reconcile/teardown lifecycle.
-- **`useDebouncedPost`** _(planned)_ — the debounced, focus-gated, auto-teardown
-  router POST used by mark-read, mark-thread-read, and draft persistence.
+- **`useDebouncedPost`** — the debounced, focus-gated, auto-teardown router POST
+  used by mark-read, mark-thread-read, and draft persistence.
 - **`ScrollableMessageList`** _(planned)_ — the scroll container + `useScrollPin` +
   "jump to latest / N new" pill, shared by the channel view and the thread panel.
 - **`ConfirmDialog`** _(planned)_ — one confirmation-dialog module the

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,123 @@
+# Domain & Architecture Context
+
+This file is the shared vocabulary for the codebase. It exists so that new work
+(new issues, new features) names concepts the way the rest of the code already
+does — and reuses the **deep modules** we've deliberately built instead of
+re-inventing shallow ones. Architecture reviews (`/improve-codebase-architecture`)
+read this file first.
+
+If you introduce a new concept or sharpen a fuzzy one while working, **update this
+file in the same change**. Decisions that should not be re-litigated live as ADRs
+in [`docs/adr/`](docs/adr/).
+
+---
+
+## Architecture vocabulary
+
+Use these terms exactly. Don't drift into "service", "component" (except a Vue
+component), "layer", "wrapper", or "boundary" when you mean one of these.
+
+- **module** — a unit that hides complexity behind an interface (a class, an
+  Action, a composable, a `lib/*.ts` helper).
+- **interface** — the surface a caller must understand to use a module.
+- **depth** — a **deep** module has a small interface hiding a lot of
+  implementation; a **shallow** module has an interface nearly as wide as its
+  implementation (it hides almost nothing).
+- **seam** — a clean point where behaviour can be substituted or tested.
+- **leverage** — how much reuse/power a module gives per unit of interface.
+- **locality** — related logic living together, so a reader or bug-hunter doesn't
+  bounce between files.
+- **deletion test** — would deleting this module *concentrate* complexity (good —
+  it was carrying weight) or just *move* it around (bad — it was a shallow
+  pass-through)?
+
+---
+
+## Domain glossary
+
+The nouns the product is built from.
+
+- **Team** — a workspace. A user belongs to teams through a **Membership**.
+- **Membership** — the pivot between a User and a Team; carries role
+  (Owner/Admin/Member). Creating one auto-joins the team's `#general`.
+- **Channel** — a conversation space inside a Team. A user's relationship to a
+  channel (membership, star, mute, notification level, draft, placement) lives on
+  the **channel-member pivot**.
+- **Message** — a post in a channel. May reply into a **Thread**, forward another
+  message, mention users, carry reactions and link previews. `MessageData` is the
+  canonical read-model DTO.
+- **Thread** — the reply tree hanging off a root Message. Read state is tracked
+  per-thread (`ThreadRead`).
+- **Scheduled message** — a Message queued to send later.
+- **Reaction** — an emoji a user attaches to a Message.
+- **Audit activity** / **Security event** — append-only records of what a user
+  did (workspace admin actions vs. account-security actions respectively).
+
+---
+
+## Named seams — the deep modules to build and reuse
+
+These are the deep modules that carry the codebase's real weight. **When new work
+touches one of these concerns, route through the named module — do not re-inline
+the logic.** Items marked _(planned)_ are being introduced by the
+architecture-hardening epic; build them once, then reuse.
+
+### Backend (`app/`)
+
+- **Message load-set scope** _(planned — ADR-0002)_ — the single query scope that
+  eager-loads exactly the relations `MessageData::fromMessage()` reads. Every
+  timeline / thread / search / broadcast / edit payload goes through it, so the
+  N+1 contract has one home. Never hand-write the `with([...])` relation list.
+- **Visible-channels ACL** _(planned — ADR-0003)_ — one scope on `User` returning
+  the channel ids a user may see in a team. This *is* the authorization boundary
+  for search, the thread inbox, unread dots, and forwarding. Never re-`pluck` it.
+- **Channel timeline window** _(planned — ADR-0004)_ — the read-model/query object
+  that resolves where a channel's initial message window opens (unread anchoring,
+  jump context, paging). Takes explicit params; the controller keeps HTTP glue.
+- **Domain-event recording** _(ADR-0005)_ — audit and security events are recorded
+  via the event→listener seam (`RecordSecurityEvents`), next to the mutation, not
+  by inline `record()` calls in controllers.
+- **`AuditRecorder` / `SecurityEventRecorder`** — deep modules hiding the
+  activity-log builder. Keep them; only change *where they're called from*.
+- **Channel membership settings** — star, mute, notification level, draft, and
+  placement are all mutations of the channel-member pivot; treat them as one
+  concern, not five unrelated ones.
+- **Message thread-state scopes** (`Message::withThreadReadState`, `followedBy`) —
+  exemplary depth; correlated-subquery logic hidden behind a scope that reuses one
+  SQL constant so scope and filter can't disagree. The model to aspire to.
+
+### Frontend (`resources/js/`)
+
+- **`lib/*.ts` pure helpers** — the canonical pattern: pure, deep, each paired with
+  a `*.test.ts`. New pure logic (formatting, parsing, decisions) goes here, not
+  into a `.vue` setup block. Examples: `messageBody`, `reactions`, `shouldChime`,
+  `unreadDivider`, `readReceipts`, `scheduleTime`.
+- **`useMessageStream`** — deep composable: a simple `appendLive`/`applyPatch`
+  interface hiding a three-source merge engine. The model for composables.
+- **`useChannelRealtime`** _(planned — ADR-0006)_ — owns the channel's Echo
+  subscribe/route/teardown and feeds the message streams; its placement decisions
+  push into a pure `lib/` helper. Realtime wiring never lives inline in a page.
+- **`useChannelFleetSubscription`** _(planned — ADR-0006)_ — one engine for
+  subscribing to a set of channels (sidebar badges, chimes, and the active
+  channel all share it). One tested reconcile/teardown lifecycle.
+- **`useDebouncedPost`** _(planned)_ — the debounced, focus-gated, auto-teardown
+  router POST used by mark-read, mark-thread-read, and draft persistence.
+- **`ScrollableMessageList`** _(planned)_ — the scroll container + `useScrollPin` +
+  "jump to latest / N new" pill, shared by the channel view and the thread panel.
+- **`ConfirmDialog`** _(planned)_ — one confirmation-dialog module the
+  leave/remove/cancel/delete/transfer/archive modals become thin call-sites of.
+
+---
+
+## Where new work goes (quick reference)
+
+- New pure logic (format/parse/decide) → a `lib/*.ts` with a paired test.
+- New realtime behaviour → a composable with a seam + a pure decision core in
+  `lib/`; never inline in a page.
+- New channel message payload → the **Message load-set scope**.
+- New "which channels can this user see" check → the **Visible-channels ACL**.
+- New auditable mutation → record it via the **domain-event seam**, next to the
+  mutation.
+- New channel-member preference → the **channel membership settings** concern.
+- A `.vue` file crossing ~400 lines or owning several independent lifecycles →
+  decompose into composables before adding more.

--- a/app/Actions/Channels/EditMessage.php
+++ b/app/Actions/Channels/EditMessage.php
@@ -31,8 +31,7 @@ class EditMessage
         $this->syncMentions->handle($channel, $message);
         $this->syncLinkPreviews->handle($message);
 
-        $message->loadMissing('user');
-        $message->load(['mentionedUsers', 'linkPreviews', 'reactions.user']);
+        $message->loadMessageDataRelations();
         MessageUpdated::dispatch($channel, MessageData::fromMessage($message));
 
         return $message;

--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -54,8 +54,7 @@ class PostMessage
         if ($message->wasRecentlyCreated) {
             $this->syncMentions->handle($channel, $message);
             $this->syncLinkPreviews->handle($message);
-            $message->setRelation('user', $author);
-            $message->load(['mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
+            $message->loadMessageDataRelations();
             MessageSent::dispatch($channel, MessageData::fromMessage($message));
 
             if ($threadRootId !== null) {
@@ -80,7 +79,7 @@ class PostMessage
         $root = $channel->messages()->withTrashed()->findOrFail($threadRootId);
         $root->forceFill(['reply_count' => $root->reply_count + 1, 'last_reply_at' => now()])->save();
 
-        $root->load(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants']);
+        $root->loadMessageDataRelations();
         MessageUpdated::dispatch($channel, MessageData::fromMessage($root));
     }
 }

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -40,10 +40,13 @@ class SearchMessages
             return new Collection;
         }
 
-        return Message::search($query)
+        $matches = Message::search($query)
             ->whereIn('channel_id', $channelIds)
             ->take($limit)
-            ->get()
-            ->load(['user', 'channel', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
+            ->get();
+
+        // The search result also names each match's own channel; that is the
+        // MessageSearchResultData shell around the payload, not part of it.
+        return Message::loadMessageDataRelationsInto($matches)->load('channel');
     }
 }

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -31,10 +31,7 @@ class SearchMessages
     {
         $query = trim($query);
 
-        $channelIds = $user->channels()
-            ->where('channels.team_id', $team->id)
-            ->pluck('channels.id')
-            ->all();
+        $channelIds = $user->visibleChannelIds($team)->all();
 
         if ($query === '' || $channelIds === []) {
             return new Collection;

--- a/app/Actions/Channels/SetChannelPlacement.php
+++ b/app/Actions/Channels/SetChannelPlacement.php
@@ -26,10 +26,7 @@ class SetChannelPlacement
      */
     public function handle(User $user, Team $team, Channel $channel, array $orderedIds, bool $moveSection, ?string $sectionId): void
     {
-        $memberChannelIds = $user->channels()
-            ->where('channels.team_id', $team->id)
-            ->pluck('channels.id')
-            ->all();
+        $memberChannelIds = $user->visibleChannelIds($team)->all();
 
         foreach ($orderedIds as $index => $id) {
             if (in_array($id, $memberChannelIds, true)) {

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -186,7 +186,7 @@ class ChannelController extends Controller
             // "message deleted" tombstone in place; MessageData blanks their body.
             'messages' => Inertia::scroll(fn () => $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
                 ->withThreadReadState($request->user())
-                ->with(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
+                ->withMessageDataRelations()
                 ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
                 ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
@@ -231,7 +231,7 @@ class ChannelController extends Controller
         $root = $this->resolveThreadRoot($request, $channel);
 
         $query = $root !== null
-            ? $root->threadReplies()->withTrashed()->with(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers'])
+            ? $root->threadReplies()->withTrashed()->withMessageDataRelations()
             : Message::query()->whereRaw('1 = 0');
 
         return $query
@@ -257,7 +257,7 @@ class ChannelController extends Controller
         return $channel->messages()
             ->whereNull('thread_root_id')
             ->withThreadReadState($request->user())
-            ->with(['user', 'mentionedUsers', 'linkPreviews', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
+            ->withMessageDataRelations()
             ->find($rootId);
     }
 

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -9,7 +9,6 @@ use App\Actions\Channels\MarkChannelRead;
 use App\Actions\Channels\MarkThreadRead;
 use App\Data\ChannelData;
 use App\Data\ChannelReaderData;
-use App\Data\MessageData;
 use App\Data\ScheduledMessageData;
 use App\Data\UserData;
 use App\Enums\AuditAction;
@@ -21,8 +20,7 @@ use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
 use App\Support\AuditRecorder;
-use Illuminate\Contracts\Pagination\CursorPaginator;
-use Illuminate\Database\Eloquent\Builder;
+use App\Support\ChannelTimelineWindow;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -31,32 +29,6 @@ use Inertia\Response;
 
 class ChannelController extends Controller
 {
-    /**
-     * How many messages newer than a jump target to keep loaded below it, so a
-     * jumped-to message shows following context and is not pinned to the bottom.
-     */
-    private const int JUMP_CONTEXT = 15;
-
-    /**
-     * How many messages the initial timeline window loads. Mirrors the page size
-     * of {@see Builder::cursorPaginate()} below and
-     * feeds the read-boundary window math.
-     */
-    private const int MESSAGE_PAGE_SIZE = 50;
-
-    /**
-     * How many replies a thread page loads. The panel pages older replies in on
-     * scroll-up, mirroring the main timeline.
-     */
-    private const int THREAD_PAGE_SIZE = 50;
-
-    /**
-     * How many already-read messages to keep loaded above the "New messages"
-     * boundary when a channel opens deep enough into unread history that the
-     * boundary would otherwise fall outside the initial window.
-     */
-    private const int UNREAD_CONTEXT = 10;
-
     /**
      * Redirect a bare team URL to the team's #general channel.
      */
@@ -107,17 +79,18 @@ class ChannelController extends Controller
         // non-member has no pivot row, so the composer opens empty.
         $channel->setAttribute('draft', $membership?->draft);
 
-        // When arriving from a search result the URL carries the target message
-        // id. If it belongs to this channel, cap the initial window a few messages
-        // above the target so it loads with context on both sides; the client
-        // scrolls to and highlights it, and older history still pages in above via
-        // InfiniteScroll. Absent a jump, anchor the window around the read pointer
-        // so a channel with more unread than a page holds still loads the
-        // "New messages" boundary rather than freezing it at the oldest loaded row.
-        $jumpToMessageId = $this->resolveJumpTarget($request, $channel);
-        $windowCeilingId = $jumpToMessageId !== null
-            ? $this->jumpWindowCeiling($channel, $jumpToMessageId)
-            : $this->unreadWindowCeiling($channel, $membership?->last_read_message_id);
+        // The timeline read-model owns where the initial window opens — jump
+        // anchoring, unread-boundary anchoring, page-size arithmetic — and
+        // assembles the timeline and thread payloads. It takes explicit params
+        // (the raw `?message=` / `?thread=` query values and the read pointer),
+        // so this action stays HTTP glue: resolve params, call it, render.
+        $window = new ChannelTimelineWindow(
+            channel: $channel,
+            viewer: $request->user(),
+            requestedJumpId: $request->query('message'),
+            lastReadMessageId: $membership?->last_read_message_id,
+            requestedThreadRootId: $request->query('thread'),
+        );
 
         return Inertia::render('channels/Show', [
             'team' => [
@@ -139,7 +112,7 @@ class ChannelController extends Controller
             'notificationLevels' => NotificationLevel::options(),
             // The message the client should scroll to and highlight on load, or
             // null for a normal channel visit.
-            'jumpToMessageId' => $jumpToMessageId,
+            'jumpToMessageId' => $window->jumpToMessageId(),
             // The viewer's read pointer captured at render time, before the
             // client's debounced MarkChannelRead advances it. Drives the
             // "New messages" divider so it lands at the last-read boundary on
@@ -149,12 +122,12 @@ class ChannelController extends Controller
             // param, or null for a normal visit. The client opens a thread by
             // visiting `?thread=<root>`, which also drives the paginated replies
             // below; the closure returns null cheaply when no thread is requested.
-            'thread' => fn () => $this->threadPayload($request, $channel),
+            'thread' => fn () => $window->thread(),
             // The open thread's replies, oldest last, paginated so a very long
             // thread doesn't ship in one payload. Its own cursor name keeps it
             // independent of the main timeline's, and the client's reverse
             // InfiniteScroll pages older replies in above as it scrolls up.
-            'threadReplies' => Inertia::scroll(fn () => $this->threadRepliesPage($request, $channel)),
+            'threadReplies' => Inertia::scroll(fn () => $window->threadReplies()),
             // The viewer's own pending scheduled messages for this channel, soonest
             // first, feeding the composer's "Scheduled" affordance. Only pending
             // rows are listed — sent and cancelled ones drop off. The reply quote
@@ -184,180 +157,8 @@ class ChannelController extends Controller
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a
             // "message deleted" tombstone in place; MessageData blanks their body.
-            'messages' => Inertia::scroll(fn () => $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
-                ->withThreadReadState($request->user())
-                ->withMessageDataRelations()
-                ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
-                ->orderByDesc('id')
-                ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
-                ->through(fn (Message $message) => MessageData::fromMessage($message))),
+            'messages' => Inertia::scroll(fn () => $window->messages()),
         ]);
-    }
-
-    /**
-     * Resolve the open thread's root from the `?thread=` query param.
-     *
-     * Returns the root message (annotated with the viewer's thread read-state)
-     * when the param names a live root in this channel, or null when it is absent
-     * or points elsewhere. The replies are delivered separately and paginated by
-     * {@see self::threadRepliesPage()}.
-     *
-     * @return array{root: MessageData}|null
-     */
-    private function threadPayload(Request $request, Channel $channel): ?array
-    {
-        $root = $this->resolveThreadRoot($request, $channel);
-
-        if ($root === null) {
-            return null;
-        }
-
-        return ['root' => MessageData::fromMessage($root)];
-    }
-
-    /**
-     * The open thread's replies as a cursor-paginated page for infinite scroll.
-     *
-     * Ordered newest first (the client reverses for display and pages older
-     * replies in on scroll-up), tombstones included so deletions render in place.
-     * Its own cursor name keeps the pagination independent of the main timeline's.
-     * Falls back to an empty page when no live root is named, so the scroll prop
-     * always has a well-formed shape even on a normal channel visit.
-     *
-     * @return CursorPaginator<int, MessageData>
-     */
-    private function threadRepliesPage(Request $request, Channel $channel): CursorPaginator
-    {
-        $root = $this->resolveThreadRoot($request, $channel);
-
-        $query = $root !== null
-            ? $root->threadReplies()->withTrashed()->withMessageDataRelations()
-            : Message::query()->whereRaw('1 = 0');
-
-        return $query
-            ->orderByDesc('id')
-            ->cursorPaginate(self::THREAD_PAGE_SIZE, ['*'], 'thread_cursor')
-            ->through(fn (Message $message) => MessageData::fromMessage($message));
-    }
-
-    /**
-     * Resolve the live root message named by the `?thread=` query param, or null.
-     *
-     * The eager-load set mirrors the main timeline so the root renders its quote
-     * and thread affordances identically.
-     */
-    private function resolveThreadRoot(Request $request, Channel $channel): ?Message
-    {
-        $rootId = $request->query('thread');
-
-        if (! is_string($rootId) || $rootId === '') {
-            return null;
-        }
-
-        return $channel->messages()
-            ->whereNull('thread_root_id')
-            ->withThreadReadState($request->user())
-            ->withMessageDataRelations()
-            ->find($rootId);
-    }
-
-    /**
-     * Resolve the `?message=` jump target to an id belonging to this channel.
-     *
-     * Returns the message id when it identifies a message in the channel
-     * (soft-deleted rows included), or null when the parameter is absent or
-     * points at a message from another channel.
-     */
-    private function resolveJumpTarget(Request $request, Channel $channel): ?string
-    {
-        $messageId = $request->query('message');
-
-        if (! is_string($messageId) || $messageId === '') {
-            return null;
-        }
-
-        return $channel->messages()->withTrashed()->whereKey($messageId)->exists()
-            ? $messageId
-            : null;
-    }
-
-    /**
-     * Resolve the id that caps the initial message window for a jump.
-     *
-     * Returns the id of the message JUMP_CONTEXT positions newer than the target
-     * so it loads with following context below it rather than pinned to the very
-     * bottom of the view. Returns null when fewer than that many newer messages
-     * exist — the target is then already near the newest, so no cap is needed.
-     */
-    private function jumpWindowCeiling(Channel $channel, string $targetId): ?string
-    {
-        return $channel->messages()
-            ->withTrashed()
-            ->where('id', '>', $targetId)
-            ->orderBy('id')
-            ->offset(self::JUMP_CONTEXT - 1)
-            ->value('id');
-    }
-
-    /**
-     * Resolve the id that caps the initial window so the "New messages" boundary
-     * loads, or null to keep the default "open at newest" window.
-     *
-     * The boundary sits at the first message newer than the viewer's read
-     * pointer. When few enough messages sit at or after it to fit inside the
-     * newest page, the boundary already loads and no window is needed. A busier
-     * channel is anchored: the window is capped UNREAD_CONTEXT read messages
-     * above the boundary so it opens with the "New messages" line near the top
-     * and unread history below, while older history still pages in above via
-     * InfiniteScroll.
-     *
-     * A never-read channel (null pointer) has no last-read boundary to anchor,
-     * so it keeps the default "open at newest" window rather than landing the
-     * viewer on the oldest message of a long backlog.
-     */
-    private function unreadWindowCeiling(Channel $channel, ?string $lastReadMessageId): ?string
-    {
-        if ($lastReadMessageId === null) {
-            return null;
-        }
-
-        $firstUnreadId = $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
-            ->where('id', '>', $lastReadMessageId)
-            ->orderBy('id')
-            ->value('id');
-
-        if ($firstUnreadId === null) {
-            return null;
-        }
-
-        // The boundary already loads when the messages at or after it fit in the
-        // newest page, so keep opening at newest for read/lightly-unread channels.
-        $atOrAfterBoundary = $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
-            ->where('id', '>=', $firstUnreadId)
-            ->count();
-
-        if ($atOrAfterBoundary <= self::MESSAGE_PAGE_SIZE) {
-            return null;
-        }
-
-        return $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
-            ->where('id', '>', $firstUnreadId)
-            ->orderBy('id')
-            ->offset(self::MESSAGE_PAGE_SIZE - self::UNREAD_CONTEXT - 1)
-            ->value('id');
-    }
-
-    /**
-     * Constrain a message query to the main channel timeline: top-level messages
-     * plus thread replies explicitly "also sent to channel". Thread replies
-     * otherwise live only in the thread view.
-     *
-     * @param  Builder<Message>  $query
-     * @return Builder<Message>
-     */
-    private function mainTimeline(Builder $query): Builder
-    {
-        return $query->where(fn (Builder $inner) => $inner->whereNull('thread_root_id')->orWhere('sent_to_channel', true));
     }
 
     /**

--- a/app/Http/Controllers/Channels/ThreadsController.php
+++ b/app/Http/Controllers/Channels/ThreadsController.php
@@ -48,7 +48,10 @@ class ThreadsController extends Controller
                 ->where('reply_count', '>', 0)
                 ->followedBy($user)
                 ->withThreadReadState($user)
-                ->with(['user', 'channel', 'mentionedUsers', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
+                ->withMessageDataRelations()
+                // The inbox row also names the message's own channel; that is the
+                // ThreadInboxItemData shell around the payload, not part of it.
+                ->with('channel')
                 ->orderByDesc('last_reply_at')
                 ->orderByDesc('id')
                 ->cursorPaginate(self::PAGE_SIZE)

--- a/app/Http/Controllers/Channels/ThreadsController.php
+++ b/app/Http/Controllers/Channels/ThreadsController.php
@@ -32,9 +32,7 @@ class ThreadsController extends Controller
     {
         $user = $request->user();
 
-        $channelIds = $user->channels()
-            ->where('channels.team_id', $team->id)
-            ->pluck('channels.id');
+        $channelIds = $user->visibleChannelIds($team);
 
         return Inertia::render('channels/Threads', [
             'team' => [

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -142,12 +142,8 @@ class HandleInertiaRequests extends Middleware
             return false;
         }
 
-        $channelIds = $user->channels()
-            ->where('channels.team_id', $team->id)
-            ->pluck('channels.id');
-
         return Message::query()
-            ->whereIn('channel_id', $channelIds)
+            ->whereIn('channel_id', $user->visibleChannelIds($team))
             ->whereNull('thread_root_id')
             ->where('reply_count', '>', 0)
             ->followedBy($user)

--- a/app/Http/Requests/Channels/ForwardMessageRequest.php
+++ b/app/Http/Requests/Channels/ForwardMessageRequest.php
@@ -71,13 +71,14 @@ class ForwardMessageRequest extends FormRequest
     }
 
     /**
-     * The ids of channels the author belongs to, scoping the valid forward
-     * destinations to their own memberships.
+     * The ids of channels the author may see in the source's team, scoping the
+     * valid forward destinations to their own memberships. Forwarding stays
+     * within one team, so the source channel's team is the destination's team.
      *
      * @return array<int, string>
      */
     protected function membershipChannelIds(): array
     {
-        return $this->user()->channels()->pluck('channels.id')->all();
+        return $this->user()->visibleChannelIds($this->sourceChannel()->team)->all();
     }
 }

--- a/app/Jobs/UnfurlMessageLinks.php
+++ b/app/Jobs/UnfurlMessageLinks.php
@@ -14,17 +14,6 @@ class UnfurlMessageLinks implements ShouldQueue
 {
     use Queueable;
 
-    /**
-     * The relations {@see MessageData::fromMessage()} reads to build the broadcast.
-     *
-     * @var array<int, string>
-     */
-    private const array MESSAGE_RELATIONS = [
-        'user', 'mentionedUsers', 'linkPreviews', 'reactions.user',
-        'replyTo.user', 'replyTo.mentionedUsers',
-        'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers',
-    ];
-
     public function __construct(private string $messageId) {}
 
     /**
@@ -64,7 +53,7 @@ class UnfurlMessageLinks implements ShouldQueue
                 ]);
         }
 
-        $message->load(self::MESSAGE_RELATIONS);
+        $message->loadMessageDataRelations();
         MessageUpdated::dispatch($message->channel, MessageData::fromMessage($message));
     }
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -63,6 +63,32 @@ class Message extends Model
     ];
 
     /**
+     * The relations {@see MessageData::fromMessage()} — and its nested reply,
+     * forward, and reaction DTOs — read to render a message payload.
+     *
+     * This is the single home of the message payload's N+1 contract: every
+     * timeline, thread, search, post, edit, and broadcast path eager-loads
+     * exactly this set — query paths through {@see scopeWithMessageDataRelations()},
+     * post-fetch paths through {@see loadMessageDataRelations()} or
+     * {@see loadMessageDataRelationsInto()}. When `MessageData` starts reading a
+     * new relation, add it here, never at a call site.
+     *
+     * @var list<string>
+     */
+    private const MESSAGE_DATA_RELATIONS = [
+        'user',
+        'mentionedUsers',
+        'linkPreviews',
+        'reactions.user',
+        'replyTo.user',
+        'replyTo.mentionedUsers',
+        'forwardedFrom.user',
+        'forwardedFrom.channel',
+        'forwardedFrom.mentionedUsers',
+        'threadParticipants',
+    ];
+
+    /**
      * Get the channel the message was posted to.
      *
      * @return BelongsTo<Channel, $this>
@@ -252,6 +278,48 @@ class Message extends Model
     public function scopeWhereThreadUnreadFor(Builder $query, User $user): void
     {
         $query->whereRaw(self::THREAD_HAS_UNREAD_SQL, [$user->id, $user->id, $user->id, NotificationLevel::All->value]);
+    }
+
+    /**
+     * Eager-load the message-payload relation set onto a message query, so the
+     * resulting {@see MessageData} builds without an N+1. The one query
+     * interface to {@see self::MESSAGE_DATA_RELATIONS}; callers add only the
+     * extra relations their own read-model needs (e.g. the message's own
+     * `channel` for search or the thread inbox) on top.
+     *
+     * @param  Builder<Message>  $query
+     */
+    public function scopeWithMessageDataRelations(Builder $query): void
+    {
+        $query->with(self::MESSAGE_DATA_RELATIONS);
+    }
+
+    /**
+     * Eager-load the message-payload relation set onto an already-fetched
+     * message, for the post-create / post-edit broadcast paths that hold a model
+     * rather than a query. Forces a reload so a freshly edited body's mentions
+     * and previews are the current set. The single-model mirror of
+     * {@see self::scopeWithMessageDataRelations()}.
+     */
+    public function loadMessageDataRelations(): static
+    {
+        $this->load(self::MESSAGE_DATA_RELATIONS);
+
+        return $this;
+    }
+
+    /**
+     * Eager-load the message-payload relation set across a hydrated collection
+     * in a single batch, for the search path that holds its Scout matches as a
+     * collection (not a query) and must not load per-row. The collection mirror
+     * of {@see self::scopeWithMessageDataRelations()}.
+     *
+     * @param  Collection<int, Message>  $messages
+     * @return Collection<int, Message>
+     */
+    public static function loadMessageDataRelationsInto(Collection $messages): Collection
+    {
+        return $messages->load(self::MESSAGE_DATA_RELATIONS);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
@@ -125,6 +126,26 @@ class User extends Authenticatable
         return $this->belongsToMany(Channel::class, 'channel_members')
             ->withPivot(['last_read_message_id', 'muted', 'notification_level', 'draft', 'starred', 'section_id', 'position'])
             ->withTimestamps();
+    }
+
+    /**
+     * The ids of the channels this user may see in a team — the whole
+     * authorization boundary for message search, the thread inbox, unread
+     * indicators, forwarding, and sidebar placement.
+     *
+     * "Visible" is membership scoped to the team: every channel the user belongs
+     * to within it, archived ones included (they are still readable, just hidden
+     * from the sidebar). This is the single home of that decision — no consumer
+     * re-derives the ACL with its own query, so tightening it (a block-list, an
+     * archived exclusion) is one change every consumer inherits.
+     *
+     * @return SupportCollection<int, string>
+     */
+    public function visibleChannelIds(Team $team): SupportCollection
+    {
+        return $this->channels()
+            ->where('channels.team_id', $team->id)
+            ->pluck('channels.id');
     }
 
     /**

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -42,8 +42,7 @@ class ChannelPolicy
      */
     public function updatePreference(User $user, Channel $channel): bool
     {
-        return $user->belongsToTeam($channel->team)
-            && $channel->members()->whereKey($user->id)->exists();
+        return $this->isMember($user, $channel);
     }
 
     /**
@@ -55,8 +54,7 @@ class ChannelPolicy
      */
     public function updateStar(User $user, Channel $channel): bool
     {
-        return $user->belongsToTeam($channel->team)
-            && $channel->members()->whereKey($user->id)->exists();
+        return $this->isMember($user, $channel);
     }
 
     /**
@@ -69,8 +67,7 @@ class ChannelPolicy
      */
     public function place(User $user, Channel $channel): bool
     {
-        return $user->belongsToTeam($channel->team)
-            && $channel->members()->whereKey($user->id)->exists();
+        return $this->isMember($user, $channel);
     }
 
     /**
@@ -82,8 +79,7 @@ class ChannelPolicy
      */
     public function saveDraft(User $user, Channel $channel): bool
     {
-        return $user->belongsToTeam($channel->team)
-            && $channel->members()->whereKey($user->id)->exists();
+        return $this->isMember($user, $channel);
     }
 
     /**
@@ -130,6 +126,18 @@ class ChannelPolicy
     public function removeMember(User $user, Channel $channel): bool
     {
         return $this->managesMembership($user, $channel);
+    }
+
+    /**
+     * Shared rule for the pivot-preference abilities (notification preference,
+     * star, sidebar placement, draft): the user is a plain member of the channel
+     * within its team, so they have a membership row to mutate. Each of those
+     * abilities only ever touches the caller's own row.
+     */
+    private function isMember(User $user, Channel $channel): bool
+    {
+        return $user->belongsToTeam($channel->team)
+            && $channel->members()->whereKey($user->id)->exists();
     }
 
     /**

--- a/app/Support/ChannelTimelineWindow.php
+++ b/app/Support/ChannelTimelineWindow.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace App\Support;
+
+use App\Data\MessageData;
+use App\Http\Controllers\Channels\ChannelController;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\CursorPaginator;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Resolves where a channel's initial message window opens and assembles the
+ * timeline and thread payloads a channel view renders.
+ *
+ * This is the read-model behind {@see ChannelController::show()}:
+ * the most regression-prone logic in the app — unread-boundary anchoring, jump
+ * context, and page-size arithmetic. It takes explicit parameters (no `Request`)
+ * so the window math is unit-testable without an HTTP round-trip. The controller
+ * keeps HTTP glue only: resolve params from the request, call this, render.
+ *
+ * The two request-derived ids (`$requestedJumpId`, `$requestedThreadRootId`)
+ * arrive raw from query params, so they are typed `mixed` and validated here —
+ * a tampered non-string or a message from another channel resolves to null.
+ */
+class ChannelTimelineWindow
+{
+    /**
+     * How many messages newer than a jump target to keep loaded below it, so a
+     * jumped-to message shows following context and is not pinned to the bottom.
+     */
+    private const int JUMP_CONTEXT = 15;
+
+    /**
+     * How many messages the initial timeline window loads. Mirrors the page size
+     * of the cursor paginator below and feeds the read-boundary window math.
+     */
+    private const int MESSAGE_PAGE_SIZE = 50;
+
+    /**
+     * How many replies a thread page loads. The panel pages older replies in on
+     * scroll-up, mirroring the main timeline.
+     */
+    private const int THREAD_PAGE_SIZE = 50;
+
+    /**
+     * How many already-read messages to keep loaded above the "New messages"
+     * boundary when a channel opens deep enough into unread history that the
+     * boundary would otherwise fall outside the initial window.
+     */
+    private const int UNREAD_CONTEXT = 10;
+
+    private bool $jumpResolved = false;
+
+    private ?string $resolvedJumpId = null;
+
+    private bool $threadRootResolved = false;
+
+    private ?Message $resolvedThreadRoot = null;
+
+    public function __construct(
+        private readonly Channel $channel,
+        private readonly User $viewer,
+        private readonly mixed $requestedJumpId = null,
+        private readonly ?string $lastReadMessageId = null,
+        private readonly mixed $requestedThreadRootId = null,
+    ) {}
+
+    /**
+     * The `?message=` jump target resolved to an id belonging to this channel.
+     *
+     * Returns the id when it identifies a message in the channel (soft-deleted
+     * rows included), or null when the parameter is absent, non-string, or points
+     * at a message from another channel. Memoised: it also feeds {@see ceilingId()}.
+     */
+    public function jumpToMessageId(): ?string
+    {
+        if (! $this->jumpResolved) {
+            $this->resolvedJumpId = $this->resolveJumpTarget();
+            $this->jumpResolved = true;
+        }
+
+        return $this->resolvedJumpId;
+    }
+
+    /**
+     * The id that caps the initial message window, or null for the default
+     * "open at newest" window.
+     *
+     * A jump anchors the window around its target; otherwise the read pointer
+     * anchors it around the "New messages" boundary.
+     */
+    public function ceilingId(): ?string
+    {
+        $jumpId = $this->jumpToMessageId();
+
+        return $jumpId !== null
+            ? $this->jumpWindowCeiling($jumpId)
+            : $this->unreadWindowCeiling();
+    }
+
+    /**
+     * The main timeline as a cursor-paginated page of {@see MessageData}.
+     *
+     * Newest first (the client reverses for display and pages older messages in
+     * above on scroll-up). Tombstones are kept so deletions render in place; the
+     * window ceiling caps the newest loaded row.
+     *
+     * @return CursorPaginator<int, MessageData>
+     */
+    public function messages(): CursorPaginator
+    {
+        $ceilingId = $this->ceilingId();
+
+        return $this->mainTimeline()
+            ->withThreadReadState($this->viewer)
+            ->withMessageDataRelations()
+            ->when($ceilingId, fn (Builder $query) => $query->where('id', '<=', $ceilingId))
+            ->orderByDesc('id')
+            ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
+            ->through(fn (Message $message) => MessageData::fromMessage($message));
+    }
+
+    /**
+     * The open thread's root from the `?thread=` query param.
+     *
+     * Returns `['root' => MessageData]` when the param names a live root in this
+     * channel, or null when it is absent or points elsewhere. Replies are
+     * delivered separately by {@see threadReplies()}.
+     *
+     * @return array{root: MessageData}|null
+     */
+    public function thread(): ?array
+    {
+        $root = $this->resolveThreadRoot();
+
+        if ($root === null) {
+            return null;
+        }
+
+        return ['root' => MessageData::fromMessage($root)];
+    }
+
+    /**
+     * The open thread's replies as a cursor-paginated page for infinite scroll.
+     *
+     * Ordered newest first (the client reverses for display and pages older
+     * replies in on scroll-up), tombstones included so deletions render in place.
+     * Its own cursor name keeps the pagination independent of the main timeline's.
+     * Falls back to an empty page when no live root is named, so the scroll prop
+     * always has a well-formed shape even on a normal channel visit.
+     *
+     * @return CursorPaginator<int, MessageData>
+     */
+    public function threadReplies(): CursorPaginator
+    {
+        $root = $this->resolveThreadRoot();
+
+        $query = $root !== null
+            ? $root->threadReplies()->withTrashed()->withMessageDataRelations()
+            : Message::query()->whereRaw('1 = 0');
+
+        return $query
+            ->orderByDesc('id')
+            ->cursorPaginate(self::THREAD_PAGE_SIZE, ['*'], 'thread_cursor')
+            ->through(fn (Message $message) => MessageData::fromMessage($message));
+    }
+
+    /**
+     * Validate the requested jump target against this channel.
+     */
+    private function resolveJumpTarget(): ?string
+    {
+        if (! is_string($this->requestedJumpId) || $this->requestedJumpId === '') {
+            return null;
+        }
+
+        return $this->channel->messages()->withTrashed()->whereKey($this->requestedJumpId)->exists()
+            ? $this->requestedJumpId
+            : null;
+    }
+
+    /**
+     * The id that caps the initial window for a jump.
+     *
+     * Returns the id of the message JUMP_CONTEXT positions newer than the target
+     * so it loads with following context below it rather than pinned to the very
+     * bottom of the view. Returns null when fewer than that many newer messages
+     * exist — the target is then already near the newest, so no cap is needed.
+     */
+    private function jumpWindowCeiling(string $targetId): ?string
+    {
+        return $this->channel->messages()
+            ->withTrashed()
+            ->where('id', '>', $targetId)
+            ->orderBy('id')
+            ->offset(self::JUMP_CONTEXT - 1)
+            ->value('id');
+    }
+
+    /**
+     * The id that caps the initial window so the "New messages" boundary loads,
+     * or null to keep the default "open at newest" window.
+     *
+     * The boundary sits at the first message newer than the viewer's read
+     * pointer. When few enough messages sit at or after it to fit inside the
+     * newest page, the boundary already loads and no window is needed. A busier
+     * channel is anchored: the window is capped UNREAD_CONTEXT read messages
+     * above the boundary so it opens with the "New messages" line near the top
+     * and unread history below, while older history still pages in above.
+     *
+     * A never-read channel (null pointer) has no last-read boundary to anchor,
+     * so it keeps the default "open at newest" window rather than landing the
+     * viewer on the oldest message of a long backlog.
+     */
+    private function unreadWindowCeiling(): ?string
+    {
+        if ($this->lastReadMessageId === null) {
+            return null;
+        }
+
+        $firstUnreadId = $this->mainTimeline()
+            ->where('id', '>', $this->lastReadMessageId)
+            ->orderBy('id')
+            ->value('id');
+
+        if ($firstUnreadId === null) {
+            return null;
+        }
+
+        // The boundary already loads when the messages at or after it fit in the
+        // newest page, so keep opening at newest for read/lightly-unread channels.
+        $atOrAfterBoundary = $this->mainTimeline()
+            ->where('id', '>=', $firstUnreadId)
+            ->count();
+
+        if ($atOrAfterBoundary <= self::MESSAGE_PAGE_SIZE) {
+            return null;
+        }
+
+        return $this->mainTimeline()
+            ->where('id', '>', $firstUnreadId)
+            ->orderBy('id')
+            ->offset(self::MESSAGE_PAGE_SIZE - self::UNREAD_CONTEXT - 1)
+            ->value('id');
+    }
+
+    /**
+     * Resolve the live root message named by the `?thread=` query param, or null.
+     *
+     * The eager-load set mirrors the main timeline so the root renders its quote
+     * and thread affordances identically. Memoised: both {@see thread()} and
+     * {@see threadReplies()} read it.
+     */
+    private function resolveThreadRoot(): ?Message
+    {
+        if ($this->threadRootResolved) {
+            return $this->resolvedThreadRoot;
+        }
+
+        $this->threadRootResolved = true;
+
+        if (! is_string($this->requestedThreadRootId) || $this->requestedThreadRootId === '') {
+            return $this->resolvedThreadRoot;
+        }
+
+        return $this->resolvedThreadRoot = $this->channel->messages()
+            ->whereNull('thread_root_id')
+            ->withThreadReadState($this->viewer)
+            ->withMessageDataRelations()
+            ->find($this->requestedThreadRootId);
+    }
+
+    /**
+     * A fresh base query constrained to the main channel timeline: top-level
+     * messages plus thread replies explicitly "also sent to channel". Thread
+     * replies otherwise live only in the thread view.
+     *
+     * @return Builder<Message>
+     */
+    private function mainTimeline(): Builder
+    {
+        return $this->channel->messages()->withTrashed()->getQuery()
+            ->where(fn (Builder $inner) => $inner->whereNull('thread_root_id')->orWhere('sent_to_channel', true));
+    }
+}

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,26 @@
+# ADR-0001: Record architecture decisions
+
+- Status: Accepted
+- Date: 2026-07-10
+
+## Context
+
+The codebase is well-factored, but architectural decisions (why one seam exists,
+why a module is shaped a certain way) were undocumented. Architecture reviews and
+new contributors kept re-deriving — and sometimes re-litigating — settled choices.
+
+## Decision
+
+We record significant architecture decisions as short ADRs in `docs/adr/`, numbered
+sequentially (`NNNN-title.md`). Each ADR states Context, Decision, and Consequences.
+
+An ADR is warranted when a decision is load-bearing enough that a future reviewer
+would otherwise re-suggest the thing we deliberately chose against, or re-invent the
+module we deliberately built. The shared vocabulary and the named seams themselves
+live in [`CONTEXT.md`](../../CONTEXT.md); ADRs record the *decisions* behind them.
+
+## Consequences
+
+- `/improve-codebase-architecture` reads existing ADRs and does not re-surface a
+  decision an ADR already settles.
+- ADRs are append-only in spirit: supersede rather than edit, linking the successor.

--- a/docs/adr/0002-message-eager-load-set-in-one-scope.md
+++ b/docs/adr/0002-message-eager-load-set-in-one-scope.md
@@ -1,0 +1,29 @@
+# ADR-0002: Own the message eager-load set in one scope
+
+- Status: Accepted
+- Date: 2026-07-10
+- Relates to: epic architecture-hardening (child: Message load-set scope)
+
+## Context
+
+`MessageData::fromMessage()` is the canonical read-model for a message and decides
+which relations it reads. But the knowledge of *what to eager-load so it doesn't
+N+1* was hand-written at six unrelated call sites (channel timeline, thread payload,
+search, post, edit, broadcast). The relation lists had already drifted out of sync.
+This is information leakage: one design decision spread across modules that must
+change together.
+
+## Decision
+
+There is exactly one place that declares the relations `MessageData` needs — a query
+scope on `Message` (e.g. `scopeWithMessageDataRelations`). Every code path that turns
+a `Message` (or query) into `MessageData` routes through it.
+
+Hand-writing a `with([...])` relation list for a message payload is not allowed;
+add the relation to the scope instead.
+
+## Consequences
+
+- Adding a relation to `MessageData` is a one-line change in one place.
+- The N+1 contract is testable in isolation and cannot silently diverge per caller.
+- Passes the deletion test: the scope concentrates a real, reused contract.

--- a/docs/adr/0003-single-visible-channels-acl-scope.md
+++ b/docs/adr/0003-single-visible-channels-acl-scope.md
@@ -1,0 +1,27 @@
+# ADR-0003: One scope for the visible-channels ACL
+
+- Status: Accepted
+- Date: 2026-07-10
+- Relates to: epic architecture-hardening (child: Visible-channels ACL)
+
+## Context
+
+"The channel ids a user may see in a team" is the entire authorization boundary for
+message search, the thread inbox, unread indicators, and message forwarding. It was
+reimplemented as an ad-hoc `pluck` in at least five places across three different
+architectural strata (middleware, controller, Action, FormRequest). A change to what
+"visible" means (e.g. excluding archived channels, honouring a block-list) would need
+five synchronized edits, and one would be missed — a security-relevant divergence.
+
+## Decision
+
+The visible-channel id set is a single named scope/method on `User`
+(e.g. `visibleChannelIds(Team)`). Every consumer — search, thread inbox, unread
+dots, forwarding, placement — routes through it. No feature re-derives the ACL with
+its own query.
+
+## Consequences
+
+- The authorization boundary has one greppable name and one test surface.
+- Tightening the ACL is a single change that every consumer inherits.
+- Passes the deletion test: the scope carries a reused security decision.

--- a/docs/adr/0004-timeline-window-as-read-model.md
+++ b/docs/adr/0004-timeline-window-as-read-model.md
@@ -1,0 +1,29 @@
+# ADR-0004: Resolve the channel timeline window in a read-model, not the controller
+
+- Status: Accepted
+- Date: 2026-07-10
+- Relates to: epic architecture-hardening (child: Channel timeline window)
+
+## Context
+
+`ChannelController::show` had grown to ~265 of the controller's 454 lines — the
+endpoint plus seven private helpers computing where a channel's initial message
+window should open (unread-boundary anchoring, jump context, page-size arithmetic).
+This is genuinely complex, regression-prone domain logic, but it read `Request`
+state directly and ended in `Inertia::render`, so it was reachable only through a
+full HTTP round-trip. The most bug-prone code in the app had no unit-test seam.
+
+## Decision
+
+Complex message-window / read-model resolution lives in a dedicated query object /
+read-model that takes explicit parameters (channel, viewer, jump target, last-read
+id) and returns the window ceiling + payload. Controllers keep HTTP glue only:
+resolve params from the request, call the read-model, render.
+
+This applies whenever timeline-assembly logic grows beyond trivial in a controller.
+
+## Consequences
+
+- The window math becomes unit-testable without an HTTP request.
+- `show` shrinks to a thin action consistent with its siblings.
+- Passes the deletion test: real weight, moved to where it can be tested.

--- a/docs/adr/0005-domain-event-recording-seam.md
+++ b/docs/adr/0005-domain-event-recording-seam.md
@@ -1,0 +1,34 @@
+# ADR-0005: Record audit & security events via the event→listener seam
+
+- Status: Accepted
+- Date: 2026-07-10
+- Relates to: epic architecture-hardening (audit locality; supersedes divergent recorders)
+
+## Context
+
+The app has two structurally identical concerns — appending a row that describes
+something a user did — built with *opposite* seams. Security events flow through an
+event→listener (`RecordSecurityEvents`): decoupled and testable by dispatching an
+event. Audit events were recorded by direct `AuditRecorder::record()` calls wired
+into six controllers, often carrying the "is this auditable?" condition
+(`$oldRole !== $newRole`, moderation checks). The mutation lives in an Action; the
+audit that must accompany it lived in the controller — so a future non-HTTP caller
+of that Action (a command, a job) would silently skip the audit.
+`SecurityEventRecorder` also coupled itself to the live `Request` in its
+constructor, making it un-resolvable from a job.
+
+## Decision
+
+Recording "what happened" uses one seam: the mutation (in its Action) dispatches a
+domain event, and a listener records the audit/security row. Recording does not live
+in controllers, and the recorder does not depend on the live `Request`. The existing
+`RecordSecurityEvents` listener is the reference shape.
+
+`AuditRecorder` / `SecurityEventRecorder` stay as deep modules hiding the
+activity-log builder — only *where they are invoked from* changes.
+
+## Consequences
+
+- "This mutation is auditable" has one home: next to the mutation.
+- Every caller of an Action gets the audit for free; new callers can't forget it.
+- Auditing works from jobs/commands, not only HTTP.

--- a/docs/adr/0006-realtime-lives-in-composables.md
+++ b/docs/adr/0006-realtime-lives-in-composables.md
@@ -1,0 +1,39 @@
+# ADR-0006: Realtime subscription lifecycles live in composables, not components
+
+- Status: Accepted
+- Date: 2026-07-10
+- Relates to: epic architecture-hardening (children: useChannelRealtime, useChannelFleetSubscription)
+
+## Context
+
+The most behaviour-dense frontend code — subscribing to Echo channels, routing five
+event types plus typing whispers into message streams, deciding main-vs-thread
+placement, reconciling subscriptions on channel change — was inlined in `.vue` setup.
+`pages/channels/Show.vue` reached 1584 lines partly from this. The same
+subscribe/reconcile/teardown lifecycle was hand-rolled three times (the active
+channel in `Show.vue`, sidebar badges, chime notifications), each a copy waiting to
+drift. None of it had a seam: it was reachable only through a mounted component and a
+live Echo mock, while the *pure* decision helpers it should call
+(`shouldFlagThreadUnread`, `unreadDivider`) were tested but their callers were not.
+
+## Decision
+
+Realtime subscription lifecycles live in composables with a seam, not inline in
+pages or components:
+
+- `useChannelRealtime` owns the active channel's subscribe/route/teardown and feeds
+  the message streams. Its placement/routing decisions are extracted into pure
+  `lib/*.ts` helpers (with paired tests).
+- `useChannelFleetSubscription` owns the one reconcile/teardown lifecycle for
+  subscribing to a *set* of channels; sidebar badges, chimes, and the active channel
+  are consumers that supply an on-message callback.
+
+New realtime behaviour extends these composables; it is not re-inlined into a page.
+
+## Consequences
+
+- The realtime contract is assertable in isolation; the pure decision cores are
+  unit-tested like the rest of `lib/`.
+- One subscription lifecycle is verified once instead of three copies.
+- `Show.vue` decomposes into composables with seams (unblocks the god-component
+  split).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records
+
+Short records of load-bearing architecture decisions. Format and rationale:
+[ADR-0001](0001-record-architecture-decisions.md). Shared vocabulary and the named
+seams live in [`CONTEXT.md`](../../CONTEXT.md).
+
+| ADR | Decision |
+| --- | --- |
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions as ADRs |
+| [0002](0002-message-eager-load-set-in-one-scope.md) | Own the message eager-load set in one scope |
+| [0003](0003-single-visible-channels-acl-scope.md) | One scope for the visible-channels ACL |
+| [0004](0004-timeline-window-as-read-model.md) | Resolve the channel timeline window in a read-model |
+| [0005](0005-domain-event-recording-seam.md) | Record audit & security events via event→listener |
+| [0006](0006-realtime-lives-in-composables.md) | Realtime subscription lifecycles live in composables |

--- a/resources/js/composables/useChannelDraft.test.ts
+++ b/resources/js/composables/useChannelDraft.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+
+const { patch } = vi.hoisted(() => ({ patch: vi.fn() }));
+
+vi.mock('@inertiajs/vue3', () => ({ router: { patch } }));
+
+import {
+    DRAFT_DEBOUNCE_MS,
+    useChannelDraft,
+} from '@/composables/useChannelDraft';
+import type { ChannelDraft } from '@/composables/useChannelDraft';
+
+/**
+ * Run the composable inside a disposable effect scope so its channel-switch
+ * watcher and the underlying auto-teardown are exercised by stopping the scope.
+ */
+function withScope(channelSlug: Ref<string>, channelId: Ref<string>) {
+    const scope = effectScope();
+    let draft!: ChannelDraft;
+
+    scope.run(() => {
+        draft = useChannelDraft({
+            channelId: () => channelId.value,
+            teamSlug: () => 'acme',
+            channelSlug: () => channelSlug.value,
+        });
+    });
+
+    return { draft, unmount: () => scope.stop() };
+}
+
+/** The url of the nth recorded draft-save patch. */
+function patchedUrl(call = 0): string {
+    return patch.mock.calls[call][0] as string;
+}
+
+describe('useChannelDraft', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        patch.mockClear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('debounces a draft save for the current channel', () => {
+        const { draft } = withScope(ref('alpha'), ref('id-alpha'));
+
+        draft.onDraftChange('half a th');
+        draft.onDraftChange('half a thought');
+        expect(patch).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(DRAFT_DEBOUNCE_MS);
+
+        expect(patch).toHaveBeenCalledOnce();
+        expect(patchedUrl()).toContain('alpha');
+        expect(patch.mock.calls[0][1]).toEqual({ body: 'half a thought' });
+    });
+
+    it('flushes the outgoing channel draft with its own slug on a channel switch', () => {
+        const slug = ref('alpha');
+        const id = ref('id-alpha');
+        const { draft } = withScope(slug, id);
+
+        // Type into alpha, then switch to bravo before the debounce fires.
+        draft.onDraftChange('for alpha');
+        slug.value = 'bravo';
+        id.value = 'id-bravo';
+
+        return nextTick().then(() => {
+            // The pending save flushed immediately, tagged with alpha's slug —
+            // not bravo, the channel just navigated to.
+            expect(patch).toHaveBeenCalledOnce();
+            expect(patchedUrl()).toContain('alpha');
+            expect(patchedUrl()).not.toContain('bravo');
+        });
+    });
+
+    it('cancels a pending save so a send does not re-persist cleared text', () => {
+        const { draft } = withScope(ref('alpha'), ref('id-alpha'));
+
+        draft.onDraftChange('unsent');
+        draft.cancel();
+
+        vi.advanceTimersByTime(DRAFT_DEBOUNCE_MS);
+
+        expect(patch).not.toHaveBeenCalled();
+    });
+
+    it('flushes a just-typed draft on teardown so it is not lost', () => {
+        const { draft, unmount } = withScope(ref('alpha'), ref('id-alpha'));
+
+        draft.onDraftChange('outlives unmount');
+        unmount();
+
+        expect(patch).toHaveBeenCalledOnce();
+        expect(patch.mock.calls[0][1]).toEqual({ body: 'outlives unmount' });
+    });
+});

--- a/resources/js/composables/useChannelDraft.ts
+++ b/resources/js/composables/useChannelDraft.ts
@@ -1,0 +1,64 @@
+import { router } from '@inertiajs/vue3';
+import { watch } from 'vue';
+import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
+
+/**
+ * How long to coalesce composer keystrokes before persisting the draft. Long
+ * enough that ordinary typing collapses to a single request.
+ */
+export const DRAFT_DEBOUNCE_MS = 700;
+
+export interface ChannelDraftOptions {
+    /** The open channel's id; a change flushes the outgoing channel's draft. */
+    channelId: () => string;
+    /** The current team's slug, for the draft-save route. */
+    teamSlug: () => string;
+    /** The open channel's slug, tagged onto each scheduled save. */
+    channelSlug: () => string;
+}
+
+export interface ChannelDraft {
+    /** Debounce a draft save for the current channel; an empty body clears it. */
+    onDraftChange: (body: string) => void;
+    /** Drop a pending save without firing it (a send clears the draft server-side). */
+    cancel: () => void;
+}
+
+/**
+ * Own the composer draft's persistence lifecycle: debounce keystrokes into a
+ * single per-channel save, flush the outgoing channel's draft when the open
+ * channel changes, and flush again on teardown so a just-typed draft is never
+ * lost. Rides {@see useDebouncedPost} — the payload is tagged with the slug of
+ * the channel being edited, so a flush triggered by a channel switch still writes
+ * to the channel that was actually being typed in rather than the one just
+ * navigated to.
+ */
+export function useChannelDraft(options: ChannelDraftOptions): ChannelDraft {
+    function persistDraft(slug: string, body: string): void {
+        router.patch(
+            saveChannelDraft({ team: options.teamSlug(), channel: slug }).url,
+            { body },
+            { preserveScroll: true, preserveState: true, only: ['channels'] },
+        );
+    }
+
+    // The payload carries the slug of the channel it belongs to, so a flush on
+    // channel switch writes to the right place. It flushes on unmount so a
+    // just-typed draft outlives leaving the workspace.
+    const draftPost = useDebouncedPost(
+        (draft: { slug: string; body: string }) =>
+            persistDraft(draft.slug, draft.body),
+        { delay: DRAFT_DEBOUNCE_MS, flushOnUnmount: true },
+    );
+
+    function onDraftChange(body: string): void {
+        draftPost.schedule({ slug: options.channelSlug(), body });
+    }
+
+    // Persist the outgoing channel's draft before the switch settles; the pending
+    // payload still carries the old channel's slug.
+    watch(options.channelId, () => draftPost.flush());
+
+    return { onDraftChange, cancel: draftPost.cancel };
+}

--- a/resources/js/composables/useChannelFleetSubscription.ts
+++ b/resources/js/composables/useChannelFleetSubscription.ts
@@ -1,0 +1,72 @@
+import { usePage } from '@inertiajs/vue3';
+import { echo } from '@laravel/echo-vue';
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { createChannelFleet } from '@/lib/channelFleet';
+import type { Message } from '@/types';
+
+/** The Echo private-channel name a channel id broadcasts on. */
+function channelName(id: string): string {
+    return `channel.${id}`;
+}
+
+/**
+ * Subscribe to a *set* of channels — every channel in the sidebar — and run a
+ * caller-supplied callback for each realtime `MessageSent`. This is the one
+ * subscribe/reconcile/teardown lifecycle shared by the sidebar badges and the
+ * chimes (and mirrored by the open channel's own single subscription): the pure
+ * {@see createChannelFleet} owns the bound-set diffing and active-channel
+ * handoff, while this composable wires it to Echo, the shared `channels` prop,
+ * and the component lifecycle. Consumers stay thin — they only decide *what to
+ * do* on a message.
+ *
+ * The open channel's subscription is owned by its page, which leaves it on
+ * navigation; the post-flush reconcile below runs after that teardown so it
+ * re-attaches the channel just left.
+ */
+export function useChannelFleetSubscription(
+    onMessage: (channelId: string, message: Message) => void,
+): void {
+    const page = usePage();
+
+    const channels = computed(() => page.props.channels ?? []);
+    const activeChannelId = computed(
+        () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
+    );
+
+    // Only reconcile when the set of channels or the open one actually changes,
+    // not on every badge-count refresh of the shared `channels` prop.
+    const subscriptionKey = computed(
+        () =>
+            `${channels.value.map((channel) => channel.id).join('|')}::${activeChannelId.value ?? ''}`,
+    );
+
+    const fleet = createChannelFleet({
+        subscribe(id) {
+            echo()
+                .private(channelName(id))
+                .listen('MessageSent', (message: Message) => {
+                    onMessage(id, message);
+                });
+        },
+        leave(id) {
+            echo().leave(channelName(id));
+        },
+    });
+
+    function reconcile(): void {
+        fleet.reconcile(
+            channels.value.map((channel) => channel.id),
+            activeChannelId.value,
+        );
+    }
+
+    onMounted(reconcile);
+
+    // Post-flush so it runs after the open channel page's own per-channel
+    // teardown of the channel it just navigated away from.
+    watch(subscriptionKey, reconcile, { flush: 'post' });
+
+    onBeforeUnmount(() => {
+        fleet.leaveAll();
+    });
+}

--- a/resources/js/composables/useChannelPreferences.test.ts
+++ b/resources/js/composables/useChannelPreferences.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, ref } from 'vue';
+import type { Ref } from 'vue';
+
+const { patch, toastError } = vi.hoisted(() => ({
+    patch: vi.fn(),
+    toastError: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({ router: { patch } }));
+vi.mock('vue-sonner', () => ({ toast: { error: toastError } }));
+
+import { useChannelPreferences } from '@/composables/useChannelPreferences';
+import type { ChannelPreferences } from '@/composables/useChannelPreferences';
+import type { Channel, NotificationLevel } from '@/types';
+
+type PrefState = Pick<Channel, 'notificationLevel' | 'muted' | 'starred'>;
+
+function channelState(overrides: Partial<PrefState> = {}): PrefState {
+    return {
+        notificationLevel: 'all',
+        muted: false,
+        starred: false,
+        ...overrides,
+    };
+}
+
+function withScope(channel: Ref<PrefState>, channelId: Ref<string>) {
+    const scope = effectScope();
+    let prefs!: ChannelPreferences;
+
+    scope.run(() => {
+        prefs = useChannelPreferences({
+            channelId: () => channelId.value,
+            channel: () => channel.value,
+            teamSlug: () => 'acme',
+            channelSlug: () => 'general',
+        });
+    });
+
+    return { prefs, unmount: () => scope.stop() };
+}
+
+/** Invoke the onError callback of the nth recorded patch, standing in for a failed request. */
+function failPatch(call = 0): void {
+    (patch.mock.calls[call][2] as { onError: () => void }).onError();
+}
+
+describe('useChannelPreferences', () => {
+    beforeEach(() => {
+        patch.mockClear();
+        toastError.mockClear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('seeds each preference from the server state', () => {
+        const { prefs } = withScope(
+            ref(
+                channelState({
+                    notificationLevel: 'mentions',
+                    muted: true,
+                    starred: true,
+                }),
+            ),
+            ref('id-1'),
+        );
+
+        expect(prefs.notificationLevel.value).toBe('mentions');
+        expect(prefs.muted.value).toBe(true);
+        expect(prefs.starred.value).toBe(true);
+    });
+
+    it('reseeds preferences from the server on a channel switch', () => {
+        const channel = ref(channelState({ starred: false }));
+        const id = ref('id-1');
+        const { prefs } = withScope(channel, id);
+
+        channel.value = channelState({
+            notificationLevel: 'nothing',
+            muted: true,
+            starred: true,
+        });
+        id.value = 'id-2';
+
+        return Promise.resolve().then(() => {
+            expect(prefs.notificationLevel.value).toBe('nothing');
+            expect(prefs.muted.value).toBe(true);
+            expect(prefs.starred.value).toBe(true);
+        });
+    });
+
+    it('stars optimistically and rolls back on error', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        prefs.toggleStar();
+        expect(prefs.starred.value).toBe(true);
+        expect(patch.mock.calls[0][1]).toEqual({ starred: true });
+
+        failPatch();
+        expect(prefs.starred.value).toBe(false);
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('changes the notification level optimistically and rolls back on error', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        prefs.onNotificationLevelChange('mentions' as NotificationLevel);
+        expect(prefs.notificationLevel.value).toBe('mentions');
+        expect(patch.mock.calls[0][1]).toEqual({
+            muted: false,
+            notification_level: 'mentions',
+        });
+
+        failPatch();
+        expect(prefs.notificationLevel.value).toBe('all');
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('toggles mute optimistically and rolls back on error', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        prefs.onMuteChange(true);
+        expect(prefs.muted.value).toBe(true);
+
+        failPatch();
+        expect(prefs.muted.value).toBe(false);
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('suppresses thread-unread dots when muted or below "all"', () => {
+        const channel = ref(channelState());
+        const { prefs } = withScope(channel, ref('id-1'));
+
+        expect(prefs.threadUnreadSuppressed.value).toBe(false);
+
+        prefs.onMuteChange(true);
+        expect(prefs.threadUnreadSuppressed.value).toBe(true);
+
+        prefs.onMuteChange(false);
+        prefs.onNotificationLevelChange('mentions' as NotificationLevel);
+        expect(prefs.threadUnreadSuppressed.value).toBe(true);
+    });
+
+    it('derives a header cue only for a non-default notification state', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        expect(prefs.notificationStatus.value).toBeNull();
+
+        prefs.onMuteChange(true);
+        expect(prefs.notificationStatus.value?.label).toBe('Muted');
+
+        prefs.onMuteChange(false);
+        prefs.onNotificationLevelChange('nothing' as NotificationLevel);
+        expect(prefs.notificationStatus.value?.label).toBe('Notifications off');
+
+        prefs.onNotificationLevelChange('mentions' as NotificationLevel);
+        expect(prefs.notificationStatus.value?.label).toBe('Mentions only');
+    });
+});

--- a/resources/js/composables/useChannelPreferences.ts
+++ b/resources/js/composables/useChannelPreferences.ts
@@ -1,0 +1,167 @@
+import { router } from '@inertiajs/vue3';
+import { AtSign, BellMinus, BellOff } from '@lucide/vue';
+import type { AcceptableValue } from 'reka-ui';
+import { computed, ref, watch } from 'vue';
+import type { Component, ComputedRef, Ref } from 'vue';
+import { toast } from 'vue-sonner';
+import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
+import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
+import type { Channel, NotificationLevel } from '@/types';
+
+/** The member's own star/mute/notification state for the open channel. */
+type ChannelPreferenceState = Pick<
+    Channel,
+    'notificationLevel' | 'muted' | 'starred'
+>;
+
+export interface ChannelPreferencesOptions {
+    /** The open channel's id; a change reseeds the preferences from the server. */
+    channelId: () => string;
+    /** The channel's server-seeded preference state, reread on channel switch. */
+    channel: () => ChannelPreferenceState;
+    /** The current team's slug, for the preference/star routes. */
+    teamSlug: () => string;
+    /** The open channel's slug, for the preference/star routes. */
+    channelSlug: () => string;
+}
+
+export interface ChannelPreferences {
+    /** The member's notification level; drives the header menu radio group. */
+    notificationLevel: Ref<NotificationLevel>;
+    /** Whether the member has muted the channel. */
+    muted: Ref<boolean>;
+    /** Whether the member has starred the channel. */
+    starred: Ref<boolean>;
+    /** Whether thread-unread dots are silenced (muted or a quieted level). */
+    threadUnreadSuppressed: ComputedRef<boolean>;
+    /** A compact header cue for a non-default notification state, or null. */
+    notificationStatus: ComputedRef<{ icon: Component; label: string } | null>;
+    /** Star or unstar the channel, optimistically, rolled back on error. */
+    toggleStar: () => void;
+    /** Change the notification level, optimistically, rolled back on error. */
+    onNotificationLevelChange: (value: AcceptableValue) => void;
+    /** Toggle mute, optimistically, rolled back on error. */
+    onMuteChange: (value: boolean) => void;
+}
+
+/**
+ * Own the member's per-channel notification preferences: star, mute, and
+ * notification level, each seeded from the server and reseeded on every channel
+ * switch. Changes save optimistically — the sidebar reloads to reflect the new
+ * badge/dimming state — and roll back if the request fails.
+ */
+export function useChannelPreferences(
+    options: ChannelPreferencesOptions,
+): ChannelPreferences {
+    const notificationLevel = ref<NotificationLevel>(
+        options.channel().notificationLevel,
+    );
+    const muted = ref<boolean>(options.channel().muted);
+    const starred = ref<boolean>(options.channel().starred);
+
+    // Reseed from the server on channel switch; each preference is the outgoing
+    // channel's until the new channel's state is adopted here.
+    watch(options.channelId, () => {
+        const channel = options.channel();
+        notificationLevel.value = channel.notificationLevel;
+        muted.value = channel.muted;
+        starred.value = channel.starred;
+    });
+
+    // Thread-unread dots are silenced under the same rule as the sidebar's unread
+    // badge: a muted channel or any level below "all". Mirrors the server's
+    // suppression so a live dot and a navigation-time dot agree.
+    const threadUnreadSuppressed = computed(
+        () => muted.value || notificationLevel.value !== 'all',
+    );
+
+    // A compact header cue for the member's non-default notification state; the
+    // "all" default shows nothing to keep the header clean.
+    const notificationStatus = computed(() => {
+        if (muted.value) {
+            return { icon: BellOff, label: 'Muted' };
+        }
+
+        if (notificationLevel.value === 'nothing') {
+            return { icon: BellMinus, label: 'Notifications off' };
+        }
+
+        if (notificationLevel.value === 'mentions') {
+            return { icon: AtSign, label: 'Mentions only' };
+        }
+
+        return null;
+    });
+
+    function toggleStar(): void {
+        const previous = starred.value;
+        starred.value = !previous;
+
+        router.patch(
+            updateChannelStar({
+                team: options.teamSlug(),
+                channel: options.channelSlug(),
+            }).url,
+            { starred: starred.value },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['channels'],
+                onError: () => {
+                    starred.value = previous;
+                    toast.error(
+                        'Failed to update the channel. Please try again.',
+                    );
+                },
+            },
+        );
+    }
+
+    function savePreferences(rollback: () => void): void {
+        router.patch(
+            updateChannelPreferences({
+                team: options.teamSlug(),
+                channel: options.channelSlug(),
+            }).url,
+            { muted: muted.value, notification_level: notificationLevel.value },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['channels'],
+                onError: () => {
+                    rollback();
+                    toast.error(
+                        'Failed to update notification preferences. Please try again.',
+                    );
+                },
+            },
+        );
+    }
+
+    function onNotificationLevelChange(value: AcceptableValue): void {
+        const previous = notificationLevel.value;
+        notificationLevel.value = value as NotificationLevel;
+        savePreferences(() => {
+            notificationLevel.value = previous;
+        });
+    }
+
+    function onMuteChange(value: boolean): void {
+        const previous = muted.value;
+        muted.value = value;
+        savePreferences(() => {
+            muted.value = previous;
+        });
+    }
+
+    return {
+        notificationLevel,
+        muted,
+        starred,
+        threadUnreadSuppressed,
+        notificationStatus,
+        toggleStar,
+        onNotificationLevelChange,
+        onMuteChange,
+    };
+}

--- a/resources/js/composables/useChannelRealtime.ts
+++ b/resources/js/composables/useChannelRealtime.ts
@@ -1,0 +1,187 @@
+import { echo } from '@laravel/echo-vue';
+import type { Ref } from 'vue';
+import { onBeforeUnmount, onMounted, watch } from 'vue';
+import type { useMessageStream } from '@/composables/useMessageStream';
+import type {
+    TypingUser,
+    useTypingIndicator,
+} from '@/composables/useTypingIndicator';
+import { createChannelFleet } from '@/lib/channelFleet';
+import { placeIncomingMessage } from '@/lib/messagePlacement';
+import type { ChannelReader, Message, MessageAuthor, Reaction } from '@/types';
+
+type MessageStream = ReturnType<typeof useMessageStream>;
+type TypingIndicator = ReturnType<typeof useTypingIndicator>;
+
+export interface ChannelRealtimeOptions {
+    /** The open channel's id; re-read on change to move the subscription. */
+    channelId: () => string;
+    /** The current viewer's id, to drop own read-echoes and own-reply dots. */
+    currentUserId: () => string;
+    /** The main channel timeline stream. */
+    mainStream: MessageStream;
+    /** The open thread panel's stream. */
+    threadStream: MessageStream;
+    /** The root id of the thread currently open in the panel, or `null`. */
+    activeThreadRootId: Ref<string | null>;
+    /** The main timeline's rendered messages, to resolve a root's follow state. */
+    displayMessages: () => Message[];
+    /** Whether thread unread dots are silenced for this channel. */
+    isThreadUnreadSuppressed: () => boolean;
+    /** The channel's read-receipt map, advanced by peers' `MessageRead`. */
+    readers: Ref<Map<string, ChannelReader>>;
+    /** Whether the viewer is scrolled near the bottom of the main timeline. */
+    isNearBottom: () => boolean;
+    /** Follow a live append down, or raise the "new messages" count instead. */
+    notifyAppended: (wasNearBottom: boolean) => void;
+    /** The channel's typing indicator, for whisper receipt and settle-on-send. */
+    typing: TypingIndicator;
+    /** Advance the channel's read pointer (a message landed while focused). */
+    markRead: () => void;
+    /** Advance the open thread's read pointer. */
+    markThreadRead: () => void;
+}
+
+/** The Echo private-channel name a channel id broadcasts on. */
+function channelName(id: string): string {
+    return `channel.${id}`;
+}
+
+/**
+ * Own the *active* channel's realtime lifecycle: subscribe to its Echo channel,
+ * route the five broadcast events plus typing whispers into the two message
+ * streams, and move the subscription when the open channel changes.
+ *
+ * The subscribe/leave bookkeeping rides {@see createChannelFleet} — the same
+ * engine behind {@see useChannelFleetSubscription} — driven as a single-element
+ * fleet: each reconcile passes `null` as the active id (so the fleet's
+ * active-channel handoff never engages) and the sole desired id, which leaves the
+ * channel just navigated away from and subscribes the new one. The placement of
+ * each arriving message is decided by the pure {@see placeIncomingMessage}, so
+ * this composable stays a thin bridge between Echo and the streams.
+ */
+export function useChannelRealtime(options: ChannelRealtimeOptions): void {
+    // An edit or deletion may touch either timeline (or both, for a
+    // sent-to-channel reply); patch both streams, since a patch is ignored where
+    // the message isn't rendered.
+    function applyPatch(message: Message): void {
+        options.mainStream.applyPatch(message);
+        options.threadStream.applyPatch(message);
+    }
+
+    // Route a broadcast message to the timeline it belongs to, following the main
+    // timeline down when the reader is near the bottom and reconciling the open
+    // thread's read state — all decided by `placeIncomingMessage`.
+    function routeIncoming(message: Message): void {
+        const root = options
+            .displayMessages()
+            .find((candidate) => candidate.id === message.threadRootId);
+
+        const placement = placeIncomingMessage({
+            threadRootId: message.threadRootId,
+            sentToChannel: message.sentToChannel,
+            isOwnMessage: message.user.id === options.currentUserId(),
+            activeThreadRootId: options.activeThreadRootId.value,
+            isTabFocused: document.hasFocus(),
+            isFollowedThread: root?.threadFollowed ?? false,
+            isThreadUnreadSuppressed: options.isThreadUnreadSuppressed(),
+        });
+
+        if (placement.appendToMain) {
+            const wasNearBottom = options.isNearBottom();
+
+            if (options.mainStream.appendLive(message)) {
+                options.notifyAppended(wasNearBottom);
+            }
+        }
+
+        if (placement.appendToThread) {
+            options.threadStream.appendLive(message);
+        }
+
+        if (placement.markThreadReadNow) {
+            options.markThreadRead();
+        }
+
+        if (placement.flagRootThreadUnread && message.threadRootId !== null) {
+            options.mainStream.patchThreadState(message.threadRootId, {
+                threadUnread: true,
+            });
+        }
+    }
+
+    const fleet = createChannelFleet({
+        subscribe(id) {
+            echo()
+                .private(channelName(id))
+                .listen('MessageSent', (message: Message) => {
+                    // Their message landed; stop showing them as typing.
+                    options.typing.forget(message.user.id);
+                    routeIncoming(message);
+                    // Keep the open, focused channel read as new messages arrive.
+                    options.markRead();
+                })
+                .listen('MessageUpdated', (message: Message) => {
+                    applyPatch(message);
+                })
+                .listen('MessageDeleted', (message: Message) => {
+                    applyPatch(message);
+                })
+                .listen(
+                    'MessageReactionChanged',
+                    (event: { messageId: string; reactions: Reaction[] }) => {
+                        // The authoritative, viewer-free summary; patch it into
+                        // whichever timeline renders the message (no-op elsewhere).
+                        options.mainStream.patchReactions(
+                            event.messageId,
+                            event.reactions,
+                        );
+                        options.threadStream.patchReactions(
+                            event.messageId,
+                            event.reactions,
+                        );
+                    },
+                )
+                .listen(
+                    'MessageRead',
+                    (event: {
+                        reader: MessageAuthor;
+                        lastReadMessageId: string;
+                    }) => {
+                        // Our own advance echoes back on the shared private
+                        // channel; the "Seen by" row never shows the viewer, so
+                        // drop it here.
+                        if (event.reader.id === options.currentUserId()) {
+                            return;
+                        }
+
+                        const next = new Map(options.readers.value);
+                        next.set(event.reader.id, {
+                            user: event.reader,
+                            lastReadMessageId: event.lastReadMessageId,
+                        });
+                        options.readers.value = next;
+                    },
+                )
+                .listenForWhisper('typing', (user: TypingUser) => {
+                    options.typing.receiveTyping(user);
+                });
+        },
+        leave(id) {
+            echo().leave(channelName(id));
+        },
+    });
+
+    // Drive the fleet as a single-channel subscription: `null` active id keeps the
+    // handoff dormant, so each reconcile leaves the previous channel and
+    // subscribes the current one.
+    function moveSubscription(): void {
+        fleet.reconcile([options.channelId()], null);
+    }
+
+    onMounted(moveSubscription);
+    watch(options.channelId, moveSubscription);
+    onBeforeUnmount(() => {
+        fleet.leaveAll();
+    });
+}

--- a/resources/js/composables/useChimeNotifications.ts
+++ b/resources/js/composables/useChimeNotifications.ts
@@ -1,20 +1,19 @@
 import { usePage } from '@inertiajs/vue3';
-import { echo } from '@laravel/echo-vue';
-import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted } from 'vue';
+import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
 import { playChime, unlockChimeAudio } from '@/lib/chimeSounds';
 import { shouldChime } from '@/lib/shouldChime';
-import type { ChimeSound, Message } from '@/types';
+import type { ChimeSound } from '@/types';
 
 /**
  * Play a chime for qualifying realtime messages across every channel in the
  * sidebar — not just the open one — so activity elsewhere is still audible.
  *
- * Mounted once in the persistent channel layout, it subscribes to each sidebar
- * channel's broadcast and runs {@see shouldChime} per arrival. Show.vue owns the
- * open channel's subscription and tears it down with a full `leave` on navigation,
- * which also drops our listener on it; the post-flush reconcile below re-attaches
- * the channel it just left. Chimes for the open channel are suppressed while it is
- * focused, and Show.vue never chimes, so there is no double playback.
+ * Mounted once in the persistent channel layout, it rides
+ * {@see useChannelFleetSubscription} — the shared subscribe/reconcile/teardown
+ * engine — and runs {@see shouldChime} per arrival. Chimes for the open channel
+ * are suppressed while it is focused, and the open channel page never chimes, so
+ * there is no double playback.
  */
 export function useChimeNotifications(): void {
     const page = usePage();
@@ -28,21 +27,7 @@ export function useChimeNotifications(): void {
         () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
     );
 
-    // Only reconcile when the set of channels or the open one actually changes,
-    // not on every badge-count refresh of the shared `channels` prop.
-    const subscriptionKey = computed(
-        () =>
-            `${channels.value.map((channel) => channel.id).join('|')}::${activeChannelId.value ?? ''}`,
-    );
-
-    const bound = new Set<string>();
-    let previousActiveId: string | null = null;
-
-    function channelName(id: string): string {
-        return `channel.${id}`;
-    }
-
-    function handleMessage(channelId: string, message: Message): void {
+    useChannelFleetSubscription((channelId, message) => {
         const preference =
             channels.value.find((channel) => channel.id === channelId) ?? null;
 
@@ -67,48 +52,7 @@ export function useChimeNotifications(): void {
         if (decision) {
             playChime(chimeSound.value);
         }
-    }
-
-    function listen(id: string): void {
-        echo()
-            .private(channelName(id))
-            .listen('MessageSent', (message: Message) => {
-                handleMessage(id, message);
-            });
-    }
-
-    function reconcile(): void {
-        const desired = new Set(channels.value.map((channel) => channel.id));
-        const active = activeChannelId.value;
-
-        if (previousActiveId !== null && previousActiveId !== active) {
-            bound.delete(previousActiveId);
-        }
-
-        previousActiveId = active;
-
-        for (const id of desired) {
-            if (!bound.has(id)) {
-                listen(id);
-                bound.add(id);
-            }
-        }
-
-        for (const id of [...bound]) {
-            if (!desired.has(id)) {
-                echo().leave(channelName(id));
-                bound.delete(id);
-            }
-        }
-    }
-
-    function leaveAll(): void {
-        for (const id of bound) {
-            echo().leave(channelName(id));
-        }
-
-        bound.clear();
-    }
+    });
 
     onMounted(() => {
         // The autoplay policy keeps the AudioContext suspended until a gesture.
@@ -116,15 +60,10 @@ export function useChimeNotifications(): void {
             once: true,
         });
         window.addEventListener('keydown', unlockChimeAudio, { once: true });
-        reconcile();
     });
-
-    // Post-flush so it runs after Show.vue's own per-channel teardown.
-    watch(subscriptionKey, reconcile, { flush: 'post' });
 
     onBeforeUnmount(() => {
         window.removeEventListener('pointerdown', unlockChimeAudio);
         window.removeEventListener('keydown', unlockChimeAudio);
-        leaveAll();
     });
 }

--- a/resources/js/composables/useDebouncedPost.test.ts
+++ b/resources/js/composables/useDebouncedPost.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope } from 'vue';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
+import type {
+    DebouncedPost,
+    DebouncedPostOptions,
+} from '@/composables/useDebouncedPost';
+
+/**
+ * Run the composable inside a disposable effect scope so `onScopeDispose` — the
+ * auto-teardown — can be exercised by stopping the scope, standing in for a
+ * component unmount.
+ */
+function withScope<T>(
+    run: (payload: T) => void,
+    options: DebouncedPostOptions,
+): { post: DebouncedPost<T>; unmount: () => void } {
+    const scope = effectScope();
+    let post!: DebouncedPost<T>;
+
+    scope.run(() => {
+        post = useDebouncedPost(run, options);
+    });
+
+    return { post, unmount: () => scope.stop() };
+}
+
+describe('useDebouncedPost', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('runs the action once, with the payload, after the delay elapses', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('a');
+        expect(run).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(399);
+        expect(run).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1);
+        expect(run).toHaveBeenCalledExactlyOnceWith('a');
+    });
+
+    it('coalesces a burst into a single run carrying the latest payload', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('first');
+        vi.advanceTimersByTime(200);
+        post.schedule('second');
+        vi.advanceTimersByTime(200);
+        // The window restarted on the second call, so nothing has fired yet.
+        expect(run).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(200);
+        expect(run).toHaveBeenCalledExactlyOnceWith('second');
+    });
+
+    it('flushes the pending payload immediately and cancels the timer', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('now');
+        post.flush();
+        expect(run).toHaveBeenCalledExactlyOnceWith('now');
+
+        // The timer was cancelled by the flush, so it never fires a second time.
+        vi.advanceTimersByTime(400);
+        expect(run).toHaveBeenCalledOnce();
+    });
+
+    it('flush is a no-op when nothing is pending', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.flush();
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('cancel drops a pending run without firing it', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('dropped');
+        post.cancel();
+
+        vi.advanceTimersByTime(400);
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('drops a call made while the gate is closed, leaving no timer', () => {
+        const run = vi.fn();
+        let focused = false;
+        const { post } = withScope<string>(run, {
+            delay: 400,
+            gate: () => focused,
+        });
+
+        post.schedule('blurred');
+        vi.advanceTimersByTime(400);
+        expect(run).not.toHaveBeenCalled();
+
+        focused = true;
+        post.schedule('focused');
+        vi.advanceTimersByTime(400);
+        expect(run).toHaveBeenCalledExactlyOnceWith('focused');
+    });
+
+    it('cancels a pending run on scope teardown by default', () => {
+        const run = vi.fn();
+        const { post, unmount } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('pending');
+        unmount();
+
+        vi.advanceTimersByTime(400);
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('flushes a pending run on scope teardown when flushOnUnmount is set', () => {
+        const run = vi.fn();
+        const { post, unmount } = withScope<string>(run, {
+            delay: 400,
+            flushOnUnmount: true,
+        });
+
+        post.schedule('kept');
+        unmount();
+
+        expect(run).toHaveBeenCalledExactlyOnceWith('kept');
+    });
+});

--- a/resources/js/composables/useDebouncedPost.ts
+++ b/resources/js/composables/useDebouncedPost.ts
@@ -1,0 +1,97 @@
+import { onScopeDispose } from 'vue';
+
+export interface DebouncedPostOptions {
+    /** Milliseconds to coalesce a burst of `schedule` calls into a single run. */
+    delay: number;
+    /**
+     * Checked at `schedule` time: when it returns false the call is dropped and
+     * any already-pending run is left untouched. Used to gate reads on tab focus
+     * (`() => document.hasFocus()`) so a channel is only marked read while looked
+     * at. Omit for an ungated post.
+     */
+    gate?: () => boolean;
+    /**
+     * Fire a pending run on teardown instead of dropping it. Draft persistence
+     * sets this so a just-typed draft outlives an unmount; reads leave it false so
+     * a stale mark-read never fires after the view is gone.
+     */
+    flushOnUnmount?: boolean;
+}
+
+export interface DebouncedPost<T> {
+    /** Restart the debounce window, remembering `payload` as the latest to run. */
+    schedule: (payload: T) => void;
+    /** Run the pending payload now, cancelling the timer; a no-op when idle. */
+    flush: () => void;
+    /** Drop any pending run without firing it. */
+    cancel: () => void;
+}
+
+/**
+ * The one debounced, optionally gated, auto-torn-down `router` POST/PATCH behind
+ * mark-read, mark-thread-read, draft persistence, sidebar-badge refresh, and
+ * search — each of which had hand-rolled its own timer handle, `clearTimeout`
+ * dance, and `onBeforeUnmount` cleanup.
+ *
+ * `run` receives the latest scheduled payload; a burst of `schedule` calls within
+ * `delay` collapses to one run. The timer is owned here and disposed with the
+ * surrounding effect scope (component unmount), so callers keep only *what* to
+ * post, not the bookkeeping.
+ */
+export function useDebouncedPost<T = void>(
+    run: (payload: T) => void,
+    options: DebouncedPostOptions,
+): DebouncedPost<T> {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let pending: { payload: T } | null = null;
+
+    function clearTimer(): void {
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    }
+
+    function fire(): void {
+        if (!pending) {
+            return;
+        }
+
+        const { payload } = pending;
+        pending = null;
+        run(payload);
+    }
+
+    function schedule(payload: T): void {
+        if (options.gate && !options.gate()) {
+            return;
+        }
+
+        pending = { payload };
+        clearTimer();
+        timer = setTimeout(() => {
+            timer = null;
+            fire();
+        }, options.delay);
+    }
+
+    function flush(): void {
+        clearTimer();
+        fire();
+    }
+
+    function cancel(): void {
+        clearTimer();
+        pending = null;
+    }
+
+    onScopeDispose(() => {
+        if (options.flushOnUnmount) {
+            flush();
+        } else {
+            cancel();
+        }
+    });
+
+    return { schedule, flush, cancel };
+}

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -1,8 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
-import { echo } from '@laravel/echo-vue';
-import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { computed, onBeforeUnmount } from 'vue';
+import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
 import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
-import type { Message } from '@/types';
 
 /** Coalesce a burst of arrivals into a single sidebar reload. */
 const REFRESH_DEBOUNCE_MS = 500;
@@ -14,39 +13,21 @@ const REFRESH_DEBOUNCE_MS = 500;
  * but only refreshes on navigation and when the open channel is marked read, so a
  * message posted in a channel the user belongs to but is not viewing would not move
  * its badge until the next visit. Mounted once in the persistent channel layout,
- * this subscribes to each sidebar channel's private broadcast and, on a qualifying
- * MessageSent, debounces a partial reload of `channels` so the badge updates without
- * a manual navigation. A single reload recomputes every channel's count, so bursts
- * across channels collapse to one request.
- *
- * It mirrors useChimeNotifications' subscription bookkeeping: Show.vue owns the open
- * channel's subscription and tears it down with a full `leave` on navigation, which
- * also drops our listener on it; the post-flush reconcile re-attaches the channel it
- * just left.
+ * this rides {@see useChannelFleetSubscription} — the shared subscribe/reconcile/
+ * teardown engine — and, on a qualifying MessageSent, debounces a partial reload of
+ * `channels` so the badge updates without a manual navigation. A single reload
+ * recomputes every channel's count, so bursts across channels collapse to one
+ * request.
  */
 export function useSidebarBadges(): void {
     const page = usePage();
 
     const currentUserId = computed(() => String(page.props.auth.user.id));
-    const channels = computed(() => page.props.channels ?? []);
     const activeChannelId = computed(
         () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
     );
 
-    // Only reconcile when the set of channels or the open one actually changes,
-    // not on every badge-count refresh of the shared `channels` prop.
-    const subscriptionKey = computed(
-        () =>
-            `${channels.value.map((channel) => channel.id).join('|')}::${activeChannelId.value ?? ''}`,
-    );
-
-    const bound = new Set<string>();
-    let previousActiveId: string | null = null;
     let refreshTimer: ReturnType<typeof setTimeout> | null = null;
-
-    function channelName(id: string): string {
-        return `channel.${id}`;
-    }
 
     function scheduleRefresh(): void {
         if (refreshTimer) {
@@ -61,7 +42,7 @@ export function useSidebarBadges(): void {
         }, REFRESH_DEBOUNCE_MS);
     }
 
-    function handleMessage(channelId: string, message: Message): void {
+    useChannelFleetSubscription((channelId, message) => {
         const decision = shouldRefreshSidebar({
             isOwnMessage: message.user.id === currentUserId.value,
             isChannelMessage:
@@ -76,59 +57,11 @@ export function useSidebarBadges(): void {
         if (decision) {
             scheduleRefresh();
         }
-    }
-
-    function listen(id: string): void {
-        echo()
-            .private(channelName(id))
-            .listen('MessageSent', (message: Message) => {
-                handleMessage(id, message);
-            });
-    }
-
-    function reconcile(): void {
-        const desired = new Set(channels.value.map((channel) => channel.id));
-        const active = activeChannelId.value;
-
-        if (previousActiveId !== null && previousActiveId !== active) {
-            bound.delete(previousActiveId);
-        }
-
-        previousActiveId = active;
-
-        for (const id of desired) {
-            if (!bound.has(id)) {
-                listen(id);
-                bound.add(id);
-            }
-        }
-
-        for (const id of [...bound]) {
-            if (!desired.has(id)) {
-                echo().leave(channelName(id));
-                bound.delete(id);
-            }
-        }
-    }
-
-    function leaveAll(): void {
-        for (const id of bound) {
-            echo().leave(channelName(id));
-        }
-
-        bound.clear();
-    }
-
-    onMounted(reconcile);
-
-    // Post-flush so it runs after Show.vue's own per-channel teardown.
-    watch(subscriptionKey, reconcile, { flush: 'post' });
+    });
 
     onBeforeUnmount(() => {
         if (refreshTimer) {
             clearTimeout(refreshTimer);
         }
-
-        leaveAll();
     });
 }

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -1,6 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
-import { computed, onBeforeUnmount } from 'vue';
+import { computed } from 'vue';
 import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
 
 /** Coalesce a burst of arrivals into a single sidebar reload. */
@@ -27,20 +28,13 @@ export function useSidebarBadges(): void {
         () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
     );
 
-    let refreshTimer: ReturnType<typeof setTimeout> | null = null;
-
-    function scheduleRefresh(): void {
-        if (refreshTimer) {
-            clearTimeout(refreshTimer);
-        }
-
-        refreshTimer = setTimeout(() => {
-            // reload defaults to preserving scroll and page state; it re-evaluates
-            // the shared `channels` prop to recompute every badge count, plus the
-            // aggregate `hasUnreadThreads` flag behind the sidebar's Threads dot.
-            router.reload({ only: ['channels', 'hasUnreadThreads'] });
-        }, REFRESH_DEBOUNCE_MS);
-    }
+    // reload defaults to preserving scroll and page state; it re-evaluates the
+    // shared `channels` prop to recompute every badge count, plus the aggregate
+    // `hasUnreadThreads` flag behind the sidebar's Threads dot.
+    const refresh = useDebouncedPost(
+        () => router.reload({ only: ['channels', 'hasUnreadThreads'] }),
+        { delay: REFRESH_DEBOUNCE_MS },
+    );
 
     useChannelFleetSubscription((channelId, message) => {
         const decision = shouldRefreshSidebar({
@@ -55,13 +49,7 @@ export function useSidebarBadges(): void {
         });
 
         if (decision) {
-            scheduleRefresh();
-        }
-    });
-
-    onBeforeUnmount(() => {
-        if (refreshTimer) {
-            clearTimeout(refreshTimer);
+            refresh.schedule();
         }
     });
 }

--- a/resources/js/composables/useUnreadDivider.test.ts
+++ b/resources/js/composables/useUnreadDivider.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+import { useUnreadDivider } from '@/composables/useUnreadDivider';
+import type { UnreadDivider } from '@/composables/useUnreadDivider';
+import type { Message } from '@/types';
+
+type IntersectionCallback = (entries: { isIntersecting: boolean }[]) => void;
+
+const observe = vi.fn();
+const disconnect = vi.fn();
+let capturedCallback: IntersectionCallback | null = null;
+
+class FakeIntersectionObserver {
+    constructor(callback: IntersectionCallback) {
+        capturedCallback = callback;
+    }
+
+    observe = observe;
+    disconnect = disconnect;
+}
+
+/** A message with just the fields the divider decision reads. */
+function message(id: string, userId: string): Message {
+    return { id, user: { id: userId } } as unknown as Message;
+}
+
+function withScope(options: {
+    channelId: Ref<string>;
+    messages: () => Message[];
+    lastReadMessageId: Ref<string | null>;
+    currentUserId?: string;
+}) {
+    const scope = effectScope();
+    let divider!: UnreadDivider;
+
+    scope.run(() => {
+        divider = useUnreadDivider({
+            channelId: () => options.channelId.value,
+            scrollContainer: ref({} as HTMLElement),
+            messages: options.messages,
+            lastReadMessageId: () => options.lastReadMessageId.value,
+            currentUserId: () => options.currentUserId ?? 'me',
+        });
+    });
+
+    return { divider, unmount: () => scope.stop() };
+}
+
+describe('useUnreadDivider', () => {
+    beforeEach(() => {
+        observe.mockClear();
+        disconnect.mockClear();
+        capturedCallback = null;
+        vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
+        vi.stubGlobal('document', {
+            getElementById: (id: string) =>
+                id === 'unread-divider' ? ({} as Element) : null,
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('freezes the divider at the first unread peer message and shows the pill', async () => {
+        const { divider } = withScope({
+            channelId: ref('c1'),
+            // m1 is read; m2 is the viewer's own; m3 is the first unread peer.
+            messages: () => [
+                message('m1', 'peer'),
+                message('m2', 'me'),
+                message('m3', 'peer'),
+            ],
+            lastReadMessageId: ref('m1'),
+        });
+
+        expect(divider.unreadDividerId.value).toBe('m3');
+        expect(divider.showJumpToUnread.value).toBe(true);
+
+        // The observer attaches after the divider element renders.
+        await nextTick();
+        expect(observe).toHaveBeenCalledOnce();
+    });
+
+    it('hides the pill once the divider scrolls into view', async () => {
+        const { divider } = withScope({
+            channelId: ref('c1'),
+            messages: () => [message('m1', 'peer')],
+            lastReadMessageId: ref(null),
+        });
+
+        await nextTick();
+        capturedCallback?.([{ isIntersecting: true }]);
+
+        expect(divider.showJumpToUnread.value).toBe(false);
+    });
+
+    it('marks no boundary when every message is already read', () => {
+        const { divider } = withScope({
+            channelId: ref('c1'),
+            messages: () => [message('m1', 'peer'), message('m2', 'peer')],
+            lastReadMessageId: ref('m2'),
+        });
+
+        expect(divider.unreadDividerId.value).toBeNull();
+        expect(divider.showJumpToUnread.value).toBe(false);
+        // No boundary, so no observer is attached.
+        expect(observe).not.toHaveBeenCalled();
+    });
+
+    it('refreezes the boundary for the new channel on a switch', async () => {
+        const channelId = ref('c1');
+        const lastReadMessageId = ref<string | null>('m2');
+        let messages: Message[] = [
+            message('m1', 'peer'),
+            message('m2', 'peer'),
+        ];
+
+        const { divider } = withScope({
+            channelId,
+            messages: () => messages,
+            lastReadMessageId,
+        });
+
+        expect(divider.unreadDividerId.value).toBeNull();
+
+        // Switch to a channel with an unread peer message below the pointer.
+        messages = [message('n1', 'peer'), message('n2', 'peer')];
+        lastReadMessageId.value = 'n1';
+        channelId.value = 'c2';
+        await nextTick();
+
+        expect(divider.unreadDividerId.value).toBe('n2');
+    });
+
+    it('disconnects the observer on teardown', async () => {
+        const { unmount } = withScope({
+            channelId: ref('c1'),
+            messages: () => [message('m1', 'peer')],
+            lastReadMessageId: ref(null),
+        });
+
+        await nextTick();
+        disconnect.mockClear();
+        unmount();
+
+        expect(disconnect).toHaveBeenCalledOnce();
+    });
+});

--- a/resources/js/composables/useUnreadDivider.ts
+++ b/resources/js/composables/useUnreadDivider.ts
@@ -1,0 +1,108 @@
+import { computed, nextTick, onScopeDispose, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { unreadDividerMessageId } from '@/lib/unreadDivider';
+import type { Message } from '@/types';
+
+/** The stable DOM id the "New messages" divider element renders with. */
+const DIVIDER_ELEMENT_ID = 'unread-divider';
+
+export interface UnreadDividerOptions {
+    /** The open channel's id; a change refreezes the divider for that channel. */
+    channelId: () => string;
+    /** The scroll container the divider lives in, used as the observer root. */
+    scrollContainer: Ref<HTMLElement | null>;
+    /**
+     * The channel's messages at open, oldest-first. Read from the server page
+     * (not the live-merged list) so the boundary is immune to the order in which
+     * per-channel state resets on a channel switch.
+     */
+    messages: () => Message[];
+    /** The read pointer captured when the channel opened, or null if never read. */
+    lastReadMessageId: () => string | null;
+    /** The current viewer's id, so their own trailing messages aren't flagged. */
+    currentUserId: () => string;
+}
+
+export interface UnreadDivider {
+    /** The message the divider sits above, frozen at open; null when none. */
+    unreadDividerId: Ref<string | null>;
+    /** Whether to show the floating "jump to new messages" pill. */
+    showJumpToUnread: ComputedRef<boolean>;
+    /** Smooth-scroll the divider into view. */
+    scrollToUnread: () => void;
+}
+
+/**
+ * Own the "New messages" divider's lifecycle: freeze its position at channel
+ * open (and refreeze on every channel switch), and watch the divider element so
+ * the floating jump pill hides once the boundary scrolls into view.
+ *
+ * The boundary itself is decided by the pure {@see unreadDividerMessageId}; this
+ * composable is the reactive + IntersectionObserver wiring around it. The divider
+ * is deliberately *not* a plain computed: it is captured once per channel so the
+ * read pointer advancing as the user reads doesn't move the line under them.
+ */
+export function useUnreadDivider(options: UnreadDividerOptions): UnreadDivider {
+    const unreadDividerId = ref<string | null>(null);
+    const unreadDividerInView = ref(false);
+    let observer: IntersectionObserver | null = null;
+
+    // The pill shows only while there's a boundary the reader hasn't reached yet.
+    const showJumpToUnread = computed(
+        () => unreadDividerId.value !== null && !unreadDividerInView.value,
+    );
+
+    // Watch the divider element so the pill hides once it scrolls into view.
+    function observeDivider(): void {
+        observer?.disconnect();
+        observer = null;
+        unreadDividerInView.value = false;
+
+        if (unreadDividerId.value === null) {
+            return;
+        }
+
+        nextTick(() => {
+            const el = document.getElementById(DIVIDER_ELEMENT_ID);
+            const root = options.scrollContainer.value;
+
+            if (!el || !root) {
+                return;
+            }
+
+            observer = new IntersectionObserver(
+                ([entry]) => {
+                    unreadDividerInView.value = entry.isIntersecting;
+                },
+                { root },
+            );
+            observer.observe(el);
+        });
+    }
+
+    function recompute(): void {
+        unreadDividerId.value = unreadDividerMessageId(
+            options.messages(),
+            options.lastReadMessageId(),
+            options.currentUserId(),
+        );
+
+        observeDivider();
+    }
+
+    function scrollToUnread(): void {
+        document
+            .getElementById(DIVIDER_ELEMENT_ID)
+            ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+
+    // Freeze on open and refreeze on each channel switch; `recompute` owns the
+    // reset (divider id, observer, in-view flag) so the page doesn't hand-reset it.
+    watch(options.channelId, recompute, { immediate: true });
+
+    onScopeDispose(() => {
+        observer?.disconnect();
+    });
+
+    return { unreadDividerId, showJumpToUnread, scrollToUnread };
+}

--- a/resources/js/lib/channelFleet.test.ts
+++ b/resources/js/lib/channelFleet.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { createChannelFleet } from '@/lib/channelFleet';
+
+/**
+ * Drive a fleet with spy handlers, recording the sequence of subscribe/leave
+ * calls so a test can assert exactly which channels were touched and when.
+ */
+function trackedFleet() {
+    const subscribed: string[] = [];
+    const left: string[] = [];
+    const fleet = createChannelFleet({
+        subscribe: (id) => subscribed.push(id),
+        leave: (id) => left.push(id),
+    });
+
+    return { fleet, subscribed, left };
+}
+
+describe('createChannelFleet', () => {
+    it('subscribes each desired channel once and reports them as bound', () => {
+        const { fleet, subscribed } = trackedFleet();
+
+        fleet.reconcile(['a', 'b'], null);
+        fleet.reconcile(['a', 'b'], null);
+
+        expect(subscribed).toEqual(['a', 'b']);
+        expect(fleet.boundIds()).toEqual(['a', 'b']);
+    });
+
+    it('subscribes a newly added channel without re-subscribing the rest', () => {
+        const { fleet, subscribed } = trackedFleet();
+
+        fleet.reconcile(['a'], null);
+        fleet.reconcile(['a', 'b'], null);
+
+        expect(subscribed).toEqual(['a', 'b']);
+    });
+
+    it('leaves a channel that drops out of the desired set', () => {
+        const { fleet, subscribed, left } = trackedFleet();
+
+        fleet.reconcile(['a', 'b'], null);
+        fleet.reconcile(['a'], null);
+
+        expect(subscribed).toEqual(['a', 'b']);
+        expect(left).toEqual(['b']);
+        expect(fleet.boundIds()).toEqual(['a']);
+    });
+
+    it('re-subscribes the just-left active channel on handoff without leaving it itself', () => {
+        // The open-channel page owns the active channel's subscription and tears
+        // it down with a full leave on navigation, which also drops the fleet's
+        // listener on it. On the next reconcile the fleet must re-attach the
+        // channel it just moved away from — and must never call leave on it,
+        // since the page already did.
+        const { fleet, subscribed, left } = trackedFleet();
+
+        fleet.reconcile(['a', 'b'], 'a');
+        fleet.reconcile(['a', 'b'], 'b');
+
+        expect(subscribed).toEqual(['a', 'b', 'a']);
+        expect(left).toEqual([]);
+        expect(fleet.boundIds()).toEqual(['b', 'a']);
+    });
+
+    it('leaves every bound channel on teardown and forgets them', () => {
+        const { fleet, left } = trackedFleet();
+
+        fleet.reconcile(['a', 'b'], null);
+        fleet.leaveAll();
+
+        expect(left).toEqual(['a', 'b']);
+        expect(fleet.boundIds()).toEqual([]);
+    });
+});

--- a/resources/js/lib/channelFleet.ts
+++ b/resources/js/lib/channelFleet.ts
@@ -1,0 +1,85 @@
+/**
+ * The subscribe/reconcile/teardown bookkeeping for a *fleet* of channel
+ * subscriptions — the shared lifecycle behind sidebar badges, chime
+ * notifications, and the active channel. Pure and framework-free: it owns the
+ * bound-set diffing and the active-channel handoff, and defers the actual Echo
+ * subscribe/leave to injected handlers, so the tricky part is unit-testable
+ * without Vue or a live Echo mock.
+ */
+export interface ChannelFleetHandlers {
+    /** Attach a live subscription (an Echo private-channel listener) for an id. */
+    subscribe: (channelId: string) => void;
+    /** Tear down the subscription for an id. */
+    leave: (channelId: string) => void;
+}
+
+export interface ChannelFleet {
+    /**
+     * Reconcile the live subscriptions to `desired`, given which channel (if
+     * any) is currently open. New ids are subscribed, ids no longer desired are
+     * left. The open-channel page owns the *active* channel's subscription and
+     * tears it down with a full leave on navigation — which also drops this
+     * fleet's listener on it — so when the active channel changes the fleet
+     * forgets the previous one (without leaving it) and re-subscribes it on this
+     * pass if it is still desired.
+     */
+    reconcile: (
+        desired: Iterable<string>,
+        activeChannelId: string | null,
+    ) => void;
+    /** Leave every bound channel and forget them (component teardown). */
+    leaveAll: () => void;
+    /** The currently bound channel ids, for inspection and tests. */
+    boundIds: () => string[];
+}
+
+/**
+ * Create a channel fleet over the given subscribe/leave handlers.
+ */
+export function createChannelFleet(
+    handlers: ChannelFleetHandlers,
+): ChannelFleet {
+    const bound = new Set<string>();
+    let previousActiveId: string | null = null;
+
+    function reconcile(
+        desired: Iterable<string>,
+        activeChannelId: string | null,
+    ): void {
+        const desiredSet = new Set(desired);
+
+        if (previousActiveId !== null && previousActiveId !== activeChannelId) {
+            bound.delete(previousActiveId);
+        }
+
+        previousActiveId = activeChannelId;
+
+        for (const id of desiredSet) {
+            if (!bound.has(id)) {
+                handlers.subscribe(id);
+                bound.add(id);
+            }
+        }
+
+        for (const id of [...bound]) {
+            if (!desiredSet.has(id)) {
+                handlers.leave(id);
+                bound.delete(id);
+            }
+        }
+    }
+
+    function leaveAll(): void {
+        for (const id of bound) {
+            handlers.leave(id);
+        }
+
+        bound.clear();
+    }
+
+    function boundIds(): string[] {
+        return [...bound];
+    }
+
+    return { reconcile, leaveAll, boundIds };
+}

--- a/resources/js/lib/messagePlacement.test.ts
+++ b/resources/js/lib/messagePlacement.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { placeIncomingMessage } from '@/lib/messagePlacement';
+import type { IncomingPlacementInput } from '@/lib/messagePlacement';
+
+/**
+ * A qualifying baseline: a plain channel message (not a reply) arriving while the
+ * viewer has the tab focused and no thread open. Each test overrides one axis to
+ * probe a single routing branch.
+ */
+function input(
+    overrides: Partial<IncomingPlacementInput> = {},
+): IncomingPlacementInput {
+    return {
+        threadRootId: null,
+        sentToChannel: false,
+        isOwnMessage: false,
+        activeThreadRootId: null,
+        isTabFocused: true,
+        isFollowedThread: false,
+        isThreadUnreadSuppressed: false,
+        ...overrides,
+    };
+}
+
+describe('placeIncomingMessage', () => {
+    it('routes a plain channel message to the main timeline only', () => {
+        expect(placeIncomingMessage(input())).toEqual({
+            appendToMain: true,
+            appendToThread: false,
+            markThreadReadNow: false,
+            flagRootThreadUnread: false,
+        });
+    });
+
+    it('keeps a thread reply out of the main timeline and out of a closed thread', () => {
+        expect(placeIncomingMessage(input({ threadRootId: 'root-1' }))).toEqual(
+            {
+                appendToMain: false,
+                appendToThread: false,
+                markThreadReadNow: false,
+                flagRootThreadUnread: false,
+            },
+        );
+    });
+
+    it('lands a sent-to-channel reply in the main timeline as well', () => {
+        const placement = placeIncomingMessage(
+            input({ threadRootId: 'root-1', sentToChannel: true }),
+        );
+
+        expect(placement.appendToMain).toBe(true);
+    });
+
+    it('appends a reply into the open thread and marks it read while focused', () => {
+        expect(
+            placeIncomingMessage(
+                input({ threadRootId: 'root-1', activeThreadRootId: 'root-1' }),
+            ),
+        ).toEqual({
+            appendToMain: false,
+            appendToThread: true,
+            markThreadReadNow: true,
+            flagRootThreadUnread: false,
+        });
+    });
+
+    it('does not mark-read a reply in the open thread when the tab is blurred', () => {
+        const placement = placeIncomingMessage(
+            input({
+                threadRootId: 'root-1',
+                activeThreadRootId: 'root-1',
+                isTabFocused: false,
+                isFollowedThread: true,
+            }),
+        );
+
+        expect(placement.appendToThread).toBe(true);
+        expect(placement.markThreadReadNow).toBe(false);
+        expect(placement.flagRootThreadUnread).toBe(true);
+    });
+
+    it('flags a followed thread whose reply arrives while it is closed', () => {
+        const placement = placeIncomingMessage(
+            input({ threadRootId: 'root-1', isFollowedThread: true }),
+        );
+
+        expect(placement.appendToThread).toBe(false);
+        expect(placement.flagRootThreadUnread).toBe(true);
+    });
+
+    it("never flags the viewer's own reply", () => {
+        const placement = placeIncomingMessage(
+            input({
+                threadRootId: 'root-1',
+                isFollowedThread: true,
+                isOwnMessage: true,
+            }),
+        );
+
+        expect(placement.flagRootThreadUnread).toBe(false);
+    });
+
+    it('never flags when thread unread dots are suppressed for the channel', () => {
+        const placement = placeIncomingMessage(
+            input({
+                threadRootId: 'root-1',
+                isFollowedThread: true,
+                isThreadUnreadSuppressed: true,
+            }),
+        );
+
+        expect(placement.flagRootThreadUnread).toBe(false);
+    });
+});

--- a/resources/js/lib/messagePlacement.ts
+++ b/resources/js/lib/messagePlacement.ts
@@ -1,0 +1,69 @@
+import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
+
+export type IncomingPlacementInput = {
+    /** The reply's root message id, or `null` for a top-level channel message. */
+    threadRootId: string | null;
+    /** A thread reply the author also chose to echo into the channel timeline. */
+    sentToChannel: boolean;
+    /** The arriving message was authored by the current viewer. */
+    isOwnMessage: boolean;
+    /** The root id of the thread currently open in the panel, or `null`. */
+    activeThreadRootId: string | null;
+    /** The tab is focused, so an open thread's replies are actively being read. */
+    isTabFocused: boolean;
+    /**
+     * The viewer follows the reply's thread (authored its root, replied, or was
+     * @mentioned); only followed threads raise a dot. See {@see shouldFlagThreadUnread}.
+     */
+    isFollowedThread: boolean;
+    /** Thread dots are silenced for this channel (muted or below "all"). */
+    isThreadUnreadSuppressed: boolean;
+};
+
+export type IncomingPlacement = {
+    /** Append the message to the main channel timeline. */
+    appendToMain: boolean;
+    /** Append the message to the open thread panel. */
+    appendToThread: boolean;
+    /** Advance the open thread's read pointer now (it's focused, so already read). */
+    markThreadReadNow: boolean;
+    /** Raise the unread dot on the reply's root back in the main timeline. */
+    flagRootThreadUnread: boolean;
+};
+
+/**
+ * Decide where a freshly-arrived realtime message belongs: the main timeline, the
+ * open thread, both, or neither — and whether it advances or dots the thread's
+ * read state.
+ *
+ * This is the pure decision core of `Show.vue`'s realtime routing. A top-level
+ * message (or a reply explicitly sent to the channel) shows in the main timeline;
+ * a reply into the *open* thread appends there and, while the tab is focused,
+ * keeps that thread read; a reply into a *closed* followed thread raises its
+ * unread dot instead — the last branch deferring to {@see shouldFlagThreadUnread}
+ * so a live dot and a navigation-time dot agree.
+ */
+export function placeIncomingMessage(
+    input: IncomingPlacementInput,
+): IncomingPlacement {
+    const isReply = input.threadRootId !== null;
+    const isActiveThread =
+        isReply && input.threadRootId === input.activeThreadRootId;
+    const isViewingThreadFocused = isActiveThread && input.isTabFocused;
+
+    return {
+        appendToMain: !isReply || input.sentToChannel,
+        appendToThread: isActiveThread,
+        markThreadReadNow: isViewingThreadFocused,
+        flagRootThreadUnread:
+            isReply &&
+            !isViewingThreadFocused &&
+            shouldFlagThreadUnread({
+                isReply: true,
+                isOwnReply: input.isOwnMessage,
+                isFollowedThread: input.isFollowedThread,
+                isViewingThreadFocused: false,
+                isSuppressed: input.isThreadUnreadSuppressed,
+            }),
+    };
+}

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -9,6 +9,7 @@ import {
 import { index as search } from '@/actions/App/Http/Controllers/Channels/SearchController';
 import { Input } from '@/components/ui/input';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { getInitials } from '@/composables/useInitials';
 import { formatDateTime } from '@/lib/datetime';
 import { renderMessageBody } from '@/lib/messageBody';
@@ -32,14 +33,8 @@ const term = ref(props.query);
 
 // Debounce keystrokes into a single scoped reload that only refreshes the
 // results (and the echoed query), preserving the input's focus and caret.
-let debounce: ReturnType<typeof setTimeout> | null = null;
-
-watch(term, (value) => {
-    if (debounce) {
-        clearTimeout(debounce);
-    }
-
-    debounce = setTimeout(() => {
+const searchPost = useDebouncedPost(
+    (value: string) => {
         router.get(
             search(props.team.slug).url,
             { q: value },
@@ -50,7 +45,12 @@ watch(term, (value) => {
                 only: ['results', 'query'],
             },
         );
-    }, 300);
+    },
+    { delay: 300 },
+);
+
+watch(term, (value) => {
+    searchPost.schedule(value);
 });
 
 const page = usePage();

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -72,6 +72,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useChannelRealtime } from '@/composables/useChannelRealtime';
 import {
     useMessageStream,
     optimisticMessage,
@@ -82,18 +83,15 @@ import { useTimezone } from '@/composables/useTimezone';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
 import { toggleReaction } from '@/lib/reactions';
-import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
 import { unreadDividerMessageId } from '@/lib/unreadDivider';
 import type {
     Channel,
     ChannelReader,
     Mention,
     Message,
-    MessageAuthor,
     MessagePage,
     NotificationLevel,
     NotificationLevelOption,
-    Reaction,
     ScheduledMessage,
     Thread,
 } from '@/types';
@@ -306,66 +304,6 @@ function scrollToUnread(): void {
         ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
 }
 
-// Append a message to the main timeline. When the reader was near the bottom the
-// view follows it down; otherwise the arrival raises the "new messages" count on
-// the jump-to-latest control instead of scrolling silently.
-function appendLiveMain(message: Message): void {
-    const wasNearBottom = isNearBottom();
-
-    if (mainStream.appendLive(message)) {
-        notifyAppended(wasNearBottom);
-    }
-}
-
-// Route a broadcast message to the timeline it belongs to. A thread reply stays
-// out of the main timeline unless it was explicitly "also sent to channel"; the
-// open thread only appends replies belonging to its root. The two are not
-// exclusive — a sent-to-channel reply in the open thread lands in both.
-function routeIncoming(message: Message): void {
-    if (message.threadRootId === null || message.sentToChannel) {
-        appendLiveMain(message);
-    }
-
-    if (
-        message.threadRootId !== null &&
-        message.threadRootId === activeThreadRootId.value
-    ) {
-        threadStream.appendLive(message);
-    }
-
-    // A thread reply either keeps the open, focused thread read as it streams in,
-    // or raises the unread dot on its root back in the main timeline.
-    if (message.threadRootId !== null) {
-        const viewingThreadFocused =
-            message.threadRootId === activeThreadRootId.value &&
-            document.hasFocus();
-
-        if (viewingThreadFocused) {
-            markThreadRead();
-
-            return;
-        }
-
-        const root = displayMessages.value.find(
-            (candidate) => candidate.id === message.threadRootId,
-        );
-
-        if (
-            shouldFlagThreadUnread({
-                isReply: true,
-                isOwnReply: message.user.id === currentUser.value.id,
-                isFollowedThread: root?.threadFollowed ?? false,
-                isViewingThreadFocused: false,
-                isSuppressed: threadUnreadSuppressed.value,
-            })
-        ) {
-            mainStream.patchThreadState(message.threadRootId, {
-                threadUnread: true,
-            });
-        }
-    }
-}
-
 // Advance the open thread's read pointer so its unread dot clears, mirroring the
 // channel's markRead: debounced, gated on focus, and optimistically clearing the
 // dot on the root back in the main timeline.
@@ -401,65 +339,6 @@ function channelName(id: string): string {
     return `channel.${id}`;
 }
 
-// An edit or deletion may touch either timeline (or both, for a sent-to-channel
-// reply); patch both streams, since a patch is ignored where the message isn't
-// rendered.
-function applyPatch(message: Message): void {
-    mainStream.applyPatch(message);
-    threadStream.applyPatch(message);
-}
-
-function subscribe(id: string): void {
-    echo()
-        .private(channelName(id))
-        .listen('MessageSent', (message: Message) => {
-            // Their message landed; stop showing them as typing.
-            typing.forget(message.user.id);
-            routeIncoming(message);
-            // Keep the open, focused channel read as new messages arrive.
-            markRead();
-        })
-        .listen('MessageUpdated', (message: Message) => {
-            applyPatch(message);
-        })
-        .listen('MessageDeleted', (message: Message) => {
-            applyPatch(message);
-        })
-        .listen(
-            'MessageReactionChanged',
-            (event: { messageId: string; reactions: Reaction[] }) => {
-                // The authoritative, viewer-free summary; patch it into whichever
-                // timeline renders the message (the patch is a no-op elsewhere).
-                mainStream.patchReactions(event.messageId, event.reactions);
-                threadStream.patchReactions(event.messageId, event.reactions);
-            },
-        )
-        .listen(
-            'MessageRead',
-            (event: { reader: MessageAuthor; lastReadMessageId: string }) => {
-                // Our own advance echoes back on the shared private channel; the
-                // "Seen by" row never shows the viewer, so drop it here.
-                if (event.reader.id === currentUser.value.id) {
-                    return;
-                }
-
-                const next = new Map(readers.value);
-                next.set(event.reader.id, {
-                    user: event.reader,
-                    lastReadMessageId: event.lastReadMessageId,
-                });
-                readers.value = next;
-            },
-        )
-        .listenForWhisper('typing', (user: TypingUser) => {
-            typing.receiveTyping(user);
-        });
-}
-
-function unsubscribe(id: string): void {
-    echo().leave(channelName(id));
-}
-
 // Advance the read pointer for the open channel so its sidebar badge clears.
 // Debounced and gated on tab focus: a channel is only "read" while the user is
 // actually looking at it, and a burst of arriving messages collapses to one
@@ -487,8 +366,26 @@ function markRead(): void {
     }, 400);
 }
 
+// The active channel's Echo subscribe/route/teardown lives in this composable: it
+// moves the subscription as the open channel changes and routes each broadcast
+// into the two streams. `Show.vue` only supplies the state it reconciles against.
+useChannelRealtime({
+    channelId: () => props.channel.id,
+    currentUserId: () => currentUser.value.id,
+    mainStream,
+    threadStream,
+    activeThreadRootId,
+    displayMessages: () => displayMessages.value,
+    isThreadUnreadSuppressed: () => threadUnreadSuppressed.value,
+    readers,
+    isNearBottom,
+    notifyAppended,
+    typing,
+    markRead,
+    markThreadRead,
+});
+
 onMounted(() => {
-    subscribe(props.channel.id);
     seedReaders();
     computeUnreadDivider();
     markRead();
@@ -531,18 +428,15 @@ watch(
     },
 );
 
-// Inertia may reuse this page component when navigating between channels; move
-// the subscription and reset per-channel state when the channel changes.
+// Inertia may reuse this page component when navigating between channels; reset
+// per-channel state when the channel changes. `useChannelRealtime` moves the Echo
+// subscription on the same change via its own watcher.
 watch(
     () => props.channel.id,
-    (newId, oldId) => {
+    () => {
         // Persist the outgoing channel's draft before switching; `pendingDraft`
         // still carries the old channel's slug, so it writes to the right place.
         flushDraft();
-
-        if (oldId) {
-            unsubscribe(oldId);
-        }
 
         mainStream.reset();
         resetScrollPin();
@@ -552,7 +446,6 @@ watch(
         notificationLevel.value = props.channel.notificationLevel;
         muted.value = props.channel.muted;
         starred.value = props.channel.starred;
-        subscribe(newId);
         seedReaders();
         computeUnreadDivider();
         markRead();
@@ -563,7 +456,6 @@ onBeforeUnmount(() => {
     // Leaving the workspace (or a full navigation away) still persists a
     // just-typed draft that the debounce hasn't written yet.
     flushDraft();
-    unsubscribe(props.channel.id);
     unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
     window.removeEventListener('focus', markThreadRead);
@@ -944,6 +836,15 @@ function appendPendingMain(message: Message): void {
     if (pinned) {
         nextTick(() => scrollToBottom());
     }
+}
+
+// Patch a message into both timelines at once — it may render in either (or both,
+// for a sent-to-channel reply), and a patch is ignored where it isn't shown. Used
+// by the optimistic edit/delete paths; the realtime echo re-applies it via
+// `useChannelRealtime`.
+function applyPatch(message: Message): void {
+    mainStream.applyPatch(message);
+    threadStream.applyPatch(message);
 }
 
 function editMessage(message: Message, body: string): void {

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -4,15 +4,11 @@ import { echo } from '@laravel/echo-vue';
 import {
     Archive,
     ArrowUp,
-    AtSign,
-    BellMinus,
-    BellOff,
     CalendarClock,
     ChevronDown,
     EllipsisVertical,
     Star,
 } from '@lucide/vue';
-import type { AcceptableValue } from 'reka-ui';
 import {
     computed,
     nextTick,
@@ -28,9 +24,6 @@ import {
     readThread as markThreadReadAction,
     show as showChannel,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
-import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
-import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
-import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
 import { store as forwardMessageAction } from '@/actions/App/Http/Controllers/Channels/ForwardMessageController';
 import {
     destroy as destroyMessage,
@@ -72,6 +65,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useChannelDraft } from '@/composables/useChannelDraft';
+import { useChannelPreferences } from '@/composables/useChannelPreferences';
 import { useChannelRealtime } from '@/composables/useChannelRealtime';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import {
@@ -83,15 +78,14 @@ import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTimezone } from '@/composables/useTimezone';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
+import { useUnreadDivider } from '@/composables/useUnreadDivider';
 import { toggleReaction } from '@/lib/reactions';
-import { unreadDividerMessageId } from '@/lib/unreadDivider';
 import type {
     Channel,
     ChannelReader,
     Mention,
     Message,
     MessagePage,
-    NotificationLevel,
     NotificationLevelOption,
     ScheduledMessage,
     Thread,
@@ -246,64 +240,17 @@ function jumpToMessage(id: string): void {
     });
 }
 
-// The message the "New messages" divider sits above, frozen at the moment the
-// channel opens: the read pointer keeps advancing as the user reads, but the
-// boundary stays put until they leave the channel. Recomputed on open and on
-// every channel switch from the read pointer the server captured before its
-// debounced advance.
-const unreadDividerId = ref<string | null>(null);
-const unreadDividerInView = ref(false);
-let unreadObserver: IntersectionObserver | null = null;
-
-// The floating "jump to new messages" pill shows only while there's a boundary
-// the user hasn't scrolled to yet.
-const showJumpToUnread = computed(
-    () => unreadDividerId.value !== null && !unreadDividerInView.value,
-);
-
-function computeUnreadDivider(): void {
-    unreadDividerId.value = unreadDividerMessageId(
-        displayMessages.value,
-        props.lastReadMessageId ?? null,
-        currentUser.value.id,
-    );
-
-    observeUnreadDivider();
-}
-
-// Watch the divider element so the jump pill hides once it scrolls into view.
-function observeUnreadDivider(): void {
-    unreadObserver?.disconnect();
-    unreadObserver = null;
-    unreadDividerInView.value = false;
-
-    if (unreadDividerId.value === null) {
-        return;
-    }
-
-    nextTick(() => {
-        const el = document.getElementById('unread-divider');
-        const root = scrollContainer.value;
-
-        if (!el || !root) {
-            return;
-        }
-
-        unreadObserver = new IntersectionObserver(
-            ([entry]) => {
-                unreadDividerInView.value = entry.isIntersecting;
-            },
-            { root },
-        );
-        unreadObserver.observe(el);
-    });
-}
-
-function scrollToUnread(): void {
-    document
-        .getElementById('unread-divider')
-        ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-}
+// The "New messages" divider's lifecycle — freeze its position at open, refreeze
+// on each channel switch, and hide the jump pill once it scrolls into view —
+// lives in this composable. It reads the server page (not the live-merged list)
+// so the boundary is immune to the order per-channel state resets on a switch.
+const { unreadDividerId, showJumpToUnread, scrollToUnread } = useUnreadDivider({
+    channelId: () => props.channel.id,
+    scrollContainer,
+    messages: () => serverMessages.value,
+    lastReadMessageId: () => props.lastReadMessageId ?? null,
+    currentUserId: () => currentUser.value.id,
+});
 
 // Advance the open thread's read pointer so its unread dot clears, mirroring the
 // channel's markRead: debounced, gated on focus, and optimistically clearing the
@@ -362,6 +309,26 @@ function markRead(): void {
     readPost.schedule();
 }
 
+// The member's own star/mute/notification-level preferences for this channel:
+// seeded from the server, reseeded on every channel switch, saved optimistically
+// and rolled back on error. `threadUnreadSuppressed` mirrors the server's dot
+// suppression and feeds the realtime router below.
+const {
+    notificationLevel,
+    muted,
+    starred,
+    threadUnreadSuppressed,
+    notificationStatus,
+    toggleStar,
+    onNotificationLevelChange,
+    onMuteChange,
+} = useChannelPreferences({
+    channelId: () => props.channel.id,
+    channel: () => props.channel,
+    teamSlug: () => props.team.slug,
+    channelSlug: () => props.channel.slug,
+});
+
 // The active channel's Echo subscribe/route/teardown lives in this composable: it
 // moves the subscription as the open channel changes and routes each broadcast
 // into the two streams. `Show.vue` only supplies the state it reconciles against.
@@ -383,7 +350,6 @@ useChannelRealtime({
 
 onMounted(() => {
     seedReaders();
-    computeUnreadDivider();
     markRead();
     window.addEventListener('focus', markRead);
     window.addEventListener('focus', markThreadRead);
@@ -425,26 +391,18 @@ watch(
 );
 
 // Inertia may reuse this page component when navigating between channels; reset
-// per-channel state when the channel changes. `useChannelRealtime` moves the Echo
-// subscription on the same change via its own watcher.
+// the message-orchestration state this page owns when the channel changes. The
+// extracted composables (realtime, draft, preferences, unread divider) each move
+// or refreeze their own state on the same change via their own watchers.
 watch(
     () => props.channel.id,
     () => {
-        // Persist the outgoing channel's draft before switching; the pending
-        // payload still carries the old channel's slug, so it writes to the right
-        // place.
-        draftPost.flush();
-
         mainStream.reset();
         resetScrollPin();
         resetThreadPanel();
         replyTarget.value = null;
         typing.reset();
-        notificationLevel.value = props.channel.notificationLevel;
-        muted.value = props.channel.muted;
-        starred.value = props.channel.starred;
         seedReaders();
-        computeUnreadDivider();
         markRead();
     },
 );
@@ -453,7 +411,6 @@ onBeforeUnmount(() => {
     // The draft persists itself on teardown (flushOnUnmount) and the read posts
     // cancel themselves, so leaving the workspace neither loses a just-typed draft
     // nor fires a stale mark-read.
-    unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
     window.removeEventListener('focus', markThreadRead);
 
@@ -565,39 +522,19 @@ function forwardMessage({
 }
 
 // The member's unsent composer text is persisted per channel so it survives
-// navigation, reloads and other devices. Saves are debounced — a burst of
-// keystrokes collapses to one request — and reload only the shared `channels`
-// prop so the sidebar's draft cue updates without disturbing the timeline. A
-// send clears the draft server-side, so only manual edits flow through here.
-const DRAFT_DEBOUNCE_MS = 700;
-
-function persistDraft(slug: string, body: string): void {
-    router.patch(
-        saveChannelDraft({ team: props.team.slug, channel: slug }).url,
-        { body },
-        { preserveScroll: true, preserveState: true, only: ['channels'] },
-    );
-}
-
-// The debounced draft save. The payload is tagged with the slug of the channel it
-// belongs to, so a flush triggered by switching channels still writes to the
-// channel that was actually being edited rather than the one just navigated to.
-// It flushes on unmount so a just-typed draft is never lost to an unfired timer.
-const draftPost = useDebouncedPost(
-    (draft: { slug: string; body: string }) =>
-        persistDraft(draft.slug, draft.body),
-    { delay: DRAFT_DEBOUNCE_MS, flushOnUnmount: true },
-);
-
-// Debounce a draft save for the current channel; an empty body clears it.
-function onDraftChange(body: string): void {
-    draftPost.schedule({ slug: props.channel.slug, body });
-}
+// navigation, reloads and other devices. This composable owns the debounce, the
+// channel-switch flush, and the flush-on-unmount; a send clears the draft
+// server-side, so only manual edits flow through `onDraftChange`.
+const { onDraftChange, cancel: cancelDraft } = useChannelDraft({
+    channelId: () => props.channel.id,
+    teamSlug: () => props.team.slug,
+    channelSlug: () => props.channel.slug,
+});
 
 function send(body: string, mentions: Mention[]): void {
     // Sending clears the draft server-side, so drop any debounced save still in
     // flight; otherwise it would re-persist the just-sent text after the clear.
-    draftPost.cancel();
+    cancelDraft();
 
     const clientUuid = crypto.randomUUID();
     const target = replyTarget.value;
@@ -648,7 +585,7 @@ function scheduleMessage(
     _mentions: Mention[],
     sendAt: string,
 ): void {
-    draftPost.cancel();
+    cancelDraft();
 
     const target = replyTarget.value;
 
@@ -957,104 +894,6 @@ function closeThread(): void {
         },
     );
 }
-
-// The member's own notification preferences for this channel, seeded from the
-// server and reseeded on every channel switch. Changes are saved optimistically
-// (the sidebar reloads to reflect the new badge/dimming state) and rolled back
-// if the request fails.
-const notificationLevel = ref<NotificationLevel>(
-    props.channel.notificationLevel,
-);
-const muted = ref<boolean>(props.channel.muted);
-const starred = ref<boolean>(props.channel.starred);
-
-/**
- * Star or unstar this channel, reloading only the shared `channels` prop so the
- * sidebar re-partitions its "Starred" section. Optimistic, rolled back on error.
- */
-function toggleStar(): void {
-    const previous = starred.value;
-    starred.value = !previous;
-
-    router.patch(
-        updateChannelStar({
-            team: props.team.slug,
-            channel: props.channel.slug,
-        }).url,
-        { starred: starred.value },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['channels'],
-            onError: () => {
-                starred.value = previous;
-                toast.error('Failed to update the channel. Please try again.');
-            },
-        },
-    );
-}
-
-// Thread-unread dots are silenced under the same rule as the sidebar's unread
-// badge: a muted channel or any level below "all". Mirrors the server's
-// suppression so a live dot and a navigation-time dot agree.
-const threadUnreadSuppressed = computed(
-    () => muted.value || notificationLevel.value !== 'all',
-);
-
-function savePreferences(rollback: () => void): void {
-    router.patch(
-        updateChannelPreferences({
-            team: props.team.slug,
-            channel: props.channel.slug,
-        }).url,
-        { muted: muted.value, notification_level: notificationLevel.value },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['channels'],
-            onError: () => {
-                rollback();
-                toast.error(
-                    'Failed to update notification preferences. Please try again.',
-                );
-            },
-        },
-    );
-}
-
-function onNotificationLevelChange(value: AcceptableValue): void {
-    const previous = notificationLevel.value;
-    notificationLevel.value = value as NotificationLevel;
-    savePreferences(() => {
-        notificationLevel.value = previous;
-    });
-}
-
-function onMuteChange(value: boolean): void {
-    const previous = muted.value;
-    muted.value = value;
-    savePreferences(() => {
-        muted.value = previous;
-    });
-}
-
-// A compact header cue for the member's non-default notification state (muted or
-// a quieted level); the "all" default shows nothing to keep the header clean.
-const notificationStatus = computed(() => {
-    if (muted.value) {
-        return { icon: BellOff, label: 'Muted' };
-    }
-
-    if (notificationLevel.value === 'nothing') {
-        return { icon: BellMinus, label: 'Notifications off' };
-    }
-
-    if (notificationLevel.value === 'mentions') {
-        return { icon: AtSign, label: 'Mentions only' };
-    }
-
-    return null;
-});
 
 // Drives the archive confirmation dialog opened from the channel header menu.
 const confirmingArchive = ref(false);

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -73,6 +73,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useChannelRealtime } from '@/composables/useChannelRealtime';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import {
     useMessageStream,
     optimisticMessage,
@@ -306,21 +307,10 @@ function scrollToUnread(): void {
 
 // Advance the open thread's read pointer so its unread dot clears, mirroring the
 // channel's markRead: debounced, gated on focus, and optimistically clearing the
-// dot on the root back in the main timeline.
-let threadReadTimer: ReturnType<typeof setTimeout> | null = null;
-
-function markThreadRead(): void {
-    const rootId = activeThreadRootId.value;
-
-    if (!rootId || !document.hasFocus()) {
-        return;
-    }
-
-    if (threadReadTimer) {
-        clearTimeout(threadReadTimer);
-    }
-
-    threadReadTimer = setTimeout(() => {
+// dot on the root back in the main timeline. The root id is captured as the
+// debounced payload so a fire uses the thread that was open when it was scheduled.
+const threadReadPost = useDebouncedPost(
+    (rootId: string) => {
         router.post(
             markThreadReadAction({
                 team: props.team.slug,
@@ -332,7 +322,18 @@ function markThreadRead(): void {
         );
 
         mainStream.patchThreadState(rootId, { threadUnread: false });
-    }, 400);
+    },
+    { delay: 400, gate: () => document.hasFocus() },
+);
+
+function markThreadRead(): void {
+    const rootId = activeThreadRootId.value;
+
+    if (!rootId) {
+        return;
+    }
+
+    threadReadPost.schedule(rootId);
 }
 
 function channelName(id: string): string {
@@ -343,18 +344,8 @@ function channelName(id: string): string {
 // Debounced and gated on tab focus: a channel is only "read" while the user is
 // actually looking at it, and a burst of arriving messages collapses to one
 // request. The redirect refreshes just the shared `channels` prop.
-let markReadTimer: ReturnType<typeof setTimeout> | null = null;
-
-function markRead(): void {
-    if (!document.hasFocus()) {
-        return;
-    }
-
-    if (markReadTimer) {
-        clearTimeout(markReadTimer);
-    }
-
-    markReadTimer = setTimeout(() => {
+const readPost = useDebouncedPost(
+    () => {
         router.post(
             markChannelRead({
                 team: props.team.slug,
@@ -363,7 +354,12 @@ function markRead(): void {
             {},
             { preserveScroll: true, preserveState: true, only: ['channels'] },
         );
-    }, 400);
+    },
+    { delay: 400, gate: () => document.hasFocus() },
+);
+
+function markRead(): void {
+    readPost.schedule();
 }
 
 // The active channel's Echo subscribe/route/teardown lives in this composable: it
@@ -434,9 +430,10 @@ watch(
 watch(
     () => props.channel.id,
     () => {
-        // Persist the outgoing channel's draft before switching; `pendingDraft`
-        // still carries the old channel's slug, so it writes to the right place.
-        flushDraft();
+        // Persist the outgoing channel's draft before switching; the pending
+        // payload still carries the old channel's slug, so it writes to the right
+        // place.
+        draftPost.flush();
 
         mainStream.reset();
         resetScrollPin();
@@ -453,20 +450,12 @@ watch(
 );
 
 onBeforeUnmount(() => {
-    // Leaving the workspace (or a full navigation away) still persists a
-    // just-typed draft that the debounce hasn't written yet.
-    flushDraft();
+    // The draft persists itself on teardown (flushOnUnmount) and the read posts
+    // cancel themselves, so leaving the workspace neither loses a just-typed draft
+    // nor fires a stale mark-read.
     unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
     window.removeEventListener('focus', markThreadRead);
-
-    if (markReadTimer) {
-        clearTimeout(markReadTimer);
-    }
-
-    if (threadReadTimer) {
-        clearTimeout(threadReadTimer);
-    }
 
     if (highlightTimer) {
         clearTimeout(highlightTimer);
@@ -582,13 +571,6 @@ function forwardMessage({
 // send clears the draft server-side, so only manual edits flow through here.
 const DRAFT_DEBOUNCE_MS = 700;
 
-let draftTimer: ReturnType<typeof setTimeout> | null = null;
-
-// The latest pending draft, tagged with the slug of the channel it belongs to,
-// so a flush triggered by switching channels still writes to the channel that
-// was actually being edited rather than the one just navigated to.
-let pendingDraft: { slug: string; body: string } | null = null;
-
 function persistDraft(slug: string, body: string): void {
     router.patch(
         saveChannelDraft({ team: props.team.slug, channel: slug }).url,
@@ -597,40 +579,25 @@ function persistDraft(slug: string, body: string): void {
     );
 }
 
-// Write any pending draft immediately, cancelling the debounce. Called before
-// leaving the channel so a just-typed draft is never lost to an unfired timer.
-function flushDraft(): void {
-    if (draftTimer) {
-        clearTimeout(draftTimer);
-        draftTimer = null;
-    }
-
-    if (pendingDraft) {
-        persistDraft(pendingDraft.slug, pendingDraft.body);
-        pendingDraft = null;
-    }
-}
+// The debounced draft save. The payload is tagged with the slug of the channel it
+// belongs to, so a flush triggered by switching channels still writes to the
+// channel that was actually being edited rather than the one just navigated to.
+// It flushes on unmount so a just-typed draft is never lost to an unfired timer.
+const draftPost = useDebouncedPost(
+    (draft: { slug: string; body: string }) =>
+        persistDraft(draft.slug, draft.body),
+    { delay: DRAFT_DEBOUNCE_MS, flushOnUnmount: true },
+);
 
 // Debounce a draft save for the current channel; an empty body clears it.
 function onDraftChange(body: string): void {
-    pendingDraft = { slug: props.channel.slug, body };
-
-    if (draftTimer) {
-        clearTimeout(draftTimer);
-    }
-
-    draftTimer = setTimeout(flushDraft, DRAFT_DEBOUNCE_MS);
+    draftPost.schedule({ slug: props.channel.slug, body });
 }
 
 function send(body: string, mentions: Mention[]): void {
     // Sending clears the draft server-side, so drop any debounced save still in
     // flight; otherwise it would re-persist the just-sent text after the clear.
-    if (draftTimer) {
-        clearTimeout(draftTimer);
-        draftTimer = null;
-    }
-
-    pendingDraft = null;
+    draftPost.cancel();
 
     const clientUuid = crypto.randomUUID();
     const target = replyTarget.value;
@@ -681,12 +648,7 @@ function scheduleMessage(
     _mentions: Mention[],
     sendAt: string,
 ): void {
-    if (draftTimer) {
-        clearTimeout(draftTimer);
-        draftTimer = null;
-    }
-
-    pendingDraft = null;
+    draftPost.cancel();
 
     const target = replyTarget.value;
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -25,6 +25,12 @@
       "skillPath": "skills/engineering/implement/SKILL.md",
       "computedHash": "5eedab2e36a68278662484e8e243624fe0bb74040299aa6c8a525feb65b0365c"
     },
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/improve-codebase-architecture/SKILL.md",
+      "computedHash": "8bf292143ca93b00276a0de0fc5f84f2381f4690c5b0d32e99fa283a072f392f"
+    },
     "tdd": {
       "source": "mattpocock/skills",
       "sourceType": "github",

--- a/tests/Feature/Channels/ChannelPolicyTest.php
+++ b/tests/Feature/Channels/ChannelPolicyTest.php
@@ -188,3 +188,23 @@ test('a non-team-member cannot manage a private channel membership', function ()
     expect($outsider->can('addMember', $private))->toBeFalse()
         ->and($outsider->can('removeMember', $private))->toBeFalse();
 });
+
+test('the pivot-preference abilities are granted only to channel members', function (string $ability) {
+    $channelMember = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($channelMember, 'Acme');
+    $channel = Channel::factory()->for($team)->create();
+    $channel->channelMembers()->create(['user_id' => $channelMember->id]);
+
+    // A team member who never joined this channel — the team branch of the
+    // shared isMember predicate is true, the membership branch is false.
+    $teamMember = User::factory()->create();
+    $team->memberships()->create(['user_id' => $teamMember->id, 'role' => TeamRole::Member]);
+
+    // An outsider who does not belong to the team at all — the team branch is
+    // false, so the predicate short-circuits before touching membership.
+    $outsider = User::factory()->create();
+
+    expect($channelMember->can($ability, $channel))->toBeTrue()
+        ->and($teamMember->can($ability, $channel))->toBeFalse()
+        ->and($outsider->can($ability, $channel))->toBeFalse();
+})->with(['updatePreference', 'updateStar', 'place', 'saveDraft']);

--- a/tests/Feature/Channels/ChannelTimelineWindowTest.php
+++ b/tests/Feature/Channels/ChannelTimelineWindowTest.php
@@ -1,0 +1,243 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Data\MessageData;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\ChannelTimelineWindow;
+use Illuminate\Support\Collection;
+
+/**
+ * A user in a fresh team with its auto-created #general channel. The window
+ * read-model is exercised directly against these — no HTTP round-trip.
+ *
+ * @return array{user: User, team: Team, general: Channel}
+ */
+function windowFixture(): array
+{
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return ['user' => $user, 'team' => $team, 'general' => $general];
+}
+
+/**
+ * Create $count top-level messages in the channel, bodies "message 1".."message N",
+ * in ascending (ordered-uuid) id order.
+ *
+ * @return Collection<int, Message>
+ */
+function windowMessages(Channel $channel, User $author, int $count): Collection
+{
+    return collect(range(1, $count))->map(
+        fn (int $i) => Message::factory()->for($channel)->for($author)->create(['body' => "message {$i}"])
+    );
+}
+
+/**
+ * The bodies of a window's main timeline page, newest first.
+ *
+ * @return array<int, string>
+ */
+function bodiesOf(ChannelTimelineWindow $window): array
+{
+    return collect($window->messages()->items())
+        ->map(fn (MessageData $message) => $message->body)
+        ->all();
+}
+
+it('opens at newest with no ceiling on a never-read channel', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    windowMessages($general, $user, 60);
+
+    // Null read pointer: nothing to anchor, so the default newest window holds.
+    $window = new ChannelTimelineWindow(channel: $general, viewer: $user, lastReadMessageId: null);
+
+    expect($window->ceilingId())->toBeNull()
+        ->and($window->jumpToMessageId())->toBeNull();
+
+    $bodies = bodiesOf($window);
+    expect($bodies)->toHaveCount(50)
+        ->and($bodies[0])->toBe('message 60')
+        ->and($bodies[49])->toBe('message 11');
+});
+
+it('opens at newest with no ceiling on a fully-read channel', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 60);
+
+    // Read pointer at the newest message: nothing is unread.
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        lastReadMessageId: $messages[59]->id,
+    );
+
+    expect($window->ceilingId())->toBeNull();
+    expect(bodiesOf($window))->toHaveCount(50);
+});
+
+it('keeps the newest window when unread fits within a page', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 60);
+
+    // Read through message 20: 40 unread fit inside one 50-row page.
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        lastReadMessageId: $messages[19]->id,
+    );
+
+    expect($window->ceilingId())->toBeNull();
+
+    $bodies = bodiesOf($window);
+    expect($bodies[0])->toBe('message 60')
+        ->and($bodies[49])->toBe('message 11');
+});
+
+it('anchors the window around the boundary when unread exceeds a page', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 100);
+
+    // Read through message 30: 70 unread exceed one page, so the window caps
+    // 39 messages past the boundary (message 71) and holds messages 22..71.
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        lastReadMessageId: $messages[29]->id,
+    );
+
+    expect($window->ceilingId())->toBe($messages[70]->id);
+
+    $bodies = bodiesOf($window);
+    expect($bodies)->toHaveCount(50)
+        ->and($bodies[0])->toBe('message 71')
+        ->and($bodies[49])->toBe('message 22');
+});
+
+it('windows a jump target with newer context below it', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 30);
+    $target = $messages[4]; // message 5
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        requestedJumpId: $target->id,
+    );
+
+    expect($window->jumpToMessageId())->toBe($target->id)
+        // 15 messages newer than the target cap the window at message 20.
+        ->and($window->ceilingId())->toBe($messages[19]->id);
+
+    $bodies = bodiesOf($window);
+    expect($bodies)->toHaveCount(20)
+        ->and($bodies[0])->toBe('message 20');
+});
+
+it('leaves a jump near the newest message uncapped', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 5);
+    $target = $messages[4]; // the newest
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        requestedJumpId: $target->id,
+    );
+
+    // Fewer than JUMP_CONTEXT newer messages exist, so no ceiling is needed.
+    expect($window->jumpToMessageId())->toBe($target->id)
+        ->and($window->ceilingId())->toBeNull();
+    expect(bodiesOf($window))->toHaveCount(5);
+});
+
+it('ignores a jump target from another channel', function () {
+    ['user' => $user, 'team' => $team, 'general' => $general] = windowFixture();
+    windowMessages($general, $user, 3);
+    $other = Channel::factory()->for($team)->create(['created_by' => $user->id]);
+    $foreign = Message::factory()->for($other)->for($user)->create();
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        requestedJumpId: $foreign->id,
+    );
+
+    expect($window->jumpToMessageId())->toBeNull()
+        ->and($window->ceilingId())->toBeNull();
+});
+
+it('ignores an absent or non-string jump target', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    windowMessages($general, $user, 3);
+
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user))->jumpToMessageId())->toBeNull();
+    // A tampered array query value never resolves to a target.
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user, requestedJumpId: ['x']))->jumpToMessageId())
+        ->toBeNull();
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user, requestedJumpId: ''))->jumpToMessageId())
+        ->toBeNull();
+});
+
+it('includes thread replies sent to the channel and excludes those that are not', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $root = Message::factory()->for($general)->for($user)->create(['body' => 'root']);
+    Message::factory()->for($user)->inThread($root)->sentToChannel()->create(['body' => 'echoed reply']);
+    Message::factory()->for($user)->inThread($root)->create(['body' => 'thread-only reply']);
+
+    $window = new ChannelTimelineWindow(channel: $general, viewer: $user);
+
+    $bodies = bodiesOf($window);
+    expect($bodies)->toContain('root')
+        ->and($bodies)->toContain('echoed reply')
+        ->and($bodies)->not->toContain('thread-only reply');
+});
+
+it('resolves the open thread root and its replies', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $root = Message::factory()->for($general)->for($user)->create(['body' => 'root']);
+    Message::factory()->for($user)->inThread($root)->create(['body' => 'reply one']);
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        requestedThreadRootId: $root->id,
+    );
+
+    $thread = $window->thread();
+    expect($thread)->not->toBeNull()
+        ->and($thread['root'])->toBeInstanceOf(MessageData::class)
+        ->and($thread['root']->id)->toBe($root->id);
+
+    $replyBodies = collect($window->threadReplies()->items())
+        ->map(fn (MessageData $message) => $message->body)
+        ->all();
+    expect($replyBodies)->toBe(['reply one']);
+});
+
+it('returns no thread and an empty replies page without a thread param', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    windowMessages($general, $user, 2);
+
+    $window = new ChannelTimelineWindow(channel: $general, viewer: $user);
+
+    expect($window->thread())->toBeNull()
+        ->and($window->threadReplies()->items())->toBe([]);
+});
+
+it('returns no thread for a non-string or foreign thread param', function () {
+    ['user' => $user, 'team' => $team, 'general' => $general] = windowFixture();
+    $other = Channel::factory()->for($team)->create(['created_by' => $user->id]);
+    $foreignRoot = Message::factory()->for($other)->for($user)->create();
+
+    // A tampered array query value resolves to no thread.
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user, requestedThreadRootId: ['x']))->thread())
+        ->toBeNull();
+    // A root in another channel is not this channel's thread.
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user, requestedThreadRootId: $foreignRoot->id))->thread())
+        ->toBeNull();
+});

--- a/tests/Feature/Channels/MessageLoadSetScopeTest.php
+++ b/tests/Feature/Channels/MessageLoadSetScopeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Data\MessageData;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\MessageReaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Build a fully-decorated root message: it quotes a parent, forwards a
+ * cross-channel source, carries mentions, link previews, and reactions, and
+ * owns a thread with a reply by another author (so it has thread participants).
+ * Returns the root's id so the test can re-fetch it through the scope.
+ */
+function decoratedMessage(): string
+{
+    $author = User::factory()->create();
+    $mentioned = User::factory()->create();
+    $reactor = User::factory()->create();
+    $replier = User::factory()->create();
+
+    $channel = Channel::factory()->create();
+    $otherChannel = Channel::factory()->create();
+
+    $parent = Message::factory()->for($channel)->for($author, 'user')->create();
+    $source = Message::factory()->for($otherChannel)->for($author, 'user')->create();
+
+    $root = Message::factory()
+        ->for($channel)
+        ->for($author, 'user')
+        ->replyTo($parent)
+        ->forwardedFrom($source)
+        ->create();
+
+    $root->mentionedUsers()->attach($mentioned->id);
+    $root->linkPreviews()->create(['url' => 'https://example.com', 'position' => 0]);
+    MessageReaction::factory()->for($root, 'message')->for($reactor, 'user')->create();
+
+    Message::factory()->for($channel)->for($replier, 'user')->inThread($root)->create();
+
+    return $root->id;
+}
+
+it('builds MessageData with no follow-up queries when loaded through the scope', function () {
+    $id = decoratedMessage();
+
+    $message = Message::query()->withMessageDataRelations()->findOrFail($id);
+
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    $data = MessageData::fromMessage($message);
+
+    expect(DB::connection()->getQueryLog())->toBe([]);
+
+    // Sanity-check the scope actually loaded the full decorated payload, so the
+    // "no queries" assertion above is meaningful and not passing on empty data.
+    expect($data->replyTo)->not->toBeNull()
+        ->and($data->forwardedFrom)->not->toBeNull()
+        ->and($data->mentions)->toHaveCount(1)
+        ->and($data->linkPreviews)->toHaveCount(1)
+        ->and($data->reactions)->toHaveCount(1)
+        ->and($data->threadParticipants)->not->toBeEmpty();
+});

--- a/tests/Feature/Channels/VisibleChannelsAclTest.php
+++ b/tests/Feature/Channels/VisibleChannelsAclTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * A user in a team, joined to a mix of channels, alongside channels they cannot
+ * see: one in the same team they never joined, and one in another team.
+ *
+ * @return array{user: User, team: Team, visible: array<int, string>, hidden: array<int, string>}
+ */
+function aclFixture(): array
+{
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    $joined = Channel::factory()->for($team)->create();
+    $joined->channelMembers()->create(['user_id' => $user->id]);
+
+    // An archived channel the user still belongs to stays in the ACL — "visible"
+    // for authorization is membership, not sidebar presence.
+    $archivedJoined = Channel::factory()->for($team)->create(['archived_at' => now()]);
+    $archivedJoined->channelMembers()->create(['user_id' => $user->id]);
+
+    // Same team, never joined — must not be visible.
+    $notJoined = Channel::factory()->for($team)->create();
+
+    // Another team the user also belongs to; its channels must not leak into
+    // this team's ACL.
+    $otherTeam = app(CreateTeam::class)->handle($user, 'Globex');
+    $otherTeamChannel = Channel::factory()->for($otherTeam)->create();
+    $otherTeamChannel->channelMembers()->create(['user_id' => $user->id]);
+
+    return [
+        'user' => $user,
+        'team' => $team,
+        'visible' => [$general->id, $joined->id, $archivedJoined->id],
+        'hidden' => [$notJoined->id, $otherTeamChannel->id],
+    ];
+}
+
+it('returns exactly the channels a user has joined in the team', function () {
+    ['user' => $user, 'team' => $team, 'visible' => $visible, 'hidden' => $hidden] = aclFixture();
+
+    $ids = $user->visibleChannelIds($team)->all();
+
+    expect($ids)->toEqualCanonicalizing($visible)
+        ->and($ids)->not->toContain(...$hidden);
+});
+
+it('excludes channels in other teams even when the user is a member', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $otherTeam = app(CreateTeam::class)->handle($user, 'Globex');
+    $otherChannel = Channel::factory()->for($otherTeam)->create();
+    $otherChannel->channelMembers()->create(['user_id' => $user->id]);
+
+    expect($user->visibleChannelIds($team)->all())->not->toContain($otherChannel->id);
+});
+
+it('excludes channels in the team the user never joined', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+    $private = Channel::factory()->for($team)->create();
+    $private->channelMembers()->create(['user_id' => $stranger->id]);
+
+    expect($user->visibleChannelIds($team)->all())->not->toContain($private->id);
+});


### PR DESCRIPTION
Integration PR for the architecture-hardening epic (#131). Merges the whole
scaffold branch to master in one shot now that all eight children have landed.

## What this lands

The guardrail plus the Strong-set refactors, each already merged into this
branch with its own tests and a full-gate pass:

- #123 message load-set scope (ADR-0002)
- #124 visible-channels ACL (ADR-0003)
- #126 isMember predicate in ChannelPolicy
- #128 useChannelFleetSubscription (ADR-0006)
- #127 useChannelRealtime (ADR-0006)
- #129 useDebouncedPost
- #125 ChannelTimelineWindow read-model (ADR-0004)
- #130 Show.vue decomposed into channel-view composables (ADR-0006)

Plus the scaffold: the CONTEXT.md design vocabulary and named deep modules, the
ADRs (0001-0006), and the vendored improve-codebase-architecture skill. The
final commit clears the planned markers on the six delivered seams;
ScrollableMessageList and ConfirmDialog stay planned as deferred follow-ups.

## Testing

The integrated branch is green: composer test at 100% coverage with Pint and
PHPStan clean (655 tests), and the frontend gate — lint, format, types, build,
and test:js — all pass via Sail.
