### PR TITLE
refactor(channels): decompose Show.vue into composables and components

### DIFF
--- a/resources/js/components/ChannelEmptyState.vue
+++ b/resources/js/components/ChannelEmptyState.vue
@@ -1,0 +1,211 @@
+<script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
+import { Send, UserPlus } from '@lucide/vue';
+import { computed, ref } from 'vue';
+import CreateChannelModal from '@/components/CreateChannelModal.vue';
+import InviteMemberModal from '@/components/InviteMemberModal.vue';
+import { useOnboardingTour } from '@/composables/useOnboardingTour';
+import type { Channel } from '@/types';
+
+const props = defineProps<{
+    channel: Channel;
+    // Whether the open DM is the viewer's own space, tuning the empty-state copy.
+    isSelfDm: boolean;
+    teamName: string;
+    teamSlug: string;
+}>();
+
+const emit = defineEmits<{
+    focusComposer: [];
+}>();
+
+const page = usePage();
+
+// The brand-new-workspace welcome replaces the plain "no messages" empty state on
+// a fresh #general for a user who has not yet completed onboarding — the reachable
+// "first channel, first message" moment. Any other empty channel/DM keeps the
+// plain copy.
+const showWelcome = computed(
+    () =>
+        props.channel.slug === 'general' &&
+        page.props.auth.user.onboarding_completed_at == null,
+);
+
+// The welcome's "Invite your teammates" action reuses the member-invite modal,
+// gated on the same permission and roles the workspace already shares.
+const inviteOpen = ref(false);
+const canInviteToCurrentTeam = computed(
+    () => page.props.canInviteToCurrentTeam ?? false,
+);
+const invitableRoles = computed(() => page.props.invitableRoles ?? []);
+const currentTeamForInvite = computed(() => page.props.currentTeam);
+
+const { open: openOnboardingTour } = useOnboardingTour();
+</script>
+
+<template>
+    <div class="flex h-full flex-col items-center justify-center gap-1 px-6">
+        <!-- Brand-new workspace: the reachable first-run welcome, shown on an
+             empty #general until the viewer completes onboarding. -->
+        <div
+            v-if="showWelcome"
+            data-test="workspace-welcome"
+            class="flex w-full max-w-[460px] flex-col items-center text-center"
+        >
+            <svg width="52" height="52" viewBox="0 0 40 40" aria-hidden="true">
+                <polygon
+                    points="20,18 36,27 20,36 4,27"
+                    class="fill-foreground/40"
+                />
+                <polygon
+                    points="20,11 36,20 20,29 4,20"
+                    class="fill-foreground/70"
+                />
+                <polygon points="20,4 36,13 20,22 4,13" class="fill-brass" />
+            </svg>
+            <h2
+                class="mt-5 font-serif text-[30px] font-semibold tracking-[-0.015em] text-foreground"
+            >
+                {{ $t('Welcome to :team', { team: props.teamName }) }}
+            </h2>
+            <p
+                class="mt-3 max-w-[400px] text-[15px] leading-[1.6] text-muted-foreground"
+            >
+                {{
+                    $t(
+                        'Your workspace is ready. A few small steps and it starts feeling like home.',
+                    )
+                }}
+            </p>
+
+            <div class="mt-7 flex w-full flex-col gap-2.5">
+                <CreateChannelModal :team-slug="props.teamSlug">
+                    <button
+                        type="button"
+                        data-test="welcome-create-channel"
+                        class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
+                    >
+                        <span
+                            class="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-brass-fill text-[16px] font-semibold text-brass-fill-foreground"
+                            >#</span
+                        >
+                        <span class="flex flex-1 flex-col">
+                            <span
+                                class="text-[14.5px] font-semibold text-foreground"
+                                >{{ $t('Create your first channel') }}</span
+                            >
+                            <span class="text-[12.5px] text-muted-foreground">{{
+                                $t('Group conversations by topic or project')
+                            }}</span>
+                        </span>
+                        <span
+                            class="inline-flex h-9 items-center rounded-full bg-primary px-4 text-[13px] font-semibold text-primary-foreground"
+                            >{{ $t('Create') }}</span
+                        >
+                    </button>
+                </CreateChannelModal>
+
+                <button
+                    v-if="canInviteToCurrentTeam"
+                    type="button"
+                    data-test="welcome-invite"
+                    class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
+                    @click="inviteOpen = true"
+                >
+                    <span
+                        class="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-brass-fill text-brass-fill-foreground"
+                    >
+                        <UserPlus class="size-[17px]" />
+                    </span>
+                    <span class="flex flex-1 flex-col">
+                        <span
+                            class="text-[14.5px] font-semibold text-foreground"
+                            >{{ $t('Invite your teammates') }}</span
+                        >
+                        <span class="text-[12.5px] text-muted-foreground">{{
+                            $t('A workspace comes alive with people')
+                        }}</span>
+                    </span>
+                    <span
+                        class="inline-flex h-9 items-center rounded-full border border-input bg-background px-4 text-[13px] font-semibold text-foreground"
+                        >{{ $t('Invite') }}</span
+                    >
+                </button>
+
+                <button
+                    type="button"
+                    data-test="welcome-post-message"
+                    class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
+                    @click="emit('focusComposer')"
+                >
+                    <span
+                        class="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-brass-fill text-brass-fill-foreground"
+                    >
+                        <Send class="size-[16px]" />
+                    </span>
+                    <span class="flex flex-1 flex-col">
+                        <span
+                            class="text-[14.5px] font-semibold text-foreground"
+                            >{{ $t('Post your first message') }}</span
+                        >
+                        <span class="text-[12.5px] text-muted-foreground">{{
+                            $t('Break the ice — even a wave counts')
+                        }}</span>
+                    </span>
+                    <span
+                        class="inline-flex h-9 items-center rounded-full border border-input bg-background px-4 text-[13px] font-semibold text-foreground"
+                        >{{ $t('Compose') }}</span
+                    >
+                </button>
+            </div>
+
+            <p class="mt-5 text-[12.5px] text-muted-foreground">
+                {{ $t('Prefer to explore on your own?') }}
+                <button
+                    type="button"
+                    data-test="welcome-take-tour"
+                    class="font-semibold text-brass-fill-foreground hover:underline"
+                    @click="openOnboardingTour"
+                >
+                    {{ $t('Take the 30-second tour') }}
+                </button>
+            </p>
+        </div>
+
+        <!-- Every other empty channel or DM. -->
+        <template v-else>
+            <div
+                class="font-serif text-[64px] leading-none text-border italic"
+                aria-hidden="true"
+            >
+                {{ props.channel.isDirect ? '@' : '#' }}
+            </div>
+            <p
+                class="mt-1.5 font-serif text-[20px] font-semibold text-foreground"
+            >
+                {{ $t('No messages yet') }}
+            </p>
+            <p class="text-[13.5px] text-muted-foreground">
+                {{
+                    props.channel.isDirect
+                        ? props.isSelfDm
+                            ? $t('This is your space — jot anything down.')
+                            : $t(
+                                  'This is the start of your conversation with :name.',
+                                  { name: props.channel.name },
+                              )
+                        : $t('Be the first to say something in #:channel.', {
+                              channel: props.channel.name,
+                          })
+                }}
+            </p>
+        </template>
+
+        <InviteMemberModal
+            v-if="currentTeamForInvite && canInviteToCurrentTeam"
+            v-model:open="inviteOpen"
+            :team="currentTeamForInvite"
+            :available-roles="invitableRoles"
+        />
+    </div>
+</template>

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -1,0 +1,290 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
+import { Archive, EllipsisVertical, Search, Star } from '@lucide/vue';
+import type { AcceptableValue } from 'reka-ui';
+import { computed } from 'vue';
+import { index as searchMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
+import {
+    DropdownMenu,
+    DropdownMenuCheckboxItem,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { getInitials } from '@/composables/useInitials';
+import { memberAvatarStack } from '@/lib/memberAvatars';
+import type { NotificationIndicator } from '@/lib/notificationIndicator';
+import type {
+    Channel,
+    Mention,
+    NotificationLevel,
+    NotificationLevelOption,
+} from '@/types';
+
+const props = defineProps<{
+    channel: Channel;
+    teamSlug: string;
+    // The team roster the page already carries for the composer, reused for the
+    // overlapping member facepile.
+    members: Mention[];
+    // Ids of team members currently online, driving the DM presence dot.
+    onlineIds: Set<string>;
+    // The viewer-relative title (self-DM reads "You"); the page also feeds it to
+    // `<Head>`, so it is resolved once there and passed down.
+    title: string;
+    canManagePreferences: boolean;
+    canArchive: boolean;
+    notificationLevels: NotificationLevelOption[];
+    starred: boolean;
+    muted: boolean;
+    notificationLevel: NotificationLevel;
+    // A compact header cue for a non-default notification state, or null.
+    notificationStatus: NotificationIndicator | null;
+}>();
+
+const emit = defineEmits<{
+    toggleStar: [];
+    notificationLevelChange: [value: AcceptableValue];
+    muteChange: [value: boolean];
+    archive: [];
+}>();
+
+// How many member avatars the masthead shows before collapsing the rest into a
+// single "+N" overflow chip.
+const MAX_MASTHEAD_AVATARS = 3;
+
+// The overlapping member avatars for the masthead's right side.
+const mastheadAvatars = computed(() =>
+    memberAvatarStack(props.members, MAX_MASTHEAD_AVATARS),
+);
+
+// A DM renders viewer-relative: the other participant's presence dot follows the
+// team roster. A DM is a fixed pair, so the "who's in the channel" facepile is
+// meaningless and hidden.
+const dmParticipantOnline = computed(
+    () =>
+        props.channel.dmUserId != null &&
+        props.onlineIds.has(props.channel.dmUserId),
+);
+</script>
+
+<template>
+    <header
+        class="flex shrink-0 items-end gap-4 border-b border-border px-7 pt-5 pb-3.5"
+    >
+        <SidebarTrigger
+            class="mb-1 -ml-1.5 size-8 shrink-0 text-muted-foreground md:hidden"
+        />
+
+        <div class="min-w-0 flex-1">
+            <h1
+                class="flex items-center gap-2 truncate font-serif text-[32px] leading-none font-semibold tracking-[-0.02em] text-foreground"
+            >
+                <!-- A DM shows the participant's avatar + presence dot instead of
+                     the channel "#"; the name is already viewer-relative (self
+                     reads "You"). -->
+                <span
+                    v-if="props.channel.isDirect"
+                    data-test="masthead-dm-avatar"
+                    class="relative inline-flex size-7 shrink-0"
+                >
+                    <span
+                        class="flex size-7 items-center justify-center rounded-full bg-primary/10 text-[11px] font-semibold text-primary select-none"
+                        aria-hidden="true"
+                        >{{ getInitials(props.channel.name) }}</span
+                    >
+                    <span
+                        :data-online="dmParticipantOnline"
+                        :aria-label="
+                            dmParticipantOnline ? $t('Online') : $t('Offline')
+                        "
+                        class="absolute -right-0.5 -bottom-0.5 size-2.5 rounded-full ring-2 ring-card"
+                        :class="
+                            dmParticipantOnline
+                                ? 'bg-emerald-500'
+                                : 'bg-muted-foreground/50'
+                        "
+                    />
+                </span>
+                <span v-else class="text-brass italic">#</span>
+                <span class="truncate">{{ props.title }}</span>
+                <!-- The mute / notification-level indicator sits inline with the
+                     title so it reads as a property of this conversation rather
+                     than floating in the meta row (which is empty for a DM with
+                     no topic). -->
+                <Tooltip v-if="props.notificationStatus">
+                    <TooltipTrigger as-child>
+                        <span
+                            data-test="notification-status"
+                            :data-status="props.notificationStatus.status"
+                            class="inline-flex shrink-0 items-center text-muted-foreground"
+                            :aria-label="$t(props.notificationStatus.label)"
+                        >
+                            <component
+                                :is="props.notificationStatus.icon"
+                                class="size-4"
+                            />
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipContent>{{
+                        $t(props.notificationStatus.label)
+                    }}</TooltipContent>
+                </Tooltip>
+            </h1>
+
+            <div
+                v-if="props.channel.isArchived || props.channel.topic"
+                class="mt-1.5 flex items-center gap-2 text-[13px] text-muted-foreground"
+            >
+                <span
+                    v-if="props.channel.isArchived"
+                    class="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+                >
+                    <Archive class="size-3" />
+                    {{ $t('Archived') }}
+                </span>
+
+                <p v-if="props.channel.topic" class="min-w-0 truncate">
+                    {{ props.channel.topic }}
+                </p>
+            </div>
+        </div>
+
+        <div class="flex shrink-0 items-center gap-3 pb-1">
+            <span
+                v-if="
+                    !props.channel.isDirect &&
+                    mastheadAvatars.visible.length > 0
+                "
+                data-test="masthead-members"
+                class="flex -space-x-1.5"
+            >
+                <span
+                    v-for="member in mastheadAvatars.visible"
+                    :key="member.id"
+                    class="flex size-6 items-center justify-center rounded-full bg-primary/10 text-[9px] font-semibold text-primary ring-2 ring-card select-none"
+                    :title="member.name"
+                    aria-hidden="true"
+                >
+                    {{ getInitials(member.name) }}
+                </span>
+                <span
+                    v-if="mastheadAvatars.overflow > 0"
+                    class="flex size-6 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-card select-none"
+                    aria-hidden="true"
+                >
+                    +{{ mastheadAvatars.overflow }}
+                </span>
+            </span>
+
+            <Link
+                :href="searchMessages(props.teamSlug).url"
+                data-test="masthead-search"
+                :aria-label="$t('Search messages')"
+                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+                <Search class="size-4" />
+            </Link>
+
+            <DropdownMenu v-if="props.canManagePreferences || props.canArchive">
+                <DropdownMenuTrigger as-child>
+                    <button
+                        type="button"
+                        :aria-label="$t('Channel options')"
+                        data-test="channel-options"
+                        class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    >
+                        <EllipsisVertical class="size-4" />
+                    </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" class="w-56">
+                    <template v-if="props.canManagePreferences">
+                        <!-- Starring files a channel into the sidebar's "Starred"
+                             group; DMs live in their own fixed group and are never
+                             filed, so the affordance is hidden for them. -->
+                        <DropdownMenuItem
+                            v-if="!props.channel.isDirect"
+                            data-test="star-channel"
+                            :aria-pressed="props.starred"
+                            @select="
+                                (event: Event) => {
+                                    event.preventDefault();
+                                    emit('toggleStar');
+                                }
+                            "
+                        >
+                            <Star
+                                :class="
+                                    props.starred
+                                        ? 'fill-current text-amber-500'
+                                        : ''
+                                "
+                            />
+                            {{
+                                props.starred
+                                    ? $t('Unstar channel')
+                                    : $t('Star channel')
+                            }}
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator v-if="!props.channel.isDirect" />
+                        <DropdownMenuLabel
+                            class="text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
+                        >
+                            {{ $t('Notifications') }}
+                        </DropdownMenuLabel>
+                        <DropdownMenuRadioGroup
+                            :model-value="props.notificationLevel"
+                            @update:model-value="
+                                (value) =>
+                                    emit('notificationLevelChange', value)
+                            "
+                        >
+                            <DropdownMenuRadioItem
+                                v-for="level in props.notificationLevels"
+                                :key="level.value"
+                                :value="level.value"
+                                :data-test="`notification-level-${level.value}`"
+                            >
+                                {{ level.label }}
+                            </DropdownMenuRadioItem>
+                        </DropdownMenuRadioGroup>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuCheckboxItem
+                            :model-value="props.muted"
+                            data-test="mute-channel"
+                            @update:model-value="
+                                (value) => emit('muteChange', value)
+                            "
+                            @select="(event: Event) => event.preventDefault()"
+                        >
+                            {{ $t('Mute channel') }}
+                        </DropdownMenuCheckboxItem>
+                    </template>
+                    <template v-if="props.canArchive">
+                        <DropdownMenuSeparator
+                            v-if="props.canManagePreferences"
+                        />
+                        <DropdownMenuItem
+                            data-test="archive-channel"
+                            class="text-destructive focus:text-destructive"
+                            @select="emit('archive')"
+                        >
+                            <Archive class="size-4" />
+                            {{ $t('Archive channel') }}
+                        </DropdownMenuItem>
+                    </template>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    </header>
+</template>

--- a/resources/js/composables/useMessageActions.test.ts
+++ b/resources/js/composables/useMessageActions.test.ts
@@ -1,0 +1,449 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+
+const { post, patch, destroy, toastError, toastSuccess } = vi.hoisted(() => ({
+    post: vi.fn(),
+    patch: vi.fn(),
+    destroy: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post, patch, delete: destroy },
+}));
+vi.mock('vue-sonner', () => ({
+    toast: { error: toastError, success: toastSuccess },
+}));
+
+import { useMessageActions } from '@/composables/useMessageActions';
+import type { MessageActions } from '@/composables/useMessageActions';
+import { useMessageStream } from '@/composables/useMessageStream';
+import type { Mention, Message } from '@/types';
+import type { ForwardTarget } from '@/types/forward';
+
+type Stream = ReturnType<typeof useMessageStream>;
+
+/** A message carrying just the fields the actions read. */
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        reactions: [],
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        ...overrides,
+    };
+}
+
+const me: Mention = { id: 'me', name: 'Me' };
+const channel = {
+    id: 'chan-1',
+    slug: 'general',
+    name: 'general',
+    isDirect: false,
+};
+
+function harness(
+    setup: {
+        serverMain?: Message[];
+        serverThread?: Message[];
+        activeThreadRootId?: string | null;
+        replyTarget?: Message | null;
+        isNearBottom?: boolean;
+    } = {},
+) {
+    const scope = effectScope();
+    const cancelDraft = vi.fn();
+    const cancelReply = vi.fn();
+    const scrollToBottom = vi.fn();
+    const activeThreadRootId: Ref<string | null> = ref(
+        setup.activeThreadRootId ?? null,
+    );
+    const replyTarget: Ref<Message | null> = ref(setup.replyTarget ?? null);
+
+    let actions!: MessageActions;
+    let mainStream!: Stream;
+    let threadStream!: Stream;
+
+    scope.run(() => {
+        mainStream = useMessageStream(ref(setup.serverMain ?? []));
+        threadStream = useMessageStream(ref(setup.serverThread ?? []));
+        actions = useMessageActions({
+            teamSlug: () => 'acme',
+            channel: () => channel,
+            currentUser: () => me,
+            mainStream,
+            threadStream,
+            activeThreadRootId,
+            replyTarget,
+            isNearBottom: () => setup.isNearBottom ?? true,
+            scrollToBottom,
+            cancelDraft,
+            cancelReply,
+        });
+    });
+
+    return {
+        actions,
+        mainStream,
+        threadStream,
+        activeThreadRootId,
+        cancelDraft,
+        cancelReply,
+        scrollToBottom,
+        unmount: () => scope.stop(),
+    };
+}
+
+/** The options (third argument) of the nth recorded call on a router mock. */
+function optionsOf(
+    mock: typeof post,
+    call = 0,
+): {
+    only?: string[];
+    onError?: () => void;
+    onSuccess?: () => void;
+} {
+    return mock.mock.calls[call][2];
+}
+
+/** The payload (second argument) of the nth recorded call on a router mock. */
+function payloadOf(mock: typeof post, call = 0): Record<string, unknown> {
+    return mock.mock.calls[call][1];
+}
+
+/** `router.delete` takes its options as the second argument (no request body). */
+function deleteOptionsOf(call = 0): {
+    only?: string[];
+    onError?: () => void;
+    onSuccess?: () => void;
+} {
+    return destroy.mock.calls[call][1];
+}
+
+describe('useMessageActions', () => {
+    beforeEach(() => {
+        post.mockClear();
+        patch.mockClear();
+        destroy.mockClear();
+        toastError.mockClear();
+        toastSuccess.mockClear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('send', () => {
+        it('renders an optimistic row, clears draft/reply, and scrolls', async () => {
+            const h = harness({ replyTarget: message({ id: 'parent' }) });
+
+            h.actions.send('a new line', []);
+
+            expect(h.cancelDraft).toHaveBeenCalledOnce();
+            expect(h.cancelReply).toHaveBeenCalledOnce();
+            expect(
+                h.mainStream.displayMessages.value.some(
+                    (m) => m.body === 'a new line',
+                ),
+            ).toBe(true);
+            expect(payloadOf(post)).toMatchObject({
+                body: 'a new line',
+                reply_to_id: 'parent',
+            });
+
+            await nextTick();
+            expect(h.scrollToBottom).toHaveBeenCalled();
+        });
+
+        it('rolls the optimistic row back and toasts on error', () => {
+            const h = harness();
+
+            h.actions.send('doomed', []);
+            expect(h.mainStream.pendingUuids.value).toHaveLength(1);
+
+            optionsOf(post).onError?.();
+            expect(h.mainStream.pendingUuids.value).toHaveLength(0);
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('editMessage', () => {
+        it('patches optimistically and rolls back to the prior copy on error', () => {
+            const original = message({ body: 'before' });
+            const h = harness({ serverMain: [original] });
+
+            h.actions.editMessage(original, 'after');
+            expect(
+                h.mainStream.displayMessages.value.find((m) => m.id === 'm1')
+                    ?.body,
+            ).toBe('after');
+            expect(payloadOf(patch)).toEqual({ body: 'after' });
+
+            optionsOf(patch).onError?.();
+            expect(
+                h.mainStream.displayMessages.value.find((m) => m.id === 'm1')
+                    ?.body,
+            ).toBe('before');
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('deleteMessage', () => {
+        it('shows a tombstone optimistically and restores it on error', () => {
+            const original = message({ body: 'delete me' });
+            const h = harness({ serverMain: [original] });
+
+            h.actions.deleteMessage(original);
+            expect(
+                h.mainStream.displayMessages.value.find((m) => m.id === 'm1')
+                    ?.isDeleted,
+            ).toBe(true);
+
+            deleteOptionsOf().onError?.();
+            expect(
+                h.mainStream.displayMessages.value.find((m) => m.id === 'm1')
+                    ?.isDeleted,
+            ).toBe(false);
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('reactToMessage', () => {
+        it('patches reactions optimistically and rolls back on error', () => {
+            const original = message();
+            const h = harness({ serverMain: [original] });
+
+            h.actions.reactToMessage(original, '👍');
+            expect(
+                h.mainStream.displayMessages.value.find((m) => m.id === 'm1')
+                    ?.reactions,
+            ).toHaveLength(1);
+            expect(optionsOf(post).only).toEqual(['channels']);
+
+            optionsOf(post).onError?.();
+            expect(
+                h.mainStream.displayMessages.value.find((m) => m.id === 'm1')
+                    ?.reactions,
+            ).toHaveLength(0);
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('forwardMessage', () => {
+        const channelTarget = (
+            id: string,
+            name = 'elsewhere',
+        ): ForwardTarget => ({
+            kind: 'channel',
+            id,
+            name,
+        });
+
+        it('appends an optimistic copy when forwarding into the current channel', () => {
+            const h = harness();
+            const source = message({ id: 'src', body: 'original' });
+
+            h.actions.forwardMessage(source, {
+                target: channelTarget('chan-1'),
+                note: 'passing this on',
+            });
+
+            expect(h.mainStream.pendingUuids.value).toHaveLength(1);
+            expect(payloadOf(post)).toMatchObject({
+                body: 'passing this on',
+                target_channel_id: 'chan-1',
+            });
+
+            // A successful forward to the current channel stays silent — the echo
+            // confirms it — so no toast fires.
+            optionsOf(post).onSuccess?.();
+            expect(toastSuccess).not.toHaveBeenCalled();
+
+            // On error the optimistic copy is rolled back.
+            optionsOf(post).onError?.();
+            expect(h.mainStream.pendingUuids.value).toHaveLength(0);
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+
+        it('confirms a forward elsewhere with a toast and no optimistic row', () => {
+            const h = harness();
+            const source = message({ id: 'src' });
+
+            h.actions.forwardMessage(source, {
+                target: channelTarget('chan-2', 'random'),
+                note: '',
+            });
+
+            expect(h.mainStream.pendingUuids.value).toHaveLength(0);
+            expect(payloadOf(post)).toMatchObject({
+                target_channel_id: 'chan-2',
+            });
+
+            optionsOf(post).onSuccess?.();
+            expect(toastSuccess).toHaveBeenCalledOnce();
+        });
+
+        it('routes a person target to their DM', () => {
+            const h = harness();
+
+            h.actions.forwardMessage(message({ id: 'src' }), {
+                target: { kind: 'user', id: 'user-3', name: 'Grace' },
+                note: '',
+            });
+
+            expect(payloadOf(post)).toMatchObject({ target_user_id: 'user-3' });
+        });
+    });
+
+    describe('sendThreadReply', () => {
+        it('does nothing when no thread is open', () => {
+            const h = harness({ activeThreadRootId: null });
+
+            h.actions.sendThreadReply('into the void', []);
+
+            expect(post).not.toHaveBeenCalled();
+        });
+
+        it('adds a pending reply to the thread and marks the root followed', () => {
+            const root = message({ id: 'root-1' });
+            const h = harness({
+                serverMain: [root],
+                activeThreadRootId: 'root-1',
+            });
+
+            h.actions.sendThreadReply('a reply', []);
+
+            expect(h.threadStream.pendingUuids.value).toHaveLength(1);
+            // The root's dot clears in the main timeline.
+            expect(
+                h.mainStream.displayMessages.value.find(
+                    (m) => m.id === 'root-1',
+                )?.threadFollowed,
+            ).toBe(true);
+            expect(payloadOf(post)).toMatchObject({
+                thread_root_id: 'root-1',
+                sent_to_channel: false,
+            });
+        });
+
+        it('also echoes into the main timeline when sent to channel', () => {
+            const root = message({ id: 'root-1' });
+            const h = harness({
+                serverMain: [root],
+                activeThreadRootId: 'root-1',
+            });
+
+            h.actions.sendThreadReply('shared reply', [], true);
+
+            expect(h.threadStream.pendingUuids.value).toHaveLength(1);
+            expect(h.mainStream.pendingUuids.value).toHaveLength(1);
+
+            optionsOf(post).onError?.();
+            expect(h.threadStream.pendingUuids.value).toHaveLength(0);
+            expect(h.mainStream.pendingUuids.value).toHaveLength(0);
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('scheduleMessage', () => {
+        it('posts to the scheduled surface and toasts on success/error', () => {
+            const h = harness();
+
+            h.actions.scheduleMessage('later', [], '2024-06-01T09:00:00Z');
+
+            expect(h.cancelDraft).toHaveBeenCalledOnce();
+            expect(h.cancelReply).toHaveBeenCalledOnce();
+            expect(optionsOf(post).only).toEqual([
+                'scheduledMessages',
+                'channels',
+            ]);
+            expect(payloadOf(post)).toMatchObject({
+                body: 'later',
+                send_at: '2024-06-01T09:00:00Z',
+            });
+
+            optionsOf(post).onSuccess?.();
+            expect(toastSuccess).toHaveBeenCalledOnce();
+
+            optionsOf(post).onError?.();
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('updateScheduled', () => {
+        it('patches the scheduled message and toasts on error', () => {
+            const h = harness();
+
+            h.actions.updateScheduled({
+                id: 's1',
+                body: 'edited',
+                sendAt: '2024-06-02T09:00:00Z',
+            });
+
+            expect(optionsOf(patch).only).toEqual(['scheduledMessages']);
+            expect(payloadOf(patch)).toEqual({
+                body: 'edited',
+                send_at: '2024-06-02T09:00:00Z',
+            });
+
+            optionsOf(patch).onError?.();
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('cancelScheduled', () => {
+        it('deletes the scheduled message and toasts on success/error', () => {
+            const h = harness();
+
+            h.actions.cancelScheduled('s1');
+
+            expect(deleteOptionsOf().only).toEqual(['scheduledMessages']);
+
+            deleteOptionsOf().onSuccess?.();
+            expect(toastSuccess).toHaveBeenCalledOnce();
+
+            deleteOptionsOf().onError?.();
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('setReminder', () => {
+        it('posts the reminder and toasts on success/error', () => {
+            const h = harness();
+
+            h.actions.setReminder('m9', '2024-06-03T09:00:00Z');
+
+            expect(optionsOf(post).only).toEqual([
+                'reminders',
+                'firedReminders',
+            ]);
+            expect(payloadOf(post)).toEqual({
+                message_id: 'm9',
+                remind_at: '2024-06-03T09:00:00Z',
+            });
+
+            optionsOf(post).onSuccess?.();
+            expect(toastSuccess).toHaveBeenCalledOnce();
+
+            optionsOf(post).onError?.();
+            expect(toastError).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/resources/js/composables/useMessageActions.ts
+++ b/resources/js/composables/useMessageActions.ts
@@ -1,0 +1,529 @@
+import { router } from '@inertiajs/vue3';
+import { nextTick } from 'vue';
+import type { Ref } from 'vue';
+import { toast } from 'vue-sonner';
+import { store as forwardMessageAction } from '@/actions/App/Http/Controllers/Channels/ForwardMessageController';
+import {
+    destroy as destroyMessage,
+    store as storeMessage,
+    update as updateMessage,
+} from '@/actions/App/Http/Controllers/Channels/MessageController';
+import { store as remindMessage } from '@/actions/App/Http/Controllers/Channels/MessageReminderController';
+import { store as toggleReactionAction } from '@/actions/App/Http/Controllers/Channels/ReactionController';
+import {
+    destroy as destroyScheduledMessage,
+    store as storeScheduledMessage,
+    update as updateScheduledMessage,
+} from '@/actions/App/Http/Controllers/Channels/ScheduledMessageController';
+import type { useMessageStream } from '@/composables/useMessageStream';
+import { optimisticMessage } from '@/composables/useMessageStream';
+import { useTranslations } from '@/composables/useTranslations';
+import { planForward } from '@/lib/forwardPlacement';
+import { toggleReaction } from '@/lib/reactions';
+import type { Channel, Mention, Message } from '@/types';
+import type { ForwardTarget } from '@/types/forward';
+
+type MessageStream = ReturnType<typeof useMessageStream>;
+
+/** The subset of the open channel the message actions route and quote against. */
+type ActionChannel = Pick<Channel, 'id' | 'slug' | 'name' | 'isDirect'>;
+
+export interface MessageActionsOptions {
+    /** The current team's slug, for every message route. */
+    teamSlug: () => string;
+    /** The open channel; re-read per call so a channel switch routes correctly. */
+    channel: () => ActionChannel;
+    /** The current viewer, stamped as the author of optimistic rows. */
+    currentUser: () => Mention;
+    /** The main channel timeline stream. */
+    mainStream: MessageStream;
+    /** The open thread panel's stream. */
+    threadStream: MessageStream;
+    /** The root id of the thread currently open in the panel, or `null`. */
+    activeThreadRootId: Ref<string | null>;
+    /** The message the composer is quoting, or `null` for a normal send. */
+    replyTarget: Ref<Message | null>;
+    /** Whether the viewer is scrolled near the bottom of the main timeline. */
+    isNearBottom: () => boolean;
+    /** Smooth-scroll the main timeline to the newest message. */
+    scrollToBottom: () => void;
+    /** Drop a pending draft save (a send/schedule clears the draft server-side). */
+    cancelDraft: () => void;
+    /** Clear the composer's reply quote. */
+    cancelReply: () => void;
+}
+
+export interface MessageActions {
+    /** Send a message, optimistically, rolling the row back on error. */
+    send: (body: string, mentions: Mention[]) => void;
+    /** Save an edit, optimistically, rolling the patch back on error. */
+    editMessage: (message: Message, body: string) => void;
+    /** Delete a message, optimistically, rolling the tombstone back on error. */
+    deleteMessage: (message: Message) => void;
+    /** Toggle the viewer's reaction, optimistically, rolled back on error. */
+    reactToMessage: (message: Message, emoji: string) => void;
+    /** Forward a message to a channel or a person, optimistic to the current channel. */
+    forwardMessage: (
+        source: Message,
+        payload: { target: ForwardTarget; note: string },
+    ) => void;
+    /** Post a reply into the open thread, optionally echoed to the channel. */
+    sendThreadReply: (
+        body: string,
+        mentions: Mention[],
+        sendToChannel?: boolean,
+    ) => void;
+    /** Schedule the composer's text for later delivery. */
+    scheduleMessage: (
+        body: string,
+        mentions: Mention[],
+        sendAt: string,
+    ) => void;
+    /** Edit a pending scheduled message's body and send time. */
+    updateScheduled: (payload: {
+        id: string;
+        body: string;
+        sendAt: string;
+    }) => void;
+    /** Cancel a pending scheduled message so it is never delivered. */
+    cancelScheduled: (id: string) => void;
+    /** Set (or re-arm) a personal reminder on a message at a chosen instant. */
+    setReminder: (messageId: string, remindAt: string) => void;
+}
+
+/**
+ * Own the channel's optimistic-mutation engine: every message action follows the
+ * same shape — capture the previous state, apply optimistically, fire the router
+ * call, then roll back and toast on failure. Concentrating the eight-plus call
+ * sites behind one seam keeps the optimistic/rollback contract in a single,
+ * unit-testable module rather than scattered through `Show.vue`'s setup block.
+ *
+ * The pure forward-placement decision (current-channel target, DM quote naming)
+ * lives in {@see planForward}; the optimistic row factory is the shared
+ * {@see optimisticMessage}. Realtime echoes re-apply the same patches via
+ * {@see useChannelRealtime}, so a rolled-back optimistic copy and its later
+ * broadcast stay consistent.
+ */
+export function useMessageActions(
+    options: MessageActionsOptions,
+): MessageActions {
+    const { t } = useTranslations();
+
+    /** Add an optimistic row to the main timeline, honouring the pin-to-bottom rule. */
+    function appendPendingMain(message: Message): void {
+        const pinned = options.isNearBottom();
+        options.mainStream.addPending(message);
+
+        if (pinned) {
+            nextTick(() => options.scrollToBottom());
+        }
+    }
+
+    /** Patch a message into both timelines at once; ignored where it isn't shown. */
+    function applyPatch(message: Message): void {
+        options.mainStream.applyPatch(message);
+        options.threadStream.applyPatch(message);
+    }
+
+    function send(body: string, mentions: Mention[]): void {
+        // Sending clears the draft server-side, so drop any debounced save still
+        // in flight; otherwise it would re-persist the just-sent text.
+        options.cancelDraft();
+
+        const channel = options.channel();
+        const clientUuid = crypto.randomUUID();
+        const target = options.replyTarget.value;
+
+        // The optimistic row mirrors the parent quote so the reference renders
+        // immediately; the server echo replaces it, keyed on the same client uuid.
+        options.mainStream.addPending(
+            optimisticMessage({
+                clientUuid,
+                body,
+                author: options.currentUser(),
+                mentions,
+                replyTo: target,
+            }),
+        );
+
+        options.cancelReply();
+        nextTick(() => options.scrollToBottom());
+
+        router.post(
+            storeMessage({ team: options.teamSlug(), channel: channel.slug })
+                .url,
+            { body, client_uuid: clientUuid, reply_to_id: target?.id ?? null },
+            {
+                preserveScroll: true,
+                onError: () => {
+                    // The optimistic row failed to persist; roll it back and notify.
+                    options.mainStream.removePending(clientUuid);
+                    toast.error(
+                        t('Your message failed to send. Please try again.'),
+                    );
+                },
+            },
+        );
+    }
+
+    function editMessage(message: Message, body: string): void {
+        const channel = options.channel();
+        const previousMain = options.mainStream.getPatch(message.clientUuid);
+        const previousThread = options.threadStream.getPatch(
+            message.clientUuid,
+        );
+
+        // Optimistically show the edit; the broadcast echo later confirms it.
+        applyPatch({ ...message, body, editedAt: new Date().toISOString() });
+
+        router.patch(
+            updateMessage({
+                team: options.teamSlug(),
+                channel: channel.slug,
+                message: message.id,
+            }).url,
+            { body },
+            {
+                preserveScroll: true,
+                onError: () => {
+                    options.mainStream.restorePatch(
+                        message.clientUuid,
+                        previousMain,
+                    );
+                    options.threadStream.restorePatch(
+                        message.clientUuid,
+                        previousThread,
+                    );
+                    toast.error(
+                        t('Your edit failed to save. Please try again.'),
+                    );
+                },
+            },
+        );
+    }
+
+    function deleteMessage(message: Message): void {
+        const channel = options.channel();
+        const previousMain = options.mainStream.getPatch(message.clientUuid);
+        const previousThread = options.threadStream.getPatch(
+            message.clientUuid,
+        );
+
+        // Optimistically show the tombstone; the broadcast echo later confirms it.
+        applyPatch({ ...message, body: '', isDeleted: true });
+
+        router.delete(
+            destroyMessage({
+                team: options.teamSlug(),
+                channel: channel.slug,
+                message: message.id,
+            }).url,
+            {
+                preserveScroll: true,
+                onError: () => {
+                    options.mainStream.restorePatch(
+                        message.clientUuid,
+                        previousMain,
+                    );
+                    options.threadStream.restorePatch(
+                        message.clientUuid,
+                        previousThread,
+                    );
+                    toast.error(
+                        t('Failed to delete the message. Please try again.'),
+                    );
+                },
+            },
+        );
+    }
+
+    function reactToMessage(message: Message, emoji: string): void {
+        const channel = options.channel();
+        const previousMain = options.mainStream.getPatch(message.clientUuid);
+        const previousThread = options.threadStream.getPatch(
+            message.clientUuid,
+        );
+
+        const next = toggleReaction(
+            message.reactions,
+            emoji,
+            options.currentUser(),
+        );
+        options.mainStream.patchReactions(message.id, next);
+        options.threadStream.patchReactions(message.id, next);
+
+        router.post(
+            toggleReactionAction({
+                team: options.teamSlug(),
+                channel: channel.slug,
+                message: message.id,
+            }).url,
+            { emoji },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['channels'],
+                onError: () => {
+                    options.mainStream.restorePatch(
+                        message.clientUuid,
+                        previousMain,
+                    );
+                    options.threadStream.restorePatch(
+                        message.clientUuid,
+                        previousThread,
+                    );
+                    toast.error(
+                        t('Failed to update the reaction. Please try again.'),
+                    );
+                },
+            },
+        );
+    }
+
+    function forwardMessage(
+        source: Message,
+        payload: { target: ForwardTarget; note: string },
+    ): void {
+        const channel = options.channel();
+        const { target, note } = payload;
+        const clientUuid = crypto.randomUUID();
+        const plan = planForward({ target, channel });
+
+        if (plan.toCurrentChannel) {
+            appendPendingMain(
+                optimisticMessage({
+                    clientUuid,
+                    body: note,
+                    author: options.currentUser(),
+                    mentions: [],
+                    forwardedFrom: {
+                        id: source.id,
+                        body: source.body,
+                        authorName: source.user.name,
+                        channelName: plan.quoteChannelName,
+                        isDeleted: source.isDeleted,
+                        mentions: source.mentions,
+                    },
+                }),
+            );
+        }
+
+        router.post(
+            forwardMessageAction({
+                team: options.teamSlug(),
+                channel: channel.slug,
+                message: source.id,
+            }).url,
+            { body: note, client_uuid: clientUuid, ...plan.destination },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['channels'],
+                onSuccess: () => {
+                    if (plan.toCurrentChannel) {
+                        return;
+                    }
+
+                    toast.success(
+                        target.kind === 'channel'
+                            ? t('Message forwarded to #:channel.', {
+                                  channel: target.name,
+                              })
+                            : t('Message forwarded to :name.', {
+                                  name: target.name,
+                              }),
+                    );
+                },
+                onError: () => {
+                    if (plan.toCurrentChannel) {
+                        options.mainStream.removePending(clientUuid);
+                    }
+
+                    toast.error(
+                        t('Failed to forward the message. Please try again.'),
+                    );
+                },
+            },
+        );
+    }
+
+    function sendThreadReply(
+        body: string,
+        mentions: Mention[],
+        sendToChannel?: boolean,
+    ): void {
+        const rootId = options.activeThreadRootId.value;
+
+        if (!rootId) {
+            return;
+        }
+
+        const channel = options.channel();
+        const clientUuid = crypto.randomUUID();
+        const optimistic = optimisticMessage({
+            clientUuid,
+            body,
+            author: options.currentUser(),
+            mentions,
+            threadRootId: rootId,
+            sentToChannel: sendToChannel ?? false,
+        });
+
+        options.threadStream.addPending(optimistic);
+
+        // Replying makes the viewer a follower of the thread and means they've
+        // seen it, so keep the root's affordance in the main timeline dot-free.
+        options.mainStream.patchThreadState(rootId, {
+            threadFollowed: true,
+            threadUnread: false,
+        });
+
+        if (sendToChannel) {
+            appendPendingMain(optimistic);
+        }
+
+        router.post(
+            storeMessage({ team: options.teamSlug(), channel: channel.slug })
+                .url,
+            {
+                body,
+                client_uuid: clientUuid,
+                thread_root_id: rootId,
+                sent_to_channel: sendToChannel ?? false,
+            },
+            {
+                preserveScroll: true,
+                onError: () => {
+                    options.threadStream.removePending(clientUuid);
+
+                    if (sendToChannel) {
+                        options.mainStream.removePending(clientUuid);
+                    }
+
+                    toast.error(
+                        t('Your reply failed to send. Please try again.'),
+                    );
+                },
+            },
+        );
+    }
+
+    function scheduleMessage(
+        body: string,
+        _mentions: Mention[],
+        sendAt: string,
+    ): void {
+        options.cancelDraft();
+
+        const channel = options.channel();
+        const target = options.replyTarget.value;
+
+        router.post(
+            storeScheduledMessage({
+                team: options.teamSlug(),
+                channel: channel.slug,
+            }).url,
+            {
+                body,
+                client_uuid: crypto.randomUUID(),
+                reply_to_id: target?.id ?? null,
+                send_at: sendAt,
+            },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['scheduledMessages', 'channels'],
+                onSuccess: () => toast.success(t('Message scheduled.')),
+                onError: () =>
+                    toast.error(
+                        t('Failed to schedule your message. Please try again.'),
+                    ),
+            },
+        );
+
+        options.cancelReply();
+    }
+
+    function updateScheduled(payload: {
+        id: string;
+        body: string;
+        sendAt: string;
+    }): void {
+        const channel = options.channel();
+
+        router.patch(
+            updateScheduledMessage({
+                team: options.teamSlug(),
+                channel: channel.slug,
+                scheduledMessage: payload.id,
+            }).url,
+            { body: payload.body, send_at: payload.sendAt },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['scheduledMessages'],
+                onError: () =>
+                    toast.error(
+                        t(
+                            'Failed to update the scheduled message. Please try again.',
+                        ),
+                    ),
+            },
+        );
+    }
+
+    function cancelScheduled(id: string): void {
+        const channel = options.channel();
+
+        router.delete(
+            destroyScheduledMessage({
+                team: options.teamSlug(),
+                channel: channel.slug,
+                scheduledMessage: id,
+            }).url,
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['scheduledMessages'],
+                onSuccess: () =>
+                    toast.success(t('Scheduled message cancelled.')),
+                onError: () =>
+                    toast.error(
+                        t(
+                            'Failed to cancel the scheduled message. Please try again.',
+                        ),
+                    ),
+            },
+        );
+    }
+
+    function setReminder(messageId: string, remindAt: string): void {
+        router.post(
+            remindMessage({ team: options.teamSlug() }).url,
+            { message_id: messageId, remind_at: remindAt },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                only: ['reminders', 'firedReminders'],
+                onSuccess: () => toast.success(t('Reminder set.')),
+                onError: () =>
+                    toast.error(
+                        t('Failed to set the reminder. Please try again.'),
+                    ),
+            },
+        );
+    }
+
+    return {
+        send,
+        editMessage,
+        deleteMessage,
+        reactToMessage,
+        forwardMessage,
+        sendThreadReply,
+        scheduleMessage,
+        updateScheduled,
+        cancelScheduled,
+        setReminder,
+    };
+}

--- a/resources/js/composables/useThreadPanel.test.ts
+++ b/resources/js/composables/useThreadPanel.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+
+const { post, get } = vi.hoisted(() => ({ post: vi.fn(), get: vi.fn() }));
+
+vi.mock('@inertiajs/vue3', () => ({ router: { post, get } }));
+
+import { useMessageStream } from '@/composables/useMessageStream';
+import {
+    THREAD_READ_DEBOUNCE_MS,
+    useThreadPanel,
+} from '@/composables/useThreadPanel';
+import type { ThreadPanel } from '@/composables/useThreadPanel';
+import type { Message, MessagePage, Thread } from '@/types';
+
+/** A message carrying just the fields the panel reads. */
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'root-1',
+        clientUuid: 'uuid-root',
+        body: 'the root',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        reactions: [],
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        ...overrides,
+    };
+}
+
+const emptyPage: MessagePage = {
+    data: [],
+    next_cursor: null,
+    prev_cursor: null,
+};
+
+function harness(
+    setup: {
+        channelId?: Ref<string>;
+        thread?: Ref<Thread | null | undefined>;
+        threadReplies?: Ref<MessagePage>;
+    } = {},
+) {
+    const scope = effectScope();
+    const channelId = setup.channelId ?? ref('chan-1');
+    const thread = setup.thread ?? ref<Thread | null | undefined>(null);
+    const threadReplies = setup.threadReplies ?? ref(emptyPage);
+    const mainStream = useMessageStream(ref<Message[]>([message()]));
+
+    let panel!: ThreadPanel;
+
+    scope.run(() => {
+        panel = useThreadPanel({
+            teamSlug: () => 'acme',
+            channelSlug: () => 'general',
+            channelId: () => channelId.value,
+            mainStream,
+            thread: () => thread.value,
+            threadReplies: () => threadReplies.value,
+        });
+    });
+
+    return {
+        panel,
+        mainStream,
+        channelId,
+        thread,
+        threadReplies,
+        unmount: () => scope.stop(),
+    };
+}
+
+/** The options object of the nth recorded `router.get`. */
+function getOptions(call = 0): {
+    only?: string[];
+    reset?: string[];
+    onFinish?: () => void;
+} {
+    return get.mock.calls[call][2];
+}
+
+describe('useThreadPanel', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.stubGlobal('document', { hasFocus: () => true });
+        post.mockClear();
+        get.mockClear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it('opens a thread: sets state, clears the root dot, and navigates', () => {
+        const h = harness();
+
+        h.panel.openThread('root-1');
+
+        expect(h.panel.activeThreadRootId.value).toBe('root-1');
+        expect(h.panel.threadLoading.value).toBe(true);
+        // The root's dot clears immediately in the main timeline.
+        expect(
+            h.mainStream.displayMessages.value.find((m) => m.id === 'root-1')
+                ?.threadUnread,
+        ).toBe(false);
+        expect(getOptions().only).toEqual(['thread', 'threadReplies']);
+    });
+
+    it('ignores reopening the already-open thread', () => {
+        const h = harness();
+
+        h.panel.openThread('root-1');
+        get.mockClear();
+        h.panel.openThread('root-1');
+
+        expect(get).not.toHaveBeenCalled();
+    });
+
+    it('stops loading and schedules a mark-read once the thread finishes loading', () => {
+        const h = harness();
+
+        h.panel.openThread('root-1');
+        getOptions().onFinish?.();
+
+        expect(h.panel.threadLoading.value).toBe(false);
+
+        // The debounced, focus-gated thread mark-read fires after its delay.
+        vi.advanceTimersByTime(THREAD_READ_DEBOUNCE_MS);
+        expect(post).toHaveBeenCalledOnce();
+        expect(post.mock.calls[0][2].only).toEqual(['channels']);
+    });
+
+    it('does not mark a thread read while the tab is blurred', () => {
+        vi.stubGlobal('document', { hasFocus: () => false });
+        const h = harness();
+
+        h.panel.openThread('root-1');
+        getOptions().onFinish?.();
+        vi.advanceTimersByTime(THREAD_READ_DEBOUNCE_MS);
+
+        expect(post).not.toHaveBeenCalled();
+    });
+
+    it('closes an open thread: resets state and navigates back', () => {
+        const h = harness();
+
+        h.panel.openThread('root-1');
+        get.mockClear();
+        h.panel.closeThread();
+
+        expect(h.panel.activeThreadRootId.value).toBeNull();
+        expect(h.panel.threadData.value).toBeNull();
+        expect(h.panel.threadLoading.value).toBe(false);
+        expect(get).toHaveBeenCalledOnce();
+    });
+
+    it('does nothing when closing an already-closed panel', () => {
+        const h = harness();
+
+        h.panel.closeThread();
+
+        expect(get).not.toHaveBeenCalled();
+    });
+
+    it('resets the panel on a channel switch', async () => {
+        const channelId = ref('chan-1');
+        const h = harness({ channelId });
+
+        h.panel.openThread('root-1');
+        expect(h.panel.activeThreadRootId.value).toBe('root-1');
+
+        channelId.value = 'chan-2';
+        await nextTick();
+
+        expect(h.panel.activeThreadRootId.value).toBeNull();
+        expect(h.panel.threadData.value).toBeNull();
+    });
+
+    it('adopts a deep-linked thread from the initial load', () => {
+        const thread = ref<Thread | null | undefined>({
+            root: message({ id: 'deep-root' }),
+        });
+        const h = harness({ thread });
+
+        h.panel.adoptDeepLinkedThread();
+
+        expect(h.panel.activeThreadRootId.value).toBe('deep-root');
+        expect(h.panel.threadData.value?.root.id).toBe('deep-root');
+    });
+
+    it('adopts nothing when there is no deep-linked thread', () => {
+        const h = harness();
+
+        h.panel.adoptDeepLinkedThread();
+
+        expect(h.panel.activeThreadRootId.value).toBeNull();
+    });
+
+    it('copies in a late-arriving thread prop for the open root, ending the load', async () => {
+        const thread = ref<Thread | null | undefined>(null);
+        const h = harness({ thread });
+
+        h.panel.openThread('root-1');
+        expect(h.panel.threadLoading.value).toBe(true);
+
+        // The requested thread prop arrives for the root we're opening.
+        thread.value = { root: message({ id: 'root-1' }) };
+        await nextTick();
+
+        expect(h.panel.threadData.value?.root.id).toBe('root-1');
+        expect(h.panel.threadLoading.value).toBe(false);
+    });
+
+    it('ignores a thread prop for a root other than the open one', async () => {
+        const thread = ref<Thread | null | undefined>(null);
+        const h = harness({ thread });
+
+        h.panel.openThread('root-1');
+        thread.value = { root: message({ id: 'some-other-root' }) };
+        await nextTick();
+
+        expect(h.panel.threadData.value).toBeNull();
+        expect(h.panel.threadLoading.value).toBe(true);
+    });
+
+    it('builds the rendered list with the root first, then replies by time', () => {
+        const thread = ref<Thread | null | undefined>({
+            root: message({
+                id: 'root-1',
+                clientUuid: 'uuid-root',
+                createdAt: '2024-01-01T00:00:00.000Z',
+            }),
+        });
+        // Replies arrive newest-first from the server.
+        const threadReplies = ref<MessagePage>({
+            data: [
+                message({
+                    id: 'r2',
+                    clientUuid: 'uuid-r2',
+                    createdAt: '2024-01-01T00:02:00.000Z',
+                }),
+                message({
+                    id: 'r1',
+                    clientUuid: 'uuid-r1',
+                    createdAt: '2024-01-01T00:01:00.000Z',
+                }),
+            ],
+            next_cursor: null,
+            prev_cursor: null,
+        });
+        const h = harness({ thread, threadReplies });
+
+        h.panel.adoptDeepLinkedThread();
+
+        expect(h.panel.threadMessages.value.map((m) => m.id)).toEqual([
+            'root-1',
+            'r1',
+            'r2',
+        ]);
+    });
+});

--- a/resources/js/composables/useThreadPanel.ts
+++ b/resources/js/composables/useThreadPanel.ts
@@ -1,0 +1,232 @@
+import { router } from '@inertiajs/vue3';
+import { computed, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import {
+    readThread as markThreadReadAction,
+    show as showChannel,
+} from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
+import { useMessageStream } from '@/composables/useMessageStream';
+import type { Message, MessagePage, Thread } from '@/types';
+
+type MessageStream = ReturnType<typeof useMessageStream>;
+
+/** How long thread mark-read requests coalesce, mirroring the channel's markRead. */
+export const THREAD_READ_DEBOUNCE_MS = 400;
+
+export interface ThreadPanelOptions {
+    /** The current team's slug, for the thread show/read routes. */
+    teamSlug: () => string;
+    /** The open channel's slug, for the thread show/read routes. */
+    channelSlug: () => string;
+    /** The open channel's id; a change resets the panel for the new channel. */
+    channelId: () => string;
+    /** The main channel timeline stream, so a root's unread dot can be cleared. */
+    mainStream: MessageStream;
+    /** The server-resolved thread root, present only on a reload that requests it. */
+    thread: () => Thread | null | undefined;
+    /** The thread's reply page, newest-first, growing as older replies page in. */
+    threadReplies: () => MessagePage;
+}
+
+export interface ThreadPanel {
+    /** The open thread's root id, kept client-side; null when the panel is closed. */
+    activeThreadRootId: Ref<string | null>;
+    /** The open thread's root + metadata, or null before it loads / when closed. */
+    threadData: Ref<Thread | null>;
+    /** Whether the panel is waiting for the root and first reply page to arrive. */
+    threadLoading: Ref<boolean>;
+    /** The panel's own optimistic + realtime merge stream. */
+    threadStream: MessageStream;
+    /** The panel's rendered messages (root pinned first, replies by timestamp). */
+    threadMessages: ComputedRef<Message[]>;
+    /** The client uuids of the panel's optimistic, unconfirmed replies. */
+    threadPendingUuids: ComputedRef<string[]>;
+    /** Open the thread rooted at a message: navigate, load, and clear its dot. */
+    openThread: (rootId: string) => void;
+    /** Close the panel: drop `?thread=` from the URL and reset client state. */
+    closeThread: () => void;
+    /** Reset the panel's client state without navigating (e.g. channel switch). */
+    resetThreadPanel: () => void;
+    /** Advance the open thread's read pointer, debounced and gated on focus. */
+    markThreadRead: () => void;
+    /** Adopt a deep-linked thread resolved on the initial page load. */
+    adoptDeepLinkedThread: () => void;
+}
+
+/**
+ * Own the thread panel's open → load → reset → mark-read lifecycle, previously
+ * interleaved with the main timeline in `Show.vue`. The panel runs its own
+ * {@see useMessageStream} instance over the root plus its paginated replies, kept
+ * client-side so a partial reload that omits the optional `thread` prop can't
+ * blank an open panel.
+ *
+ * Opening puts `?thread=<root>` in the URL (loading the root and first reply
+ * page), closing drops it, and a channel switch resets the panel here via its own
+ * watcher — one seam for the reset-on-switch behaviour. The mark-read post rides
+ * {@see useDebouncedPost}, gated on tab focus and capturing the root id so a
+ * fire uses the thread that was open when it was scheduled. Posting a reply stays
+ * in `useMessageActions`, which shares this panel's stream.
+ */
+export function useThreadPanel(options: ThreadPanelOptions): ThreadPanel {
+    const activeThreadRootId = ref<string | null>(null);
+    const threadData = ref<Thread | null>(null);
+    const threadLoading = ref(false);
+
+    // The reply page arrives newest-first (older replies page in on scroll-up);
+    // the root is the thread's oldest message, so it leads the reversed list. The
+    // stream then re-sorts by timestamp, keeping the root pinned to the top.
+    const threadServerMessages = computed<Message[]>(() =>
+        threadData.value
+            ? [
+                  threadData.value.root,
+                  ...[...(options.threadReplies()?.data ?? [])].reverse(),
+              ]
+            : [],
+    );
+
+    const threadStream = useMessageStream(threadServerMessages);
+    const threadMessages = threadStream.displayMessages;
+    const threadPendingUuids = threadStream.pendingUuids;
+
+    // Advance the open thread's read pointer so its unread dot clears, mirroring
+    // the channel's markRead: debounced, gated on focus, and optimistically
+    // clearing the dot on the root back in the main timeline. The root id is
+    // captured as the payload so a fire uses the thread open when it was scheduled.
+    const threadReadPost = useDebouncedPost(
+        (rootId: string) => {
+            router.post(
+                markThreadReadAction({
+                    team: options.teamSlug(),
+                    channel: options.channelSlug(),
+                    message: rootId,
+                }).url,
+                {},
+                {
+                    preserveScroll: true,
+                    preserveState: true,
+                    only: ['channels'],
+                },
+            );
+
+            options.mainStream.patchThreadState(rootId, {
+                threadUnread: false,
+            });
+        },
+        { delay: THREAD_READ_DEBOUNCE_MS, gate: () => document.hasFocus() },
+    );
+
+    function markThreadRead(): void {
+        const rootId = activeThreadRootId.value;
+
+        if (!rootId) {
+            return;
+        }
+
+        threadReadPost.schedule(rootId);
+    }
+
+    function resetThreadPanel(): void {
+        activeThreadRootId.value = null;
+        threadData.value = null;
+        threadLoading.value = false;
+        threadStream.reset();
+    }
+
+    function openThread(rootId: string): void {
+        if (activeThreadRootId.value === rootId) {
+            return;
+        }
+
+        activeThreadRootId.value = rootId;
+        threadStream.reset();
+        threadData.value = null;
+        threadLoading.value = true;
+
+        // Opening the thread clears its dot straight away; the read pointer
+        // advances once the replies load (and again on focus / as replies stream).
+        options.mainStream.patchThreadState(rootId, { threadUnread: false });
+
+        router.get(
+            showChannel(
+                { team: options.teamSlug(), channel: options.channelSlug() },
+                { query: { thread: rootId } },
+            ).url,
+            {},
+            {
+                only: ['thread', 'threadReplies'],
+                reset: ['threadReplies'],
+                preserveState: true,
+                preserveScroll: true,
+                replace: true,
+                onFinish: () => {
+                    threadLoading.value = false;
+                    markThreadRead();
+                },
+            },
+        );
+    }
+
+    function closeThread(): void {
+        if (activeThreadRootId.value === null) {
+            return;
+        }
+
+        resetThreadPanel();
+
+        router.get(
+            showChannel({
+                team: options.teamSlug(),
+                channel: options.channelSlug(),
+            }).url,
+            {},
+            {
+                only: ['thread', 'threadReplies'],
+                reset: ['threadReplies'],
+                preserveState: true,
+                preserveScroll: true,
+                replace: true,
+            },
+        );
+    }
+
+    // Reopen a deep-linked thread: the `thread` prop is already resolved from the
+    // `?thread=` param on the initial load, so adopt it directly.
+    function adoptDeepLinkedThread(): void {
+        const thread = options.thread();
+
+        if (thread) {
+            activeThreadRootId.value = thread.root.id;
+            threadData.value = thread;
+        }
+    }
+
+    // The thread prop only arrives on a partial reload that requests it; copy it
+    // into client state (guarded to the thread we're actually opening) so a later
+    // full visit that omits the optional prop can't blank the open panel.
+    watch(options.thread, (thread) => {
+        if (thread && thread.root.id === activeThreadRootId.value) {
+            threadData.value = thread;
+            threadLoading.value = false;
+        }
+    });
+
+    // Inertia may reuse the page component when navigating between channels; the
+    // URL has already moved off any open thread, so reset the panel for the new
+    // channel — the one seam for the reset-on-channel-switch behaviour.
+    watch(options.channelId, resetThreadPanel);
+
+    return {
+        activeThreadRootId,
+        threadData,
+        threadLoading,
+        threadStream,
+        threadMessages,
+        threadPendingUuids,
+        openThread,
+        closeThread,
+        resetThreadPanel,
+        markThreadRead,
+        adoptDeepLinkedThread,
+    };
+}

--- a/resources/js/lib/forwardPlacement.test.ts
+++ b/resources/js/lib/forwardPlacement.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { planForward } from '@/lib/forwardPlacement';
+import type { ForwardTarget } from '@/types/forward';
+
+/** A public channel the forward may or may not target. */
+const channel = { id: 'chan-1', isDirect: false, name: 'general' };
+
+/** The current viewer's self-DM, standing in for any direct-message source. */
+const dm = { id: 'dm-1', isDirect: true, name: 'Ada Lovelace' };
+
+const toChannel = (id: string, name = 'somewhere'): ForwardTarget => ({
+    kind: 'channel',
+    id,
+    name,
+});
+const toUser = (id: string, name = 'Grace'): ForwardTarget => ({
+    kind: 'user',
+    id,
+    name,
+});
+
+describe('planForward', () => {
+    it('flags a forward back into the current channel so it renders optimistically', () => {
+        const plan = planForward({ target: toChannel('chan-1'), channel });
+
+        expect(plan.toCurrentChannel).toBe(true);
+        expect(plan.destination).toEqual({ target_channel_id: 'chan-1' });
+    });
+
+    it('does not flag a forward into a different channel', () => {
+        const plan = planForward({ target: toChannel('chan-2'), channel });
+
+        expect(plan.toCurrentChannel).toBe(false);
+        expect(plan.destination).toEqual({ target_channel_id: 'chan-2' });
+    });
+
+    it('routes a person target to their DM and never treats it as the current channel', () => {
+        const plan = planForward({ target: toUser('user-9'), channel });
+
+        expect(plan.toCurrentChannel).toBe(false);
+        expect(plan.destination).toEqual({ target_user_id: 'user-9' });
+    });
+
+    it('quotes a channel source by its name so the reference reads "#general"', () => {
+        const plan = planForward({ target: toChannel('chan-2'), channel });
+
+        expect(plan.quoteChannelName).toBe('general');
+    });
+
+    it('quotes a DM source with a null channel name so it reads "a direct message"', () => {
+        const plan = planForward({ target: toChannel('chan-2'), channel: dm });
+
+        expect(plan.quoteChannelName).toBeNull();
+    });
+});

--- a/resources/js/lib/forwardPlacement.ts
+++ b/resources/js/lib/forwardPlacement.ts
@@ -1,0 +1,46 @@
+import type { ForwardTarget } from '@/types/forward';
+
+/** The server payload naming a forward's destination. */
+export type ForwardDestination =
+    { target_channel_id: string } | { target_user_id: string };
+
+export type ForwardPlan = {
+    /**
+     * The forward lands back in the channel it originated from, so it renders
+     * optimistically in the timeline and dedups against the broadcast echo.
+     */
+    toCurrentChannel: boolean;
+    /** The destination payload: a channel id, or a person whose DM is opened. */
+    destination: ForwardDestination;
+    /**
+     * The channel name to stamp on the forwarded-from quote, or `null` for a DM
+     * source — matching the server so the quote reads "a direct message" rather
+     * than a participant's name.
+     */
+    quoteChannelName: string | null;
+};
+
+/**
+ * The pure decision core behind forwarding a message: whether the target is the
+ * current channel (so the optimistic copy is appended locally), the destination
+ * payload the request carries, and the channel name to quote the source by.
+ *
+ * The source always lives in the current channel — the action originates from its
+ * timeline or thread — so `quoteChannelName` reflects the *current* channel, null
+ * for a DM.
+ */
+export function planForward(input: {
+    target: ForwardTarget;
+    channel: { id: string; isDirect: boolean; name: string };
+}): ForwardPlan {
+    const { target, channel } = input;
+
+    return {
+        toCurrentChannel: target.kind === 'channel' && target.id === channel.id,
+        destination:
+            target.kind === 'channel'
+                ? { target_channel_id: target.id }
+                : { target_user_id: target.id },
+        quoteChannelName: channel.isDirect ? null : channel.name,
+    };
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1,17 +1,7 @@
 <script setup lang="ts">
-import { Head, InfiniteScroll, Link, router, usePage } from '@inertiajs/vue3';
+import { Head, InfiniteScroll, router, usePage } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
-import {
-    Archive,
-    ArrowUp,
-    CalendarClock,
-    ChevronDown,
-    EllipsisVertical,
-    Search,
-    Send,
-    Star,
-    UserPlus,
-} from '@lucide/vue';
+import { ArrowUp, CalendarClock, ChevronDown } from '@lucide/vue';
 import {
     computed,
     nextTick,
@@ -24,26 +14,10 @@ import { toast } from 'vue-sonner';
 import {
     archive as archiveChannel,
     read as markChannelRead,
-    readThread as markThreadReadAction,
-    show as showChannel,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
-import { store as forwardMessageAction } from '@/actions/App/Http/Controllers/Channels/ForwardMessageController';
-import {
-    destroy as destroyMessage,
-    store as storeMessage,
-    update as updateMessage,
-} from '@/actions/App/Http/Controllers/Channels/MessageController';
-import { store as remindMessage } from '@/actions/App/Http/Controllers/Channels/MessageReminderController';
-import { store as toggleReactionAction } from '@/actions/App/Http/Controllers/Channels/ReactionController';
-import {
-    destroy as destroyScheduledMessage,
-    store as storeScheduledMessage,
-    update as updateScheduledMessage,
-} from '@/actions/App/Http/Controllers/Channels/ScheduledMessageController';
-import { index as searchMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
-import CreateChannelModal from '@/components/CreateChannelModal.vue';
+import ChannelEmptyState from '@/components/ChannelEmptyState.vue';
+import ChannelMasthead from '@/components/ChannelMasthead.vue';
 import ForwardMessageDialog from '@/components/ForwardMessageDialog.vue';
-import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
 import ScheduledMessagesDialog from '@/components/ScheduledMessagesDialog.vue';
@@ -60,42 +34,20 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import {
-    DropdownMenu,
-    DropdownMenuCheckboxItem,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuRadioGroup,
-    DropdownMenuRadioItem,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { SidebarTrigger } from '@/components/ui/sidebar';
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipTrigger,
-} from '@/components/ui/tooltip';
 import { useChannelDraft } from '@/composables/useChannelDraft';
 import { useChannelPreferences } from '@/composables/useChannelPreferences';
 import { useChannelRealtime } from '@/composables/useChannelRealtime';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
-import { getInitials } from '@/composables/useInitials';
-import {
-    useMessageStream,
-    optimisticMessage,
-} from '@/composables/useMessageStream';
-import { useOnboardingTour } from '@/composables/useOnboardingTour';
+import { useMessageActions } from '@/composables/useMessageActions';
+import { useMessageStream } from '@/composables/useMessageStream';
 import { useScrollPin } from '@/composables/useScrollPin';
 import { useTeamPresence } from '@/composables/useTeamPresence';
+import { useThreadPanel } from '@/composables/useThreadPanel';
 import { useTimezone } from '@/composables/useTimezone';
 import { useTranslations } from '@/composables/useTranslations';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import type { TypingUser } from '@/composables/useTypingIndicator';
 import { useUnreadDivider } from '@/composables/useUnreadDivider';
-import { memberAvatarStack } from '@/lib/memberAvatars';
-import { toggleReaction } from '@/lib/reactions';
 import type {
     Channel,
     ChannelReader,
@@ -180,20 +132,10 @@ const mentionableMembers = computed(() =>
     props.members.filter((member) => member.id !== currentUser.value.id),
 );
 
-// How many member avatars the masthead shows before collapsing the rest into a
-// single "+N" overflow chip.
-const MAX_MASTHEAD_AVATARS = 3;
-
-// The overlapping member avatars for the masthead's right side, driven by the
-// team roster the page already carries for the composer.
-const mastheadAvatars = computed(() =>
-    memberAvatarStack(props.members, MAX_MASTHEAD_AVATARS),
-);
-
 // A direct message renders viewer-relative: no "#", the other participant's
-// name and presence (the viewer's own self-DM reads "You"), and no team
-// facepile — a DM is a fixed pair, so the "who's in the channel" stack is
-// meaningless there.
+// name (the viewer's own self-DM reads "You"). Drives the `<Head>` title, the
+// masthead, and the empty state's viewer-relative copy; the masthead owns the DM
+// presence dot and member facepile itself.
 const isSelfDm = computed(
     () =>
         props.channel.isDirect &&
@@ -201,11 +143,6 @@ const isSelfDm = computed(
 );
 const mastheadTitle = computed(() =>
     isSelfDm.value ? t('You') : props.channel.name,
-);
-const dmParticipantOnline = computed(
-    () =>
-        props.channel.dmUserId != null &&
-        onlineIds.value.has(props.channel.dmUserId),
 );
 
 // A team Admin+ may delete anyone's message in the channel (moderation).
@@ -241,52 +178,34 @@ const pendingUuids = mainStream.pendingUuids;
 
 const hasMessages = computed(() => displayMessages.value.length > 0);
 
-// The brand-new-workspace welcome replaces the plain "no messages" empty state on
-// a fresh #general for a user who has not yet completed onboarding — the reachable
-// "first channel, first message" moment. Any other empty channel/DM keeps the
-// plain copy.
-const { open: openOnboardingTour } = useOnboardingTour();
-const showWelcome = computed(
-    () =>
-        props.channel.slug === 'general' &&
-        page.props.auth.user.onboarding_completed_at == null,
-);
-
-// The welcome's "Invite your teammates" action reuses the member-invite modal,
-// gated on the same permission and roles the workspace already shares.
-const inviteOpen = ref(false);
-const canInviteToCurrentTeam = computed(
-    () => page.props.canInviteToCurrentTeam ?? false,
-);
-const invitableRoles = computed(() => page.props.invitableRoles ?? []);
-const currentTeamForInvite = computed(() => page.props.currentTeam);
-
+// Focus the channel composer — from the empty-state welcome's "Post your first
+// message" card, or a profile hover card dropping in a mention.
 function focusComposer(): void {
     channelComposer.value?.focus();
 }
 
-// The open thread's root, kept client-side so a partial reload that omits the
-// optional `thread` prop can't drop it. The panel runs its own stream instance
-// over the root plus its paginated replies.
-const activeThreadRootId = ref<string | null>(null);
-const threadData = ref<Thread | null>(null);
-const threadLoading = ref(false);
-
-// The reply page arrives newest-first (older replies page in on scroll-up); the
-// root is the thread's oldest message, so it leads the reversed list. The stream
-// then re-sorts by timestamp, keeping the root pinned to the top.
-const threadServerMessages = computed<Message[]>(() =>
-    threadData.value
-        ? [
-              threadData.value.root,
-              ...[...(props.threadReplies?.data ?? [])].reverse(),
-          ]
-        : [],
-);
-
-const threadStream = useMessageStream(threadServerMessages);
-const threadMessages = threadStream.displayMessages;
-const threadPendingUuids = threadStream.pendingUuids;
+// The thread panel's whole open → load → reset → mark-read lifecycle, with its own
+// merge stream over the root plus paginated replies. It resets itself on a channel
+// switch, so this page no longer juggles two stream lifecycles inline;
+// `sendThreadReply` stays in `useMessageActions`, sharing this panel's stream.
+const {
+    activeThreadRootId,
+    threadLoading,
+    threadStream,
+    threadMessages,
+    threadPendingUuids,
+    openThread,
+    closeThread,
+    markThreadRead,
+    adoptDeepLinkedThread,
+} = useThreadPanel({
+    teamSlug: () => props.team.slug,
+    channelSlug: () => props.channel.slug,
+    channelId: () => props.channel.id,
+    mainStream,
+    thread: () => props.thread,
+    threadReplies: () => props.threadReplies,
+});
 
 // The message to briefly highlight after a search jump. The server windows the
 // initial page so the target is loaded; we scroll it into view and clear the
@@ -323,37 +242,6 @@ const { unreadDividerId, showJumpToUnread, scrollToUnread } = useUnreadDivider({
     lastReadMessageId: () => props.lastReadMessageId ?? null,
     currentUserId: () => currentUser.value.id,
 });
-
-// Advance the open thread's read pointer so its unread dot clears, mirroring the
-// channel's markRead: debounced, gated on focus, and optimistically clearing the
-// dot on the root back in the main timeline. The root id is captured as the
-// debounced payload so a fire uses the thread that was open when it was scheduled.
-const threadReadPost = useDebouncedPost(
-    (rootId: string) => {
-        router.post(
-            markThreadReadAction({
-                team: props.team.slug,
-                channel: props.channel.slug,
-                message: rootId,
-            }).url,
-            {},
-            { preserveScroll: true, preserveState: true, only: ['channels'] },
-        );
-
-        mainStream.patchThreadState(rootId, { threadUnread: false });
-    },
-    { delay: 400, gate: () => document.hasFocus() },
-);
-
-function markThreadRead(): void {
-    const rootId = activeThreadRootId.value;
-
-    if (!rootId) {
-        return;
-    }
-
-    threadReadPost.schedule(rootId);
-}
 
 function channelName(id: string): string {
     return `channel.${id}`;
@@ -430,26 +318,9 @@ onMounted(() => {
         jumpToMessage(props.jumpToMessageId);
     }
 
-    // Reopen a deep-linked thread: the `thread` prop is already resolved from
-    // the `?thread=` param on the initial load, so adopt it directly.
-    if (props.thread) {
-        activeThreadRootId.value = props.thread.root.id;
-        threadData.value = props.thread;
-    }
+    // Reopen a deep-linked thread resolved from the `?thread=` param on load.
+    adoptDeepLinkedThread();
 });
-
-// The thread prop only arrives on a partial reload that requests it; copy it
-// into client state (guarded to the thread we're actually opening) so a later
-// full visit that omits the optional prop can't blank the open panel.
-watch(
-    () => props.thread,
-    (thread) => {
-        if (thread && thread.root.id === activeThreadRootId.value) {
-            threadData.value = thread;
-            threadLoading.value = false;
-        }
-    },
-);
 
 // A jump to another result in the same already-open channel reuses this
 // component, so the channel-id watch won't fire; react to the target changing.
@@ -464,14 +335,14 @@ watch(
 
 // Inertia may reuse this page component when navigating between channels; reset
 // the message-orchestration state this page owns when the channel changes. The
-// extracted composables (realtime, draft, preferences, unread divider) each move
-// or refreeze their own state on the same change via their own watchers.
+// extracted composables (realtime, draft, preferences, unread divider, thread
+// panel) each move or refreeze their own state on the same change via their own
+// watchers.
 watch(
     () => props.channel.id,
     () => {
         mainStream.reset();
         resetScrollPin();
-        resetThreadPanel();
         replyTarget.value = null;
         typing.reset();
         seedReaders();
@@ -531,94 +402,14 @@ function openForward(message: Message): void {
     forwardDialogOpen.value = true;
 }
 
-// Forward the selected message into a channel or a person's DM with an optional
-// note. The source always lives in the current channel (the action originates
-// from its timeline or thread), so a forward back into the current channel
-// renders optimistically and dedups against the broadcast echo; a forward
-// elsewhere (another channel or a DM) just confirms with a toast. A person
-// target opens-or-creates the DM server-side via `target_user_id`.
-function forwardMessage({
-    target,
-    note,
-}: {
-    target: ForwardTarget;
-    note: string;
-}): void {
+// Submit the forward dialog: hand the selected source and destination to the
+// actions engine, then clear the target so the dialog resets.
+function submitForward(payload: { target: ForwardTarget; note: string }): void {
     const source = forwardTarget.value;
 
-    if (!source) {
-        return;
+    if (source) {
+        actions.forwardMessage(source, payload);
     }
-
-    const clientUuid = crypto.randomUUID();
-    const toCurrentChannel =
-        target.kind === 'channel' && target.id === props.channel.id;
-
-    if (toCurrentChannel) {
-        appendPendingMain(
-            optimisticMessage({
-                clientUuid,
-                body: note,
-                author: currentUser.value,
-                mentions: [],
-                forwardedFrom: {
-                    id: source.id,
-                    body: source.body,
-                    authorName: source.user.name,
-                    // A DM has no channel name; match the server so the quote
-                    // reads "a direct message" instead of the participant's name.
-                    channelName: props.channel.isDirect
-                        ? null
-                        : props.channel.name,
-                    isDeleted: source.isDeleted,
-                    mentions: source.mentions,
-                },
-            }),
-        );
-    }
-
-    const destination =
-        target.kind === 'channel'
-            ? { target_channel_id: target.id }
-            : { target_user_id: target.id };
-
-    router.post(
-        forwardMessageAction({
-            team: props.team.slug,
-            channel: props.channel.slug,
-            message: source.id,
-        }).url,
-        { body: note, client_uuid: clientUuid, ...destination },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['channels'],
-            onSuccess: () => {
-                if (toCurrentChannel) {
-                    return;
-                }
-
-                toast.success(
-                    target.kind === 'channel'
-                        ? t('Message forwarded to #:channel.', {
-                              channel: target.name,
-                          })
-                        : t('Message forwarded to :name.', {
-                              name: target.name,
-                          }),
-                );
-            },
-            onError: () => {
-                if (toCurrentChannel) {
-                    mainStream.removePending(clientUuid);
-                }
-
-                toast.error(
-                    t('Failed to forward the message. Please try again.'),
-                );
-            },
-        },
-    );
 
     forwardTarget.value = null;
 }
@@ -633,45 +424,34 @@ const { onDraftChange, cancel: cancelDraft } = useChannelDraft({
     channelSlug: () => props.channel.slug,
 });
 
-function send(body: string, mentions: Mention[]): void {
-    // Sending clears the draft server-side, so drop any debounced save still in
-    // flight; otherwise it would re-persist the just-sent text after the clear.
-    cancelDraft();
+// The channel's optimistic-mutation engine: send/edit/delete/react/forward,
+// thread replies, scheduling, and reminders all follow the same optimistic-apply
+// → router-call → rollback-on-error shape, concentrated behind one seam.
+const actions = useMessageActions({
+    teamSlug: () => props.team.slug,
+    channel: () => props.channel,
+    currentUser: () => currentUser.value,
+    mainStream,
+    threadStream,
+    activeThreadRootId,
+    replyTarget,
+    isNearBottom,
+    scrollToBottom,
+    cancelDraft,
+    cancelReply,
+});
 
-    const clientUuid = crypto.randomUUID();
-    const target = replyTarget.value;
-
-    // The optimistic row mirrors the parent quote so the reference renders
-    // immediately; the server echo replaces it, keyed on the same client uuid.
-    mainStream.addPending(
-        optimisticMessage({
-            clientUuid,
-            body,
-            author: currentUser.value,
-            mentions,
-            replyTo: target,
-        }),
-    );
-
-    cancelReply();
-    nextTick(() => scrollToBottom());
-
-    router.post(
-        storeMessage({ team: props.team.slug, channel: props.channel.slug })
-            .url,
-        { body, client_uuid: clientUuid, reply_to_id: target?.id ?? null },
-        {
-            preserveScroll: true,
-            onError: () => {
-                // The optimistic row failed to persist; roll it back and notify.
-                mainStream.removePending(clientUuid);
-                toast.error(
-                    t('Your message failed to send. Please try again.'),
-                );
-            },
-        },
-    );
-}
+const {
+    send,
+    editMessage,
+    deleteMessage,
+    reactToMessage,
+    sendThreadReply,
+    scheduleMessage,
+    updateScheduled,
+    cancelScheduled,
+    setReminder,
+} = actions;
 
 // The viewer's stored timezone, driving the schedule picker's presets and the
 // list's "sends at" labels so a scheduled time always reads in their own zone.
@@ -680,121 +460,10 @@ const { timezone } = useTimezone();
 // Whether the "Scheduled messages" management dialog is open.
 const scheduledDialogOpen = ref(false);
 
-// Schedule the composer's text for later delivery. Unlike a send it renders
-// nothing in the timeline (it isn't posted yet) — it only lands in the
-// "Scheduled" surface. Scheduling consumes the composer text like a send, so any
-// debounced draft save in flight is dropped and the server clears the draft.
-function scheduleMessage(
-    body: string,
-    _mentions: Mention[],
-    sendAt: string,
-): void {
-    cancelDraft();
-
-    const target = replyTarget.value;
-
-    router.post(
-        storeScheduledMessage({
-            team: props.team.slug,
-            channel: props.channel.slug,
-        }).url,
-        {
-            body,
-            client_uuid: crypto.randomUUID(),
-            reply_to_id: target?.id ?? null,
-            send_at: sendAt,
-        },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['scheduledMessages', 'channels'],
-            onSuccess: () => toast.success(t('Message scheduled.')),
-            onError: () =>
-                toast.error(
-                    t('Failed to schedule your message. Please try again.'),
-                ),
-        },
-    );
-
-    cancelReply();
-}
-
-// Save an edit to a pending scheduled message's body and send time.
-function updateScheduled({
-    id,
-    body,
-    sendAt,
-}: {
-    id: string;
-    body: string;
-    sendAt: string;
-}): void {
-    router.patch(
-        updateScheduledMessage({
-            team: props.team.slug,
-            channel: props.channel.slug,
-            scheduledMessage: id,
-        }).url,
-        { body, send_at: sendAt },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['scheduledMessages'],
-            onError: () =>
-                toast.error(
-                    t(
-                        'Failed to update the scheduled message. Please try again.',
-                    ),
-                ),
-        },
-    );
-}
-
-// Cancel a pending scheduled message so it is never delivered.
-function cancelScheduled(id: string): void {
-    router.delete(
-        destroyScheduledMessage({
-            team: props.team.slug,
-            channel: props.channel.slug,
-            scheduledMessage: id,
-        }).url,
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['scheduledMessages'],
-            onSuccess: () => toast.success(t('Scheduled message cancelled.')),
-            onError: () =>
-                toast.error(
-                    t(
-                        'Failed to cancel the scheduled message. Please try again.',
-                    ),
-                ),
-        },
-    );
-}
-
 // The message a custom-time reminder is being set for, and whether the custom
 // date & time picker is open.
 const reminderTargetId = ref<string | null>(null);
 const reminderCustomOpen = ref(false);
-
-// Set (or re-arm) a personal reminder on a message at a chosen instant. Only the
-// shared reminder props are reloaded, so the pending list and any nudge stay
-// current without disturbing the timeline.
-function setReminder(messageId: string, remindAt: string): void {
-    router.post(
-        remindMessage({ team: props.team.slug }).url,
-        { message_id: messageId, remind_at: remindAt },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['reminders', 'firedReminders'],
-            onSuccess: () => toast.success(t('Reminder set.')),
-            onError: () =>
-                toast.error(t('Failed to set the reminder. Please try again.')),
-        },
-    );
-}
 
 // A preset was chosen from a message's reminder popover.
 function remindWith(message: Message, remindAt: string): void {
@@ -815,240 +484,6 @@ function confirmCustomReminder(remindAt: string): void {
 
     setReminder(reminderTargetId.value, remindAt);
     reminderTargetId.value = null;
-}
-
-// Post a reply into the open thread. It renders optimistically in the panel and,
-// when "also send to channel" is checked, in the main timeline too.
-function sendThreadReply(
-    body: string,
-    mentions: Mention[],
-    sendToChannel?: boolean,
-): void {
-    const rootId = activeThreadRootId.value;
-
-    if (!rootId) {
-        return;
-    }
-
-    const clientUuid = crypto.randomUUID();
-    const optimistic = optimisticMessage({
-        clientUuid,
-        body,
-        author: currentUser.value,
-        mentions,
-        threadRootId: rootId,
-        sentToChannel: sendToChannel ?? false,
-    });
-
-    threadStream.addPending(optimistic);
-
-    // Replying makes the viewer a follower of the thread and means they've seen
-    // it, so keep the root's affordance in the main timeline dot-free.
-    mainStream.patchThreadState(rootId, {
-        threadFollowed: true,
-        threadUnread: false,
-    });
-
-    if (sendToChannel) {
-        appendPendingMain(optimistic);
-    }
-
-    router.post(
-        storeMessage({ team: props.team.slug, channel: props.channel.slug })
-            .url,
-        {
-            body,
-            client_uuid: clientUuid,
-            thread_root_id: rootId,
-            sent_to_channel: sendToChannel ?? false,
-        },
-        {
-            preserveScroll: true,
-            onError: () => {
-                threadStream.removePending(clientUuid);
-
-                if (sendToChannel) {
-                    mainStream.removePending(clientUuid);
-                }
-
-                toast.error(t('Your reply failed to send. Please try again.'));
-            },
-        },
-    );
-}
-
-// Add an optimistic row to the main timeline, keeping the pinned-to-bottom rule.
-// This is the viewer's own message (a forward or sent-to-channel reply), so it
-// follows them down when near the bottom but never inflates the unread count.
-function appendPendingMain(message: Message): void {
-    const pinned = isNearBottom();
-    mainStream.addPending(message);
-
-    if (pinned) {
-        nextTick(() => scrollToBottom());
-    }
-}
-
-// Patch a message into both timelines at once — it may render in either (or both,
-// for a sent-to-channel reply), and a patch is ignored where it isn't shown. Used
-// by the optimistic edit/delete paths; the realtime echo re-applies it via
-// `useChannelRealtime`.
-function applyPatch(message: Message): void {
-    mainStream.applyPatch(message);
-    threadStream.applyPatch(message);
-}
-
-function editMessage(message: Message, body: string): void {
-    const previousMain = mainStream.getPatch(message.clientUuid);
-    const previousThread = threadStream.getPatch(message.clientUuid);
-
-    // Optimistically show the edit; the broadcast echo later confirms it.
-    applyPatch({ ...message, body, editedAt: new Date().toISOString() });
-
-    router.patch(
-        updateMessage({
-            team: props.team.slug,
-            channel: props.channel.slug,
-            message: message.id,
-        }).url,
-        { body },
-        {
-            preserveScroll: true,
-            onError: () => {
-                mainStream.restorePatch(message.clientUuid, previousMain);
-                threadStream.restorePatch(message.clientUuid, previousThread);
-                toast.error(t('Your edit failed to save. Please try again.'));
-            },
-        },
-    );
-}
-
-function deleteMessage(message: Message): void {
-    const previousMain = mainStream.getPatch(message.clientUuid);
-    const previousThread = threadStream.getPatch(message.clientUuid);
-
-    // Optimistically show the tombstone; the broadcast echo later confirms it.
-    applyPatch({ ...message, body: '', isDeleted: true });
-
-    router.delete(
-        destroyMessage({
-            team: props.team.slug,
-            channel: props.channel.slug,
-            message: message.id,
-        }).url,
-        {
-            preserveScroll: true,
-            onError: () => {
-                mainStream.restorePatch(message.clientUuid, previousMain);
-                threadStream.restorePatch(message.clientUuid, previousThread);
-                toast.error(
-                    t('Failed to delete the message. Please try again.'),
-                );
-            },
-        },
-    );
-}
-
-// Toggle the viewer's emoji reaction on a message. The pills update
-// optimistically in whichever timeline renders it; the authoritative summary
-// arrives over the MessageReactionChanged broadcast (including the viewer's own
-// echo), and a failed request rolls the optimistic patch back.
-function reactToMessage(message: Message, emoji: string): void {
-    const previousMain = mainStream.getPatch(message.clientUuid);
-    const previousThread = threadStream.getPatch(message.clientUuid);
-
-    const next = toggleReaction(message.reactions, emoji, currentUser.value);
-    mainStream.patchReactions(message.id, next);
-    threadStream.patchReactions(message.id, next);
-
-    router.post(
-        toggleReactionAction({
-            team: props.team.slug,
-            channel: props.channel.slug,
-            message: message.id,
-        }).url,
-        { emoji },
-        {
-            preserveScroll: true,
-            preserveState: true,
-            only: ['channels'],
-            onError: () => {
-                mainStream.restorePatch(message.clientUuid, previousMain);
-                threadStream.restorePatch(message.clientUuid, previousThread);
-                toast.error(
-                    t('Failed to update the reaction. Please try again.'),
-                );
-            },
-        },
-    );
-}
-
-// Reset the panel's client state without navigating. Used when switching
-// channels, where the URL has already moved off any open thread.
-function resetThreadPanel(): void {
-    activeThreadRootId.value = null;
-    threadData.value = null;
-    threadLoading.value = false;
-    threadStream.reset();
-}
-
-// Open the thread rooted at a message by putting `?thread=<root>` in the URL, so
-// the root (`thread`) and the first page of replies (`threadReplies`) load and
-// the reply InfiniteScroll's paging requests carry the root. `reset` clears any
-// previous thread's merged replies; a skeleton shows until the root arrives.
-function openThread(rootId: string): void {
-    if (activeThreadRootId.value === rootId) {
-        return;
-    }
-
-    activeThreadRootId.value = rootId;
-    threadStream.reset();
-    threadData.value = null;
-    threadLoading.value = true;
-
-    // Opening the thread clears its dot straight away; the read pointer advances
-    // once the replies load (and again on focus / as new replies stream in).
-    mainStream.patchThreadState(rootId, { threadUnread: false });
-
-    router.get(
-        showChannel(
-            { team: props.team.slug, channel: props.channel.slug },
-            { query: { thread: rootId } },
-        ).url,
-        {},
-        {
-            only: ['thread', 'threadReplies'],
-            reset: ['threadReplies'],
-            preserveState: true,
-            preserveScroll: true,
-            replace: true,
-            onFinish: () => {
-                threadLoading.value = false;
-                markThreadRead();
-            },
-        },
-    );
-}
-
-// Close the thread: drop `?thread=` from the URL and reset the panel.
-function closeThread(): void {
-    if (activeThreadRootId.value === null) {
-        return;
-    }
-
-    resetThreadPanel();
-
-    router.get(
-        showChannel({ team: props.team.slug, channel: props.channel.slug }).url,
-        {},
-        {
-            only: ['thread', 'threadReplies'],
-            reset: ['threadReplies'],
-            preserveState: true,
-            preserveScroll: true,
-            replace: true,
-        },
-    );
 }
 
 // Drives the archive confirmation dialog opened from the channel header menu.
@@ -1081,220 +516,24 @@ function archive(): void {
 
     <div class="flex min-h-0 flex-1 overflow-hidden">
         <div class="flex min-w-0 flex-1 flex-col">
-            <header
-                class="flex shrink-0 items-end gap-4 border-b border-border px-7 pt-5 pb-3.5"
-            >
-                <SidebarTrigger
-                    class="mb-1 -ml-1.5 size-8 shrink-0 text-muted-foreground md:hidden"
-                />
-
-                <div class="min-w-0 flex-1">
-                    <h1
-                        class="flex items-center gap-2 truncate font-serif text-[32px] leading-none font-semibold tracking-[-0.02em] text-foreground"
-                    >
-                        <!-- A DM shows the participant's avatar + presence dot
-                             instead of the channel "#"; the name is already
-                             viewer-relative (self reads "You"). -->
-                        <span
-                            v-if="props.channel.isDirect"
-                            data-test="masthead-dm-avatar"
-                            class="relative inline-flex size-7 shrink-0"
-                        >
-                            <span
-                                class="flex size-7 items-center justify-center rounded-full bg-primary/10 text-[11px] font-semibold text-primary select-none"
-                                aria-hidden="true"
-                                >{{ getInitials(props.channel.name) }}</span
-                            >
-                            <span
-                                :data-online="dmParticipantOnline"
-                                :aria-label="
-                                    dmParticipantOnline
-                                        ? $t('Online')
-                                        : $t('Offline')
-                                "
-                                class="absolute -right-0.5 -bottom-0.5 size-2.5 rounded-full ring-2 ring-card"
-                                :class="
-                                    dmParticipantOnline
-                                        ? 'bg-emerald-500'
-                                        : 'bg-muted-foreground/50'
-                                "
-                            />
-                        </span>
-                        <span v-else class="text-brass italic">#</span>
-                        <span class="truncate">{{ mastheadTitle }}</span>
-                        <!-- The mute / notification-level indicator sits inline
-                             with the title so it reads as a property of this
-                             conversation rather than floating in the meta row
-                             (which is empty for a DM with no topic). -->
-                        <Tooltip v-if="notificationStatus">
-                            <TooltipTrigger as-child>
-                                <span
-                                    data-test="notification-status"
-                                    :data-status="notificationStatus.status"
-                                    class="inline-flex shrink-0 items-center text-muted-foreground"
-                                    :aria-label="$t(notificationStatus.label)"
-                                >
-                                    <component
-                                        :is="notificationStatus.icon"
-                                        class="size-4"
-                                    />
-                                </span>
-                            </TooltipTrigger>
-                            <TooltipContent>{{
-                                $t(notificationStatus.label)
-                            }}</TooltipContent>
-                        </Tooltip>
-                    </h1>
-
-                    <div
-                        v-if="props.channel.isArchived || props.channel.topic"
-                        class="mt-1.5 flex items-center gap-2 text-[13px] text-muted-foreground"
-                    >
-                        <span
-                            v-if="props.channel.isArchived"
-                            class="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
-                        >
-                            <Archive class="size-3" />
-                            {{ $t('Archived') }}
-                        </span>
-
-                        <p v-if="props.channel.topic" class="min-w-0 truncate">
-                            {{ props.channel.topic }}
-                        </p>
-                    </div>
-                </div>
-
-                <div class="flex shrink-0 items-center gap-3 pb-1">
-                    <span
-                        v-if="
-                            !props.channel.isDirect &&
-                            mastheadAvatars.visible.length > 0
-                        "
-                        data-test="masthead-members"
-                        class="flex -space-x-1.5"
-                    >
-                        <span
-                            v-for="member in mastheadAvatars.visible"
-                            :key="member.id"
-                            class="flex size-6 items-center justify-center rounded-full bg-primary/10 text-[9px] font-semibold text-primary ring-2 ring-card select-none"
-                            :title="member.name"
-                            aria-hidden="true"
-                        >
-                            {{ getInitials(member.name) }}
-                        </span>
-                        <span
-                            v-if="mastheadAvatars.overflow > 0"
-                            class="flex size-6 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-card select-none"
-                            aria-hidden="true"
-                        >
-                            +{{ mastheadAvatars.overflow }}
-                        </span>
-                    </span>
-
-                    <Link
-                        :href="searchMessages(props.team.slug).url"
-                        data-test="masthead-search"
-                        :aria-label="$t('Search messages')"
-                        class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                    >
-                        <Search class="size-4" />
-                    </Link>
-
-                    <DropdownMenu
-                        v-if="props.canManagePreferences || props.canArchive"
-                    >
-                        <DropdownMenuTrigger as-child>
-                            <button
-                                type="button"
-                                :aria-label="$t('Channel options')"
-                                data-test="channel-options"
-                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                            >
-                                <EllipsisVertical class="size-4" />
-                            </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" class="w-56">
-                            <template v-if="props.canManagePreferences">
-                                <!-- Starring files a channel into the sidebar's
-                                     "Starred" group; DMs live in their own fixed
-                                     group and are never filed, so the affordance
-                                     is hidden for them. -->
-                                <DropdownMenuItem
-                                    v-if="!props.channel.isDirect"
-                                    data-test="star-channel"
-                                    :aria-pressed="starred"
-                                    @select="
-                                        (event: Event) => {
-                                            event.preventDefault();
-                                            toggleStar();
-                                        }
-                                    "
-                                >
-                                    <Star
-                                        :class="
-                                            starred
-                                                ? 'fill-current text-amber-500'
-                                                : ''
-                                        "
-                                    />
-                                    {{
-                                        starred
-                                            ? $t('Unstar channel')
-                                            : $t('Star channel')
-                                    }}
-                                </DropdownMenuItem>
-                                <DropdownMenuSeparator
-                                    v-if="!props.channel.isDirect"
-                                />
-                                <DropdownMenuLabel
-                                    class="text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
-                                >
-                                    {{ $t('Notifications') }}
-                                </DropdownMenuLabel>
-                                <DropdownMenuRadioGroup
-                                    :model-value="notificationLevel"
-                                    @update:model-value="
-                                        onNotificationLevelChange
-                                    "
-                                >
-                                    <DropdownMenuRadioItem
-                                        v-for="level in props.notificationLevels"
-                                        :key="level.value"
-                                        :value="level.value"
-                                        :data-test="`notification-level-${level.value}`"
-                                    >
-                                        {{ level.label }}
-                                    </DropdownMenuRadioItem>
-                                </DropdownMenuRadioGroup>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuCheckboxItem
-                                    :model-value="muted"
-                                    data-test="mute-channel"
-                                    @update:model-value="onMuteChange"
-                                    @select="
-                                        (event: Event) => event.preventDefault()
-                                    "
-                                >
-                                    {{ $t('Mute channel') }}
-                                </DropdownMenuCheckboxItem>
-                            </template>
-                            <template v-if="props.canArchive">
-                                <DropdownMenuSeparator
-                                    v-if="props.canManagePreferences"
-                                />
-                                <DropdownMenuItem
-                                    data-test="archive-channel"
-                                    class="text-destructive focus:text-destructive"
-                                    @select="confirmingArchive = true"
-                                >
-                                    <Archive class="size-4" />
-                                    {{ $t('Archive channel') }}
-                                </DropdownMenuItem>
-                            </template>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
-                </div>
-            </header>
+            <ChannelMasthead
+                :channel="props.channel"
+                :team-slug="props.team.slug"
+                :members="props.members"
+                :online-ids="onlineIds"
+                :title="mastheadTitle"
+                :can-manage-preferences="props.canManagePreferences"
+                :can-archive="props.canArchive"
+                :notification-levels="props.notificationLevels"
+                :starred="starred"
+                :muted="muted"
+                :notification-level="notificationLevel"
+                :notification-status="notificationStatus"
+                @toggle-star="toggleStar"
+                @notification-level-change="onNotificationLevelChange"
+                @mute-change="onMuteChange"
+                @archive="confirmingArchive = true"
+            />
 
             <div class="relative flex min-h-0 flex-1 flex-col">
                 <div class="relative flex min-h-0 flex-1 flex-col">
@@ -1354,217 +593,14 @@ function archive(): void {
                             />
                         </InfiniteScroll>
 
-                        <div
+                        <ChannelEmptyState
                             v-else
-                            class="flex h-full flex-col items-center justify-center gap-1 px-6"
-                        >
-                            <!-- Brand-new workspace: the reachable first-run
-                                 welcome, shown on an empty #general until the
-                                 viewer completes onboarding. -->
-                            <div
-                                v-if="showWelcome"
-                                data-test="workspace-welcome"
-                                class="flex w-full max-w-[460px] flex-col items-center text-center"
-                            >
-                                <svg
-                                    width="52"
-                                    height="52"
-                                    viewBox="0 0 40 40"
-                                    aria-hidden="true"
-                                >
-                                    <polygon
-                                        points="20,18 36,27 20,36 4,27"
-                                        class="fill-foreground/40"
-                                    />
-                                    <polygon
-                                        points="20,11 36,20 20,29 4,20"
-                                        class="fill-foreground/70"
-                                    />
-                                    <polygon
-                                        points="20,4 36,13 20,22 4,13"
-                                        class="fill-brass"
-                                    />
-                                </svg>
-                                <h2
-                                    class="mt-5 font-serif text-[30px] font-semibold tracking-[-0.015em] text-foreground"
-                                >
-                                    {{
-                                        $t('Welcome to :team', {
-                                            team: props.team.name,
-                                        })
-                                    }}
-                                </h2>
-                                <p
-                                    class="mt-3 max-w-[400px] text-[15px] leading-[1.6] text-muted-foreground"
-                                >
-                                    {{
-                                        $t(
-                                            'Your workspace is ready. A few small steps and it starts feeling like home.',
-                                        )
-                                    }}
-                                </p>
-
-                                <div class="mt-7 flex w-full flex-col gap-2.5">
-                                    <CreateChannelModal
-                                        :team-slug="props.team.slug"
-                                    >
-                                        <button
-                                            type="button"
-                                            data-test="welcome-create-channel"
-                                            class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
-                                        >
-                                            <span
-                                                class="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-brass-fill text-[16px] font-semibold text-brass-fill-foreground"
-                                                >#</span
-                                            >
-                                            <span class="flex flex-1 flex-col">
-                                                <span
-                                                    class="text-[14.5px] font-semibold text-foreground"
-                                                    >{{
-                                                        $t(
-                                                            'Create your first channel',
-                                                        )
-                                                    }}</span
-                                                >
-                                                <span
-                                                    class="text-[12.5px] text-muted-foreground"
-                                                    >{{
-                                                        $t(
-                                                            'Group conversations by topic or project',
-                                                        )
-                                                    }}</span
-                                                >
-                                            </span>
-                                            <span
-                                                class="inline-flex h-9 items-center rounded-full bg-primary px-4 text-[13px] font-semibold text-primary-foreground"
-                                                >{{ $t('Create') }}</span
-                                            >
-                                        </button>
-                                    </CreateChannelModal>
-
-                                    <button
-                                        v-if="canInviteToCurrentTeam"
-                                        type="button"
-                                        data-test="welcome-invite"
-                                        class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
-                                        @click="inviteOpen = true"
-                                    >
-                                        <span
-                                            class="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-brass-fill text-brass-fill-foreground"
-                                        >
-                                            <UserPlus class="size-[17px]" />
-                                        </span>
-                                        <span class="flex flex-1 flex-col">
-                                            <span
-                                                class="text-[14.5px] font-semibold text-foreground"
-                                                >{{
-                                                    $t('Invite your teammates')
-                                                }}</span
-                                            >
-                                            <span
-                                                class="text-[12.5px] text-muted-foreground"
-                                                >{{
-                                                    $t(
-                                                        'A workspace comes alive with people',
-                                                    )
-                                                }}</span
-                                            >
-                                        </span>
-                                        <span
-                                            class="inline-flex h-9 items-center rounded-full border border-input bg-background px-4 text-[13px] font-semibold text-foreground"
-                                            >{{ $t('Invite') }}</span
-                                        >
-                                    </button>
-
-                                    <button
-                                        type="button"
-                                        data-test="welcome-post-message"
-                                        class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
-                                        @click="focusComposer"
-                                    >
-                                        <span
-                                            class="flex size-9 shrink-0 items-center justify-center rounded-[11px] bg-brass-fill text-brass-fill-foreground"
-                                        >
-                                            <Send class="size-[16px]" />
-                                        </span>
-                                        <span class="flex flex-1 flex-col">
-                                            <span
-                                                class="text-[14.5px] font-semibold text-foreground"
-                                                >{{
-                                                    $t(
-                                                        'Post your first message',
-                                                    )
-                                                }}</span
-                                            >
-                                            <span
-                                                class="text-[12.5px] text-muted-foreground"
-                                                >{{
-                                                    $t(
-                                                        'Break the ice — even a wave counts',
-                                                    )
-                                                }}</span
-                                            >
-                                        </span>
-                                        <span
-                                            class="inline-flex h-9 items-center rounded-full border border-input bg-background px-4 text-[13px] font-semibold text-foreground"
-                                            >{{ $t('Compose') }}</span
-                                        >
-                                    </button>
-                                </div>
-
-                                <p
-                                    class="mt-5 text-[12.5px] text-muted-foreground"
-                                >
-                                    {{ $t('Prefer to explore on your own?') }}
-                                    <button
-                                        type="button"
-                                        data-test="welcome-take-tour"
-                                        class="font-semibold text-brass-fill-foreground hover:underline"
-                                        @click="openOnboardingTour"
-                                    >
-                                        {{ $t('Take the 30-second tour') }}
-                                    </button>
-                                </p>
-                            </div>
-
-                            <!-- Every other empty channel or DM. -->
-                            <template v-else>
-                                <div
-                                    class="font-serif text-[64px] leading-none text-border italic"
-                                    aria-hidden="true"
-                                >
-                                    {{ props.channel.isDirect ? '@' : '#' }}
-                                </div>
-                                <p
-                                    class="mt-1.5 font-serif text-[20px] font-semibold text-foreground"
-                                >
-                                    {{ $t('No messages yet') }}
-                                </p>
-                                <p class="text-[13.5px] text-muted-foreground">
-                                    {{
-                                        props.channel.isDirect
-                                            ? isSelfDm
-                                                ? $t(
-                                                      'This is your space — jot anything down.',
-                                                  )
-                                                : $t(
-                                                      'This is the start of your conversation with :name.',
-                                                      {
-                                                          name: props.channel
-                                                              .name,
-                                                      },
-                                                  )
-                                            : $t(
-                                                  'Be the first to say something in #:channel.',
-                                                  {
-                                                      channel:
-                                                          props.channel.name,
-                                                  },
-                                              )
-                                    }}
-                                </p>
-                            </template>
-                        </div>
+                            :channel="props.channel"
+                            :is-self-dm="isSelfDm"
+                            :team-name="props.team.name"
+                            :team-slug="props.team.slug"
+                            @focus-composer="focusComposer"
+                        />
                     </div>
 
                     <Transition
@@ -1708,14 +744,7 @@ function archive(): void {
         :channels="forwardableChannels"
         :people="forwardablePeople"
         :current-user-id="currentUser.id"
-        @submit="forwardMessage"
-    />
-
-    <InviteMemberModal
-        v-if="currentTeamForInvite && canInviteToCurrentTeam"
-        v-model:open="inviteOpen"
-        :team="currentTeamForInvite"
-        :available-roles="invitableRoles"
+        @submit="submitForward"
     />
 
     <ScheduledMessagesDialog


### PR DESCRIPTION
Closes #235.

## What & why

`resources/js/pages/channels/Show.vue` was **1767 lines**, owning several independent lifecycles in one setup block — tripping CONTEXT.md's own "decompose a `.vue` past ~400 lines / several lifecycles" rule. ADR-0006 split out the realtime lifecycle and noted this "unblocks the god-component split"; this finishes it.

Four extractions, each landed test-first behind its own seam. `Show.vue` is now **796 lines** and reads as orchestration only.

## Extractions

### 1. `useMessageActions` — the optimistic-mutation engine
Owns `send`, `editMessage`, `deleteMessage`, `reactToMessage`, `forwardMessage`, `sendThreadReply`, `scheduleMessage`, `updateScheduled`, `cancelScheduled`, `setReminder` plus the shared `applyPatch`/`appendPendingMain` primitives. Every one is the same optimistic-apply → `router` call → rollback-on-error shape, now concentrated in one module with a unit-testable seam. Reuses the standalone `optimisticMessage` factory.
- `useMessageActions.test.ts` asserts optimistic apply + rollback + toast (and `only:` reload keys) per action.

### 2. `lib/forwardPlacement.ts` — pure decision core
`planForward` decides the forward-to-current-channel flag, the destination payload, and the DM `channelName: null` quote rule. Paired `forwardPlacement.test.ts`.

### 3. `useThreadPanel` — the thread open/load/reset/mark-read lifecycle
Owns `activeThreadRootId`, `threadData`, `threadLoading`, the panel's own `useMessageStream`, `openThread`/`closeThread`/`resetThreadPanel`, the debounced `markThreadRead`, deep-link adoption, and the `watch(props.thread)` guard. Resets itself on channel switch — one seam for the reset-on-switch behaviour, so the page no longer juggles two stream lifecycles inline.
- `useThreadPanel.test.ts` covers open/close/reset, focus-gated mark-read scheduling, deep-link adoption, and the late-arriving-prop guard.

### 4. `ChannelMasthead.vue` + `ChannelEmptyState.vue` — presentational chrome
The ~210-line header (DM avatar/presence, notification cue, member facepile, search link, preferences/archive menu) and the ~210-line empty-state / first-run welcome (create-channel / invite / post-message cards, take-the-tour) leave the page as focused components. Per the repo's testing reality (no `.vue` render harness), these carry no logic to unit-test and stay covered by the existing `tests/Feature/Channels/*` Pest tests.

## Constraints honoured
- **TDD** — every extraction driven red → green.
- **Pure refactor** — no user-facing behaviour or copy change; all moved strings keep going through `$t`/`__()`. No new i18n keys (all pre-existing).
- **Reuse, don't touch** — `useChannelRealtime`, `useMessageStream`, `useScrollPin`, `useChannelPreferences`, `useChannelDraft`, `useUnreadDivider` unchanged. Aligns with ADR-0006 (realtime in composables; decision cores in `lib/`). No new base folders.

## Verification (all green)
- `./vendor/bin/sail composer test` → Pint passed, PHPStan 0 errors, Pest **773 passed / 4 skipped**, coverage **Total: 100.0 %**.
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — all pass.
- `sail npm run test:js` → **309 passed** (incl. 3 new suites: 15 + 12 + 5).
- Existing `tests/Feature/Channels/{ChannelTest,MessageTest,WorkspaceShellTest}.php` stay green (28 tests).