### PR TITLE
feat(messaging): thread card + serif header (#152)

### DIFF
--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -36,6 +36,7 @@ import { tokenizeMessageBody } from '@/lib/messageBody';
 import type { MessageBodySegment } from '@/lib/messageBody';
 import { readersForMessage } from '@/lib/readReceipts';
 import { buildTimelineItems } from '@/lib/timeline';
+import type { TimelineGroup } from '@/lib/timeline';
 import type {
     ChannelReader,
     Mention,
@@ -90,6 +91,15 @@ function threadAvatars(message: Message): Mention[] {
 
 function extraThreadParticipants(message: Message): number {
     return Math.max(0, message.threadParticipants.length - MAX_THREAD_AVATARS);
+}
+
+/**
+ * Inside a thread panel, the root message — the only one with no thread root of
+ * its own — earns a brass left accent so it reads as the conversation's origin,
+ * setting it apart from the replies below.
+ */
+function isThreadRoot(item: TimelineGroup): boolean {
+    return props.inThread === true && item.messages[0]?.threadRootId === null;
 }
 
 // How many reader avatars to preview on the "Seen by" row before collapsing the
@@ -397,7 +407,14 @@ function confirmDelete(): void {
                         >{{ formatTime(item.leadCreatedAt) }}</span
                     >
                 </div>
-                <div class="min-w-0 flex-1 border-l border-border pl-[18px]">
+                <div
+                    class="min-w-0 flex-1 pl-[18px]"
+                    :class="
+                        isThreadRoot(item)
+                            ? 'border-l-2 border-brass'
+                            : 'border-l border-border'
+                    "
+                >
                     <UserHoverCard
                         :team-slug="props.teamSlug"
                         :user-id="item.author.id"

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -103,32 +103,36 @@ watch(
 <template>
     <aside
         data-test="thread-panel"
-        class="flex w-full min-w-0 shrink-0 flex-col border-l border-border md:w-96"
+        class="flex w-full min-w-0 shrink-0 flex-col overflow-hidden border-l border-border md:m-3.5 md:w-96 md:rounded-[14px] md:border md:border-border md:bg-sidebar md:shadow-sm"
     >
         <header
-            class="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4"
+            class="flex shrink-0 items-start gap-2 border-b border-border px-[18px] pt-4 pb-3"
         >
             <div class="min-w-0 flex-1">
-                <h2 class="text-[14px] font-semibold text-foreground">
+                <h2
+                    class="font-serif text-[19px] leading-[1.1] font-semibold text-foreground"
+                >
                     Thread
                 </h2>
                 <p
-                    v-if="replyCount > 0"
                     data-test="thread-reply-count"
-                    class="text-[11.5px] text-muted-foreground"
+                    class="mt-0.5 text-[11.5px] text-muted-foreground"
                 >
-                    {{ replyCount }}
-                    {{ replyCount === 1 ? 'reply' : 'replies' }}
+                    <template v-if="replyCount > 0"
+                        >{{ replyCount }}
+                        {{ replyCount === 1 ? 'reply' : 'replies' }}
+                        · </template
+                    >#{{ props.channelName }}
                 </p>
             </div>
             <button
                 type="button"
                 data-test="thread-close"
                 aria-label="Close thread"
-                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                class="flex size-[26px] shrink-0 items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-muted hover:text-foreground"
                 @click="emit('close')"
             >
-                <X class="size-4" />
+                <X class="size-3.5" />
             </button>
         </header>
 


### PR DESCRIPTION
Reskins `ThreadPanel.vue` into "The Desk" right-hand **thread card** (§5a).

## Changes
- **Card framing** — at `md+` the panel floats as its own rounded card on the warm canvas: `bg-sidebar` (the design's `#fbfaf7` / dark `#1e1b15`), hairline border, `shadow-sm`, `rounded-[14px]`, `m-3.5` inset — consistent with the dock/main cards. Mobile keeps the full-width slide-in panel.
- **Header** — serif **"Thread" 19px** title over a muted **"N replies · #channel"** subline (channel name is new; shows just `#channel` before the first reply). Close button is now a bordered `26px` rounded square.
- **Root brass accent** — the thread root gets a `border-l-2 border-brass` in `MessageList.vue` (new `isThreadRoot` helper) so it reads as the conversation's origin, set apart from the replies.
- The **pill reply composer** + **"also send to #channel"** checkbox row come from #151.

## Wiring intact
Open/close, reply send, scroll pinning / "N new replies", mention-into-thread, skeleton, infinite scroll, read-only — all unchanged. `data-test` selectors (`thread-panel`, `thread-close`, `thread-reply-count`, `jump-to-latest-thread`) preserved.

## Deviation from the design
The root **keeps its avatar gutter** (the mock renders the root without one) rather than forking the shared `MessageList` row rendering — a targeted, low-risk approach that still delivers the brass-left-border signal. Worth a look during the #161 QA pass.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan + coverage)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
- Styling-only reskin; the `isThreadRoot` predicate is presentation glue (reads a prop), so no new Vitest suite.

Part of the redesign epic #145. Closes #152.
