### PR TITLE
DMs: backend foundation (schema + open-or-create endpoint) (#177)

### DIFF
--- a/app/Actions/Channels/OpenDirectMessage.php
+++ b/app/Actions/Channels/OpenDirectMessage.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Actions\Channels;
+
+use App\Enums\ChannelType;
+use App\Enums\ChannelVisibility;
+use App\Enums\NotificationLevel;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class OpenDirectMessage
+{
+    /**
+     * Find or create the 1:1 direct message between two team members.
+     *
+     * The participants' UUIDs are sorted and colon-joined into a canonical
+     * `dm_key` (a single UUID for a self-DM), so the same pair always maps to the
+     * same key regardless of who initiates. The find-or-create runs in a
+     * transaction and the `unique(team_id, dm_key)` index guarantees exactly one
+     * DM per pair — opening from either direction resolves the same channel.
+     */
+    public function handle(Team $team, User $initiator, User $target): Channel
+    {
+        $participantIds = $this->participantIds($initiator, $target);
+        $dmKey = $participantIds->implode(':');
+
+        return DB::transaction(function () use ($team, $initiator, $dmKey, $participantIds) {
+            $existing = $team->channels()->where('dm_key', $dmKey)->first();
+
+            if ($existing !== null) {
+                return $existing;
+            }
+
+            $channel = $team->channels()->create([
+                'name' => null,
+                'slug' => 'dm-'.Str::lower(Str::random(12)),
+                'visibility' => ChannelVisibility::Private,
+                'type' => ChannelType::Direct,
+                'dm_key' => $dmKey,
+                'created_by' => $initiator->id,
+            ]);
+
+            foreach ($participantIds as $userId) {
+                $channel->channelMembers()->create([
+                    'user_id' => $userId,
+                    'notification_level' => NotificationLevel::All,
+                ]);
+            }
+
+            return $channel;
+        });
+    }
+
+    /**
+     * The DM's participant UUIDs, de-duplicated and sorted for a canonical key.
+     *
+     * A self-DM (initiator === target) collapses to a single UUID.
+     *
+     * @return Collection<int, string>
+     */
+    private function participantIds(User $initiator, User $target): Collection
+    {
+        return collect([$initiator->id, $target->id])
+            ->unique()
+            ->sort()
+            ->values();
+    }
+}

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -4,6 +4,7 @@ namespace App\Data;
 
 use App\Enums\NotificationLevel;
 use App\Models\Channel;
+use App\Models\User;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
@@ -27,6 +28,8 @@ class ChannelData extends Data
         public bool $starred = false,
         public ?string $sectionId = null,
         public int $position = 0,
+        public bool $isDirect = false,
+        public ?string $dmUserId = null,
     ) {}
 
     /**
@@ -76,9 +79,18 @@ class ChannelData extends Data
 
         $position = (int) ($channel->getAttribute('position') ?? 0);
 
+        // DMs have no stored name; they render viewer-relative — the current user
+        // sees the other participant (themselves, labelled "You" by the client, in
+        // a self-DM). `dmUserId` lets the sidebar key presence and the avatar off
+        // that participant. Standard channels keep their own `name`.
+        $viewer = auth()->user();
+        $isDirect = $channel->isDirect();
+        $dmParticipant = $isDirect && $viewer instanceof User ? $channel->directParticipantFor($viewer) : null;
+        $name = $dmParticipant !== null ? $dmParticipant->name : (string) $channel->name;
+
         return new self(
             id: $channel->id,
-            name: $channel->name,
+            name: $name,
             slug: $channel->slug,
             visibility: $channel->visibility->value,
             topic: $channel->topic,
@@ -93,6 +105,8 @@ class ChannelData extends Data
             starred: $starred,
             sectionId: $sectionId,
             position: $position,
+            isDirect: $isDirect,
+            dmUserId: $dmParticipant?->id,
         );
     }
 }

--- a/app/Enums/ChannelType.php
+++ b/app/Enums/ChannelType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+enum ChannelType: string
+{
+    /**
+     * An ordinary named channel (public or private).
+     */
+    case Standard = 'standard';
+
+    /**
+     * A 1:1 direct message, modelled as a nameless private channel keyed on its
+     * two participants (a single participant for a self-DM).
+     */
+    case Direct = 'direct';
+
+    /**
+     * A multi-party direct message (3+ participants). Reserved for a future
+     * group-DM issue; no channel is created with this type yet.
+     */
+    case GroupDirect = 'group_direct';
+}

