### PR TITLE
refactor(messaging): own the message eager-load set in one scope (#123)

### DIFF
--- a/app/Actions/Channels/EditMessage.php
+++ b/app/Actions/Channels/EditMessage.php
@@ -31,8 +31,7 @@ class EditMessage
         $this->syncMentions->handle($channel, $message);
         $this->syncLinkPreviews->handle($message);
 
-        $message->loadMissing('user');
-        $message->load(['mentionedUsers', 'linkPreviews', 'reactions.user']);
+        $message->loadMessageDataRelations();
         MessageUpdated::dispatch($channel, MessageData::fromMessage($message));
 
         return $message;

--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -54,8 +54,7 @@ class PostMessage
         if ($message->wasRecentlyCreated) {
             $this->syncMentions->handle($channel, $message);
             $this->syncLinkPreviews->handle($message);
-            $message->setRelation('user', $author);
-            $message->load(['mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
+            $message->loadMessageDataRelations();
             MessageSent::dispatch($channel, MessageData::fromMessage($message));
 
             if ($threadRootId !== null) {
@@ -80,7 +79,7 @@ class PostMessage
         $root = $channel->messages()->withTrashed()->findOrFail($threadRootId);
         $root->forceFill(['reply_count' => $root->reply_count + 1, 'last_reply_at' => now()])->save();
 
-        $root->load(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'threadParticipants']);
+        $root->loadMessageDataRelations();
         MessageUpdated::dispatch($channel, MessageData::fromMessage($root));
     }
 }

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -40,10 +40,13 @@ class SearchMessages
             return new Collection;
         }
 
-        return Message::search($query)
+        $matches = Message::search($query)
             ->whereIn('channel_id', $channelIds)
             ->take($limit)
-            ->get()
-            ->load(['user', 'channel', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers']);
+            ->get();
+
+        // The search result also names each match's own channel; that is the
+        // MessageSearchResultData shell around the payload, not part of it.
+        return Message::loadMessageDataRelationsInto($matches)->load('channel');
     }
 }

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -186,7 +186,7 @@ class ChannelController extends Controller
             // "message deleted" tombstone in place; MessageData blanks their body.
             'messages' => Inertia::scroll(fn () => $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
                 ->withThreadReadState($request->user())
-                ->with(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
+                ->withMessageDataRelations()
                 ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
                 ->orderByDesc('id')
                 ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
@@ -231,7 +231,7 @@ class ChannelController extends Controller
         $root = $this->resolveThreadRoot($request, $channel);
 
         $query = $root !== null
-            ? $root->threadReplies()->withTrashed()->with(['user', 'mentionedUsers', 'linkPreviews', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers'])
+            ? $root->threadReplies()->withTrashed()->withMessageDataRelations()
             : Message::query()->whereRaw('1 = 0');
 
         return $query
@@ -257,7 +257,7 @@ class ChannelController extends Controller
         return $channel->messages()
             ->whereNull('thread_root_id')
             ->withThreadReadState($request->user())
-            ->with(['user', 'mentionedUsers', 'linkPreviews', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
+            ->withMessageDataRelations()
             ->find($rootId);
     }
 

--- a/app/Http/Controllers/Channels/ThreadsController.php
+++ b/app/Http/Controllers/Channels/ThreadsController.php
@@ -48,7 +48,10 @@ class ThreadsController extends Controller
                 ->where('reply_count', '>', 0)
                 ->followedBy($user)
                 ->withThreadReadState($user)
-                ->with(['user', 'channel', 'mentionedUsers', 'reactions.user', 'replyTo.user', 'replyTo.mentionedUsers', 'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers', 'threadParticipants'])
+                ->withMessageDataRelations()
+                // The inbox row also names the message's own channel; that is the
+                // ThreadInboxItemData shell around the payload, not part of it.
+                ->with('channel')
                 ->orderByDesc('last_reply_at')
                 ->orderByDesc('id')
                 ->cursorPaginate(self::PAGE_SIZE)

--- a/app/Jobs/UnfurlMessageLinks.php
+++ b/app/Jobs/UnfurlMessageLinks.php
@@ -14,17 +14,6 @@ class UnfurlMessageLinks implements ShouldQueue
 {
     use Queueable;
 
-    /**
-     * The relations {@see MessageData::fromMessage()} reads to build the broadcast.
-     *
-     * @var array<int, string>
-     */
-    private const array MESSAGE_RELATIONS = [
-        'user', 'mentionedUsers', 'linkPreviews', 'reactions.user',
-        'replyTo.user', 'replyTo.mentionedUsers',
-        'forwardedFrom.user', 'forwardedFrom.channel', 'forwardedFrom.mentionedUsers',
-    ];
-
     public function __construct(private string $messageId) {}
 
     /**
@@ -64,7 +53,7 @@ class UnfurlMessageLinks implements ShouldQueue
                 ]);
         }
 
-        $message->load(self::MESSAGE_RELATIONS);
+        $message->loadMessageDataRelations();
         MessageUpdated::dispatch($message->channel, MessageData::fromMessage($message));
     }
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -63,6 +63,32 @@ class Message extends Model
     ];
 
     /**
+     * The relations {@see MessageData::fromMessage()} — and its nested reply,
+     * forward, and reaction DTOs — read to render a message payload.
+     *
+     * This is the single home of the message payload's N+1 contract: every
+     * timeline, thread, search, post, edit, and broadcast path eager-loads
+     * exactly this set — query paths through {@see scopeWithMessageDataRelations()},
+     * post-fetch paths through {@see loadMessageDataRelations()} or
+     * {@see loadMessageDataRelationsInto()}. When `MessageData` starts reading a
+     * new relation, add it here, never at a call site.
+     *
+     * @var list<string>
+     */
+    private const MESSAGE_DATA_RELATIONS = [
+        'user',
+        'mentionedUsers',
+        'linkPreviews',
+        'reactions.user',
+        'replyTo.user',
+        'replyTo.mentionedUsers',
+        'forwardedFrom.user',
+        'forwardedFrom.channel',
+        'forwardedFrom.mentionedUsers',
+        'threadParticipants',
+    ];
+
+    /**
      * Get the channel the message was posted to.
      *
      * @return BelongsTo<Channel, $this>
@@ -252,6 +278,48 @@ class Message extends Model
     public function scopeWhereThreadUnreadFor(Builder $query, User $user): void
     {
         $query->whereRaw(self::THREAD_HAS_UNREAD_SQL, [$user->id, $user->id, $user->id, NotificationLevel::All->value]);
+    }
+
+    /**
+     * Eager-load the message-payload relation set onto a message query, so the
+     * resulting {@see MessageData} builds without an N+1. The one query
+     * interface to {@see self::MESSAGE_DATA_RELATIONS}; callers add only the
+     * extra relations their own read-model needs (e.g. the message's own
+     * `channel` for search or the thread inbox) on top.
+     *
+     * @param  Builder<Message>  $query
+     */
+    public function scopeWithMessageDataRelations(Builder $query): void
+    {
+        $query->with(self::MESSAGE_DATA_RELATIONS);
+    }
+
+    /**
+     * Eager-load the message-payload relation set onto an already-fetched
+     * message, for the post-create / post-edit broadcast paths that hold a model
+     * rather than a query. Forces a reload so a freshly edited body's mentions
+     * and previews are the current set. The single-model mirror of
+     * {@see self::scopeWithMessageDataRelations()}.
+     */
+    public function loadMessageDataRelations(): static
+    {
+        $this->load(self::MESSAGE_DATA_RELATIONS);
+
+        return $this;
+    }
+
+    /**
+     * Eager-load the message-payload relation set across a hydrated collection
+     * in a single batch, for the search path that holds its Scout matches as a
+     * collection (not a query) and must not load per-row. The collection mirror
+     * of {@see self::scopeWithMessageDataRelations()}.
+     *
+     * @param  Collection<int, Message>  $messages
+     * @return Collection<int, Message>
+     */
+    public static function loadMessageDataRelationsInto(Collection $messages): Collection
+    {
+        return $messages->load(self::MESSAGE_DATA_RELATIONS);
     }
 
     /**

--- a/tests/Feature/Channels/MessageLoadSetScopeTest.php
+++ b/tests/Feature/Channels/MessageLoadSetScopeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Data\MessageData;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\MessageReaction;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Build a fully-decorated root message: it quotes a parent, forwards a
+ * cross-channel source, carries mentions, link previews, and reactions, and
+ * owns a thread with a reply by another author (so it has thread participants).
+ * Returns the root's id so the test can re-fetch it through the scope.
+ */
+function decoratedMessage(): string
+{
+    $author = User::factory()->create();
+    $mentioned = User::factory()->create();
+    $reactor = User::factory()->create();
+    $replier = User::factory()->create();
+
+    $channel = Channel::factory()->create();
+    $otherChannel = Channel::factory()->create();
+
+    $parent = Message::factory()->for($channel)->for($author, 'user')->create();
+    $source = Message::factory()->for($otherChannel)->for($author, 'user')->create();
+
+    $root = Message::factory()
+        ->for($channel)
+        ->for($author, 'user')
+        ->replyTo($parent)
+        ->forwardedFrom($source)
+        ->create();
+
+    $root->mentionedUsers()->attach($mentioned->id);
+    $root->linkPreviews()->create(['url' => 'https://example.com', 'position' => 0]);
+    MessageReaction::factory()->for($root, 'message')->for($reactor, 'user')->create();
+
+    Message::factory()->for($channel)->for($replier, 'user')->inThread($root)->create();
+
+    return $root->id;
+}
+
+it('builds MessageData with no follow-up queries when loaded through the scope', function () {
+    $id = decoratedMessage();
+
+    $message = Message::query()->withMessageDataRelations()->findOrFail($id);
+
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    $data = MessageData::fromMessage($message);
+
+    expect(DB::connection()->getQueryLog())->toBe([]);
+
+    // Sanity-check the scope actually loaded the full decorated payload, so the
+    // "no queries" assertion above is meaningful and not passing on empty data.
+    expect($data->replyTo)->not->toBeNull()
+        ->and($data->forwardedFrom)->not->toBeNull()
+        ->and($data->mentions)->toHaveCount(1)
+        ->and($data->linkPreviews)->toHaveCount(1)
+        ->and($data->reactions)->toHaveCount(1)
+        ->and($data->threadParticipants)->not->toBeEmpty();
+});


### PR DESCRIPTION
Closes #123. Part of the architecture-hardening epic (#131); targets the integration branch, not `master`. Implements **ADR-0002**.

## Problem

`MessageData::fromMessage()` is the canonical message read-model, but the eager-load list that keeps it from N+1'ing was hand-written at **seven** call sites — and had drifted:

- `ChannelController::resolveThreadRoot()` omitted `reactions.user`
- `ThreadsController` (thread inbox) omitted `linkPreviews`
- `PostMessage`'s new-message load omitted `user` / `threadParticipants`
- `UnfurlMessageLinks` carried a **second copy** of the list that had lost `threadParticipants`

One design decision smeared across modules that must change together.

## Change

The relation set now has one home on `Message` — a private `MESSAGE_DATA_RELATIONS` list with three thin routes to it:

- `scopeWithMessageDataRelations()` — query paths (timeline, thread replies, thread root, thread inbox)
- `loadMessageDataRelations()` — post-create / post-edit / unfurl broadcast paths that hold a model
- `loadMessageDataRelationsInto()` — the Scout search collection (batched, not per-row)

Every timeline / thread / search / post / edit / unfurl payload routes through it. Call sites that also need the message's **own** `channel` (search results, thread inbox) add just that one relation on top — it's the DTO shell, not part of the payload. `ToggleReaction` (builds `ReactionData`) and the scheduled-message query (`ScheduledMessageData`) are different read-models and are left alone.

## Acceptance criteria

- [x] One list declares the message-payload relation set; no call site hand-writes it
- [x] All former call sites use it; drift (missing `reactions.user`, `linkPreviews`, `threadParticipants`) is gone
- [x] A test asserts a `MessageData` build issues **no follow-up queries** for a message with replies / reactions / mentions / previews / forward / thread participants
- [x] `./vendor/bin/sail composer test` green at 100% coverage; Pint + PHPStan clean

## Notes

The issue enumerated six call sites; a seventh (`UnfurlMessageLinks`, which kept a drifted private copy of the list) was found and folded in — it's the exact leak the ADR targets.