### PR TITLE
refactor(navigation): extract useChannelFleetSubscription (#128)

### DIFF
--- a/resources/js/composables/useChannelFleetSubscription.ts
+++ b/resources/js/composables/useChannelFleetSubscription.ts
@@ -1,0 +1,72 @@
+import { usePage } from '@inertiajs/vue3';
+import { echo } from '@laravel/echo-vue';
+import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { createChannelFleet } from '@/lib/channelFleet';
+import type { Message } from '@/types';
+
+/** The Echo private-channel name a channel id broadcasts on. */
+function channelName(id: string): string {
+    return `channel.${id}`;
+}
+
+/**
+ * Subscribe to a *set* of channels — every channel in the sidebar — and run a
+ * caller-supplied callback for each realtime `MessageSent`. This is the one
+ * subscribe/reconcile/teardown lifecycle shared by the sidebar badges and the
+ * chimes (and mirrored by the open channel's own single subscription): the pure
+ * {@see createChannelFleet} owns the bound-set diffing and active-channel
+ * handoff, while this composable wires it to Echo, the shared `channels` prop,
+ * and the component lifecycle. Consumers stay thin — they only decide *what to
+ * do* on a message.
+ *
+ * The open channel's subscription is owned by its page, which leaves it on
+ * navigation; the post-flush reconcile below runs after that teardown so it
+ * re-attaches the channel just left.
+ */
+export function useChannelFleetSubscription(
+    onMessage: (channelId: string, message: Message) => void,
+): void {
+    const page = usePage();
+
+    const channels = computed(() => page.props.channels ?? []);
+    const activeChannelId = computed(
+        () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
+    );
+
+    // Only reconcile when the set of channels or the open one actually changes,
+    // not on every badge-count refresh of the shared `channels` prop.
+    const subscriptionKey = computed(
+        () =>
+            `${channels.value.map((channel) => channel.id).join('|')}::${activeChannelId.value ?? ''}`,
+    );
+
+    const fleet = createChannelFleet({
+        subscribe(id) {
+            echo()
+                .private(channelName(id))
+                .listen('MessageSent', (message: Message) => {
+                    onMessage(id, message);
+                });
+        },
+        leave(id) {
+            echo().leave(channelName(id));
+        },
+    });
+
+    function reconcile(): void {
+        fleet.reconcile(
+            channels.value.map((channel) => channel.id),
+            activeChannelId.value,
+        );
+    }
+
+    onMounted(reconcile);
+
+    // Post-flush so it runs after the open channel page's own per-channel
+    // teardown of the channel it just navigated away from.
+    watch(subscriptionKey, reconcile, { flush: 'post' });
+
+    onBeforeUnmount(() => {
+        fleet.leaveAll();
+    });
+}

--- a/resources/js/composables/useChimeNotifications.ts
+++ b/resources/js/composables/useChimeNotifications.ts
@@ -1,20 +1,19 @@
 import { usePage } from '@inertiajs/vue3';
-import { echo } from '@laravel/echo-vue';
-import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted } from 'vue';
+import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
 import { playChime, unlockChimeAudio } from '@/lib/chimeSounds';
 import { shouldChime } from '@/lib/shouldChime';
