### PR TITLE
feat(admin): reskin teams pages for "The Desk" (#159)

### DIFF
--- a/resources/js/components/TeamInvitationAlert.vue
+++ b/resources/js/components/TeamInvitationAlert.vue
@@ -14,11 +14,12 @@ defineProps<Props>();
 <template>
     <div data-test="team-invitation-alert">
         <Alert
-            class="border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/50 dark:text-blue-100 [&>svg]:text-blue-600 dark:[&>svg]:text-blue-400"
+            class="border-brass/30 bg-brass-fill text-foreground [&>svg]:text-brass"
         >
             <Info class="size-4" />
-            <AlertDescription class="text-blue-900 dark:text-blue-100">
-                {{ action }} to join the "{{ invitation.teamName }}" team.
+            <AlertDescription class="text-foreground">
+                {{ action }} to join the &ldquo;{{ invitation.teamName }}&rdquo;
+                team.
             </AlertDescription>
         </Alert>
     </div>

--- a/resources/js/pages/teams/Audit.vue
+++ b/resources/js/pages/teams/Audit.vue
@@ -137,11 +137,11 @@ function occurredAt(iso: string): string {
             <li
                 v-for="entry in entries.data"
                 :key="entry.id"
-                class="flex flex-col gap-1 rounded-lg border border-border p-4 sm:flex-row sm:items-center sm:justify-between"
+                class="flex flex-col gap-1 rounded-lg border border-border bg-card p-4 shadow-[0_2px_8px_rgba(29,26,21,0.05)] sm:flex-row sm:items-center sm:justify-between"
                 :data-test="`audit-entry-${entry.id}`"
             >
                 <div class="min-w-0 space-y-0.5">
-                    <p class="text-sm font-medium">
+                    <p class="text-sm font-semibold">
                         {{ entry.actorName ?? 'Unknown member' }}
                     </p>
                     <p class="text-sm text-muted-foreground">
@@ -166,6 +166,7 @@ function occurredAt(iso: string): string {
                 as-child
                 variant="outline"
                 size="sm"
+                class="rounded-full"
                 data-test="audit-prev-page"
             >
                 <Link :href="entries.prevPageUrl" preserve-scroll>
@@ -179,6 +180,7 @@ function occurredAt(iso: string): string {
                 as-child
                 variant="outline"
                 size="sm"
+                class="rounded-full"
                 data-test="audit-next-page"
             >
                 <Link :href="entries.nextPageUrl" preserve-scroll>

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -140,6 +140,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
                 <div class="flex items-center gap-4">
                     <Button
                         type="submit"
+                        class="rounded-full px-6"
                         data-test="team-save-button"
                         :disabled="processing"
                     >
@@ -168,6 +169,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
 
                 <Button
                     v-if="permissions.canCreateInvitation"
+                    class="rounded-full"
                     data-test="invite-member-button"
                     @click="inviteDialogOpen = true"
                 >
@@ -180,7 +182,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
                     v-for="member in members"
                     :key="member.id"
                     data-test="member-row"
-                    class="flex items-center justify-between rounded-lg border p-4"
+                    class="flex items-center justify-between rounded-lg border bg-card p-4 shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
                 >
                     <div class="flex items-center gap-4">
                         <Avatar class="h-10 w-10">
@@ -196,7 +198,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
                         <div>
                             <Link
                                 :href="showMember([team.slug, member.id])"
-                                class="font-medium underline-offset-4 hover:underline"
+                                class="font-semibold underline-offset-4 hover:underline"
                                 data-test="member-profile-link"
                             >
                                 {{ member.name }}
@@ -308,7 +310,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
                     v-for="invitation in invitations"
                     :key="invitation.code"
                     data-test="invitation-row"
-                    class="flex items-center justify-between rounded-lg border p-4"
+                    class="flex items-center justify-between rounded-lg border bg-card p-4 shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
                 >
                     <div class="flex items-center gap-4">
                         <div
@@ -317,7 +319,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
                             <Mail class="h-5 w-5 text-muted-foreground" />
                         </div>
                         <div>
-                            <div class="font-medium">
+                            <div class="font-semibold">
                                 {{ invitation.email }}
                             </div>
                             <div class="text-sm text-muted-foreground">
@@ -354,7 +356,12 @@ const confirmTransferOwnership = (member: TeamMember) => {
                 title="Audit log"
                 description="Review moderation and admin actions in this workspace"
             />
-            <Button as-child variant="outline" data-test="view-audit-log-link">
+            <Button
+                as-child
+                variant="outline"
+                class="rounded-full"
+                data-test="view-audit-log-link"
+            >
                 <Link :href="auditIndex(team.slug)">View audit log</Link>
             </Button>
         </div>
@@ -362,31 +369,26 @@ const confirmTransferOwnership = (member: TeamMember) => {
         <!-- Danger Zone -->
         <div
             v-if="permissions.canDeleteTeam && !team.isPersonal"
-            class="space-y-6"
+            class="space-y-3"
         >
-            <Heading
-                variant="small"
-                title="Delete team"
-                description="Permanently delete your team"
-            />
-            <div
-                class="space-y-4 rounded-lg border border-red-100 bg-red-50 p-4 dark:border-red-200/10 dark:bg-red-700/10"
-            >
-                <div
-                    class="relative space-y-0.5 text-red-600 dark:text-red-100"
+            <div>
+                <h3
+                    class="font-serif text-[17px] font-semibold text-destructive"
                 >
-                    <p class="font-medium">Warning</p>
-                    <p class="text-sm">
-                        Please proceed with caution, this cannot be undone.
-                    </p>
-                </div>
-                <Button
-                    data-test="delete-team-button"
-                    variant="destructive"
-                    @click="deleteDialogOpen = true"
-                    >Delete team</Button
-                >
+                    Delete team
+                </h3>
+                <p class="mt-1 text-sm text-muted-foreground">
+                    Permanently delete this team and all of its data. This
+                    cannot be undone.
+                </p>
             </div>
+            <Button
+                data-test="delete-team-button"
+                variant="outline"
+                class="rounded-full border-destructive/40 text-destructive hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive"
+                @click="deleteDialogOpen = true"
+                >Delete team&hellip;</Button
+            >
         </div>
     </div>
 

--- a/resources/js/pages/teams/Index.vue
+++ b/resources/js/pages/teams/Index.vue
@@ -58,7 +58,7 @@ defineOptions({
             />
 
             <CreateTeamModal>
-                <Button data-test="teams-new-team-button">
+                <Button class="rounded-full" data-test="teams-new-team-button">
                     <Plus /> New team
                 </Button>
             </CreateTeamModal>
@@ -69,12 +69,12 @@ defineOptions({
                 v-for="team in teams"
                 :key="team.id"
                 data-test="team-row"
-                class="flex items-center justify-between gap-4 rounded-lg border p-4"
+                class="flex items-center justify-between gap-4 rounded-lg border bg-card p-4 shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
             >
                 <div class="flex items-center gap-4">
                     <div>
                         <div class="flex items-center gap-2">
-                            <span class="font-medium">{{ team.name }}</span>
+                            <span class="font-semibold">{{ team.name }}</span>
                             <Badge v-if="team.isPersonal" variant="secondary">
                                 Personal
                             </Badge>

--- a/resources/js/pages/teams/MemberProfile.vue
+++ b/resources/js/pages/teams/MemberProfile.vue
@@ -82,7 +82,9 @@ const localTime = computed(() =>
             :description="`Member of ${team.name}`"
         />
 
-        <div class="flex items-start gap-4 rounded-lg border p-6">
+        <div
+            class="flex items-start gap-4 rounded-lg border bg-card p-6 shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
+        >
             <Avatar class="h-16 w-16 text-lg">
                 <AvatarFallback>{{ getInitials(profile.name) }}</AvatarFallback>
             </Avatar>
@@ -90,7 +92,7 @@ const localTime = computed(() =>
             <div class="min-w-0 flex-1 space-y-3">
                 <div>
                     <div class="flex flex-wrap items-center gap-2">
-                        <h3 class="text-lg font-semibold">
+                        <h3 class="font-serif text-xl font-semibold">
                             {{ profile.name }}
                         </h3>
                         <span


### PR DESCRIPTION
Reskins the teams screens and the remaining team modals to **The Desk** (teams aren't in the mockup — extrapolated from the system). Closes #159. Part of epic #145.

## Layout decision (design-first)
The existing structures already fit the system, so this **warms them rather than re-architecting**:
- **Audit** stays a filtered list (action/actor selects → warm entry cards → pager).
- **MemberProfile** stays a profile card (avatar + detail grid).

## Pages — `Index.vue`, `Edit.vue`, `Audit.vue`, `MemberProfile.vue`
- Team / member / invitation / audit rows are now **warm cream cards** (`bg-card`, the 14px `--radius` via `rounded-lg`, soft ink shadow) instead of bare-bordered rows on the canvas; names bump to semibold.
- Serif section titles are already inherited from the shared `Heading` (#157).
- **MemberProfile**: serif member name on a warm profile card.
- **Pill actions**: New team, Invite member, Save, View audit log, Newer/Older pagination.
- **Edit "Delete team" danger zone**: dropped the raw `red-50/red-100` box for a serif `destructive` heading + destructive-outline pill — matching the Profile Delete-account treatment from #157.

## Team modals
- **LeaveTeamModal, RemoveMemberModal, TransferOwnershipModal, CancelInvitationModal** already inherit the cream/serif/pill dialog treatment from the shared `ui/dialog` primitive (#155) — verified, no change needed.
- **TeamInvitationAlert** (an inline `Alert`, not a dialog, so not cascaded): swapped its raw blue palette for a warm **brass informational tint** (`bg-brass-fill`, brass border + icon). This also shows on the auth pages (Login/Register), now consistent with #158.

All Fortify/Inertia wiring, permissions gating, validation, and `data-test` hooks are unchanged.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan clean; no PHP touched)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
- `sail npm run test:js` → 231 passed (styling only; no pure logic)
