### PR TITLE
feat(identity): reskin settings pages for "The Desk" (#157)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,7 @@ export default defineConfigWithVueTs(
     },
     {
         ignores: [
+            '.claude',
             'vendor',
             'node_modules',
             'public',

--- a/resources/js/components/AppearanceTabs.vue
+++ b/resources/js/components/AppearanceTabs.vue
@@ -1,33 +1,31 @@
 <script setup lang="ts">
-import { Monitor, Moon, Sun } from '@lucide/vue';
 import { useAppearance } from '@/composables/useAppearance';
 
 const { appearance, updateAppearance } = useAppearance();
 
 const tabs = [
-    { value: 'light', Icon: Sun, label: 'Light' },
-    { value: 'dark', Icon: Moon, label: 'Dark' },
-    { value: 'system', Icon: Monitor, label: 'System' },
+    { value: 'light', label: 'Light' },
+    { value: 'dark', label: 'Dark' },
+    { value: 'system', label: 'System' },
 ] as const;
 </script>
 
 <template>
     <div
-        class="inline-flex gap-1 rounded-lg bg-neutral-100 p-1 dark:bg-neutral-800"
+        class="inline-flex w-full max-w-sm gap-1.5 rounded-full bg-muted p-[3px]"
     >
         <button
-            v-for="{ value, Icon, label } in tabs"
+            v-for="{ value, label } in tabs"
             :key="value"
             @click="updateAppearance(value)"
             :class="[
-                'flex items-center rounded-md px-3.5 py-1.5 transition-colors',
+                'flex h-7 flex-1 items-center justify-center rounded-full text-xs font-medium transition-colors',
                 appearance === value
-                    ? 'bg-white shadow-xs dark:bg-neutral-700 dark:text-neutral-100'
-                    : 'text-neutral-500 hover:bg-neutral-200/60 hover:text-black dark:text-neutral-400 dark:hover:bg-neutral-700/60',
+                    ? 'border border-border bg-card text-foreground shadow-xs'
+                    : 'text-muted-foreground hover:text-foreground',
             ]"
         >
-            <component :is="Icon" class="-ml-1 h-4 w-4" />
-            <span class="ml-1.5 text-sm">{{ label }}</span>
+            {{ label }}
         </button>
     </div>
 </template>

--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -2,7 +2,6 @@
 import { Form } from '@inertiajs/vue3';
 import { useTemplateRef } from 'vue';
 import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
-import Heading from '@/components/Heading.vue';
 import InputError from '@/components/InputError.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
@@ -22,92 +21,86 @@ const passwordInput = useTemplateRef('passwordInput');
 </script>
 
 <template>
-    <div class="space-y-6">
-        <Heading
-            variant="small"
-            title="Delete account"
-            description="Delete your account and all of its resources"
-        />
-        <div
-            class="space-y-4 rounded-lg border border-red-100 bg-red-50 p-4 dark:border-red-200/10 dark:bg-red-700/10"
-        >
-            <div class="relative space-y-0.5 text-red-600 dark:text-red-100">
-                <p class="font-medium">Warning</p>
-                <p class="text-sm">
-                    Please proceed with caution, this cannot be undone.
-                </p>
-            </div>
-            <Dialog>
-                <DialogTrigger as-child>
-                    <Button variant="destructive" data-test="delete-user-button"
-                        >Delete account</Button
-                    >
-                </DialogTrigger>
-                <DialogContent>
-                    <Form
-                        v-bind="ProfileController.destroy.form()"
-                        reset-on-success
-                        @error="() => passwordInput?.focus()"
-                        :options="{
-                            preserveScroll: true,
-                        }"
-                        class="space-y-6"
-                        v-slot="{ errors, processing, reset, clearErrors }"
-                    >
-                        <DialogHeader class="space-y-3">
-                            <DialogTitle
-                                >Are you sure you want to delete your
-                                account?</DialogTitle
-                            >
-                            <DialogDescription>
-                                Once your account is deleted, all of its
-                                resources and data will also be permanently
-                                deleted. Please enter your password to confirm
-                                you would like to permanently delete your
-                                account.
-                            </DialogDescription>
-                        </DialogHeader>
-
-                        <div class="grid gap-2">
-                            <Label for="password" class="sr-only"
-                                >Password</Label
-                            >
-                            <PasswordInput
-                                id="password"
-                                name="password"
-                                ref="passwordInput"
-                                placeholder="Password"
-                            />
-                            <InputError :message="errors.password" />
-                        </div>
-
-                        <DialogFooter class="gap-2">
-                            <DialogClose as-child>
-                                <Button
-                                    variant="secondary"
-                                    @click="
-                                        () => {
-                                            clearErrors();
-                                            reset();
-                                        }
-                                    "
-                                >
-                                    Cancel
-                                </Button>
-                            </DialogClose>
-
-                            <Button
-                                type="submit"
-                                variant="destructive"
-                                :disabled="processing"
-                                data-test="confirm-delete-user-button"
-                            >
-                                Delete account
-                            </Button>
-                        </DialogFooter>
-                    </Form>
-                </DialogContent>
-            </Dialog>
+    <div class="space-y-3">
+        <div>
+            <h3 class="font-serif text-[17px] font-semibold text-destructive">
+                Delete account
+            </h3>
+            <p class="mt-1 text-sm text-muted-foreground">
+                Permanently remove your account and all of its data. This cannot
+                be undone.
+            </p>
         </div>
