### PR TITLE
feat(security): rework auth pages to the single-card "The Desk" design

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME="The Desk"
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/docs/future-claude-designs.md
+++ b/docs/future-claude-designs.md
@@ -1,0 +1,83 @@
+# Design & Product Gaps
+
+## Product Flows
+
+### First-run / No Team State
+- User registers with no invitation.
+- Create-your-first-team screen.
+- General "Create Team" flow.
+
+### Invitation Accept Flow
+- Landing on an invite link while logged in.
+- Accept / decline invitation.
+- Pending invitations list.
+
+### Team Settings
+- Members list with roles.
+- Invite member.
+- Transfer ownership.
+- Delete team.
+- Existing modals are implemented, but a complete settings page has not been designed.
+
+### Search & Threads
+- Search results page.
+- Thread inbox (the **Threads** navigation item currently leads to an undesigned destination).
+
+### Scheduled Messages
+- Scheduled messages list/dialog.
+- "Send later" option in the composer.
+
+---
+
+## Settings (Beyond 5i)
+
+- Sessions management.
+- Security activity log.
+- Data export.
+- Delete account (`DataPrivacy.vue`).
+- Appearance (Light / Dark / System).
+- Notification preferences.
+- Chime preferences.
+
+---
+
+## System States
+
+- Error pages:
+    - 403
+    - 404
+    - 500
+    - Maintenance
+- Designed in **The Desk** brand voice.
+- Loading & skeleton states.
+- Toast notifications (`flashToast` already exists in code).
+- Dark mode for auth pages.
+- Mobile layouts for auth and welcome pages.
+
+---
+
+## Non-UI Surfaces
+
+### Transactional Emails
+Code exists, but no visual design for:
+- Verify email.
+- Reset password.
+- Team invitation.
+- Data export ready.
+
+### Branding Assets
+- Favicon.
+- Open Graph (OG) image for the welcome page.
+
+---
+
+# Priority
+
+1. First-run / Create Team flow.
+2. Invitation Accept flow.
+3. Error pages.
+4. Transactional emails (currently the most neglected brand surface).
+
+---
+
+**Recommendation:** Start with **First-run / Create Team**, then **Invitation Accept**, followed by **Error Pages**, and finally the **Transactional Emails**.

--- a/resources/js/components/AuthStatus.vue
+++ b/resources/js/components/AuthStatus.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { CircleCheck } from '@lucide/vue';
+</script>
+
+<template>
+    <div
+        class="flex items-center gap-2.5 rounded-[10px] border border-emerald-600/30 bg-emerald-600/10 px-3.5 py-2.5 text-sm text-emerald-800 dark:text-emerald-300"
+    >
+        <CircleCheck class="size-4 shrink-0 text-emerald-600" />
+        <span class="leading-snug"><slot /></span>
+    </div>
+</template>

--- a/resources/js/components/InputError.vue
+++ b/resources/js/components/InputError.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 <template>
     <div v-show="message">
-        <p class="text-sm text-red-600 dark:text-red-500">
+        <p class="text-sm text-destructive">
             {{ message }}
         </p>
     </div>

--- a/resources/js/components/TextLink.vue
+++ b/resources/js/components/TextLink.vue
@@ -18,7 +18,7 @@ defineProps<Props>();
         :tabindex="tabindex"
         :method="method"
         :as="as"
-        class="text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500"
+        class="text-brass-fill-foreground underline decoration-brass-border/40 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-brass-border"
     >
         <slot />
     </Link>

--- a/resources/js/layouts/AuthLayout.vue
+++ b/resources/js/layouts/AuthLayout.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
-import AuthLayout from '@/layouts/auth/AuthSplitLayout.vue';
+import AuthLayout from '@/layouts/auth/AuthCardLayout.vue';
 
-const { title = '', description = '' } = defineProps<{
+const {
+    title = '',
+    description = '',
+    icon = 'logo',
+} = defineProps<{
     title?: string;
     description?: string;
+    icon?: 'logo' | 'lock' | 'mail';
 }>();
 </script>
 
 <template>
-    <AuthLayout :title="title" :description="description">
+    <AuthLayout :title="title" :description="description" :icon="icon">
         <slot />
     </AuthLayout>
 </template>

--- a/resources/js/layouts/auth/AuthCardLayout.vue
+++ b/resources/js/layouts/auth/AuthCardLayout.vue
@@ -1,49 +1,73 @@
 <script setup lang="ts">
-import { Link } from '@inertiajs/vue3';
+import { Link, usePage } from '@inertiajs/vue3';
+import { Lock, Mail } from '@lucide/vue';
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
-import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-} from '@/components/ui/card';
 import { home } from '@/routes';
 
