### PR TITLE
feat(shell): floating-card canvas + dock reskin (#147)

### DIFF
--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -156,6 +156,7 @@ trait HasTeams
             isPersonal: $team->is_personal,
             role: $role?->value,
             roleLabel: $role?->label(),
+            membersCount: $team->members()->count(),
             isCurrent: $this->isCurrentTeam($team),
         );
     }

--- a/app/Data/UserTeam.php
+++ b/app/Data/UserTeam.php
@@ -11,6 +11,7 @@ readonly class UserTeam
         public bool $isPersonal,
         public ?string $role,
         public ?string $roleLabel,
+        public int $membersCount = 0,
         public ?bool $isCurrent = null,
     ) {
         //

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use App\Data\ChannelData;
 use App\Data\ChannelSectionData;
+use App\Enums\TeamRole;
 use App\Models\Message;
 use App\Models\Team;
 use App\Models\TeamInvitation;
@@ -54,6 +55,13 @@ class HandleInertiaRequests extends Middleware
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
             'teams' => fn () => $user?->toUserTeams(includeCurrent: true) ?? [],
+            // The dock header's "invite" affordance reuses the member-invite modal,
+            // so the current team's invite permission and the assignable roles ride
+            // along with every workspace request.
+            'canInviteToCurrentTeam' => fn () => $user?->currentTeam
+                ? $user->toTeamPermissions($user->currentTeam)->canCreateInvitation
+                : false,
+            'invitableRoles' => TeamRole::assignable(),
             'channels' => fn () => $this->channelsForSidebar($request, $user),
             'channelSections' => fn () => $this->channelSectionsForSidebar($request, $user),
             'collapsedChannelSections' => fn () => $user->collapsed_channel_sections ?? [],

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -68,6 +68,7 @@
 
     /* Brass accent — the single warm highlight (focus, active affordances, reaction pills). */
     --color-brass: var(--brass);
+    --color-brass-foreground: var(--brass-foreground);
     --color-brass-border: var(--brass-border);
     --color-brass-fill: var(--brass-fill);
     --color-brass-fill-foreground: var(--brass-fill-foreground);
@@ -127,6 +128,8 @@
     --input: #e0dbcd;
     --ring: #c9a35c;
     --brass: #c9a35c;
+    /* Ink text on a solid-brass fill (unread badges); stays ink in dark too. */
+    --brass-foreground: #1d1a15;
     --brass-border: #b98e3f;
     --brass-fill: rgba(201, 163, 92, 0.14);
     --brass-fill-foreground: #7d6023;

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -68,7 +68,7 @@ function toggleStar(): void {
             as-child
             :is-active="channel.slug === activeChannelSlug"
             :data-muted="channel.muted"
-            class="h-[30px] gap-1.5 rounded-md py-0 pr-2 pl-7 text-[13.5px] text-sidebar-foreground/80 hover:bg-sidebar-accent/60 hover:text-sidebar-foreground data-[active=true]:relative data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100"
+            class="h-8 gap-2 rounded-[9px] py-0 pr-2.5 pl-7 text-[13.5px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[active=true]:bg-sidebar-primary data-[active=true]:font-medium data-[active=true]:text-sidebar-primary-foreground data-[active=true]:shadow-[0_2px_6px_rgba(29,26,21,0.25)] data-[active=true]:hover:bg-sidebar-primary data-[active=true]:hover:text-sidebar-primary-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100"
         >
             <Link
                 :href="
@@ -79,23 +79,21 @@ function toggleStar(): void {
                 "
             >
                 <span
-                    v-if="channel.slug === activeChannelSlug"
-                    aria-hidden="true"
-                    class="absolute top-[7px] bottom-[7px] left-0 w-[3px] rounded-full bg-primary"
-                />
-                <span
-                    class="font-medium"
+                    class="shrink-0 font-medium"
                     :class="
                         channel.slug === activeChannelSlug
-                            ? 'text-sidebar-foreground/70'
-                            : 'text-muted-foreground/80'
+                            ? 'text-brass'
+                            : channel.unreadCount > 0
+                              ? 'text-muted-foreground'
+                              : 'text-muted-foreground/60'
                     "
                     >#</span
                 >
                 <span
                     class="truncate"
                     :class="
-                        channel.unreadCount > 0
+                        channel.unreadCount > 0 &&
+                        channel.slug !== activeChannelSlug
                             ? 'font-semibold text-sidebar-foreground'
                             : ''
                     "
@@ -107,7 +105,7 @@ function toggleStar(): void {
                 <span
                     v-if="channel.mentionCount > 0"
                     data-test="mention-badge"
-                    class="ml-auto flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-primary px-1 text-[11px] font-semibold text-primary-foreground tabular-nums"
+                    class="ml-auto flex h-[17px] min-w-[18px] items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums"
                     :aria-label="`${channel.mentionCount} unread mentions`"
                     >{{ channel.mentionCount }}</span
                 >
@@ -126,7 +124,7 @@ function toggleStar(): void {
                     v-else-if="channel.unreadCount > 0"
                     data-test="unread-dot"
                     aria-hidden="true"
-                    class="ml-auto size-1.5 rounded-full bg-primary"
+                    class="ml-auto size-1.5 rounded-full bg-brass"
                 />
             </Link>
         </SidebarMenuButton>
@@ -145,7 +143,7 @@ function toggleStar(): void {
                     : `Star ${channel.name}`
             "
             :title="channel.starred ? 'Unstar channel' : 'Star channel'"
-            class="absolute top-1/2 left-1 z-10 flex size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/60 opacity-70 transition hover:text-amber-500 hover:opacity-100 data-[starred=true]:text-amber-500 data-[starred=true]:opacity-100"
+            class="absolute top-1/2 left-1 z-10 flex size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground/60 opacity-70 transition hover:text-brass hover:opacity-100 data-[starred=true]:text-brass data-[starred=true]:opacity-100"
             @click="toggleStar"
         >
             <Star
@@ -158,7 +156,7 @@ function toggleStar(): void {
              section. Revealed on hover or focus, and pinned open while the menu
              is; a solid background masks any unread badge underneath. -->
         <div
-            class="absolute top-1/2 right-1 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md bg-sidebar pl-1 opacity-0 transition group-hover/row:opacity-100 group-data-[active=true]/row:bg-sidebar-accent focus-within:opacity-100"
+            class="absolute top-1/2 right-1 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md bg-sidebar pl-1 opacity-0 transition group-hover/row:opacity-100 group-data-[active=true]/row:bg-sidebar-primary focus-within:opacity-100"
             :class="menuOpen ? 'opacity-100' : ''"
         >
             <button
@@ -166,7 +164,7 @@ function toggleStar(): void {
                 :data-test="`channel-drag-handle-${channel.slug}`"
                 :aria-label="`Reorder ${channel.name}`"
                 title="Drag to reorder"
-                class="channel-drag-handle flex size-5 cursor-grab items-center justify-center rounded text-muted-foreground/60 transition hover:text-sidebar-foreground active:cursor-grabbing"
+                class="channel-drag-handle flex size-5 cursor-grab items-center justify-center rounded text-muted-foreground/60 transition group-data-[active=true]/row:text-sidebar-primary-foreground/70 hover:text-sidebar-foreground group-data-[active=true]/row:hover:text-sidebar-primary-foreground active:cursor-grabbing"
             >
                 <GripVertical class="size-3.5" />
             </button>
@@ -180,7 +178,7 @@ function toggleStar(): void {
                         :data-test="`channel-menu-${channel.slug}`"
                         :aria-label="`Channel options for ${channel.name}`"
                         title="More options"
-                        class="flex size-5 items-center justify-center rounded text-muted-foreground/60 transition hover:text-sidebar-foreground data-[state=open]:text-sidebar-foreground"
+                        class="flex size-5 items-center justify-center rounded text-muted-foreground/60 transition group-data-[active=true]/row:text-sidebar-primary-foreground/70 hover:text-sidebar-foreground group-data-[active=true]/row:hover:text-sidebar-primary-foreground data-[state=open]:text-sidebar-foreground"
                     >
                         <MoreVertical class="size-3.5" />
                     </button>

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -2,6 +2,7 @@
 import { usePage } from '@inertiajs/vue3';
 import { ChevronsUpDown } from '@lucide/vue';
 import { computed } from 'vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -13,15 +14,17 @@ import {
     SidebarMenuItem,
     useSidebar,
 } from '@/components/ui/sidebar';
-import UserInfo from '@/components/UserInfo.vue';
 import UserMenuContent from '@/components/UserMenuContent.vue';
+import { useInitials } from '@/composables/useInitials';
 import type { Team } from '@/types';
 
 const page = usePage();
 const user = page.props.auth.user;
 const { isMobile, state } = useSidebar();
+const { getInitials } = useInitials();
 
 const currentTeam = computed(() => page.props.currentTeam as Team | null);
+const hasAvatar = computed(() => !!user.avatar && user.avatar !== '');
 </script>
 
 <template>
@@ -30,12 +33,41 @@ const currentTeam = computed(() => page.props.currentTeam as Team | null);
             <DropdownMenu>
                 <DropdownMenuTrigger as-child>
                     <SidebarMenuButton
-                        size="lg"
-                        class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+                        class="h-auto gap-2.5 rounded-[10px] bg-sidebar-accent/70 p-1.5 hover:bg-sidebar-accent data-[state=open]:bg-sidebar-accent"
                         data-test="sidebar-menu-button"
                     >
-                        <UserInfo :user="user" :team="currentTeam" />
-                        <ChevronsUpDown class="ml-auto size-4" />
+                        <span class="relative shrink-0">
+                            <Avatar class="size-7 rounded-full">
+                                <AvatarImage
+                                    v-if="hasAvatar"
+                                    :src="user.avatar!"
+                                    :alt="user.name"
+                                />
+                                <AvatarFallback
+                                    class="rounded-full bg-brass-fill text-[10px] font-semibold text-sidebar-foreground"
+                                >
+                                    {{ getInitials(user.name) }}
+                                </AvatarFallback>
+                            </Avatar>
+                            <span
+                                aria-hidden="true"
+                                class="absolute -right-0.5 -bottom-0.5 size-[9px] rounded-full border-2 border-sidebar-accent bg-emerald-600"
+                            />
+                        </span>
+                        <span class="grid flex-1 text-left leading-tight">
+                            <span
+                                class="truncate text-[12.5px] font-medium text-sidebar-foreground"
+                                >{{ user.name }}</span
+                            >
+                            <span
+                                v-if="currentTeam"
+                                class="truncate text-[10.5px] text-muted-foreground"
+                                >{{ currentTeam.name }}</span
+                            >
+                        </span>
+                        <ChevronsUpDown
+                            class="ml-auto size-[13px] text-muted-foreground"
+                        />
                     </SidebarMenuButton>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent

--- a/resources/js/layouts/channels/Layout.vue
+++ b/resources/js/layouts/channels/Layout.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
 import {
+    Check,
     ChevronRight,
     FolderPlus,
     GripVertical,
@@ -11,6 +12,7 @@ import {
     Plus,
     Search,
     Trash2,
+    UserPlus,
 } from '@lucide/vue';
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { toast } from 'vue-sonner';
@@ -32,18 +34,19 @@ import { update as updateSidebarSections } from '@/actions/App/Http/Controllers/
 import ChannelListItem from '@/components/ChannelListItem.vue';
 import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
+import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import KeyboardShortcutsModal from '@/components/KeyboardShortcutsModal.vue';
 import NavUser from '@/components/NavUser.vue';
 import PendingInvitationsModal from '@/components/PendingInvitationsModal.vue';
 import QuickSwitcher from '@/components/QuickSwitcher.vue';
-import TeamSwitcher from '@/components/TeamSwitcher.vue';
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Separator } from '@/components/ui/separator';
 import {
     Sidebar,
     SidebarContent,
@@ -58,11 +61,6 @@ import {
     SidebarMenuItem,
     SidebarProvider,
 } from '@/components/ui/sidebar';
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipTrigger,
-} from '@/components/ui/tooltip';
 import { adjacentSlug } from '@/composables/keyboardShortcuts';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useInitials } from '@/composables/useInitials';
@@ -77,6 +75,7 @@ import {
 } from '@/lib/channelSections';
 import type { SidebarSectionKey } from '@/lib/channelSections';
 import type { Channel, ChannelSection } from '@/types/channels';
+import type { RoleOption } from '@/types/teams';
 
 const page = usePage();
 
@@ -95,6 +94,16 @@ const activeChannelSlug = computed(
 );
 const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
 const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
+
+// The dock header's "invite people" mini-button reuses the member-invite modal;
+// the permission and assignable roles ride along on the shared workspace props.
+const canInviteToCurrentTeam = computed(
+    () => page.props.canInviteToCurrentTeam ?? false,
+);
+const invitableRoles = computed<RoleOption[]>(
+    () => page.props.invitableRoles ?? [],
+);
+const inviteOpen = ref(false);
 
 // The user's custom sidebar sections for the current team, kept in their
 // persisted order.
@@ -479,381 +488,308 @@ onMounted(() => {
 </script>
 
 <template>
-    <SidebarProvider style="--sidebar-width: calc(3.5rem + 16rem)">
-        <Sidebar collapsible="offcanvas" class="overflow-hidden">
-            <!-- Nested rail + channel list; a single flex-row wrapper keeps them
-                 side by side in both the desktop sidebar and the mobile Sheet. -->
-            <div class="flex h-full w-full flex-row">
-                <!-- Team rail -->
-                <div
-                    class="flex w-14 shrink-0 flex-col items-center gap-2 border-r border-sidebar-border bg-sidebar-rail py-3"
-                    data-test="team-rail"
-                >
-                    <div
-                        v-for="team in teams"
-                        :key="team.id"
-                        class="relative flex w-full justify-center"
-                    >
-                        <span
-                            v-if="team.id === currentTeam?.id"
-                            aria-hidden="true"
-                            class="absolute top-1/2 left-0 h-[22px] w-[3px] -translate-y-1/2 rounded-r-full bg-primary"
-                        />
-                        <Tooltip>
-                            <TooltipTrigger as-child>
-                                <button
-                                    type="button"
-                                    data-test="team-rail-item"
-                                    :data-active="team.id === currentTeam?.id"
-                                    :aria-current="
-                                        team.id === currentTeam?.id
-                                            ? 'true'
-                                            : undefined
-                                    "
-                                    class="flex size-9 items-center justify-center rounded-[10px] text-xs font-semibold transition-colors"
-                                    :class="
-                                        team.id === currentTeam?.id
-                                            ? 'bg-primary text-primary-foreground'
-                                            : 'border border-border text-muted-foreground hover:bg-sidebar-accent'
-                                    "
-                                    @click="switchTeam(team)"
-                                >
-                                    {{ getInitials(team.name) }}
-                                </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="right">
-                                {{ team.name }}
-                            </TooltipContent>
-                        </Tooltip>
-                    </div>
-
-                    <Separator class="my-1 w-6" />
-
-                    <CreateTeamModal>
-                        <button
-                            type="button"
-                            title="New team"
-                            data-test="team-rail-add"
-                            class="flex size-9 items-center justify-center rounded-[10px] border border-dashed border-border text-muted-foreground transition-colors hover:bg-sidebar-accent"
-                        >
-                            <Plus class="size-[15px]" />
-                            <span class="sr-only">New team</span>
-                        </button>
-                    </CreateTeamModal>
-                </div>
-
-                <!-- Channel sidebar -->
-                <Sidebar collapsible="none" class="flex-1">
-                    <SidebarHeader
-                        class="h-12 shrink-0 flex-row items-center justify-between border-b border-sidebar-border px-3.5"
-                    >
-                        <TeamSwitcher />
-                    </SidebarHeader>
-
-                    <SidebarContent>
-                        <div class="px-2 pt-2">
+    <SidebarProvider
+        class="bg-background"
+        style="--sidebar-width: calc(272px + 1.75rem)"
+    >
+        <!-- The dock: a single floating card. Team switching, invite, and
+             new-team fold into the workspace header (the vertical team rail is
+             gone); on mobile the whole card slides in as the built-in Sheet. -->
+        <Sidebar collapsible="offcanvas" variant="floating" class="p-3.5">
+            <SidebarHeader
+                class="gap-0 border-b border-sidebar-border p-3.5 pb-2.5"
+            >
+                <div class="flex items-center gap-2">
+                    <DropdownMenu>
+                        <DropdownMenuTrigger as-child>
                             <button
                                 type="button"
-                                data-test="quick-switcher-trigger"
-                                class="flex w-full items-center gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/40 px-2.5 py-1.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
-                                @click="quickSwitcherOpen = true"
+                                data-test="workspace-switcher"
+                                class="-m-1 flex min-w-0 flex-1 items-center gap-2 rounded-[9px] p-1 text-left transition-colors hover:bg-sidebar-accent"
                             >
-                                <Search class="size-[15px] shrink-0" />
-                                <span>Jump to…</span>
-                                <kbd
-                                    class="ml-auto rounded border border-sidebar-border bg-sidebar px-1.5 py-0.5 font-mono text-[10px] tracking-wide text-muted-foreground"
-                                    >⌘K</kbd
+                                <span
+                                    class="flex size-8 shrink-0 items-center justify-center rounded-[9px] bg-sidebar-primary text-[11px] font-semibold text-sidebar-primary-foreground"
+                                    >{{
+                                        getInitials(currentTeam?.name ?? '')
+                                    }}</span
                                 >
+                                <span class="min-w-0 flex-1">
+                                    <span
+                                        class="block truncate text-sm font-semibold text-sidebar-foreground"
+                                        >{{
+                                            currentTeam?.name ?? 'Select team'
+                                        }}</span
+                                    >
+                                    <span
+                                        class="block text-[11px] text-muted-foreground"
+                                        >{{ currentTeam?.membersCount ?? 0 }}
+                                        {{
+                                            (currentTeam?.membersCount ?? 0) ===
+                                            1
+                                                ? 'member'
+                                                : 'members'
+                                        }}</span
+                                    >
+                                </span>
                             </button>
-                        </div>
-                        <!-- Starred channels, pinned above the main list; the
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="start" class="w-56">
+                            <DropdownMenuLabel
+                                class="text-xs text-muted-foreground"
+                            >
+                                Teams
+                            </DropdownMenuLabel>
+                            <DropdownMenuItem
+                                v-for="team in teams"
+                                :key="team.id"
+                                data-test="team-switcher-item"
+                                class="cursor-pointer gap-2"
+                                @click="switchTeam(team)"
+                            >
+                                {{ team.name }}
+                                <Check
+                                    v-if="team.id === currentTeam?.id"
+                                    class="ml-auto size-4"
+                                />
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <CreateTeamModal>
+                                <DropdownMenuItem
+                                    data-test="team-switcher-new-team"
+                                    class="cursor-pointer gap-2"
+                                    @select.prevent
+                                >
+                                    <Plus class="size-4" />
+                                    <span class="text-muted-foreground"
+                                        >New team</span
+                                    >
+                                </DropdownMenuItem>
+                            </CreateTeamModal>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                    <div class="flex shrink-0 items-center gap-1">
+                        <button
+                            v-if="canInviteToCurrentTeam"
+                            type="button"
+                            title="Invite people"
+                            data-test="invite-member-trigger"
+                            class="flex size-6 items-center justify-center rounded-[7px] border border-sidebar-border text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                            @click="inviteOpen = true"
+                        >
+                            <UserPlus class="size-3" />
+                            <span class="sr-only">Invite people</span>
+                        </button>
+                        <CreateTeamModal>
+                            <button
+                                type="button"
+                                title="New team"
+                                data-test="new-team-trigger"
+                                class="flex size-6 items-center justify-center rounded-[7px] border border-dashed border-sidebar-border text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                            >
+                                <Plus class="size-3" />
+                                <span class="sr-only">New team</span>
+                            </button>
+                        </CreateTeamModal>
+                    </div>
+                </div>
+            </SidebarHeader>
+
+            <SidebarContent>
+                <div class="px-2 pt-2">
+                    <button
+                        type="button"
+                        data-test="quick-switcher-trigger"
+                        class="flex h-8 w-full items-center gap-2 rounded-[9px] bg-muted px-2.5 text-[13px] text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                        @click="quickSwitcherOpen = true"
+                    >
+                        <Search class="size-[13px] shrink-0" />
+                        <span>Jump to…</span>
+                        <kbd
+                            class="ml-auto font-mono text-[10px] font-semibold tracking-wide text-muted-foreground/70"
+                            >⌘K</kbd
+                        >
+                    </button>
+                </div>
+                <!-- Starred channels, pinned above the main list; the
                              whole section is hidden until the user stars one.
                              Reorderable within itself (its own drag group), but a
                              starred row can't be dragged into a custom section —
                              starring wins, so its move menu stays hidden. -->
-                        <SidebarGroup
-                            v-if="starredList.length > 0"
-                            class="pb-0"
+                <SidebarGroup v-if="starredList.length > 0" class="pb-0">
+                    <button
+                        type="button"
+                        data-test="section-toggle-starred"
+                        :aria-expanded="!isSectionCollapsed('starred')"
+                        class="flex h-7 w-full items-center gap-1 rounded-md px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/70 uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                        @click="toggleSection('starred')"
+                    >
+                        <ChevronRight
+                            class="size-3 shrink-0 transition-transform"
+                            :class="
+                                isSectionCollapsed('starred') ? '' : 'rotate-90'
+                            "
+                        />
+                        Starred
+                    </button>
+                    <SidebarGroupContent
+                        v-show="!isSectionCollapsed('starred')"
+                        data-test="section-content-starred"
+                    >
+                        <draggable
+                            v-model="starredList"
+                            :group="{ name: 'starred' }"
+                            handle=".channel-drag-handle"
+                            item-key="id"
+                            tag="ul"
+                            class="flex w-full min-w-0 flex-col gap-1"
+                            :animation="150"
+                            @change="onStarredChange"
                         >
-                            <button
-                                type="button"
-                                data-test="section-toggle-starred"
-                                :aria-expanded="!isSectionCollapsed('starred')"
-                                class="flex h-7 w-full items-center gap-1 rounded-md px-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
-                                @click="toggleSection('starred')"
-                            >
-                                <ChevronRight
-                                    class="size-3 shrink-0 transition-transform"
-                                    :class="
-                                        isSectionCollapsed('starred')
-                                            ? ''
-                                            : 'rotate-90'
-                                    "
+                            <template #item="{ element }">
+                                <ChannelListItem
+                                    :channel="element"
+                                    :team-slug="currentTeam?.slug ?? ''"
+                                    :active-channel-slug="activeChannelSlug"
                                 />
-                                Starred
-                            </button>
-                            <SidebarGroupContent
-                                v-show="!isSectionCollapsed('starred')"
-                                data-test="section-content-starred"
-                            >
-                                <draggable
-                                    v-model="starredList"
-                                    :group="{ name: 'starred' }"
-                                    handle=".channel-drag-handle"
-                                    item-key="id"
-                                    tag="ul"
-                                    class="flex w-full min-w-0 flex-col gap-1"
-                                    :animation="150"
-                                    @change="onStarredChange"
-                                >
-                                    <template #item="{ element }">
-                                        <ChannelListItem
-                                            :channel="element"
-                                            :team-slug="currentTeam?.slug ?? ''"
-                                            :active-channel-slug="
-                                                activeChannelSlug
-                                            "
-                                        />
-                                    </template>
-                                </draggable>
-                            </SidebarGroupContent>
-                        </SidebarGroup>
+                            </template>
+                        </draggable>
+                    </SidebarGroupContent>
+                </SidebarGroup>
 
-                        <!-- The user's custom sections, drag-reorderable amongst
+                <!-- The user's custom sections, drag-reorderable amongst
                              themselves; each holds a channel list that shares a
                              drag group with the default "Channels" list below, so
                              channels can be dragged across them. -->
-                        <draggable
-                            v-if="customGroups.length > 0"
-                            v-model="customGroups"
-                            :group="{ name: 'sections' }"
-                            handle=".section-drag-handle"
-                            :item-key="sectionKey"
-                            tag="div"
-                            :animation="150"
-                            @change="onSectionReorder"
+                <draggable
+                    v-if="customGroups.length > 0"
+                    v-model="customGroups"
+                    :group="{ name: 'sections' }"
+                    handle=".section-drag-handle"
+                    :item-key="sectionKey"
+                    tag="div"
+                    :animation="150"
+                    @change="onSectionReorder"
+                >
+                    <template #item="{ element: group }">
+                        <SidebarGroup
+                            class="pb-0"
+                            :data-test="`section-custom-${group.section.id}`"
                         >
-                            <template #item="{ element: group }">
-                                <SidebarGroup
-                                    class="pb-0"
-                                    :data-test="`section-custom-${group.section.id}`"
+                            <div
+                                class="group/section flex h-7 w-full items-center gap-1 rounded-md pr-1 pl-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/70 uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                            >
+                                <button
+                                    type="button"
+                                    :data-test="`section-drag-${group.section.id}`"
+                                    :aria-label="`Reorder ${group.section.name}`"
+                                    title="Drag to reorder section"
+                                    class="section-drag-handle flex size-4 shrink-0 cursor-grab items-center justify-center rounded text-muted-foreground/50 opacity-0 transition group-hover/section:opacity-100 hover:text-sidebar-foreground active:cursor-grabbing"
                                 >
-                                    <div
-                                        class="group/section flex h-7 w-full items-center gap-1 rounded-md pr-1 pl-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                                    <GripVertical class="size-3" />
+                                </button>
+                                <button
+                                    type="button"
+                                    :data-test="`section-toggle-custom-${group.section.id}`"
+                                    :aria-expanded="!group.section.collapsed"
+                                    class="flex min-w-0 flex-1 items-center gap-1"
+                                    @click="toggleCustomSection(group)"
+                                >
+                                    <ChevronRight
+                                        class="size-3 shrink-0 transition-transform"
+                                        :class="
+                                            group.section.collapsed
+                                                ? ''
+                                                : 'rotate-90'
+                                        "
+                                    />
+                                    <input
+                                        v-if="
+                                            renamingSectionId ===
+                                            group.section.id
+                                        "
+                                        :ref="setRenameInput"
+                                        v-model="renameValue"
+                                        :data-test="`section-rename-input-${group.section.id}`"
+                                        class="w-full min-w-0 rounded-sm border border-sidebar-border bg-sidebar px-1 py-0.5 text-[11px] tracking-normal text-sidebar-foreground normal-case focus:outline-none"
+                                        type="text"
+                                        maxlength="50"
+                                        @click.stop
+                                        @keydown.enter.prevent="
+                                            renameInput?.blur()
+                                        "
+                                        @keydown.esc="cancelRename"
+                                        @blur="submitRename(group.section)"
+                                    />
+                                    <span
+                                        v-else
+                                        class="truncate"
+                                        @dblclick.stop="
+                                            startRename(group.section)
+                                        "
+                                        >{{ group.section.name }}</span
                                     >
+                                </button>
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger as-child>
                                         <button
                                             type="button"
-                                            :data-test="`section-drag-${group.section.id}`"
-                                            :aria-label="`Reorder ${group.section.name}`"
-                                            title="Drag to reorder section"
-                                            class="section-drag-handle flex size-4 shrink-0 cursor-grab items-center justify-center rounded text-muted-foreground/50 opacity-0 transition group-hover/section:opacity-100 hover:text-sidebar-foreground active:cursor-grabbing"
+                                            :data-test="`section-menu-${group.section.id}`"
+                                            :aria-label="`Options for ${group.section.name}`"
+                                            title="Section options"
+                                            class="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition group-hover/section:opacity-100 hover:text-sidebar-foreground focus-visible:opacity-100 data-[state=open]:opacity-100"
                                         >
-                                            <GripVertical class="size-3" />
+                                            <MoreVertical class="size-3.5" />
                                         </button>
-                                        <button
-                                            type="button"
-                                            :data-test="`section-toggle-custom-${group.section.id}`"
-                                            :aria-expanded="
-                                                !group.section.collapsed
-                                            "
-                                            class="flex min-w-0 flex-1 items-center gap-1"
-                                            @click="toggleCustomSection(group)"
-                                        >
-                                            <ChevronRight
-                                                class="size-3 shrink-0 transition-transform"
-                                                :class="
-                                                    group.section.collapsed
-                                                        ? ''
-                                                        : 'rotate-90'
-                                                "
-                                            />
-                                            <input
-                                                v-if="
-                                                    renamingSectionId ===
-                                                    group.section.id
-                                                "
-                                                :ref="setRenameInput"
-                                                v-model="renameValue"
-                                                :data-test="`section-rename-input-${group.section.id}`"
-                                                class="w-full min-w-0 rounded-sm border border-sidebar-border bg-sidebar px-1 py-0.5 text-[11px] tracking-normal text-sidebar-foreground normal-case focus:outline-none"
-                                                type="text"
-                                                maxlength="50"
-                                                @click.stop
-                                                @keydown.enter.prevent="
-                                                    renameInput?.blur()
-                                                "
-                                                @keydown.esc="cancelRename"
-                                                @blur="
-                                                    submitRename(group.section)
-                                                "
-                                            />
-                                            <span
-                                                v-else
-                                                class="truncate"
-                                                @dblclick.stop="
-                                                    startRename(group.section)
-                                                "
-                                                >{{ group.section.name }}</span
-                                            >
-                                        </button>
-                                        <DropdownMenu>
-                                            <DropdownMenuTrigger as-child>
-                                                <button
-                                                    type="button"
-                                                    :data-test="`section-menu-${group.section.id}`"
-                                                    :aria-label="`Options for ${group.section.name}`"
-                                                    title="Section options"
-                                                    class="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/60 opacity-0 transition group-hover/section:opacity-100 hover:text-sidebar-foreground focus-visible:opacity-100 data-[state=open]:opacity-100"
-                                                >
-                                                    <MoreVertical
-                                                        class="size-3.5"
-                                                    />
-                                                </button>
-                                            </DropdownMenuTrigger>
-                                            <DropdownMenuContent
-                                                align="end"
-                                                class="w-40"
-                                            >
-                                                <DropdownMenuItem
-                                                    :data-test="`section-rename-${group.section.id}`"
-                                                    @select="
-                                                        startRename(
-                                                            group.section,
-                                                        )
-                                                    "
-                                                >
-                                                    <Pencil class="size-3.5" />
-                                                    Rename
-                                                </DropdownMenuItem>
-                                                <DropdownMenuItem
-                                                    variant="destructive"
-                                                    :data-test="`section-delete-${group.section.id}`"
-                                                    @select="
-                                                        deleteSection(
-                                                            group.section,
-                                                        )
-                                                    "
-                                                >
-                                                    <Trash2 class="size-3.5" />
-                                                    Delete
-                                                </DropdownMenuItem>
-                                            </DropdownMenuContent>
-                                        </DropdownMenu>
-                                    </div>
-                                    <SidebarGroupContent
-                                        v-show="!group.section.collapsed"
-                                        :data-test="`section-content-custom-${group.section.id}`"
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent
+                                        align="end"
+                                        class="w-40"
                                     >
-                                        <draggable
-                                            v-model="group.channels"
-                                            :group="{
-                                                name: 'sidebar-channels',
-                                            }"
-                                            handle=".channel-drag-handle"
-                                            item-key="id"
-                                            tag="ul"
-                                            class="flex w-full min-w-0 flex-col gap-1"
-                                            :class="
-                                                group.channels.length === 0
-                                                    ? 'min-h-6'
-                                                    : ''
-                                            "
-                                            :animation="150"
-                                            @change="
-                                                (change) =>
-                                                    onChannelChange(
-                                                        change,
-                                                        group.channels,
-                                                        group.section.id,
-                                                    )
+                                        <DropdownMenuItem
+                                            :data-test="`section-rename-${group.section.id}`"
+                                            @select="startRename(group.section)"
+                                        >
+                                            <Pencil class="size-3.5" />
+                                            Rename
+                                        </DropdownMenuItem>
+                                        <DropdownMenuItem
+                                            variant="destructive"
+                                            :data-test="`section-delete-${group.section.id}`"
+                                            @select="
+                                                deleteSection(group.section)
                                             "
                                         >
-                                            <template #item="{ element }">
-                                                <ChannelListItem
-                                                    :channel="element"
-                                                    :team-slug="
-                                                        currentTeam?.slug ?? ''
-                                                    "
-                                                    :active-channel-slug="
-                                                        activeChannelSlug
-                                                    "
-                                                    :sections="customSections"
-                                                    :current-section-id="
-                                                        group.section.id
-                                                    "
-                                                    @move="
-                                                        (sectionId) =>
-                                                            moveChannelToSection(
-                                                                element,
-                                                                sectionId,
-                                                            )
-                                                    "
-                                                />
-                                            </template>
-                                        </draggable>
-                                        <p
-                                            v-if="group.channels.length === 0"
-                                            class="px-7 pb-1 text-[12px] text-muted-foreground/50 normal-case"
-                                        >
-                                            Drag channels here
-                                        </p>
-                                    </SidebarGroupContent>
-                                </SidebarGroup>
-                            </template>
-                        </draggable>
-
-                        <!-- The default "Channels" list: unstarred, unassigned
-                             channels. Shares a drag group with the custom sections
-                             so channels can be dragged in and out. -->
-                        <SidebarGroup>
-                            <button
-                                type="button"
-                                data-test="section-toggle-channels"
-                                :aria-expanded="!isSectionCollapsed('channels')"
-                                class="flex h-7 w-full items-center gap-1 rounded-md px-2 text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
-                                @click="toggleSection('channels')"
-                            >
-                                <ChevronRight
-                                    class="size-3 shrink-0 transition-transform"
-                                    :class="
-                                        isSectionCollapsed('channels')
-                                            ? ''
-                                            : 'rotate-90'
-                                    "
-                                />
-                                Channels
-                            </button>
-                            <CreateChannelModal
-                                v-if="currentTeam"
-                                :team-slug="currentTeam.slug"
-                            >
-                                <SidebarGroupAction
-                                    title="Create channel"
-                                    data-test="create-channel-trigger"
-                                    class="top-2 size-5 rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                                >
-                                    <Plus class="size-[13px]" />
-                                    <span class="sr-only">Create channel</span>
-                                </SidebarGroupAction>
-                            </CreateChannelModal>
+                                            <Trash2 class="size-3.5" />
+                                            Delete
+                                        </DropdownMenuItem>
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
+                            </div>
                             <SidebarGroupContent
-                                v-show="!isSectionCollapsed('channels')"
-                                data-test="section-content-channels"
+                                v-show="!group.section.collapsed"
+                                :data-test="`section-content-custom-${group.section.id}`"
                             >
                                 <draggable
-                                    v-model="defaultList"
-                                    :group="{ name: 'sidebar-channels' }"
+                                    v-model="group.channels"
+                                    :group="{
+                                        name: 'sidebar-channels',
+                                    }"
                                     handle=".channel-drag-handle"
                                     item-key="id"
                                     tag="ul"
                                     class="flex w-full min-w-0 flex-col gap-1"
+                                    :class="
+                                        group.channels.length === 0
+                                            ? 'min-h-6'
+                                            : ''
+                                    "
                                     :animation="150"
                                     @change="
                                         (change) =>
                                             onChannelChange(
                                                 change,
-                                                defaultList,
-                                                null,
+                                                group.channels,
+                                                group.section.id,
                                             )
                                     "
                                 >
@@ -865,7 +801,9 @@ onMounted(() => {
                                                 activeChannelSlug
                                             "
                                             :sections="customSections"
-                                            :current-section-id="null"
+                                            :current-section-id="
+                                                group.section.id
+                                            "
                                             @move="
                                                 (sectionId) =>
                                                     moveChannelToSection(
@@ -876,126 +814,206 @@ onMounted(() => {
                                         />
                                     </template>
                                 </draggable>
-                            </SidebarGroupContent>
-                        </SidebarGroup>
-
-                        <!-- Create a new custom section. -->
-                        <SidebarGroup class="py-0">
-                            <SidebarGroupContent>
-                                <div v-if="sectionFormOpen" class="px-2">
-                                    <input
-                                        ref="sectionNameInput"
-                                        v-model="newSectionName"
-                                        data-test="create-section-input"
-                                        class="w-full rounded-md border border-sidebar-border bg-sidebar px-2 py-1 text-[13px] text-sidebar-foreground focus:outline-none"
-                                        type="text"
-                                        maxlength="50"
-                                        placeholder="New section name"
-                                        @keydown.enter.prevent="
-                                            sectionNameInput?.blur()
-                                        "
-                                        @keydown.esc="cancelSectionForm"
-                                        @blur="createSection"
-                                    />
-                                </div>
-                                <button
-                                    v-else
-                                    type="button"
-                                    data-test="create-section-trigger"
-                                    class="flex h-7 w-full items-center gap-1.5 rounded-md px-2 text-[12px] text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
-                                    @click="openSectionForm"
+                                <p
+                                    v-if="group.channels.length === 0"
+                                    class="px-7 pb-1 text-[12px] text-muted-foreground/50 normal-case"
                                 >
-                                    <FolderPlus class="size-3.5" />
-                                    New section
-                                </button>
+                                    Drag channels here
+                                </p>
                             </SidebarGroupContent>
                         </SidebarGroup>
+                    </template>
+                </draggable>
 
-                        <!-- Workspace navigation, always visible regardless of
+                <!-- The default "Channels" list: unstarred, unassigned
+                             channels. Shares a drag group with the custom sections
+                             so channels can be dragged in and out. -->
+                <SidebarGroup>
+                    <button
+                        type="button"
+                        data-test="section-toggle-channels"
+                        :aria-expanded="!isSectionCollapsed('channels')"
+                        class="flex h-7 w-full items-center gap-1 rounded-md px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/70 uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                        @click="toggleSection('channels')"
+                    >
+                        <ChevronRight
+                            class="size-3 shrink-0 transition-transform"
+                            :class="
+                                isSectionCollapsed('channels')
+                                    ? ''
+                                    : 'rotate-90'
+                            "
+                        />
+                        Channels
+                    </button>
+                    <CreateChannelModal
+                        v-if="currentTeam"
+                        :team-slug="currentTeam.slug"
+                    >
+                        <SidebarGroupAction
+                            title="Create channel"
+                            data-test="create-channel-trigger"
+                            class="top-2 size-5 rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                        >
+                            <Plus class="size-[13px]" />
+                            <span class="sr-only">Create channel</span>
+                        </SidebarGroupAction>
+                    </CreateChannelModal>
+                    <SidebarGroupContent
+                        v-show="!isSectionCollapsed('channels')"
+                        data-test="section-content-channels"
+                    >
+                        <draggable
+                            v-model="defaultList"
+                            :group="{ name: 'sidebar-channels' }"
+                            handle=".channel-drag-handle"
+                            item-key="id"
+                            tag="ul"
+                            class="flex w-full min-w-0 flex-col gap-1"
+                            :animation="150"
+                            @change="
+                                (change) =>
+                                    onChannelChange(change, defaultList, null)
+                            "
+                        >
+                            <template #item="{ element }">
+                                <ChannelListItem
+                                    :channel="element"
+                                    :team-slug="currentTeam?.slug ?? ''"
+                                    :active-channel-slug="activeChannelSlug"
+                                    :sections="customSections"
+                                    :current-section-id="null"
+                                    @move="
+                                        (sectionId) =>
+                                            moveChannelToSection(
+                                                element,
+                                                sectionId,
+                                            )
+                                    "
+                                />
+                            </template>
+                        </draggable>
+                    </SidebarGroupContent>
+                </SidebarGroup>
+
+                <!-- Create a new custom section. -->
+                <SidebarGroup class="py-0">
+                    <SidebarGroupContent>
+                        <div v-if="sectionFormOpen" class="px-2">
+                            <input
+                                ref="sectionNameInput"
+                                v-model="newSectionName"
+                                data-test="create-section-input"
+                                class="w-full rounded-md border border-sidebar-border bg-sidebar px-2 py-1 text-[13px] text-sidebar-foreground focus:outline-none"
+                                type="text"
+                                maxlength="50"
+                                placeholder="New section name"
+                                @keydown.enter.prevent="
+                                    sectionNameInput?.blur()
+                                "
+                                @keydown.esc="cancelSectionForm"
+                                @blur="createSection"
+                            />
+                        </div>
+                        <button
+                            v-else
+                            type="button"
+                            data-test="create-section-trigger"
+                            class="flex h-7 w-full items-center gap-1.5 rounded-md px-2 text-[12px] text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
+                            @click="openSectionForm"
+                        >
+                            <FolderPlus class="size-3.5" />
+                            New section
+                        </button>
+                    </SidebarGroupContent>
+                </SidebarGroup>
+
+                <!-- Workspace navigation, always visible regardless of
                              which channel sections are collapsed. -->
-                        <SidebarGroup class="pt-0">
-                            <SidebarGroupContent>
-                                <SidebarMenu>
-                                    <SidebarMenuItem>
-                                        <SidebarMenuButton
-                                            as-child
-                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
-                                        >
-                                            <Link
-                                                v-if="currentTeam"
-                                                :href="
-                                                    threadsInbox(
-                                                        currentTeam.slug,
-                                                    ).url
-                                                "
-                                                data-test="threads-inbox"
-                                            >
-                                                <MessagesSquare
-                                                    class="size-[13px]"
-                                                />
-                                                <span>Threads</span>
-                                                <span
-                                                    v-if="hasUnreadThreads"
-                                                    data-test="threads-unread-dot"
-                                                    aria-hidden="true"
-                                                    class="ml-auto size-1.5 rounded-full bg-primary"
-                                                />
-                                            </Link>
-                                        </SidebarMenuButton>
-                                    </SidebarMenuItem>
-                                    <SidebarMenuItem>
-                                        <SidebarMenuButton
-                                            as-child
-                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
-                                        >
-                                            <Link
-                                                v-if="currentTeam"
-                                                :href="
-                                                    searchMessages(
-                                                        currentTeam.slug,
-                                                    ).url
-                                                "
-                                                data-test="search-messages"
-                                            >
-                                                <MessageSquareText
-                                                    class="size-[13px]"
-                                                />
-                                                <span>Search messages</span>
-                                            </Link>
-                                        </SidebarMenuButton>
-                                    </SidebarMenuItem>
-                                    <SidebarMenuItem>
-                                        <SidebarMenuButton
-                                            as-child
-                                            class="h-[30px] gap-1.5 rounded-md px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
-                                        >
-                                            <Link
-                                                v-if="currentTeam"
-                                                :href="
-                                                    browse(currentTeam.slug).url
-                                                "
-                                                data-test="browse-channels"
-                                            >
-                                                <Search class="size-[13px]" />
-                                                <span>Browse channels</span>
-                                            </Link>
-                                        </SidebarMenuButton>
-                                    </SidebarMenuItem>
-                                </SidebarMenu>
-                            </SidebarGroupContent>
-                        </SidebarGroup>
-                    </SidebarContent>
+                <SidebarGroup class="pt-0">
+                    <SidebarGroupContent>
+                        <SidebarMenu>
+                            <SidebarMenuItem>
+                                <SidebarMenuButton
+                                    as-child
+                                    class="h-[30px] gap-2 rounded-[9px] px-2.5 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                >
+                                    <Link
+                                        v-if="currentTeam"
+                                        :href="
+                                            threadsInbox(currentTeam.slug).url
+                                        "
+                                        data-test="threads-inbox"
+                                    >
+                                        <MessagesSquare class="size-[13px]" />
+                                        <span>Threads</span>
+                                        <span
+                                            v-if="hasUnreadThreads"
+                                            data-test="threads-unread-dot"
+                                            aria-hidden="true"
+                                            class="ml-auto size-1.5 rounded-full bg-brass"
+                                        />
+                                    </Link>
+                                </SidebarMenuButton>
+                            </SidebarMenuItem>
+                            <SidebarMenuItem>
+                                <SidebarMenuButton
+                                    as-child
+                                    class="h-[30px] gap-2 rounded-[9px] px-2.5 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                >
+                                    <Link
+                                        v-if="currentTeam"
+                                        :href="
+                                            searchMessages(currentTeam.slug).url
+                                        "
+                                        data-test="search-messages"
+                                    >
+                                        <MessageSquareText
+                                            class="size-[13px]"
+                                        />
+                                        <span>Search messages</span>
+                                    </Link>
+                                </SidebarMenuButton>
+                            </SidebarMenuItem>
+                            <SidebarMenuItem>
+                                <SidebarMenuButton
+                                    as-child
+                                    class="h-[30px] gap-2 rounded-[9px] px-2.5 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                >
+                                    <Link
+                                        v-if="currentTeam"
+                                        :href="browse(currentTeam.slug).url"
+                                        data-test="browse-channels"
+                                    >
+                                        <Search class="size-[13px]" />
+                                        <span>Browse channels</span>
+                                    </Link>
+                                </SidebarMenuButton>
+                            </SidebarMenuItem>
+                        </SidebarMenu>
+                    </SidebarGroupContent>
+                </SidebarGroup>
+            </SidebarContent>
 
-                    <SidebarFooter class="border-t border-sidebar-border p-2">
-                        <NavUser />
-                    </SidebarFooter>
-                </Sidebar>
-            </div>
+            <SidebarFooter class="border-t border-sidebar-border p-2.5">
+                <NavUser />
+            </SidebarFooter>
         </Sidebar>
 
-        <SidebarInset class="flex h-svh flex-col">
+        <!-- Main card: fills the screen on mobile, floats on the warm canvas
+             (matching the dock) from md up. -->
+        <SidebarInset
+            class="flex h-svh flex-col overflow-hidden md:my-3.5 md:mr-3.5 md:h-[calc(100svh-1.75rem)] md:rounded-[14px] md:border md:border-border md:bg-card md:shadow-sm"
+        >
             <slot />
         </SidebarInset>
+
+        <InviteMemberModal
+            v-if="currentTeam && canInviteToCurrentTeam"
+            v-model:open="inviteOpen"
+            :team="currentTeam"
+            :available-roles="invitableRoles"
+        />
 
         <PendingInvitationsModal
             v-if="pendingInvitations.length > 0"

--- a/resources/js/theme/designTokens.test.ts
+++ b/resources/js/theme/designTokens.test.ts
@@ -78,8 +78,15 @@ describe('"The Desk" design foundation', () => {
             );
         });
 
+        it('keeps solid-brass badge text ink in both themes', () => {
+            expect(tokenValue(':root', '--brass-foreground')).toBe('#1d1a15');
+        });
+
         it('exposes brass as Tailwind color utilities via @theme inline', () => {
             expect(appCss).toContain('--color-brass: var(--brass);');
+            expect(appCss).toContain(
+                '--color-brass-foreground: var(--brass-foreground);',
+            );
             expect(appCss).toContain('--color-brass-fill: var(--brass-fill);');
             expect(appCss).toContain(
                 '--color-brass-fill-foreground: var(--brass-fill-foreground);',

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -1,6 +1,6 @@
 import type { Auth } from '@/types/auth';
 import type { Channel, ChannelSection } from '@/types/channels';
-import type { DashboardInvitation, Team } from '@/types/teams';
+import type { DashboardInvitation, RoleOption, Team } from '@/types/teams';
 
 // Extend ImportMeta interface for Vite...
 declare module 'vite/client' {
@@ -23,6 +23,8 @@ declare module '@inertiajs/core' {
             sidebarOpen: boolean;
             currentTeam: Team | null;
             teams: Team[];
+            canInviteToCurrentTeam: boolean;
+            invitableRoles: RoleOption[];
             channels?: Channel[];
             channelSections?: ChannelSection[];
             collapsedChannelSections?: string[];

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -7,6 +7,7 @@ export type Team = {
     isPersonal: boolean;
     role?: TeamRole;
     roleLabel?: string;
+    membersCount: number;
     isCurrent?: boolean;
 };
 

--- a/tests/Feature/Channels/WorkspaceShellTest.php
+++ b/tests/Feature/Channels/WorkspaceShellTest.php
@@ -62,6 +62,23 @@ test('a logged in user lands in the #general workspace', function () {
         );
 });
 
+test('the workspace shell shares the dock header affordances', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('channels.show', [
+            'team' => $user->currentTeam->slug,
+            'channel' => Channel::GENERAL_SLUG,
+        ]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('currentTeam.membersCount', 1)
+            ->where('canInviteToCurrentTeam', true)
+            ->has('invitableRoles')
+            ->where('invitableRoles.0.value', 'admin')
+        );
+});
+
 test('login to workspace smoke: land in #general, create a channel, then browse', function () {
     $user = User::factory()->create();
     $slug = $user->currentTeam->slug;

--- a/tests/Feature/Concerns/HasTeamsTest.php
+++ b/tests/Feature/Concerns/HasTeamsTest.php
@@ -55,6 +55,16 @@ test('fallback team returns the first team ordered by name', function () {
     expect($user->fallbackTeam()->id)->toBe($alpha->id);
 });
 
+test('user team dto carries the team member count', function () {
+    $user = User::factory()->create();
+
+    $team = Team::factory()->create();
+    $team->members()->attach($user, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach(User::factory()->create(), ['role' => TeamRole::Member->value]);
+
+    expect($user->toUserTeam($team)->membersCount)->toBe(2);
+});
+
 test('fallback team can exclude a given team', function () {
     $user = User::factory()->create(['name' => 'Zzz']);
 


### PR DESCRIPTION
Closes #147. Second landing of the **"The Desk"** epic #145 — the floating-card shell and dock everything else renders inside. Consumes the #146 tokens (semantic tokens only, no raw hex). Pure reskin, no new product capability.

## Shell
- `SidebarProvider` sits on the warm canvas (`bg-background`); the dock and main render as rounded **14px** cards with a warm border + soft shadow. The main card fills the screen on mobile and floats (`md:my/mr-3.5`) from `md` up; the dock slides in as the built-in **Sheet** drawer on mobile (existing `SidebarTrigger` in each page header still opens it).

## Dock
- **Team rail removed** — team switching folds into the header: workspace avatar (ink square) + name + **member count**, opening the teams dropdown. Two mini-buttons beside it: **invite people** (reuses `InviteMemberModal`) and **new team** (`CreateTeamModal`).
- **Jump to… ⌘K** row restyled (muted fill, mono hint) — same quick-switcher behavior.
- **Starred / Channels / custom** group labels → faint, wide-tracked uppercase with chevron; Channels keeps its trailing `+` create action.
- **Channel rows** (`ChannelListItem`): active = **ink pill** with brass `#` + shadow; unread = ink/semibold name + **brass count badge / dot**; **brass star** affordance. Drag-reorder, kebab move, draft cue, mute all preserved.
- **Footer** `NavUser`: muted rounded fill, 28px avatar + presence dot, name/team, chevrons.

## Data
- `UserTeam` DTO gains `membersCount`; `HandleInertiaRequests` shares `canInviteToCurrentTeam` + `invitableRoles` so the dock's invite button works globally. New `--brass-foreground` token (ink-on-brass, both themes) for the solid-brass unread badge.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan 0 errors)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` → all green (build self-hosts fonts, no external request)
- `sail npm run test:js` → 24 files, 220 tests passing

Part of epic #145. Next: masthead/timeline/messaging children (#148–#154).