### PR TITLE
chore(search): bump Meilisearch to v1.49 and auto-reindex on volume rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ docker compose -f docker-compose.prod.yml up -d --build
 ```
 
 Your data persists across `down`/`up` in named volumes (`pgsql-data`,
-`meili-data`, `storage-app`).
+`the-desk-meili-<version>`, `storage-app`).
+
+> **Meilisearch upgrades reindex automatically.** The search index lives in a
+> version-scoped volume, so bumping `MEILISEARCH_VERSION` starts the new
+> Meilisearch on a fresh volume and the app rebuilds the index from Postgres on
+> boot (`php artisan search:sync`) — no manual dump/migration. The old volume is
+> left behind; prune it with `docker volume rm the-desk-meili-<old-version>`.
 
 > **MAJOR version upgrades may contain breaking changes.** Before upgrading
 > across a major version, read the [CHANGELOG](CHANGELOG.md) and the

--- a/app/Console/Commands/SearchIndexSyncCommand.php
+++ b/app/Console/Commands/SearchIndexSyncCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Message;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Meilisearch\Client;
+use Meilisearch\Exceptions\ApiException;
+
+/**
+ * Rebuild the Meilisearch search index when it is empty.
+ *
+ * Meilisearch's on-disk format changes between versions, so the production
+ * stack pins the index to a version-scoped named volume; bumping the pinned
+ * tag rotates the volume and Meilisearch boots against an empty data directory.
+ * The search index is derived data (the database is the source of truth), so
+ * this command repopulates it from the database instead of running a
+ * dump-based Meilisearch migration. It runs on boot and is a no-op once the
+ * index is already populated.
+ */
+#[Signature('search:sync')]
+#[Description('Import searchable models into Meilisearch when the index is empty (e.g. after a volume reset)')]
+class SearchIndexSyncCommand extends Command
+{
+    /**
+     * Searchable models to keep in sync with the search index.
+     *
+     * @var list<class-string<Message>>
+     */
+    private const SEARCHABLE_MODELS = [
+        Message::class,
+    ];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(Client $meilisearch): int
+    {
+        if (config('scout.driver') !== 'meilisearch') {
+            $this->info('Search driver is not Meilisearch; nothing to sync.');
+
+            return self::SUCCESS;
+        }
+
+        foreach (self::SEARCHABLE_MODELS as $model) {
+            $this->syncModel($meilisearch, $model);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Import the model when its index is empty but the database has records.
+     *
+     * @param  class-string<Message>  $model
+     */
+    private function syncModel(Client $meilisearch, string $model): void
+    {
+        $indexed = $this->indexedDocumentCount($meilisearch, (new $model)->searchableAs());
+
+        if ($indexed > 0) {
+            $this->info("[{$model}] index already holds {$indexed} document(s); skipping.");
+
+            return;
+        }
+
+        $pending = $model::query()->count();
+
+        if ($pending === 0) {
+            $this->info("[{$model}] has no records to index; skipping.");
+
+            return;
+        }
+
+        $this->info("[{$model}] index is empty; importing {$pending} record(s)...");
+        $model::makeAllSearchable();
+    }
+
+    /**
+     * Number of documents currently held in the model's Meilisearch index.
+     *
+     * A fresh volume has no index yet, which Meilisearch reports as a 404;
+     * treat that (and any missing counter) as an empty index.
+     */
+    private function indexedDocumentCount(Client $meilisearch, string $index): int
+    {
+        try {
+            $stats = $meilisearch->index($index)->stats();
+        } catch (ApiException) {
+            return 0;
+        }
+
+        return (int) ($stats['numberOfDocuments'] ?? 0);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
+use Meilisearch\Client;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -15,7 +16,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(Client::class, fn (): Client => new Client(
+            config('scout.meilisearch.host'),
+            config('scout.meilisearch.key'),
+        ));
     }
 
     /**

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -87,7 +87,13 @@ services:
       retries: 5
 
   meilisearch:
-    image: getmeili/meilisearch:v1.49
+    # Meilisearch's on-disk format is version-specific and it will refuse to
+    # boot against a data directory written by a different version. MEILISEARCH_VERSION
+    # pins both the image tag and the data volume name (see `volumes` below), so
+    # bumping it starts the new version against a fresh volume; the app then
+    # rebuilds the index from Postgres on boot (`php artisan search:sync`). No
+    # dump-based migration is needed — the search index is derived data.
+    image: getmeili/meilisearch:${MEILISEARCH_VERSION:-v1.49}
     environment:
       MEILI_MASTER_KEY: ${MEILISEARCH_KEY:?MEILISEARCH_KEY is required}
       MEILI_ENV: production
@@ -110,4 +116,8 @@ networks:
 volumes:
   pgsql-data:
   meili-data:
+    # Version-scoped so a MEILISEARCH_VERSION bump lands on a new empty volume and
+    # the new Meilisearch boots cleanly. The previous version's volume is left
+    # behind for manual pruning (`docker volume rm the-desk-meili-<old>`).
+    name: the-desk-meili-${MEILISEARCH_VERSION:-v1.49}
   storage-app:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -87,7 +87,7 @@ services:
       retries: 5
 
   meilisearch:
-    image: getmeili/meilisearch:v1.16
+    image: getmeili/meilisearch:v1.49
     environment:
       MEILI_MASTER_KEY: ${MEILISEARCH_KEY:?MEILISEARCH_KEY is required}
       MEILI_ENV: production

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,6 +16,11 @@ mkdir -p \
 if [ "${AUTORUN_MIGRATIONS:-false}" = "true" ]; then
     echo "Running database migrations..."
     php artisan migrate --force
+
+    # Rebuild the search index if it is empty (e.g. after a Meilisearch version
+    # bump rotated its data volume). No-op once the index is populated.
+    echo "Syncing search index..."
+    php artisan search:sync
 fi
 
 # Cache config/routes/events against the runtime environment (compose injects it

--- a/tests/Feature/Console/SearchIndexSyncCommandTest.php
+++ b/tests/Feature/Console/SearchIndexSyncCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Models\Message;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Scout\Jobs\MakeSearchable;
+use Meilisearch\Client;
+use Meilisearch\Endpoints\Indexes;
+use Meilisearch\Exceptions\ApiException;
+
+/**
+ * Bind a fake Meilisearch client whose `messages` index reports the given
+ * document count, so the command can decide whether a reindex is needed
+ * without talking to a real Meilisearch instance.
+ */
+function fakeMeilisearchDocumentCount(int $documents): void
+{
+    $index = Mockery::mock(Indexes::class);
+    $index->shouldReceive('stats')->andReturn(['numberOfDocuments' => $documents]);
+
+    test()->mock(Client::class, function ($mock) use ($index): void {
+        $mock->shouldReceive('index')->with('messages')->andReturn($index);
+    });
+}
+
+it('does nothing when the search driver is not meilisearch', function (): void {
+    config()->set('scout.driver', 'collection');
+    Queue::fake();
+
+    $this->artisan('search:sync')
+        ->expectsOutputToContain('not Meilisearch')
+        ->assertSuccessful();
+
+    Queue::assertNothingPushed();
+});
+
+it('imports records when the meilisearch index is empty', function (): void {
+    config()->set('scout.driver', 'meilisearch');
+    Queue::fake();
+    fakeMeilisearchDocumentCount(0);
+
+    Message::withoutSyncingToSearch(fn () => Message::factory()->count(3)->create());
+
+    $this->artisan('search:sync')->assertSuccessful();
+
+    Queue::assertPushed(MakeSearchable::class);
+});
+
+it('imports when the meilisearch index does not exist yet', function (): void {
+    config()->set('scout.driver', 'meilisearch');
+    Queue::fake();
+
+    $index = Mockery::mock(Indexes::class);
+    $index->shouldReceive('stats')->andThrow(new ApiException(
+        new Response(404, [], (string) json_encode(['code' => 'index_not_found'])),
+        ['code' => 'index_not_found'],
+    ));
+    $this->mock(Client::class, fn ($mock) => $mock->shouldReceive('index')->andReturn($index));
+
+    Message::withoutSyncingToSearch(fn () => Message::factory()->count(2)->create());
+
+    $this->artisan('search:sync')->assertSuccessful();
+
+    Queue::assertPushed(MakeSearchable::class);
+});
+
+it('skips import when the meilisearch index is already populated', function (): void {
+    config()->set('scout.driver', 'meilisearch');
+    Queue::fake();
+    fakeMeilisearchDocumentCount(5);
+
+    Message::withoutSyncingToSearch(fn () => Message::factory()->count(3)->create());
+
+    $this->artisan('search:sync')->assertSuccessful();
+
+    Queue::assertNotPushed(MakeSearchable::class);
+});
+
+it('skips import when there are no records to index', function (): void {
+    config()->set('scout.driver', 'meilisearch');
+    Queue::fake();
+    fakeMeilisearchDocumentCount(0);
+
+    $this->artisan('search:sync')->assertSuccessful();
+
+    Queue::assertNotPushed(MakeSearchable::class);
+});


### PR DESCRIPTION
Closes #222

## Summary

Bumps the pinned Meilisearch tag from `v1.16` to `v1.49` and adds an automatic reindex path so future version bumps don't require a manual dump-based migration.

Meilisearch's on-disk format is version-specific, so a newer binary refuses to boot against an older version's data directory. Since Postgres is the source of truth and the search index is derived data, we sidestep dump migration entirely: scope the data volume to the version, and rebuild the index from the database on boot.

## Changes

- **Pin bump** — `getmeili/meilisearch:v1.16` → `v1.49`, still explicitly pinned (not `:latest`).
- **Version-scoped volume** — `MEILISEARCH_VERSION` now drives both the image tag and the data-volume name (`the-desk-meili-${MEILISEARCH_VERSION}`), so a bump starts the new version on a fresh empty volume that boots cleanly. The old volume is left for manual pruning.
- **`search:sync` command** — for each searchable model (`Message`), imports from the database only when the Meilisearch index is empty (idempotent no-op once populated, when there are no records, or when the driver isn't Meilisearch). A missing index (404 on a fresh volume) counts as empty.
- **Boot wiring** — entrypoint runs `php artisan search:sync` after migrations, gated to the `app` service (same `AUTORUN_MIGRATIONS` guard) so containers don't race.
- **Container binding** for the Meilisearch client (injectable + mockable), plus an operator note in the README.

## Upgrade path (replaces AC #3's dump docs)

The version-scoped volume + boot reindex *is* the upgrade path — bump `MEILISEARCH_VERSION`, redeploy, and the index rebuilds automatically. No manual dump/import step.

## Testing

- 5 new tests cover the command's branches (non-Meili driver, empty index, missing index, populated index, no records) via a mocked Meilisearch client + `Queue::fake()`.
- Full gate green: Pint, PHPStan, and `artisan test --coverage --min=100` → **759 tests, 100.0%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)