--- a/app/Http/Controllers/Channels/DirectMessageController.php
+++ b/app/Http/Controllers/Channels/DirectMessageController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\OpenDirectMessage;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Channels\OpenDirectMessageRequest;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+
+class DirectMessageController extends Controller
+{
+    /**
+     * Open (find-or-create) the 1:1 direct message with the target user and
+     * redirect into it. Deduped by the participant `dm_key`, so repeated opens
+     * from either side land in the same channel.
+     */
+    public function store(OpenDirectMessageRequest $request, Team $team, OpenDirectMessage $openDirectMessage): RedirectResponse
+    {
+        $target = User::whereKey($request->validated('user_id'))->firstOrFail();
+
+        $channel = $openDirectMessage->handle($team, $request->user(), $target);
+
+        return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
+    }
+}

--- a/app/Http/Requests/Channels/OpenDirectMessageRequest.php
+++ b/app/Http/Requests/Channels/OpenDirectMessageRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Team;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class OpenDirectMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * The current user must belong to the team; the target-shares-the-team half
+     * of the rule is enforced by the `user_id` membership constraint below.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->belongsToTeam($this->team()) ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // The target must be a member of the same team — this is the whole
+            // authorization rule for opening a DM (self is allowed and passes).
+            'user_id' => [
+                // Bail before the exists lookup so a non-UUID value fails on format
+                // rather than reaching the query (ids are UUIDs; a malformed string
+                // would otherwise raise a Postgres uuid cast error).
+                'bail',
+                'required',
+                'string',
+                'uuid',
+                Rule::exists('team_members', 'user_id')->where('team_id', $this->team()->id),
+            ],
+        ];
+    }
+
+    /**
+     * Get the team the direct message is being opened in.
+     */
+    public function team(): Team
+    {
+        $team = $this->route('team');
+
+        abort_if(! $team instanceof Team, 404);
+
+        return $team;
+    }
+}

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ChannelType;
 use App\Enums\ChannelVisibility;
 use Database\Factories\ChannelFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -17,9 +18,11 @@ use Illuminate\Support\Carbon;
 /**
  * @property string $id
  * @property string $team_id
- * @property string $name
+ * @property string|null $name
  * @property string $slug
  * @property ChannelVisibility $visibility
+ * @property ChannelType $type
+ * @property string|null $dm_key
  * @property string|null $topic
  * @property string|null $created_by
  * @property Carbon|null $archived_at
@@ -35,7 +38,7 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, User> $members
  * @property-read Collection<int, Message> $messages
  */
