### PR TITLE
feat(security): reskin auth pages for "The Desk" (#158)

### DIFF
--- a/resources/js/layouts/AuthLayout.vue
+++ b/resources/js/layouts/AuthLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import AuthLayout from '@/layouts/auth/AuthSimpleLayout.vue';
+import AuthLayout from '@/layouts/auth/AuthSplitLayout.vue';
 
 const { title = '', description = '' } = defineProps<{
     title?: string;

--- a/resources/js/layouts/auth/AuthSplitLayout.vue
+++ b/resources/js/layouts/auth/AuthSplitLayout.vue
@@ -13,34 +13,64 @@ defineProps<{
 </script>
 
 <template>
-    <div
-        class="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0"
-    >
+    <div class="grid min-h-svh lg:grid-cols-2">
+        <!--
+          Brand panel — a warm ink surface with brass accents. `bg-primary` is
+          ink in light; in dark `--primary` flips light, so fall back to the
+          raised `card` shade to keep the panel dark-warm against the darker
+          canvas in both modes.
+        -->
         <div
-            class="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r"
+            class="relative hidden flex-col justify-between overflow-hidden border-border bg-primary p-10 text-primary-foreground lg:flex lg:border-r dark:bg-card dark:text-card-foreground"
         >
-            <div class="absolute inset-0 bg-zinc-900" />
             <Link
                 :href="home()"
-                class="relative z-20 flex items-center text-lg font-medium"
+                class="relative z-10 flex items-center gap-2.5 font-serif text-lg font-semibold"
             >
-                <AppLogoIcon class="mr-2 size-8 fill-current text-white" />
+                <AppLogoIcon class="size-7 fill-current text-brass" />
                 {{ name }}
             </Link>
+
+            <blockquote class="relative z-10">
+                <p
+                    class="max-w-sm font-serif text-2xl leading-snug text-primary-foreground/90 italic dark:text-card-foreground/90"
+                >
+                    Where your team&rsquo;s conversations come together.
+                </p>
+            </blockquote>
         </div>
-        <div class="lg:p-8">
-            <div
-                class="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]"
-            >
-                <div class="flex flex-col space-y-2 text-center">
-                    <h1 class="text-xl font-medium tracking-tight" v-if="title">
+
+        <!-- Form column, on the warm canvas. -->
+        <div
+            class="flex flex-col items-center justify-center bg-background p-6 md:p-10"
+        >
+            <div class="w-full max-w-sm">
+                <Link
+                    :href="home()"
+                    class="mb-8 flex items-center justify-center lg:hidden"
+                >
+                    <AppLogoIcon class="size-9 fill-current text-foreground" />
+                    <span class="sr-only">{{ name }}</span>
+                </Link>
+
+                <div
+                    v-if="title || description"
+                    class="flex flex-col gap-2 text-center"
+                >
+                    <h1
+                        v-if="title"
+                        class="font-serif text-2xl font-semibold tracking-tight"
+                    >
                         {{ title }}
                     </h1>
-                    <p class="text-sm text-muted-foreground" v-if="description">
+                    <p v-if="description" class="text-sm text-muted-foreground">
                         {{ description }}
                     </p>
                 </div>
-                <slot />
+
+                <div class="mt-8">
+                    <slot />
+                </div>
             </div>
         </div>
     </div>

--- a/resources/js/pages/auth/ConfirmPassword.vue
+++ b/resources/js/pages/auth/ConfirmPassword.vue
@@ -41,7 +41,7 @@ defineOptions({
 
             <div class="flex items-center">
                 <Button
-                    class="w-full"
+                    class="w-full rounded-full"
                     :disabled="processing"
                     data-test="confirm-password-button"
                 >

--- a/resources/js/pages/auth/ForgotPassword.vue
+++ b/resources/js/pages/auth/ForgotPassword.vue
@@ -48,7 +48,7 @@ defineProps<{
 
             <div class="my-6 flex items-center justify-start">
                 <Button
-                    class="w-full"
+                    class="w-full rounded-full"
                     :disabled="processing"
                     data-test="email-password-reset-link-button"
                 >

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -98,7 +98,7 @@ defineProps<{
 
             <Button
                 type="submit"
-                class="mt-4 w-full"
+                class="mt-4 w-full rounded-full"
                 :tabindex="4"
                 :disabled="processing"
                 data-test="login-button"

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -100,7 +100,7 @@ defineOptions({
 
             <Button
                 type="submit"
-                class="mt-2 w-full"
+                class="mt-2 w-full rounded-full"
                 tabindex="5"
                 :disabled="processing"
                 data-test="register-user-button"

--- a/resources/js/pages/auth/ResetPassword.vue
+++ b/resources/js/pages/auth/ResetPassword.vue
@@ -78,7 +78,7 @@ const inputEmail = ref(props.email);
 
             <Button
                 type="submit"
-                class="mt-4 w-full"
+                class="mt-4 w-full rounded-full"
                 :disabled="processing"
                 data-test="reset-password-button"
             >

--- a/resources/js/pages/auth/VerifyEmail.vue
+++ b/resources/js/pages/auth/VerifyEmail.vue
@@ -35,7 +35,7 @@ defineProps<{
         class="space-y-6 text-center"
         v-slot="{ processing }"
     >
-        <Button :disabled="processing" variant="secondary">
+        <Button :disabled="processing" variant="secondary" class="rounded-full">
             <Spinner v-if="processing" />
             Resend verification email
         </Button>


### PR DESCRIPTION
Reskins the auth screens to **The Desk**. The mockup doesn't spec auth, so this extrapolates the system. Closes #158. Part of epic #145.

## Chosen composition (design-first, approved)
A **split layout** — a warm ink/brass brand panel beside the form. `AuthLayout` now delegates to the split variant (was the simple/cardless layout).

## `AuthSplitLayout.vue` (full rework off the raw zinc/white palette)
- **Left brand panel**: warm ink surface with a brass logo mark, serif wordmark (app name), and a serif-italic tagline. Uses `bg-primary` in light; in dark, `--primary` flips light, so it falls back to the raised `card` shade — keeping the panel dark-warm against the darker canvas in **both** modes. Hidden below `lg` (form-only on mobile).
- **Right column** on the warm canvas: a centered logo (mobile), serif heading, muted description, then the form.

## Pages
- Primary submit buttons are now **pills** (`rounded-full`) across Login / Register / Forgot / Reset / Confirm / Verify.
- All Fortify form wiring, validation, error display, `tabindex`, and `data-test` hooks are unchanged. Inputs/labels/checkbox inherit the warm tokens from #146.

## Notes
- `AuthSimpleLayout.vue` and `AuthCardLayout.vue` are now **unused** (no importers). Left in place as alternate compositions rather than deleted.
- Tagline copy ("Where your team's conversations come together.") is a placeholder — easy to tweak.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan clean)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
- `sail npm run test:js` → 231 passed (styling/layout only; no pure logic)
- Visually verified the login split layout in the running app.
