### PR TITLE
feat(platform): runtime-configurable Reverb settings for a reusable image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,8 +67,6 @@ AWS_DEFAULT_REGION=us-east-1
 AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
-VITE_APP_NAME="${APP_NAME}"
-
 SCOUT_DRIVER=meilisearch
 MEILISEARCH_HOST=http://meilisearch:7700
 
@@ -82,8 +80,11 @@ REVERB_HOST="reverb"
 REVERB_PORT=8080
 REVERB_SCHEME=http
 
-VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
-# Browser-side host the client connects to: the host-mapped Reverb port.
-VITE_REVERB_HOST="localhost"
-VITE_REVERB_PORT="${REVERB_PORT}"
-VITE_REVERB_SCHEME="${REVERB_SCHEME}"
+# The browser connects to Reverb using REVERB_APP_KEY above, served to the SPA at
+# runtime (no VITE_* build args). The browser-facing host/port/scheme default to
+# the APP_URL host + REVERB_PORT + REVERB_SCHEME, which is correct for local dev.
+# Override any of them only when the browser reaches Reverb differently than the
+# server does (e.g. a dedicated WS domain, or wss/443 through a TLS proxy):
+# REVERB_HOST_PUBLIC=
+# REVERB_PORT_PUBLIC=
+# REVERB_SCHEME_PUBLIC=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -2,17 +2,19 @@
 # Production environment template for the Docker self-hosting stack.
 #
 #   cp .env.prod.example .env
-#   docker run --rm laravel-slack-clone:latest php artisan key:generate --show
+#   docker run --rm ghcr.io/emmpaul/the-desk:latest php artisan key:generate --show
 #   # paste the value into APP_KEY below, fill in the rest, then:
-#   docker compose -f docker-compose.prod.yml up -d --build
+#   docker compose -f docker-compose.prod.yml up -d
 #
-# Values consumed at BUILD time (VITE_*) are compiled into the browser bundle,
-# so they must be correct before `--build`. Change one → rebuild the image.
+# Every setting here is read at RUNTIME — including the browser-facing Reverb
+# values, which the app serves to the frontend at boot. Changing any of them
+# only requires a container restart, never an image rebuild, so the same image
+# works for any host.
 # =============================================================================
 
-APP_NAME="Laravel Slack Clone"
+APP_NAME="The Desk"
 APP_ENV=production
-# Generate once with: docker run --rm laravel-slack-clone:latest php artisan key:generate --show
+# Generate once with: docker run --rm ghcr.io/emmpaul/the-desk:latest php artisan key:generate --show
 APP_KEY=
 APP_DEBUG=false
 # Public URL your reverse proxy serves the app on.
@@ -67,23 +69,25 @@ MEILISEARCH_KEY=
 MEILISEARCH_NO_ANALYTICS=true
 
 # --- Broadcasting (reverb service) -------------------------------------------
-# Required — generate with: docker run --rm laravel-slack-clone:latest php artisan reverb:secret
+# Required — generate with: docker run --rm ghcr.io/emmpaul/the-desk:latest php artisan reverb:secret
 REVERB_APP_ID=
 REVERB_APP_KEY=
 REVERB_APP_SECRET=
-# Server-side host the app broadcasts to: the reverb container on the compose network.
+# Server-side host/port/scheme the app broadcasts to: the reverb container on the
+# compose network (plain http on 8080, behind your TLS proxy).
 REVERB_HOST=reverb
 REVERB_PORT=8080
 REVERB_SCHEME=http
 
-# Browser-side values (through your TLS proxy). BUILD-time — compiled into the
-# frontend bundle, so set them before `--build`. Use your public domain and
-# wss/https in production. VITE_REVERB_APP_KEY must equal REVERB_APP_KEY above
-# (gen-secrets.sh keeps them in sync).
-VITE_REVERB_APP_KEY=
-VITE_REVERB_HOST=chat.example.com
-VITE_REVERB_PORT=443
-VITE_REVERB_SCHEME=https
+# Browser-side values, served to the SPA at RUNTIME (no rebuild). The browser
+# uses REVERB_APP_KEY above; host/port/scheme default to the APP_URL host +
+# REVERB_PORT + REVERB_SCHEME. Since your TLS proxy terminates https/wss on 443
+# while the container speaks http on 8080, override the port and scheme so the
+# browser connects over wss:
+REVERB_PORT_PUBLIC=443
+REVERB_SCHEME_PUBLIC=https
+# Set only for a dedicated WebSocket subdomain (otherwise the APP_URL host is used):
+# REVERB_HOST_PUBLIC=ws.example.com
 
 # --- Container port mapping (host side) --------------------------------------
 # Host port the app is published on (proxy sits in front of this). Defaults to 80.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,10 +74,9 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=edge,enable={{is_default_branch}}
 
