### PR TITLE
fix(docker): mount pgsql volume at /var/lib/postgresql for Postgres 18

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -73,7 +73,10 @@ services:
       POSTGRES_USER: ${DB_USERNAME:-laravel}
       POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
     volumes:
-      - pgsql-data:/var/lib/postgresql/data
+      # Postgres 18+ stores data in a major-version subdirectory and expects the
+      # mount at /var/lib/postgresql (not /var/lib/postgresql/data, the pre-18
+      # path); mounting the old path makes the container refuse to start.
+      - pgsql-data:/var/lib/postgresql
     restart: unless-stopped
     networks:
       - app


### PR DESCRIPTION
## Summary

The prod stack failed to come up because `postgres:18-alpine` refuses to start when the data volume is mounted at the pre-18 `/var/lib/postgresql/data` path. That left `pgsql` unhealthy, cascading into every dependent service's `depends_on` (`meilisearch`, `app`, `reverb`, `queue`, `scheduler`).

Postgres 18 stores data in a major-version subdirectory and expects the mount at **`/var/lib/postgresql`**. This changes the mount point accordingly.

## Verification

Ran `postgres:18-alpine` with the new mount from a clean volume:

- `pg_isready` passes in ~3s.
- Image creates its `18/` version subdir; `PGDATA=/var/lib/postgresql/18/docker`.
- No "unused mount/volume" error in the logs.

## Migration note for existing deployments

Operators with an existing `pgsql-data` volume populated at the old `/var/lib/postgresql/data` path will need to migrate, since the mount point moves. Fresh installs are unaffected.

Fixes #223