-#[Fillable(['team_id', 'name', 'slug', 'visibility', 'topic', 'created_by', 'archived_at'])]
+#[Fillable(['team_id', 'name', 'slug', 'visibility', 'type', 'dm_key', 'topic', 'created_by', 'archived_at'])]
 class Channel extends Model
 {
     /** @use HasFactory<ChannelFactory> */
@@ -52,6 +55,31 @@ class Channel extends Model
     public function isGeneral(): bool
     {
         return $this->slug === self::GENERAL_SLUG;
+    }
+
+    /**
+     * Determine whether the channel is a 1:1 direct message.
+     */
+    public function isDirect(): bool
+    {
+        return $this->type === ChannelType::Direct;
+    }
+
+    /**
+     * Resolve the DM participant to display to the given viewer.
+     *
+     * DMs render viewer-relative: in a two-person DM the viewer sees the other
+     * participant; in a self-DM (a single member) they see themselves, which the
+     * frontend labels "You". Returns null for a standard channel.
+     */
+    public function directParticipantFor(User $viewer): ?User
+    {
+        if (! $this->isDirect()) {
+            return null;
+        }
+
+        return $this->members()->where('users.id', '!=', $viewer->id)->first()
+            ?? $this->members()->whereKey($viewer->id)->first();
     }
 
     /**
@@ -141,6 +169,7 @@ class Channel extends Model
     {
         return [
             'visibility' => ChannelVisibility::class,
+            'type' => ChannelType::class,
             'archived_at' => 'datetime',
         ];
     }

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -165,7 +165,9 @@ class ChannelPolicy
      */
     public function archive(User $user, Channel $channel): bool
     {
-        if ($channel->isGeneral() || $channel->isArchived()) {
+        // Direct messages are never archived — they have no archive affordance and
+        // are managed only through the open-or-create flow.
+        if ($channel->isGeneral() || $channel->isArchived() || $channel->isDirect()) {
             return false;
         }
 

--- a/database/factories/ChannelFactory.php
+++ b/database/factories/ChannelFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\ChannelType;
 use App\Enums\ChannelVisibility;
 use App\Models\Channel;
 use App\Models\Team;
@@ -28,6 +29,7 @@ class ChannelFactory extends Factory
             'name' => $name,
             'slug' => Str::slug($name),
             'visibility' => ChannelVisibility::Public,
+            'type' => ChannelType::Standard,
             'topic' => null,
             'created_by' => User::factory(),
             'archived_at' => null,
@@ -51,6 +53,23 @@ class ChannelFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'archived_at' => now(),
+        ]);
+    }
+
+    /**
+     * Indicate that the channel is a nameless 1:1 direct message.
+     *
+     * The caller attaches the participants and sets the real `dm_key`; the
+     * placeholder here just satisfies the unique index for standalone rows.
+     */
+    public function direct(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => null,
+            'slug' => 'dm-'.Str::lower(Str::random(12)),
+            'visibility' => ChannelVisibility::Private,
+            'type' => ChannelType::Direct,
+            'dm_key' => (string) Str::uuid(),
         ]);
     }
 }

