### PR TITLE
fix(ssr): guard useUnreadDivider DOM access on the server (#165)

### DIFF
--- a/resources/js/composables/useUnreadDivider.test.ts
+++ b/resources/js/composables/useUnreadDivider.test.ts
@@ -147,4 +147,34 @@ describe('useUnreadDivider', () => {
 
         expect(disconnect).toHaveBeenCalledOnce();
     });
+
+    it('computes the boundary without touching the DOM during SSR', async () => {
+        // The server has no DOM; the immediate watcher must still compute the
+        // pure boundary without scheduling any document/observer access (which
+        // would throw and crash the SSR render).
+        const rejections: unknown[] = [];
+        const onRejection = (reason: unknown): void => {
+            rejections.push(reason);
+        };
+        process.on('unhandledRejection', onRejection);
+
+        vi.stubGlobal('document', undefined);
+        vi.stubGlobal('IntersectionObserver', undefined);
+
+        const { divider } = withScope({
+            channelId: ref('c1'),
+            messages: () => [message('m1', 'peer')],
+            lastReadMessageId: ref(null),
+        });
+
+        // The pure decision still runs on the server.
+        expect(divider.unreadDividerId.value).toBe('m1');
+
+        // Let any scheduled microtasks surface an unhandled rejection.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        process.off('unhandledRejection', onRejection);
+
+        expect(rejections).toEqual([]);
+        expect(observe).not.toHaveBeenCalled();
+    });
 });

--- a/resources/js/composables/useUnreadDivider.ts
+++ b/resources/js/composables/useUnreadDivider.ts
@@ -58,7 +58,11 @@ export function useUnreadDivider(options: UnreadDividerOptions): UnreadDivider {
         observer = null;
         unreadDividerInView.value = false;
 
-        if (unreadDividerId.value === null) {
+        // The divider element and IntersectionObserver only exist in the
+        // browser. During SSR there's no DOM, so skip the wiring entirely — the
+        // client re-runs this on hydration. Guards against a `document is not
+        // defined` crash when the immediate watcher fires on the server.
+        if (unreadDividerId.value === null || typeof document === 'undefined') {
             return;
         }
 


### PR DESCRIPTION
Fixes the pre-existing SSR crash surfaced while working on the "The Desk" redesign (#149/#150 dev sessions).

## Bug
`useUnreadDivider` registers `watch(channelId, recompute, { immediate: true })`, which fires during server render. For a channel **with** an unread boundary, `observeDivider` scheduled `nextTick(() => document.getElementById(...))`; `document` is undefined on the server, so it threw:

```
ReferenceError: document is not defined
    at useUnreadDivider.ts (document.getElementById)
```

This crashed the SSR render of `channels/Show`, falling back to client rendering with a noisy error log. Channels with no unread divider were unaffected (early return before the DOM access), so it only crashed intermittently.

## Fix
Skip the divider-element / IntersectionObserver wiring when there is no DOM (`typeof document === 'undefined'`). The **pure boundary decision still runs**, so the divider renders server-side; the client re-attaches the observer on hydration (the immediate watcher runs again during setup in the browser).

## Test
New SSR test in `useUnreadDivider.test.ts` stubs `document`/`IntersectionObserver` as undefined, asserts the boundary is still computed and that no unhandled rejection / observer access occurs. It **fails on the old code** (captures the exact `getElementById` TypeError) and passes with the guard.

## Gates
- `sail composer test` → **Total: 100.0 %**
- `sail npm run lint:check` / `format:check` / `types:check` / `build` → green
- Vitest → 231 passed

Closes #165. Not part of epic #145 (discovered during it).
