### PR TITLE
refactor(messaging): decompose Show.vue into channel-view composables (#130)

### DIFF
--- a/resources/js/composables/useChannelDraft.test.ts
+++ b/resources/js/composables/useChannelDraft.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+
+const { patch } = vi.hoisted(() => ({ patch: vi.fn() }));
+
+vi.mock('@inertiajs/vue3', () => ({ router: { patch } }));
+
+import {
+    DRAFT_DEBOUNCE_MS,
+    useChannelDraft,
+} from '@/composables/useChannelDraft';
+import type { ChannelDraft } from '@/composables/useChannelDraft';
+
+/**
+ * Run the composable inside a disposable effect scope so its channel-switch
+ * watcher and the underlying auto-teardown are exercised by stopping the scope.
+ */
+function withScope(channelSlug: Ref<string>, channelId: Ref<string>) {
+    const scope = effectScope();
+    let draft!: ChannelDraft;
+
+    scope.run(() => {
+        draft = useChannelDraft({
+            channelId: () => channelId.value,
+            teamSlug: () => 'acme',
+            channelSlug: () => channelSlug.value,
+        });
+    });
+
+    return { draft, unmount: () => scope.stop() };
+}
+
+/** The url of the nth recorded draft-save patch. */
+function patchedUrl(call = 0): string {
+    return patch.mock.calls[call][0] as string;
+}
+
+describe('useChannelDraft', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        patch.mockClear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('debounces a draft save for the current channel', () => {
+        const { draft } = withScope(ref('alpha'), ref('id-alpha'));
+
+        draft.onDraftChange('half a th');
+        draft.onDraftChange('half a thought');
+        expect(patch).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(DRAFT_DEBOUNCE_MS);
+
+        expect(patch).toHaveBeenCalledOnce();
+        expect(patchedUrl()).toContain('alpha');
+        expect(patch.mock.calls[0][1]).toEqual({ body: 'half a thought' });
+    });
+
+    it('flushes the outgoing channel draft with its own slug on a channel switch', () => {
+        const slug = ref('alpha');
+        const id = ref('id-alpha');
+        const { draft } = withScope(slug, id);
+
+        // Type into alpha, then switch to bravo before the debounce fires.
+        draft.onDraftChange('for alpha');
+        slug.value = 'bravo';
+        id.value = 'id-bravo';
+
+        return nextTick().then(() => {
+            // The pending save flushed immediately, tagged with alpha's slug —
+            // not bravo, the channel just navigated to.
+            expect(patch).toHaveBeenCalledOnce();
+            expect(patchedUrl()).toContain('alpha');
+            expect(patchedUrl()).not.toContain('bravo');
+        });
+    });
+
+    it('cancels a pending save so a send does not re-persist cleared text', () => {
+        const { draft } = withScope(ref('alpha'), ref('id-alpha'));
+
+        draft.onDraftChange('unsent');
+        draft.cancel();
+
+        vi.advanceTimersByTime(DRAFT_DEBOUNCE_MS);
+
+        expect(patch).not.toHaveBeenCalled();
+    });
+
+    it('flushes a just-typed draft on teardown so it is not lost', () => {
+        const { draft, unmount } = withScope(ref('alpha'), ref('id-alpha'));
+
+        draft.onDraftChange('outlives unmount');
+        unmount();
+
+        expect(patch).toHaveBeenCalledOnce();
+        expect(patch.mock.calls[0][1]).toEqual({ body: 'outlives unmount' });
+    });
+});

--- a/resources/js/composables/useChannelDraft.ts
+++ b/resources/js/composables/useChannelDraft.ts
@@ -1,0 +1,64 @@
+import { router } from '@inertiajs/vue3';
+import { watch } from 'vue';
+import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
+
+/**
+ * How long to coalesce composer keystrokes before persisting the draft. Long
+ * enough that ordinary typing collapses to a single request.
+ */
+export const DRAFT_DEBOUNCE_MS = 700;
+
+export interface ChannelDraftOptions {
+    /** The open channel's id; a change flushes the outgoing channel's draft. */
+    channelId: () => string;
+    /** The current team's slug, for the draft-save route. */
+    teamSlug: () => string;
+    /** The open channel's slug, tagged onto each scheduled save. */
+    channelSlug: () => string;
+}
+
+export interface ChannelDraft {
+    /** Debounce a draft save for the current channel; an empty body clears it. */
+    onDraftChange: (body: string) => void;
+    /** Drop a pending save without firing it (a send clears the draft server-side). */
+    cancel: () => void;
+}
+
+/**
+ * Own the composer draft's persistence lifecycle: debounce keystrokes into a
+ * single per-channel save, flush the outgoing channel's draft when the open
+ * channel changes, and flush again on teardown so a just-typed draft is never
+ * lost. Rides {@see useDebouncedPost} — the payload is tagged with the slug of
+ * the channel being edited, so a flush triggered by a channel switch still writes
+ * to the channel that was actually being typed in rather than the one just
+ * navigated to.
+ */
+export function useChannelDraft(options: ChannelDraftOptions): ChannelDraft {
+    function persistDraft(slug: string, body: string): void {
+        router.patch(
+            saveChannelDraft({ team: options.teamSlug(), channel: slug }).url,
+            { body },
+            { preserveScroll: true, preserveState: true, only: ['channels'] },
+        );
+    }
+
+    // The payload carries the slug of the channel it belongs to, so a flush on
+    // channel switch writes to the right place. It flushes on unmount so a
+    // just-typed draft outlives leaving the workspace.
+    const draftPost = useDebouncedPost(
+        (draft: { slug: string; body: string }) =>
+            persistDraft(draft.slug, draft.body),
+        { delay: DRAFT_DEBOUNCE_MS, flushOnUnmount: true },
+    );
+
+    function onDraftChange(body: string): void {
+        draftPost.schedule({ slug: options.channelSlug(), body });
+    }
+
+    // Persist the outgoing channel's draft before the switch settles; the pending
+    // payload still carries the old channel's slug.
+    watch(options.channelId, () => draftPost.flush());
+
+    return { onDraftChange, cancel: draftPost.cancel };
+}

