### PR TITLE
feat(platform): publish production image to GHCR (#203)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,8 @@ on:
       - main
       - master
       - workos
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - develop
@@ -20,13 +22,77 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # `contents: read` to check out; `packages: write` to publish to GHCR. The
+    # push steps below only run for master / `v*`-tag pushes, so PR and fork code
+    # is built but never published.
+    permissions:
+      contents: read
+      packages: write
+
+    # Publish on a push to master (moving `edge` tag) or to a `v*` release tag
+    # (created by release-please). Everything else — pull requests and pushes to
+    # other branches — is build-only.
+    env:
+      PUBLISH: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      # Validate that the production image builds. Build-only: nothing is pushed
-      # to a registry.
+      # ---- Build-only validation (pull requests, non-publishing branches) ----
+      # Validates that the production image builds. Nothing is pushed.
       - name: Build production image
-        run: docker build --tag laravel-slack-clone:ci --file Dockerfile .
+        if: env.PUBLISH != 'true'
+        run: docker build --tag the-desk:ci --file Dockerfile .
+
+      # ---- Publish to GitHub Container Registry (master + v* tags) ----
+      - name: Set up Docker Buildx
+        if: env.PUBLISH == 'true'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        if: env.PUBLISH == 'true'
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Image name tracks ${{ github.repository }} so it survives a repo rename.
+      # v* tags → X.Y.Z, X.Y, and latest; master → the moving `edge` tag.
+      - name: Derive image tags and labels
+        if: env.PUBLISH == 'true'
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=edge,enable={{is_default_branch}}
+
+      # amd64 only for now (arm64 emulation is deferred — see the issue).
+      # VITE_* values are baked into the browser bundle at build time, so this
+      # published image is a reference/demo image carrying these fixed settings;
+      # build-from-source remains the supported production path.
+      - name: Build and push image
+        if: env.PUBLISH == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VITE_APP_NAME=The Desk
+            VITE_REVERB_APP_KEY=reverb
+            VITE_REVERB_HOST=localhost
+            VITE_REVERB_PORT=8080
+            VITE_REVERB_SCHEME=http

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ Run the quality gate before pushing:
 
 ## Self-Hosting with Docker
 
-The production stack is built **from source at a release tag** and orchestrated
-with `docker-compose.prod.yml`. There is no prebuilt image to pull; you clone the
-repo, check out a tagged release, and bring the stack up. The app is served with
+The supported production stack is built **from source at a release tag** and
+orchestrated with `docker-compose.prod.yml`: you clone the repo, check out a
+tagged release, and bring the stack up. The app is served with
 [FrankenPHP](https://frankenphp.dev/); Postgres, Meilisearch, Reverb, a queue
 worker, and the scheduler all run as containers.
+
+A prebuilt image is also published to the GitHub Container Registry, but only as
+a **reference/demo image** — see [Pulling the reference image](#pulling-the-reference-image-from-ghcr)
+below for its limitations. Build-from-source remains the supported path for real
+deployments.
 
 ### Prerequisites
 
@@ -109,6 +114,35 @@ Your data persists across `down`/`up` in named volumes (`pgsql-data`,
 > across a major version, read the [CHANGELOG](CHANGELOG.md) and the
 > corresponding [GitHub Release notes](https://github.com/emmpaul/laravel-slack-clone/releases)
 > for required manual steps.
+
+### Pulling the reference image from GHCR
+
+Each release also publishes a prebuilt image to the GitHub Container Registry at
+`ghcr.io/emmpaul/the-desk` (tags `X.Y.Z`, `X.Y`, and `latest`; `edge` tracks the
+tip of `master`).
+
+> **This is a reference/demo image, not a turnkey production artifact.** The
+> browser-side `VITE_REVERB_APP_KEY`, `VITE_REVERB_HOST`, `VITE_REVERB_PORT`,
+> `VITE_REVERB_SCHEME`, and `VITE_APP_NAME` values are compiled into the
+> JavaScript bundle **at build time**, so the published image carries one fixed
+> set of settings (a `localhost` Reverb host). It is fine for `docker run` and
+> clicking around, but real-time broadcasting will point at the wrong host on any
+> other domain. For a real deployment, **build from source** (above) so your own
+> `VITE_*` values are baked in.
+
+The package is currently **private**, so pulling requires authenticating to GHCR
+with a [personal access token](https://github.com/settings/tokens) that has the
+`read:packages` scope:
+
+```bash
+echo "$GHCR_PAT" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+docker pull ghcr.io/emmpaul/the-desk:latest
+```
+
+> **Maintainer note:** the GHCR package is created private on first push. When
+> the repository is made public, flip the package to public in its package
+> settings (**Package settings → Change visibility**) so unauthenticated pulls
+> work — CI cannot toggle this.
 
 ### What runs, and why no Redis
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,7 +21,7 @@ x-app: &app
       VITE_REVERB_HOST: ${VITE_REVERB_HOST}
       VITE_REVERB_PORT: ${VITE_REVERB_PORT:-8080}
       VITE_REVERB_SCHEME: ${VITE_REVERB_SCHEME:-https}
-  image: laravel-slack-clone:latest
+  image: the-desk:latest
   env_file:
     - .env
   restart: unless-stopped


### PR DESCRIPTION
Closes #203.

## What

Adds GitHub Container Registry publishing to `.github/workflows/docker.yml`, alongside the existing build-only validation established in #111.

- **`v*` tag push** (release-please releases) → builds and pushes `ghcr.io/<repo>` with tags `X.Y.Z`, `X.Y`, and `latest`.
- **`master` push** → moves the `edge` tag.
- **Pull requests / other branches** → build-only, nothing is pushed (fork/PR code is never published).

## How

- SHA-pinned `docker/setup-buildx-action`, `docker/login-action`, `docker/metadata-action`, `docker/build-push-action` (repo convention).
- Job granted `packages: write` + `contents: read`; the push steps are gated on a `PUBLISH` expression so PR/fork runs skip login entirely.
- Image name derived from `ghcr.io/${{ github.repository }}` — no hardcoded name, survives a repo rename.
- `type=gha` layer caching for fast release builds; `linux/amd64` only.
- `VITE_*` build args baked in with reference defaults.

## Reference-image limitation

The `VITE_*` values are compiled into the browser bundle at build time, so the published image carries one fixed (localhost) Reverb/app config. It is a **reference/demo image**, not a turnkey artifact — build-from-source remains the supported production path. This is documented in the self-hosting README (baked-VITE caveat, `docker login` + pull commands, and the "make package public when the repo goes public" step).

## Cosmetic renames

- `docker-compose.prod.yml`: `image: laravel-slack-clone:latest` → `the-desk:latest`.
- `docker.yml` build-only tag: `laravel-slack-clone:ci` → `the-desk:ci`.

## Testing

Ran the production build locally with the workflow's exact build args — image builds successfully. The workflow only runs `docker build` (build-only) / `build-push` (publish); no application code changed, so the PHP/JS test suites are unaffected.

## Follow-ups

- #204 — runtime-configurable Reverb/app settings (prerequisite for a genuinely reusable image).
- #205 — multi-arch (arm64) publishing.

## Operational note

The GHCR package is created **private** on first push; keep it private for now. When the repo is made public, flip the package to public in its settings (CI cannot toggle this).