-defineProps<{
+const {
+    title = '',
+    description = '',
+    icon = 'logo',
+} = defineProps<{
     title?: string;
     description?: string;
+    icon?: 'logo' | 'lock' | 'mail';
 }>();
+
+const page = usePage();
+const name = page.props.name;
 </script>
 
 <template>
     <div
-        class="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10"
+        class="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10"
     >
-        <div class="flex w-full max-w-md flex-col gap-6">
-            <Link
-                :href="home()"
-                class="flex items-center gap-2 self-center font-medium"
+        <div class="flex w-full max-w-sm flex-col items-center gap-5">
+            <div
+                class="w-full rounded-2xl border border-border bg-sidebar px-8 pt-8 pb-7 shadow-[0_16px_40px_-12px_rgba(29,26,21,0.18),0_2px_8px_rgba(29,26,21,0.06)]"
             >
-                <div class="flex h-9 w-9 items-center justify-center">
-                    <AppLogoIcon
-                        class="size-9 fill-current text-black dark:text-white"
-                    />
-                </div>
-            </Link>
+                <div class="flex flex-col items-center text-center">
+                    <Link
+                        v-if="icon === 'logo'"
+                        :href="home()"
+                        class="inline-flex"
+                        aria-label="Home"
+                    >
+                        <AppLogoIcon class="size-8 fill-current text-brass" />
+                    </Link>
+                    <span
+                        v-else
+                        class="flex size-11 items-center justify-center rounded-full border border-brass/30 bg-brass-fill text-brass-fill-foreground"
+                    >
+                        <Lock v-if="icon === 'lock'" class="size-[18px]" />
+                        <Mail v-else class="size-[18px]" />
+                    </span>
 
-            <div class="flex flex-col gap-6">
-                <Card class="rounded-xl">
-                    <CardHeader class="px-10 pt-8 pb-0 text-center">
-                        <CardTitle class="text-xl">{{ title }}</CardTitle>
-                        <CardDescription>
-                            {{ description }}
-                        </CardDescription>
-                    </CardHeader>
-                    <CardContent class="px-10 py-8">
-                        <slot />
-                    </CardContent>
-                </Card>
+                    <h1
+                        v-if="title"
+                        class="mt-3.5 font-serif text-[25px] leading-tight font-semibold tracking-tight"
+                    >
+                        {{ title }}
+                    </h1>
+                    <p
+                        v-if="description"
+                        class="mt-1.5 text-sm text-muted-foreground"
+                    >
+                        {{ description }}
+                    </p>
+                </div>
+
+                <div class="mt-6">
+                    <slot />
+                </div>
+            </div>
+
+            <div
+                class="flex items-baseline gap-1.5 text-xs text-muted-foreground"
+            >
+                <span class="font-serif italic">{{ name }}</span>
+                <span>&middot;</span>
+                <span>Team chat, quietly done</span>
             </div>
         </div>
     </div>

--- a/resources/js/pages/auth/ConfirmPassword.vue
+++ b/resources/js/pages/auth/ConfirmPassword.vue
@@ -12,6 +12,7 @@ defineOptions({
         title: 'Confirm password',
         description:
             'This is a secure area of the application. Please confirm your password before continuing.',
+        icon: 'lock',
     },
 });
 </script>

--- a/resources/js/pages/auth/ForgotPassword.vue
+++ b/resources/js/pages/auth/ForgotPassword.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
+import AuthStatus from '@/components/AuthStatus.vue';
 import InputError from '@/components/InputError.vue';
 import TextLink from '@/components/TextLink.vue';
 import { Button } from '@/components/ui/button';
