### PR TITLE
refactor(security): extract isMember predicate in ChannelPolicy (#126)

### DIFF
--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -42,8 +42,7 @@ class ChannelPolicy
      */
     public function updatePreference(User $user, Channel $channel): bool
     {
-        return $user->belongsToTeam($channel->team)
-            && $channel->members()->whereKey($user->id)->exists();
+        return $this->isMember($user, $channel);
     }
 
     /**
@@ -55,8 +54,7 @@ class ChannelPolicy
      */
     public function updateStar(User $user, Channel $channel): bool
     {
-        return $user->belongsToTeam($channel->team)
-            && $channel->members()->whereKey($user->id)->exists();
+        return $this->isMember($user, $channel);
     }
 
     /**
@@ -69,8 +67,7 @@ class ChannelPolicy
      */
     public function place(User $user, Channel $channel): bool
     {
-        return $user->belongsToTeam($channel->team)
-            && $channel->members()->whereKey($user->id)->exists();
+        return $this->isMember($user, $channel);
     }
 
     /**
@@ -82,8 +79,7 @@ class ChannelPolicy
      */
     public function saveDraft(User $user, Channel $channel): bool
     {
-        return $user->belongsToTeam($channel->team)
-            && $channel->members()->whereKey($user->id)->exists();
+        return $this->isMember($user, $channel);
     }
 
     /**
@@ -130,6 +126,18 @@ class ChannelPolicy
     public function removeMember(User $user, Channel $channel): bool
     {
         return $this->managesMembership($user, $channel);
+    }
+
+    /**
+     * Shared rule for the pivot-preference abilities (notification preference,
+     * star, sidebar placement, draft): the user is a plain member of the channel
+     * within its team, so they have a membership row to mutate. Each of those
+     * abilities only ever touches the caller's own row.
+     */
+    private function isMember(User $user, Channel $channel): bool
+    {
+        return $user->belongsToTeam($channel->team)
+            && $channel->members()->whereKey($user->id)->exists();
     }
 
     /**

--- a/tests/Feature/Channels/ChannelPolicyTest.php
+++ b/tests/Feature/Channels/ChannelPolicyTest.php
@@ -188,3 +188,23 @@ test('a non-team-member cannot manage a private channel membership', function ()
     expect($outsider->can('addMember', $private))->toBeFalse()
         ->and($outsider->can('removeMember', $private))->toBeFalse();
 });
+
+test('the pivot-preference abilities are granted only to channel members', function (string $ability) {
+    $channelMember = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($channelMember, 'Acme');
+    $channel = Channel::factory()->for($team)->create();
+    $channel->channelMembers()->create(['user_id' => $channelMember->id]);
+
+    // A team member who never joined this channel — the team branch of the
+    // shared isMember predicate is true, the membership branch is false.
+    $teamMember = User::factory()->create();
+    $team->memberships()->create(['user_id' => $teamMember->id, 'role' => TeamRole::Member]);
+
+    // An outsider who does not belong to the team at all — the team branch is
+    // false, so the predicate short-circuits before touching membership.
+    $outsider = User::factory()->create();
+
+    expect($channelMember->can($ability, $channel))->toBeTrue()
+        ->and($teamMember->can($ability, $channel))->toBeFalse()
+        ->and($outsider->can($ability, $channel))->toBeFalse();
+})->with(['updatePreference', 'updateStar', 'place', 'saveDraft']);


### PR DESCRIPTION
Closes #126. Part of the architecture-hardening epic (#131); targets the integration branch, not `master`.

## Problem

`ChannelPolicy::updatePreference`, `updateStar`, `place`, and `saveDraft` each inlined the same predicate:

```php
return $user->belongsToTeam($channel->team)
    && $channel->members()->whereKey($user->id)->exists();
```

Four copies of one authorization rule — and the policy **already** extracted `managesMembership()` for the `addMember`/`removeMember` pair, so the duplication was inconsistent with its own convention. A change to what "membership" means would need four synchronized edits.

## Change

A private `isMember(User, Channel): bool` predicate the four pivot-preference abilities delegate to, mirroring `managesMembership()`. `view`, `postMessage`, and `managesMembership` keep their own distinct membership rules (they combine it with visibility / archived / admin checks), so they are intentionally left alone.

## Acceptance criteria

- [x] The four methods delegate to one `isMember` predicate; no inlined duplicate remains
- [x] Existing policy tests still pass; added a dataset-driven test exercising the predicate's team-branch and membership-branch across all four abilities
- [x] `./vendor/bin/sail composer test` green at 100% coverage; Pint + PHPStan clean