+        <Dialog>
+            <DialogTrigger as-child>
+                <Button
+                    variant="outline"
+                    class="rounded-full border-destructive/40 text-destructive hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive"
+                    data-test="delete-user-button"
+                    >Delete account…</Button
+                >
+            </DialogTrigger>
+            <DialogContent>
+                <Form
+                    v-bind="ProfileController.destroy.form()"
+                    reset-on-success
+                    @error="() => passwordInput?.focus()"
+                    :options="{
+                        preserveScroll: true,
+                    }"
+                    class="space-y-6"
+                    v-slot="{ errors, processing, reset, clearErrors }"
+                >
+                    <DialogHeader class="space-y-3">
+                        <DialogTitle
+                            >Are you sure you want to delete your
+                            account?</DialogTitle
+                        >
+                        <DialogDescription>
+                            Once your account is deleted, all of its resources
+                            and data will also be permanently deleted. Please
+                            enter your password to confirm you would like to
+                            permanently delete your account.
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div class="grid gap-2">
+                        <Label for="password" class="sr-only">Password</Label>
+                        <PasswordInput
+                            id="password"
+                            name="password"
+                            ref="passwordInput"
+                            placeholder="Password"
+                        />
+                        <InputError :message="errors.password" />
+                    </div>
+
+                    <DialogFooter class="gap-2">
+                        <DialogClose as-child>
+                            <Button
+                                variant="secondary"
+                                @click="
+                                    () => {
+                                        clearErrors();
+                                        reset();
+                                    }
+                                "
+                            >
+                                Cancel
+                            </Button>
+                        </DialogClose>
+
+                        <Button
+                            type="submit"
+                            variant="destructive"
+                            :disabled="processing"
+                            data-test="confirm-delete-user-button"
+                        >
+                            Delete account
+                        </Button>
+                    </DialogFooter>
+                </Form>
+            </DialogContent>
+        </Dialog>
     </div>
 </template>

