### PR TITLE
feat(platform): reskin welcome/landing page for "The Desk" (#160)

### DIFF
--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -2,451 +2,616 @@
 import { Head, Link, usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import { index as channelsWorkspace } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import AppLogoIcon from '@/components/AppLogoIcon.vue';
+import { Button } from '@/components/ui/button';
 import { login, register } from '@/routes';
 
 const page = usePage();
+
+const name = page.props.name;
+const user = computed(() => page.props.auth.user);
+const registrationEnabled = computed(() => page.props.registrationEnabled);
+
 const workspaceUrl = computed(() =>
     page.props.currentTeam
         ? channelsWorkspace(page.props.currentTeam.slug).url
         : '/',
 );
+
+const getStartedUrl = computed(() =>
+    registrationEnabled.value ? register() : login(),
+);
 </script>
 
 <template>
-    <Head title="Welcome">
-        <link rel="preconnect" href="https://rsms.me/" />
-        <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
-    </Head>
+    <Head title="Welcome" />
+
     <div
-        class="flex min-h-screen flex-col items-center bg-[#FDFDFC] p-6 text-[#1b1b18] lg:justify-center lg:p-8 dark:bg-[#0a0a0a]"
+        class="flex min-h-screen flex-col bg-[radial-gradient(1200px_500px_at_50%_-100px,var(--muted),var(--background))] text-foreground transition-opacity duration-700 starting:opacity-0"
     >
-        <header
-            class="mb-6 w-full max-w-[335px] text-sm not-has-[nav]:hidden lg:max-w-4xl"
-        >
-            <nav class="flex items-center justify-end gap-4">
+        <!-- Nav -->
+        <header class="mx-auto w-full max-w-[1160px] px-6 py-6 sm:px-8">
+            <nav class="flex items-center justify-between">
                 <Link
-                    v-if="$page.props.auth.user"
-                    :href="workspaceUrl"
-                    class="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
+                    :href="user ? workspaceUrl : '/'"
+                    class="flex items-center gap-2.5 font-serif text-lg font-semibold tracking-tight"
                 >
-                    Workspace
+                    <AppLogoIcon class="size-6 fill-current text-brass" />
+                    {{ name }}
                 </Link>
-                <template v-else>
-                    <Link
-                        :href="login()"
-                        class="inline-block rounded-sm border border-transparent px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#19140035] dark:text-[#EDEDEC] dark:hover:border-[#3E3E3A]"
-                    >
-                        Log in
-                    </Link>
-                    <Link
-                        v-if="$page.props.registrationEnabled"
-                        :href="register()"
-                        class="inline-block rounded-sm border border-[#19140035] px-5 py-1.5 text-sm leading-normal text-[#1b1b18] hover:border-[#1915014a] dark:border-[#3E3E3A] dark:text-[#EDEDEC] dark:hover:border-[#62605b]"
-                    >
-                        Register
-                    </Link>
-                </template>
+
+                <div class="flex items-center gap-2">
+                    <template v-if="user">
+                        <Button as-child class="rounded-full">
+                            <Link :href="workspaceUrl">Open workspace</Link>
+                        </Button>
+                    </template>
+                    <template v-else>
+                        <Button as-child variant="ghost" class="rounded-full">
+                            <Link :href="login()">Log in</Link>
+                        </Button>
+                        <Button
+                            v-if="registrationEnabled"
+                            as-child
+                            class="rounded-full"
+                        >
+                            <Link :href="register()">Sign up</Link>
+                        </Button>
+                    </template>
+                </div>
             </nav>
         </header>
-        <div
-            class="flex w-full items-center justify-center opacity-100 transition-opacity duration-750 lg:grow starting:opacity-0"
+
+        <!-- Hero -->
+        <main
+            class="flex flex-col items-center px-6 pt-10 text-center sm:px-8 lg:pt-14"
         >
-            <main
-                class="flex w-full max-w-[335px] flex-col-reverse overflow-hidden rounded-lg lg:max-w-4xl lg:flex-row"
+            <span
+                class="text-xs font-semibold tracking-[0.14em] text-brass-fill-foreground uppercase"
             >
+                Team chat, quietly done
+            </span>
+            <h1
+                class="mt-5 max-w-3xl font-serif text-[clamp(2.75rem,5.4vw,4.25rem)] leading-[1.02] font-semibold tracking-tight text-balance"
+            >
+                Where your team&rsquo;s work finds its focus.
+            </h1>
+            <p
+                class="mt-6 max-w-xl text-[17px] leading-relaxed text-pretty text-muted-foreground"
+            >
+                Channels, threads, and reactions &mdash; calm, fast, and out of
+                your way. A warm place for the conversation behind the work.
+            </p>
+            <div class="mt-9 flex flex-wrap items-center justify-center gap-3">
+                <template v-if="user">
+                    <Button as-child size="lg" class="h-12 rounded-full px-8">
+                        <Link :href="workspaceUrl">Open workspace</Link>
+                    </Button>
+                </template>
+                <template v-else>
+                    <Button
+                        as-child
+                        size="lg"
+                        class="h-12 rounded-full px-8"
+                        data-test="welcome-primary-cta"
+                    >
+                        <Link :href="getStartedUrl">Get started</Link>
+                    </Button>
+                    <Button
+                        as-child
+                        size="lg"
+                        variant="outline"
+                        class="h-12 rounded-full bg-card/60 px-7"
+                    >
+                        <Link :href="login()">Log in</Link>
+                    </Button>
+                </template>
+            </div>
+        </main>
+
+        <!-- App preview: 3-pane workspace (decorative) -->
+        <div class="mx-auto w-full max-w-[1280px] px-6 pt-16 pb-6 sm:px-8">
+            <div
+                aria-hidden="true"
+                class="flex gap-3 overflow-hidden rounded-[18px] border border-border bg-muted p-3 shadow-[0_40px_80px_-24px_rgba(29,26,21,0.28),0_4px_16px_rgba(29,26,21,0.08)] lg:h-[640px]"
+            >
+                <!-- Sidebar -->
                 <div
-                    class="flex-1 rounded-br-lg rounded-bl-lg bg-white p-6 pb-12 text-[13px] leading-[20px] shadow-[inset_0px_0px_0px_1px_rgba(26,26,0,0.16)] lg:rounded-tl-lg lg:rounded-br-none lg:p-20 dark:bg-[#161615] dark:text-[#EDEDEC] dark:shadow-[inset_0px_0px_0px_1px_#fffaed2d]"
+                    class="hidden w-[236px] shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-sidebar shadow-[0_2px_8px_rgba(29,26,21,0.05)] lg:flex"
                 >
-                    <h1 class="mb-1 font-medium">Let's get started</h1>
-                    <p class="mb-2 text-[#706f6c] dark:text-[#A1A09A]">
-                        Laravel has an incredibly rich ecosystem. <br />We
-                        suggest starting with the following.
-                    </p>
-                    <ul class="mb-4 flex flex-col lg:mb-6">
-                        <li
-                            class="relative flex items-center gap-4 py-2 before:absolute before:top-1/2 before:bottom-0 before:left-[0.4rem] before:border-l before:border-[#e3e3e0] dark:before:border-[#3E3E3A]"
+                    <div class="border-b border-border px-3 pt-3 pb-2.5">
+                        <div class="flex items-center gap-2">
+                            <div
+                                class="flex size-7 items-center justify-center rounded-lg bg-primary text-[10px] font-bold text-primary-foreground"
+                            >
+                                AC
+                            </div>
+                            <div class="min-w-0 flex-1">
+                                <div
+                                    class="text-[13px] leading-tight font-bold"
+                                >
+                                    {{ name }}
+                                </div>
+                                <div class="text-[10px] text-muted-foreground">
+                                    12 members
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-1 flex-col p-2.5">
+                        <div
+                            class="mb-2.5 flex h-7 items-center gap-1.5 rounded-lg bg-muted px-2.5 text-xs text-muted-foreground"
                         >
+                            Jump to&hellip;
                             <span
-                                class="relative bg-white py-1 dark:bg-[#161615]"
+                                class="ml-auto font-mono text-[9px] font-semibold text-muted-foreground/70"
+                                >&#8984;K</span
                             >
-                                <span
-                                    class="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[#e3e3e0] bg-[#FDFDFC] shadow-[0px_0px_1px_0px_rgba(0,0,0,0.03),0px_1px_2px_0px_rgba(0,0,0,0.06)] dark:border-[#3E3E3A] dark:bg-[#161615]"
-                                >
-                                    <span
-                                        class="h-1.5 w-1.5 rounded-full bg-[#dbdbd7] dark:bg-[#3E3E3A]"
-                                    />
-                                </span>
-                            </span>
-                            <span>
-                                Read the
-                                <a
-                                    href="https://laravel.com/docs"
-                                    target="_blank"
-                                    class="ml-1 inline-flex items-center space-x-1 font-medium text-[#f53003] underline underline-offset-4 dark:text-[#FF4433]"
-                                >
-                                    <span>Documentation</span>
-                                    <svg
-                                        width="10"
-                                        height="11"
-                                        viewBox="0 0 10 11"
-                                        fill="none"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        class="h-2.5 w-2.5"
-                                    >
-                                        <path
-                                            d="M7.70833 6.95834V2.79167H3.54167M2.5 8L7.5 3.00001"
-                                            stroke="currentColor"
-                                            stroke-linecap="square"
-                                        />
-                                    </svg>
-                                </a>
-                            </span>
-                        </li>
-                        <li
-                            class="relative flex items-center gap-4 py-2 before:absolute before:top-0 before:bottom-1/2 before:left-[0.4rem] before:border-l before:border-[#e3e3e0] dark:before:border-[#3E3E3A]"
+                        </div>
+
+                        <span
+                            class="px-1.5 py-1 text-[10px] font-bold tracking-[0.1em] text-muted-foreground/70 uppercase"
+                            >Starred</span
                         >
-                            <span
-                                class="relative bg-white py-1 dark:bg-[#161615]"
+                        <div
+                            class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] text-foreground/70"
+                        >
+                            <span class="text-brass">&#9733;</span>
+                            <span class="text-muted-foreground/70">#</span
+                            >general
+                        </div>
+
+                        <span
+                            class="mt-2 px-1.5 py-1 text-[10px] font-bold tracking-[0.1em] text-muted-foreground/70 uppercase"
+                            >Channels</span
+                        >
+                        <div class="flex flex-col gap-px">
+                            <div
+                                class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] font-semibold"
                             >