--- a/resources/js/composables/useChannelPreferences.test.ts
+++ b/resources/js/composables/useChannelPreferences.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, ref } from 'vue';
+import type { Ref } from 'vue';
+
+const { patch, toastError } = vi.hoisted(() => ({
+    patch: vi.fn(),
+    toastError: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({ router: { patch } }));
+vi.mock('vue-sonner', () => ({ toast: { error: toastError } }));
+
+import { useChannelPreferences } from '@/composables/useChannelPreferences';
+import type { ChannelPreferences } from '@/composables/useChannelPreferences';
+import type { Channel, NotificationLevel } from '@/types';
+
+type PrefState = Pick<Channel, 'notificationLevel' | 'muted' | 'starred'>;
+
+function channelState(overrides: Partial<PrefState> = {}): PrefState {
+    return {
+        notificationLevel: 'all',
+        muted: false,
+        starred: false,
+        ...overrides,
+    };
+}
+
+function withScope(channel: Ref<PrefState>, channelId: Ref<string>) {
+    const scope = effectScope();
+    let prefs!: ChannelPreferences;
+
+    scope.run(() => {
+        prefs = useChannelPreferences({
+            channelId: () => channelId.value,
+            channel: () => channel.value,
+            teamSlug: () => 'acme',
+            channelSlug: () => 'general',
+        });
+    });
+
+    return { prefs, unmount: () => scope.stop() };
+}
+
+/** Invoke the onError callback of the nth recorded patch, standing in for a failed request. */
+function failPatch(call = 0): void {
+    (patch.mock.calls[call][2] as { onError: () => void }).onError();
+}
+
+describe('useChannelPreferences', () => {
+    beforeEach(() => {
+        patch.mockClear();
+        toastError.mockClear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('seeds each preference from the server state', () => {
+        const { prefs } = withScope(
+            ref(
+                channelState({
+                    notificationLevel: 'mentions',
+                    muted: true,
+                    starred: true,
+                }),
+            ),
+            ref('id-1'),
+        );
+
+        expect(prefs.notificationLevel.value).toBe('mentions');
+        expect(prefs.muted.value).toBe(true);
+        expect(prefs.starred.value).toBe(true);
+    });
+
+    it('reseeds preferences from the server on a channel switch', () => {
+        const channel = ref(channelState({ starred: false }));
+        const id = ref('id-1');
+        const { prefs } = withScope(channel, id);
+
+        channel.value = channelState({
+            notificationLevel: 'nothing',
+            muted: true,
+            starred: true,
+        });
+        id.value = 'id-2';
+
+        return Promise.resolve().then(() => {
+            expect(prefs.notificationLevel.value).toBe('nothing');
+            expect(prefs.muted.value).toBe(true);
+            expect(prefs.starred.value).toBe(true);
+        });
+    });
+
+    it('stars optimistically and rolls back on error', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        prefs.toggleStar();
+        expect(prefs.starred.value).toBe(true);
+        expect(patch.mock.calls[0][1]).toEqual({ starred: true });
+
+        failPatch();
+        expect(prefs.starred.value).toBe(false);
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('changes the notification level optimistically and rolls back on error', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        prefs.onNotificationLevelChange('mentions' as NotificationLevel);
+        expect(prefs.notificationLevel.value).toBe('mentions');
+        expect(patch.mock.calls[0][1]).toEqual({
+            muted: false,
+            notification_level: 'mentions',
+        });
+
+        failPatch();
+        expect(prefs.notificationLevel.value).toBe('all');
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('toggles mute optimistically and rolls back on error', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        prefs.onMuteChange(true);
+        expect(prefs.muted.value).toBe(true);
+
+        failPatch();
+        expect(prefs.muted.value).toBe(false);
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('suppresses thread-unread dots when muted or below "all"', () => {
+        const channel = ref(channelState());
+        const { prefs } = withScope(channel, ref('id-1'));
+
+        expect(prefs.threadUnreadSuppressed.value).toBe(false);
+
+        prefs.onMuteChange(true);
+        expect(prefs.threadUnreadSuppressed.value).toBe(true);
+
+        prefs.onMuteChange(false);
+        prefs.onNotificationLevelChange('mentions' as NotificationLevel);
+        expect(prefs.threadUnreadSuppressed.value).toBe(true);
+    });
+
+    it('derives a header cue only for a non-default notification state', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        expect(prefs.notificationStatus.value).toBeNull();
+
+        prefs.onMuteChange(true);
+        expect(prefs.notificationStatus.value?.label).toBe('Muted');
+
+        prefs.onMuteChange(false);
+        prefs.onNotificationLevelChange('nothing' as NotificationLevel);
+        expect(prefs.notificationStatus.value?.label).toBe('Notifications off');
+
+        prefs.onNotificationLevelChange('mentions' as NotificationLevel);
+        expect(prefs.notificationStatus.value?.label).toBe('Mentions only');
+    });
+});

--- a/resources/js/composables/useChannelPreferences.ts
+++ b/resources/js/composables/useChannelPreferences.ts
@@ -1,0 +1,167 @@
+import { router } from '@inertiajs/vue3';
+import { AtSign, BellMinus, BellOff } from '@lucide/vue';
+import type { AcceptableValue } from 'reka-ui';
+import { computed, ref, watch } from 'vue';
+import type { Component, ComputedRef, Ref } from 'vue';
+import { toast } from 'vue-sonner';
+import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
+import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
+import type { Channel, NotificationLevel } from '@/types';
+
+/** The member's own star/mute/notification state for the open channel. */
+type ChannelPreferenceState = Pick<
+    Channel,
+    'notificationLevel' | 'muted' | 'starred'
+>;
+
+export interface ChannelPreferencesOptions {
+    /** The open channel's id; a change reseeds the preferences from the server. */
+    channelId: () => string;
+    /** The channel's server-seeded preference state, reread on channel switch. */
+    channel: () => ChannelPreferenceState;
+    /** The current team's slug, for the preference/star routes. */
+    teamSlug: () => string;
+    /** The open channel's slug, for the preference/star routes. */
+    channelSlug: () => string;
+}
+
+export interface ChannelPreferences {
+    /** The member's notification level; drives the header menu radio group. */
+    notificationLevel: Ref<NotificationLevel>;
+    /** Whether the member has muted the channel. */
+    muted: Ref<boolean>;
+    /** Whether the member has starred the channel. */
+    starred: Ref<boolean>;
+    /** Whether thread-unread dots are silenced (muted or a quieted level). */
+    threadUnreadSuppressed: ComputedRef<boolean>;
+    /** A compact header cue for a non-default notification state, or null. */
+    notificationStatus: ComputedRef<{ icon: Component; label: string } | null>;
+    /** Star or unstar the channel, optimistically, rolled back on error. */
+    toggleStar: () => void;
+    /** Change the notification level, optimistically, rolled back on error. */
+    onNotificationLevelChange: (value: AcceptableValue) => void;
+    /** Toggle mute, optimistically, rolled back on error. */
+    onMuteChange: (value: boolean) => void;
+}
+
+/**
+ * Own the member's per-channel notification preferences: star, mute, and
+ * notification level, each seeded from the server and reseeded on every channel
+ * switch. Changes save optimistically — the sidebar reloads to reflect the new
+ * badge/dimming state — and roll back if the request fails.
+ */
+export function useChannelPreferences(
+    options: ChannelPreferencesOptions,
+): ChannelPreferences {
+    const notificationLevel = ref<NotificationLevel>(
+        options.channel().notificationLevel,
+    );
+    const muted = ref<boolean>(options.channel().muted);
+    const starred = ref<boolean>(options.channel().starred);
+
+    // Reseed from the server on channel switch; each preference is the outgoing
+    // channel's until the new channel's state is adopted here.
+    watch(options.channelId, () => {
+        const channel = options.channel();
+        notificationLevel.value = channel.notificationLevel;
+        muted.value = channel.muted;
+        starred.value = channel.starred;
+    });
+
+    // Thread-unread dots are silenced under the same rule as the sidebar's unread
+    // badge: a muted channel or any level below "all". Mirrors the server's
+    // suppression so a live dot and a navigation-time dot agree.
+    const threadUnreadSuppressed = computed(
+        () => muted.value || notificationLevel.value !== 'all',
+    );
+
+    // A compact header cue for the member's non-default notification state; the
+    // "all" default shows nothing to keep the header clean.
+    const notificationStatus = computed(() => {
+        if (muted.value) {
+            return { icon: BellOff, label: 'Muted' };
+        }
+
+        if (notificationLevel.value === 'nothing') {
+            return { icon: BellMinus, label: 'Notifications off' };
+        }
+
+        if (notificationLevel.value === 'mentions') {
+            return { icon: AtSign, label: 'Mentions only' };
+        }
+
+        return null;
+    });
+
+    function toggleStar(): void {
+        const previous = starred.value;
+        starred.value = !previous;
+
+        router.patch(
+            updateChannelStar({
+                team: options.teamSlug(),
+                channel: options.channelSlug(),
+            }).url,
+            { starred: starred.value },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['channels'],
+                onError: () => {
+                    starred.value = previous;
+                    toast.error(
+                        'Failed to update the channel. Please try again.',
+                    );
+                },
+            },
+        );
+    }
+
+    function savePreferences(rollback: () => void): void {
+        router.patch(
+            updateChannelPreferences({
+                team: options.teamSlug(),
+                channel: options.channelSlug(),
+            }).url,
+            { muted: muted.value, notification_level: notificationLevel.value },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['channels'],
+                onError: () => {
+                    rollback();
+                    toast.error(
+                        'Failed to update notification preferences. Please try again.',
+                    );
+                },
+            },
+        );
+    }
+
+    function onNotificationLevelChange(value: AcceptableValue): void {
+        const previous = notificationLevel.value;
+        notificationLevel.value = value as NotificationLevel;
+        savePreferences(() => {
+            notificationLevel.value = previous;
+        });
+    }
+
+    function onMuteChange(value: boolean): void {
+        const previous = muted.value;
+        muted.value = value;
+        savePreferences(() => {
+            muted.value = previous;
+        });
+    }
+
+    return {
+        notificationLevel,
+        muted,
+        starred,
+        threadUnreadSuppressed,
+        notificationStatus,
+        toggleStar,
+        onNotificationLevelChange,
+        onMuteChange,
+    };
+}

--- a/resources/js/composables/useUnreadDivider.test.ts
+++ b/resources/js/composables/useUnreadDivider.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+import { useUnreadDivider } from '@/composables/useUnreadDivider';
+import type { UnreadDivider } from '@/composables/useUnreadDivider';
+import type { Message } from '@/types';
+
+type IntersectionCallback = (entries: { isIntersecting: boolean }[]) => void;
+
+const observe = vi.fn();
+const disconnect = vi.fn();
+let capturedCallback: IntersectionCallback | null = null;
+
+class FakeIntersectionObserver {
+    constructor(callback: IntersectionCallback) {
+        capturedCallback = callback;
+    }
+
+    observe = observe;
+    disconnect = disconnect;
+}
+
+/** A message with just the fields the divider decision reads. */
+function message(id: string, userId: string): Message {
+    return { id, user: { id: userId } } as unknown as Message;
+}
+
+function withScope(options: {
+    channelId: Ref<string>;
+    messages: () => Message[];
+    lastReadMessageId: Ref<string | null>;
+    currentUserId?: string;
+}) {
+    const scope = effectScope();
+    let divider!: UnreadDivider;
+
+    scope.run(() => {
+        divider = useUnreadDivider({
+            channelId: () => options.channelId.value,
+            scrollContainer: ref({} as HTMLElement),
+            messages: options.messages,
+            lastReadMessageId: () => options.lastReadMessageId.value,
+            currentUserId: () => options.currentUserId ?? 'me',
+        });
+    });
+
+    return { divider, unmount: () => scope.stop() };
+}
+
+describe('useUnreadDivider', () => {
+    beforeEach(() => {
+        observe.mockClear();
+        disconnect.mockClear();
+        capturedCallback = null;
+        vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver);
+        vi.stubGlobal('document', {
+            getElementById: (id: string) =>
+                id === 'unread-divider' ? ({} as Element) : null,
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('freezes the divider at the first unread peer message and shows the pill', async () => {
+        const { divider } = withScope({
+            channelId: ref('c1'),
+            // m1 is read; m2 is the viewer's own; m3 is the first unread peer.
+            messages: () => [
+                message('m1', 'peer'),
+                message('m2', 'me'),
+                message('m3', 'peer'),
+            ],
+            lastReadMessageId: ref('m1'),
+        });
+
+        expect(divider.unreadDividerId.value).toBe('m3');
+        expect(divider.showJumpToUnread.value).toBe(true);
+
+        // The observer attaches after the divider element renders.
+        await nextTick();
+        expect(observe).toHaveBeenCalledOnce();
+    });
+
+    it('hides the pill once the divider scrolls into view', async () => {
+        const { divider } = withScope({
+            channelId: ref('c1'),
+            messages: () => [message('m1', 'peer')],
+            lastReadMessageId: ref(null),
+        });
+
+        await nextTick();
+        capturedCallback?.([{ isIntersecting: true }]);
+
+        expect(divider.showJumpToUnread.value).toBe(false);
+    });
+
+    it('marks no boundary when every message is already read', () => {
+        const { divider } = withScope({
+            channelId: ref('c1'),
+            messages: () => [message('m1', 'peer'), message('m2', 'peer')],
+            lastReadMessageId: ref('m2'),
+        });
+
+        expect(divider.unreadDividerId.value).toBeNull();
+        expect(divider.showJumpToUnread.value).toBe(false);
+        // No boundary, so no observer is attached.
+        expect(observe).not.toHaveBeenCalled();
+    });
+
+    it('refreezes the boundary for the new channel on a switch', async () => {
+        const channelId = ref('c1');
+        const lastReadMessageId = ref<string | null>('m2');
+        let messages: Message[] = [
+            message('m1', 'peer'),
+            message('m2', 'peer'),
+        ];
+
+        const { divider } = withScope({
+            channelId,
+            messages: () => messages,
+            lastReadMessageId,
+        });
+
+        expect(divider.unreadDividerId.value).toBeNull();
+
+        // Switch to a channel with an unread peer message below the pointer.
+        messages = [message('n1', 'peer'), message('n2', 'peer')];
+        lastReadMessageId.value = 'n1';
+        channelId.value = 'c2';
+        await nextTick();
+
+        expect(divider.unreadDividerId.value).toBe('n2');
+    });
+
+    it('disconnects the observer on teardown', async () => {
+        const { unmount } = withScope({
+            channelId: ref('c1'),
+            messages: () => [message('m1', 'peer')],
+            lastReadMessageId: ref(null),
+        });
+
+        await nextTick();
+        disconnect.mockClear();
+        unmount();
+
+        expect(disconnect).toHaveBeenCalledOnce();
+    });
+});

--- a/resources/js/composables/useUnreadDivider.ts
+++ b/resources/js/composables/useUnreadDivider.ts
@@ -1,0 +1,108 @@
+import { computed, nextTick, onScopeDispose, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { unreadDividerMessageId } from '@/lib/unreadDivider';
+import type { Message } from '@/types';
+
+/** The stable DOM id the "New messages" divider element renders with. */
+const DIVIDER_ELEMENT_ID = 'unread-divider';
+
+export interface UnreadDividerOptions {
+    /** The open channel's id; a change refreezes the divider for that channel. */
+    channelId: () => string;
+    /** The scroll container the divider lives in, used as the observer root. */
+    scrollContainer: Ref<HTMLElement | null>;
+    /**
+     * The channel's messages at open, oldest-first. Read from the server page
+     * (not the live-merged list) so the boundary is immune to the order in which
+     * per-channel state resets on a channel switch.
+     */
+    messages: () => Message[];
+    /** The read pointer captured when the channel opened, or null if never read. */
+    lastReadMessageId: () => string | null;
+    /** The current viewer's id, so their own trailing messages aren't flagged. */
+    currentUserId: () => string;
+}
+
+export interface UnreadDivider {
+    /** The message the divider sits above, frozen at open; null when none. */
+    unreadDividerId: Ref<string | null>;
+    /** Whether to show the floating "jump to new messages" pill. */
+    showJumpToUnread: ComputedRef<boolean>;
+    /** Smooth-scroll the divider into view. */
+    scrollToUnread: () => void;
+}
+
+/**
+ * Own the "New messages" divider's lifecycle: freeze its position at channel
+ * open (and refreeze on every channel switch), and watch the divider element so
+ * the floating jump pill hides once the boundary scrolls into view.
+ *
+ * The boundary itself is decided by the pure {@see unreadDividerMessageId}; this
+ * composable is the reactive + IntersectionObserver wiring around it. The divider
+ * is deliberately *not* a plain computed: it is captured once per channel so the
+ * read pointer advancing as the user reads doesn't move the line under them.
+ */
+export function useUnreadDivider(options: UnreadDividerOptions): UnreadDivider {
+    const unreadDividerId = ref<string | null>(null);
+    const unreadDividerInView = ref(false);
+    let observer: IntersectionObserver | null = null;
+
+    // The pill shows only while there's a boundary the reader hasn't reached yet.
+    const showJumpToUnread = computed(
+        () => unreadDividerId.value !== null && !unreadDividerInView.value,
+    );
+
+    // Watch the divider element so the pill hides once it scrolls into view.
+    function observeDivider(): void {
+        observer?.disconnect();
+        observer = null;
+        unreadDividerInView.value = false;
+
+        if (unreadDividerId.value === null) {
+            return;
+        }
+
+        nextTick(() => {
+            const el = document.getElementById(DIVIDER_ELEMENT_ID);
+            const root = options.scrollContainer.value;
+
+            if (!el || !root) {
+                return;
+            }
+
+            observer = new IntersectionObserver(
+                ([entry]) => {
+                    unreadDividerInView.value = entry.isIntersecting;
+                },
+                { root },
+            );
+            observer.observe(el);
+        });
+    }
+
+    function recompute(): void {
+        unreadDividerId.value = unreadDividerMessageId(
+            options.messages(),
+            options.lastReadMessageId(),
+            options.currentUserId(),
+        );
+
+        observeDivider();
+    }
+
+    function scrollToUnread(): void {
+        document
+            .getElementById(DIVIDER_ELEMENT_ID)
+            ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+
+    // Freeze on open and refreeze on each channel switch; `recompute` owns the
+    // reset (divider id, observer, in-view flag) so the page doesn't hand-reset it.
+    watch(options.channelId, recompute, { immediate: true });
+
+    onScopeDispose(() => {
+        observer?.disconnect();
+    });
+
+    return { unreadDividerId, showJumpToUnread, scrollToUnread };
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -4,15 +4,11 @@ import { echo } from '@laravel/echo-vue';
 import {
     Archive,
     ArrowUp,
-    AtSign,
-    BellMinus,
-    BellOff,
     CalendarClock,
     ChevronDown,
     EllipsisVertical,
     Star,
 } from '@lucide/vue';
-import type { AcceptableValue } from 'reka-ui';
 import {
     computed,
     nextTick,
@@ -28,9 +24,6 @@ import {
     readThread as markThreadReadAction,
     show as showChannel,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
-import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
-import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
-import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
 import { store as forwardMessageAction } from '@/actions/App/Http/Controllers/Channels/ForwardMessageController';
 import {
     destroy as destroyMessage,
@@ -72,6 +65,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { useChannelDraft } from '@/composables/useChannelDraft';
+import { useChannelPreferences } from '@/composables/useChannelPreferences';
 import { useChannelRealtime } from '@/composables/useChannelRealtime';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import {
@@ -83,15 +78,14 @@ import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTimezone } from '@/composables/useTimezone';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
+import { useUnreadDivider } from '@/composables/useUnreadDivider';
 import { toggleReaction } from '@/lib/reactions';
-import { unreadDividerMessageId } from '@/lib/unreadDivider';
 import type {
     Channel,
     ChannelReader,
     Mention,
     Message,
     MessagePage,
-    NotificationLevel,
     NotificationLevelOption,
     ScheduledMessage,
     Thread,
@@ -246,64 +240,17 @@ function jumpToMessage(id: string): void {
     });
 }
 
-// The message the "New messages" divider sits above, frozen at the moment the
-// channel opens: the read pointer keeps advancing as the user reads, but the
-// boundary stays put until they leave the channel. Recomputed on open and on
-// every channel switch from the read pointer the server captured before its
-// debounced advance.
-const unreadDividerId = ref<string | null>(null);
-const unreadDividerInView = ref(false);
-let unreadObserver: IntersectionObserver | null = null;
-
-// The floating "jump to new messages" pill shows only while there's a boundary
-// the user hasn't scrolled to yet.
-const showJumpToUnread = computed(
-    () => unreadDividerId.value !== null && !unreadDividerInView.value,
-);
-
-function computeUnreadDivider(): void {
-    unreadDividerId.value = unreadDividerMessageId(
-        displayMessages.value,
-        props.lastReadMessageId ?? null,
-        currentUser.value.id,
-    );
-
-    observeUnreadDivider();
-}
-
-// Watch the divider element so the jump pill hides once it scrolls into view.
-function observeUnreadDivider(): void {
-    unreadObserver?.disconnect();
-    unreadObserver = null;
-    unreadDividerInView.value = false;
-
-    if (unreadDividerId.value === null) {
-        return;
-    }
-
-    nextTick(() => {
-        const el = document.getElementById('unread-divider');
-        const root = scrollContainer.value;
-
-        if (!el || !root) {
-            return;
-        }
-
-        unreadObserver = new IntersectionObserver(
-            ([entry]) => {
-                unreadDividerInView.value = entry.isIntersecting;
-            },
-            { root },
-        );
-        unreadObserver.observe(el);
-    });
-}
-
-function scrollToUnread(): void {
-    document
-        .getElementById('unread-divider')
-        ?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-}
+// The "New messages" divider's lifecycle — freeze its position at open, refreeze
+// on each channel switch, and hide the jump pill once it scrolls into view —
+// lives in this composable. It reads the server page (not the live-merged list)
+// so the boundary is immune to the order per-channel state resets on a switch.
+const { unreadDividerId, showJumpToUnread, scrollToUnread } = useUnreadDivider({
+    channelId: () => props.channel.id,
+    scrollContainer,
+    messages: () => serverMessages.value,
+    lastReadMessageId: () => props.lastReadMessageId ?? null,
+    currentUserId: () => currentUser.value.id,
+});
 
 // Advance the open thread's read pointer so its unread dot clears, mirroring the
 // channel's markRead: debounced, gated on focus, and optimistically clearing the
@@ -362,6 +309,26 @@ function markRead(): void {
     readPost.schedule();
 }
 
+// The member's own star/mute/notification-level preferences for this channel:
+// seeded from the server, reseeded on every channel switch, saved optimistically
+// and rolled back on error. `threadUnreadSuppressed` mirrors the server's dot
+// suppression and feeds the realtime router below.
+const {
+    notificationLevel,
+    muted,
+    starred,
+    threadUnreadSuppressed,
+    notificationStatus,
+    toggleStar,
+    onNotificationLevelChange,
+    onMuteChange,
+} = useChannelPreferences({
+    channelId: () => props.channel.id,
+    channel: () => props.channel,
+    teamSlug: () => props.team.slug,
+    channelSlug: () => props.channel.slug,
+});
+
 // The active channel's Echo subscribe/route/teardown lives in this composable: it
 // moves the subscription as the open channel changes and routes each broadcast
 // into the two streams. `Show.vue` only supplies the state it reconciles against.
@@ -383,7 +350,6 @@ useChannelRealtime({
 
 onMounted(() => {
     seedReaders();
-    computeUnreadDivider();
     markRead();
     window.addEventListener('focus', markRead);
     window.addEventListener('focus', markThreadRead);
@@ -425,26 +391,18 @@ watch(
 );
 
 // Inertia may reuse this page component when navigating between channels; reset
-// per-channel state when the channel changes. `useChannelRealtime` moves the Echo
-// subscription on the same change via its own watcher.
+// the message-orchestration state this page owns when the channel changes. The
+// extracted composables (realtime, draft, preferences, unread divider) each move
+// or refreeze their own state on the same change via their own watchers.
 watch(
     () => props.channel.id,
     () => {
-        // Persist the outgoing channel's draft before switching; the pending
-        // payload still carries the old channel's slug, so it writes to the right
-        // place.
-        draftPost.flush();
-
         mainStream.reset();
         resetScrollPin();
         resetThreadPanel();
         replyTarget.value = null;
         typing.reset();
-        notificationLevel.value = props.channel.notificationLevel;
-        muted.value = props.channel.muted;
-        starred.value = props.channel.starred;
         seedReaders();
-        computeUnreadDivider();
         markRead();
     },
 );
@@ -453,7 +411,6 @@ onBeforeUnmount(() => {
     // The draft persists itself on teardown (flushOnUnmount) and the read posts
     // cancel themselves, so leaving the workspace neither loses a just-typed draft
     // nor fires a stale mark-read.
-    unreadObserver?.disconnect();
     window.removeEventListener('focus', markRead);
     window.removeEventListener('focus', markThreadRead);
 
@@ -565,39 +522,19 @@ function forwardMessage({
 }
 
 // The member's unsent composer text is persisted per channel so it survives
-// navigation, reloads and other devices. Saves are debounced — a burst of
-// keystrokes collapses to one request — and reload only the shared `channels`
-// prop so the sidebar's draft cue updates without disturbing the timeline. A
-// send clears the draft server-side, so only manual edits flow through here.
-const DRAFT_DEBOUNCE_MS = 700;
-
-function persistDraft(slug: string, body: string): void {
-    router.patch(
-        saveChannelDraft({ team: props.team.slug, channel: slug }).url,
-        { body },
-        { preserveScroll: true, preserveState: true, only: ['channels'] },
-    );
-}
-
-// The debounced draft save. The payload is tagged with the slug of the channel it
-// belongs to, so a flush triggered by switching channels still writes to the
-// channel that was actually being edited rather than the one just navigated to.
-// It flushes on unmount so a just-typed draft is never lost to an unfired timer.
-const draftPost = useDebouncedPost(
-    (draft: { slug: string; body: string }) =>
-        persistDraft(draft.slug, draft.body),
-    { delay: DRAFT_DEBOUNCE_MS, flushOnUnmount: true },
-);
-
-// Debounce a draft save for the current channel; an empty body clears it.
-function onDraftChange(body: string): void {
-    draftPost.schedule({ slug: props.channel.slug, body });
-}
+// navigation, reloads and other devices. This composable owns the debounce, the
+// channel-switch flush, and the flush-on-unmount; a send clears the draft
+// server-side, so only manual edits flow through `onDraftChange`.
+const { onDraftChange, cancel: cancelDraft } = useChannelDraft({
+    channelId: () => props.channel.id,
+    teamSlug: () => props.team.slug,
+    channelSlug: () => props.channel.slug,
+});
 
 function send(body: string, mentions: Mention[]): void {
     // Sending clears the draft server-side, so drop any debounced save still in
     // flight; otherwise it would re-persist the just-sent text after the clear.
-    draftPost.cancel();
+    cancelDraft();
 
     const clientUuid = crypto.randomUUID();
     const target = replyTarget.value;
@@ -648,7 +585,7 @@ function scheduleMessage(
     _mentions: Mention[],
     sendAt: string,
 ): void {
-    draftPost.cancel();
+    cancelDraft();
 
     const target = replyTarget.value;
 
@@ -957,104 +894,6 @@ function closeThread(): void {
         },
     );
 }
-
-// The member's own notification preferences for this channel, seeded from the
-// server and reseeded on every channel switch. Changes are saved optimistically
-// (the sidebar reloads to reflect the new badge/dimming state) and rolled back
-// if the request fails.
-const notificationLevel = ref<NotificationLevel>(
-    props.channel.notificationLevel,
-);
-const muted = ref<boolean>(props.channel.muted);
-const starred = ref<boolean>(props.channel.starred);
-
-/**
- * Star or unstar this channel, reloading only the shared `channels` prop so the
- * sidebar re-partitions its "Starred" section. Optimistic, rolled back on error.
- */
-function toggleStar(): void {
-    const previous = starred.value;
-    starred.value = !previous;
-
-    router.patch(
-        updateChannelStar({
-            team: props.team.slug,
-            channel: props.channel.slug,
-        }).url,
-        { starred: starred.value },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['channels'],
-            onError: () => {
-                starred.value = previous;
-                toast.error('Failed to update the channel. Please try again.');
-            },
-        },
-    );
-}
-
-// Thread-unread dots are silenced under the same rule as the sidebar's unread
-// badge: a muted channel or any level below "all". Mirrors the server's
-// suppression so a live dot and a navigation-time dot agree.
-const threadUnreadSuppressed = computed(
-    () => muted.value || notificationLevel.value !== 'all',
-);
-
-function savePreferences(rollback: () => void): void {
-    router.patch(
-        updateChannelPreferences({
-            team: props.team.slug,
-            channel: props.channel.slug,
-        }).url,
-        { muted: muted.value, notification_level: notificationLevel.value },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['channels'],
-            onError: () => {
-                rollback();
-                toast.error(
-                    'Failed to update notification preferences. Please try again.',
-                );
-            },
-        },
-    );
-}
-
-function onNotificationLevelChange(value: AcceptableValue): void {
-    const previous = notificationLevel.value;
-    notificationLevel.value = value as NotificationLevel;
-    savePreferences(() => {
-        notificationLevel.value = previous;
-    });
-}
-
-function onMuteChange(value: boolean): void {
-    const previous = muted.value;
-    muted.value = value;
-    savePreferences(() => {
-        muted.value = previous;
-    });
-}
-
-// A compact header cue for the member's non-default notification state (muted or
-// a quieted level); the "all" default shows nothing to keep the header clean.
-const notificationStatus = computed(() => {
-    if (muted.value) {
-        return { icon: BellOff, label: 'Muted' };
-    }
-
-    if (notificationLevel.value === 'nothing') {
-        return { icon: BellMinus, label: 'Notifications off' };
-    }
-
-    if (notificationLevel.value === 'mentions') {
-        return { icon: AtSign, label: 'Mentions only' };
-    }
-
-    return null;
-});
 
 // Drives the archive confirmation dialog opened from the channel header menu.
 const confirmingArchive = ref(false);


### PR DESCRIPTION
Closes #130. Part of the architecture-hardening epic (#131); targets the
integration branch, not master. Implements ADR-0006. Depends on #127 and
#129, both already merged into the scaffold.

## Problem

`pages/channels/Show.vue` was a god component owning ~12 independent
lifecycles in one scope. The tell was a `watch(() => props.channel.id)`
handler that hand-reset nine separate pieces of state. With realtime (#127)
and the debounced post (#129) already extracted, the remaining inline
lifecycles were draft persistence, the unread-divider observer, and channel
preferences.

## Change

Each remaining lifecycle now lives in a composable with a seam, reusing the
existing engines:

- `useChannelDraft` — debounced per-channel draft save, channel-switch flush
  (the payload is tagged with the editing channel's slug), and
  flush-on-unmount, riding `useDebouncedPost`.
- `useUnreadDivider` — freezes the "New messages" boundary at open and
  refreezes per channel, and owns the IntersectionObserver that hides the
  jump pill. The boundary decision stays the pure `unreadDividerMessageId`.
  It reads the server page rather than the live-merged list, so the boundary
  is immune to the order per-channel state resets on a switch.
- `useChannelPreferences` — star, mute, and notification level, seeded and
  reseeded per channel, saved optimistically with rollback, plus the
  `threadUnreadSuppressed` and `notificationStatus` derivations.

Each composable owns its own reset via its own watcher, so the page's
`channel.id` watch collapses to the message-orchestration state that is
Show.vue's real job (streams, scroll pin, thread panel, reply target, typing,
reader seeding, mark-read). Show.vue drops from 1447 to 1286 lines.

Each extracted composable has its own test: draft debounce/flush/cancel,
preference optimistic-rollback and reseed, and divider freeze/observer/
teardown (the DOM-bound observer driven through stubbed globals).

## Acceptance criteria

- [x] `Show.vue` no longer owns realtime, debounced-post, draft,
  unread-observer, or preference lifecycles inline.
- [x] The `channel.id` watch no longer hand-resets a pile of independent
  state; each composable owns its own reset.
- [x] Each extracted composable has its own test (unit where pure, mounted
  where it must be).
- [x] No behavioural regression: existing channel-view coverage passes.
- [x] Frontend gate green via Sail: lint:check, format:check, types:check,
  build, and test:js (198 tests).