--- a/resources/js/components/Heading.vue
+++ b/resources/js/components/Heading.vue
@@ -15,8 +15,8 @@ withDefaults(defineProps<Props>(), {
         <h2
             :class="
                 variant === 'small'
-                    ? 'mb-0.5 text-base font-medium'
-                    : 'text-xl font-semibold tracking-tight'
+                    ? 'mb-0.5 font-serif text-xl font-semibold'
+                    : 'font-serif text-[32px] leading-none font-semibold tracking-tight'
             "
         >
             {{ title }}

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
-import Heading from '@/components/Heading.vue';
-import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { useCurrentUrl } from '@/composables/useCurrentUrl';
 import { toUrl } from '@/lib/utils';
@@ -40,32 +38,33 @@ const { isCurrentOrParentUrl } = useCurrentUrl();
 
 <template>
     <div class="px-4 py-6">
-        <Heading
-            title="Settings"
-            description="Manage your profile and account settings"
-        />
+        <header class="mb-6 border-b border-border pb-5">
+            <h2
+                class="font-serif text-[32px] leading-none font-semibold tracking-tight"
+            >
+                Settings
+            </h2>
+            <p class="mt-1.5 text-sm text-muted-foreground">
+                Manage your profile and account settings
+            </p>
+        </header>
 
         <div class="flex flex-col lg:flex-row lg:space-x-12">
             <aside class="w-full max-w-xl lg:w-48">
-                <nav
-                    class="flex flex-col space-y-1 space-x-0"
-                    aria-label="Settings"
-                >
-                    <Button
+                <nav class="flex flex-col gap-0.5" aria-label="Settings">
+                    <Link
                         v-for="item in sidebarNavItems"
                         :key="toUrl(item.href)"
-                        variant="ghost"
+                        :href="item.href"
                         :class="[
-                            'w-full justify-start',
-                            { 'bg-muted': isCurrentOrParentUrl(item.href) },
+                            'flex h-[34px] items-center rounded-lg px-3 text-sm font-medium transition-colors',
+                            isCurrentOrParentUrl(item.href)
+                                ? 'bg-primary text-primary-foreground'
+                                : 'text-muted-foreground hover:bg-accent hover:text-foreground',
                         ]"
-                        as-child
                     >
-                        <Link :href="item.href">
-                            <component :is="item.icon" class="h-4 w-4" />
-                            {{ item.title }}
-                        </Link>
-                    </Button>
+                        {{ item.title }}
+                    </Link>
                 </nav>
             </aside>
 

--- a/resources/js/pages/settings/Notifications.vue
+++ b/resources/js/pages/settings/Notifications.vue
@@ -84,6 +84,7 @@ const { shareReadReceipts, updateShareReadReceipts } = useReadReceipts();
                     type="button"
                     variant="outline"
                     size="icon"
+                    class="rounded-full"
                     :disabled="selected === 'off'"
                     data-test="preview-chime"
                     aria-label="Preview chime"

--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -73,7 +73,7 @@ function onTimezoneSelect(value: unknown): void {
         <Form
             v-bind="ProfileController.update.form()"
             class="space-y-6"
-            v-slot="{ errors, processing }"
+            v-slot="{ errors, processing, recentlySuccessful }"
         >
             <div class="grid gap-2">
                 <Label for="name">Name</Label>
@@ -166,9 +166,25 @@ function onTimezoneSelect(value: unknown): void {
             </div>
 
             <div class="flex items-center gap-4">
-                <Button :disabled="processing" data-test="update-profile-button"
+                <Button
+                    :disabled="processing"
+                    class="rounded-full px-6"
+                    data-test="update-profile-button"
                     >Save</Button
                 >
+                <Transition
+                    enter-active-class="transition ease-in-out"
+                    enter-from-class="opacity-0"
+                    leave-active-class="transition ease-in-out"
+                    leave-to-class="opacity-0"
+                >
+                    <p
+                        v-show="recentlySuccessful"
+                        class="font-serif text-sm text-muted-foreground italic"
+                    >
+                        Saved just now
+                    </p>
+                </Transition>
             </div>
         </Form>
 

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -56,7 +56,7 @@ defineOptions({
                 'current_password',
             ]"
             class="space-y-6"
-            v-slot="{ errors, processing }"
+            v-slot="{ errors, processing, recentlySuccessful }"
         >
             <div class="grid gap-2">
                 <Label for="current_password">Current password</Label>
@@ -99,10 +99,24 @@ defineOptions({
             <div class="flex items-center gap-4">
                 <Button
                     :disabled="processing"
+                    class="rounded-full px-6"
                     data-test="update-password-button"
                 >
                     Save
                 </Button>
+                <Transition
+                    enter-active-class="transition ease-in-out"
+                    enter-from-class="opacity-0"
+                    leave-active-class="transition ease-in-out"
+                    leave-to-class="opacity-0"
+                >
+                    <p
+                        v-show="recentlySuccessful"
+                        class="font-serif text-sm text-muted-foreground italic"
+                    >
+                        Saved just now
+                    </p>
+                </Transition>
             </div>
         </Form>
 


### PR DESCRIPTION
Reskins the four settings screens and the settings sub-nav to **The Desk** §5i. Closes #157. Part of epic #145.

## Shared `Heading` (settings + teams titles)
- Titles now render in the **Newsreader serif** — default variant 32px, small variant 20px — matching the Desk masthead treatment. `Heading` is shared with the teams pages (#159/#160), which now inherit serif titles ahead of their own reskins (covered by #161 QA).

## Settings shell (`layouts/settings/Layout.vue`)
- Serif **"Settings"** header + subtitle over a hairline bottom border.
- Sub-nav is now a **pill list**: ink active row (`bg-primary`), muted inactive rows with a warm hover tint.

## Profile / Security
- **Pill Save buttons** with a serif-italic **"Saved just now"** affordance driven by the Inertia `<Form>`'s `recentlySuccessful` state.

## Delete account (`DeleteUser.vue`)
- Dropped the raw `red-50/red-100` warning box for a **serif destructive heading** + a **destructive-outline pill** trigger; the confirm dialog (from #155) is unchanged. Uses the semantic `destructive` token.

## Appearance (`AppearanceTabs.vue`)
- Warm **segmented Light / Dark / System pill** on `bg-muted`; active segment is a bordered card chip. Replaces the old raw `neutral-*` palette with tokens.

## Notifications
- Round **pill chime-preview** button; serif card title + warm switch inherited.

## Tooling
- Added `.claude` to the **eslint ignore list** so a sibling agent's nested linked worktree under `.claude/worktrees/` can't break `eslint .`. (A concurrent worktree appeared mid-task and was being linted; `.claude/` is harness territory and should never be linted by the main project.)

## Deviations from §5i (precedents: #149, #153, #154, #155)
- **Read-receipts toggle** stays on the Notifications screen (where it already lives, and where the mock's notifications card shows it) rather than moving to Security.
- The appearance segmented control is **text-only** per the mock (dropped the sun/moon/monitor icons).
- The destructive brick-red maps to the semantic **`destructive`** token (no raw hex).

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan clean). *Note: an initial run hit 9 transient DB-contention failures — `relation "users" does not exist` / deadlocks in unrelated tests — from a concurrent agent's test run sharing the `testing` database; the re-run was a clean 100%. No PHP changed in this PR.*
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
- `sail npm run test:js` → 231 passed (no new pure logic; styling + Form state)