--- a/database/migrations/2026_07_11_121629_add_direct_message_columns_to_channels_table.php
+++ b/database/migrations/2026_07_11_121629_add_direct_message_columns_to_channels_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            // Distinguishes ordinary channels from 1:1 direct messages (with
+            // `group_direct` reserved for a future group-DM issue). Defaulting to
+            // `standard` keeps every existing row a normal channel.
+            $table->string('type')->default('standard')->after('visibility');
+            // Sorted, colon-joined participant UUIDs (a single UUID for a self-DM).
+            // Null for standard channels; the unique index below makes it the
+            // canonical dedup key so exactly one DM exists per pair per team.
+            $table->string('dm_key')->nullable()->after('type');
+
+            // DMs have no name; standard channels still require one at the app layer.
+            $table->string('name')->nullable()->change();
+
+            $table->unique(['team_id', 'dm_key']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropUnique(['team_id', 'dm_key']);
+            $table->dropColumn(['type', 'dm_key']);
+            $table->string('name')->nullable(false)->change();
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Channels\ChannelPlacementController;
 use App\Http\Controllers\Channels\ChannelPreferenceController;
 use App\Http\Controllers\Channels\ChannelSectionController;
 use App\Http\Controllers\Channels\ChannelStarController;
+use App\Http\Controllers\Channels\DirectMessageController;
 use App\Http\Controllers\Channels\ForwardMessageController;
 use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Channels\ReactionController;
@@ -28,6 +29,7 @@ Route::get('locales/{locale}.json', [LocaleCatalogController::class, 'show'])
 Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(function () {
     Route::get('t/{team}', [ChannelController::class, 'index'])->name('channels.index');
     Route::post('t/{team}/channels', [ChannelController::class, 'store'])->name('channels.store');
+    Route::post('t/{team}/dm', [DirectMessageController::class, 'store'])->name('channels.dm.store');
     Route::get('t/{team}/channels/browse', [ChannelController::class, 'browse'])->name('channels.browse');
     Route::get('t/{team}/search', [SearchController::class, 'index'])->name('search');
     Route::get('t/{team}/search/suggest', [SearchController::class, 'suggest'])->name('search.suggest');

--- a/tests/Feature/Channels/DirectMessageChannelDataTest.php
+++ b/tests/Feature/Channels/DirectMessageChannelDataTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Actions\Channels\OpenDirectMessage;
+use App\Actions\Teams\CreateTeam;
+use App\Data\ChannelData;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\User;
+
+test('a standard channel has no direct participant', function () {
+    $viewer = User::factory()->create();
+    $channel = Channel::factory()->create();
+
+    expect($channel->directParticipantFor($viewer))->toBeNull();
+});
+
+test('a direct channel renders the other participant viewer-relatively', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+
+    $dm = app(OpenDirectMessage::class)->handle($team, $owner, $other);
+
+    $this->actingAs($owner);
+    $ownerView = ChannelData::fromChannel($dm->fresh());
+
+    expect($ownerView->isDirect)->toBeTrue()
+        ->and($ownerView->name)->toBe($other->name)
+        ->and($ownerView->dmUserId)->toBe($other->id);
+
+    $this->actingAs($other);
+    $otherView = ChannelData::fromChannel($dm->fresh());
+
+    expect($otherView->name)->toBe($owner->name)
+        ->and($otherView->dmUserId)->toBe($owner->id);
+});
+
+test('a self direct channel resolves the viewer as the participant', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $dm = app(OpenDirectMessage::class)->handle($team, $owner, $owner);
+
+    $this->actingAs($owner);
+    $view = ChannelData::fromChannel($dm->fresh());
+
+    expect($view->isDirect)->toBeTrue()
+        ->and($view->name)->toBe($owner->name)
+        ->and($view->dmUserId)->toBe($owner->id);
+});

--- a/tests/Feature/Channels/DirectMessageGuardsTest.php
+++ b/tests/Feature/Channels/DirectMessageGuardsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Actions\Channels\OpenDirectMessage;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelType;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Open a direct message between the owner and a fresh team member.
+ *
+ * @return array{0: Channel, 1: User, 2: User}
+ */
+function openDmWithNewMember(Team $team, User $owner): array
+{
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+
+    return [app(OpenDirectMessage::class)->handle($team, $owner, $other), $owner, $other];
+}
+
+test('a channel created through the store endpoint is always a standard channel', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)->post(route('channels.store', ['team' => $team->slug]), [
+        'name' => 'Marketing',
+        'visibility' => 'public',
+    ]);
+
+    $channel = Channel::where('team_id', $team->id)->where('slug', 'marketing')->firstOrFail();
+
+    expect($channel->type)->toBe(ChannelType::Standard)
+        ->and($channel->isDirect())->toBeFalse();
+});
+
+test('a direct message cannot be archived', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    [$dm] = openDmWithNewMember($team, $owner);
+
+    $this->actingAs($owner)
+        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $dm->slug]))
+        ->assertForbidden();
+
+    expect($dm->fresh()->isArchived())->toBeFalse();
+});
+
+test('direct messages are excluded from the browse directory', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    [$dm] = openDmWithNewMember($team, $owner);
+
+    $this->actingAs($owner)
+        ->get(route('channels.browse', ['team' => $team->slug]))
+        ->assertInertia(fn ($page) => $page
+            ->component('channels/Browse')
+            ->where('joinableChannels', fn ($channels) => collect($channels)->doesntContain('id', $dm->id))
+        );
+});