+                                <span class="text-muted-foreground/80">#</span
+                                >announcements
                                 <span
-                                    class="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[#e3e3e0] bg-[#FDFDFC] shadow-[0px_0px_1px_0px_rgba(0,0,0,0.03),0px_1px_2px_0px_rgba(0,0,0,0.06)] dark:border-[#3E3E3A] dark:bg-[#161615]"
+                                    class="ml-auto flex h-4 min-w-[17px] items-center justify-center rounded-full bg-brass px-1.5 text-[9.5px] font-bold text-brass-foreground"
+                                    >3</span
                                 >
-                                    <span
-                                        class="h-1.5 w-1.5 rounded-full bg-[#dbdbd7] dark:bg-[#3E3E3A]"
-                                    />
-                                </span>
-                            </span>
-                            <span>
-                                Watch video tutorials at
-                                <a
-                                    href="https://laracasts.com"
-                                    target="_blank"
-                                    class="ml-1 inline-flex items-center space-x-1 font-medium text-[#f53003] underline underline-offset-4 dark:text-[#FF4433]"
-                                >
-                                    <span>Laracasts</span>
-                                    <svg
-                                        width="10"
-                                        height="11"
-                                        viewBox="0 0 10 11"
-                                        fill="none"
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        class="h-2.5 w-2.5"
-                                    >
-                                        <path
-                                            d="M7.70833 6.95834V2.79167H3.54167M2.5 8L7.5 3.00001"
-                                            stroke="currentColor"
-                                            stroke-linecap="square"
-                                        />
-                                    </svg>
-                                </a>
-                            </span>
-                        </li>
-                    </ul>
-                    <ul class="flex gap-3 text-sm leading-normal">
-                        <li>
-                            <a
-                                href="https://cloud.laravel.com"
-                                target="_blank"
-                                class="inline-block rounded-sm border border-black bg-[#1b1b18] px-5 py-1.5 text-sm leading-normal text-white hover:border-black hover:bg-black dark:border-[#eeeeec] dark:bg-[#eeeeec] dark:text-[#1C1C1A] dark:hover:border-white dark:hover:bg-white"
+                            </div>
+                            <div
+                                class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] text-foreground/70"
                             >
-                                Deploy now
-                            </a>
-                        </li>
-                    </ul>
+                                <span class="text-muted-foreground/70">#</span
+                                >leadership
+                            </div>
+                            <div
+                                class="flex h-7 items-center gap-1.5 rounded-lg bg-primary px-2.5 text-[12.5px] font-medium text-primary-foreground shadow-[0_2px_6px_rgba(29,26,21,0.25)]"
+                            >
+                                <span class="text-brass">#</span>design
+                            </div>
+                            <div
+                                class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] text-foreground/70"
+                            >
+                                <span class="text-muted-foreground/70">#</span
+                                >support
+                            </div>
+                        </div>
+
+                        <div class="mx-1 my-2.5 h-px bg-border"></div>
+
+                        <div
+                            class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-xs text-foreground/70"
+                        >
+                            Threads
+                            <span
+                                class="ml-auto size-1.5 rounded-full bg-brass"
+                            ></span>
+                        </div>
+                        <div
+                            class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-xs text-muted-foreground"
+                        >
+                            Browse channels
+                        </div>
+                    </div>
+
+                    <div class="border-t border-border p-2.5">
+                        <div
+                            class="flex items-center gap-2 rounded-lg bg-muted px-2 py-1.5"
+                        >
+                            <div class="relative size-6 shrink-0">
+                                <div
+                                    class="flex size-6 items-center justify-center rounded-full bg-accent text-[9.5px] font-bold text-foreground/70"
+                                >
+                                    MC
+                                </div>
+                                <span
+                                    class="absolute -right-px -bottom-px size-2 rounded-full bg-emerald-500 ring-2 ring-muted"
+                                ></span>
+                            </div>
+                            <div class="flex min-w-0 flex-1 flex-col">
+                                <span class="text-xs leading-tight font-medium"
+                                    >Maya Chen</span
+                                >
+                                <span
+                                    class="text-[10px] leading-tight text-muted-foreground"
+                                    >{{ name }}</span
+                                >
+                            </div>
+                        </div>
+                    </div>
                 </div>
+
+                <!-- Channel -->
                 <div
-                    class="relative -mb-px aspect-[335/364] w-full shrink-0 overflow-hidden rounded-t-lg bg-[#fff2f2] lg:mb-0 lg:-ml-px lg:aspect-auto lg:w-[438px] lg:rounded-t-none lg:rounded-r-lg dark:bg-[#1D0002]"
+                    class="flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
                 >