-      # amd64 only for now (arm64 emulation is deferred — see the issue).
-      # VITE_* values are baked into the browser bundle at build time, so this
-      # published image is a reference/demo image carrying these fixed settings;
-      # build-from-source remains the supported production path.
+      # amd64 only for now (arm64 emulation is deferred — see #205). No VITE_*
+      # build args: the app name and browser-facing Reverb settings are served to
+      # the SPA at runtime, so this single image works for any operator's host.
       - name: Build and push image
         if: env.PUBLISH == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -90,9 +89,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            VITE_APP_NAME=The Desk
-            VITE_REVERB_APP_KEY=reverb
-            VITE_REVERB_HOST=localhost
-            VITE_REVERB_PORT=8080
-            VITE_REVERB_SCHEME=http

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,20 +62,9 @@ RUN npm ci
 COPY --from=vendor /app/vendor ./vendor
 COPY . .
 
-# VITE_* values are compiled into the browser bundle at build time, so the
-# operator's real Reverb/app settings must be passed as build args. These are
-# wired up from the .env file in docker-compose.prod.yml.
-ARG VITE_APP_NAME=Laravel
-ARG VITE_REVERB_APP_KEY
-ARG VITE_REVERB_HOST=localhost
-ARG VITE_REVERB_PORT=8080
-ARG VITE_REVERB_SCHEME=https
-ENV VITE_APP_NAME=${VITE_APP_NAME} \
-    VITE_REVERB_APP_KEY=${VITE_REVERB_APP_KEY} \
-    VITE_REVERB_HOST=${VITE_REVERB_HOST} \
-    VITE_REVERB_PORT=${VITE_REVERB_PORT} \
-    VITE_REVERB_SCHEME=${VITE_REVERB_SCHEME}
-
+# No VITE_* build args: the app name and the browser-facing Reverb settings are
+# served to the SPA at runtime (an Inertia shared prop read at boot), so nothing
+# operator-specific is baked into the bundle. One built image works for any host.
 RUN npm run build
 
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -26,16 +26,19 @@ Run the quality gate before pushing:
 
 ## Self-Hosting with Docker
 
