### PR TITLE
feat(messaging): serif empty channel state (#153)

### DIFF
--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1161,13 +1161,13 @@ function archive(): void {
                             class="flex h-full flex-col items-center justify-center gap-1"
                         >
                             <div
-                                class="flex size-14 items-center justify-center rounded-2xl border border-border bg-muted text-2xl font-semibold text-muted-foreground"
+                                class="font-serif text-[64px] leading-none text-border italic"
                                 aria-hidden="true"
                             >
                                 #
                             </div>
                             <p
-                                class="mt-2.5 text-[15px] font-semibold text-foreground"
+                                class="mt-1.5 font-serif text-[20px] font-semibold text-foreground"
                             >
                                 No messages yet
                             </p>


### PR DESCRIPTION
Reskins the empty channel state (shown in `Show.vue` when a channel has no messages) to match §5b.

## Changes
- Centered stack: a faint **serif-italic `#` glyph** (`64px`), a serif **"No messages yet"** (`20px/600`), and the muted **"Be the first to say something in #{name}."** sub. The masthead + pill composer still frame it (unchanged).
- Replaces the old rounded-square `#` badge.

## Deviation from the issue wording
The issue said "brass `#`", but §5b renders the glyph in a **faint sand** tone (`#e0dbcd`), not brass. Following the design (source of truth), the glyph uses `text-border` — the closest semantic token to that sand — so it stays faint in light and dark. Same class of call as #149's serif-italic divider.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan + coverage)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
- Styling-only; no logic, so existing tests + compile gates cover it.

Part of the redesign epic #145. Closes #153.