-                    <!-- Laravel Logo -->
-                    <svg
-                        class="w-full max-w-none translate-y-0 text-[#F53003] opacity-100 transition-all duration-750 dark:text-[#F61500] starting:opacity-0 motion-safe:starting:translate-y-6"
-                        viewBox="0 0 438 104"
-                        fill="none"
-                        xmlns="http://www.w3.org/2000/svg"
-                    >
-                        <path
-                            d="M17.2036 -3H0V102.197H49.5189V86.7187H17.2036V-3Z"
-                            fill="currentColor"
-                        />
-                        <path
-                            d="M110.256 41.6337C108.061 38.1275 104.945 35.3731 100.905 33.3681C96.8667 31.3647 92.8016 30.3618 88.7131 30.3618C83.4247 30.3618 78.5885 31.3389 74.201 33.2923C69.8111 35.2456 66.0474 37.928 62.9059 41.3333C59.7643 44.7401 57.3198 48.6726 55.5754 53.1293C53.8287 57.589 52.9572 62.274 52.9572 67.1813C52.9572 72.1925 53.8287 76.8995 55.5754 81.3069C57.3191 85.7173 59.7636 89.6241 62.9059 93.0293C66.0474 96.4361 69.8119 99.1155 74.201 101.069C78.5885 103.022 83.4247 103.999 88.7131 103.999C92.8016 103.999 96.8667 102.997 100.905 100.994C104.945 98.9911 108.061 96.2359 110.256 92.7282V102.195H126.563V32.1642H110.256V41.6337ZM108.76 75.7472C107.762 78.4531 106.366 80.8078 104.572 82.8112C102.776 84.8161 100.606 86.4183 98.0637 87.6206C95.5202 88.823 92.7004 89.4238 89.6103 89.4238C86.5178 89.4238 83.7252 88.823 81.2324 87.6206C78.7388 86.4183 76.5949 84.8161 74.7998 82.8112C73.004 80.8078 71.6319 78.4531 70.6856 75.7472C69.7356 73.0421 69.2644 70.1868 69.2644 67.1821C69.2644 64.1758 69.7356 61.3205 70.6856 58.6154C71.6319 55.9102 73.004 53.5571 74.7998 51.5522C76.5949 49.5495 78.738 47.9451 81.2324 46.7427C83.7252 45.5404 86.5178 44.9396 89.6103 44.9396C92.7012 44.9396 95.5202 45.5404 98.0637 46.7427C100.606 47.9451 102.776 49.5487 104.572 51.5522C106.367 53.5571 107.762 55.9102 108.76 58.6154C109.756 61.3205 110.256 64.1758 110.256 67.1821C110.256 70.1868 109.756 73.0421 108.76 75.7472Z"
-                            fill="currentColor"
-                        />
-                        <path
-                            d="M242.805 41.6337C240.611 38.1275 237.494 35.3731 233.455 33.3681C229.416 31.3647 225.351 30.3618 221.262 30.3618C215.974 30.3618 211.138 31.3389 206.75 33.2923C202.36 35.2456 198.597 37.928 195.455 41.3333C192.314 44.7401 189.869 48.6726 188.125 53.1293C186.378 57.589 185.507 62.274 185.507 67.1813C185.507 72.1925 186.378 76.8995 188.125 81.3069C189.868 85.7173 192.313 89.6241 195.455 93.0293C198.597 96.4361 202.361 99.1155 206.75 101.069C211.138 103.022 215.974 103.999 221.262 103.999C225.351 103.999 229.416 102.997 233.455 100.994C237.494 98.9911 240.611 96.2359 242.805 92.7282V102.195H259.112V32.1642H242.805V41.6337ZM241.31 75.7472C240.312 78.4531 238.916 80.8078 237.122 82.8112C235.326 84.8161 233.156 86.4183 230.614 87.6206C228.07 88.823 225.251 89.4238 222.16 89.4238C219.068 89.4238 216.275 88.823 213.782 87.6206C211.289 86.4183 209.145 84.8161 207.35 82.8112C205.554 80.8078 204.182 78.4531 203.236 75.7472C202.286 73.0421 201.814 70.1868 201.814 67.1821C201.814 64.1758 202.286 61.3205 203.236 58.6154C204.182 55.9102 205.554 53.5571 207.35 51.5522C209.145 49.5495 211.288 47.9451 213.782 46.7427C216.275 45.5404 219.068 44.9396 222.16 44.9396C225.251 44.9396 228.07 45.5404 230.614 46.7427C233.156 47.9451 235.326 49.5487 237.122 51.5522C238.917 53.5571 240.312 55.9102 241.31 58.6154C242.306 61.3205 242.806 64.1758 242.806 67.1821C242.805 70.1868 242.305 73.0421 241.31 75.7472Z"
-                            fill="currentColor"
-                        />
-                        <path
-                            d="M438 -3H421.694V102.197H438V-3Z"
-                            fill="currentColor"
-                        />
-                        <path
-                            d="M139.43 102.197H155.735V48.2834H183.712V32.1665H139.43V102.197Z"
-                            fill="currentColor"
-                        />
-                        <path
-                            d="M324.49 32.1665L303.995 85.794L283.498 32.1665H266.983L293.748 102.197H314.242L341.006 32.1665H324.49Z"
-                            fill="currentColor"
-                        />
-                        <path
-                            d="M376.571 30.3656C356.603 30.3656 340.797 46.8497 340.797 67.1828C340.797 89.6597 356.094 104 378.661 104C391.29 104 399.354 99.1488 409.206 88.5848L398.189 80.0226C398.183 80.031 389.874 90.9895 377.468 90.9895C363.048 90.9895 356.977 79.3111 356.977 73.269H411.075C413.917 50.1328 398.775 30.3656 376.571 30.3656ZM357.02 61.0967C357.145 59.7487 359.023 43.3761 376.442 43.3761C393.861 43.3761 395.978 59.7464 396.099 61.0967H357.02Z"
-                            fill="currentColor"
-                        />
-                    </svg>
-
-                    <!-- 13 -->
-                    <svg
-                        class="relative -mt-[6.6rem] -ml-8 w-[438px] max-w-none [--stroke-color:#1B1B18] lg:ml-0 dark:[--stroke-color:#FF750F]"
-                        viewBox="0 0 440 392"
-                        fill="none"
-                        xmlns="http://www.w3.org/2000/svg"
-                    >
-                        <g
-                            class="text-[#1B1B18] opacity-100 mix-blend-darken transition-all delay-300 duration-750 dark:text-black dark:mix-blend-normal starting:opacity-0"
-                        >
-                            <mask
-                                id="path-1-mask"
-                                maskUnits="userSpaceOnUse"
-                                x="-0.328613"
-                                y="103"
-                                width="338"
-                                height="299"
-                                fill="black"
-                            >
-                                <rect
-                                    fill="white"
-                                    x="-0.328613"
-                                    y="103"
-                                    width="338"
-                                    height="299"
-                                />
-                                <path
-                                    d="M234.936 400.8C204.136 400.8 178.936 392.4 159.336 375.6C140.136 358.8 130.536 337 130.536 310.2H200.736C200.736 318.2 203.736 324.8 209.736 330C215.736 335.2 223.736 337.8 233.736 337.8C243.336 337.8 251.136 335 257.136 329.4C263.536 323.8 266.736 316.6 266.736 307.8C266.736 299.8 263.936 293.2 258.336 288C252.736 282.8 245.536 280.2 236.736 280.2H199.536V218.4H236.736C243.536 218.4 249.336 216 254.136 211.2C258.936 206.4 261.336 200.4 261.336 193.2C261.336 184.8 258.736 178.2 253.536 173.4C248.336 168.6 241.736 166.2 233.736 166.2C226.536 166.2 220.336 168.4 215.136 172.8C210.336 177.2 207.936 182.8 207.936 189.6H141.336C141.336 164.8 150.136 144.6 167.736 129C185.336 113 207.936 105 235.536 105C263.136 105 285.536 112.2 302.736 126.6C320.336 141 329.136 160 329.136 183.6C329.136 200.8 324.536 214.8 315.336 225.6C306.136 236 294.336 243.2 279.936 247.2C297.136 252 310.736 260.2 320.736 271.8C331.136 283.4 336.336 298 336.336 315.6C336.336 340.4 326.936 360.8 308.136 376.8C289.336 392.8 264.936 400.8 234.936 400.8Z"
-                                />
-                                <path
-                                    d="M26.8714 167.6H1.67139V105.2H94.6714V400.2H26.8714V167.6Z"
-                                />
-                            </mask>
-                            <path
-                                d="M234.936 400.8C204.136 400.8 178.936 392.4 159.336 375.6C140.136 358.8 130.536 337 130.536 310.2H200.736C200.736 318.2 203.736 324.8 209.736 330C215.736 335.2 223.736 337.8 233.736 337.8C243.336 337.8 251.136 335 257.136 329.4C263.536 323.8 266.736 316.6 266.736 307.8C266.736 299.8 263.936 293.2 258.336 288C252.736 282.8 245.536 280.2 236.736 280.2H199.536V218.4H236.736C243.536 218.4 249.336 216 254.136 211.2C258.936 206.4 261.336 200.4 261.336 193.2C261.336 184.8 258.736 178.2 253.536 173.4C248.336 168.6 241.736 166.2 233.736 166.2C226.536 166.2 220.336 168.4 215.136 172.8C210.336 177.2 207.936 182.8 207.936 189.6H141.336C141.336 164.8 150.136 144.6 167.736 129C185.336 113 207.936 105 235.536 105C263.136 105 285.536 112.2 302.736 126.6C320.336 141 329.136 160 329.136 183.6C329.136 200.8 324.536 214.8 315.336 225.6C306.136 236 294.336 243.2 279.936 247.2C297.136 252 310.736 260.2 320.736 271.8C331.136 283.4 336.336 298 336.336 315.6C336.336 340.4 326.936 360.8 308.136 376.8C289.336 392.8 264.936 400.8 234.936 400.8Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M26.8714 167.6H1.67139V105.2H94.6714V400.2H26.8714V167.6Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M234.936 400.8C204.136 400.8 178.936 392.4 159.336 375.6C140.136 358.8 130.536 337 130.536 310.2H200.736C200.736 318.2 203.736 324.8 209.736 330C215.736 335.2 223.736 337.8 233.736 337.8C243.336 337.8 251.136 335 257.136 329.4C263.536 323.8 266.736 316.6 266.736 307.8C266.736 299.8 263.936 293.2 258.336 288C252.736 282.8 245.536 280.2 236.736 280.2H199.536V218.4H236.736C243.536 218.4 249.336 216 254.136 211.2C258.936 206.4 261.336 200.4 261.336 193.2C261.336 184.8 258.736 178.2 253.536 173.4C248.336 168.6 241.736 166.2 233.736 166.2C226.536 166.2 220.336 168.4 215.136 172.8C210.336 177.2 207.936 182.8 207.936 189.6H141.336C141.336 164.8 150.136 144.6 167.736 129C185.336 113 207.936 105 235.536 105C263.136 105 285.536 112.2 302.736 126.6C320.336 141 329.136 160 329.136 183.6C329.136 200.8 324.536 214.8 315.336 225.6C306.136 236 294.336 243.2 279.936 247.2C297.136 252 310.736 260.2 320.736 271.8C331.136 283.4 336.336 298 336.336 315.6C336.336 340.4 326.936 360.8 308.136 376.8C289.336 392.8 264.936 400.8 234.936 400.8Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-1-mask)"
-                            />
-                            <path
-                                d="M26.8714 167.6H1.67139V105.2H94.6714V400.2H26.8714V167.6Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-1-mask)"
-                            />
-                        </g>
-
-                        <g
-                            class="text-[#F3BEC7] opacity-100 transition-all delay-400 duration-750 dark:text-[#4B0600] starting:opacity-0 motion-safe:starting:-translate-x-[26px]"
-                        >
-                            <mask
-                                id="path-2-mask"
-                                maskUnits="userSpaceOnUse"
-                                x="25.3357"
-                                y="103"
-                                width="338"
-                                height="299"
-                                fill="black"
-                            >
-                                <rect
-                                    fill="white"
-                                    x="25.3357"
-                                    y="103"
-                                    width="338"
-                                    height="299"
-                                />
-                                <path
-                                    d="M260.6 400.8C229.8 400.8 204.6 392.4 185 375.6C165.8 358.8 156.2 337 156.2 310.2H226.4C226.4 318.2 229.4 324.8 235.4 330C241.4 335.2 249.4 337.8 259.4 337.8C269 337.8 276.8 335 282.8 329.4C289.2 323.8 292.4 316.6 292.4 307.8C292.4 299.8 289.6 293.2 284 288C278.4 282.8 271.2 280.2 262.4 280.2H225.2V218.4H262.4C269.2 218.4 275 216 279.8 211.2C284.6 206.4 287 200.4 287 193.2C287 184.8 284.4 178.2 279.2 173.4C274 168.6 267.4 166.2 259.4 166.2C252.2 166.2 246 168.4 240.8 172.8C236 177.2 233.6 182.8 233.6 189.6H167C167 164.8 175.8 144.6 193.4 129C211 113 233.6 105 261.2 105C288.8 105 311.2 112.2 328.4 126.6C346 141 354.8 160 354.8 183.6C354.8 200.8 350.2 214.8 341 225.6C331.8 236 320 243.2 305.6 247.2C322.8 252 336.4 260.2 346.4 271.8C356.8 283.4 362 298 362 315.6C362 340.4 352.6 360.8 333.8 376.8C315 392.8 290.6 400.8 260.6 400.8Z"
-                                />
-                                <path
-                                    d="M52.5357 167.6H27.3357V105.2H120.336V400.2H52.5357V167.6Z"
-                                />
-                            </mask>
-                            <path
-                                d="M260.6 400.8C229.8 400.8 204.6 392.4 185 375.6C165.8 358.8 156.2 337 156.2 310.2H226.4C226.4 318.2 229.4 324.8 235.4 330C241.4 335.2 249.4 337.8 259.4 337.8C269 337.8 276.8 335 282.8 329.4C289.2 323.8 292.4 316.6 292.4 307.8C292.4 299.8 289.6 293.2 284 288C278.4 282.8 271.2 280.2 262.4 280.2H225.2V218.4H262.4C269.2 218.4 275 216 279.8 211.2C284.6 206.4 287 200.4 287 193.2C287 184.8 284.4 178.2 279.2 173.4C274 168.6 267.4 166.2 259.4 166.2C252.2 166.2 246 168.4 240.8 172.8C236 177.2 233.6 182.8 233.6 189.6H167C167 164.8 175.8 144.6 193.4 129C211 113 233.6 105 261.2 105C288.8 105 311.2 112.2 328.4 126.6C346 141 354.8 160 354.8 183.6C354.8 200.8 350.2 214.8 341 225.6C331.8 236 320 243.2 305.6 247.2C322.8 252 336.4 260.2 346.4 271.8C356.8 283.4 362 298 362 315.6C362 340.4 352.6 360.8 333.8 376.8C315 392.8 290.6 400.8 260.6 400.8Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M52.5357 167.6H27.3357V105.2H120.336V400.2H52.5357V167.6Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M260.6 400.8C229.8 400.8 204.6 392.4 185 375.6C165.8 358.8 156.2 337 156.2 310.2H226.4C226.4 318.2 229.4 324.8 235.4 330C241.4 335.2 249.4 337.8 259.4 337.8C269 337.8 276.8 335 282.8 329.4C289.2 323.8 292.4 316.6 292.4 307.8C292.4 299.8 289.6 293.2 284 288C278.4 282.8 271.2 280.2 262.4 280.2H225.2V218.4H262.4C269.2 218.4 275 216 279.8 211.2C284.6 206.4 287 200.4 287 193.2C287 184.8 284.4 178.2 279.2 173.4C274 168.6 267.4 166.2 259.4 166.2C252.2 166.2 246 168.4 240.8 172.8C236 177.2 233.6 182.8 233.6 189.6H167C167 164.8 175.8 144.6 193.4 129C211 113 233.6 105 261.2 105C288.8 105 311.2 112.2 328.4 126.6C346 141 354.8 160 354.8 183.6C354.8 200.8 350.2 214.8 341 225.6C331.8 236 320 243.2 305.6 247.2C322.8 252 336.4 260.2 346.4 271.8C356.8 283.4 362 298 362 315.6C362 340.4 352.6 360.8 333.8 376.8C315 392.8 290.6 400.8 260.6 400.8Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-2-mask)"
-                            />
-                            <path
-                                d="M52.5357 167.6H27.3357V105.2H120.336V400.2H52.5357V167.6Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-2-mask)"
-                            />
-                        </g>
-
-                        <g
-                            class="text-[#F8B803] opacity-100 mix-blend-color transition-all delay-400 duration-750 dark:text-[#391800] dark:mix-blend-hard-light starting:opacity-0 motion-safe:starting:-translate-x-[51px]"
-                        >
-                            <mask
-                                id="path-3-mask"
-                                maskUnits="userSpaceOnUse"
-                                x="51"
-                                y="103"
-                                width="338"
-                                height="299"
-                                fill="black"
-                            >
-                                <rect
-                                    fill="white"
-                                    x="51"
-                                    y="103"
-                                    width="338"
-                                    height="299"
-                                />
-                                <path
-                                    d="M286.264 400.8C255.464 400.8 230.264 392.4 210.664 375.6C191.464 358.8 181.864 337 181.864 310.2H252.064C252.064 318.2 255.064 324.8 261.064 330C267.064 335.2 275.064 337.8 285.064 337.8C294.664 337.8 302.464 335 308.464 329.4C314.864 323.8 318.064 316.6 318.064 307.8C318.064 299.8 315.264 293.2 309.664 288C304.064 282.8 296.864 280.2 288.064 280.2H250.864V218.4H288.064C294.864 218.4 300.664 216 305.464 211.2C310.264 206.4 312.664 200.4 312.664 193.2C312.664 184.8 310.064 178.2 304.864 173.4C299.664 168.6 293.064 166.2 285.064 166.2C277.864 166.2 271.664 168.4 266.464 172.8C261.664 177.2 259.264 182.8 259.264 189.6H192.664C192.664 164.8 201.464 144.6 219.064 129C236.664 113 259.264 105 286.864 105C314.464 105 336.864 112.2 354.064 126.6C371.664 141 380.464 160 380.464 183.6C380.464 200.8 375.864 214.8 366.664 225.6C357.464 236 345.664 243.2 331.264 247.2C348.464 252 362.064 260.2 372.064 271.8C382.464 283.4 387.664 298 387.664 315.6C387.664 340.4 378.264 360.8 359.464 376.8C340.664 392.8 316.264 400.8 286.264 400.8Z"
-                                />
-                                <path
-                                    d="M78.2 167.6H53V105.2H146V400.2H78.2V167.6Z"
-                                />
-                            </mask>
-                            <path
-                                d="M286.264 400.8C255.464 400.8 230.264 392.4 210.664 375.6C191.464 358.8 181.864 337 181.864 310.2H252.064C252.064 318.2 255.064 324.8 261.064 330C267.064 335.2 275.064 337.8 285.064 337.8C294.664 337.8 302.464 335 308.464 329.4C314.864 323.8 318.064 316.6 318.064 307.8C318.064 299.8 315.264 293.2 309.664 288C304.064 282.8 296.864 280.2 288.064 280.2H250.864V218.4H288.064C294.864 218.4 300.664 216 305.464 211.2C310.264 206.4 312.664 200.4 312.664 193.2C312.664 184.8 310.064 178.2 304.864 173.4C299.664 168.6 293.064 166.2 285.064 166.2C277.864 166.2 271.664 168.4 266.464 172.8C261.664 177.2 259.264 182.8 259.264 189.6H192.664C192.664 164.8 201.464 144.6 219.064 129C236.664 113 259.264 105 286.864 105C314.464 105 336.864 112.2 354.064 126.6C371.664 141 380.464 160 380.464 183.6C380.464 200.8 375.864 214.8 366.664 225.6C357.464 236 345.664 243.2 331.264 247.2C348.464 252 362.064 260.2 372.064 271.8C382.464 283.4 387.664 298 387.664 315.6C387.664 340.4 378.264 360.8 359.464 376.8C340.664 392.8 316.264 400.8 286.264 400.8Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M78.2 167.6H53V105.2H146V400.2H78.2V167.6Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M286.264 400.8C255.464 400.8 230.264 392.4 210.664 375.6C191.464 358.8 181.864 337 181.864 310.2H252.064C252.064 318.2 255.064 324.8 261.064 330C267.064 335.2 275.064 337.8 285.064 337.8C294.664 337.8 302.464 335 308.464 329.4C314.864 323.8 318.064 316.6 318.064 307.8C318.064 299.8 315.264 293.2 309.664 288C304.064 282.8 296.864 280.2 288.064 280.2H250.864V218.4H288.064C294.864 218.4 300.664 216 305.464 211.2C310.264 206.4 312.664 200.4 312.664 193.2C312.664 184.8 310.064 178.2 304.864 173.4C299.664 168.6 293.064 166.2 285.064 166.2C277.864 166.2 271.664 168.4 266.464 172.8C261.664 177.2 259.264 182.8 259.264 189.6H192.664C192.664 164.8 201.464 144.6 219.064 129C236.664 113 259.264 105 286.864 105C314.464 105 336.864 112.2 354.064 126.6C371.664 141 380.464 160 380.464 183.6C380.464 200.8 375.864 214.8 366.664 225.6C357.464 236 345.664 243.2 331.264 247.2C348.464 252 362.064 260.2 372.064 271.8C382.464 283.4 387.664 298 387.664 315.6C387.664 340.4 378.264 360.8 359.464 376.8C340.664 392.8 316.264 400.8 286.264 400.8Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-3-mask)"
-                            />
-                            <path
-                                d="M78.2 167.6H53V105.2H146V400.2H78.2V167.6Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-3-mask)"
-                            />
-                        </g>
-
-                        <g
-                            class="text-[#F3BEC7] opacity-100 mix-blend-multiply transition-all delay-400 duration-750 dark:text-[#733000] dark:mix-blend-normal starting:opacity-0 motion-safe:starting:-translate-x-[78px]"
-                        >
-                            <mask
-                                id="path-4-mask"
-                                maskUnits="userSpaceOnUse"
-                                x="76.6643"
-                                y="103"
-                                width="338"
-                                height="299"
-                                fill="black"
-                            >
-                                <rect
-                                    fill="white"
-                                    x="76.6643"
-                                    y="103"
-                                    width="338"
-                                    height="299"
-                                />
-                                <path
-                                    d="M311.929 400.8C281.129 400.8 255.929 392.4 236.329 375.6C217.129 358.8 207.529 337 207.529 310.2H277.729C277.729 318.2 280.729 324.8 286.729 330C292.729 335.2 300.729 337.8 310.729 337.8C320.329 337.8 328.129 335 334.129 329.4C340.529 323.8 343.729 316.6 343.729 307.8C343.729 299.8 340.929 293.2 335.329 288C329.729 282.8 322.529 280.2 313.729 280.2H276.529V218.4H313.729C320.529 218.4 326.329 216 331.129 211.2C335.929 206.4 338.329 200.4 338.329 193.2C338.329 184.8 335.729 178.2 330.529 173.4C325.329 168.6 318.729 166.2 310.729 166.2C303.529 166.2 297.329 168.4 292.129 172.8C287.329 177.2 284.929 182.8 284.929 189.6H218.329C218.329 164.8 227.129 144.6 244.729 129C262.329 113 284.929 105 312.529 105C340.129 105 362.529 112.2 379.729 126.6C397.329 141 406.129 160 406.129 183.6C406.129 200.8 401.529 214.8 392.329 225.6C383.129 236 371.329 243.2 356.929 247.2C374.129 252 387.729 260.2 397.729 271.8C408.129 283.4 413.329 298 413.329 315.6C413.329 340.4 403.929 360.8 385.129 376.8C366.329 392.8 341.929 400.8 311.929 400.8Z"
-                                />
-                                <path
-                                    d="M103.864 167.6H78.6643V105.2H171.664V400.2H103.864V167.6Z"
-                                />
-                            </mask>
-                            <path
-                                d="M311.929 400.8C281.129 400.8 255.929 392.4 236.329 375.6C217.129 358.8 207.529 337 207.529 310.2H277.729C277.729 318.2 280.729 324.8 286.729 330C292.729 335.2 300.729 337.8 310.729 337.8C320.329 337.8 328.129 335 334.129 329.4C340.529 323.8 343.729 316.6 343.729 307.8C343.729 299.8 340.929 293.2 335.329 288C329.729 282.8 322.529 280.2 313.729 280.2H276.529V218.4H313.729C320.529 218.4 326.329 216 331.129 211.2C335.929 206.4 338.329 200.4 338.329 193.2C338.329 184.8 335.729 178.2 330.529 173.4C325.329 168.6 318.729 166.2 310.729 166.2C303.529 166.2 297.329 168.4 292.129 172.8C287.329 177.2 284.929 182.8 284.929 189.6H218.329C218.329 164.8 227.129 144.6 244.729 129C262.329 113 284.929 105 312.529 105C340.129 105 362.529 112.2 379.729 126.6C397.329 141 406.129 160 406.129 183.6C406.129 200.8 401.529 214.8 392.329 225.6C383.129 236 371.329 243.2 356.929 247.2C374.129 252 387.729 260.2 397.729 271.8C408.129 283.4 413.329 298 413.329 315.6C413.329 340.4 403.929 360.8 385.129 376.8C366.329 392.8 341.929 400.8 311.929 400.8Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M103.864 167.6H78.6643V105.2H171.664V400.2H103.864V167.6Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M311.929 400.8C281.129 400.8 255.929 392.4 236.329 375.6C217.129 358.8 207.529 337 207.529 310.2H277.729C277.729 318.2 280.729 324.8 286.729 330C292.729 335.2 300.729 337.8 310.729 337.8C320.329 337.8 328.129 335 334.129 329.4C340.529 323.8 343.729 316.6 343.729 307.8C343.729 299.8 340.929 293.2 335.329 288C329.729 282.8 322.529 280.2 313.729 280.2H276.529V218.4H313.729C320.529 218.4 326.329 216 331.129 211.2C335.929 206.4 338.329 200.4 338.329 193.2C338.329 184.8 335.729 178.2 330.529 173.4C325.329 168.6 318.729 166.2 310.729 166.2C303.529 166.2 297.329 168.4 292.129 172.8C287.329 177.2 284.929 182.8 284.929 189.6H218.329C218.329 164.8 227.129 144.6 244.729 129C262.329 113 284.929 105 312.529 105C340.129 105 362.529 112.2 379.729 126.6C397.329 141 406.129 160 406.129 183.6C406.129 200.8 401.529 214.8 392.329 225.6C383.129 236 371.329 243.2 356.929 247.2C374.129 252 387.729 260.2 397.729 271.8C408.129 283.4 413.329 298 413.329 315.6C413.329 340.4 403.929 360.8 385.129 376.8C366.329 392.8 341.929 400.8 311.929 400.8Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-4-mask)"
-                            />
-                            <path
-                                d="M103.864 167.6H78.6643V105.2H171.664V400.2H103.864V167.6Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-4-mask)"
-                            />
-                        </g>
-
-                        <g
-                            class="text-[#F3BEC7] opacity-100 mix-blend-hard-light transition-all delay-400 duration-750 dark:text-[#4B0600] starting:opacity-0 motion-safe:starting:-translate-x-[102px]"
-                        >
-                            <mask
-                                id="path-5-mask"
-                                maskUnits="userSpaceOnUse"
-                                x="102.329"
-                                y="103"
-                                width="338"
-                                height="299"
-                                fill="black"
-                            >
-                                <rect
-                                    fill="white"
-                                    x="102.329"
-                                    y="103"
-                                    width="338"
-                                    height="299"
-                                />
-                                <path
-                                    d="M337.593 400.8C306.793 400.8 281.593 392.4 261.993 375.6C242.793 358.8 233.193 337 233.193 310.2H303.393C303.393 318.2 306.393 324.8 312.393 330C318.393 335.2 326.393 337.8 336.393 337.8C345.993 337.8 353.793 335 359.793 329.4C366.193 323.8 369.393 316.6 369.393 307.8C369.393 299.8 366.593 293.2 360.993 288C355.393 282.8 348.193 280.2 339.393 280.2H302.193V218.4H339.393C346.193 218.4 351.993 216 356.793 211.2C361.593 206.4 363.993 200.4 363.993 193.2C363.993 184.8 361.393 178.2 356.193 173.4C350.993 168.6 344.393 166.2 336.393 166.2C329.193 166.2 322.993 168.4 317.793 172.8C312.993 177.2 310.593 182.8 310.593 189.6H243.993C243.993 164.8 252.793 144.6 270.393 129C287.993 113 310.593 105 338.193 105C365.793 105 388.193 112.2 405.393 126.6C422.993 141 431.793 160 431.793 183.6C431.793 200.8 427.193 214.8 417.993 225.6C408.793 236 396.993 243.2 382.593 247.2C399.793 252 413.393 260.2 423.393 271.8C433.793 283.4 438.993 298 438.993 315.6C438.993 340.4 429.593 360.8 410.793 376.8C391.993 392.8 367.593 400.8 337.593 400.8Z"
-                                />
-                                <path
-                                    d="M129.529 167.6H104.329V105.2H197.329V400.2H129.529V167.6Z"
-                                />
-                            </mask>
-                            <path
-                                d="M337.593 400.8C306.793 400.8 281.593 392.4 261.993 375.6C242.793 358.8 233.193 337 233.193 310.2H303.393C303.393 318.2 306.393 324.8 312.393 330C318.393 335.2 326.393 337.8 336.393 337.8C345.993 337.8 353.793 335 359.793 329.4C366.193 323.8 369.393 316.6 369.393 307.8C369.393 299.8 366.593 293.2 360.993 288C355.393 282.8 348.193 280.2 339.393 280.2H302.193V218.4H339.393C346.193 218.4 351.993 216 356.793 211.2C361.593 206.4 363.993 200.4 363.993 193.2C363.993 184.8 361.393 178.2 356.193 173.4C350.993 168.6 344.393 166.2 336.393 166.2C329.193 166.2 322.993 168.4 317.793 172.8C312.993 177.2 310.593 182.8 310.593 189.6H243.993C243.993 164.8 252.793 144.6 270.393 129C287.993 113 310.593 105 338.193 105C365.793 105 388.193 112.2 405.393 126.6C422.993 141 431.793 160 431.793 183.6C431.793 200.8 427.193 214.8 417.993 225.6C408.793 236 396.993 243.2 382.593 247.2C399.793 252 413.393 260.2 423.393 271.8C433.793 283.4 438.993 298 438.993 315.6C438.993 340.4 429.593 360.8 410.793 376.8C391.993 392.8 367.593 400.8 337.593 400.8Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M129.529 167.6H104.329V105.2H197.329V400.2H129.529V167.6Z"
-                                fill="currentColor"
-                            />
-                            <path
-                                d="M337.593 400.8C306.793 400.8 281.593 392.4 261.993 375.6C242.793 358.8 233.193 337 233.193 310.2H303.393C303.393 318.2 306.393 324.8 312.393 330C318.393 335.2 326.393 337.8 336.393 337.8C345.993 337.8 353.793 335 359.793 329.4C366.193 323.8 369.393 316.6 369.393 307.8C369.393 299.8 366.593 293.2 360.993 288C355.393 282.8 348.193 280.2 339.393 280.2H302.193V218.4H339.393C346.193 218.4 351.993 216 356.793 211.2C361.593 206.4 363.993 200.4 363.993 193.2C363.993 184.8 361.393 178.2 356.193 173.4C350.993 168.6 344.393 166.2 336.393 166.2C329.193 166.2 322.993 168.4 317.793 172.8C312.993 177.2 310.593 182.8 310.593 189.6H243.993C243.993 164.8 252.793 144.6 270.393 129C287.993 113 310.593 105 338.193 105C365.793 105 388.193 112.2 405.393 126.6C422.993 141 431.793 160 431.793 183.6C431.793 200.8 427.193 214.8 417.993 225.6C408.793 236 396.993 243.2 382.593 247.2C399.793 252 413.393 260.2 423.393 271.8C433.793 283.4 438.993 298 438.993 315.6C438.993 340.4 429.593 360.8 410.793 376.8C391.993 392.8 367.593 400.8 337.593 400.8Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-5-mask)"
-                            />
-                            <path
-                                d="M129.529 167.6H104.329V105.2H197.329V400.2H129.529V167.6Z"
-                                stroke="var(--stroke-color)"
-                                stroke-width="2.4"
-                                mask="url(#path-5-mask)"
-                            />
-                        </g>
-                    </svg>
                     <div
