### PR TITLE
ci(release): use PAT so release tags trigger GHCR publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Use a PAT (not the built-in GITHUB_TOKEN) so the `v*` tag release-please
+      # pushes triggers downstream workflows — notably docker.yml's GHCR publish.
+      # GitHub deliberately suppresses `on: push` triggers for refs created by
+      # GITHUB_TOKEN, so with the default token a release would tag but never
+      # publish the versioned image. RELEASE_PLEASE_TOKEN needs `contents: write`
+      # and `pull-requests: write`.
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Follow-up to #203 / #206.

## Problem

release-please creates the `v*` tag using the built-in `GITHUB_TOKEN`. GitHub **deliberately suppresses `on: push` triggers for refs created by `GITHUB_TOKEN`** (anti-recursion), so tagged releases tag the repo but never trigger `docker.yml`'s versioned GHCR publish. `v0.4.0` had to be published manually by re-pushing the tag from local credentials.

## Fix

Point release-please at a PAT (`RELEASE_PLEASE_TOKEN`) instead of `GITHUB_TOKEN`. Refs pushed with a real user token trigger downstream workflows normally, so the next release will auto-publish `X.Y.Z` / `X.Y` / `latest` with no manual step. `docker.yml` is unchanged.

## ⚠️ Required before the next release — add the secret

This PR is inert until the secret exists. Create a token and add it:

1. **Create a PAT** at GitHub → Settings → Developer settings → Personal access tokens.
   - **Fine-grained** (recommended), scoped to `emmpaul/the-desk`, with repository permissions: **Contents: Read and write** and **Pull requests: Read and write**.
   - *(Classic alternative: the `repo` scope.)*
2. **Add it as a repo secret** named `RELEASE_PLEASE_TOKEN` (Repo → Settings → Secrets and variables → Actions → New repository secret).

If the secret is missing when release-please next runs, the release job will fail authentication — so add it before merging a future release PR.

## Testing

Workflow-only change; no application code touched. The end-to-end publish path was already validated on `v0.4.0` (image is live and public at `ghcr.io/emmpaul/the-desk`).