-import type { ChimeSound, Message } from '@/types';
+import type { ChimeSound } from '@/types';
 
 /**
  * Play a chime for qualifying realtime messages across every channel in the
  * sidebar — not just the open one — so activity elsewhere is still audible.
  *
- * Mounted once in the persistent channel layout, it subscribes to each sidebar
- * channel's broadcast and runs {@see shouldChime} per arrival. Show.vue owns the
- * open channel's subscription and tears it down with a full `leave` on navigation,
- * which also drops our listener on it; the post-flush reconcile below re-attaches
- * the channel it just left. Chimes for the open channel are suppressed while it is
- * focused, and Show.vue never chimes, so there is no double playback.
+ * Mounted once in the persistent channel layout, it rides
+ * {@see useChannelFleetSubscription} — the shared subscribe/reconcile/teardown
+ * engine — and runs {@see shouldChime} per arrival. Chimes for the open channel
+ * are suppressed while it is focused, and the open channel page never chimes, so
+ * there is no double playback.
  */
 export function useChimeNotifications(): void {
     const page = usePage();
@@ -28,21 +27,7 @@ export function useChimeNotifications(): void {
         () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
     );
 
-    // Only reconcile when the set of channels or the open one actually changes,
-    // not on every badge-count refresh of the shared `channels` prop.
-    const subscriptionKey = computed(
-        () =>
-            `${channels.value.map((channel) => channel.id).join('|')}::${activeChannelId.value ?? ''}`,
-    );
-
-    const bound = new Set<string>();
-    let previousActiveId: string | null = null;
-
-    function channelName(id: string): string {
-        return `channel.${id}`;
-    }
-
-    function handleMessage(channelId: string, message: Message): void {
+    useChannelFleetSubscription((channelId, message) => {
         const preference =
             channels.value.find((channel) => channel.id === channelId) ?? null;
 
@@ -67,48 +52,7 @@ export function useChimeNotifications(): void {
         if (decision) {
             playChime(chimeSound.value);
         }
-    }
-
-    function listen(id: string): void {
-        echo()
-            .private(channelName(id))
-            .listen('MessageSent', (message: Message) => {
-                handleMessage(id, message);
-            });
-    }
-
-    function reconcile(): void {
-        const desired = new Set(channels.value.map((channel) => channel.id));
-        const active = activeChannelId.value;
-
-        if (previousActiveId !== null && previousActiveId !== active) {
-            bound.delete(previousActiveId);
-        }
-
-        previousActiveId = active;
-
-        for (const id of desired) {
-            if (!bound.has(id)) {
-                listen(id);
-                bound.add(id);
-            }
-        }
-
-        for (const id of [...bound]) {
-            if (!desired.has(id)) {
-                echo().leave(channelName(id));
-                bound.delete(id);
-            }
-        }
-    }
-
-    function leaveAll(): void {
-        for (const id of bound) {
-            echo().leave(channelName(id));
-        }
-
-        bound.clear();
-    }
+    });
 
     onMounted(() => {
         // The autoplay policy keeps the AudioContext suspended until a gesture.
@@ -116,15 +60,10 @@ export function useChimeNotifications(): void {
             once: true,
         });
         window.addEventListener('keydown', unlockChimeAudio, { once: true });
-        reconcile();
     });
-
-    // Post-flush so it runs after Show.vue's own per-channel teardown.
-    watch(subscriptionKey, reconcile, { flush: 'post' });
 
     onBeforeUnmount(() => {
         window.removeEventListener('pointerdown', unlockChimeAudio);
         window.removeEventListener('keydown', unlockChimeAudio);
-        leaveAll();
     });
 }

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -1,8 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
-import { echo } from '@laravel/echo-vue';
-import { computed, onBeforeUnmount, onMounted, watch } from 'vue';
+import { computed, onBeforeUnmount } from 'vue';
+import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
 import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
-import type { Message } from '@/types';
 
 /** Coalesce a burst of arrivals into a single sidebar reload. */
 const REFRESH_DEBOUNCE_MS = 500;
@@ -14,39 +13,21 @@ const REFRESH_DEBOUNCE_MS = 500;
  * but only refreshes on navigation and when the open channel is marked read, so a
  * message posted in a channel the user belongs to but is not viewing would not move
  * its badge until the next visit. Mounted once in the persistent channel layout,