--- a/tests/Feature/Channels/OpenDirectMessageTest.php
+++ b/tests/Feature/Channels/OpenDirectMessageTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelType;
+use App\Enums\ChannelVisibility;
+use App\Enums\NotificationLevel;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Add a user to the team as a plain member and return them.
+ */
+function dmTeamMember(Team $team): User
+{
+    $user = User::factory()->create();
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+
+    return $user;
+}
+
+test('opening a direct message creates a private direct channel with both members', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = dmTeamMember($team);
+
+    $this->actingAs($owner)
+        ->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $other->id])
+        ->assertRedirect();
+
+    $dm = Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->firstOrFail();
+
+    expect($dm->type)->toBe(ChannelType::Direct)
+        ->and($dm->visibility)->toBe(ChannelVisibility::Private)
+        ->and($dm->name)->toBeNull()
+        ->and($dm->slug)->toStartWith('dm-')
+        ->and($dm->dm_key)->toBe(collect([$owner->id, $other->id])->sort()->implode(':'))
+        ->and($dm->members()->whereKey($owner->id)->exists())->toBeTrue()
+        ->and($dm->members()->whereKey($other->id)->exists())->toBeTrue()
+        ->and($dm->channelMembers()->where('user_id', $owner->id)->value('notification_level'))
+        ->toBe(NotificationLevel::All);
+});
+
+test('opening a direct message redirects to the channel via its synthetic slug', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = dmTeamMember($team);
+
+    $response = $this->actingAs($owner)
+        ->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $other->id]);
+
+    $dm = Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->firstOrFail();
+
+    $response->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]));
+});
+
+test('opening a direct message twice in either direction yields the same channel', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = dmTeamMember($team);
+
+    $this->actingAs($owner)
+        ->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $other->id]);
+    $this->actingAs($other)
+        ->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $owner->id]);
+
+    expect(Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->count())->toBe(1);
+});
+
+test('a user can open a self direct message rendering a single member', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)
+        ->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $owner->id])
+        ->assertRedirect();
+
+    $dm = Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->firstOrFail();
+
+    expect($dm->dm_key)->toBe($owner->id)
+        ->and($dm->members()->count())->toBe(1)
+        ->and($dm->members()->whereKey($owner->id)->exists())->toBeTrue();
+});
+
+test('opening a self direct message twice yields the same channel', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $owner->id]);
+    $this->actingAs($owner)->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $owner->id]);
+
+    expect(Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->count())->toBe(1);
+});
+
+test('a direct message cannot be opened with a non-team-member', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $outsider = User::factory()->create();
+
+    $this->actingAs($owner)
+        ->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $outsider->id])
+        ->assertSessionHasErrors('user_id');
+
+    expect(Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->exists())->toBeFalse();
+});
+
+test('opening a direct message requires an existing user', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)
+        ->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => 'not-a-user'])
+        ->assertSessionHasErrors('user_id');
+});
+
+test('a non-team-member cannot open a direct message in the team', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $outsider = User::factory()->create();
+
+    $this->actingAs($outsider)
+        ->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $owner->id])
+        ->assertForbidden();
+});
+
+test('a direct channel resolves through the existing channel show route', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = dmTeamMember($team);
+
+    $this->actingAs($owner)->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $other->id]);
+    $dm = Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->firstOrFail();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]))
+        ->assertOk();
+});
+
+test('a team member who is not a participant cannot view a direct message', function () {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = dmTeamMember($team);
+    $bystander = dmTeamMember($team);
+
+    $this->actingAs($owner)->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $other->id]);
+    $dm = Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->firstOrFail();
+
+    $this->actingAs($bystander)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]))
+        ->assertForbidden();
+});


### PR DESCRIPTION
Backend + data foundation for 1:1 DMs. **Merges into the epic branch `feat/direct-messages-176`, not master.**

## What's here
- **Migration**: `channels.type` (`standard`|`direct`, `group_direct` reserved), nullable `dm_key` + `unique(team_id, dm_key)`, `name` made nullable.
- **Channel model**: `type` cast, `isDirect()`, viewer-relative `directParticipantFor()`.
- **`OpenDirectMessage` action**: find-or-create by sorted-participant `dm_key` in a transaction; self-DM allowed; private, synthetic `dm-<shortid>` slug, null name, both members added with `notification_level = all`.
- **`POST t/{team}/dm`** endpoint (Wayfinder-typed) + `OpenDirectMessageRequest` enforcing the target shares the team (self allowed, non-UUID/non-member rejected).
- **Guards**: DMs can't be archived, excluded from browse; only created via the open-or-create flow.
- **`ChannelData`**: viewer-relative `name`, `isDirect`, `dmUserId` for the sidebar/masthead.

## Acceptance criteria
- ✅ Opening a DM twice (either direction) yields the same channel (unique index); self-DM covered.
- ✅ A DM resolves through the existing `channels.show` route via its synthetic slug.
- ✅ Non-team-member and create-as-direct attempts rejected; tests prove it.
- ✅ Gates green: `composer test` 100% coverage, Pint, PHPStan, and `lint:check`/`format:check`/`types:check`/`build`.

Part of #176. Closes #177.