### PR TITLE
refactor(security): own the visible-channels ACL in one method (#124)

### DIFF
--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -31,10 +31,7 @@ class SearchMessages
     {
         $query = trim($query);
 
-        $channelIds = $user->channels()
-            ->where('channels.team_id', $team->id)
-            ->pluck('channels.id')
-            ->all();
+        $channelIds = $user->visibleChannelIds($team)->all();
 
         if ($query === '' || $channelIds === []) {
             return new Collection;

--- a/app/Actions/Channels/SetChannelPlacement.php
+++ b/app/Actions/Channels/SetChannelPlacement.php
@@ -26,10 +26,7 @@ class SetChannelPlacement
      */
     public function handle(User $user, Team $team, Channel $channel, array $orderedIds, bool $moveSection, ?string $sectionId): void
     {
-        $memberChannelIds = $user->channels()
-            ->where('channels.team_id', $team->id)
-            ->pluck('channels.id')
-            ->all();
+        $memberChannelIds = $user->visibleChannelIds($team)->all();
 
         foreach ($orderedIds as $index => $id) {
             if (in_array($id, $memberChannelIds, true)) {

--- a/app/Http/Controllers/Channels/ThreadsController.php
+++ b/app/Http/Controllers/Channels/ThreadsController.php
@@ -32,9 +32,7 @@ class ThreadsController extends Controller
     {
         $user = $request->user();
 
-        $channelIds = $user->channels()
-            ->where('channels.team_id', $team->id)
-            ->pluck('channels.id');
+        $channelIds = $user->visibleChannelIds($team);
 
         return Inertia::render('channels/Threads', [
             'team' => [

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -142,12 +142,8 @@ class HandleInertiaRequests extends Middleware
             return false;
         }
 
-        $channelIds = $user->channels()
-            ->where('channels.team_id', $team->id)
-            ->pluck('channels.id');
-
         return Message::query()
-            ->whereIn('channel_id', $channelIds)
+            ->whereIn('channel_id', $user->visibleChannelIds($team))
             ->whereNull('thread_root_id')
             ->where('reply_count', '>', 0)
             ->followedBy($user)

--- a/app/Http/Requests/Channels/ForwardMessageRequest.php
+++ b/app/Http/Requests/Channels/ForwardMessageRequest.php
@@ -71,13 +71,14 @@ class ForwardMessageRequest extends FormRequest
     }
 
     /**
-     * The ids of channels the author belongs to, scoping the valid forward
-     * destinations to their own memberships.
+     * The ids of channels the author may see in the source's team, scoping the
+     * valid forward destinations to their own memberships. Forwarding stays
+     * within one team, so the source channel's team is the destination's team.
      *
      * @return array<int, string>
      */
     protected function membershipChannelIds(): array
     {
-        return $this->user()->channels()->pluck('channels.id')->all();
+        return $this->user()->visibleChannelIds($this->sourceChannel()->team)->all();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
@@ -125,6 +126,26 @@ class User extends Authenticatable
         return $this->belongsToMany(Channel::class, 'channel_members')
             ->withPivot(['last_read_message_id', 'muted', 'notification_level', 'draft', 'starred', 'section_id', 'position'])
             ->withTimestamps();
+    }
+
+    /**
+     * The ids of the channels this user may see in a team — the whole
+     * authorization boundary for message search, the thread inbox, unread
+     * indicators, forwarding, and sidebar placement.
+     *
+     * "Visible" is membership scoped to the team: every channel the user belongs
+     * to within it, archived ones included (they are still readable, just hidden
+     * from the sidebar). This is the single home of that decision — no consumer
+     * re-derives the ACL with its own query, so tightening it (a block-list, an
+     * archived exclusion) is one change every consumer inherits.
+     *
+     * @return SupportCollection<int, string>
+     */
+    public function visibleChannelIds(Team $team): SupportCollection
+    {
+        return $this->channels()
+            ->where('channels.team_id', $team->id)
+            ->pluck('channels.id');
     }
 
     /**

--- a/tests/Feature/Channels/VisibleChannelsAclTest.php
+++ b/tests/Feature/Channels/VisibleChannelsAclTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * A user in a team, joined to a mix of channels, alongside channels they cannot
+ * see: one in the same team they never joined, and one in another team.
+ *
+ * @return array{user: User, team: Team, visible: array<int, string>, hidden: array<int, string>}
+ */
+function aclFixture(): array
+{
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    $joined = Channel::factory()->for($team)->create();
+    $joined->channelMembers()->create(['user_id' => $user->id]);
+
+    // An archived channel the user still belongs to stays in the ACL — "visible"
+    // for authorization is membership, not sidebar presence.
+    $archivedJoined = Channel::factory()->for($team)->create(['archived_at' => now()]);
+    $archivedJoined->channelMembers()->create(['user_id' => $user->id]);
+
+    // Same team, never joined — must not be visible.
+    $notJoined = Channel::factory()->for($team)->create();
+
+    // Another team the user also belongs to; its channels must not leak into
+    // this team's ACL.
+    $otherTeam = app(CreateTeam::class)->handle($user, 'Globex');
+    $otherTeamChannel = Channel::factory()->for($otherTeam)->create();
+    $otherTeamChannel->channelMembers()->create(['user_id' => $user->id]);
+
+    return [
+        'user' => $user,
+        'team' => $team,
+        'visible' => [$general->id, $joined->id, $archivedJoined->id],
+        'hidden' => [$notJoined->id, $otherTeamChannel->id],
+    ];
+}
+
+it('returns exactly the channels a user has joined in the team', function () {
+    ['user' => $user, 'team' => $team, 'visible' => $visible, 'hidden' => $hidden] = aclFixture();
+
+    $ids = $user->visibleChannelIds($team)->all();
+
+    expect($ids)->toEqualCanonicalizing($visible)
+        ->and($ids)->not->toContain(...$hidden);
+});
+
+it('excludes channels in other teams even when the user is a member', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $otherTeam = app(CreateTeam::class)->handle($user, 'Globex');
+    $otherChannel = Channel::factory()->for($otherTeam)->create();
+    $otherChannel->channelMembers()->create(['user_id' => $user->id]);
+
+    expect($user->visibleChannelIds($team)->all())->not->toContain($otherChannel->id);
+});
+
+it('excludes channels in the team the user never joined', function () {
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $stranger = User::factory()->create();
+    $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
+    $private = Channel::factory()->for($team)->create();
+    $private->channelMembers()->create(['user_id' => $stranger->id]);
+
+    expect($user->visibleChannelIds($team)->all())->not->toContain($private->id);
+});


### PR DESCRIPTION
Closes #124. Part of the architecture-hardening epic (#131); targets the integration branch, not `master`. Implements **ADR-0003**.

## Problem

"The channel ids a user may see in a team" is the entire authorization boundary for message **search**, the **thread inbox**, **unread indicators**, message **forwarding**, and sidebar **placement**. It was reimplemented as an ad-hoc `$user->channels()->…->pluck('channels.id')` at five call sites across three architectural strata (middleware, controller, Action, FormRequest). A change to what "visible" means (exclude archived, honour a block-list) would need five synchronized edits — and one would be missed. That is a security-relevant divergence.

## Change

The visible-channel id set now has one home: `User::visibleChannelIds(Team)`. Every consumer routes through it:

- `HandleInertiaRequests::hasUnreadThreads()` (sidebar "Threads" dot)
- `ThreadsController::index()` (thread inbox)
- `SearchMessages` (message search ACL)
- `SetChannelPlacement` (drag-reorder guard)
- `ForwardMessageRequest` (valid forward destinations)

"Visible" is preserved as current behaviour — team-scoped membership, **archived channels included** (still readable, just hidden from the sidebar). `ForwardMessageRequest` previously plucked the user's channels across *all* teams and leaned on its `exists` rule's `team_id` clause to scope; it now scopes to the source channel's team directly (forwarding stays within one team), so the id set itself is correct rather than incidentally filtered downstream.

## Acceptance criteria

- [x] One method owns the visible-channel id set; the five call sites use it
- [x] No remaining ad-hoc `$user->channels()->…->pluck('channels.id')` for ACL purposes
- [x] A test asserts the ACL excludes channels in other teams / not joined (`VisibleChannelsAclTest`); the five consumers' own feature tests continue to pass, exercising each path
- [x] `./vendor/bin/sail composer test` green at 100% coverage; Pint + PHPStan clean