### PR TITLE
chore(release-please): surface refactor commits in the changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance" }
+        { "type": "perf", "section": "Performance" },
+        { "type": "refactor", "section": "Code Refactoring" }
       ]
     }
   }


### PR DESCRIPTION
## Problem

The architecture-hardening epic (#131) landed on master as a single
`refactor(architecture)` commit, but it did not appear in the release-please
PR (#116). The config's `changelog-sections` only listed `feat`, `fix`, and
`perf`, so `refactor` commits were dropped from the notes entirely.

## Change

Add a "Code Refactoring" section for `refactor` commits. They now surface in
the changelog when a release is cut. This does not make refactors
release-triggering — only `feat`/`fix`/`perf` bump the version — so the
proposed version stays the same; the section is just populated when a release
already happens.

Once this merges, release-please's next run re-scans commits since 0.1.0 and
lists the epic's refactor commit under the new section in #116.