### PR TITLE
feat(auth): add REGISTRATION_ENABLED flag to toggle public registration (#122)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ PHP_CLI_SERVER_WORKERS=4
 
 BCRYPT_ROUNDS=12
 
+# Set to false to close public sign-ups on a private/invite-only instance.
+# When false, the /register page and POST both return 404 and the "sign up"
+# links disappear. Leave true (the default) to keep self-service registration.
+REGISTRATION_ENABLED=true
+
 LOG_CHANNEL=stack
 LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Registration is open, so onboarding is self-service:
    verification email is delivered, then verify.
 3. Create your first workspace from **Settings → Teams**, then invite teammates.
 
+> **Locking down registration.** Public sign-ups are open by default. To run a
+> private/invite-only instance, set `REGISTRATION_ENABLED=false` in `.env`
+> (create your own account first). With it off, `/register` returns 404 and the
+> "sign up" links are hidden — existing users and email invitations still work.
+
 ### Upgrading
 
 Upgrades follow the same tag-based flow. Check out the newer release tag and

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Middleware;
+use Laravel\Fortify\Features;
 
 class HandleInertiaRequests extends Middleware
 {
@@ -49,6 +50,10 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'name' => config('app.name'),
+            // A single deploy-time flag lets self-hosters lock down public
+            // registration; when off, Fortify never registers the register
+            // routes, so the frontend hides its "sign up" affordances to match.
+            'registrationEnabled' => Features::enabled(Features::registration()),
             'auth' => [
                 'user' => $user,
             ],

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -142,10 +142,10 @@ return [
     |
     */
 
-    'features' => [
-        Features::registration(),
+    'features' => array_filter([
+        env('REGISTRATION_ENABLED', true) ? Features::registration() : null,
         Features::resetPasswords(),
         Features::emailVerification(),
-    ],
+    ]),
 
 ];

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -39,6 +39,7 @@ const workspaceUrl = computed(() =>
                         Log in
                     </Link>
                     <Link
+                        v-if="$page.props.registrationEnabled"
                         :href="register()"
                         class="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
                     >

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -108,7 +108,10 @@ defineProps<{
             </Button>
         </div>
 
-        <div class="text-center text-sm text-muted-foreground">
+        <div
+            v-if="$page.props.registrationEnabled"
+            class="text-center text-sm text-muted-foreground"
+        >
             Don't have an account?
             <TextLink
                 :href="

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -20,6 +20,7 @@ declare module '@inertiajs/core' {
         sharedPageProps: {
             name: string;
             auth: Auth;
+            registrationEnabled: boolean;
             sidebarOpen: boolean;
             currentTeam: Team | null;
             teams: Team[];

--- a/tests/Feature/Auth/RegistrationFlagTest.php
+++ b/tests/Feature/Auth/RegistrationFlagTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Inertia\Testing\AssertableInertia as Assert;
+
+afterEach(function () {
+    putenv('REGISTRATION_ENABLED');
+    unset($_ENV['REGISTRATION_ENABLED'], $_SERVER['REGISTRATION_ENABLED']);
+});
+
+test('registration routes respond when registration is enabled', function () {
+    $this->reloadWithRegistrationEnabled(true);
+
+    $this->get('/register')->assertOk();
+
+    $response = $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $this->assertAuthenticated();
+    $response->assertRedirect();
+});
+
+test('registration routes return 404 when registration is disabled', function () {
+    $this->reloadWithRegistrationEnabled(false);
+
+    $this->get('/register')->assertNotFound();
+    $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertNotFound();
+
+    $this->assertGuest();
+});
+
+test('the shared registrationEnabled prop is true when registration is enabled', function () {
+    $this->reloadWithRegistrationEnabled(true);
+
+    $this->get(route('home'))->assertInertia(fn (Assert $page) => $page
+        ->component('Welcome')
+        ->where('registrationEnabled', true),
+    );
+
+    $this->get(route('login'))->assertInertia(fn (Assert $page) => $page
+        ->component('auth/Login')
+        ->where('registrationEnabled', true),
+    );
+});
+
+test('the shared registrationEnabled prop is false when registration is disabled', function () {
+    $this->reloadWithRegistrationEnabled(false);
+
+    $this->get(route('home'))->assertInertia(fn (Assert $page) => $page
+        ->component('Welcome')
+        ->where('registrationEnabled', false),
+    );
+
+    $this->get(route('login'))->assertInertia(fn (Assert $page) => $page
+        ->component('auth/Login')
+        ->where('registrationEnabled', false),
+    );
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,4 +13,29 @@ abstract class TestCase extends BaseTestCase
             $this->markTestSkipped($message ?? "Fortify feature [{$feature}] is not enabled.");
         }
     }
+
+    /**
+     * Reboot the application with the given REGISTRATION_ENABLED value.
+     *
+     * Fortify decides whether to register the `/register` routes at boot from
+     * `config('fortify.features')`, so the env var has to be in place before the
+     * app boots — hence the refresh rather than a runtime `config()` override.
+     */
+    protected function reloadWithRegistrationEnabled(bool $enabled): void
+    {
+        $value = $enabled ? 'true' : 'false';
+
+        putenv("REGISTRATION_ENABLED={$value}");
+        $_ENV['REGISTRATION_ENABLED'] = $value;
+        $_SERVER['REGISTRATION_ENABLED'] = $value;
+
+        $this->refreshApplication();
+
+        // RefreshDatabase opened its transaction against the pre-refresh
+        // connection; re-open one on the fresh app so writes in this test are
+        // still rolled back instead of leaking into the next test.
+        if (method_exists($this, 'beginDatabaseTransaction')) {
+            $this->beginDatabaseTransaction();
+        }
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Env;
 use Laravel\Fortify\Features;
 
 abstract class TestCase extends BaseTestCase
@@ -28,6 +29,13 @@ abstract class TestCase extends BaseTestCase
         putenv("REGISTRATION_ENABLED={$value}");
         $_ENV['REGISTRATION_ENABLED'] = $value;
         $_SERVER['REGISTRATION_ENABLED'] = $value;
+
+        // Reset the memoized env repository so its immutable "already loaded"
+        // guard is cleared. Without this, a value baked into .env at first boot
+        // (as CI does via `cp .env.example .env`) would survive the reload and
+        // clobber the override above; a fresh repository instead treats our
+        // value as an external definition that reloading .env leaves untouched.
+        Env::enablePutenv();
 
         $this->refreshApplication();
 


### PR DESCRIPTION
Closes #122.

## Summary

Lets self-hosters control whether public registration is open via a single deploy-time env flag, `REGISTRATION_ENABLED` (defaults to `true`, so the hosted demo and existing deployments are unaffected).

Gated through **Fortify's own feature array** — no new dependency:

- `config/fortify.php` conditionally includes `Features::registration()` based on `env('REGISTRATION_ENABLED', true)`. When disabled, Fortify never registers `GET`/`POST /register`, so both return **404** — no extra middleware, no bypass.
- `HandleInertiaRequests::share()` exposes a `registrationEnabled` shared prop, sourced from `Features::enabled(Features::registration())` (single source of truth, no config key to drift).
- `Login.vue` and `Welcome.vue` `v-if` their register links/CTAs off the prop.
- `.env.example` documents the flag for self-hosters; the README self-hosting section explains locking down registration.

## Tests

New `tests/Feature/Auth/RegistrationFlagTest.php` covers both flag states — route status codes (200/404) and the shared prop value on Login and Welcome. Because Fortify registers the register routes at boot, a `reloadWithRegistrationEnabled()` test helper reboots the app with the env set (re-opening the RefreshDatabase transaction so writes don't leak).

Full gate green: `composer test` at **100.0%** coverage (Pint + PHPStan pass), and frontend `lint:check` / `format:check` / `types:check` / `build` all pass.

## Out of scope

Per-user/runtime flags (Pennant), a branded "registration closed" page (relies on 404), invite-based registration flows.