### PR TITLE
DMs: realtime new-DM delivery (per-user channel) (#180)

### DIFF
--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Channels;
 
 use App\Data\MessageData;
+use App\Events\DirectMessageStarted;
 use App\Events\MessageSent;
 use App\Events\MessageUpdated;
 use App\Models\Channel;
@@ -57,6 +58,8 @@ class PostMessage
             $message->loadMessageDataRelations();
             MessageSent::dispatch($channel, MessageData::fromMessage($message));
 
+            $this->announceFirstDirectMessage($channel, $author);
+
             if ($threadRootId !== null) {
                 $this->bumpThreadRoot($channel, $threadRootId);
             } elseif ($clearDraft) {
@@ -68,6 +71,25 @@ class PostMessage
         }
 
         return $message;
+    }
+
+    /**
+     * When a direct message receives its very first message, notify the other
+     * participant(s) on their private `user.{id}` channel so the DM appears in
+     * their sidebar live. Only the first message announces — thereafter the DM is
+     * already listed and the sidebar fleet keeps its badge current. A self-DM has
+     * no other participant, so nothing is announced.
+     */
+    private function announceFirstDirectMessage(Channel $channel, User $author): void
+    {
+        if (! $channel->isDirect() || $channel->messages()->count() !== 1) {
+            return;
+        }
+
+        $channel->members()
+            ->where('users.id', '!=', $author->id)
+            ->pluck('users.id')
+            ->each(fn (string $recipientId) => DirectMessageStarted::dispatch($recipientId, $channel->id));
     }
 
     /**

--- a/app/Events/DirectMessageStarted.php
+++ b/app/Events/DirectMessageStarted.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fired to a DM recipient when the conversation receives its first message, so
+ * their sidebar can surface the freshly-visible DM without a manual reload.
+ *
+ * It carries no message content — only the channel id — and rides the
+ * recipient's own private `user.{id}` channel, so nothing about the DM leaks
+ * onto the shared team presence channel. The client responds by reloading the
+ * `channels` prop, whose counts are recomputed server-side (so the unread badge
+ * is correct even if the reload lands after the message itself).
+ */
+class DirectMessageStarted implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public string $recipientId,
+        public string $channelId,
+    ) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('user.'.$this->recipientId),
+        ];
+    }
+
+    /**
+     * Get the data to broadcast.
+     *
+     * @return array<string, string>
+     */
+    public function broadcastWith(): array
+    {
+        return ['channelId' => $this->channelId];
+    }
+}

--- a/resources/js/composables/useNewDirectMessages.ts
+++ b/resources/js/composables/useNewDirectMessages.ts
@@ -1,0 +1,40 @@
+import { router, usePage } from '@inertiajs/vue3';
+import { echo } from '@laravel/echo-vue';
+import { computed, onBeforeUnmount, onMounted } from 'vue';
+
+/**
+ * Surface a brand-new direct message in the sidebar live.
+ *
+ * An empty DM the recipient was never messaged in is hidden from them (see the
+ * sidebar listing predicate), so when someone messages them for the first time
+ * the DM must appear without a manual reload. This subscribes to the viewer's
+ * own private `user.{id}` channel and, on a `DirectMessageStarted` signal,
+ * reloads only the `channels` prop: the DM then passes the predicate and the
+ * sidebar fleet auto-subscribes to `channel.{dmId}`. Counts are recomputed
+ * server-side, so the unread badge is correct even if the reload lands after
+ * the first message itself.
+ */
+export function useNewDirectMessages(): void {
+    const page = usePage();
+
+    const currentUserId = computed(() => String(page.props.auth.user.id));
+
+    function channelName(): string {
+        return `user.${currentUserId.value}`;
+    }
+
+    // Echo opens a websocket, so touch it only in the browser (never on the SSR
+    // pass). The authenticated user is stable for the session, so a single
+    // subscribe/teardown pair is enough.
+    onMounted(() => {
+        echo()
+            .private(channelName())
+            .listen('DirectMessageStarted', () => {
+                router.reload({ only: ['channels'] });
+            });
+    });
+
+    onBeforeUnmount(() => {
+        echo().leave(channelName());
+    });
+}

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -69,6 +69,7 @@ import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useInitials } from '@/composables/useInitials';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
 import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
+import { useNewDirectMessages } from '@/composables/useNewDirectMessages';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
@@ -101,6 +102,10 @@ useChimeNotifications();
 // Keep the sidebar unread/mention badges live as messages arrive in channels the
 // user is a member of but not currently viewing.
 useSidebarBadges();
