### PR TITLE
feat(messaging): reskin message micro-components (#150)

### DIFF
--- a/resources/js/components/LinkPreview.vue
+++ b/resources/js/components/LinkPreview.vue
@@ -34,16 +34,20 @@ const siteLabel = computed(
             loading="lazy"
             class="w-full"
         />
-        <div class="p-3">
-            <p class="truncate text-[11.5px] font-medium text-muted-foreground">
+        <div class="px-[15px] py-[13px]">
+            <p
+                class="truncate text-[10px] font-semibold tracking-[0.08em] text-muted-foreground/70 uppercase"
+            >
                 {{ siteLabel }}
             </p>
-            <p class="mt-0.5 text-[13px] font-semibold text-foreground">
+            <p
+                class="mt-1 font-serif text-[15px] leading-[1.3] font-semibold text-foreground"
+            >
                 {{ preview.title }}
             </p>
             <p
                 v-if="preview.description"
-                class="mt-0.5 line-clamp-3 text-[12.5px] leading-[1.45] text-foreground/80"
+                class="mt-1 line-clamp-3 text-[12.5px] leading-[1.5] text-muted-foreground"
             >
                 {{ preview.description }}
             </p>

--- a/resources/js/components/MessageForward.vue
+++ b/resources/js/components/MessageForward.vue
@@ -36,7 +36,7 @@ const rendered = computed(() =>
             <p
                 v-if="isDeleted"
                 data-test="forward-deleted"
-                class="text-[13px] text-muted-foreground/70 italic"
+                class="font-serif text-[13px] text-muted-foreground/70 italic"
             >
                 Original message was deleted
             </p>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -445,7 +445,7 @@ function confirmDelete(): void {
                         <p
                             v-if="message.isDeleted"
                             :data-test="'message-tombstone'"
-                            class="py-0.5 text-[13.5px] text-muted-foreground/70 italic"
+                            class="py-0.5 font-serif text-[13.5px] text-muted-foreground/70 italic"
                         >
                             This message was deleted
                         </p>
@@ -587,49 +587,60 @@ function confirmDelete(): void {
                             @toggle="(emoji) => emit('react', message, emoji)"
                         />
 
-                        <button
+                        <div
                             v-if="showThreadSummary(message)"
-                            type="button"
-                            data-test="thread-summary"
-                            :aria-label="`View thread, ${message.threadReplyCount} ${message.threadReplyCount === 1 ? 'reply' : 'replies'}`"
-                            class="mt-1 flex items-center gap-2 rounded-md py-0.5 pr-2 text-left"
-                            @click="emit('openThread', message.id)"
+                            class="mt-1.5 flex flex-wrap items-center gap-2"
                         >
-                            <span class="flex -space-x-1">
-                                <span
-                                    v-for="participant in threadAvatars(
-                                        message,
-                                    )"
-                                    :key="participant.id"
-                                    class="flex size-5 items-center justify-center rounded-[6px] bg-primary/10 text-[9px] font-semibold text-primary ring-2 ring-background select-none"
-                                    aria-hidden="true"
-                                >
-                                    {{ getInitials(participant.name) }}
-                                </span>
-                                <span
-                                    v-if="extraThreadParticipants(message) > 0"
-                                    class="flex size-5 items-center justify-center rounded-[6px] bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-background select-none"
-                                    aria-hidden="true"
-                                >
-                                    +{{ extraThreadParticipants(message) }}
-                                </span>
-                            </span>
-                            <span
-                                v-if="message.threadUnread"
-                                data-test="thread-unread-dot"
-                                aria-label="Unread replies"
-                                class="size-2 shrink-0 rounded-full bg-rose-500"
-                            ></span>
-                            <span
-                                class="text-[12.5px] font-semibold text-primary hover:underline"
+                            <button
+                                type="button"
+                                data-test="thread-summary"
+                                :aria-label="`View thread, ${message.threadReplyCount} ${message.threadReplyCount === 1 ? 'reply' : 'replies'}`"
+                                class="inline-flex items-center gap-2 rounded-full border border-border bg-card px-2.5 py-1 text-left transition-colors hover:bg-muted/50"
+                                @click="emit('openThread', message.id)"
                             >
-                                {{ message.threadReplyCount }}
-                                {{
-                                    message.threadReplyCount === 1
-                                        ? 'reply'
-                                        : 'replies'
-                                }}
-                            </span>
+                                <span class="flex -space-x-1">
+                                    <span
+                                        v-for="participant in threadAvatars(
+                                            message,
+                                        )"
+                                        :key="participant.id"
+                                        class="flex size-4 items-center justify-center rounded-full bg-primary/10 text-[8px] font-semibold text-primary ring-2 ring-card select-none"
+                                        aria-hidden="true"
+                                    >
+                                        {{ getInitials(participant.name) }}
+                                    </span>
+                                    <span
+                                        v-if="
+                                            extraThreadParticipants(message) > 0
+                                        "
+                                        class="flex size-4 items-center justify-center rounded-full bg-muted text-[8px] font-semibold text-muted-foreground ring-2 ring-card select-none"
+                                        aria-hidden="true"
+                                    >
+                                        +{{ extraThreadParticipants(message) }}
+                                    </span>
+                                </span>
+                                <span
+                                    v-if="message.threadUnread"
+                                    data-test="thread-unread-dot"
+                                    aria-label="Unread replies"
+                                    class="size-2 shrink-0 rounded-full bg-rose-500"
+                                ></span>
+                                <span
+                                    class="text-[12px] font-semibold text-foreground"
+                                >
+                                    {{ message.threadReplyCount }}
+                                    {{
+                                        message.threadReplyCount === 1
+                                            ? 'reply'
+                                            : 'replies'
+                                    }}
+                                </span>
+                                <span
+                                    aria-hidden="true"
+                                    class="text-[12px] text-muted-foreground"
+                                    >→</span
+                                >
+                            </button>
                             <span
                                 v-if="message.threadLastReplyAt"
                                 class="text-[11.5px] text-muted-foreground"
@@ -637,7 +648,7 @@ function confirmDelete(): void {
                                 Last reply
                                 {{ formatTime(message.threadLastReplyAt) }}
                             </span>
-                        </button>
+                        </div>
 
                         <div
                             v-if="
@@ -728,21 +739,21 @@ function confirmDelete(): void {
             class="mt-1.5 flex items-center justify-end gap-1.5 pr-1"
             :title="seenByLabel"
         >
-            <span class="text-[11px] font-medium text-muted-foreground">
+            <span class="font-serif text-[11px] text-muted-foreground italic">
                 Seen by
             </span>
             <span class="flex -space-x-1">
                 <span
                     v-for="reader in seenByAvatars"
                     :key="reader.id"
-                    class="flex size-4 items-center justify-center rounded-[5px] bg-primary/10 text-[8px] font-semibold text-primary ring-2 ring-background select-none"
+                    class="flex size-4 items-center justify-center rounded-full bg-primary/10 text-[8px] font-semibold text-primary ring-2 ring-card select-none"
                     aria-hidden="true"
                 >
                     {{ getInitials(reader.name) }}
                 </span>
                 <span
                     v-if="extraSeenBy > 0"
-                    class="flex size-4 items-center justify-center rounded-[5px] bg-muted text-[8px] font-semibold text-muted-foreground ring-2 ring-background select-none"
+                    class="flex size-4 items-center justify-center rounded-full bg-muted text-[8px] font-semibold text-muted-foreground ring-2 ring-card select-none"
                     aria-hidden="true"
                 >
                     +{{ extraSeenBy }}

--- a/resources/js/components/MessageQuote.vue
+++ b/resources/js/components/MessageQuote.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { CornerUpLeft } from '@lucide/vue';
 import { computed } from 'vue';
 import { messageBodyPreview } from '@/lib/messageBody';
 
@@ -17,23 +16,22 @@ const preview = computed(() =>
 </script>
 
 <template>
-    <span class="flex min-w-0 items-center gap-1.5 text-[12.5px] leading-tight">
-        <CornerUpLeft
-            class="size-3 shrink-0 text-muted-foreground/60"
-            aria-hidden="true"
-        />
+    <span
+        class="flex min-w-0 items-baseline gap-1.5 border-l-2 pl-2.5 text-[12.5px] leading-tight"
+        :class="isDeleted ? 'border-border' : 'border-brass'"
+    >
         <span
             v-if="isDeleted"
             data-test="quote-deleted"
-            class="truncate text-muted-foreground/70 italic"
+            class="truncate font-serif text-muted-foreground/70 italic"
         >
             Original message was deleted
         </span>
         <template v-else>
-            <span class="shrink-0 font-semibold text-muted-foreground">{{
+            <span class="shrink-0 font-semibold text-foreground/80">{{
                 authorName
             }}</span>
-            <span class="truncate text-muted-foreground/80">{{ preview }}</span>
+            <span class="truncate text-muted-foreground">{{ preview }}</span>
         </template>
     </span>
 </template>

--- a/resources/js/components/MessageReactions.vue
+++ b/resources/js/components/MessageReactions.vue
@@ -74,7 +74,7 @@ function toggle(emoji: string): void {
                     class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[12px] leading-none transition-colors"
                     :class="
                         reacted(reaction)
-                            ? 'border-primary/40 bg-primary/10 text-primary'
+                            ? 'border-brass-border bg-brass-fill text-brass-fill-foreground'
                             : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted'
                     "
                     @click="toggle(reaction.emoji)"


### PR DESCRIPTION
Reskins the message sub-components to **"The Desk" §5h / §5a**, completing the timeline surface begun in #148/#149.

## What changed
- **Reactions** (`MessageReactions.vue`) — the own/active pill turns **brass** (`border-brass-border bg-brass-fill text-brass-fill-foreground`); inactive pills stay warm cream. Emoji + count unchanged.
- **Message quote** (`MessageQuote.vue`) — a **left brass border** with muted quoted text; a deleted parent renders serif-italic on a plain border (dropped the reply icon per §5h).
- **Deleted states** — the message tombstone and forwarded-source deleted line render **serif-italic**.
- **"Seen by"** — serif-italic label with overlapping **round 16px** avatars.
- **Reply-count affordance** — a bordered **pill**: mini round avatar stack + "N replies →" (last-reply time kept beside it).
- **Link preview** (`LinkPreview.vue`) — serif title, uppercase faint site label, muted description.

## Behaviour
Styling only. Toggle-reaction, open-thread, and jump-to-quote are unchanged; all `data-test` hooks and emits preserved. The underlying logic (`hasReacted`, `reactionRoster`, `messageBodyPreview`) is already unit-tested, so behaviour stays covered.

## Tokens
Semantic tokens only (`brass`, `brass-border`, `brass-fill`, `brass-fill-foreground`, `foreground`, `border`, `muted-foreground`, `card`) — dark (§5d) follows automatically. No raw hex.

## Gates
- `sail composer test` → **Total: 100.0 %**
- `sail npm run lint:check` / `format:check` / `types:check` / `build` → green
- Vitest → 230 passed

Closes #150. Part of epic #145.
