### PR TITLE
fix(composer): focus textarea when clicking anywhere in the input card (#169)

### DIFF
--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -6,6 +6,7 @@ import ScheduleMessageDialog from '@/components/ScheduleMessageDialog.vue';
 import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
 import { useTranslations } from '@/composables/useTranslations';
+import { isInteractiveComposerTarget } from '@/lib/composerFocus';
 import type { Mention, Message } from '@/types';
 
 const props = defineProps<{
@@ -256,6 +257,33 @@ function focus(): void {
     nextTick(() => textarea.value?.focus());
 }
 
+// The whole card reads as "the message box", so a click anywhere in its chrome —
+// the padding, the whitespace around the single line of text — should activate
+// the input. Clicks that land on a control (send/attachment/schedule buttons) or
+// on the textarea itself carry their own behaviour and are left untouched; only
+// clicks on the non-interactive chrome fall through here to focus the field with
+// the caret at the end. `mousedown` is preventable before focus shifts, so the
+// redirect happens without a flicker of the card losing then regaining focus.
+function focusFromCard(event: MouseEvent): void {
+    const el = textarea.value;
+
+    if (
+        !el ||
+        isInteractiveComposerTarget(
+            event.target as Element | null,
+            event.currentTarget as Element,
+        )
+    ) {
+        return;
+    }
+
+    event.preventDefault();
+    el.focus();
+
+    const end = el.value.length;
+    el.setSelectionRange(end, end);
+}
+
 defineExpose({ insertMention, focus });
 
 // Clear the composer after the text has been handed off (an immediate send or a
@@ -408,6 +436,7 @@ function onKeydown(event: KeyboardEvent): void {
                  wraps, with the tools pinned to the bottom edge. -->
             <div
                 class="flex items-end gap-2.5 rounded-[26px] border border-input bg-card py-2 pr-2 pl-[18px] shadow-[0_3px_12px_rgba(29,26,21,0.08)] focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/20 dark:shadow-[0_3px_12px_rgba(0,0,0,0.3)]"
+                @mousedown="focusFromCard"
             >
                 <textarea
                     ref="textarea"

--- a/resources/js/lib/composerFocus.test.ts
+++ b/resources/js/lib/composerFocus.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { isInteractiveComposerTarget } from '@/lib/composerFocus';
+
+type Node = { tagName: string; parentElement: Node | null };
+
+/** Build a node chain from a leaf up to a card boundary, returning both ends. */
+function chain(...tags: string[]): { boundary: Node; leaf: Node } {
+    const boundary: Node = { tagName: 'DIV', parentElement: null };
+    let node = boundary;
+
+    for (const tagName of tags) {
+        node = { tagName, parentElement: node };
+    }
+
+    return { boundary, leaf: node };
+}
+
+describe('isInteractiveComposerTarget', () => {
+    it('treats a click on the card padding as non-interactive', () => {
+        const { boundary, leaf } = chain('SPAN');
+
+        expect(isInteractiveComposerTarget(leaf, boundary)).toBe(false);
+    });
+
+    it('treats a click on the card itself as non-interactive', () => {
+        const { boundary } = chain();
+
+        expect(isInteractiveComposerTarget(boundary, boundary)).toBe(false);
+    });
+
+    it('treats a click on the textarea as interactive', () => {
+        const { boundary, leaf } = chain('TEXTAREA');
+
+        expect(isInteractiveComposerTarget(leaf, boundary)).toBe(true);
+    });
+
+    it('treats a click on a toolbar button as interactive', () => {
+        const { boundary, leaf } = chain('BUTTON');
+
+        expect(isInteractiveComposerTarget(leaf, boundary)).toBe(true);
+    });
+
+    it('treats a click on an icon nested inside a button as interactive', () => {
+        const { boundary, leaf } = chain('BUTTON', 'SVG', 'PATH');
+
+        expect(isInteractiveComposerTarget(leaf, boundary)).toBe(true);
+    });
+
+    it('treats a click on the checkbox input as interactive', () => {
+        const { boundary, leaf } = chain('LABEL', 'INPUT');
+
+        expect(isInteractiveComposerTarget(leaf, boundary)).toBe(true);
+    });
+
+    it('stops at the boundary and does not inspect the card ancestors', () => {
+        const outerButton: Node = { tagName: 'BUTTON', parentElement: null };
+        const boundary: Node = { tagName: 'DIV', parentElement: outerButton };
+        const leaf: Node = { tagName: 'SPAN', parentElement: boundary };
+
+        expect(isInteractiveComposerTarget(leaf, boundary)).toBe(false);
+    });
+
+    it('treats a null target as non-interactive', () => {
+        const { boundary } = chain();
+
+        expect(isInteractiveComposerTarget(null, boundary)).toBe(false);
+    });
+});

--- a/resources/js/lib/composerFocus.ts
+++ b/resources/js/lib/composerFocus.ts
@@ -1,0 +1,47 @@
+/**
+ * Element tags that carry their own click behaviour inside the composer card —
+ * the send/attachment/schedule buttons, the "also send to channel" checkbox,
+ * and the textarea itself. A click landing on (or inside) any of these must run
+ * that control's own action and keep its native focus/caret handling.
+ */
+const INTERACTIVE_TAGS = new Set([
+    'BUTTON',
+    'INPUT',
+    'TEXTAREA',
+    'SELECT',
+    'A',
+    'LABEL',
+]);
+
+/** The minimal slice of `Element` this predicate walks — the DOM node chain. */
+type ClickNode = {
+    tagName: string;
+    parentElement: ClickNode | null;
+};
+
+/**
+ * Whether a click that originated on `target` should defer to an interactive
+ * control rather than being redirected into the composer textarea.
+ *
+ * Walks the ancestor chain from `target` up to — but not including — the card
+ * `boundary`, treating the click as interactive when any node along the way is a
+ * button, input, textarea, select, link, or label. Clicks on the card's own
+ * padding or whitespace reach the boundary without matching, so they fall
+ * through to focus the textarea instead.
+ */
+export function isInteractiveComposerTarget(
+    target: ClickNode | null,
+    boundary: ClickNode,
+): boolean {
+    let node: ClickNode | null = target;
+
+    while (node && node !== boundary) {
+        if (INTERACTIVE_TAGS.has(node.tagName)) {
+            return true;
+        }
+
+        node = node.parentElement;
+    }
+
+    return false;
+}


### PR DESCRIPTION
Closes #169.

## Problem

The composer card reads as a single "message box", but only clicking the one-line `<textarea>` focused it. Clicking the card's padding or the whitespace beside the tool buttons did nothing, so the user had to aim precisely at the one-line field to start typing.

## Fix

A `@mousedown` handler on the composer card redirects clicks that land on its non-interactive chrome to the textarea, placing the caret at the end. Clicks on the send / attachment / schedule buttons — or on the textarea itself — keep their native behaviour and caret handling.

The decision of whether a click should defer to a control is extracted into a pure `isInteractiveComposerTarget()` predicate (`resources/js/lib/composerFocus.ts`), which walks the ancestor chain from the click target up to the card boundary. `mousedown` (rather than `click`) is used so the redirect can `preventDefault()` before focus shifts, avoiding a flicker of the card losing then regaining focus.

## Acceptance criteria

- [x] Clicking anywhere in the composer card focuses the textarea and it becomes active.
- [x] Caret is placed at the end of any existing text.
- [x] Clicking the toolbar buttons / checkbox still triggers their own action and does not hijack focus.
- [x] Covered by a test — `resources/js/lib/composerFocus.test.ts` (8 cases: padding, card itself, textarea, buttons, nested icon, checkbox, boundary stop, null target).

## Verification

`lint:check`, `format:check`, `types:check`, `build`, and `test:js` (317 tests) all pass through Sail.