### PR TITLE
feat(ui): serif/cream dialog reskin (#155)

### DIFF
--- a/resources/js/components/CreateChannelModal.vue
+++ b/resources/js/components/CreateChannelModal.vue
@@ -65,13 +65,21 @@ function handleOpenChange(value: boolean) {
                 <div class="grid gap-4">
                     <div class="grid gap-2">
                         <Label for="name">Name</Label>
-                        <Input
-                            id="name"
-                            name="name"
-                            data-test="create-channel-name"
-                            placeholder="marketing"
-                            required
-                        />
+                        <div class="relative">
+                            <span
+                                aria-hidden="true"
+                                class="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 font-serif text-[15px] text-brass italic"
+                                >#</span
+                            >
+                            <Input
+                                id="name"
+                                name="name"
+                                data-test="create-channel-name"
+                                placeholder="marketing"
+                                class="pl-7"
+                                required
+                            />
+                        </div>
                         <InputError :message="errors.name" />
                     </div>
 

--- a/resources/js/components/ForwardMessageDialog.vue
+++ b/resources/js/components/ForwardMessageDialog.vue
@@ -90,7 +90,7 @@ function submit(): void {
 
             <div
                 v-if="message"
-                class="rounded-md border-l-2 border-border bg-muted/30 px-3 py-2"
+                class="rounded-r-lg border-l-2 border-brass bg-muted/30 px-3 py-2"
             >
                 <p class="text-[12.5px] font-semibold text-foreground">
                     {{ message.user.name }}

--- a/resources/js/components/ui/dialog/DialogContent.vue
+++ b/resources/js/components/ui/dialog/DialogContent.vue
@@ -34,7 +34,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-bind="{ ...$attrs, ...forwarded }"
       :class="
         cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-sidebar data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-[0_16px_40px_rgba(29,26,21,0.14)] duration-200 sm:max-w-lg',
           props.class,
         )"
     >

--- a/resources/js/components/ui/dialog/DialogFooter.vue
+++ b/resources/js/components/ui/dialog/DialogFooter.vue
@@ -15,7 +15,12 @@ const props = withDefaults(defineProps<{
 <template>
   <div
     data-slot="dialog-footer"
-    :class="cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', props.class)"
+    :class="
+      cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end [&_button]:rounded-full',
+        props.class,
+      )
+    "
   >
     <slot />
     <DialogClose v-if="showCloseButton" as-child>

--- a/resources/js/components/ui/dialog/DialogTitle.vue
+++ b/resources/js/components/ui/dialog/DialogTitle.vue
@@ -16,7 +16,12 @@ const forwardedProps = useForwardProps(delegatedProps)
   <DialogTitle
     data-slot="dialog-title"
     v-bind="forwardedProps"
-    :class="cn('text-lg leading-none font-semibold', props.class)"
+    :class="
+      cn(
+        'font-serif text-[22px] leading-none font-semibold tracking-[-0.01em]',
+        props.class,
+      )
+    "
   >
     <slot />
   </DialogTitle>


### PR DESCRIPTION
Reskins the dialog family to "The Desk" §5f — serif titles, cream cards, pill buttons.

## Approach: treat the shared primitive so every modal inherits it
- **`DialogContent`** → cream card (`bg-sidebar`), `rounded-2xl`, warm `0 16px 40px` ink shadow.
- **`DialogTitle`** → Newsreader **serif, 22px**, tight tracking.
- **`DialogFooter`** → `[&_button]:rounded-full` so footer CTAs become **pills**: default (ink) primary, `secondary` cancel, `destructive` red — all inherited, no per-dialog edits.

This cascades the §5f look to all six named dialogs (Create channel, Forward, Schedule, Scheduled messages, Invite, Delete team, Keyboard shortcuts) **and** the rest of the ui/dialog modal family, as the issue asked ("apply to the shared primitive so other modals inherit it").

## Two §5f-specific touches
- **Create channel** — serif-italic **brass `#`** prefix inside the Name field.
- **Forward message** — quote gets a **brass left border**, rounded on the right only.

Keyboard shortcuts already renders grouped categories (Navigation / Messages) with mono key chips; it inherits the cream card + serif title.

## Wiring intact
All `<Form>` / validation / `data-test` hooks (`create-channel-*`, `keyboard-shortcuts-modal`, `shortcut-row`, …) unchanged.

## Deviation from the mock
**Cancel** keeps the soft **`secondary`** pill rather than a bordered outline — `outline`'s `bg-background` reads as a darker fill on the cream card, whereas `secondary` (`#eeeade`) stays a light, uniform cancel across the whole family with no per-dialog overrides. Worth a glance during #161 QA.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan + coverage)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
- Styling-only; no new pure logic.

Part of the redesign epic #145. Closes #155.