-                        class="absolute inset-0 rounded-t-lg shadow-[inset_0px_0px_0px_1px_rgba(26,26,0,0.16)] lg:rounded-t-none lg:rounded-r-lg dark:shadow-[inset_0px_0px_0px_1px_#fffaed2d]"
-                    ></div>
+                        class="flex items-end gap-4 border-b border-border px-6 pt-[18px] pb-3"
+                    >
+                        <div class="min-w-0 flex-1">
+                            <div
+                                class="font-serif text-[27px] leading-none font-semibold tracking-tight"
+                            >
+                                <span class="text-brass italic">#</span>design
+                            </div>
+                            <div class="mt-1.5 text-xs text-muted-foreground">
+                                Product design, specs, and review threads
+                            </div>
+                        </div>
+                        <div class="flex pb-0.5">
+                            <span
+                                class="flex size-[22px] items-center justify-center rounded-full bg-accent text-[8px] font-bold text-foreground/70 ring-2 ring-card"
+                                >MC</span
+                            >
+                            <span
+                                class="-ml-1.5 flex size-[22px] items-center justify-center rounded-full bg-muted text-[8px] font-bold text-foreground/70 ring-2 ring-card"
+                                >JW</span
+                            >
+                            <span
+                                class="-ml-1.5 flex size-[22px] items-center justify-center rounded-full bg-accent text-[8px] font-bold text-foreground/70 ring-2 ring-card"
+                                >PN</span
+                            >
+                            <span
+                                class="-ml-1.5 flex size-[22px] items-center justify-center rounded-full bg-muted text-[8px] font-bold text-muted-foreground ring-2 ring-card"
+                                >+9</span
+                            >
+                        </div>
+                    </div>
+
+                    <div
+                        class="flex flex-1 flex-col justify-end overflow-hidden px-6 pt-3.5"
+                    >
+                        <!-- Message -->
+                        <div class="flex">
+                            <div
+                                class="flex w-14 shrink-0 flex-col items-center gap-1 pt-0.5"
+                            >
+                                <div class="relative size-[30px]">
+                                    <div
+                                        class="flex size-[30px] items-center justify-center rounded-full bg-accent text-[10px] font-bold text-foreground/70"
+                                    >
+                                        MC
+                                    </div>
+                                    <span
+                                        class="absolute -right-px -bottom-px size-2.5 rounded-full bg-emerald-500 ring-2 ring-card"
+                                    ></span>
+                                </div>
+                                <span
+                                    class="font-mono text-[9px] text-muted-foreground/70"
+                                    >9:14</span
+                                >
+                            </div>
+                            <div
+                                class="min-w-0 flex-1 border-l border-border pb-1 pl-4"
+                            >
+                                <div class="text-[13px] font-bold">
+                                    Maya Chen
+                                </div>
+                                <div
+                                    class="mt-0.5 text-[13.5px] leading-relaxed text-foreground/80"
+                                >
+                                    Shipped the thread panel &mdash;
+                                    <span
+                                        class="border-b-[1.5px] border-brass font-medium text-foreground"
+                                        >@Jonas Weber</span
+                                    >
+                                    can you review the scroll pinning?
+                                </div>
+                                <div class="mt-1.5 flex items-center gap-1.5">
+                                    <span
+                                        class="inline-flex items-center gap-1 rounded-full border border-brass-border bg-brass-fill px-2 py-0.5 text-[11px] text-brass-fill-foreground"
+                                        >👍
+                                        <span class="font-semibold"
+                                            >3</span
+                                        ></span
+                                    >
+                                    <span
+                                        class="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] text-muted-foreground"
+                                        >🎉
+                                        <span class="font-semibold"
+                                            >1</span
+                                        ></span
+                                    >
+                                    <span
+                                        class="ml-1 inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-0.5 text-[11px] font-semibold"
+                                    >
+                                        <span class="flex">
+                                            <span
+                                                class="flex size-[15px] items-center justify-center rounded-full bg-muted text-[6.5px] font-bold text-foreground/70 ring-[1.5px] ring-card"
+                                                >JW</span
+                                            >
+                                            <span
+                                                class="-ml-1 flex size-[15px] items-center justify-center rounded-full bg-accent text-[6.5px] font-bold text-foreground/70 ring-[1.5px] ring-card"
+                                                >PN</span
+                                            >
+                                        </span>
+                                        4 replies &rarr;
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- "new" divider -->
+                        <div class="my-3.5 flex items-center gap-3">
+                            <span
+                                class="h-px flex-1 bg-gradient-to-r from-transparent to-brass-border"
+                            ></span>
+                            <span
+                                class="font-serif text-xs text-brass-border italic"
+                                >new</span
+                            >
+                            <span
+                                class="h-px flex-1 bg-gradient-to-l from-transparent to-brass-border"
+                            ></span>
+                        </div>
+
+                        <!-- Message -->
+                        <div class="flex">
+                            <div
+                                class="flex w-14 shrink-0 flex-col items-center gap-1 pt-0.5"
+                            >
+                                <div
+                                    class="flex size-[30px] items-center justify-center rounded-full bg-muted text-[10px] font-bold text-foreground/70"
+                                >
+                                    JW
+                                </div>
+                                <span
+                                    class="font-mono text-[9px] text-muted-foreground/70"
+                                    >10:41</span
+                                >
+                            </div>
+                            <div
+                                class="min-w-0 flex-1 border-l border-border pb-1 pl-4"
+                            >
+                                <div class="text-[13px] font-bold">
+                                    Jonas Weber
+                                </div>
+                                <div
+                                    class="mt-0.5 text-[13.5px] leading-relaxed text-foreground/80"
+                                >
+                                    On it. Repro steps in
+                                    <span
+                                        class="border-b border-brass-border/40 text-brass-fill-foreground"
+                                        >the linked issue</span
+                                    >.
+                                </div>
+                            </div>
+                        </div>
+
+                        <div
+                            class="mt-1.5 mb-1 flex items-center justify-end gap-1.5"
+                        >
+                            <span
+                                class="font-serif text-[10.5px] text-muted-foreground/70 italic"
+                                >Seen by</span
+                            >
+                            <span class="flex">
+                                <span
+                                    class="flex size-[15px] items-center justify-center rounded-full bg-accent text-[7px] font-bold text-foreground/70 ring-[1.5px] ring-card"
+                                    >PN</span
+                                >
+                                <span
+                                    class="-ml-1 flex size-[15px] items-center justify-center rounded-full bg-muted text-[7px] font-bold text-foreground/70 ring-[1.5px] ring-card"
+                                    >JW</span
+                                >
+                            </span>
+                        </div>
+                    </div>
+
+                    <!-- Composer -->
+                    <div class="px-5 pb-4">
+                        <div
+                            class="mb-1 flex h-5 items-center gap-1.5 px-1.5 font-serif text-[11.5px] text-muted-foreground italic"
+                        >
+                            <span class="flex items-end gap-0.5">
+                                <span
+                                    class="size-1 rounded-full bg-muted-foreground/40"
+                                ></span>
+                                <span
+                                    class="size-1 rounded-full bg-muted-foreground/60"
+                                ></span>
+                                <span
+                                    class="size-1 rounded-full bg-muted-foreground/90"
+                                ></span>
+                            </span>
+                            Priya Nair is typing
+                        </div>
+                        <div
+                            class="flex items-center gap-2.5 rounded-full border border-input bg-card py-1.5 pr-1.5 pl-4 shadow-[0_3px_12px_rgba(29,26,21,0.08)]"
+                        >
+                            <span class="flex-1 text-[13px] text-foreground/80"
+                                >Thanks &mdash; looking now</span
+                            >
+                            <span
+                                class="flex size-6 items-center justify-center rounded-full text-muted-foreground"
+                                >+</span
+                            >
+                            <span
+                                class="flex size-[31px] items-center justify-center rounded-full bg-primary text-brass"
+                                >&uarr;</span
+                            >
+                        </div>
+                    </div>
                 </div>
