### PR TITLE
feat(navigation): reskin overlays for "The Desk" (#156)

### DIFF
--- a/resources/js/components/EmojiPickerPopover.vue
+++ b/resources/js/components/EmojiPickerPopover.vue
@@ -43,15 +43,57 @@ function onPick(payload: { i: string }): void {
                 align="start"
                 :side-offset="6"
                 :collision-padding="8"
-                class="z-50 outline-none"
+                class="emoji-picker-shell z-50 overflow-hidden rounded-2xl border bg-popover shadow-[0_10px_28px_rgba(29,26,21,0.14)] outline-none"
             >
                 <EmojiPicker
                     :native="true"
                     :hide-search="false"
-                    theme="auto"
+                    theme="light"
                     @select="onPick"
                 />
             </PopoverContent>
         </PopoverPortal>
     </PopoverRoot>
 </template>
+
+<!--
+  vue3-emoji-picker themes itself through `--v3-picker-*` custom properties. We
+  remap them onto "The Desk" semantic tokens so the picker follows the warm
+  light/dark palette instead of its own black/white auto theme (hence
+  `theme="light"` above — it disables the library's dark overrides so our
+  token-driven values win in both modes). The shell card carries the border and
+  shadow, so the picker's own chrome is flattened.
+-->
+<style scoped>
+.emoji-picker-shell :deep(.v3-emoji-picker) {
+    width: 300px;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    --v3-picker-bg: var(--popover);
+    --v3-picker-fg: var(--popover-foreground);
+    --v3-picker-border: var(--border);
+    --v3-picker-input-bg: var(--muted);
+    --v3-picker-input-border: transparent;
+    --v3-picker-input-focus-border: var(--brass);
+    --v3-picker-emoji-hover: var(--accent);
+}
+
+.emoji-picker-shell :deep(.v3-search input) {
+    height: 32px;
+    padding: 0 13px;
+    border-radius: 999px;
+}
+
+.emoji-picker-shell :deep(.v3-emojis button) {
+    border-radius: 8px;
+}
+
+.emoji-picker-shell :deep(.v3-body-inner .v3-group h5) {
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+}
+</style>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -376,6 +376,7 @@ function confirmDelete(): void {
                         :team-slug="props.teamSlug"
                         :user-id="item.author.id"
                         :name="item.author.name"
+                        :online="isOnline(item.author.id)"
                         @mention="(member) => emit('mention', member)"
                     >
                         <div class="relative size-[34px] cursor-pointer">
@@ -419,6 +420,7 @@ function confirmDelete(): void {
                         :team-slug="props.teamSlug"
                         :user-id="item.author.id"
                         :name="item.author.name"
+                        :online="isOnline(item.author.id)"
                         @mention="(member) => emit('mention', member)"
                     >
                         <span

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { router, usePage } from '@inertiajs/vue3';
-import { CornerDownLeft, Hash, Search } from '@lucide/vue';
+import { Search } from '@lucide/vue';
 import { ListboxFilter } from 'reka-ui';
 import { computed, ref, watch } from 'vue';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
@@ -104,8 +104,8 @@ function seeAllResults(): void {
         title="Quick switcher"
         description="Jump to a channel or search messages"
     >
-        <div class="flex h-11 items-center gap-2 border-b px-3">
-            <Search class="size-4 shrink-0 opacity-50" />
+        <div class="flex h-12 items-center gap-2.5 border-b px-4">
+            <Search class="size-4 shrink-0 text-muted-foreground/70" />
             <ListboxFilter
                 v-model="query"
                 auto-focus
@@ -121,11 +121,20 @@ function seeAllResults(): void {
                     :key="channel.id"
                     :value="`channel:${channel.id}`"
                     data-test="quick-switcher-channel"
-                    class="gap-2"
+                    class="group h-[38px] gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground"
                     @select="selectChannel(channel)"
                 >
-                    <Hash class="size-4 shrink-0 opacity-60" />
+                    <span
+                        class="shrink-0 font-semibold text-muted-foreground/70 group-data-[highlighted]:text-brass"
+                        aria-hidden="true"
+                        >#</span
+                    >
                     <span class="truncate">{{ channel.name }}</span>
+                    <span
+                        class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100"
+                        aria-hidden="true"
+                        >↵</span
+                    >
                 </CommandItem>
             </CommandGroup>
 
@@ -160,7 +169,7 @@ function seeAllResults(): void {
                     </div>
                     <div class="min-w-0 flex-1">
                         <div class="flex items-baseline gap-1.5 text-xs">
-                            <span class="font-medium text-foreground">{{
+                            <span class="font-semibold text-foreground">{{
                                 result.message.user.name
                             }}</span>
                             <span class="text-muted-foreground/70"
@@ -192,14 +201,16 @@ function seeAllResults(): void {
                 <CommandItem
                     value="see-all-results"
                     data-test="quick-switcher-see-all"
-                    class="gap-2 text-muted-foreground"
+                    class="mt-1 gap-2 rounded-lg border-t border-border px-2.5 font-serif text-[13px] text-muted-foreground italic data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
                     @select="seeAllResults"
                 >
-                    <CornerDownLeft class="size-4 shrink-0 opacity-60" />
                     <span class="truncate"
                         >See all results for &ldquo;{{
                             trimmedQuery
                         }}&rdquo;</span
+                    >
+                    <span class="ml-auto shrink-0 not-italic" aria-hidden="true"
+                        >&rarr;</span
                     >
                 </CommandItem>
             </CommandGroup>

--- a/resources/js/components/UserHoverCard.vue
+++ b/resources/js/components/UserHoverCard.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
     teamSlug: string;
     userId: string;
     name: string;
+    online?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -61,7 +62,9 @@ function onMention(): void {
         <HoverCardTrigger as-child>
             <slot />
         </HoverCardTrigger>
-        <HoverCardContent class="w-72">
+        <HoverCardContent
+            class="w-72 rounded-2xl p-5 shadow-[0_10px_28px_rgba(29,26,21,0.14)]"
+        >
             <!-- Loading skeleton until the first fetch resolves. -->
             <div v-if="loading && !profile" class="flex animate-pulse gap-3">
                 <div class="size-12 rounded-full bg-muted" />
@@ -71,21 +74,35 @@ function onMention(): void {
                 </div>
             </div>
 
-            <div v-else class="space-y-3">
+            <div v-else class="space-y-4">
                 <div class="flex items-start gap-3">
-                    <Avatar class="size-12 text-base">
-                        <AvatarFallback>{{
-                            getInitials(profile?.name ?? name)
-                        }}</AvatarFallback>
-                    </Avatar>
+                    <div class="relative size-12 shrink-0">
+                        <Avatar class="size-12 text-base">
+                            <AvatarFallback>{{
+                                getInitials(profile?.name ?? name)
+                            }}</AvatarFallback>
+                        </Avatar>
+                        <span
+                            data-test="hover-card-presence"
+                            :data-online="online === true"
+                            :aria-label="online ? 'Online' : 'Offline'"
+                            class="absolute right-0 bottom-0 size-3 rounded-full ring-[2.5px] ring-popover"
+                            :class="
+                                online
+                                    ? 'bg-emerald-500'
+                                    : 'bg-muted-foreground/60'
+                            "
+                        />
+                    </div>
                     <div class="min-w-0 flex-1">
-                        <div class="flex flex-wrap items-center gap-x-2">
-                            <span class="font-semibold">{{
-                                profile?.name ?? name
-                            }}</span>
+                        <div class="flex flex-wrap items-baseline gap-x-2">
+                            <span
+                                class="font-serif text-[17px] font-semibold"
+                                >{{ profile?.name ?? name }}</span
+                            >
                             <span
                                 v-if="profile?.pronouns"
-                                class="text-xs text-muted-foreground"
+                                class="font-serif text-xs text-muted-foreground/80 italic"
                                 >{{ profile.pronouns }}</span
                             >
                         </div>
@@ -96,9 +113,13 @@ function onMention(): void {
                             {{ profile.title }}
                         </p>
                         <div
-                            class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1"
+                            class="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1"
                         >
-                            <Badge v-if="profile?.roleLabel" variant="outline">
+                            <Badge
+                                v-if="profile?.roleLabel"
+                                variant="outline"
+                                class="border-brass px-2 text-[10px] font-semibold tracking-wide text-brass-fill-foreground uppercase"
+                            >
                                 {{ profile.roleLabel }}
                             </Badge>
                             <span
@@ -112,17 +133,21 @@ function onMention(): void {
 
                 <div class="flex gap-2">
                     <Button
-                        variant="secondary"
                         size="sm"
-                        class="flex-1"
+                        class="h-8 flex-1 rounded-full"
                         data-test="hover-card-mention"
                         @click="onMention"
                     >
                         <AtSign class="size-4" /> Mention
                     </Button>
-                    <Button variant="outline" size="sm" class="flex-1" as-child>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        class="h-8 flex-1 rounded-full"
+                        as-child
+                    >
                         <Link :href="show([teamSlug, userId])">
-                            <UserRound class="size-4" /> Profile
+                            <UserRound class="size-4" /> View profile
                         </Link>
                     </Button>
                 </div>

--- a/resources/js/components/ui/command/CommandGroup.vue
+++ b/resources/js/components/ui/command/CommandGroup.vue
@@ -37,7 +37,7 @@ onUnmounted(() => {
     :class="cn('text-foreground overflow-hidden p-1', props.class)"
     :hidden="isRender ? undefined : true"
   >
-    <ListboxGroupLabel v-if="heading" data-slot="command-group-heading" class="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+    <ListboxGroupLabel v-if="heading" data-slot="command-group-heading" class="px-2.5 pt-1.5 pb-1 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/80 uppercase">
       {{ heading }}
     </ListboxGroupLabel>
     <slot />


### PR DESCRIPTION
Reskins the three §5g overlays for **The Desk** — quick switcher, user hover card, and emoji picker — onto the warm ink/sand/brass palette. Closes #156. Part of epic #145.

## Quick switcher (`QuickSwitcher.vue` + shared `ui/command`)
- Uppercase, tracked, brass-muted group headings (`CommandGroup` primitive — only consumed by the quick switcher).
- Channel rows get an **ink active row** (`bg-primary`) with a brass `#` glyph and a monospace `↵` hint that fades in on highlight.
- Serif-italic **"See all results"** footer, separated by a top border.

## User hover card (`UserHoverCard.vue`)
- Serif name, serif-italic pronouns, brass-outlined uppercase Owner/role pill, and ink/outline **pill buttons** ("View profile").
- **Presence dot** on the avatar, driven by a new optional `online` prop wired from `MessageList`'s existing presence roster (`onlineIds`) — passed to both the avatar and name triggers, so it reflects real team presence.

## Emoji picker (`EmojiPickerPopover.vue`)
- Warm popover shell (cream card, border, soft shadow) wrapping the third-party `vue3-emoji-picker`, remapped onto Desk tokens via its `--v3-picker-*` custom properties. `theme="light"` disables the library's own black/white dark theme so our tokens drive both light and dark.

## Deviations from the §5g mock (precedents: #149, #153, #154, #155)
- **Presence dot** reuses the existing emerald timeline treatment rather than the mock's one-off green (`#4d7c4a`), for cross-app consistency. The issue's "brass active row" follows the design's **ink-background** active row with a brass accent.
- Faint warm greys map to `muted-foreground` at reduced opacity — there's no exact token for the mock's `#b3ab97` (semantic tokens only).
- The emoji grid/categories are library-rendered, so **"Frequently used"** is the picker's own recent-emoji group rather than a bespoke section.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan clean)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
- `sail npm run test:js` → 231 passed (no new pure logic to test; styling + a boolean prop)
