### PR TITLE
feat(messaging): avatar-gutter message timeline (#149)

### DIFF
--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -35,6 +35,7 @@ import { formatTimeOfDay } from '@/lib/datetime';
 import { tokenizeMessageBody } from '@/lib/messageBody';
 import type { MessageBodySegment } from '@/lib/messageBody';
 import { readersForMessage } from '@/lib/readReceipts';
+import { buildTimelineItems } from '@/lib/timeline';
 import type {
     ChannelReader,
     Mention,
@@ -178,43 +179,17 @@ function previewFor(
     return message.linkPreviews.find((preview) => preview.url === href);
 }
 
-// Consecutive messages from the same author within this window are grouped
-// under a single avatar + header line.
-const GROUPING_WINDOW_MS = 5 * 60 * 1000;
-
-type RenderGroup = {
-    type: 'group';
-    key: string;
-    author: MessageAuthor;
-    leadCreatedAt: string;
-    messages: Message[];
-};
-
-type RenderDivider = {
-    type: 'divider';
-    key: string;
-    label: string;
-    // 'day' groups messages by date; 'unread' is the "New messages" boundary.
-    variant: 'day' | 'unread';
-};
-
-type RenderItem = RenderGroup | RenderDivider;
-
-function dayKey(iso: string): string {
-    return new Date(iso).toDateString();
-}
-
 function dividerLabel(iso: string): string {
     const date = new Date(iso);
     const today = new Date();
     const yesterday = new Date();
     yesterday.setDate(today.getDate() - 1);
 
-    if (dayKey(iso) === today.toDateString()) {
+    if (date.toDateString() === today.toDateString()) {
         return 'Today';
     }
 
-    if (dayKey(iso) === yesterday.toDateString()) {
+    if (date.toDateString() === yesterday.toDateString()) {
         return 'Yesterday';
     }
 
@@ -231,72 +206,12 @@ function formatTime(iso: string): string {
     return formatTimeOfDay(iso, viewerTimeZone.value);
 }
 
-const renderItems = computed<RenderItem[]>(() => {
-    const items: RenderItem[] = [];
-    let currentGroup: RenderGroup | null = null;
-    let currentDay: string | null = null;
-    let lastCreatedAt: string | null = null;
-
-    for (const message of props.messages) {
-        const messageDay = dayKey(message.createdAt);
-        const startsNewDay = messageDay !== currentDay;
-
-        if (startsNewDay) {
-            items.push({
-                type: 'divider',
-                key: `divider-${messageDay}`,
-                label: dividerLabel(message.createdAt),
-                variant: 'day',
-            });
-            currentDay = messageDay;
-        }
-
-        // The "New messages" boundary breaks the run of grouped messages so the
-        // divider sits on its own line directly above the first unread message.
-        const isUnreadBoundary =
-            props.unreadDividerId != null &&
-            message.id === props.unreadDividerId;
-
-        if (isUnreadBoundary) {
-            items.push({
-                type: 'divider',
-                key: 'unread-divider',
-                label: 'New',
-                variant: 'unread',
-            });
-        }
-
-        const sameAuthor = currentGroup?.author.id === message.user.id;
-        const withinWindow =
-            lastCreatedAt !== null &&
-            new Date(message.createdAt).getTime() -
-                new Date(lastCreatedAt).getTime() <=
-                GROUPING_WINDOW_MS;
-
-        if (
-            !currentGroup ||
-            startsNewDay ||
-            isUnreadBoundary ||
-            !sameAuthor ||
-            !withinWindow
-        ) {
-            currentGroup = {
-                type: 'group',
-                key: `group-${message.id}`,
-                author: message.user,
-                leadCreatedAt: message.createdAt,
-                messages: [message],
-            };
-            items.push(currentGroup);
-        } else {
-            currentGroup.messages.push(message);
-        }
-
-        lastCreatedAt = message.createdAt;
-    }
-
-    return items;
-});
+// The grouped, divider-interleaved render list. The grouping and boundary logic
+// lives in a pure, unit-tested helper; the day label is formatted here so it
+// stays relative to the viewer's "today".
+const renderItems = computed(() =>
+    buildTimelineItems(props.messages, props.unreadDividerId ?? null),
+);
 
 const pending = computed(() => new Set(props.pendingUuids ?? []));
 
@@ -415,77 +330,85 @@ function confirmDelete(): void {
                 v-if="item.type === 'divider' && item.variant === 'unread'"
                 id="unread-divider"
                 data-test="unread-divider"
-                class="relative my-3 flex items-center gap-2"
+                class="my-4 flex items-center gap-3"
             >
-                <span aria-hidden="true" class="h-px flex-1 bg-rose-500/50" />
                 <span
-                    class="text-[11px] font-semibold tracking-[0.05em] text-rose-500 uppercase"
-                >
-                    {{ item.label }}
+                    aria-hidden="true"
+                    class="h-px flex-1 bg-gradient-to-r from-transparent to-brass-border"
+                />
+                <span class="font-serif text-[13px] text-brass-border italic">
+                    new
                 </span>
+                <span
+                    aria-hidden="true"
+                    class="h-px flex-1 bg-gradient-to-r from-brass-border to-transparent"
+                />
             </div>
 
             <div
                 v-else-if="item.type === 'divider'"
-                class="relative my-4 flex items-center justify-center"
+                class="my-4 flex items-center gap-3"
             >
+                <span aria-hidden="true" class="h-px flex-1 bg-border" />
                 <span
-                    aria-hidden="true"
-                    class="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-border"
-                />
-                <span
-                    class="relative rounded-full border border-border bg-background px-3 py-0.5 text-[11.5px] font-medium text-muted-foreground"
+                    class="font-serif text-[13px] text-muted-foreground italic"
                 >
-                    {{ item.label }}
+                    {{ dividerLabel(item.iso!) }}
                 </span>
+                <span aria-hidden="true" class="h-px flex-1 bg-border" />
             </div>
 
-            <div v-else class="mt-[18px] flex items-start gap-3">
-                <UserHoverCard
-                    :team-slug="props.teamSlug"
-                    :user-id="item.author.id"
-                    :name="item.author.name"
-                    @mention="(member) => emit('mention', member)"
+            <div v-else class="mt-[18px] flex">
+                <div
+                    class="flex w-16 shrink-0 flex-col items-center gap-1 pt-0.5"
                 >
-                    <div class="relative mt-0.5 size-9 shrink-0 cursor-pointer">
-                        <div
-                            class="flex size-9 items-center justify-center rounded-[10px] bg-primary/10 text-[12px] font-semibold text-primary select-none"
-                            aria-hidden="true"
-                        >
-                            {{ getInitials(item.author.name) }}
-                        </div>
-                        <span
-                            data-test="presence-dot"
-                            :data-online="isOnline(item.author.id)"
-                            :aria-label="
-                                isOnline(item.author.id) ? 'Online' : 'Offline'
-                            "
-                            class="absolute right-0.5 bottom-0.5 size-2.5 rounded-full ring-2 ring-background"
-                            :class="
-                                isOnline(item.author.id)
-                                    ? 'bg-emerald-500'
-                                    : 'bg-muted-foreground/60'
-                            "
-                        />
-                    </div>
-                </UserHoverCard>
-                <div class="min-w-0 flex-1">
-                    <div class="flex items-baseline gap-2">
-                        <UserHoverCard
-                            :team-slug="props.teamSlug"
-                            :user-id="item.author.id"
-                            :name="item.author.name"
-                            @mention="(member) => emit('mention', member)"
-                        >
-                            <span
-                                class="cursor-pointer text-[14.5px] font-semibold text-foreground hover:underline"
-                                >{{ item.author.name }}</span
+                    <UserHoverCard
+                        :team-slug="props.teamSlug"
+                        :user-id="item.author.id"
+                        :name="item.author.name"
+                        @mention="(member) => emit('mention', member)"
+                    >
+                        <div class="relative size-[34px] cursor-pointer">
+                            <div
+                                class="flex size-[34px] items-center justify-center rounded-full bg-primary/10 text-[11px] font-semibold text-primary select-none"
+                                aria-hidden="true"
                             >
-                        </UserHoverCard>
-                        <span class="text-[11px] text-muted-foreground/80">{{
-                            formatTime(item.leadCreatedAt)
-                        }}</span>
-                    </div>
+                                {{ getInitials(item.author.name) }}
+                            </div>
+                            <span
+                                data-test="presence-dot"
+                                :data-online="isOnline(item.author.id)"
+                                :aria-label="
+                                    isOnline(item.author.id)
+                                        ? 'Online'
+                                        : 'Offline'
+                                "
+                                class="absolute right-0 bottom-0 size-2.5 rounded-full ring-2 ring-card"
+                                :class="
+                                    isOnline(item.author.id)
+                                        ? 'bg-emerald-500'
+                                        : 'bg-muted-foreground/60'
+                                "
+                            />
+                        </div>
+                    </UserHoverCard>
+                    <span
+                        class="font-mono text-[9.5px] text-muted-foreground/70"
+                        >{{ formatTime(item.leadCreatedAt) }}</span
+                    >
+                </div>
+                <div class="min-w-0 flex-1 border-l border-border pl-[18px]">
+                    <UserHoverCard
+                        :team-slug="props.teamSlug"
+                        :user-id="item.author.id"
+                        :name="item.author.name"
+                        @mention="(member) => emit('mention', member)"
+                    >
+                        <span
+                            class="cursor-pointer text-[14px] font-semibold text-foreground hover:underline"
+                            >{{ item.author.name }}</span
+                        >
+                    </UserHoverCard>
                     <div
                         v-for="(message, index) in item.messages"
                         :id="`message-${message.id}`"
@@ -587,7 +510,7 @@ function confirmDelete(): void {
                                 >
                                     <span
                                         data-test="message-mention"
-                                        class="cursor-pointer rounded bg-blue-500/10 px-1 py-0.5 font-medium text-blue-700 dark:bg-blue-400/15 dark:text-blue-300"
+                                        class="cursor-pointer border-b-[1.5px] border-brass font-medium text-foreground hover:border-brass-border"
                                         >@{{ segment.name }}</span
                                     >
                                 </UserHoverCard>

--- a/resources/js/lib/timeline.test.ts
+++ b/resources/js/lib/timeline.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { buildTimelineItems } from '@/lib/timeline';
+import type { Message } from '@/types';
+
+/** A message carrying just the fields the timeline grouping reads. */
+function message(
+    id: string,
+    userId: string,
+    name: string,
+    createdAt: string,
+): Message {
+    return { id, user: { id: userId, name }, createdAt } as unknown as Message;
+}
+
+// Noon timestamps keep day boundaries unambiguous regardless of the runner's
+// timezone; a calendar day never flips around midday.
+const DAY_1_NOON = '2026-07-10T12:00:00.000Z';
+
+function minutesLater(iso: string, minutes: number): string {
+    return new Date(new Date(iso).getTime() + minutes * 60_000).toISOString();
+}
+
+describe('buildTimelineItems', () => {
+    it('returns no items for an empty timeline', () => {
+        expect(buildTimelineItems([], null)).toEqual([]);
+    });
+
+    it('groups consecutive messages from the same author within the window', () => {
+        const items = buildTimelineItems(
+            [
+                message('m1', 'u1', 'Maya', DAY_1_NOON),
+                message('m2', 'u1', 'Maya', minutesLater(DAY_1_NOON, 2)),
+            ],
+            null,
+        );
+
+        // A single day divider then one group holding both messages.
+        expect(items.map((item) => item.type)).toEqual(['divider', 'group']);
+        const group = items[1];
+        expect(
+            group.type === 'group' && group.messages.map((m) => m.id),
+        ).toEqual(['m1', 'm2']);
+        expect(group.type === 'group' && group.author.name).toBe('Maya');
+    });
+
+    it('starts a new group when the author changes', () => {
+        const items = buildTimelineItems(
+            [
+                message('m1', 'u1', 'Maya', DAY_1_NOON),
+                message('m2', 'u2', 'Jonas', minutesLater(DAY_1_NOON, 1)),
+            ],
+            null,
+        );
+
+        const groups = items.filter((item) => item.type === 'group');
+        expect(groups).toHaveLength(2);
+    });
+
+    it('starts a new group when the same author pauses past the window', () => {
+        const items = buildTimelineItems(
+            [
+                message('m1', 'u1', 'Maya', DAY_1_NOON),
+                // 6 minutes later, past the 5-minute grouping window.
+                message('m2', 'u1', 'Maya', minutesLater(DAY_1_NOON, 6)),
+            ],
+            null,
+        );
+
+        const groups = items.filter((item) => item.type === 'group');
+        expect(groups).toHaveLength(2);
+    });
+
+    it('inserts a day divider carrying the crossing message time', () => {
+        const nextDay = '2026-07-11T12:00:00.000Z';
+        const items = buildTimelineItems(
+            [
+                message('m1', 'u1', 'Maya', DAY_1_NOON),
+                message('m2', 'u1', 'Maya', nextDay),
+            ],
+            null,
+        );
+
+        const dividers = items.filter(
+            (item) => item.type === 'divider' && item.variant === 'day',
+        );
+        expect(dividers).toHaveLength(2);
+        expect(dividers[1].type === 'divider' && dividers[1].iso).toBe(nextDay);
+    });
+
+    it('breaks the group with an unread divider above the first unread message', () => {
+        const items = buildTimelineItems(
+            [
+                message('m1', 'u1', 'Maya', DAY_1_NOON),
+                message('m2', 'u1', 'Maya', minutesLater(DAY_1_NOON, 1)),
+            ],
+            'm2',
+        );
+
+        // day divider, group[m1], unread divider, group[m2].
+        expect(items.map((item) => item.type)).toEqual([
+            'divider',
+            'group',
+            'divider',
+            'group',
+        ]);
+        const unread = items[2];
+        expect(unread.type === 'divider' && unread.variant).toBe('unread');
+    });
+});

--- a/resources/js/lib/timeline.ts
+++ b/resources/js/lib/timeline.ts
@@ -1,0 +1,114 @@
+import type { Message, MessageAuthor } from '@/types';
+
+// Consecutive messages from the same author within this window collapse under a
+// single avatar + header line in the timeline.
+export const GROUPING_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * A run of consecutive messages from one author, rendered under a single avatar
+ * gutter. `leadCreatedAt` is the timestamp shown under the avatar.
+ */
+export type TimelineGroup = {
+    type: 'group';
+    key: string;
+    author: MessageAuthor;
+    leadCreatedAt: string;
+    messages: Message[];
+};
+
+/**
+ * A divider between groups: a `day` boundary (carrying the crossing message's
+ * timestamp so the view can format its label) or the `unread` "new" boundary.
+ */
+export type TimelineDivider = {
+    type: 'divider';
+    key: string;
+    variant: 'day' | 'unread';
+    iso?: string;
+};
+
+export type TimelineItem = TimelineGroup | TimelineDivider;
+
+/**
+ * The day bucket a timestamp falls in, as a stable string key. Uses the runner's
+ * local date so dividers land on the viewer's calendar days.
+ */
+function dayKey(iso: string): string {
+    return new Date(iso).toDateString();
+}
+
+/**
+ * Fold a flat, chronological message list into the timeline's render items:
+ * day dividers, the "new" unread boundary, and author-grouped runs.
+ *
+ * A new group begins whenever the day changes, the unread boundary is crossed,
+ * the author changes, or the same author pauses longer than `groupingWindowMs`.
+ * The unread divider sits directly above the first unread message and always
+ * breaks the run so the boundary is never buried mid-group.
+ */
+export function buildTimelineItems(
+    messages: Message[],
+    unreadDividerId: string | null,
+    groupingWindowMs: number = GROUPING_WINDOW_MS,
+): TimelineItem[] {
+    const items: TimelineItem[] = [];
+    let currentGroup: TimelineGroup | null = null;
+    let currentDay: string | null = null;
+    let lastCreatedAt: string | null = null;
+
+    for (const message of messages) {
+        const messageDay = dayKey(message.createdAt);
+        const startsNewDay = messageDay !== currentDay;
+
+        if (startsNewDay) {
+            items.push({
+                type: 'divider',
+                key: `divider-${messageDay}`,
+                variant: 'day',
+                iso: message.createdAt,
+            });
+            currentDay = messageDay;
+        }
+
+        const isUnreadBoundary =
+            unreadDividerId != null && message.id === unreadDividerId;
+
+        if (isUnreadBoundary) {
+            items.push({
+                type: 'divider',
+                key: 'unread-divider',
+                variant: 'unread',
+            });
+        }
+
+        const sameAuthor = currentGroup?.author.id === message.user.id;
+        const withinWindow =
+            lastCreatedAt !== null &&
+            new Date(message.createdAt).getTime() -
+                new Date(lastCreatedAt).getTime() <=
+                groupingWindowMs;
+
+        if (
+            !currentGroup ||
+            startsNewDay ||
+            isUnreadBoundary ||
+            !sameAuthor ||
+            !withinWindow
+        ) {
+            currentGroup = {
+                type: 'group',
+                key: `group-${message.id}`,
+                author: message.user,
+                leadCreatedAt: message.createdAt,
+                messages: [message],
+            };
+            items.push(currentGroup);
+        } else {
+            currentGroup.messages.push(message);
+        }
+
+        lastCreatedAt = message.createdAt;
+    }
+
+    return items;
+}


### PR DESCRIPTION
Reskins `MessageList.vue` to **"The Desk" §5a** — the avatar-gutter timeline that pairs with the #148 masthead.

## What changed
- **Avatar-gutter layout** — a `w-16` (64px) left gutter holds the `size-[34px]` round avatar (presence dot, `ring-card`) with a **mono 9.5px timestamp** beneath it. The right column gains a **left hairline rule** (`border-l`), the author name (14px/semibold), and the grouped bodies aligned under the first line.
- **Date divider** — serif-italic muted label between two hairline rules (§5a/§5h).
- **"new" unread divider** — serif-italic **brass** "new" centered between two brass gradient rules (replaces the old rose "New" bar).
- **Mentions** — brass-underlined text (`border-b-[1.5px] border-brass`) instead of the blue pill.

## Grouping logic preserved (TDD)
The consecutive-same-author grouping, day boundaries, and unread-break logic moved out of a component-internal computed into a pure helper `lib/timeline.ts` (`buildTimelineItems`), driven red→green by `timeline.test.ts` (6 cases: grouping window, author change, day divider carries the crossing timestamp, unread boundary breaks the run). The component now only formats the day label. This directly locks in the "grouping preserved" acceptance criterion.

## Tokens
Semantic tokens only — `brass`, `brass-border`, `foreground`, `border`, `muted-foreground`, `card` — so dark mode (§5d) follows automatically. No raw hex.

## Gates
- `sail composer test` → **Total: 100.0 %**
- `sail npm run lint:check` / `format:check` / `types:check` / `build` → green
- Vitest → 230 passed (incl. new `timeline` suite)

## Note — unrelated defect found
While testing with the SSR dev server I hit a **pre-existing** SSR crash (`document is not defined` in `useUnreadDivider`, unrelated to this reskin). Filed as **#165** rather than fixed inline.

Closes #149. Part of epic #145.
