### PR TITLE
fix(messaging): scope @mention autocomplete to DM participants (#216)

### DIFF
--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -140,9 +140,16 @@ class ChannelController extends Controller
                     ->orderBy('send_at')
                     ->get()
             ),
-            // Team members feed the composer's @mention autocomplete; mentions are
-            // scoped to the team, never limited to the current channel's members.
-            'members' => UserData::collect($team->members()->orderBy('name')->get()),
+            // Feeds the composer's @mention autocomplete. A standard channel is
+            // team-scoped — you may mention anyone on the team. A direct message
+            // is scoped to its own participants, since mentioning someone who
+            // isn't in the conversation would never reach them (this generalizes
+            // to group DMs, whatever their member count).
+            'members' => UserData::collect(
+                ($channel->isDirect() ? $channel->members() : $team->members())
+                    ->orderBy('name')
+                    ->get()
+            ),
             // Read pointers of the channel's other members who share read receipts,
             // seeding the "Seen by" affordance at open; later advances arrive via the
             // MessageRead broadcast. The viewer and opted-out members are excluded.

--- a/tests/Feature/Channels/MentionMembersPropTest.php
+++ b/tests/Feature/Channels/MentionMembersPropTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\ChannelType;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('a standard channel ships the whole team for mention autocomplete', function () {
+    $owner = User::factory()->create(['name' => 'Zoe Owner']);
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $member = User::factory()->create(['name' => 'Amy Member']);
+    $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('members', 2)
+            ->where('members.0.name', 'Amy Member')
+            ->where('members.1.name', 'Zoe Owner')
+        );
+});
+
+test('a direct message scopes mention autocomplete to its participants', function () {
+    $owner = User::factory()->create(['name' => 'Zoe Owner']);
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $other = User::factory()->create(['name' => 'Amy Member']);
+    $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
+    $bystander = User::factory()->create(['name' => 'Bob Bystander']);
+    $team->memberships()->create(['user_id' => $bystander->id, 'role' => TeamRole::Member]);
+
+    $this->actingAs($owner)->post(route('channels.dm.store', ['team' => $team->slug]), ['user_id' => $other->id]);
+    $dm = Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->firstOrFail();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('members', 2)
+            // Only the two DM participants, ordered by name; the bystander is excluded.
+            ->where('members.0.name', 'Amy Member')
+            ->where('members.1.name', 'Zoe Owner')
+        );
+});


### PR DESCRIPTION
Closes #216

## Problem

Inside a direct message, the composer's `@mention` autocomplete listed **every team member** instead of only the DM's participants. In a 1:1 DM the only mentionable person should be the other participant — mentioning people who aren't in the conversation makes no sense (they never receive it).

## Fix

`ChannelController@show` always shipped the full team roster as the `members` prop. Now the prop is scoped by channel type:

- **Direct message** → the channel's own participants (generalizes to group DMs whatever their count).
- **Standard channel** → the whole team, unchanged.

The client already filters out the current user, so a 1:1 DM now offers only the other participant. No frontend change was needed.

## Tests

New `MentionMembersPropTest` covers both paths:
- standard channel ships the whole team
- a DM scopes the `members` prop to its participants (a team bystander is excluded)

Gates green: `sail composer test` reports **100.0%** coverage, PHPStan clean, Pint clean.