@@ -24,12 +25,7 @@ defineProps<{
 <template>
     <Head title="Forgot password" />
 
-    <div
-        v-if="status"
-        class="mb-4 text-center text-sm font-medium text-green-600"
-    >
-        {{ status }}
-    </div>
+    <AuthStatus v-if="status" class="mb-6">{{ status }}</AuthStatus>
 
     <div class="space-y-6">
         <Form v-bind="email.form()" v-slot="{ errors, processing }">

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
+import AuthStatus from '@/components/AuthStatus.vue';
 import InputError from '@/components/InputError.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import TeamInvitationAlert from '@/components/TeamInvitationAlert.vue';
@@ -31,101 +32,98 @@ defineProps<{
 <template>
     <Head title="Log in" />
 
-    <div
-        v-if="status"
-        class="mb-4 text-center text-sm font-medium text-green-600"
-    >
-        {{ status }}
-    </div>
+    <div class="flex flex-col gap-5">
+        <AuthStatus v-if="status">{{ status }}</AuthStatus>
 
-    <TeamInvitationAlert
-        v-if="teamInvitation"
-        :invitation="teamInvitation"
-        action="Log in"
-    />
+        <TeamInvitationAlert
+            v-if="teamInvitation"
+            :invitation="teamInvitation"
+            action="Log in"
+        />
 
-    <Form
-        v-bind="store.form()"
-        :reset-on-success="['password']"
-        v-slot="{ errors, processing }"
-        class="flex flex-col gap-6"
-    >
-        <div class="grid gap-6">
-            <div class="grid gap-2">
-                <Label for="email">Email address</Label>
-                <Input
-                    id="email"
-                    type="email"
-                    name="email"
-                    required
-                    autofocus
-                    :tabindex="1"
-                    autocomplete="email"
-                    placeholder="email@example.com"
-                />
-                <InputError :message="errors.email" />
-            </div>
-
-            <div class="grid gap-2">
-                <div class="flex items-center justify-between">
-                    <Label for="password">Password</Label>
-                    <TextLink
-                        v-if="canResetPassword"
-                        :href="request()"
-                        class="text-sm"
-                        :tabindex="5"
-                    >
-                        Forgot password?
-                    </TextLink>
-                </div>
-                <PasswordInput
-                    id="password"
-                    name="password"
-                    required
-                    :tabindex="2"
-                    autocomplete="current-password"
-                    placeholder="Password"
-                />
-                <InputError :message="errors.password" />
-            </div>
-
-            <div class="flex items-center justify-between">
-                <Label for="remember" class="flex items-center space-x-3">
-                    <Checkbox id="remember" name="remember" :tabindex="3" />
-                    <span>Remember me</span>
-                </Label>
-            </div>
-
-            <Button
-                type="submit"
-                class="mt-4 w-full rounded-full"
-                :tabindex="4"
-                :disabled="processing"
-                data-test="login-button"
-            >
-                <Spinner v-if="processing" />
-                Log in
-            </Button>
-        </div>
-
-        <div
-            v-if="$page.props.registrationEnabled"
-            class="text-center text-sm text-muted-foreground"
+        <Form
+            v-bind="store.form()"
+            :reset-on-success="['password']"
+            v-slot="{ errors, processing }"
+            class="flex flex-col gap-6"
         >
-            Don't have an account?
-            <TextLink
-                :href="
-                    register({
-                        query: {
-                            invitation: teamInvitation?.code,
-                        },
-                    })
-                "
-                :tabindex="5"
-                data-test="register-link"
+            <div class="grid gap-6">
+                <div class="grid gap-2">
+                    <Label for="email">Email address</Label>
+                    <Input
+                        id="email"
+                        type="email"
+                        name="email"
+                        required
+                        autofocus
+                        :tabindex="1"
+                        autocomplete="email"
+                        placeholder="email@example.com"
+                    />
+                    <InputError :message="errors.email" />
+                </div>
+
+                <div class="grid gap-2">
+                    <div class="flex items-center justify-between">
+                        <Label for="password">Password</Label>
+                        <TextLink
+                            v-if="canResetPassword"
+                            :href="request()"
+                            class="text-sm"
+                            :tabindex="5"
+                        >
+                            Forgot password?
+                        </TextLink>
+                    </div>
+                    <PasswordInput
+                        id="password"
+                        name="password"
+                        required
+                        :tabindex="2"
+                        autocomplete="current-password"
+                        placeholder="Password"
+                    />
+                    <InputError :message="errors.password" />
+                </div>
+
+                <div class="flex items-center justify-between">
+                    <Label for="remember" class="flex items-center space-x-3">
+                        <Checkbox id="remember" name="remember" :tabindex="3" />
+                        <span>Remember me</span>
+                    </Label>
+                </div>
+
+                <Button
+                    type="submit"
+                    class="mt-4 w-full rounded-full"
+                    :tabindex="4"
+                    :disabled="processing"
+                    data-test="login-button"
+                >
+                    <Spinner v-if="processing" />
+                    Log in
+                </Button>
+            </div>
+
+            <div
+                v-if="$page.props.registrationEnabled"
+                class="text-center text-sm text-muted-foreground"
             >
-                Sign up
-            </TextLink>
-        </div>
-    </Form>
+                Don't have an account?
+                <TextLink
+                    :href="
+                        register({
+                            query: {
+                                invitation: teamInvitation?.code,
+                            },
+                        })
+                    "
+                    :tabindex="5"
+                    data-test="register-link"
+                >
+                    Sign up
+                </TextLink>
+            </div>
+        </Form>
+    </div>
 </template>

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -28,106 +28,108 @@ defineOptions({
 <template>
     <Head title="Register" />
 
-    <TeamInvitationAlert
-        v-if="teamInvitation"
-        :invitation="teamInvitation"
-        action="Register"
-    />
+    <div class="flex flex-col gap-5">
+        <TeamInvitationAlert
+            v-if="teamInvitation"
+            :invitation="teamInvitation"
+            action="Register"
+        />
 
-    <Form
-        v-bind="store.form()"
-        :reset-on-success="['password', 'password_confirmation']"
-        v-slot="{ errors, processing }"
-        class="flex flex-col gap-6"
-    >
-        <div class="grid gap-6">
-            <div class="grid gap-2">
-                <Label for="name">Name</Label>
-                <Input
-                    id="name"
-                    type="text"
-                    required
-                    autofocus
-                    :tabindex="1"
-                    autocomplete="name"
-                    name="name"
-                    placeholder="Full name"
-                />
-                <InputError :message="errors.name" />
+        <Form
+            v-bind="store.form()"
+            :reset-on-success="['password', 'password_confirmation']"
+            v-slot="{ errors, processing }"
+            class="flex flex-col gap-6"
+        >
+            <div class="grid gap-6">
+                <div class="grid gap-2">
+                    <Label for="name">Name</Label>
+                    <Input
+                        id="name"
+                        type="text"
+                        required
+                        autofocus
+                        :tabindex="1"
+                        autocomplete="name"
+                        name="name"
+                        placeholder="Full name"
+                    />
+                    <InputError :message="errors.name" />
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="email">Email address</Label>
+                    <Input
+                        id="email"
+                        type="email"
+                        required
+                        :tabindex="2"
+                        autocomplete="email"
+                        name="email"
+                        placeholder="email@example.com"
+                    />
+                    <InputError :message="errors.email" />
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="password">Password</Label>
+                    <PasswordInput
+                        id="password"
+                        required
+                        :tabindex="3"
+                        autocomplete="new-password"
+                        name="password"
+                        placeholder="Password"
+                        :passwordrules="passwordRules"
+                    />
+                    <InputError :message="errors.password" />
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="password_confirmation">Confirm password</Label>
+                    <PasswordInput
+                        id="password_confirmation"
+                        required
+                        :tabindex="4"
+                        autocomplete="new-password"
+                        name="password_confirmation"
+                        placeholder="Confirm password"
+                        :passwordrules="passwordRules"
+                    />
+                    <InputError :message="errors.password_confirmation" />
+                </div>
+
+                <Button
+                    type="submit"
+                    class="mt-2 w-full rounded-full"
+                    tabindex="5"
+                    :disabled="processing"
+                    data-test="register-user-button"
+                >
+                    <Spinner v-if="processing" />
+                    Create account
+                </Button>
             </div>
 
-            <div class="grid gap-2">
-                <Label for="email">Email address</Label>
-                <Input
-                    id="email"
-                    type="email"
-                    required
-                    :tabindex="2"
-                    autocomplete="email"
-                    name="email"
-                    placeholder="email@example.com"
-                />
-                <InputError :message="errors.email" />
+            <div class="text-center text-sm text-muted-foreground">
+                Already have an account?
+                <TextLink
+                    :href="
+                        teamInvitation
+                            ? login.url({
+                                  query: {
+                                      invitation: teamInvitation.code,
+                                  },
+                              })
+                            : login()
+                    "
+                    class="underline underline-offset-4"
+                    :tabindex="6"
+                    data-test="team-invitation-login-link"
+                >
+                    Log in
+                </TextLink>
             </div>
-
-            <div class="grid gap-2">
-                <Label for="password">Password</Label>
-                <PasswordInput
-                    id="password"
-                    required
-                    :tabindex="3"
-                    autocomplete="new-password"
-                    name="password"
-                    placeholder="Password"
-                    :passwordrules="passwordRules"
-                />
-                <InputError :message="errors.password" />
-            </div>
-
-            <div class="grid gap-2">
-                <Label for="password_confirmation">Confirm password</Label>
-                <PasswordInput
-                    id="password_confirmation"
-                    required
-                    :tabindex="4"
-                    autocomplete="new-password"
-                    name="password_confirmation"
-                    placeholder="Confirm password"
-                    :passwordrules="passwordRules"
-                />
-                <InputError :message="errors.password_confirmation" />
-            </div>
-
-            <Button
-                type="submit"
-                class="mt-2 w-full rounded-full"
-                tabindex="5"
-                :disabled="processing"
-                data-test="register-user-button"
-            >
-                <Spinner v-if="processing" />
-                Create account
-            </Button>
-        </div>
-
-        <div class="text-center text-sm text-muted-foreground">
-            Already have an account?
-            <TextLink
-                :href="
-                    teamInvitation
-                        ? login.url({
-                              query: {
-                                  invitation: teamInvitation.code,
-                              },
-                          })
-                        : login()
-                "
-                class="underline underline-offset-4"
-                :tabindex="6"
-                data-test="team-invitation-login-link"
-            >
-                Log in
-            </TextLink>
-        </div>
-    </Form>
+        </Form>
+    </div>
 </template>

--- a/resources/js/pages/auth/VerifyEmail.vue
+++ b/resources/js/pages/auth/VerifyEmail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { Form, Head } from '@inertiajs/vue3';
-import TextLink from '@/components/TextLink.vue';
+import { Form, Head, Link } from '@inertiajs/vue3';
+import AuthStatus from '@/components/AuthStatus.vue';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
 import { logout } from '@/routes';
@@ -8,9 +8,10 @@ import { send } from '@/routes/verification';
 
 defineOptions({
     layout: {
-        title: 'Email verification',
+        title: 'Check your email',
         description:
             'Please verify your email address by clicking on the link we just emailed to you.',
+        icon: 'mail',
     },
 });
 
@@ -22,26 +23,31 @@ defineProps<{
 <template>
     <Head title="Email verification" />
 
-    <div
-        v-if="status === 'verification-link-sent'"
-        class="mb-4 text-center text-sm font-medium text-green-600"
-    >
+    <AuthStatus v-if="status === 'verification-link-sent'" class="mb-5">
         A new verification link has been sent to the email address you provided
         during registration.
-    </div>
+    </AuthStatus>
 
     <Form
         v-bind="send.form()"
-        class="space-y-6 text-center"
+        class="flex flex-col items-center gap-4"
         v-slot="{ processing }"
     >
-        <Button :disabled="processing" variant="secondary" class="rounded-full">
+        <Button
+            :disabled="processing"
+            variant="outline"
+            class="w-full rounded-full bg-muted hover:bg-accent"
+        >
             <Spinner v-if="processing" />
             Resend verification email
         </Button>
 
-        <TextLink :href="logout()" as="button" class="mx-auto block text-sm">
+        <Link
+            :href="logout()"
+            as="button"
+            class="text-sm text-muted-foreground underline decoration-input underline-offset-4 transition-colors hover:text-foreground"
+        >
             Log out
-        </TextLink>
+        </Link>
     </Form>
 </template>


### PR DESCRIPTION
Reworks the #158 auth reskin to the **finalized Claude Design "Auth Pages" source** — a single floating card, not the earlier split layout. Refines #158; part of epic #145.

## `AuthLayout` → reworked `AuthCardLayout`
- Warm canvas with one **`bg-sidebar` card** (`border-border`, `rounded-2xl`, soft ink shadow) holding a centered brass mark, serif **25px** title, muted description, then the form slot; a serif-italic **"{name} · Team chat, quietly done"** line sits beneath the card (ties auth to the landing page).
- New optional **`icon` layout prop** (`'logo' | 'lock' | 'mail'`) so **Confirm** shows a brass lock badge and **Verify** a brass mail badge in place of the logo.

## Shared bits
- **TextLink** → brass link with a brass underline (auth is its only consumer).
- **InputError** → semantic **`text-destructive`** (was raw `red-600`).
- New **`AuthStatus`** banner (warm emerald success) replaces the raw green status text on Login / Forgot / Verify.

## Pages
- **Verify**: title "Check your email", mail badge, outline resend pill, muted log-out link.
- **Confirm**: lock badge.
- **Login / Register**: status / invitation / form wrapped in an even gap.
- All Fortify wiring, validation, `tabindex`, and `data-test` hooks unchanged.

## Also
- `AuthSimpleLayout` + `AuthSplitLayout` are now unused (kept as alternates).
- **`docs/future-claude-designs.md`** — design/product gap notes.
- **`.env.example`**: `APP_NAME="The Desk"` so the wordmark/footer render the brand.

## Gates
- `sail composer test` → **Total: 100.0 %** (Pint + PHPStan clean)
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all green