- * this subscribes to each sidebar channel's private broadcast and, on a qualifying
- * MessageSent, debounces a partial reload of `channels` so the badge updates without
- * a manual navigation. A single reload recomputes every channel's count, so bursts
- * across channels collapse to one request.
- *
- * It mirrors useChimeNotifications' subscription bookkeeping: Show.vue owns the open
- * channel's subscription and tears it down with a full `leave` on navigation, which
- * also drops our listener on it; the post-flush reconcile re-attaches the channel it
- * just left.
+ * this rides {@see useChannelFleetSubscription} — the shared subscribe/reconcile/
+ * teardown engine — and, on a qualifying MessageSent, debounces a partial reload of
+ * `channels` so the badge updates without a manual navigation. A single reload
+ * recomputes every channel's count, so bursts across channels collapse to one
+ * request.
  */
 export function useSidebarBadges(): void {
     const page = usePage();
 
     const currentUserId = computed(() => String(page.props.auth.user.id));
-    const channels = computed(() => page.props.channels ?? []);
     const activeChannelId = computed(
         () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
     );
 
-    // Only reconcile when the set of channels or the open one actually changes,
-    // not on every badge-count refresh of the shared `channels` prop.
-    const subscriptionKey = computed(
-        () =>
-            `${channels.value.map((channel) => channel.id).join('|')}::${activeChannelId.value ?? ''}`,
-    );
-
-    const bound = new Set<string>();
-    let previousActiveId: string | null = null;
     let refreshTimer: ReturnType<typeof setTimeout> | null = null;
-
-    function channelName(id: string): string {
-        return `channel.${id}`;
-    }
 
     function scheduleRefresh(): void {
         if (refreshTimer) {
@@ -61,7 +42,7 @@ export function useSidebarBadges(): void {
         }, REFRESH_DEBOUNCE_MS);
     }
 
-    function handleMessage(channelId: string, message: Message): void {
+    useChannelFleetSubscription((channelId, message) => {
         const decision = shouldRefreshSidebar({
             isOwnMessage: message.user.id === currentUserId.value,
             isChannelMessage:
@@ -76,59 +57,11 @@ export function useSidebarBadges(): void {
         if (decision) {
             scheduleRefresh();
         }
-    }
-
-    function listen(id: string): void {
-        echo()
-            .private(channelName(id))
-            .listen('MessageSent', (message: Message) => {
-                handleMessage(id, message);
-            });
-    }
-
-    function reconcile(): void {
-        const desired = new Set(channels.value.map((channel) => channel.id));
-        const active = activeChannelId.value;
-
-        if (previousActiveId !== null && previousActiveId !== active) {
-            bound.delete(previousActiveId);
-        }
-
-        previousActiveId = active;
-
-        for (const id of desired) {
-            if (!bound.has(id)) {
-                listen(id);
-                bound.add(id);
-            }
-        }
-
-        for (const id of [...bound]) {
-            if (!desired.has(id)) {
-                echo().leave(channelName(id));
-                bound.delete(id);
-            }
-        }
-    }
-
-    function leaveAll(): void {
-        for (const id of bound) {
-            echo().leave(channelName(id));
-        }
-
-        bound.clear();
-    }
-
-    onMounted(reconcile);
-
-    // Post-flush so it runs after Show.vue's own per-channel teardown.
-    watch(subscriptionKey, reconcile, { flush: 'post' });
+    });
 
     onBeforeUnmount(() => {
         if (refreshTimer) {
             clearTimeout(refreshTimer);
         }
-
-        leaveAll();
     });
 }

--- a/resources/js/lib/channelFleet.test.ts
+++ b/resources/js/lib/channelFleet.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { createChannelFleet } from '@/lib/channelFleet';
+
+/**
+ * Drive a fleet with spy handlers, recording the sequence of subscribe/leave
+ * calls so a test can assert exactly which channels were touched and when.
+ */
+function trackedFleet() {
+    const subscribed: string[] = [];
+    const left: string[] = [];
+    const fleet = createChannelFleet({
+        subscribe: (id) => subscribed.push(id),
+        leave: (id) => left.push(id),
+    });
+
+    return { fleet, subscribed, left };
+}
+
+describe('createChannelFleet', () => {
+    it('subscribes each desired channel once and reports them as bound', () => {
+        const { fleet, subscribed } = trackedFleet();
+
+        fleet.reconcile(['a', 'b'], null);
+        fleet.reconcile(['a', 'b'], null);
+
+        expect(subscribed).toEqual(['a', 'b']);
+        expect(fleet.boundIds()).toEqual(['a', 'b']);
+    });
+
+    it('subscribes a newly added channel without re-subscribing the rest', () => {
+        const { fleet, subscribed } = trackedFleet();
+
+        fleet.reconcile(['a'], null);
+        fleet.reconcile(['a', 'b'], null);
+
+        expect(subscribed).toEqual(['a', 'b']);
+    });
+
+    it('leaves a channel that drops out of the desired set', () => {
+        const { fleet, subscribed, left } = trackedFleet();
+
+        fleet.reconcile(['a', 'b'], null);
+        fleet.reconcile(['a'], null);
+
+        expect(subscribed).toEqual(['a', 'b']);
+        expect(left).toEqual(['b']);
+        expect(fleet.boundIds()).toEqual(['a']);
+    });
+
+    it('re-subscribes the just-left active channel on handoff without leaving it itself', () => {
+        // The open-channel page owns the active channel's subscription and tears
+        // it down with a full leave on navigation, which also drops the fleet's
+        // listener on it. On the next reconcile the fleet must re-attach the
+        // channel it just moved away from — and must never call leave on it,
+        // since the page already did.
+        const { fleet, subscribed, left } = trackedFleet();
+
+        fleet.reconcile(['a', 'b'], 'a');
+        fleet.reconcile(['a', 'b'], 'b');
+
+        expect(subscribed).toEqual(['a', 'b', 'a']);
+        expect(left).toEqual([]);
+        expect(fleet.boundIds()).toEqual(['b', 'a']);
+    });
+
+    it('leaves every bound channel on teardown and forgets them', () => {
+        const { fleet, left } = trackedFleet();
+
+        fleet.reconcile(['a', 'b'], null);
+        fleet.leaveAll();
+
+        expect(left).toEqual(['a', 'b']);
+        expect(fleet.boundIds()).toEqual([]);
+    });
+});

--- a/resources/js/lib/channelFleet.ts
+++ b/resources/js/lib/channelFleet.ts
@@ -1,0 +1,85 @@
+/**
+ * The subscribe/reconcile/teardown bookkeeping for a *fleet* of channel
+ * subscriptions — the shared lifecycle behind sidebar badges, chime
+ * notifications, and the active channel. Pure and framework-free: it owns the
+ * bound-set diffing and the active-channel handoff, and defers the actual Echo
+ * subscribe/leave to injected handlers, so the tricky part is unit-testable
+ * without Vue or a live Echo mock.
+ */
+export interface ChannelFleetHandlers {
+    /** Attach a live subscription (an Echo private-channel listener) for an id. */
+    subscribe: (channelId: string) => void;
+    /** Tear down the subscription for an id. */
+    leave: (channelId: string) => void;
+}
+
+export interface ChannelFleet {
+    /**
+     * Reconcile the live subscriptions to `desired`, given which channel (if
+     * any) is currently open. New ids are subscribed, ids no longer desired are
+     * left. The open-channel page owns the *active* channel's subscription and
+     * tears it down with a full leave on navigation — which also drops this
+     * fleet's listener on it — so when the active channel changes the fleet
+     * forgets the previous one (without leaving it) and re-subscribes it on this
+     * pass if it is still desired.
+     */
+    reconcile: (
+        desired: Iterable<string>,
+        activeChannelId: string | null,
+    ) => void;
+    /** Leave every bound channel and forget them (component teardown). */
+    leaveAll: () => void;
+    /** The currently bound channel ids, for inspection and tests. */
+    boundIds: () => string[];
+}
+
+/**
+ * Create a channel fleet over the given subscribe/leave handlers.
+ */
+export function createChannelFleet(
+    handlers: ChannelFleetHandlers,
+): ChannelFleet {
+    const bound = new Set<string>();
+    let previousActiveId: string | null = null;
+
+    function reconcile(
+        desired: Iterable<string>,
+        activeChannelId: string | null,
+    ): void {
+        const desiredSet = new Set(desired);
+
+        if (previousActiveId !== null && previousActiveId !== activeChannelId) {
+            bound.delete(previousActiveId);
+        }
+
+        previousActiveId = activeChannelId;
+
+        for (const id of desiredSet) {
+            if (!bound.has(id)) {
+                handlers.subscribe(id);
+                bound.add(id);
+            }
+        }
+
+        for (const id of [...bound]) {
+            if (!desiredSet.has(id)) {
+                handlers.leave(id);
+                bound.delete(id);
+            }
+        }
+    }
+
+    function leaveAll(): void {
+        for (const id of bound) {
+            handlers.leave(id);
+        }
+
+        bound.clear();
+    }
+
+    function boundIds(): string[] {
+        return [...bound];
+    }
+
+    return { reconcile, leaveAll, boundIds };
+}


### PR DESCRIPTION
Closes #128. Part of the architecture-hardening epic (#131); targets the integration branch, not `master`. Implements **ADR-0006** (realtime lifecycles live in composables, pure cores in `lib/`).

## Problem

`composables/useSidebarBadges.ts` (134 lines) and `composables/useChimeNotifications.ts` (130 lines) were ~80% structurally identical — the same `subscriptionKey` computed, the same `bound` Set + `previousActiveId`, a near-verbatim `reconcile()` and `leaveAll()`, even the same post-flush teardown comment. The only real difference was what happens on a message (debounced sidebar reload vs. chime). Three hand-rolled copies of one subscribe/reconcile/teardown lifecycle (counting the open channel's own subscription), each a copy waiting to drift.

## Change

- **`lib/channelFleet.ts`** — a pure `createChannelFleet({ subscribe, leave })` core owning the bound-set diffing and the **active-channel handoff** (the open channel page leaves its own subscription on navigation, dropping the fleet's listener on it, so the fleet forgets the previous active id and re-subscribes it on the next pass). No Vue, no Echo — unit-tested directly (`channelFleet.test.ts`).
- **`composables/useChannelFleetSubscription.ts`** — the thin Vue+Echo wiring: it feeds the pure core the sidebar `channels` and the active channel, wires `subscribe`/`leave` to Echo, and drives `reconcile`/`leaveAll` from the component lifecycle (post-flush watch so it runs after the open channel's teardown).
- **`useSidebarBadges` / `useChimeNotifications`** — reduced to thin "what to do on a message" callbacks over the shared engine; no duplicated `reconcile` / `leaveAll` / `subscriptionKey`.

## Acceptance criteria

- [x] One composable owns the fleet subscribe/reconcile/teardown lifecycle
- [x] Badges and chimes are defined as callbacks over it; no duplicated `reconcile`/`leaveAll`/`subscriptionKey`
- [x] The reconcile/teardown behaviour (channel added/removed, active-channel handoff, teardown) is unit-tested once (`channelFleet.test.ts`, 5 cases)
- [x] Frontend gate green: `lint:check`, `format:check`, `types:check`, `build` (via Sail); `test:js` (166) covers the engine. Backend gate also green at 100%.