### PR TITLE
feat(navigation): reskin browse channels (#154)

### DIFF
--- a/resources/js/pages/channels/Browse.vue
+++ b/resources/js/pages/channels/Browse.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Form, Head, Link } from '@inertiajs/vue3';
-import { Search } from '@lucide/vue';
+import { ArrowLeft, Search } from '@lucide/vue';
 import {
     index,
     join,
@@ -26,32 +26,50 @@ const props = defineProps<{
     <Head title="Browse channels" />
 
     <header
-        class="flex h-12 shrink-0 items-center gap-2.5 border-b border-border px-5"
+        class="flex shrink-0 items-end gap-4 border-b border-border px-7 pt-5 pb-3.5"
     >
         <SidebarTrigger
-            class="-ml-1.5 size-8 text-muted-foreground md:hidden"
+            class="mb-1 -ml-1.5 size-8 shrink-0 text-muted-foreground md:hidden"
         />
-        <h1 class="text-[15px] font-semibold text-foreground">
-            Browse channels
-        </h1>
+        <div class="min-w-0 flex-1">
+            <h1
+                class="truncate font-serif text-[32px] leading-none font-semibold tracking-[-0.02em] text-foreground"
+            >
+                Browse channels
+            </h1>
+            <p
+                v-if="props.joinableChannels.length > 0"
+                class="mt-1.5 text-[13px] text-muted-foreground"
+            >
+                {{ props.joinableChannels.length }}
+                {{
+                    props.joinableChannels.length === 1 ? 'channel' : 'channels'
+                }}
+                you can join
+            </p>
+        </div>
         <Link
             :href="index(props.team.slug).url"
-            class="ml-auto text-[13px] text-muted-foreground hover:text-foreground"
-            >Back</Link
+            class="flex shrink-0 items-center gap-1 pb-1 text-[13px] text-muted-foreground hover:text-foreground"
         >
+            <ArrowLeft class="size-3.5" />
+            Back
+        </Link>
     </header>
 
-    <div class="flex flex-1 justify-center overflow-y-auto px-6 pt-8">
+    <div class="flex flex-1 justify-center overflow-y-auto px-7 pt-6">
         <div class="w-full max-w-[560px]">
+            <!-- Decorative search pill: matches §5c; the list is short enough
+                 that live filtering isn't wired up. -->
             <div class="relative">
                 <Search
-                    class="absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground"
+                    class="absolute top-1/2 left-4 size-3.5 -translate-y-1/2 text-muted-foreground"
                     aria-hidden="true"
                 />
                 <Input
                     type="search"
                     placeholder="Search channels"
-                    class="h-[38px] rounded-[10px] bg-muted/40 pl-9"
+                    class="h-9 rounded-full border-0 bg-muted pl-10 text-[13.5px]"
                     aria-label="Search channels"
                 />
             </div>
@@ -63,48 +81,45 @@ const props = defineProps<{
                 There are no public channels left to join.
             </p>
 
-            <template v-else>
-                <p class="mt-4 mb-1 text-xs text-muted-foreground">
-                    {{ props.joinableChannels.length }} channels you can join
-                </p>
-
-                <ul>
-                    <li
-                        v-for="channel in props.joinableChannels"
-                        :key="channel.id"
-                        class="flex items-center justify-between gap-4 rounded-sm border-b border-border/60 px-1 py-3 last:border-0 hover:bg-accent/40"
-                    >
-                        <div class="min-w-0">
-                            <p class="text-sm font-medium text-foreground">
-                                <span class="text-muted-foreground/70">#</span
-                                >{{ channel.name }}
-                            </p>
-                            <p
-                                v-if="channel.topic"
-                                class="truncate text-[12.5px] text-muted-foreground"
-                            >
-                                {{ channel.topic }}
-                            </p>
-                        </div>
-                        <Form
-                            v-bind="
-                                join.form({
-                                    team: props.team.slug,
-                                    channel: channel.slug,
-                                })
-                            "
+            <ul v-else class="mt-2.5 flex flex-col">
+                <li
+                    v-for="channel in props.joinableChannels"
+                    :key="channel.id"
+                    class="group flex items-center justify-between gap-4 border-b border-border/60 px-1 py-[13px] transition-colors last:border-0 hover:bg-muted/40"
+                >
+                    <div class="flex min-w-0 flex-col gap-px">
+                        <span class="text-[14px] font-semibold text-foreground">
+                            <span
+                                class="mr-0.5 font-serif text-brass italic"
+                                aria-hidden="true"
+                                >#</span
+                            >{{ channel.name }}
+                        </span>
+                        <span
+                            v-if="channel.topic"
+                            class="truncate text-[12.5px] text-muted-foreground"
                         >
-                            <Button
-                                type="submit"
-                                variant="outline"
-                                size="sm"
-                                class="h-[30px] rounded-lg px-3.5 text-[13px]"
-                                >Join</Button
-                            >
-                        </Form>
-                    </li>
-                </ul>
-            </template>
+                            {{ channel.topic }}
+                        </span>
+                    </div>
+                    <Form
+                        v-bind="
+                            join.form({
+                                team: props.team.slug,
+                                channel: channel.slug,
+                            })
+                        "
+                    >
+                        <Button
+                            type="submit"
+                            variant="outline"
+                            size="sm"
+                            class="h-[30px] rounded-full border-primary bg-transparent px-4 text-[12.5px] font-semibold text-primary group-hover:border-primary group-hover:bg-primary group-hover:text-primary-foreground hover:border-primary hover:bg-primary hover:text-primary-foreground"
+                            >Join</Button
+                        >
+                    </Form>
+                </li>
+            </ul>
         </div>
     </div>
 </template>


### PR DESCRIPTION
Reskins `pages/channels/Browse.vue` to match §5c.

## Changes
- **Header** — serif **"Browse channels" 32px** title (matching the channel masthead from #148) over a muted **"N channel(s) you can join"** subline, with a **"← Back"** link (ArrowLeft + text) on the right.
- **Search** — the field becomes a `h-9 rounded-full` **muted pill** with the search icon inset (decorative — the joinable list is short, so no live filtering).
- **Channel rows** — serif-italic **brass `#`** + name (`14px/600`) over a muted topic (`12.5px`), hairline dividers, a subtle **row hover tint**, and a **Join pill** that's ink-outline by default and fills **solid ink** on row/button hover (via `group-hover`).
- Empty-state sentence kept (restyled context).

## Wiring intact
The join `<Form>` (`join.form({ team, channel })`) is unchanged — only the button's styling changed — so joining still works. Controller coverage stays at 100%.

## Deviation from the issue wording
§5c shows a **single tinted row** paired with the solid-ink Join, i.e. the **hover** state — so "subtle alt-row tint" is realized as the **row hover tint** rather than zebra striping (avoids a hover/nth-child specificity fight and matches the mock).

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan + coverage)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
- Styling-only; no new pure logic.

Part of the redesign epic #145. Closes #154.
