### PR TITLE
refactor(platform): extract useDebouncedPost (#129)

### DIFF
--- a/resources/js/composables/useDebouncedPost.test.ts
+++ b/resources/js/composables/useDebouncedPost.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope } from 'vue';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
+import type {
+    DebouncedPost,
+    DebouncedPostOptions,
+} from '@/composables/useDebouncedPost';
+
+/**
+ * Run the composable inside a disposable effect scope so `onScopeDispose` — the
+ * auto-teardown — can be exercised by stopping the scope, standing in for a
+ * component unmount.
+ */
+function withScope<T>(
+    run: (payload: T) => void,
+    options: DebouncedPostOptions,
+): { post: DebouncedPost<T>; unmount: () => void } {
+    const scope = effectScope();
+    let post!: DebouncedPost<T>;
+
+    scope.run(() => {
+        post = useDebouncedPost(run, options);
+    });
+
+    return { post, unmount: () => scope.stop() };
+}
+
+describe('useDebouncedPost', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('runs the action once, with the payload, after the delay elapses', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('a');
+        expect(run).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(399);
+        expect(run).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1);
+        expect(run).toHaveBeenCalledExactlyOnceWith('a');
+    });
+
+    it('coalesces a burst into a single run carrying the latest payload', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('first');
+        vi.advanceTimersByTime(200);
+        post.schedule('second');
+        vi.advanceTimersByTime(200);
+        // The window restarted on the second call, so nothing has fired yet.
+        expect(run).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(200);
+        expect(run).toHaveBeenCalledExactlyOnceWith('second');
+    });
+
+    it('flushes the pending payload immediately and cancels the timer', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('now');
+        post.flush();
+        expect(run).toHaveBeenCalledExactlyOnceWith('now');
+
+        // The timer was cancelled by the flush, so it never fires a second time.
+        vi.advanceTimersByTime(400);
+        expect(run).toHaveBeenCalledOnce();
+    });
+
+    it('flush is a no-op when nothing is pending', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.flush();
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('cancel drops a pending run without firing it', () => {
+        const run = vi.fn();
+        const { post } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('dropped');
+        post.cancel();
+
+        vi.advanceTimersByTime(400);
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('drops a call made while the gate is closed, leaving no timer', () => {
+        const run = vi.fn();
+        let focused = false;
+        const { post } = withScope<string>(run, {
+            delay: 400,
+            gate: () => focused,
+        });
+
+        post.schedule('blurred');
+        vi.advanceTimersByTime(400);
+        expect(run).not.toHaveBeenCalled();
+
+        focused = true;
+        post.schedule('focused');
+        vi.advanceTimersByTime(400);
+        expect(run).toHaveBeenCalledExactlyOnceWith('focused');
+    });
+
+    it('cancels a pending run on scope teardown by default', () => {
+        const run = vi.fn();
+        const { post, unmount } = withScope<string>(run, { delay: 400 });
+
+        post.schedule('pending');
+        unmount();
+
+        vi.advanceTimersByTime(400);
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('flushes a pending run on scope teardown when flushOnUnmount is set', () => {
+        const run = vi.fn();
+        const { post, unmount } = withScope<string>(run, {
+            delay: 400,
+            flushOnUnmount: true,
+        });
+
+        post.schedule('kept');
+        unmount();
+
+        expect(run).toHaveBeenCalledExactlyOnceWith('kept');
+    });
+});

--- a/resources/js/composables/useDebouncedPost.ts
+++ b/resources/js/composables/useDebouncedPost.ts
@@ -1,0 +1,97 @@
+import { onScopeDispose } from 'vue';
+
+export interface DebouncedPostOptions {
+    /** Milliseconds to coalesce a burst of `schedule` calls into a single run. */
+    delay: number;
+    /**
+     * Checked at `schedule` time: when it returns false the call is dropped and
+     * any already-pending run is left untouched. Used to gate reads on tab focus
+     * (`() => document.hasFocus()`) so a channel is only marked read while looked
+     * at. Omit for an ungated post.
+     */
+    gate?: () => boolean;
+    /**
+     * Fire a pending run on teardown instead of dropping it. Draft persistence
+     * sets this so a just-typed draft outlives an unmount; reads leave it false so
+     * a stale mark-read never fires after the view is gone.
+     */
+    flushOnUnmount?: boolean;
+}
+
+export interface DebouncedPost<T> {
+    /** Restart the debounce window, remembering `payload` as the latest to run. */
+    schedule: (payload: T) => void;
+    /** Run the pending payload now, cancelling the timer; a no-op when idle. */
+    flush: () => void;
+    /** Drop any pending run without firing it. */
+    cancel: () => void;
+}
+
+/**
+ * The one debounced, optionally gated, auto-torn-down `router` POST/PATCH behind
+ * mark-read, mark-thread-read, draft persistence, sidebar-badge refresh, and
+ * search — each of which had hand-rolled its own timer handle, `clearTimeout`
+ * dance, and `onBeforeUnmount` cleanup.
+ *
+ * `run` receives the latest scheduled payload; a burst of `schedule` calls within
+ * `delay` collapses to one run. The timer is owned here and disposed with the
+ * surrounding effect scope (component unmount), so callers keep only *what* to
+ * post, not the bookkeeping.
+ */
+export function useDebouncedPost<T = void>(
+    run: (payload: T) => void,
+    options: DebouncedPostOptions,
+): DebouncedPost<T> {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let pending: { payload: T } | null = null;
+
+    function clearTimer(): void {
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    }
+
+    function fire(): void {
+        if (!pending) {
+            return;
+        }
+
+        const { payload } = pending;
+        pending = null;
+        run(payload);
+    }
+
+    function schedule(payload: T): void {
+        if (options.gate && !options.gate()) {
+            return;
+        }
+
+        pending = { payload };
+        clearTimer();
+        timer = setTimeout(() => {
+            timer = null;
+            fire();
+        }, options.delay);
+    }
+
+    function flush(): void {
+        clearTimer();
+        fire();
+    }
+
+    function cancel(): void {
+        clearTimer();
+        pending = null;
+    }
+
+    onScopeDispose(() => {
+        if (options.flushOnUnmount) {
+            flush();
+        } else {
+            cancel();
+        }
+    });
+
+    return { schedule, flush, cancel };
+}

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -1,6 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
-import { computed, onBeforeUnmount } from 'vue';
+import { computed } from 'vue';
 import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
 
 /** Coalesce a burst of arrivals into a single sidebar reload. */
@@ -27,20 +28,13 @@ export function useSidebarBadges(): void {
         () => (page.props.channel as { id?: string } | undefined)?.id ?? null,
     );
 
-    let refreshTimer: ReturnType<typeof setTimeout> | null = null;
-
-    function scheduleRefresh(): void {
-        if (refreshTimer) {
-            clearTimeout(refreshTimer);
-        }
-
-        refreshTimer = setTimeout(() => {
-            // reload defaults to preserving scroll and page state; it re-evaluates
-            // the shared `channels` prop to recompute every badge count, plus the
-            // aggregate `hasUnreadThreads` flag behind the sidebar's Threads dot.
-            router.reload({ only: ['channels', 'hasUnreadThreads'] });
-        }, REFRESH_DEBOUNCE_MS);
-    }
+    // reload defaults to preserving scroll and page state; it re-evaluates the
+    // shared `channels` prop to recompute every badge count, plus the aggregate
+    // `hasUnreadThreads` flag behind the sidebar's Threads dot.
+    const refresh = useDebouncedPost(
+        () => router.reload({ only: ['channels', 'hasUnreadThreads'] }),
+        { delay: REFRESH_DEBOUNCE_MS },
+    );
 
     useChannelFleetSubscription((channelId, message) => {
         const decision = shouldRefreshSidebar({
@@ -55,13 +49,7 @@ export function useSidebarBadges(): void {
         });
 
         if (decision) {
-            scheduleRefresh();
-        }
-    });
-
-    onBeforeUnmount(() => {
-        if (refreshTimer) {
-            clearTimeout(refreshTimer);
+            refresh.schedule();
         }
     });
 }

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -9,6 +9,7 @@ import {
 import { index as search } from '@/actions/App/Http/Controllers/Channels/SearchController';
 import { Input } from '@/components/ui/input';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { getInitials } from '@/composables/useInitials';
 import { formatDateTime } from '@/lib/datetime';
 import { renderMessageBody } from '@/lib/messageBody';
@@ -32,14 +33,8 @@ const term = ref(props.query);
 
 // Debounce keystrokes into a single scoped reload that only refreshes the
 // results (and the echoed query), preserving the input's focus and caret.
-let debounce: ReturnType<typeof setTimeout> | null = null;
-
-watch(term, (value) => {
-    if (debounce) {
-        clearTimeout(debounce);
-    }
-
-    debounce = setTimeout(() => {
+const searchPost = useDebouncedPost(
+    (value: string) => {
         router.get(
             search(props.team.slug).url,
             { q: value },
@@ -50,7 +45,12 @@ watch(term, (value) => {
                 only: ['results', 'query'],
             },
         );
-    }, 300);
+    },
+    { delay: 300 },
+);
+
+watch(term, (value) => {
+    searchPost.schedule(value);
 });
 
 const page = usePage();

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -73,6 +73,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useChannelRealtime } from '@/composables/useChannelRealtime';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import {
     useMessageStream,
     optimisticMessage,
@@ -306,21 +307,10 @@ function scrollToUnread(): void {
 
 // Advance the open thread's read pointer so its unread dot clears, mirroring the
 // channel's markRead: debounced, gated on focus, and optimistically clearing the
-// dot on the root back in the main timeline.
-let threadReadTimer: ReturnType<typeof setTimeout> | null = null;
-
-function markThreadRead(): void {
-    const rootId = activeThreadRootId.value;
-
-    if (!rootId || !document.hasFocus()) {
-        return;
-    }
-
-    if (threadReadTimer) {
-        clearTimeout(threadReadTimer);
-    }
-
-    threadReadTimer = setTimeout(() => {
+// dot on the root back in the main timeline. The root id is captured as the
+// debounced payload so a fire uses the thread that was open when it was scheduled.
+const threadReadPost = useDebouncedPost(
+    (rootId: string) => {
         router.post(
             markThreadReadAction({
                 team: props.team.slug,
@@ -332,7 +322,18 @@ function markThreadRead(): void {
         );
 
         mainStream.patchThreadState(rootId, { threadUnread: false });
-    }, 400);
+    },
+    { delay: 400, gate: () => document.hasFocus() },
+);
+
+function markThreadRead(): void {
+    const rootId = activeThreadRootId.value;
+
+    if (!rootId) {
+        return;
+    }
+
+    threadReadPost.schedule(rootId);
 }
 
 function channelName(id: string): string {
@@ -343,18 +344,8 @@ function channelName(id: string): string {
 // Debounced and gated on tab focus: a channel is only "read" while the user is
 // actually looking at it, and a burst of arriving messages collapses to one
 // request. The redirect refreshes just the shared `channels` prop.
-let markReadTimer: ReturnType<typeof setTimeout> | null = null;
-
-function markRead(): void {
-    if (!document.hasFocus()) {
-        return;
-    }
-
-    if (markReadTimer) {
-        clearTimeout(markReadTimer);
-    }
-
-    markReadTimer = setTimeout(() => {
+const readPost = useDebouncedPost(
+    () => {
         router.post(
             markChannelRead({
                 team: props.team.slug,
@@ -363,7 +354,12 @@ function markRead(): void {
             {},
             { preserveScroll: true, preserveState: true, only: ['channels'] },
         );
-    }, 400);
+    },
+    { delay: 400, gate: () => document.hasFocus() },
+);
+
+function markRead(): void {
+    readPost.schedule();
 }
 
 // The active channel's Echo subscribe/route/teardown lives in this composable: it
@@ -434,9 +430,10 @@ watch(
 watch(
     () => props.channel.id,
     () => {
-        // Persist the outgoing channel's draft before switching; `pendingDraft`
-        // still carries the old channel's slug, so it writes to the right place.
-        flushDraft();
+        // Persist the outgoing channel's draft before switching; the pending
+        // payload still carries the old channel's slug, so it writes to the right
+        // place.
+        draftPost.flush();
 
         mainStream.reset();
         resetScrollPin();
@@ -453,20 +450,12 @@ watch(
 );
 
 onBeforeUnmount(() => {
-    // Leaving the workspace (or a full navigation away) still persists a
-    // just-typed draft that the debounce hasn't written yet.
-    flushDraft();
+    // The draft persists itself on teardown (flushOnUnmount) and the read posts
+    // cancel themselves, so leaving the workspace neither loses a just-typed draft
+    // nor fires a stale mark-read.
     unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
     window.removeEventListener('focus', markThreadRead);
-
-    if (markReadTimer) {
-        clearTimeout(markReadTimer);
-    }
-
-    if (threadReadTimer) {
-        clearTimeout(threadReadTimer);
-    }
 
     if (highlightTimer) {
         clearTimeout(highlightTimer);
@@ -582,13 +571,6 @@ function forwardMessage({
 // send clears the draft server-side, so only manual edits flow through here.
 const DRAFT_DEBOUNCE_MS = 700;
 
-let draftTimer: ReturnType<typeof setTimeout> | null = null;
-
-// The latest pending draft, tagged with the slug of the channel it belongs to,
-// so a flush triggered by switching channels still writes to the channel that
-// was actually being edited rather than the one just navigated to.
-let pendingDraft: { slug: string; body: string } | null = null;
-
 function persistDraft(slug: string, body: string): void {
     router.patch(
         saveChannelDraft({ team: props.team.slug, channel: slug }).url,
@@ -597,40 +579,25 @@ function persistDraft(slug: string, body: string): void {
     );
 }
 
-// Write any pending draft immediately, cancelling the debounce. Called before
-// leaving the channel so a just-typed draft is never lost to an unfired timer.
-function flushDraft(): void {
-    if (draftTimer) {
-        clearTimeout(draftTimer);
-        draftTimer = null;
-    }
-
-    if (pendingDraft) {
-        persistDraft(pendingDraft.slug, pendingDraft.body);
-        pendingDraft = null;
-    }
-}
+// The debounced draft save. The payload is tagged with the slug of the channel it
+// belongs to, so a flush triggered by switching channels still writes to the
+// channel that was actually being edited rather than the one just navigated to.
+// It flushes on unmount so a just-typed draft is never lost to an unfired timer.
+const draftPost = useDebouncedPost(
+    (draft: { slug: string; body: string }) =>
+        persistDraft(draft.slug, draft.body),
+    { delay: DRAFT_DEBOUNCE_MS, flushOnUnmount: true },
+);
 
 // Debounce a draft save for the current channel; an empty body clears it.
 function onDraftChange(body: string): void {
-    pendingDraft = { slug: props.channel.slug, body };
-
-    if (draftTimer) {
-        clearTimeout(draftTimer);
-    }
-
-    draftTimer = setTimeout(flushDraft, DRAFT_DEBOUNCE_MS);
+    draftPost.schedule({ slug: props.channel.slug, body });
 }
 
 function send(body: string, mentions: Mention[]): void {
     // Sending clears the draft server-side, so drop any debounced save still in
     // flight; otherwise it would re-persist the just-sent text after the clear.
-    if (draftTimer) {
-        clearTimeout(draftTimer);
-        draftTimer = null;
-    }
-
-    pendingDraft = null;
+    draftPost.cancel();
 
     const clientUuid = crypto.randomUUID();
     const target = replyTarget.value;
@@ -681,12 +648,7 @@ function scheduleMessage(
     _mentions: Mention[],
     sendAt: string,
 ): void {
-    if (draftTimer) {
-        clearTimeout(draftTimer);
-        draftTimer = null;
-    }
-
-    pendingDraft = null;
+    draftPost.cancel();
 
     const target = replyTarget.value;
 


### PR DESCRIPTION
## Problem

The shape "clear prior timer, `setTimeout`, `router` POST/PATCH with
`preserveScroll`/`preserveState`/`only`, gated on `document.hasFocus()`, with a
flush-immediately escape hatch, torn down on unmount" was hand-rolled five times,
each with its own timer handle and manual `clearTimeout`:

- `Show.vue` mark-read, mark-thread-read, and draft persistence
- `useSidebarBadges` refresh
- `Search.vue` keystroke search

Timer and teardown correctness was reimplemented — and left untested — five times.

## Change

- **`composables/useDebouncedPost.ts`** — `useDebouncedPost(run, { delay, gate?,
  flushOnUnmount? })` owns the timer, the flush/cancel escape hatches, and the
  teardown. `run` receives the latest scheduled payload; a burst within `delay`
  collapses to one run. The optional `gate` drops a call at schedule time (focus-
  gating reads), and the timer disposes with the surrounding effect scope via
  `onScopeDispose`, so callers keep only what to post.
- **Paired `useDebouncedPost.test.ts`** — covers the timer, coalescing to the
  latest payload, flush, cancel, the gate, and both teardown modes (cancel by
  default, flush when `flushOnUnmount`).
- **The five sites route through it.** mark-read / mark-thread-read collapse to a
  parameterized call gated on `document.hasFocus()`, the thread root carried as
  the payload. Draft persistence keeps only its channel-slug tagging (now the
  payload) and sets `flushOnUnmount` so a just-typed draft still saves on
  navigation away.

`Show.vue` drops ~50 lines, and no manual `clearTimeout` remains in these posts'
teardown.

## Acceptance criteria

- [x] One composable owns the debounce/flush/teardown; the 5 copies route through it.
- [x] No manual `clearTimeout` blocks left in `onBeforeUnmount` for these posts.
- [x] The timer/flush/focus-gate behaviour is unit-tested once (8 tests).
- [x] Frontend gate green: `lint:check`, `format:check`, `types:check`, `build`,
      `test:js` (182). Backend `composer test` green at 100% coverage.

Part of epic #131; targets `chore/architecture-hardening-scaffold`.