-            </main>
+
+                <!-- Thread -->
+                <div
+                    class="hidden w-[308px] shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-sidebar shadow-[0_2px_8px_rgba(29,26,21,0.05)] xl:flex"
+                >
+                    <div
+                        class="flex items-center gap-2 border-b border-border px-4 pt-3.5 pb-3"
+                    >
+                        <div class="min-w-0 flex-1">
+                            <div
+                                class="font-serif text-[17px] leading-tight font-semibold"
+                            >
+                                Thread
+                            </div>
+                            <div
+                                class="mt-0.5 text-[11px] text-muted-foreground"
+                            >
+                                4 replies &middot; #design
+                            </div>
+                        </div>
+                        <span
+                            class="flex size-6 items-center justify-center rounded-md border border-border text-muted-foreground"
+                            >&times;</span
+                        >
+                    </div>
+
+                    <div class="flex flex-1 flex-col px-4 pt-3.5">
+                        <div class="border-l-2 border-brass pl-3">
+                            <div class="flex items-baseline gap-1.5">
+                                <span class="text-xs font-bold">Maya Chen</span>
+                                <span
+                                    class="font-mono text-[9px] text-muted-foreground/70"
+                                    >9:14</span
+                                >
+                            </div>
+                            <div
+                                class="mt-0.5 text-xs leading-relaxed text-foreground/80"
+                            >
+                                Shipped the thread panel &mdash; can you review
+                                the scroll pinning?
+                            </div>
+                        </div>
+
+                        <div class="mt-3.5 flex gap-2.5">
+                            <div
+                                class="flex size-[26px] shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-bold text-foreground/70"
+                            >
+                                JW
+                            </div>
+                            <div class="min-w-0">
+                                <div class="flex items-baseline gap-1.5">
+                                    <span class="text-xs font-bold"
+                                        >Jonas Weber</span
+                                    >
+                                    <span
+                                        class="font-mono text-[9px] text-muted-foreground/70"
+                                        >10:44</span
+                                    >
+                                </div>
+                                <div
+                                    class="mt-0.5 text-xs leading-relaxed text-foreground/80"
+                                >
+                                    Pin logic looks right. One edge case when
+                                    paging older replies.
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="mt-3 flex gap-2.5">
+                            <div
+                                class="flex size-[26px] shrink-0 items-center justify-center rounded-full bg-accent text-[9px] font-bold text-foreground/70"
+                            >
+                                PN
+                            </div>
+                            <div class="min-w-0">
+                                <div class="flex items-baseline gap-1.5">
+                                    <span class="text-xs font-bold"
+                                        >Priya Nair</span
+                                    >
+                                    <span
+                                        class="font-mono text-[9px] text-muted-foreground/70"
+                                        >10:52</span
+                                    >
+                                </div>
+                                <div
+                                    class="mt-0.5 text-xs leading-relaxed text-foreground/80"
+                                >
+                                    Filed it. Repro in the issue.
+                                </div>
+                                <span
+                                    class="mt-1.5 inline-flex items-center gap-1 rounded-full border border-brass-border bg-brass-fill px-1.5 py-0.5 text-[10.5px] text-brass-fill-foreground"
+                                    >✅
+                                    <span class="font-semibold">2</span></span
+                                >
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="px-3 pt-2.5 pb-3">
+                        <div
+                            class="flex items-center gap-2 rounded-full border border-input bg-card py-1.5 pr-1.5 pl-3.5"
+                        >
+                            <span
+                                class="flex-1 text-xs text-muted-foreground/70"
+                                >Reply&hellip;</span
+                            >
+                            <span
+                                class="flex size-[26px] items-center justify-center rounded-full bg-muted text-muted-foreground/70"
+                                >&uarr;</span
+                            >
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Feature row -->
+            <div class="mt-14 flex flex-wrap justify-center gap-x-16 gap-y-10">
+                <div class="max-w-60 text-center">
+                    <div class="font-serif text-lg font-semibold">
+                        Threads that resolve
+                    </div>
+                    <div
+                        class="mt-1.5 text-[13.5px] leading-relaxed text-pretty text-muted-foreground"
+                    >
+                        Side conversations stay beside the work, not on top of
+                        it.
+                    </div>
+                </div>
+                <div class="max-w-60 text-center">
+                    <div class="font-serif text-lg font-semibold">
+                        Everything, one keystroke
+                    </div>
+                    <div
+                        class="mt-1.5 text-[13.5px] leading-relaxed text-pretty text-muted-foreground"
+                    >
+                        &#8984;K jumps to any channel or teammate. Search
+                        reaches every message.
+                    </div>
+                </div>
+                <div class="max-w-60 text-center">
+                    <div class="font-serif text-lg font-semibold">
+                        Presence, not pressure
+                    </div>
+                    <div
+                        class="mt-1.5 text-[13.5px] leading-relaxed text-pretty text-muted-foreground"
+                    >
+                        Read receipts and typing hints you can share &mdash; or
+                        switch off.
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="hidden h-14.5 lg:block"></div>
+
+        <!-- Footer -->
+        <footer
+            class="mt-auto flex items-baseline justify-center gap-2 border-t border-border px-8 py-6 text-[12.5px] text-muted-foreground"
+        >
+            <span class="font-serif italic">{{ name }}</span>
+            <span>&middot;</span>
+            <span>Team chat, quietly done</span>
+        </footer>
     </div>
 </template>


