### PR TITLE
fix(seeder): use time-ordered UUIDv7 message ids in channel backfill

### DIFF
--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -320,7 +320,12 @@ class WorkspaceSeeder extends Seeder
                 $createdAt = $date->copy()->addHours($index);
 
                 $rows[] = [
-                    'id' => (string) Str::uuid(),
+                    // Derive a UUIDv7 from this row's back-dated `created_at` so the
+                    // id encodes the historical timestamp, not "now". The `id DESC`
+                    // timeline then reads chronologically and these old rows sort
+                    // below every later, real message — a random UUIDv4 (or a
+                    // now-stamped v7) would bury real messages beneath the backlog.
+                    'id' => (string) Str::uuid7($createdAt),
                     'channel_id' => $channel->id,
                     'user_id' => $authorIds[($day + $index) % count($authorIds)],
                     'client_uuid' => (string) Str::uuid(),

--- a/tests/Feature/DatabaseSeederTest.php
+++ b/tests/Feature/DatabaseSeederTest.php
@@ -89,6 +89,25 @@ test('it backfills a busy channel to make pagination meaningful', function () {
     expect($busiest->messages_count)->toBeGreaterThanOrEqual(50);
 });
 
+test('backfilled messages carry time-ordered ids so a newly sent message sorts newest', function () {
+    $busiest = Channel::withCount('messages')->orderByDesc('messages_count')->firstOrFail();
+
+    // The timeline orders by `id DESC` and relies on ids being time-ordered
+    // (UUIDv7). Seeded ids must therefore be v7 and rank in `created_at` order,
+    // exactly like real, app-created messages — so walking the timeline newest
+    // id first yields non-increasing timestamps.
+    $timeline = $busiest->messages()->orderByDesc('id')->pluck('created_at')->map->getTimestamp()->all();
+    $chronological = collect($timeline)->sortDesc()->values()->all();
+
+    expect($timeline)->toBe($chronological);
+
+    // A message sent after seeding must land at the very top of `id DESC` — the
+    // newest row — rather than buried beneath a backlog of random-id seed rows.
+    $sent = Message::factory()->for($busiest)->for($this->demo)->create();
+
+    expect($busiest->messages()->orderByDesc('id')->value('id'))->toBe($sent->id);
+});
+
 test('it seeds edited, soft-deleted and mention-bearing messages', function () {
     expect(Message::whereNotNull('edited_at')->exists())->toBeTrue()
         ->and(Message::onlyTrashed()->exists())->toBeTrue()


### PR DESCRIPTION
Closes #242.

## Problem

`database/seeders/WorkspaceSeeder.php` seeded backfilled messages with a random **UUIDv4** (`Str::uuid()`) alongside a historical `created_at`. But the `Message` model uses `HasUuids` (**UUIDv7**), and the channel timeline orders by `id DESC` (`ChannelTimelineWindow::messages()`), which relies on ids being time-ordered.

Because v4 seed ids are random and every real, app-created message is v7, the real messages sorted **below** all seed messages. A message sent in a seeded channel (e.g. `announcements`) persisted correctly but appeared buried at the bottom of the backlog instead of newest — surfaced while testing the offline/reconnect feature (#55).

## Fix

```php
'id' => (string) Str::uuid7($createdAt),
```

Deriving the id from each row's back-dated `created_at` produces a UUIDv7 whose timestamp **is** the historical time. Seeded rows now sort chronologically among themselves *and* below every later real message.

A plain now-stamped v7 (or `Str::orderedUuid()`) would **not** have worked: backfill runs after the recent `seedMessages` rows, so now-stamped ids would out-rank them and `Str::orderedUuid()` produces a non-v7 prefix that sorts above real v7 ids.

`client_uuid` (line 326) was reviewed per the issue and left as `Str::uuid()` — it's a client-side dedup token where randomness is correct and ordering is irrelevant.

## Acceptance criteria

- [x] Seeded messages use time-ordered ids consistent with their `created_at`, so `ORDER BY id DESC` matches chronological order.
- [x] After seeding, a newly sent message appears at the bottom of the timeline (newest) without scrolling.
- [x] `client_uuid` seeding reviewed (kept `Str::uuid()` — appropriate for a dedup token).

## Testing

Added a TDD test (red → green) in `tests/Feature/DatabaseSeederTest.php` asserting the busiest channel's `id DESC` timeline is chronologically ordered and that a freshly created message sorts newest. Full gate green: Pint, PHPStan, and `php artisan test --coverage --min=100` at **Total: 100.0%**.