-The supported production stack is built **from source at a release tag** and
-orchestrated with `docker-compose.prod.yml`: you clone the repo, check out a
-tagged release, and bring the stack up. The app is served with
-[FrankenPHP](https://frankenphp.dev/); Postgres, Meilisearch, Reverb, a queue
-worker, and the scheduler all run as containers.
+The production stack is orchestrated with `docker-compose.prod.yml`. The app is
+served with [FrankenPHP](https://frankenphp.dev/); Postgres, Meilisearch, Reverb,
+a queue worker, and the scheduler all run as containers.
 
-A prebuilt image is also published to the GitHub Container Registry, but only as
-a **reference/demo image** — see [Pulling the reference image](#pulling-the-reference-image-from-ghcr)
-below for its limitations. Build-from-source remains the supported path for real
-deployments.
+There are two supported ways to get the app image, both driven by the same
+`.env`:
+
+- **Pull the prebuilt image** from the GitHub Container Registry
+  (`ghcr.io/emmpaul/the-desk`) — no build step. Every setting, including the
+  browser-facing Reverb values, is read at **runtime**, so one published image
+  works for any host. See [Using the published image](#using-the-published-image).
+- **Build from source** at a release tag — clone the repo, check out a tag, and
+  `--build`. See [First install](#first-install).
 
 ### Prerequisites
 
@@ -61,10 +64,10 @@ git checkout v0.1.0                                   # the desired release tag
 ./docker/gen-secrets.sh
 
 # 3. Edit .env and set the non-secret settings the script can't guess:
-#    APP_URL, SMTP mail credentials, and the browser-side VITE_REVERB_HOST /
-#    VITE_REVERB_PORT / VITE_REVERB_SCHEME (your public domain + wss/https).
-#    VITE_* values are compiled into the frontend at build time, so set them
-#    before building.
+#    APP_URL, SMTP mail credentials, and — since your TLS proxy terminates
+#    wss/443 while the container speaks http/8080 — REVERB_PORT_PUBLIC=443 and
+#    REVERB_SCHEME_PUBLIC=https. These are read at runtime (a restart applies
+#    changes), so no rebuild is needed when they change.
 
 # 4. Build the images and start the stack.
 docker compose -f docker-compose.prod.yml up -d --build
@@ -115,34 +118,39 @@ Your data persists across `down`/`up` in named volumes (`pgsql-data`,
 > corresponding [GitHub Release notes](https://github.com/emmpaul/laravel-slack-clone/releases)
 > for required manual steps.
 
-### Pulling the reference image from GHCR
+### Using the published image
 
-Each release also publishes a prebuilt image to the GitHub Container Registry at
+Each release publishes a prebuilt image to the GitHub Container Registry at
 `ghcr.io/emmpaul/the-desk` (tags `X.Y.Z`, `X.Y`, and `latest`; `edge` tracks the
-tip of `master`).
-
-> **This is a reference/demo image, not a turnkey production artifact.** The
-> browser-side `VITE_REVERB_APP_KEY`, `VITE_REVERB_HOST`, `VITE_REVERB_PORT`,
-> `VITE_REVERB_SCHEME`, and `VITE_APP_NAME` values are compiled into the
-> JavaScript bundle **at build time**, so the published image carries one fixed
-> set of settings (a `localhost` Reverb host). It is fine for `docker run` and
-> clicking around, but real-time broadcasting will point at the wrong host on any
-> other domain. For a real deployment, **build from source** (above) so your own
-> `VITE_*` values are baked in.
-
-The package is currently **private**, so pulling requires authenticating to GHCR
-with a [personal access token](https://github.com/settings/tokens) that has the
-`read:packages` scope:
+tip of `master`). Because the app name and the browser-facing Reverb settings are
+served to the frontend at **runtime** — not baked into the JavaScript bundle at
+build time — the same image works for any operator's host with no rebuild. Point
+it at your `.env` and go:
 
 ```bash
-echo "$GHCR_PAT" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
-docker pull ghcr.io/emmpaul/the-desk:latest
+# 1. Grab the compose file, env template, and secret generator from a release tag.
+git clone git@github.com:emmpaul/the-desk.git
+cd the-desk
+git fetch --tags && git checkout v0.4.0                # the desired release tag
+
+# 2. Generate .env secrets, then edit APP_URL, mail, and REVERB_*_PUBLIC (see below).
+./docker/gen-secrets.sh
+
+# 3. Run the published image instead of building. Pin the version to the tag.
+echo 'APP_IMAGE=ghcr.io/emmpaul/the-desk:0.4.0' >> .env
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d
 ```
 
-> **Maintainer note:** the GHCR package is created private on first push. When
-> the repository is made public, flip the package to public in its package
-> settings (**Package settings → Change visibility**) so unauthenticated pulls
-> work — CI cannot toggle this.
+`docker compose pull` fetches the prebuilt image; `up -d` runs it without a build
+step. Upgrades are just `APP_IMAGE=…:X.Y.Z`, then `pull` + `up -d` again.
+
+> **Reverb settings are runtime, so mind the browser vs. server split.** The
+> container speaks plain `http` on `8080` (`REVERB_PORT` / `REVERB_SCHEME`), but
+> the browser reaches Reverb through your TLS proxy on `wss`/`443`. Set
+> `REVERB_PORT_PUBLIC=443` and `REVERB_SCHEME_PUBLIC=https` in `.env`; the
+> browser-facing host defaults to your `APP_URL` host (override with
+> `REVERB_HOST_PUBLIC` only for a dedicated WebSocket subdomain).
 
 ### What runs, and why no Redis
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -9,6 +9,7 @@ use App\Models\Message;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Support\ReverbConfig;
 use App\Support\TranslationCatalog;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
@@ -51,6 +52,10 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'name' => config('app.name'),
+            // Browser-facing Reverb connection details, resolved at runtime so a
+            // single built image works for any operator without baking VITE_*
+            // values into the bundle. Read by app.ts to configure Echo at boot.
+            'reverb' => ReverbConfig::forFrontend(),
             'locale' => app()->getLocale(),
             // The active locale's catalog rides the initial document as a "once"
             // prop: it reaches the SSR render and first hydration (so the first

--- a/app/Support/ReverbConfig.php
+++ b/app/Support/ReverbConfig.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Support;
+
+class ReverbConfig
+{
+    /**
+     * The browser-facing Reverb connection details, served to the SPA at runtime
+     * (via an Inertia shared prop) rather than baked into the JS bundle at build
+     * time with VITE_* args. This is what lets a single published image connect
+     * to any operator's Reverb server without a rebuild.
+     *
+     * Host, port, and scheme each default to the server-facing connection (host
+     * from the APP_URL origin, port/scheme from REVERB_PORT/REVERB_SCHEME) and are
+     * independently overridable — because in a TLS-terminating reverse proxy the
+     * browser reaches Reverb on a different host/port/scheme (e.g. wss on 443)
+     * than the internal container (http on 8080).
+     *
+     * @return array{key: string|null, host: string|null, port: int, scheme: string}
+     */
+    public static function forFrontend(): array
+    {
+        $reverb = config('broadcasting.connections.reverb');
+        $options = $reverb['options'] ?? [];
+
+        $host = $reverb['public_host'] ?: (parse_url((string) config('app.url'), PHP_URL_HOST) ?: null);
+
+        return [
+            'key' => $reverb['key'] ?? null,
+            'host' => $host,
+            'port' => (int) ($reverb['public_port'] ?: $options['port'] ?? 443),
+            'scheme' => (string) ($reverb['public_scheme'] ?: $options['scheme'] ?? 'https'),
+        ];
+    }
+}

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -35,6 +35,19 @@ return [
             'key' => env('REVERB_APP_KEY'),
             'secret' => env('REVERB_APP_SECRET'),
             'app_id' => env('REVERB_APP_ID'),
+            // Browser-facing connection details, served to the SPA at runtime (see
+            // App\Support\ReverbConfig) so nothing operator-specific is baked into
+            // the bundle. Each is optional and falls back sensibly:
+            //   public_host   → APP_URL host (single-domain reverse proxy). Override
+            //                   for a dedicated WebSocket subdomain.
+            //   public_port   → REVERB_PORT. Override when the browser reaches Reverb
+            //                   on a different port than the server (e.g. 443 through
+            //                   a TLS proxy while the container listens on 8080).
+            //   public_scheme → REVERB_SCHEME. Override to https/wss when the proxy
+            //                   terminates TLS but the container speaks plain http.
+            'public_host' => env('REVERB_HOST_PUBLIC'),
+            'public_port' => env('REVERB_PORT_PUBLIC'),
+            'public_scheme' => env('REVERB_SCHEME_PUBLIC'),
             'options' => [
                 'host' => env('REVERB_HOST'),
                 'port' => env('REVERB_PORT', 443),

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,15 +13,14 @@
 # broadcasting uses Reverb — nothing resolves to Redis.
 
 x-app: &app
+  # Defaults to the local build tag (build-from-source). Set APP_IMAGE to the
+  # published image — e.g. APP_IMAGE=ghcr.io/emmpaul/the-desk:0.4.0 — to run the
+  # prebuilt turnkey image instead: `docker compose -f docker-compose.prod.yml pull`
+  # then `up -d`, no build step. Browser Reverb settings are read at runtime, so
+  # one published image works for any host.
+  image: ${APP_IMAGE:-the-desk:latest}
   build:
     context: .
-    args:
-      VITE_APP_NAME: ${APP_NAME:-Laravel}
-      VITE_REVERB_APP_KEY: ${REVERB_APP_KEY}
-      VITE_REVERB_HOST: ${VITE_REVERB_HOST}
-      VITE_REVERB_PORT: ${VITE_REVERB_PORT:-8080}
-      VITE_REVERB_SCHEME: ${VITE_REVERB_SCHEME:-https}
-  image: the-desk:latest
   env_file:
     - .env
   restart: unless-stopped

--- a/docker/gen-secrets.sh
+++ b/docker/gen-secrets.sh
@@ -7,7 +7,8 @@
 # Creates .env from .env.prod.example (if missing) and fills any EMPTY required
 # secret with a freshly generated value. Existing values are never overwritten,
 # so the script is safe to re-run. After it finishes, fill in the non-secret
-# settings (APP_URL, mail, VITE_REVERB_HOST, …) before building the stack.
+# settings (APP_URL, mail, the browser-side REVERB_*_PUBLIC values) before
+# starting the stack.
 set -eu
 
 EXAMPLE_FILE=".env.prod.example"
@@ -49,14 +50,12 @@ set_if_empty "DB_PASSWORD"     "$(openssl rand -hex 24)"
 set_if_empty "MEILISEARCH_KEY" "$(openssl rand -hex 32)"
 set_if_empty "REVERB_APP_ID"   "$(openssl rand 4 | od -An -tu4 | tr -d ' ')"
 
-# The browser (VITE_REVERB_APP_KEY) and server (REVERB_APP_KEY) must share the
-# same app key, so generate it once and set both when they are empty.
-reverb_key="$(openssl rand -hex 16)"
-set_if_empty "REVERB_APP_KEY"      "$reverb_key"
-set_if_empty "VITE_REVERB_APP_KEY" "$reverb_key"
-set_if_empty "REVERB_APP_SECRET"   "$(openssl rand -hex 16)"
+# The browser and server share the one REVERB_APP_KEY (the frontend receives it
+# at runtime), so it is generated once here.
+set_if_empty "REVERB_APP_KEY"    "$(openssl rand -hex 16)"
+set_if_empty "REVERB_APP_SECRET" "$(openssl rand -hex 16)"
 
 echo
 echo "Done. Review $ENV_FILE and set APP_URL, mail credentials, and the"
-echo "browser-side VITE_REVERB_* values before running:"
-echo "  docker compose -f docker-compose.prod.yml up -d --build"
+echo "browser-side REVERB_*_PUBLIC values before running:"
+echo "  docker compose -f docker-compose.prod.yml up -d"

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -4,17 +4,19 @@ import { initializeTheme } from '@/composables/useAppearance';
 import AuthLayout from '@/layouts/AuthLayout.vue';
 import MainLayout from '@/layouts/MainLayout.vue';
 import SettingsLayout from '@/layouts/settings/Layout.vue';
+import { reverbEchoConfig } from '@/lib/echo';
+import type { ReverbRuntimeConfig } from '@/lib/echo';
 import { initializeFlashToast } from '@/lib/flashToast';
 import { setMessages, translate } from '@/lib/i18n';
 import type { Messages } from '@/lib/i18n';
 
-configureEcho({
-    broadcaster: 'reverb',
-});
+// Seeded from the server-shared props at boot (see `withApp`), so both Echo and
+// the document title use the operator's runtime settings rather than values
+// baked into the bundle at build time.
+let appName = 'Laravel';
 
-const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
-
-createInertiaApp({
+// createInertiaApp returns a bootstrap Promise we intentionally don't await.
+void createInertiaApp({
     title: (title) => (title ? `${title} - ${appName}` : appName),
     // Seed the translation catalog from the server-shared props before the first
     // render — on both the SSR pass and the client — so the initial paint is
@@ -23,9 +25,20 @@ createInertiaApp({
     // Also expose the translation helper as a global `$t` for templates.
     withApp(app, { page }) {
         const props = page.props as {
+            name?: string;
+            reverb?: ReverbRuntimeConfig;
             locale?: string;
             translations?: Messages;
         };
+
+        appName = props.name ?? 'Laravel';
+
+        // Configure Echo once, at boot, from the runtime Reverb config — before
+        // any component's `useEcho` runs. Guard on `reverb` so a page without the
+        // shared prop (e.g. a bare error response) doesn't throw.
+        if (props.reverb) {
+            configureEcho(reverbEchoConfig(props.reverb));
+        }
 
         setMessages(props.locale ?? 'en', props.translations ?? {});
 

--- a/resources/js/lib/echo.test.ts
+++ b/resources/js/lib/echo.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { reverbEchoConfig } from '@/lib/echo';
+
+describe('reverbEchoConfig', () => {
+    it('maps runtime reverb config to Echo options with TLS forced on https', () => {
+        expect(
+            reverbEchoConfig({
+                key: 'demo-key',
+                host: 'chat.example.test',
+                port: 443,
+                scheme: 'https',
+            }),
+        ).toEqual({
+            broadcaster: 'reverb',
+            key: 'demo-key',
+            wsHost: 'chat.example.test',
+            wsPort: 443,
+            wssPort: 443,
+            forceTLS: true,
+            enabledTransports: ['ws', 'wss'],
+        });
+    });
+
+    it('does not force TLS for an http scheme', () => {
+        const config = reverbEchoConfig({
+            key: 'demo-key',
+            host: 'localhost',
+            port: 8080,
+            scheme: 'http',
+        });
+
+        expect(config.forceTLS).toBe(false);
+        expect(config.wsPort).toBe(8080);
+        expect(config.wssPort).toBe(8080);
+    });
+
+    it('coerces a missing key or host to undefined so Echo falls back gracefully', () => {
+        const config = reverbEchoConfig({
+            key: null,
+            host: null,
+            port: 443,
+            scheme: 'https',
+        });
+
+        expect(config.key).toBeUndefined();
+        expect(config.wsHost).toBeUndefined();
+    });
+});

--- a/resources/js/lib/echo.ts
+++ b/resources/js/lib/echo.ts
@@ -1,0 +1,31 @@
+/**
+ * Browser-facing Reverb connection details, provided by the backend at runtime
+ * (the `reverb` Inertia shared prop) instead of build-time `VITE_*` env vars.
+ * This is what lets a single published image connect to any operator's Reverb
+ * server without rebuilding the frontend bundle.
+ */
+export type ReverbRuntimeConfig = {
+    key: string | null;
+    host: string | null;
+    port: number;
+    scheme: string;
+};
+
+/**
+ * Translate the runtime Reverb config into the options object `configureEcho`
+ * expects. TLS is forced for the `https` scheme; a missing key/host collapses to
+ * `undefined` so Echo can fall back rather than connecting to a literal "null".
+ */
+export function reverbEchoConfig(config: ReverbRuntimeConfig) {
+    const enabledTransports: ('ws' | 'wss')[] = ['ws', 'wss'];
+
+    return {
+        broadcaster: 'reverb' as const,
+        key: config.key ?? undefined,
+        wsHost: config.host ?? undefined,
+        wsPort: config.port,
+        wssPort: config.port,
+        forceTLS: config.scheme === 'https',
+        enabledTransports,
+    };
+}

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -1,3 +1,4 @@
+import type { ReverbRuntimeConfig } from '@/lib/echo';
 import type { Auth } from '@/types/auth';
 import type { Channel, ChannelSection } from '@/types/channels';
 import type { DashboardInvitation, RoleOption, Team } from '@/types/teams';
@@ -5,7 +6,6 @@ import type { DashboardInvitation, RoleOption, Team } from '@/types/teams';
 // Extend ImportMeta interface for Vite...
 declare module 'vite/client' {
     interface ImportMetaEnv {
-        readonly VITE_APP_NAME: string;
         [key: string]: string | boolean | undefined;
     }
 
@@ -19,6 +19,7 @@ declare module '@inertiajs/core' {
     export interface InertiaConfig {
         sharedPageProps: {
             name: string;
+            reverb: ReverbRuntimeConfig;
             auth: Auth;
             registrationEnabled: boolean;
             sidebarOpen: boolean;

--- a/tests/Feature/ReverbConfigSharingTest.php
+++ b/tests/Feature/ReverbConfigSharingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('the browser-facing reverb config is shared to the frontend at runtime', function () {
+    config([
+        'app.name' => 'The Desk',
+        'app.url' => 'https://chat.example.test',
+        'broadcasting.connections.reverb.key' => 'demo-key',
+        'broadcasting.connections.reverb.public_host' => null,
+        'broadcasting.connections.reverb.options.port' => 443,
+        'broadcasting.connections.reverb.options.scheme' => 'https',
+    ]);
+
+    $this->get(route('home'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('name', 'The Desk')
+            ->where('reverb.key', 'demo-key')
+            ->where('reverb.host', 'chat.example.test')
+            ->where('reverb.port', 443)
+            ->where('reverb.scheme', 'https')
+        );
+});
+
+test('browser-facing host, port, and scheme can each override the server-facing values', function () {
+    // A TLS-terminating reverse proxy: the container speaks http on 8080, but the
+    // browser reaches Reverb as wss on 443 at a dedicated WebSocket host.
+    config([
+        'app.url' => 'https://chat.example.test',
+        'broadcasting.connections.reverb.options.port' => 8080,
+        'broadcasting.connections.reverb.options.scheme' => 'http',
+        'broadcasting.connections.reverb.public_host' => 'ws.example.test',
+        'broadcasting.connections.reverb.public_port' => 443,
+        'broadcasting.connections.reverb.public_scheme' => 'https',
+    ]);
+
+    $this->get(route('home'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('reverb.host', 'ws.example.test')
+            ->where('reverb.port', 443)
+            ->where('reverb.scheme', 'https')
+        );
+});


### PR DESCRIPTION
Closes #204. Follow-up to #203 / #206.

## Problem

The prod `Dockerfile` baked `VITE_REVERB_*` and `VITE_APP_NAME` into the browser bundle at **build time**, so the published GHCR image carried one fixed (`localhost`) Reverb host — usable only as a reference/demo image. An operator pulling it got the wrong broadcast host in their JS.

## Change

Serve the app name and browser-facing Reverb settings to the SPA at **runtime**, so a single published image works for any host without a rebuild.

**Backend**
- `App\Support\ReverbConfig::forFrontend()` derives the browser-facing `key` / `host` / `port` / `scheme` from config.
- `HandleInertiaRequests` shares it as the `reverb` prop (app name already shared as `name`).
- Host defaults to the `APP_URL` origin; port/scheme default to `REVERB_PORT` / `REVERB_SCHEME`. Each is independently overridable via `REVERB_HOST_PUBLIC` / `REVERB_PORT_PUBLIC` / `REVERB_SCHEME_PUBLIC` — because a TLS-terminating proxy reaches Reverb as `wss`/`443` while the container speaks `http`/`8080`.

**Frontend**
- `reverbEchoConfig()` (pure, unit-tested) maps the runtime prop to Echo options.
- `app.ts` configures Echo and the document title from the shared props inside `withApp`, replacing `import.meta.env.VITE_*`. Dropped the `VITE_*` type + env usage.

**Image / ops**
- Removed the `VITE_*` build args from the `Dockerfile`, `docker-compose.prod.yml`, and the CI workflow.
- `docker-compose.prod.yml` gains `APP_IMAGE` so operators can run the published image (`pull` + `up -d`, no build).
- Updated `.env.example`, `.env.prod.example`, and `gen-secrets.sh`; reworked the README to document the image as a **turnkey** path (removing the #203 reference-image caveat).

## Tests

- `tests/Feature/ReverbConfigSharingTest.php` — asserts the shared `reverb` prop, including the production browser-vs-server override case.
- `resources/js/lib/echo.test.ts` — Vitest unit tests for `reverbEchoConfig` (TLS forcing, port mapping, null coercion).

## Gate

`./vendor/bin/sail composer test` → **Total: 100.0 %** (Pint + PHPStan + tests). Frontend: `lint:check`, `format:check`, `types:check`, `build`, and Vitest (254) all pass. Prod image builds cleanly without the VITE args.

## Note

Full end-to-end (a browser actually connecting over `wss` to a real Reverb host) isn't exercisable locally without a deployed TLS proxy; the seams are covered by the feature + unit tests, and the prod build is verified.