### PR TITLE
refactor(messaging): extract ChannelTimelineWindow read-model (#125)

### DIFF
--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -9,7 +9,6 @@ use App\Actions\Channels\MarkChannelRead;
 use App\Actions\Channels\MarkThreadRead;
 use App\Data\ChannelData;
 use App\Data\ChannelReaderData;
-use App\Data\MessageData;
 use App\Data\ScheduledMessageData;
 use App\Data\UserData;
 use App\Enums\AuditAction;
@@ -21,8 +20,7 @@ use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
 use App\Support\AuditRecorder;
-use Illuminate\Contracts\Pagination\CursorPaginator;
-use Illuminate\Database\Eloquent\Builder;
+use App\Support\ChannelTimelineWindow;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -31,32 +29,6 @@ use Inertia\Response;
 
 class ChannelController extends Controller
 {
-    /**
-     * How many messages newer than a jump target to keep loaded below it, so a
-     * jumped-to message shows following context and is not pinned to the bottom.
-     */
-    private const int JUMP_CONTEXT = 15;
-
-    /**
-     * How many messages the initial timeline window loads. Mirrors the page size
-     * of {@see Builder::cursorPaginate()} below and
-     * feeds the read-boundary window math.
-     */
-    private const int MESSAGE_PAGE_SIZE = 50;
-
-    /**
-     * How many replies a thread page loads. The panel pages older replies in on
-     * scroll-up, mirroring the main timeline.
-     */
-    private const int THREAD_PAGE_SIZE = 50;
-
-    /**
-     * How many already-read messages to keep loaded above the "New messages"
-     * boundary when a channel opens deep enough into unread history that the
-     * boundary would otherwise fall outside the initial window.
-     */
-    private const int UNREAD_CONTEXT = 10;
-
     /**
      * Redirect a bare team URL to the team's #general channel.
      */
@@ -107,17 +79,18 @@ class ChannelController extends Controller
         // non-member has no pivot row, so the composer opens empty.
         $channel->setAttribute('draft', $membership?->draft);
 
-        // When arriving from a search result the URL carries the target message
-        // id. If it belongs to this channel, cap the initial window a few messages
-        // above the target so it loads with context on both sides; the client
-        // scrolls to and highlights it, and older history still pages in above via
-        // InfiniteScroll. Absent a jump, anchor the window around the read pointer
-        // so a channel with more unread than a page holds still loads the
-        // "New messages" boundary rather than freezing it at the oldest loaded row.
-        $jumpToMessageId = $this->resolveJumpTarget($request, $channel);
-        $windowCeilingId = $jumpToMessageId !== null
-            ? $this->jumpWindowCeiling($channel, $jumpToMessageId)
-            : $this->unreadWindowCeiling($channel, $membership?->last_read_message_id);
+        // The timeline read-model owns where the initial window opens — jump
+        // anchoring, unread-boundary anchoring, page-size arithmetic — and
+        // assembles the timeline and thread payloads. It takes explicit params
+        // (the raw `?message=` / `?thread=` query values and the read pointer),
+        // so this action stays HTTP glue: resolve params, call it, render.
+        $window = new ChannelTimelineWindow(
+            channel: $channel,
+            viewer: $request->user(),
+            requestedJumpId: $request->query('message'),
+            lastReadMessageId: $membership?->last_read_message_id,
+            requestedThreadRootId: $request->query('thread'),
+        );
 
         return Inertia::render('channels/Show', [
             'team' => [
@@ -139,7 +112,7 @@ class ChannelController extends Controller
             'notificationLevels' => NotificationLevel::options(),
             // The message the client should scroll to and highlight on load, or
             // null for a normal channel visit.
-            'jumpToMessageId' => $jumpToMessageId,
+            'jumpToMessageId' => $window->jumpToMessageId(),
             // The viewer's read pointer captured at render time, before the
             // client's debounced MarkChannelRead advances it. Drives the
             // "New messages" divider so it lands at the last-read boundary on
@@ -149,12 +122,12 @@ class ChannelController extends Controller
             // param, or null for a normal visit. The client opens a thread by
             // visiting `?thread=<root>`, which also drives the paginated replies
             // below; the closure returns null cheaply when no thread is requested.
-            'thread' => fn () => $this->threadPayload($request, $channel),
+            'thread' => fn () => $window->thread(),
             // The open thread's replies, oldest last, paginated so a very long
             // thread doesn't ship in one payload. Its own cursor name keeps it
             // independent of the main timeline's, and the client's reverse
             // InfiniteScroll pages older replies in above as it scrolls up.
-            'threadReplies' => Inertia::scroll(fn () => $this->threadRepliesPage($request, $channel)),
+            'threadReplies' => Inertia::scroll(fn () => $window->threadReplies()),
             // The viewer's own pending scheduled messages for this channel, soonest
             // first, feeding the composer's "Scheduled" affordance. Only pending
             // rows are listed — sent and cancelled ones drop off. The reply quote
@@ -184,180 +157,8 @@ class ChannelController extends Controller
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a
             // "message deleted" tombstone in place; MessageData blanks their body.
-            'messages' => Inertia::scroll(fn () => $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
-                ->withThreadReadState($request->user())
-                ->withMessageDataRelations()
-                ->when($windowCeilingId, fn (Builder $query) => $query->where('id', '<=', $windowCeilingId))
-                ->orderByDesc('id')
-                ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
-                ->through(fn (Message $message) => MessageData::fromMessage($message))),
+            'messages' => Inertia::scroll(fn () => $window->messages()),
         ]);
-    }
-
-    /**
-     * Resolve the open thread's root from the `?thread=` query param.
-     *
-     * Returns the root message (annotated with the viewer's thread read-state)
-     * when the param names a live root in this channel, or null when it is absent
-     * or points elsewhere. The replies are delivered separately and paginated by
-     * {@see self::threadRepliesPage()}.
-     *
-     * @return array{root: MessageData}|null
-     */
-    private function threadPayload(Request $request, Channel $channel): ?array
-    {
-        $root = $this->resolveThreadRoot($request, $channel);
-
-        if ($root === null) {
-            return null;
-        }
-
-        return ['root' => MessageData::fromMessage($root)];
-    }
-
-    /**
-     * The open thread's replies as a cursor-paginated page for infinite scroll.
-     *
-     * Ordered newest first (the client reverses for display and pages older
-     * replies in on scroll-up), tombstones included so deletions render in place.
-     * Its own cursor name keeps the pagination independent of the main timeline's.
-     * Falls back to an empty page when no live root is named, so the scroll prop
-     * always has a well-formed shape even on a normal channel visit.
-     *
-     * @return CursorPaginator<int, MessageData>
-     */
-    private function threadRepliesPage(Request $request, Channel $channel): CursorPaginator
-    {
-        $root = $this->resolveThreadRoot($request, $channel);
-
-        $query = $root !== null
-            ? $root->threadReplies()->withTrashed()->withMessageDataRelations()
-            : Message::query()->whereRaw('1 = 0');
-
-        return $query
-            ->orderByDesc('id')
-            ->cursorPaginate(self::THREAD_PAGE_SIZE, ['*'], 'thread_cursor')
-            ->through(fn (Message $message) => MessageData::fromMessage($message));
-    }
-
-    /**
-     * Resolve the live root message named by the `?thread=` query param, or null.
-     *
-     * The eager-load set mirrors the main timeline so the root renders its quote
-     * and thread affordances identically.
-     */
-    private function resolveThreadRoot(Request $request, Channel $channel): ?Message
-    {
-        $rootId = $request->query('thread');
-
-        if (! is_string($rootId) || $rootId === '') {
-            return null;
-        }
-
-        return $channel->messages()
-            ->whereNull('thread_root_id')
-            ->withThreadReadState($request->user())
-            ->withMessageDataRelations()
-            ->find($rootId);
-    }
-
-    /**
-     * Resolve the `?message=` jump target to an id belonging to this channel.
-     *
-     * Returns the message id when it identifies a message in the channel
-     * (soft-deleted rows included), or null when the parameter is absent or
-     * points at a message from another channel.
-     */
-    private function resolveJumpTarget(Request $request, Channel $channel): ?string
-    {
-        $messageId = $request->query('message');
-
-        if (! is_string($messageId) || $messageId === '') {
-            return null;
-        }
-
-        return $channel->messages()->withTrashed()->whereKey($messageId)->exists()
-            ? $messageId
-            : null;
-    }
-
-    /**
-     * Resolve the id that caps the initial message window for a jump.
-     *
-     * Returns the id of the message JUMP_CONTEXT positions newer than the target
-     * so it loads with following context below it rather than pinned to the very
-     * bottom of the view. Returns null when fewer than that many newer messages
-     * exist — the target is then already near the newest, so no cap is needed.
-     */
-    private function jumpWindowCeiling(Channel $channel, string $targetId): ?string
-    {
-        return $channel->messages()
-            ->withTrashed()
-            ->where('id', '>', $targetId)
-            ->orderBy('id')
-            ->offset(self::JUMP_CONTEXT - 1)
-            ->value('id');
-    }
-
-    /**
-     * Resolve the id that caps the initial window so the "New messages" boundary
-     * loads, or null to keep the default "open at newest" window.
-     *
-     * The boundary sits at the first message newer than the viewer's read
-     * pointer. When few enough messages sit at or after it to fit inside the
-     * newest page, the boundary already loads and no window is needed. A busier
-     * channel is anchored: the window is capped UNREAD_CONTEXT read messages
-     * above the boundary so it opens with the "New messages" line near the top
-     * and unread history below, while older history still pages in above via
-     * InfiniteScroll.
-     *
-     * A never-read channel (null pointer) has no last-read boundary to anchor,
-     * so it keeps the default "open at newest" window rather than landing the
-     * viewer on the oldest message of a long backlog.
-     */
-    private function unreadWindowCeiling(Channel $channel, ?string $lastReadMessageId): ?string
-    {
-        if ($lastReadMessageId === null) {
-            return null;
-        }
-
-        $firstUnreadId = $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
-            ->where('id', '>', $lastReadMessageId)
-            ->orderBy('id')
-            ->value('id');
-
-        if ($firstUnreadId === null) {
-            return null;
-        }
-
-        // The boundary already loads when the messages at or after it fit in the
-        // newest page, so keep opening at newest for read/lightly-unread channels.
-        $atOrAfterBoundary = $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
-            ->where('id', '>=', $firstUnreadId)
-            ->count();
-
-        if ($atOrAfterBoundary <= self::MESSAGE_PAGE_SIZE) {
-            return null;
-        }
-
-        return $this->mainTimeline($channel->messages()->withTrashed()->getQuery())
-            ->where('id', '>', $firstUnreadId)
-            ->orderBy('id')
-            ->offset(self::MESSAGE_PAGE_SIZE - self::UNREAD_CONTEXT - 1)
-            ->value('id');
-    }
-
-    /**
-     * Constrain a message query to the main channel timeline: top-level messages
-     * plus thread replies explicitly "also sent to channel". Thread replies
-     * otherwise live only in the thread view.
-     *
-     * @param  Builder<Message>  $query
-     * @return Builder<Message>
-     */
-    private function mainTimeline(Builder $query): Builder
-    {
-        return $query->where(fn (Builder $inner) => $inner->whereNull('thread_root_id')->orWhere('sent_to_channel', true));
     }
 
     /**

--- a/app/Support/ChannelTimelineWindow.php
+++ b/app/Support/ChannelTimelineWindow.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace App\Support;
+
+use App\Data\MessageData;
+use App\Http\Controllers\Channels\ChannelController;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\CursorPaginator;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Resolves where a channel's initial message window opens and assembles the
+ * timeline and thread payloads a channel view renders.
+ *
+ * This is the read-model behind {@see ChannelController::show()}:
+ * the most regression-prone logic in the app — unread-boundary anchoring, jump
+ * context, and page-size arithmetic. It takes explicit parameters (no `Request`)
+ * so the window math is unit-testable without an HTTP round-trip. The controller
+ * keeps HTTP glue only: resolve params from the request, call this, render.
+ *
+ * The two request-derived ids (`$requestedJumpId`, `$requestedThreadRootId`)
+ * arrive raw from query params, so they are typed `mixed` and validated here —
+ * a tampered non-string or a message from another channel resolves to null.
+ */
+class ChannelTimelineWindow
+{
+    /**
+     * How many messages newer than a jump target to keep loaded below it, so a
+     * jumped-to message shows following context and is not pinned to the bottom.
+     */
+    private const int JUMP_CONTEXT = 15;
+
+    /**
+     * How many messages the initial timeline window loads. Mirrors the page size
+     * of the cursor paginator below and feeds the read-boundary window math.
+     */
+    private const int MESSAGE_PAGE_SIZE = 50;
+
+    /**
+     * How many replies a thread page loads. The panel pages older replies in on
+     * scroll-up, mirroring the main timeline.
+     */
+    private const int THREAD_PAGE_SIZE = 50;
+
+    /**
+     * How many already-read messages to keep loaded above the "New messages"
+     * boundary when a channel opens deep enough into unread history that the
+     * boundary would otherwise fall outside the initial window.
+     */
+    private const int UNREAD_CONTEXT = 10;
+
+    private bool $jumpResolved = false;
+
+    private ?string $resolvedJumpId = null;
+
+    private bool $threadRootResolved = false;
+
+    private ?Message $resolvedThreadRoot = null;
+
+    public function __construct(
+        private readonly Channel $channel,
+        private readonly User $viewer,
+        private readonly mixed $requestedJumpId = null,
+        private readonly ?string $lastReadMessageId = null,
+        private readonly mixed $requestedThreadRootId = null,
+    ) {}
+
+    /**
+     * The `?message=` jump target resolved to an id belonging to this channel.
+     *
+     * Returns the id when it identifies a message in the channel (soft-deleted
+     * rows included), or null when the parameter is absent, non-string, or points
+     * at a message from another channel. Memoised: it also feeds {@see ceilingId()}.
+     */
+    public function jumpToMessageId(): ?string
+    {
+        if (! $this->jumpResolved) {
+            $this->resolvedJumpId = $this->resolveJumpTarget();
+            $this->jumpResolved = true;
+        }
+
+        return $this->resolvedJumpId;
+    }
+
+    /**
+     * The id that caps the initial message window, or null for the default
+     * "open at newest" window.
+     *
+     * A jump anchors the window around its target; otherwise the read pointer
+     * anchors it around the "New messages" boundary.
+     */
+    public function ceilingId(): ?string
+    {
+        $jumpId = $this->jumpToMessageId();
+
+        return $jumpId !== null
+            ? $this->jumpWindowCeiling($jumpId)
+            : $this->unreadWindowCeiling();
+    }
+
+    /**
+     * The main timeline as a cursor-paginated page of {@see MessageData}.
+     *
+     * Newest first (the client reverses for display and pages older messages in
+     * above on scroll-up). Tombstones are kept so deletions render in place; the
+     * window ceiling caps the newest loaded row.
+     *
+     * @return CursorPaginator<int, MessageData>
+     */
+    public function messages(): CursorPaginator
+    {
+        $ceilingId = $this->ceilingId();
+
+        return $this->mainTimeline()
+            ->withThreadReadState($this->viewer)
+            ->withMessageDataRelations()
+            ->when($ceilingId, fn (Builder $query) => $query->where('id', '<=', $ceilingId))
+            ->orderByDesc('id')
+            ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
+            ->through(fn (Message $message) => MessageData::fromMessage($message));
+    }
+
+    /**
+     * The open thread's root from the `?thread=` query param.
+     *
+     * Returns `['root' => MessageData]` when the param names a live root in this
+     * channel, or null when it is absent or points elsewhere. Replies are
+     * delivered separately by {@see threadReplies()}.
+     *
+     * @return array{root: MessageData}|null
+     */
+    public function thread(): ?array
+    {
+        $root = $this->resolveThreadRoot();
+
+        if ($root === null) {
+            return null;
+        }
+
+        return ['root' => MessageData::fromMessage($root)];
+    }
+
+    /**
+     * The open thread's replies as a cursor-paginated page for infinite scroll.
+     *
+     * Ordered newest first (the client reverses for display and pages older
+     * replies in on scroll-up), tombstones included so deletions render in place.
+     * Its own cursor name keeps the pagination independent of the main timeline's.
+     * Falls back to an empty page when no live root is named, so the scroll prop
+     * always has a well-formed shape even on a normal channel visit.
+     *
+     * @return CursorPaginator<int, MessageData>
+     */
+    public function threadReplies(): CursorPaginator
+    {
+        $root = $this->resolveThreadRoot();
+
+        $query = $root !== null
+            ? $root->threadReplies()->withTrashed()->withMessageDataRelations()
+            : Message::query()->whereRaw('1 = 0');
+
+        return $query
+            ->orderByDesc('id')
+            ->cursorPaginate(self::THREAD_PAGE_SIZE, ['*'], 'thread_cursor')
+            ->through(fn (Message $message) => MessageData::fromMessage($message));
+    }
+
+    /**
+     * Validate the requested jump target against this channel.
+     */
+    private function resolveJumpTarget(): ?string
+    {
+        if (! is_string($this->requestedJumpId) || $this->requestedJumpId === '') {
+            return null;
+        }
+
+        return $this->channel->messages()->withTrashed()->whereKey($this->requestedJumpId)->exists()
+            ? $this->requestedJumpId
+            : null;
+    }
+
+    /**
+     * The id that caps the initial window for a jump.
+     *
+     * Returns the id of the message JUMP_CONTEXT positions newer than the target
+     * so it loads with following context below it rather than pinned to the very
+     * bottom of the view. Returns null when fewer than that many newer messages
+     * exist — the target is then already near the newest, so no cap is needed.
+     */
+    private function jumpWindowCeiling(string $targetId): ?string
+    {
+        return $this->channel->messages()
+            ->withTrashed()
+            ->where('id', '>', $targetId)
+            ->orderBy('id')
+            ->offset(self::JUMP_CONTEXT - 1)
+            ->value('id');
+    }
+
+    /**
+     * The id that caps the initial window so the "New messages" boundary loads,
+     * or null to keep the default "open at newest" window.
+     *
+     * The boundary sits at the first message newer than the viewer's read
+     * pointer. When few enough messages sit at or after it to fit inside the
+     * newest page, the boundary already loads and no window is needed. A busier
+     * channel is anchored: the window is capped UNREAD_CONTEXT read messages
+     * above the boundary so it opens with the "New messages" line near the top
+     * and unread history below, while older history still pages in above.
+     *
+     * A never-read channel (null pointer) has no last-read boundary to anchor,
+     * so it keeps the default "open at newest" window rather than landing the
+     * viewer on the oldest message of a long backlog.
+     */
+    private function unreadWindowCeiling(): ?string
+    {
+        if ($this->lastReadMessageId === null) {
+            return null;
+        }
+
+        $firstUnreadId = $this->mainTimeline()
+            ->where('id', '>', $this->lastReadMessageId)
+            ->orderBy('id')
+            ->value('id');
+
+        if ($firstUnreadId === null) {
+            return null;
+        }
+
+        // The boundary already loads when the messages at or after it fit in the
+        // newest page, so keep opening at newest for read/lightly-unread channels.
+        $atOrAfterBoundary = $this->mainTimeline()
+            ->where('id', '>=', $firstUnreadId)
+            ->count();
+
+        if ($atOrAfterBoundary <= self::MESSAGE_PAGE_SIZE) {
+            return null;
+        }
+
+        return $this->mainTimeline()
+            ->where('id', '>', $firstUnreadId)
+            ->orderBy('id')
+            ->offset(self::MESSAGE_PAGE_SIZE - self::UNREAD_CONTEXT - 1)
+            ->value('id');
+    }
+
+    /**
+     * Resolve the live root message named by the `?thread=` query param, or null.
+     *
+     * The eager-load set mirrors the main timeline so the root renders its quote
+     * and thread affordances identically. Memoised: both {@see thread()} and
+     * {@see threadReplies()} read it.
+     */
+    private function resolveThreadRoot(): ?Message
+    {
+        if ($this->threadRootResolved) {
+            return $this->resolvedThreadRoot;
+        }
+
+        $this->threadRootResolved = true;
+
+        if (! is_string($this->requestedThreadRootId) || $this->requestedThreadRootId === '') {
+            return $this->resolvedThreadRoot;
+        }
+
+        return $this->resolvedThreadRoot = $this->channel->messages()
+            ->whereNull('thread_root_id')
+            ->withThreadReadState($this->viewer)
+            ->withMessageDataRelations()
+            ->find($this->requestedThreadRootId);
+    }
+
+    /**
+     * A fresh base query constrained to the main channel timeline: top-level
+     * messages plus thread replies explicitly "also sent to channel". Thread
+     * replies otherwise live only in the thread view.
+     *
+     * @return Builder<Message>
+     */
+    private function mainTimeline(): Builder
+    {
+        return $this->channel->messages()->withTrashed()->getQuery()
+            ->where(fn (Builder $inner) => $inner->whereNull('thread_root_id')->orWhere('sent_to_channel', true));
+    }
+}

--- a/tests/Feature/Channels/ChannelTimelineWindowTest.php
+++ b/tests/Feature/Channels/ChannelTimelineWindowTest.php
@@ -1,0 +1,243 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Data\MessageData;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\ChannelTimelineWindow;
+use Illuminate\Support\Collection;
+
+/**
+ * A user in a fresh team with its auto-created #general channel. The window
+ * read-model is exercised directly against these — no HTTP round-trip.
+ *
+ * @return array{user: User, team: Team, general: Channel}
+ */
+function windowFixture(): array
+{
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return ['user' => $user, 'team' => $team, 'general' => $general];
+}
+
+/**
+ * Create $count top-level messages in the channel, bodies "message 1".."message N",
+ * in ascending (ordered-uuid) id order.
+ *
+ * @return Collection<int, Message>
+ */
+function windowMessages(Channel $channel, User $author, int $count): Collection
+{
+    return collect(range(1, $count))->map(
+        fn (int $i) => Message::factory()->for($channel)->for($author)->create(['body' => "message {$i}"])
+    );
+}
+
+/**
+ * The bodies of a window's main timeline page, newest first.
+ *
+ * @return array<int, string>
+ */
+function bodiesOf(ChannelTimelineWindow $window): array
+{
+    return collect($window->messages()->items())
+        ->map(fn (MessageData $message) => $message->body)
+        ->all();
+}
+
+it('opens at newest with no ceiling on a never-read channel', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    windowMessages($general, $user, 60);
+
+    // Null read pointer: nothing to anchor, so the default newest window holds.
+    $window = new ChannelTimelineWindow(channel: $general, viewer: $user, lastReadMessageId: null);
+
+    expect($window->ceilingId())->toBeNull()
+        ->and($window->jumpToMessageId())->toBeNull();
+
+    $bodies = bodiesOf($window);
+    expect($bodies)->toHaveCount(50)
+        ->and($bodies[0])->toBe('message 60')
+        ->and($bodies[49])->toBe('message 11');
+});
+
+it('opens at newest with no ceiling on a fully-read channel', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 60);
+
+    // Read pointer at the newest message: nothing is unread.
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        lastReadMessageId: $messages[59]->id,
+    );
+
+    expect($window->ceilingId())->toBeNull();
+    expect(bodiesOf($window))->toHaveCount(50);
+});
+
+it('keeps the newest window when unread fits within a page', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 60);
+
+    // Read through message 20: 40 unread fit inside one 50-row page.
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        lastReadMessageId: $messages[19]->id,
+    );
+
+    expect($window->ceilingId())->toBeNull();
+
+    $bodies = bodiesOf($window);
+    expect($bodies[0])->toBe('message 60')
+        ->and($bodies[49])->toBe('message 11');
+});
+
+it('anchors the window around the boundary when unread exceeds a page', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 100);
+
+    // Read through message 30: 70 unread exceed one page, so the window caps
+    // 39 messages past the boundary (message 71) and holds messages 22..71.
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        lastReadMessageId: $messages[29]->id,
+    );
+
+    expect($window->ceilingId())->toBe($messages[70]->id);
+
+    $bodies = bodiesOf($window);
+    expect($bodies)->toHaveCount(50)
+        ->and($bodies[0])->toBe('message 71')
+        ->and($bodies[49])->toBe('message 22');
+});
+
+it('windows a jump target with newer context below it', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 30);
+    $target = $messages[4]; // message 5
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        requestedJumpId: $target->id,
+    );
+
+    expect($window->jumpToMessageId())->toBe($target->id)
+        // 15 messages newer than the target cap the window at message 20.
+        ->and($window->ceilingId())->toBe($messages[19]->id);
+
+    $bodies = bodiesOf($window);
+    expect($bodies)->toHaveCount(20)
+        ->and($bodies[0])->toBe('message 20');
+});
+
+it('leaves a jump near the newest message uncapped', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $messages = windowMessages($general, $user, 5);
+    $target = $messages[4]; // the newest
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        requestedJumpId: $target->id,
+    );
+
+    // Fewer than JUMP_CONTEXT newer messages exist, so no ceiling is needed.
+    expect($window->jumpToMessageId())->toBe($target->id)
+        ->and($window->ceilingId())->toBeNull();
+    expect(bodiesOf($window))->toHaveCount(5);
+});
+
+it('ignores a jump target from another channel', function () {
+    ['user' => $user, 'team' => $team, 'general' => $general] = windowFixture();
+    windowMessages($general, $user, 3);
+    $other = Channel::factory()->for($team)->create(['created_by' => $user->id]);
+    $foreign = Message::factory()->for($other)->for($user)->create();
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        requestedJumpId: $foreign->id,
+    );
+
+    expect($window->jumpToMessageId())->toBeNull()
+        ->and($window->ceilingId())->toBeNull();
+});
+
+it('ignores an absent or non-string jump target', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    windowMessages($general, $user, 3);
+
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user))->jumpToMessageId())->toBeNull();
+    // A tampered array query value never resolves to a target.
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user, requestedJumpId: ['x']))->jumpToMessageId())
+        ->toBeNull();
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user, requestedJumpId: ''))->jumpToMessageId())
+        ->toBeNull();
+});
+
+it('includes thread replies sent to the channel and excludes those that are not', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $root = Message::factory()->for($general)->for($user)->create(['body' => 'root']);
+    Message::factory()->for($user)->inThread($root)->sentToChannel()->create(['body' => 'echoed reply']);
+    Message::factory()->for($user)->inThread($root)->create(['body' => 'thread-only reply']);
+
+    $window = new ChannelTimelineWindow(channel: $general, viewer: $user);
+
+    $bodies = bodiesOf($window);
+    expect($bodies)->toContain('root')
+        ->and($bodies)->toContain('echoed reply')
+        ->and($bodies)->not->toContain('thread-only reply');
+});
+
+it('resolves the open thread root and its replies', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $root = Message::factory()->for($general)->for($user)->create(['body' => 'root']);
+    Message::factory()->for($user)->inThread($root)->create(['body' => 'reply one']);
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        requestedThreadRootId: $root->id,
+    );
+
+    $thread = $window->thread();
+    expect($thread)->not->toBeNull()
+        ->and($thread['root'])->toBeInstanceOf(MessageData::class)
+        ->and($thread['root']->id)->toBe($root->id);
+
+    $replyBodies = collect($window->threadReplies()->items())
+        ->map(fn (MessageData $message) => $message->body)
+        ->all();
+    expect($replyBodies)->toBe(['reply one']);
+});
+
+it('returns no thread and an empty replies page without a thread param', function () {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    windowMessages($general, $user, 2);
+
+    $window = new ChannelTimelineWindow(channel: $general, viewer: $user);
+
+    expect($window->thread())->toBeNull()
+        ->and($window->threadReplies()->items())->toBe([]);
+});
+
+it('returns no thread for a non-string or foreign thread param', function () {
+    ['user' => $user, 'team' => $team, 'general' => $general] = windowFixture();
+    $other = Channel::factory()->for($team)->create(['created_by' => $user->id]);
+    $foreignRoot = Message::factory()->for($other)->for($user)->create();
+
+    // A tampered array query value resolves to no thread.
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user, requestedThreadRootId: ['x']))->thread())
+        ->toBeNull();
+    // A root in another channel is not this channel's thread.
+    expect((new ChannelTimelineWindow(channel: $general, viewer: $user, requestedThreadRootId: $foreignRoot->id))->thread())
+        ->toBeNull();
+});


