### PR TITLE
fix(navigation): populate the sidebar on the message search page (#243)

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -103,6 +103,21 @@ class HandleInertiaRequests extends Middleware
     }
 
     /**
+     * Whether the current request targets an in-workspace page that renders the
+     * shared sidebar.
+     *
+     * Every such route binds a `{team}`, but not all live under the `channels.`
+     * name prefix — the message search page is named `search`/`search.suggest`,
+     * so it is matched explicitly. This is the single source of truth for the
+     * sidebar-feeding shared props below; broaden it here to add a new workspace
+     * surface rather than duplicating the pattern per prop.
+     */
+    protected function isWorkspaceRoute(Request $request): bool
+    {
+        return $request->routeIs('channels.*', 'search', 'search.suggest');
+    }
+
+    /**
      * The current user's channels for the workspace sidebar, scoped to the team in the URL.
      *
      * @return array<int, ChannelData>
@@ -111,7 +126,7 @@ class HandleInertiaRequests extends Middleware
     {
         $team = $request->route('team');
 
-        if (! $user || ! $team instanceof Team || ! $request->routeIs('channels.*')) {
+        if (! $user || ! $team instanceof Team || ! $this->isWorkspaceRoute($request)) {
             return [];
         }
 
@@ -204,7 +219,7 @@ class HandleInertiaRequests extends Middleware
     {
         $team = $request->route('team');
 
-        if (! $user || ! $team instanceof Team || ! $request->routeIs('channels.*')) {
+        if (! $user || ! $team instanceof Team || ! $this->isWorkspaceRoute($request)) {
             return [];
         }
 
@@ -226,7 +241,7 @@ class HandleInertiaRequests extends Middleware
     {
         $team = $request->route('team');
 
-        if (! $user || ! $team instanceof Team || ! $request->routeIs('channels.*')) {
+        if (! $user || ! $team instanceof Team || ! $this->isWorkspaceRoute($request)) {
             return [];
         }
 
@@ -254,7 +269,7 @@ class HandleInertiaRequests extends Middleware
     {
         $team = $request->route('team');
 
-        if (! $user || ! $team instanceof Team || ! $request->routeIs('channels.*')) {
+        if (! $user || ! $team instanceof Team || ! $this->isWorkspaceRoute($request)) {
             return [];
         }
 
@@ -279,7 +294,7 @@ class HandleInertiaRequests extends Middleware
     {
         $team = $request->route('team');
 
-        if (! $user || ! $team instanceof Team || ! $request->routeIs('channels.*')) {
+        if (! $user || ! $team instanceof Team || ! $this->isWorkspaceRoute($request)) {
             return false;
         }
 

--- a/tests/Feature/Channels/MessageSearchTest.php
+++ b/tests/Feature/Channels/MessageSearchTest.php
@@ -70,6 +70,22 @@ test('a member searches messages in their channels', function () {
         );
 });
 
+test('the search page shares the workspace sidebar props', function () {
+    [, $team, $general] = searchTeamWithGeneral();
+    $member = searchMember($team, $general, 'Ada Lovelace');
+
+    // The sidebar feeds off the same shared props as a channel page; the search
+    // route lives outside the channels.* name prefix, so it must be covered too.
+    performSearch($member, $team, '')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('channels/Search')
+            ->has('channels', 1)
+            ->where('channels.0.slug', 'general')
+            ->has('teamMembers', 2)
+        );
+});
+
 test('search does not leak messages from channels the user is not a member of', function () {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);


### PR DESCRIPTION
Closes #243.

## Problem

On the message search page (`/t/{team}/search`, route name `search`), the workspace sidebar rendered but showed **"No channels yet"** — no channels, DMs, sections, members, or reminders — even though the same sidebar is fully populated on channel pages.

Every sidebar-feeding shared prop in `HandleInertiaRequests` gated on `$request->routeIs('channels.*')`, but the search routes are named `search` / `search.suggest`, outside that name prefix. So on the search page the guard was false and the sidebar was starved of its data.

## Fix

Extract the route guard into a single `isWorkspaceRoute()` helper — the source of truth for all sidebar-feeding props — that matches `channels.*` **and** the `search` / `search.suggest` routes. Every sidebar prop now points at it, so the search page shares channels, DMs, sections, members, and reminders identically to a channel page. Adding a new workspace surface later means broadening one method, not duplicating the pattern per prop.

## Testing

- New feature test: the search page response includes the shared `channels` (and `teamMembers`) props for a user with channels.
- Full gate green: Pint, PHPStan (0 errors), 780 tests passing, **100.0%** coverage.