### PR TITLE
refactor(navigation): extract useChannelRealtime (#127)

### DIFF
--- a/resources/js/composables/useChannelRealtime.ts
+++ b/resources/js/composables/useChannelRealtime.ts
@@ -1,0 +1,187 @@
+import { echo } from '@laravel/echo-vue';
+import type { Ref } from 'vue';
+import { onBeforeUnmount, onMounted, watch } from 'vue';
+import type { useMessageStream } from '@/composables/useMessageStream';
+import type {
+    TypingUser,
+    useTypingIndicator,
+} from '@/composables/useTypingIndicator';
+import { createChannelFleet } from '@/lib/channelFleet';
+import { placeIncomingMessage } from '@/lib/messagePlacement';
+import type { ChannelReader, Message, MessageAuthor, Reaction } from '@/types';
+
+type MessageStream = ReturnType<typeof useMessageStream>;
+type TypingIndicator = ReturnType<typeof useTypingIndicator>;
+
+export interface ChannelRealtimeOptions {
+    /** The open channel's id; re-read on change to move the subscription. */
+    channelId: () => string;
+    /** The current viewer's id, to drop own read-echoes and own-reply dots. */
+    currentUserId: () => string;
+    /** The main channel timeline stream. */
+    mainStream: MessageStream;
+    /** The open thread panel's stream. */
+    threadStream: MessageStream;
+    /** The root id of the thread currently open in the panel, or `null`. */
+    activeThreadRootId: Ref<string | null>;
+    /** The main timeline's rendered messages, to resolve a root's follow state. */
+    displayMessages: () => Message[];
+    /** Whether thread unread dots are silenced for this channel. */
+    isThreadUnreadSuppressed: () => boolean;
+    /** The channel's read-receipt map, advanced by peers' `MessageRead`. */
+    readers: Ref<Map<string, ChannelReader>>;
+    /** Whether the viewer is scrolled near the bottom of the main timeline. */
+    isNearBottom: () => boolean;
+    /** Follow a live append down, or raise the "new messages" count instead. */
+    notifyAppended: (wasNearBottom: boolean) => void;
+    /** The channel's typing indicator, for whisper receipt and settle-on-send. */
+    typing: TypingIndicator;
+    /** Advance the channel's read pointer (a message landed while focused). */
+    markRead: () => void;
+    /** Advance the open thread's read pointer. */
+    markThreadRead: () => void;
+}
+
+/** The Echo private-channel name a channel id broadcasts on. */
+function channelName(id: string): string {
+    return `channel.${id}`;
+}
+
+/**
+ * Own the *active* channel's realtime lifecycle: subscribe to its Echo channel,
+ * route the five broadcast events plus typing whispers into the two message
+ * streams, and move the subscription when the open channel changes.
+ *
+ * The subscribe/leave bookkeeping rides {@see createChannelFleet} — the same
+ * engine behind {@see useChannelFleetSubscription} — driven as a single-element
+ * fleet: each reconcile passes `null` as the active id (so the fleet's
+ * active-channel handoff never engages) and the sole desired id, which leaves the
+ * channel just navigated away from and subscribes the new one. The placement of
+ * each arriving message is decided by the pure {@see placeIncomingMessage}, so
+ * this composable stays a thin bridge between Echo and the streams.
+ */
+export function useChannelRealtime(options: ChannelRealtimeOptions): void {
+    // An edit or deletion may touch either timeline (or both, for a
+    // sent-to-channel reply); patch both streams, since a patch is ignored where
+    // the message isn't rendered.
+    function applyPatch(message: Message): void {
+        options.mainStream.applyPatch(message);
+        options.threadStream.applyPatch(message);
+    }
+
+    // Route a broadcast message to the timeline it belongs to, following the main
+    // timeline down when the reader is near the bottom and reconciling the open
+    // thread's read state — all decided by `placeIncomingMessage`.
+    function routeIncoming(message: Message): void {
+        const root = options
+            .displayMessages()
+            .find((candidate) => candidate.id === message.threadRootId);
+
+        const placement = placeIncomingMessage({
+            threadRootId: message.threadRootId,
+            sentToChannel: message.sentToChannel,
+            isOwnMessage: message.user.id === options.currentUserId(),
+            activeThreadRootId: options.activeThreadRootId.value,
+            isTabFocused: document.hasFocus(),
+            isFollowedThread: root?.threadFollowed ?? false,
+            isThreadUnreadSuppressed: options.isThreadUnreadSuppressed(),
+        });
+
+        if (placement.appendToMain) {
+            const wasNearBottom = options.isNearBottom();
+
+            if (options.mainStream.appendLive(message)) {
+                options.notifyAppended(wasNearBottom);
+            }
+        }
+
+        if (placement.appendToThread) {
+            options.threadStream.appendLive(message);
+        }
+
+        if (placement.markThreadReadNow) {
+            options.markThreadRead();
+        }
+
+        if (placement.flagRootThreadUnread && message.threadRootId !== null) {
+            options.mainStream.patchThreadState(message.threadRootId, {
+                threadUnread: true,
+            });
+        }
+    }
+
+    const fleet = createChannelFleet({
+        subscribe(id) {
+            echo()
+                .private(channelName(id))
+                .listen('MessageSent', (message: Message) => {
+                    // Their message landed; stop showing them as typing.
+                    options.typing.forget(message.user.id);
+                    routeIncoming(message);
+                    // Keep the open, focused channel read as new messages arrive.
+                    options.markRead();
+                })
+                .listen('MessageUpdated', (message: Message) => {
+                    applyPatch(message);
+                })
+                .listen('MessageDeleted', (message: Message) => {
+                    applyPatch(message);
+                })
+                .listen(
+                    'MessageReactionChanged',
+                    (event: { messageId: string; reactions: Reaction[] }) => {
+                        // The authoritative, viewer-free summary; patch it into
+                        // whichever timeline renders the message (no-op elsewhere).
+                        options.mainStream.patchReactions(
+                            event.messageId,
+                            event.reactions,
+                        );
+                        options.threadStream.patchReactions(
+                            event.messageId,
+                            event.reactions,
+                        );
+                    },
+                )
+                .listen(
+                    'MessageRead',
+                    (event: {
+                        reader: MessageAuthor;
+                        lastReadMessageId: string;
+                    }) => {
+                        // Our own advance echoes back on the shared private
+                        // channel; the "Seen by" row never shows the viewer, so
+                        // drop it here.
+                        if (event.reader.id === options.currentUserId()) {
+                            return;
+                        }
+
+                        const next = new Map(options.readers.value);
+                        next.set(event.reader.id, {
+                            user: event.reader,
+                            lastReadMessageId: event.lastReadMessageId,
+                        });
+                        options.readers.value = next;
+                    },
+                )
+                .listenForWhisper('typing', (user: TypingUser) => {
+                    options.typing.receiveTyping(user);
+                });
+        },
+        leave(id) {
+            echo().leave(channelName(id));
+        },
+    });
+
+    // Drive the fleet as a single-channel subscription: `null` active id keeps the
+    // handoff dormant, so each reconcile leaves the previous channel and
+    // subscribes the current one.
+    function moveSubscription(): void {
+        fleet.reconcile([options.channelId()], null);
+    }
+
+    onMounted(moveSubscription);
+    watch(options.channelId, moveSubscription);
+    onBeforeUnmount(() => {
+        fleet.leaveAll();
+    });
+}

--- a/resources/js/lib/messagePlacement.test.ts
+++ b/resources/js/lib/messagePlacement.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { placeIncomingMessage } from '@/lib/messagePlacement';
+import type { IncomingPlacementInput } from '@/lib/messagePlacement';
+
+/**
+ * A qualifying baseline: a plain channel message (not a reply) arriving while the
+ * viewer has the tab focused and no thread open. Each test overrides one axis to
+ * probe a single routing branch.
+ */
+function input(
+    overrides: Partial<IncomingPlacementInput> = {},
+): IncomingPlacementInput {
+    return {
+        threadRootId: null,
+        sentToChannel: false,
+        isOwnMessage: false,
+        activeThreadRootId: null,
+        isTabFocused: true,
+        isFollowedThread: false,
+        isThreadUnreadSuppressed: false,
+        ...overrides,
+    };
+}
+
+describe('placeIncomingMessage', () => {
+    it('routes a plain channel message to the main timeline only', () => {
+        expect(placeIncomingMessage(input())).toEqual({
+            appendToMain: true,
+            appendToThread: false,
+            markThreadReadNow: false,
+            flagRootThreadUnread: false,
+        });
+    });
+
+    it('keeps a thread reply out of the main timeline and out of a closed thread', () => {
+        expect(placeIncomingMessage(input({ threadRootId: 'root-1' }))).toEqual(
+            {
+                appendToMain: false,
+                appendToThread: false,
+                markThreadReadNow: false,
+                flagRootThreadUnread: false,
+            },
+        );
+    });
+
+    it('lands a sent-to-channel reply in the main timeline as well', () => {
+        const placement = placeIncomingMessage(
+            input({ threadRootId: 'root-1', sentToChannel: true }),
+        );
+
+        expect(placement.appendToMain).toBe(true);
+    });
+
+    it('appends a reply into the open thread and marks it read while focused', () => {
+        expect(
+            placeIncomingMessage(
+                input({ threadRootId: 'root-1', activeThreadRootId: 'root-1' }),
+            ),
+        ).toEqual({
+            appendToMain: false,
+            appendToThread: true,
+            markThreadReadNow: true,
+            flagRootThreadUnread: false,
+        });
+    });
+
+    it('does not mark-read a reply in the open thread when the tab is blurred', () => {
+        const placement = placeIncomingMessage(
+            input({
+                threadRootId: 'root-1',
+                activeThreadRootId: 'root-1',
+                isTabFocused: false,
+                isFollowedThread: true,
+            }),
+        );
+
+        expect(placement.appendToThread).toBe(true);
+        expect(placement.markThreadReadNow).toBe(false);
+        expect(placement.flagRootThreadUnread).toBe(true);
+    });
+
+    it('flags a followed thread whose reply arrives while it is closed', () => {
+        const placement = placeIncomingMessage(
+            input({ threadRootId: 'root-1', isFollowedThread: true }),
+        );
+
+        expect(placement.appendToThread).toBe(false);
+        expect(placement.flagRootThreadUnread).toBe(true);
+    });
+
+    it("never flags the viewer's own reply", () => {
+        const placement = placeIncomingMessage(
+            input({
+                threadRootId: 'root-1',
+                isFollowedThread: true,
+                isOwnMessage: true,
+            }),
+        );
+
+        expect(placement.flagRootThreadUnread).toBe(false);
+    });
+
+    it('never flags when thread unread dots are suppressed for the channel', () => {
+        const placement = placeIncomingMessage(
+            input({
+                threadRootId: 'root-1',
+                isFollowedThread: true,
+                isThreadUnreadSuppressed: true,
+            }),
+        );
+
+        expect(placement.flagRootThreadUnread).toBe(false);
+    });
+});

--- a/resources/js/lib/messagePlacement.ts
+++ b/resources/js/lib/messagePlacement.ts
@@ -1,0 +1,69 @@
+import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
+
+export type IncomingPlacementInput = {
+    /** The reply's root message id, or `null` for a top-level channel message. */
+    threadRootId: string | null;
+    /** A thread reply the author also chose to echo into the channel timeline. */
+    sentToChannel: boolean;
+    /** The arriving message was authored by the current viewer. */
+    isOwnMessage: boolean;
+    /** The root id of the thread currently open in the panel, or `null`. */
+    activeThreadRootId: string | null;
+    /** The tab is focused, so an open thread's replies are actively being read. */
+    isTabFocused: boolean;
+    /**
+     * The viewer follows the reply's thread (authored its root, replied, or was
+     * @mentioned); only followed threads raise a dot. See {@see shouldFlagThreadUnread}.
+     */
+    isFollowedThread: boolean;
+    /** Thread dots are silenced for this channel (muted or below "all"). */
+    isThreadUnreadSuppressed: boolean;
+};
+
+export type IncomingPlacement = {
+    /** Append the message to the main channel timeline. */
+    appendToMain: boolean;
+    /** Append the message to the open thread panel. */
+    appendToThread: boolean;
+    /** Advance the open thread's read pointer now (it's focused, so already read). */
+    markThreadReadNow: boolean;
+    /** Raise the unread dot on the reply's root back in the main timeline. */
+    flagRootThreadUnread: boolean;
+};
+
+/**
+ * Decide where a freshly-arrived realtime message belongs: the main timeline, the
+ * open thread, both, or neither — and whether it advances or dots the thread's
+ * read state.
+ *
+ * This is the pure decision core of `Show.vue`'s realtime routing. A top-level
+ * message (or a reply explicitly sent to the channel) shows in the main timeline;
+ * a reply into the *open* thread appends there and, while the tab is focused,
+ * keeps that thread read; a reply into a *closed* followed thread raises its
+ * unread dot instead — the last branch deferring to {@see shouldFlagThreadUnread}
+ * so a live dot and a navigation-time dot agree.
+ */
+export function placeIncomingMessage(
+    input: IncomingPlacementInput,
+): IncomingPlacement {
+    const isReply = input.threadRootId !== null;
+    const isActiveThread =
+        isReply && input.threadRootId === input.activeThreadRootId;
+    const isViewingThreadFocused = isActiveThread && input.isTabFocused;
+
+    return {
+        appendToMain: !isReply || input.sentToChannel,
+        appendToThread: isActiveThread,
+        markThreadReadNow: isViewingThreadFocused,
+        flagRootThreadUnread:
+            isReply &&
+            !isViewingThreadFocused &&
+            shouldFlagThreadUnread({
+                isReply: true,
+                isOwnReply: input.isOwnMessage,
+                isFollowedThread: input.isFollowedThread,
+                isViewingThreadFocused: false,
+                isSuppressed: input.isThreadUnreadSuppressed,
+            }),
+    };
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -72,6 +72,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useChannelRealtime } from '@/composables/useChannelRealtime';
 import {
     useMessageStream,
     optimisticMessage,
@@ -82,18 +83,15 @@ import { useTimezone } from '@/composables/useTimezone';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
 import { toggleReaction } from '@/lib/reactions';
-import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
 import { unreadDividerMessageId } from '@/lib/unreadDivider';
 import type {
     Channel,
     ChannelReader,
     Mention,
     Message,
-    MessageAuthor,
     MessagePage,
     NotificationLevel,
     NotificationLevelOption,
-    Reaction,
     ScheduledMessage,
     Thread,
 } from '@/types';
@@ -306,66 +304,6 @@ function scrollToUnread(): void {
         ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
 }
 
-// Append a message to the main timeline. When the reader was near the bottom the
-// view follows it down; otherwise the arrival raises the "new messages" count on
-// the jump-to-latest control instead of scrolling silently.
-function appendLiveMain(message: Message): void {
-    const wasNearBottom = isNearBottom();
-
-    if (mainStream.appendLive(message)) {
-        notifyAppended(wasNearBottom);
-    }
-}
-
-// Route a broadcast message to the timeline it belongs to. A thread reply stays
-// out of the main timeline unless it was explicitly "also sent to channel"; the
-// open thread only appends replies belonging to its root. The two are not
-// exclusive — a sent-to-channel reply in the open thread lands in both.
-function routeIncoming(message: Message): void {
-    if (message.threadRootId === null || message.sentToChannel) {
-        appendLiveMain(message);
-    }
-
-    if (
-        message.threadRootId !== null &&
-        message.threadRootId === activeThreadRootId.value
-    ) {
-        threadStream.appendLive(message);
-    }
-
-    // A thread reply either keeps the open, focused thread read as it streams in,
-    // or raises the unread dot on its root back in the main timeline.
-    if (message.threadRootId !== null) {
-        const viewingThreadFocused =
-            message.threadRootId === activeThreadRootId.value &&
-            document.hasFocus();
-
-        if (viewingThreadFocused) {
-            markThreadRead();
-
-            return;
-        }
-
-        const root = displayMessages.value.find(
-            (candidate) => candidate.id === message.threadRootId,
-        );
-
-        if (
-            shouldFlagThreadUnread({
-                isReply: true,
-                isOwnReply: message.user.id === currentUser.value.id,
-                isFollowedThread: root?.threadFollowed ?? false,
-                isViewingThreadFocused: false,
-                isSuppressed: threadUnreadSuppressed.value,
-            })
-        ) {
-            mainStream.patchThreadState(message.threadRootId, {
-                threadUnread: true,
-            });
-        }
-    }
-}
-
 // Advance the open thread's read pointer so its unread dot clears, mirroring the
 // channel's markRead: debounced, gated on focus, and optimistically clearing the
 // dot on the root back in the main timeline.
@@ -401,65 +339,6 @@ function channelName(id: string): string {
     return `channel.${id}`;
 }
 
-// An edit or deletion may touch either timeline (or both, for a sent-to-channel
-// reply); patch both streams, since a patch is ignored where the message isn't
-// rendered.
-function applyPatch(message: Message): void {
-    mainStream.applyPatch(message);
-    threadStream.applyPatch(message);
-}
-
-function subscribe(id: string): void {
-    echo()
-        .private(channelName(id))
-        .listen('MessageSent', (message: Message) => {
-            // Their message landed; stop showing them as typing.
-            typing.forget(message.user.id);
-            routeIncoming(message);
-            // Keep the open, focused channel read as new messages arrive.
-            markRead();
-        })
-        .listen('MessageUpdated', (message: Message) => {
-            applyPatch(message);
-        })
-        .listen('MessageDeleted', (message: Message) => {
-            applyPatch(message);
-        })
-        .listen(
-            'MessageReactionChanged',
-            (event: { messageId: string; reactions: Reaction[] }) => {
-                // The authoritative, viewer-free summary; patch it into whichever
-                // timeline renders the message (the patch is a no-op elsewhere).
-                mainStream.patchReactions(event.messageId, event.reactions);
-                threadStream.patchReactions(event.messageId, event.reactions);
-            },
-        )
-        .listen(
-            'MessageRead',
-            (event: { reader: MessageAuthor; lastReadMessageId: string }) => {
-                // Our own advance echoes back on the shared private channel; the
-                // "Seen by" row never shows the viewer, so drop it here.
-                if (event.reader.id === currentUser.value.id) {
-                    return;
-                }
-
-                const next = new Map(readers.value);
-                next.set(event.reader.id, {
-                    user: event.reader,
-                    lastReadMessageId: event.lastReadMessageId,
-                });
-                readers.value = next;
-            },
-        )
-        .listenForWhisper('typing', (user: TypingUser) => {
-            typing.receiveTyping(user);
-        });
-}
-
-function unsubscribe(id: string): void {
-    echo().leave(channelName(id));
-}
-
 // Advance the read pointer for the open channel so its sidebar badge clears.
 // Debounced and gated on tab focus: a channel is only "read" while the user is
 // actually looking at it, and a burst of arriving messages collapses to one
@@ -487,8 +366,26 @@ function markRead(): void {
     }, 400);
 }
 