### PR DESCRIPTION
Replaces the default Laravel starter landing (raw hex, Laravel logo, external Inter web font) with a warm editorial **The Desk** landing page, built from the Claude Design "Welcome Page" source. Closes #160. Part of epic #145.

## What changed (`pages/Welcome.vue`)
- **No external font**: removes the `rsms.me`/Inter stylesheet; the page now uses the app's self-hosted **Newsreader** (serif) + **Instrument Sans** via the shared tokens.
- **Nav**: warm canvas with a soft radial wash; serif wordmark, Log in + Sign up (Sign up gated by `registrationEnabled`; a single **Open workspace** pill when already signed in).
- **Centered editorial hero**: brass eyebrow, large Newsreader headline, muted subhead, pill CTAs (Get started / Log in).
- **Decorative 3-pane workspace preview** (sidebar · channel · thread) rebuilt entirely from **semantic tokens** so it reads correctly in light and dark — serif masthead, avatar-gutter timeline with an @mention + reaction pills + "new" divider, pill composer, and a thread pane. Sidebar hides below `lg`, thread below `xl`; `aria-hidden`.
- Quiet 3-up feature row and a serif-italic footer.

## Notes
- The supplied design is a **centered hero with a full app preview below** — richer than the "split" option picked during design-first; followed the design as the source of truth.
- Wordmark/footer use the app's configured `name` rather than the design's "The Desk" codename.
- Design mid-browns without an exact token map to `muted-foreground` / `foreground/70–80` (semantic tokens only, no raw hex); the radial wash uses `var(--muted)`→`var(--background)`.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan clean; no PHP touched — `RegistrationFlagTest` still asserts the `Welcome` component + shared prop)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