+
+// Surface a brand-new direct message in the sidebar the moment someone messages
+// the viewer for the first time, without a manual reload.
+useNewDirectMessages();
 
 const currentTeam = computed(() => page.props.currentTeam);
 const teams = computed(() => page.props.teams ?? []);

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -18,6 +18,17 @@ Broadcast::channel('channel.{channelId}', function (User $user, string $channelI
 });
 
 /**
+ * Authorize a user's own private notification channel.
+ *
+ * Only the user themselves may subscribe to `user.{id}`, which delivers
+ * personal signals such as a brand-new direct message appearing in their
+ * sidebar. No other member of the team can listen in.
+ */
+Broadcast::channel('user.{userId}', function (User $user, string $userId): bool {
+    return $user->id === $userId;
+});
+
+/**
  * Track which team members are currently online.
  *
  * Only members of the team may join, and the identity returned here becomes

--- a/tests/Feature/Channels/DirectMessageRealtimeTest.php
+++ b/tests/Feature/Channels/DirectMessageRealtimeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use App\Actions\Channels\OpenDirectMessage;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Events\DirectMessageStarted;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+
+/**
+ * A team owner plus a second member.
+ *
+ * @return array{0: User, 1: Team, 2: User}
+ */
+function realtimeTeamWithMember(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = User::factory()->create();
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+
+    return [$owner, $team, $other];
+}
+
+/**
+ * Switch to a real broadcaster so routes/channels.php authorization runs.
+ */
+function useRealBroadcasterForDm(): void
+{
+    config(['broadcasting.default' => 'reverb']);
+
+    require base_path('routes/channels.php');
+}
+
+function postDmMessage(User $author, Team $team, Channel $dm, string $body): void
+{
+    test()->actingAs($author)->post(route('channels.messages.store', [
+        'team' => $team->slug,
+        'channel' => $dm->slug,
+    ]), ['body' => $body, 'client_uuid' => (string) Str::uuid7()]);
+}
+
+test('the first message in a direct message announces to the recipient user channel', function () {
+    Event::fake([DirectMessageStarted::class]);
+
+    [$owner, $team, $other] = realtimeTeamWithMember();
+    $dm = app(OpenDirectMessage::class)->handle($team, $owner, $other);
+
+    postDmMessage($owner, $team, $dm, 'Hey there');
+
+    Event::assertDispatched(DirectMessageStarted::class, function (DirectMessageStarted $event) use ($dm, $other) {
+        $target = $event->broadcastOn()[0];
+
+        expect($target)->toBeInstanceOf(PrivateChannel::class)
+            ->and($target->name)->toBe('private-user.'.$other->id);
+
+        return $event->recipientId === $other->id
+            && $event->channelId === $dm->id
+            && $event->broadcastWith() === ['channelId' => $dm->id];
+    });
+});
+
+test('only the first direct message announces; later messages do not', function () {
+    Event::fake([DirectMessageStarted::class]);
+
+    [$owner, $team, $other] = realtimeTeamWithMember();
+    $dm = app(OpenDirectMessage::class)->handle($team, $owner, $other);
+
+    postDmMessage($owner, $team, $dm, 'first');
+    postDmMessage($owner, $team, $dm, 'second');
+    postDmMessage($other, $team, $dm, 'third');
+
+    Event::assertDispatchedTimes(DirectMessageStarted::class, 1);
+});
+
+test('a self direct message announces to no one', function () {
+    Event::fake([DirectMessageStarted::class]);
+
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $dm = app(OpenDirectMessage::class)->handle($team, $owner, $owner);
+
+    postDmMessage($owner, $team, $dm, 'note to self');
+
+    Event::assertNotDispatched(DirectMessageStarted::class);
+});
+
+test('a message in a standard channel never announces a direct message', function () {
+    Event::fake([DirectMessageStarted::class]);
+
+    [$owner, $team] = realtimeTeamWithMember();
+    $general = Channel::where('team_id', $team->id)->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+
+    postDmMessage($owner, $team, $general, 'hello channel');
+
+    Event::assertNotDispatched(DirectMessageStarted::class);
+});
+
+test('a user may subscribe to their own user channel', function () {
+    useRealBroadcasterForDm();
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post('/broadcasting/auth', [
+            'channel_name' => 'private-user.'.$user->id,
+            'socket_id' => '1234.5678',
+        ])
+        ->assertOk();
+});
+
+test('a user cannot subscribe to another user channel', function () {
+    useRealBroadcasterForDm();
+
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post('/broadcasting/auth', [
+            'channel_name' => 'private-user.'.$other->id,
+            'socket_id' => '1234.5678',
+        ])
+        ->assertForbidden();
+});


### PR DESCRIPTION
Deliver a brand-new DM to the recipient's sidebar live. **Merges into the epic branch `feat/direct-messages-176`.**

## What's here
- **`user.{id}` private channel** authorized in `routes/channels.php` so only that user may subscribe.
- **First-message announce**: `PostMessage` dispatches `DirectMessageStarted` to each other participant's `user.{id}` channel on a DM's first message only (self-DM → no one; later messages / standard channels → nothing). Payload is just the channel id — no content on the shared `team.{id}` channel.
- **Client**: `useNewDirectMessages` subscribes to the viewer's own `user.{id}` and, on the signal, `router.reload({ only: ['channels'] })`; the DM passes the sidebar predicate and the fleet auto-subscribes to `channel.{dmId}`. Server-computed counts keep the badge correct across the reload race.

## Acceptance criteria
- ✅ A messaging B for the first time makes the DM appear in B's sidebar without a manual reload, with the correct unread badge.
- ✅ `user.{id}` rejects other users; broadcast-auth test covers it.
- ✅ No DM existence/content leaks onto `team.{id}`.
- ✅ Gates green: `composer test` 100% coverage, Pint, PHPStan, `lint:check`/`format:check`/`types:check`/`test:js`/`build`.

Part of #176. Closes #180.