+// The active channel's Echo subscribe/route/teardown lives in this composable: it
+// moves the subscription as the open channel changes and routes each broadcast
+// into the two streams. `Show.vue` only supplies the state it reconciles against.
+useChannelRealtime({
+    channelId: () => props.channel.id,
+    currentUserId: () => currentUser.value.id,
+    mainStream,
+    threadStream,
+    activeThreadRootId,
+    displayMessages: () => displayMessages.value,
+    isThreadUnreadSuppressed: () => threadUnreadSuppressed.value,
+    readers,
+    isNearBottom,
+    notifyAppended,
+    typing,
+    markRead,
+    markThreadRead,
+});
+
 onMounted(() => {
-    subscribe(props.channel.id);
     seedReaders();
     computeUnreadDivider();
     markRead();
@@ -531,18 +428,15 @@ watch(
     },
 );
 
-// Inertia may reuse this page component when navigating between channels; move
-// the subscription and reset per-channel state when the channel changes.
+// Inertia may reuse this page component when navigating between channels; reset
+// per-channel state when the channel changes. `useChannelRealtime` moves the Echo
+// subscription on the same change via its own watcher.
 watch(
     () => props.channel.id,
-    (newId, oldId) => {
+    () => {
         // Persist the outgoing channel's draft before switching; `pendingDraft`
         // still carries the old channel's slug, so it writes to the right place.
         flushDraft();
-
-        if (oldId) {
-            unsubscribe(oldId);
-        }
 
         mainStream.reset();
         resetScrollPin();
@@ -552,7 +446,6 @@ watch(
         notificationLevel.value = props.channel.notificationLevel;
         muted.value = props.channel.muted;
         starred.value = props.channel.starred;
-        subscribe(newId);
         seedReaders();
         computeUnreadDivider();
         markRead();
@@ -563,7 +456,6 @@ onBeforeUnmount(() => {
     // Leaving the workspace (or a full navigation away) still persists a
     // just-typed draft that the debounce hasn't written yet.
     flushDraft();
-    unsubscribe(props.channel.id);
     unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
     window.removeEventListener('focus', markThreadRead);
@@ -944,6 +836,15 @@ function appendPendingMain(message: Message): void {
     if (pinned) {
         nextTick(() => scrollToBottom());
     }
+}
+
+// Patch a message into both timelines at once — it may render in either (or both,
+// for a sent-to-channel reply), and a patch is ignored where it isn't shown. Used
+// by the optimistic edit/delete paths; the realtime echo re-applies it via
+// `useChannelRealtime`.
+function applyPatch(message: Message): void {
+    mainStream.applyPatch(message);
+    threadStream.applyPatch(message);
 }
 
 function editMessage(message: Message, body: string): void {


### PR DESCRIPTION
## Problem

The active channel's realtime wiring — subscribing to its Echo channel, routing `MessageSent` / `MessageUpdated` / `MessageDeleted` / `MessageReactionChanged` / `MessageRead` plus typing whispers into the two `useMessageStream` instances, and deciding main-vs-thread placement — was inlined in `pages/channels/Show.vue` (~324–367, 400–461) with no seam. It was reachable only through a mounted component and a live Echo mock, while the *pure* helper it should lean on (`shouldFlagThreadUnread`) was tested but its caller was not.

## Change

Give the realtime protocol a seam, with its decision core pushed into a pure `lib/` helper:

- **`lib/messagePlacement.ts`** — `placeIncomingMessage(input)`, the pure decision core. Given a broadcast message and the viewer's context it returns `{ appendToMain, appendToThread, markThreadReadNow, flagRootThreadUnread }`. It composes the existing `shouldFlagThreadUnread` (giving that helper a tested caller). Paired `messagePlacement.test.ts` covers channel-vs-thread routing, focus-gated mark-read, and the unread-flag branches.
- **`composables/useChannelRealtime.ts`** — owns the active channel's subscribe/route/teardown and moves the subscription when the open channel changes. The subscribe/leave bookkeeping rides **`createChannelFleet`** (the #128 engine) driven as a single-element fleet, so both realtime composables share one tested reconcile/teardown lifecycle instead of hand-rolling it a third time.
- **`Show.vue`** — no longer inlines subscribe/route/teardown; drops ~100 lines. Keeps only the local `applyPatch` its optimistic edit/delete paths still need.

## Acceptance criteria

- [x] Channel realtime wiring lives in the composable; `Show.vue` no longer inlines subscribe/route/teardown.
- [x] The placement/routing decision is a pure `lib/` function with a `*.test.ts` covering channel-vs-thread, focus-gated mark-read, and unread-flag branches.
- [x] `./vendor/bin/sail npm run test:js` covers the new helper; existing suites pass (174 tests).
- [x] Frontend gate green: `lint:check`, `format:check`, `types:check`, `build` (via Sail). Backend `composer test` green at 100% coverage.

## ADR

Per [ADR-0006](../blob/chore/architecture-hardening-scaffold/docs/adr/0006-realtime-lives-in-composables.md) (realtime lives in composables) and the `useChannelRealtime` entry in `CONTEXT.md`. Part of epic #131.