### PR DESCRIPTION
Closes #125. Part of the architecture-hardening epic (#131); targets the
integration branch, not master. Implements ADR-0004.

## Problem

`ChannelController::show` had grown to ~265 of the controller's 454 lines: the
endpoint plus seven private helpers computing where a channel's initial message
window opens — unread-boundary anchoring, jump context, page-size arithmetic —
plus thread root/replies assembly. This is the most regression-prone code in the
app, but it read `Request` state directly and ended in `Inertia::render`, so it
was reachable only through a full HTTP round-trip. The densest logic in the
codebase had no unit-test seam.

## Change

Window resolution now has one home: `App\Support\ChannelTimelineWindow`, a
read-model taking explicit params (channel, viewer, the raw `?message=` /
`?thread=` query values, last-read id) and exposing `jumpToMessageId()`,
`ceilingId()`, `messages()`, `thread()`, and `threadReplies()`. The two
request-derived ids arrive raw and are validated inside the object, so it carries
no `Request`. `show` shrinks to HTTP glue: resolve params, call the read-model,
render — consistent with its sibling actions.

The window math is now exercised directly, without an HTTP request: no unread,
fully read, unread-within-a-page, unread-past-a-page anchoring, jump targets
(windowed, near-newest, foreign, non-string), thread root/replies resolution, and
the main-timeline sent-to-channel inclusion. The existing HTTP feature tests for
the channel view still pass unchanged.

## Acceptance criteria

- [x] Window resolution lives in a dedicated object with an explicit-param
  interface (no `Request` inside it).
- [x] `ChannelController::show` is a thin action consistent with its siblings.
- [x] Unit tests exercise window selection directly: no unread, unread-anchored,
  jump-target, and paging edges — without an HTTP request.
- [x] Existing feature tests for the channel view still pass unchanged.
- [x] `./vendor/bin/sail composer test` green at 100% coverage; Pint + PHPStan
  clean.