### PR TITLE
build(rector): add Rector for automated PHP refactoring (#246)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run Pint
         run: composer lint
 
+      - name: Run Rector
+        run: composer refactor:check
+
       - name: Format Frontend
         run: npm run format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/sail (SAIL) - v1
 - pestphp/pest (PEST) - v4
 - phpunit/phpunit (PHPUNIT) - v12
+- rector/rector (RECTOR) - v2
 - @inertiajs/vue3 (INERTIA_VUE) - v3
 - tailwindcss (TAILWINDCSS) - v4
 - vue (VUE) - v3
@@ -238,10 +239,16 @@ Vue components must have a single root element.
 - `vue-tsc` (`npm run types:check`) doesn't use those native bindings, so it can run on the host, but prefer Sail for consistency.
 - The frontend quality gate is `./vendor/bin/sail npm run lint:check`, `format:check`, `types:check`, and `build` — all four must pass before pushing. Use `sail npm run lint` / `format` (the write variants) to auto-fix violations.
 
+## Automated Refactoring (Rector)
+
+- **Rector is the automated-fix layer for structural PHP**, complementing Pint (style) and PHPStan (detection). It enforces our conventions (explicit return types, type hints, readonly, early returns, dead-code removal, PHP/Laravel modernization) by rewriting the code, and its config lives in `rector.php` (scoped to the same paths PHPStan analyzes, plus `tests/`).
+- **`composer refactor` applies fixes; `composer refactor:check` is the dry-run.** Think of `composer refactor` as the semantic counterpart to Pint's `composer lint` formatter — run it to auto-apply structural fixes before pushing.
+- **The backend gate runs Rector.** `./vendor/bin/sail composer test` now also runs `rector process --dry-run` (via `refactor:check`), and CI runs it too. A failing dry-run fails the build — run `./vendor/bin/sail composer refactor` to apply the suggested changes, review the diff, and re-run the gate before pushing.
+
 ## Code Coverage
 
 - **100% code coverage is required — this is non-negotiable.** The test suite is gated at `--min=100` (see the `test` script in `composer.json`), so any line left uncovered fails the build.
-- **Always check coverage before pushing.** Run the full gate — which also runs Pint and PHPStan — with `./vendor/bin/sail composer test` (this executes `lint:check`, `types:check`, and `php artisan test --coverage --min=100`). Do not push or open/update a PR until it reports `Total: 100.0 %`.
+- **Always check coverage before pushing.** Run the full gate — which also runs Pint, PHPStan, and Rector — with `./vendor/bin/sail composer test` (this executes `lint:check`, `types:check`, `refactor:check`, and `php artisan test --coverage --min=100`). Do not push or open/update a PR until it reports `Total: 100.0 %` with a clean Rector dry-run.
 - If new code drops coverage, add or update tests until it is back at 100%. When a line reads as uncovered even though a test exercises it (e.g. the `: null` branch of a multi-line ternary is a known PCOV line-attribution quirk), collapse it onto a single line rather than leaving the gate red.
 
 ## Reporting Bugs Found While Doing Something Else

--- a/README.md
+++ b/README.md
@@ -20,8 +20,16 @@ composer install
 Run the quality gate before pushing:
 
 ```bash
-./vendor/bin/sail composer test        # Pint, PHPStan, and tests at 100% coverage
+./vendor/bin/sail composer test        # Pint, PHPStan, Rector (dry-run), and tests at 100% coverage
 ./vendor/bin/sail npm run lint:check    # ESLint / Prettier / vue-tsc / build
+```
+
+[Rector](https://github.com/rectorphp/rector) handles automated structural
+refactoring (the semantic counterpart to Pint's formatter). The gate runs it in
+dry-run mode; when it reports pending changes, apply them and re-run the gate:
+
+```bash
+./vendor/bin/sail composer refactor    # apply Rector's suggested refactors
 ```
 
 ## Self-Hosting with Docker

--- a/app/Actions/Channels/ArchiveChannel.php
+++ b/app/Actions/Channels/ArchiveChannel.php
@@ -15,7 +15,7 @@ class ArchiveChannel
      */
     public function handle(Channel $channel): Channel
     {
-        return DB::transaction(function () use ($channel) {
+        return DB::transaction(function () use ($channel): Channel {
             if (! $channel->isArchived()) {
                 $channel->update(['archived_at' => now()]);
             }

--- a/app/Actions/Channels/CancelScheduledMessage.php
+++ b/app/Actions/Channels/CancelScheduledMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Enums\ScheduledMessageStatus;

--- a/app/Actions/Channels/ClearMessageReminder.php
+++ b/app/Actions/Channels/ClearMessageReminder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Models\MessageReminder;

--- a/app/Actions/Channels/CreateChannel.php
+++ b/app/Actions/Channels/CreateChannel.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Str;
 
 class CreateChannel
 {
-    public function __construct(private JoinChannel $joinChannel) {}
+    public function __construct(private readonly JoinChannel $joinChannel) {}
 
     /**
      * Create a channel in the team and add its creator as a member.

--- a/app/Actions/Channels/DeleteMessage.php
+++ b/app/Actions/Channels/DeleteMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Data\MessageData;
@@ -26,6 +28,6 @@ class DeleteMessage
         $message->delete();
 
         $message->loadMissing('user');
-        MessageDeleted::dispatch($channel, MessageData::fromMessage($message));
+        event(new MessageDeleted($channel, MessageData::fromMessage($message)));
     }
 }

--- a/app/Actions/Channels/DispatchDueMessageReminders.php
+++ b/app/Actions/Channels/DispatchDueMessageReminders.php
@@ -29,7 +29,7 @@ class DispatchDueMessageReminders
                     'fired_at' => now(),
                 ]);
 
-                MessageReminderDue::dispatch($reminder->user_id);
+                event(new MessageReminderDue($reminder->user_id));
             });
     }
 }

--- a/app/Actions/Channels/DispatchDueScheduledMessages.php
+++ b/app/Actions/Channels/DispatchDueScheduledMessages.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Gate;
 
 class DispatchDueScheduledMessages
 {
-    public function __construct(private PostMessage $postMessage) {}
+    public function __construct(private readonly PostMessage $postMessage) {}
 
     /**
      * Deliver every scheduled message whose send time has arrived.

--- a/app/Actions/Channels/EditMessage.php
+++ b/app/Actions/Channels/EditMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Data\MessageData;
@@ -10,8 +12,8 @@ use App\Models\Message;
 class EditMessage
 {
     public function __construct(
-        private SyncMentions $syncMentions,
-        private SyncLinkPreviews $syncLinkPreviews,
+        private readonly SyncMentions $syncMentions,
+        private readonly SyncLinkPreviews $syncLinkPreviews,
     ) {}
 
     /**
@@ -32,7 +34,7 @@ class EditMessage
         $this->syncLinkPreviews->handle($message);
 
         $message->loadMessageDataRelations();
-        MessageUpdated::dispatch($channel, MessageData::fromMessage($message));
+        event(new MessageUpdated($channel, MessageData::fromMessage($message)));
 
         return $message;
     }

--- a/app/Actions/Channels/HideDirectMessage.php
+++ b/app/Actions/Channels/HideDirectMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Models\Channel;

--- a/app/Actions/Channels/JoinChannel.php
+++ b/app/Actions/Channels/JoinChannel.php
@@ -14,10 +14,8 @@ class JoinChannel
      */
     public function handle(Channel $channel, User $user): ChannelMember
     {
-        return DB::transaction(function () use ($channel, $user) {
-            return $channel->channelMembers()->firstOrCreate([
-                'user_id' => $user->id,
-            ]);
-        });
+        return DB::transaction(fn () => $channel->channelMembers()->firstOrCreate([
+            'user_id' => $user->id,
+        ]));
     }
 }

--- a/app/Actions/Channels/MarkChannelRead.php
+++ b/app/Actions/Channels/MarkChannelRead.php
@@ -39,7 +39,7 @@ class MarkChannelRead
         $member->update(['last_read_message_id' => $latestMessageId]);
 
         if ($user->share_read_receipts) {
-            MessageRead::dispatch($channel, UserData::fromUser($user), $latestMessageId);
+            event(new MessageRead($channel, UserData::fromUser($user), $latestMessageId));
         }
     }
 }

--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -13,8 +13,8 @@ use App\Models\User;
 class PostMessage
 {
     public function __construct(
-        private SyncMentions $syncMentions,
-        private SyncLinkPreviews $syncLinkPreviews,
+        private readonly SyncMentions $syncMentions,
+        private readonly SyncLinkPreviews $syncLinkPreviews,
     ) {}
 
     /**
@@ -56,7 +56,7 @@ class PostMessage
             $this->syncMentions->handle($channel, $message);
             $this->syncLinkPreviews->handle($message);
             $message->loadMessageDataRelations();
-            MessageSent::dispatch($channel, MessageData::fromMessage($message));
+            event(new MessageSent($channel, MessageData::fromMessage($message)));
 
             $this->announceFirstDirectMessage($channel, $author);
 
@@ -89,7 +89,7 @@ class PostMessage
         $channel->members()
             ->where('users.id', '!=', $author->id)
             ->pluck('users.id')
-            ->each(fn (string $recipientId) => DirectMessageStarted::dispatch($recipientId, $channel->id));
+            ->each(fn (string $recipientId) => event(new DirectMessageStarted($recipientId, $channel->id)));
     }
 
     /**
@@ -102,6 +102,6 @@ class PostMessage
         $root->forceFill(['reply_count' => $root->reply_count + 1, 'last_reply_at' => now()])->save();
 
         $root->loadMessageDataRelations();
-        MessageUpdated::dispatch($channel, MessageData::fromMessage($root));
+        event(new MessageUpdated($channel, MessageData::fromMessage($root)));
     }
 }

--- a/app/Actions/Channels/RemoveChannelMember.php
+++ b/app/Actions/Channels/RemoveChannelMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Models\Channel;
@@ -13,7 +15,7 @@ class RemoveChannelMember
      */
     public function handle(Channel $channel, User $user): void
     {
-        DB::transaction(function () use ($channel, $user) {
+        DB::transaction(function () use ($channel, $user): void {
             $channel->channelMembers()
                 ->where('user_id', $user->id)
                 ->delete();

--- a/app/Actions/Channels/SaveChannelDraft.php
+++ b/app/Actions/Channels/SaveChannelDraft.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Models\Channel;

--- a/app/Actions/Channels/SearchMessages.php
+++ b/app/Actions/Channels/SearchMessages.php
@@ -12,7 +12,7 @@ class SearchMessages
     /**
      * The maximum number of message matches returned for a single search.
      */
-    private const RESULT_LIMIT = 50;
+    private const int RESULT_LIMIT = 50;
 
     /**
      * Full-text search a team's messages, ACL-filtered to the user's channels.

--- a/app/Actions/Channels/SetChannelStar.php
+++ b/app/Actions/Channels/SetChannelStar.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Models\Channel;

--- a/app/Actions/Channels/SyncLinkPreviews.php
+++ b/app/Actions/Channels/SyncLinkPreviews.php
@@ -78,7 +78,7 @@ class SyncLinkPreviews
         });
 
         if ($hasPending) {
-            UnfurlMessageLinks::dispatch($message->id);
+            dispatch(new UnfurlMessageLinks($message->id));
         }
     }
 

--- a/app/Actions/Channels/ToggleReaction.php
+++ b/app/Actions/Channels/ToggleReaction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Data\ReactionData;
@@ -37,6 +39,6 @@ class ToggleReaction
 
         $message->load('reactions.user');
 
-        MessageReactionChanged::dispatch($channel, $message->id, ReactionData::forMessage($message));
+        event(new MessageReactionChanged($channel, $message->id, ReactionData::forMessage($message)));
     }
 }

--- a/app/Actions/Channels/UpdateChannelPreference.php
+++ b/app/Actions/Channels/UpdateChannelPreference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Enums\NotificationLevel;

--- a/app/Actions/Channels/UpdateScheduledMessage.php
+++ b/app/Actions/Channels/UpdateScheduledMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Channels;
 
 use App\Models\ScheduledMessage;

--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Fortify;
 
 use App\Concerns\PasswordValidationRules;

--- a/app/Actions/Onboarding/CompleteOnboarding.php
+++ b/app/Actions/Onboarding/CompleteOnboarding.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Onboarding;
 
 use App\Models\User;

--- a/app/Actions/Sidebar/DeleteChannelSection.php
+++ b/app/Actions/Sidebar/DeleteChannelSection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Sidebar;
 
 use App\Models\ChannelSection;

--- a/app/Actions/Sidebar/UpdateChannelSection.php
+++ b/app/Actions/Sidebar/UpdateChannelSection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Sidebar;
 
 use App\Models\ChannelSection;

--- a/app/Actions/Teams/TransferTeamOwnership.php
+++ b/app/Actions/Teams/TransferTeamOwnership.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Actions\Teams;
 
 use App\Enums\TeamRole;
@@ -18,7 +20,7 @@ class TransferTeamOwnership
      */
     public function handle(Team $team, User $currentOwner, User $newOwner): void
     {
-        DB::transaction(function () use ($team, $currentOwner, $newOwner) {
+        DB::transaction(function () use ($team, $currentOwner, $newOwner): void {
             $team->memberships()
                 ->where('user_id', $currentOwner->id)
                 ->update(['role' => TeamRole::Admin]);

--- a/app/Concerns/GeneratesUniqueTeamSlugs.php
+++ b/app/Concerns/GeneratesUniqueTeamSlugs.php
@@ -2,7 +2,6 @@
 
 namespace App\Concerns;
 
-use App\Models\Team;
 use Illuminate\Support\Str;
 
 trait GeneratesUniqueTeamSlugs
@@ -15,7 +14,7 @@ trait GeneratesUniqueTeamSlugs
         $defaultSlug = Str::slug($name);
 
         $query = static::withTrashed()
-            ->where(function ($query) use ($defaultSlug) {
+            ->where(function ($query) use ($defaultSlug): void {
                 $query->where('slug', $defaultSlug)
                     ->orWhere('slug', 'like', $defaultSlug.'-%');
             });
@@ -30,13 +29,14 @@ trait GeneratesUniqueTeamSlugs
             ->map(function (string $slug) use ($defaultSlug): ?int {
                 if ($slug === $defaultSlug) {
                     return 0;
-                } elseif (preg_match('/^'.preg_quote($defaultSlug, '/').'-(\d+)$/', $slug, $matches)) {
+                }
+                if (preg_match('/^'.preg_quote($defaultSlug, '/').'-(\d+)$/', $slug, $matches)) {
                     return (int) $matches[1];
                 }
 
                 return null;
             })
-            ->filter(fn (?int $suffix) => $suffix !== null)
+            ->filter(fn (?int $suffix): bool => $suffix !== null)
             ->max() ?? 0;
 
         return $existingSlugs->isEmpty()

--- a/app/Concerns/PasswordValidationRules.php
+++ b/app/Concerns/PasswordValidationRules.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Concerns;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Console/Commands/SearchIndexSyncCommand.php
+++ b/app/Console/Commands/SearchIndexSyncCommand.php
@@ -29,7 +29,7 @@ class SearchIndexSyncCommand extends Command
      *
      * @var list<class-string<Message>>
      */
-    private const SEARCHABLE_MODELS = [
+    private const array SEARCHABLE_MODELS = [
         Message::class,
     ];
 

--- a/app/Data/AnalyticsStatData.php
+++ b/app/Data/AnalyticsStatData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 use Spatie\LaravelData\Data;

--- a/app/Data/ChannelActivityData.php
+++ b/app/Data/ChannelActivityData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 use Spatie\LaravelData\Data;

--- a/app/Data/ChannelData.php
+++ b/app/Data/ChannelData.php
@@ -88,7 +88,7 @@ class ChannelData extends Data
         $viewer = auth()->user();
         $isDirect = $channel->isDirect();
         $dmParticipant = $isDirect && $viewer instanceof User ? $channel->directParticipantFor($viewer) : null;
-        $name = $dmParticipant !== null ? $dmParticipant->name : (string) $channel->name;
+        $name = $dmParticipant instanceof User ? $dmParticipant->name : (string) $channel->name;
 
         // The timestamp the "Direct messages" sidebar group orders on: the
         // channel's latest message (populated by the sidebar query as

--- a/app/Data/ContributorData.php
+++ b/app/Data/ContributorData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 use Spatie\LaravelData\Data;

--- a/app/Data/DailyMessageCountData.php
+++ b/app/Data/DailyMessageCountData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 use Spatie\LaravelData\Data;

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -81,10 +81,10 @@ class MessageData extends Data
             createdAt: $message->created_at->toIso8601String(),
             editedAt: $message->edited_at?->toIso8601String(),
             isDeleted: $isDeleted,
-            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn (User $user) => MentionData::fromUser($user))->all(),
+            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn (User $user): MentionData => MentionData::fromUser($user))->all(),
             linkPreviews: $isDeleted ? [] : $message->linkPreviews
-                ->reject(fn (MessageLinkPreview $preview) => $preview->status === LinkPreviewStatus::Failed)
-                ->map(fn (MessageLinkPreview $preview) => LinkPreviewData::fromModel($preview))
+                ->reject(fn (MessageLinkPreview $preview): bool => $preview->status === LinkPreviewStatus::Failed)
+                ->map(fn (MessageLinkPreview $preview): LinkPreviewData => LinkPreviewData::fromModel($preview))
                 ->values()
                 ->all(),
             // A tombstone carries no reactions; DeleteMessage also hard-deletes
@@ -101,7 +101,7 @@ class MessageData extends Data
             threadReplyCount: $message->reply_count,
             threadLastReplyAt: $message->last_reply_at?->toIso8601String(),
             threadParticipants: $message->relationLoaded('threadParticipants')
-                ? $message->threadParticipants->map(fn (User $user) => MentionData::fromUser($user))->all()
+                ? $message->threadParticipants->map(fn (User $user): MentionData => MentionData::fromUser($user))->all()
                 : [],
             threadFollowed: $threadFollowed,
             threadUnread: $threadFollowed && $threadHasUnread,

--- a/app/Data/MessageForwardData.php
+++ b/app/Data/MessageForwardData.php
@@ -3,6 +3,7 @@
 namespace App\Data;
 
 use App\Models\Message;
+use App\Models\User;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
@@ -44,7 +45,7 @@ class MessageForwardData extends Data
             authorName: $message->user->name,
             channelName: $message->channel->name,
             isDeleted: $isDeleted,
-            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn ($user) => MentionData::fromUser($user))->all(),
+            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn (User $user): MentionData => MentionData::fromUser($user))->all(),
         );
     }
 }

--- a/app/Data/MessageReplyData.php
+++ b/app/Data/MessageReplyData.php
@@ -3,6 +3,7 @@
 namespace App\Data;
 
 use App\Models\Message;
+use App\Models\User;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
@@ -37,7 +38,7 @@ class MessageReplyData extends Data
             body: $isDeleted ? '' : $message->body,
             authorName: $message->user->name,
             isDeleted: $isDeleted,
-            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn ($user) => MentionData::fromUser($user))->all(),
+            mentions: $isDeleted ? [] : $message->mentionedUsers->map(fn (User $user): MentionData => MentionData::fromUser($user))->all(),
         );
     }
 }

--- a/app/Data/MonthlyMemberCountData.php
+++ b/app/Data/MonthlyMemberCountData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 use Spatie\LaravelData\Data;

--- a/app/Data/ReactionData.php
+++ b/app/Data/ReactionData.php
@@ -36,10 +36,10 @@ class ReactionData extends Data
     {
         return $message->reactions
             ->groupBy('emoji')
-            ->map(fn (Collection $group, string $emoji) => new self(
+            ->map(fn (Collection $group, string $emoji): ReactionData => new self(
                 emoji: $emoji,
                 count: $group->count(),
-                reactors: $group->map(fn (MessageReaction $reaction) => MentionData::fromUser($reaction->user))->all(),
+                reactors: $group->map(fn (MessageReaction $reaction): MentionData => MentionData::fromUser($reaction->user))->all(),
             ))
             ->values()
             ->all();

--- a/app/Data/TeamPermissions.php
+++ b/app/Data/TeamPermissions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 readonly class TeamPermissions

--- a/app/Data/UserTeam.php
+++ b/app/Data/UserTeam.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 readonly class UserTeam

--- a/app/Data/WorkspaceAnalyticsData.php
+++ b/app/Data/WorkspaceAnalyticsData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Data;
 
 use Spatie\LaravelData\Attributes\DataCollectionOf;

--- a/app/Enums/AppLocale.php
+++ b/app/Enums/AppLocale.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Enums;
 
 enum AppLocale: string

--- a/app/Enums/ChannelType.php
+++ b/app/Enums/ChannelType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Enums;
 
 enum ChannelType: string

--- a/app/Enums/LinkPreviewStatus.php
+++ b/app/Enums/LinkPreviewStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Enums;
 
 enum LinkPreviewStatus: string

--- a/app/Enums/MessageReminderStatus.php
+++ b/app/Enums/MessageReminderStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Enums;
 
 enum MessageReminderStatus: string

--- a/app/Enums/ScheduledMessageStatus.php
+++ b/app/Enums/ScheduledMessageStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Enums;
 
 enum ScheduledMessageStatus: string

--- a/app/Enums/TeamPermission.php
+++ b/app/Enums/TeamPermission.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Enums;
 
 enum TeamPermission: string

--- a/app/Enums/TeamRole.php
+++ b/app/Enums/TeamRole.php
@@ -71,8 +71,8 @@ enum TeamRole: string
     public static function assignable(): array
     {
         return collect(self::cases())
-            ->filter(fn (self $role) => $role !== self::Owner)
-            ->map(fn (self $role) => ['value' => $role->value, 'label' => $role->label()])
+            ->filter(fn (self $role): bool => $role !== self::Owner)
+            ->map(fn (self $role): array => ['value' => $role->value, 'label' => $role->label()])
             ->values()
             ->toArray();
     }

--- a/app/Events/DirectMessageStarted.php
+++ b/app/Events/DirectMessageStarted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;

--- a/app/Events/MessageDeleted.php
+++ b/app/Events/MessageDeleted.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Events;
 
 use App\Data\MessageData;

--- a/app/Events/MessageReactionChanged.php
+++ b/app/Events/MessageReactionChanged.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Events;
 
 use App\Data\MessageData;
@@ -53,7 +55,7 @@ class MessageReactionChanged implements ShouldBroadcast
     {
         return [
             'messageId' => $this->messageId,
-            'reactions' => array_map(fn (ReactionData $reaction) => $reaction->toArray(), $this->reactions),
+            'reactions' => array_map(fn (ReactionData $reaction): array => $reaction->toArray(), $this->reactions),
         ];
     }
 }

--- a/app/Events/MessageRead.php
+++ b/app/Events/MessageRead.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Events;
 
 use App\Data\UserData;

--- a/app/Events/MessageReminderDue.php
+++ b/app/Events/MessageReminderDue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;

--- a/app/Events/MessageSent.php
+++ b/app/Events/MessageSent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Events;
 
 use App\Data\MessageData;

--- a/app/Events/MessageUpdated.php
+++ b/app/Events/MessageUpdated.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Events;
 
 use App\Data\MessageData;

--- a/app/Exceptions/AuditLogImmutableException.php
+++ b/app/Exceptions/AuditLogImmutableException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exceptions;
 
 use RuntimeException;

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -21,6 +21,7 @@ use App\Models\Message;
 use App\Models\Team;
 use App\Support\AuditRecorder;
 use App\Support\ChannelTimelineWindow;
+use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -122,12 +123,12 @@ class ChannelController extends Controller
             // param, or null for a normal visit. The client opens a thread by
             // visiting `?thread=<root>`, which also drives the paginated replies
             // below; the closure returns null cheaply when no thread is requested.
-            'thread' => fn () => $window->thread(),
+            'thread' => $window->thread(...),
             // The open thread's replies, oldest last, paginated so a very long
             // thread doesn't ship in one payload. Its own cursor name keeps it
             // independent of the main timeline's, and the client's reverse
             // InfiniteScroll pages older replies in above as it scrolls up.
-            'threadReplies' => Inertia::scroll(fn () => $window->threadReplies()),
+            'threadReplies' => Inertia::scroll(fn (): CursorPaginator => $window->threadReplies()),
             // The viewer's own pending scheduled messages for this channel, soonest
             // first, feeding the composer's "Scheduled" affordance. Only pending
             // rows are listed — sent and cancelled ones drop off. The reply quote
@@ -164,7 +165,7 @@ class ChannelController extends Controller
             // scrolling up appends older pages and the client reverses for display.
             // Deleted rows are kept (withTrashed) so the client can render a
             // "message deleted" tombstone in place; MessageData blanks their body.
-            'messages' => Inertia::scroll(fn () => $window->messages()),
+            'messages' => Inertia::scroll(fn (): CursorPaginator => $window->messages()),
         ]);
     }
 

--- a/app/Http/Controllers/Channels/SearchController.php
+++ b/app/Http/Controllers/Channels/SearchController.php
@@ -18,7 +18,7 @@ class SearchController extends Controller
      * The number of message matches surfaced inline in the quick switcher, kept
      * small so the palette stays a preview; the full page shows the rest.
      */
-    private const SUGGEST_LIMIT = 5;
+    private const int SUGGEST_LIMIT = 5;
 
     /**
      * Search messages in the current team, scoped to the user's channels.
@@ -32,7 +32,7 @@ class SearchController extends Controller
         $query = trim((string) $request->validated('q'));
 
         $results = $searchMessages->handle($request->user(), $team, $query)
-            ->map(fn (Message $message) => MessageSearchResultData::fromMessage($message))
+            ->map(fn (Message $message): MessageSearchResultData => MessageSearchResultData::fromMessage($message))
             ->all();
 
         return Inertia::render('channels/Search', [
@@ -58,7 +58,7 @@ class SearchController extends Controller
         $query = trim((string) $request->validated('q'));
 
         $results = $searchMessages->handle($request->user(), $team, $query, self::SUGGEST_LIMIT)
-            ->map(fn (Message $message) => MessageSearchResultData::fromMessage($message))
+            ->map(fn (Message $message): MessageSearchResultData => MessageSearchResultData::fromMessage($message))
             ->all();
 
         return response()->json(['results' => $results]);

--- a/app/Http/Controllers/Channels/ThreadsController.php
+++ b/app/Http/Controllers/Channels/ThreadsController.php
@@ -53,7 +53,7 @@ class ThreadsController extends Controller
                 ->orderByDesc('last_reply_at')
                 ->orderByDesc('id')
                 ->cursorPaginate(self::PAGE_SIZE)
-                ->through(fn (Message $message) => ThreadInboxItemData::fromMessage($message))),
+                ->through(fn (Message $message): ThreadInboxItemData => ThreadInboxItemData::fromMessage($message))),
         ]);
     }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 abstract class Controller

--- a/app/Http/Controllers/Settings/DataExportController.php
+++ b/app/Http/Controllers/Settings/DataExportController.php
@@ -37,7 +37,7 @@ class DataExportController extends Controller
             'status' => DataExportStatus::Pending,
         ]);
 
-        ExportUserData::dispatch($export->id);
+        dispatch(new ExportUserData($export->id));
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __("Preparing your data export. We'll email you when it's ready.")]);
 

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -21,7 +21,7 @@ class SecurityController extends Controller
     /**
      * The number of recent security events to surface on the settings page.
      */
-    private const RECENT_ACTIVITY_LIMIT = 20;
+    private const int RECENT_ACTIVITY_LIMIT = 20;
 
     /**
      * Show the user's security settings page.

--- a/app/Http/Controllers/Settings/SessionController.php
+++ b/app/Http/Controllers/Settings/SessionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Teams/AnalyticsController.php
+++ b/app/Http/Controllers/Teams/AnalyticsController.php
@@ -12,7 +12,7 @@ use Inertia\Response;
 
 class AnalyticsController extends Controller
 {
-    public function __construct(private WorkspaceAnalytics $analytics) {}
+    public function __construct(private readonly WorkspaceAnalytics $analytics) {}
 
     /**
      * Show the workspace analytics dashboard for the selected time window.

--- a/app/Http/Controllers/Teams/AuditController.php
+++ b/app/Http/Controllers/Teams/AuditController.php
@@ -31,8 +31,7 @@ class AuditController extends Controller
             ->where('team_id', $team->id)
             ->when($action, fn ($query) => $query->where('event', $action))
             ->when($actorId, fn ($query) => $query->where('causer_id', $actorId))
-            ->with('causer')
-            ->orderByDesc('created_at')
+            ->with('causer')->latest()
             ->orderByDesc('id')
             ->simplePaginate(self::PER_PAGE)
             ->withQueryString();

--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -59,7 +59,7 @@ class TeamController extends Controller
                 'slug' => $team->slug,
                 'isPersonal' => $team->is_personal,
             ],
-            'members' => $team->members()->get()->map(function (User $member) {
+            'members' => $team->members()->get()->map(function (User $member): array {
                 /** @var Membership $membership */
                 $membership = $member->getRelation('pivot');
 
@@ -75,7 +75,7 @@ class TeamController extends Controller
             'invitations' => $team->invitations()
                 ->whereNull('accepted_at')
                 ->get()
-                ->map(fn ($invitation) => [
+                ->map(fn ($invitation): array => [
                     'code' => $invitation->code,
                     'email' => $invitation->email,
                     'role' => $invitation->role->value,
@@ -161,10 +161,10 @@ class TeamController extends Controller
         $user = $request->user();
         $fallbackTeam = $user->isCurrentTeam($team) ? $user->fallbackTeam($team) : null;
 
-        DB::transaction(function () use ($user, $team) {
+        DB::transaction(function () use ($user, $team): void {
             User::where('current_team_id', $team->id)
                 ->where('id', '!=', $user->id)
-                ->each(fn (User $affectedUser) => $affectedUser->switchTeam($affectedUser->personalTeam()));
+                ->each(fn (User $affectedUser): bool => $affectedUser->switchTeam($affectedUser->personalTeam()));
 
             $team->invitations()->delete();
             $team->memberships()->delete();

--- a/app/Http/Controllers/Teams/TeamInvitationController.php
+++ b/app/Http/Controllers/Teams/TeamInvitationController.php
@@ -62,7 +62,7 @@ class TeamInvitationController extends Controller
     {
         $user = $request->user();
 
-        DB::transaction(function () use ($user, $invitation) {
+        DB::transaction(function () use ($user, $invitation): void {
             $team = $invitation->team;
 
             $team->memberships()->firstOrCreate(

--- a/app/Http/Middleware/EnsureTeamMembership.php
+++ b/app/Http/Middleware/EnsureTeamMembership.php
@@ -46,7 +46,7 @@ class EnsureTeamMembership
 
         abort_if(
             $requiredRole === null ||
-            $role === null ||
+            ! $role instanceof TeamRole ||
             ! $role->isAtLeast($requiredRole),
             403,
         );
@@ -60,7 +60,7 @@ class EnsureTeamMembership
         $team = $request->route('current_team') ?? $request->route('team');
 
         if (is_string($team)) {
-            $team = Team::where('slug', $team)->first();
+            return Team::where('slug', $team)->first();
         }
 
         return $team;

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -39,6 +39,7 @@ class HandleInertiaRequests extends Middleware
      *
      * @see https://inertiajs.com/asset-versioning
      */
+    #[\Override]
     public function version(Request $request): ?string
     {
         return parent::version($request);
@@ -51,6 +52,7 @@ class HandleInertiaRequests extends Middleware
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function share(Request $request): array
     {
         $user = $request->user();
@@ -85,20 +87,20 @@ class HandleInertiaRequests extends Middleware
                 ? $user->toTeamPermissions($user->currentTeam)->canCreateInvitation
                 : false,
             'invitableRoles' => TeamRole::assignable(),
-            'channels' => fn () => $this->channelsForSidebar($request, $user),
+            'channels' => fn (): array => $this->channelsForSidebar($request, $user),
             // The current team's members feed the DM entry points (the sidebar
             // people picker and the ⌘K "People" group); empty off the workspace.
-            'teamMembers' => fn () => $this->teamMembersForSidebar($request, $user),
-            'channelSections' => fn () => $this->channelSectionsForSidebar($request, $user),
+            'teamMembers' => fn (): array => $this->teamMembersForSidebar($request, $user),
+            'channelSections' => fn (): array => $this->channelSectionsForSidebar($request, $user),
             'collapsedChannelSections' => fn () => $user->collapsed_channel_sections ?? [],
-            'hasUnreadThreads' => fn () => $this->hasUnreadThreads($request, $user),
-            'pendingInvitations' => Inertia::optional(fn () => $user ? $this->pendingInvitationsFor($user) : []),
+            'hasUnreadThreads' => fn (): bool => $this->hasUnreadThreads($request, $user),
+            'pendingInvitations' => Inertia::optional(fn (): array => $user ? $this->pendingInvitationsFor($user) : []),
             // The viewer's still-pending reminders in this team, soonest first,
             // feeding the "Reminders" list and its sidebar count.
-            'reminders' => fn () => $this->remindersForSidebar($request, $user, MessageReminderStatus::Pending),
+            'reminders' => fn (): array => $this->remindersForSidebar($request, $user, MessageReminderStatus::Pending),
             // Reminders that have come due and await acknowledgement, driving the
             // in-app nudges; reloaded live when a MessageReminderDue signal lands.
-            'firedReminders' => fn () => $this->remindersForSidebar($request, $user, MessageReminderStatus::Fired),
+            'firedReminders' => fn (): array => $this->remindersForSidebar($request, $user, MessageReminderStatus::Fired),
         ];
     }
 
@@ -179,10 +181,14 @@ class HandleInertiaRequests extends Middleware
             if ($this->directMessageHidden($channel)) {
                 return false;
             }
+            if ($channel->getAttribute('last_message_at') !== null) {
+                return true;
+            }
+            if ($channel->created_by === $user->id) {
+                return true;
+            }
 
-            return $channel->getAttribute('last_message_at') !== null
-                || $channel->created_by === $user->id
-                || $channel->getKey() === $activeChannelId;
+            return $channel->getKey() === $activeChannelId;
         })->values();
 
         return ChannelData::collect($channels, 'array');
@@ -250,7 +256,7 @@ class HandleInertiaRequests extends Middleware
             ->where('status', $status)
             ->whereHas('message.channel', fn (Builder $query) => $query->where('team_id', $team->id))
             ->with(['message.user', 'message.channel.team'])
-            ->orderBy('remind_at')
+            ->oldest('remind_at')
             ->get();
 
         return MessageReminderData::collect($reminders, 'array');
@@ -275,8 +281,7 @@ class HandleInertiaRequests extends Middleware
 
         $sections = $user->channelSections()
             ->where('team_id', $team->id)
-            ->orderBy('position')
-            ->orderBy('created_at')
+            ->orderBy('position')->oldest()
             ->get();
 
         return ChannelSectionData::collect($sections, 'array');
@@ -347,7 +352,7 @@ class HandleInertiaRequests extends Middleware
                 ->orWhere('expires_at', '>=', now()))
             ->latest()
             ->get()
-            ->map(fn (TeamInvitation $invitation) => [
+            ->map(fn (TeamInvitation $invitation): array => [
                 'code' => $invitation->code,
                 'inviterName' => $invitation->inviter->name,
                 'team' => [

--- a/app/Http/Requests/Channels/CreateChannelRequest.php
+++ b/app/Http/Requests/Channels/CreateChannelRequest.php
@@ -26,6 +26,7 @@ class CreateChannelRequest extends FormRequest
     /**
      * Normalize the channel name before validation (strip a leading # and trim).
      */
+    #[\Override]
     protected function prepareForValidation(): void
     {
         $this->merge([

--- a/app/Http/Requests/Channels/EditMessageRequest.php
+++ b/app/Http/Requests/Channels/EditMessageRequest.php
@@ -20,6 +20,7 @@ class EditMessageRequest extends FormRequest
     /**
      * Trim surrounding whitespace while preserving the message's inner newlines.
      */
+    #[\Override]
     protected function prepareForValidation(): void
     {
         $this->merge([

--- a/app/Http/Requests/Channels/ForwardMessageRequest.php
+++ b/app/Http/Requests/Channels/ForwardMessageRequest.php
@@ -26,6 +26,7 @@ class ForwardMessageRequest extends FormRequest
     /**
      * Trim the optional note while preserving its inner newlines.
      */
+    #[\Override]
     protected function prepareForValidation(): void
     {
         $this->merge([

--- a/app/Http/Requests/Channels/PostMessageRequest.php
+++ b/app/Http/Requests/Channels/PostMessageRequest.php
@@ -21,6 +21,7 @@ class PostMessageRequest extends FormRequest
     /**
      * Trim surrounding whitespace while preserving the message's inner newlines.
      */
+    #[\Override]
     protected function prepareForValidation(): void
     {
         $this->merge([

--- a/app/Http/Requests/Channels/ScheduleMessageRequest.php
+++ b/app/Http/Requests/Channels/ScheduleMessageRequest.php
@@ -24,6 +24,7 @@ class ScheduleMessageRequest extends FormRequest
     /**
      * Trim surrounding whitespace while preserving the message's inner newlines.
      */
+    #[\Override]
     protected function prepareForValidation(): void
     {
         $this->merge([

--- a/app/Http/Requests/Channels/SearchMessagesRequest.php
+++ b/app/Http/Requests/Channels/SearchMessagesRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Channels;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Channels/SetMessageReminderRequest.php
+++ b/app/Http/Requests/Channels/SetMessageReminderRequest.php
@@ -27,7 +27,7 @@ class SetMessageReminderRequest extends FormRequest
     {
         $message = $this->reminderMessage();
 
-        return $message !== null
+        return $message instanceof Message
             && $message->channel->team_id === $this->team()->id
             && Gate::allows('view', $message->channel);
     }
@@ -59,7 +59,7 @@ class SetMessageReminderRequest extends FormRequest
      */
     public function reminderMessage(): ?Message
     {
-        if ($this->resolvedMessage === null) {
+        if (! $this->resolvedMessage instanceof Message) {
             $this->resolvedMessage = Message::with('channel')->find((string) $this->input('message_id'));
         }
 

--- a/app/Http/Requests/Channels/UpdateScheduledMessageRequest.php
+++ b/app/Http/Requests/Channels/UpdateScheduledMessageRequest.php
@@ -22,6 +22,7 @@ class UpdateScheduledMessageRequest extends FormRequest
     /**
      * Trim surrounding whitespace while preserving the message's inner newlines.
      */
+    #[\Override]
     protected function prepareForValidation(): void
     {
         $this->merge([

--- a/app/Http/Requests/Settings/LocalePreferencesRequest.php
+++ b/app/Http/Requests/Settings/LocalePreferencesRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Settings;
 
 use App\Enums\AppLocale;

--- a/app/Http/Requests/Settings/NotificationPreferencesRequest.php
+++ b/app/Http/Requests/Settings/NotificationPreferencesRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Settings;
 
 use App\Enums\ChimeSound;

--- a/app/Http/Requests/Settings/PasswordUpdateRequest.php
+++ b/app/Http/Requests/Settings/PasswordUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Settings;
 
 use App\Concerns\PasswordValidationRules;

--- a/app/Http/Requests/Settings/SessionRevokeRequest.php
+++ b/app/Http/Requests/Settings/SessionRevokeRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Settings;
 
 use App\Concerns\PasswordValidationRules;

--- a/app/Http/Requests/Settings/TwoFactorAuthenticationRequest.php
+++ b/app/Http/Requests/Settings/TwoFactorAuthenticationRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Settings;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Http/Requests/Sidebar/StoreChannelSectionRequest.php
+++ b/app/Http/Requests/Sidebar/StoreChannelSectionRequest.php
@@ -22,6 +22,7 @@ class StoreChannelSectionRequest extends FormRequest
     /**
      * Trim surrounding whitespace from the section name before validation.
      */
+    #[\Override]
     protected function prepareForValidation(): void
     {
         $this->merge([

--- a/app/Http/Requests/Sidebar/UpdateChannelSectionRequest.php
+++ b/app/Http/Requests/Sidebar/UpdateChannelSectionRequest.php
@@ -28,6 +28,7 @@ class UpdateChannelSectionRequest extends FormRequest
      * Trim a supplied section name before validation, leaving it absent when the
      * request only toggles the collapse state.
      */
+    #[\Override]
     protected function prepareForValidation(): void
     {
         if ($this->has('name')) {

--- a/app/Http/Requests/Teams/RespondToTeamInvitationRequest.php
+++ b/app/Http/Requests/Teams/RespondToTeamInvitationRequest.php
@@ -25,6 +25,7 @@ class RespondToTeamInvitationRequest extends FormRequest
      *
      * @return array<string, mixed>
      */
+    #[\Override]
     public function validationData(): array
     {
         return array_merge(parent::validationData(), [

--- a/app/Http/Requests/Teams/TransferTeamOwnershipRequest.php
+++ b/app/Http/Requests/Teams/TransferTeamOwnershipRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Teams;
 
 use App\Concerns\PasswordValidationRules;

--- a/app/Http/Requests/Teams/UpdateTeamMemberRequest.php
+++ b/app/Http/Requests/Teams/UpdateTeamMemberRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Teams;
 
 use App\Enums\TeamRole;

--- a/app/Http/Requests/UpdateSidebarSectionsRequest.php
+++ b/app/Http/Requests/UpdateSidebarSectionsRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Jobs/UnfurlMessageLinks.php
+++ b/app/Jobs/UnfurlMessageLinks.php
@@ -54,6 +54,6 @@ class UnfurlMessageLinks implements ShouldQueue
         }
 
         $message->loadMessageDataRelations();
-        MessageUpdated::dispatch($message->channel, MessageData::fromMessage($message));
+        event(new MessageUpdated($message->channel, MessageData::fromMessage($message)));
     }
 }

--- a/app/Listeners/RecordSecurityEvents.php
+++ b/app/Listeners/RecordSecurityEvents.php
@@ -20,7 +20,7 @@ use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
  */
 class RecordSecurityEvents
 {
-    public function __construct(private SecurityEventRecorder $recorder) {}
+    public function __construct(private readonly SecurityEventRecorder $recorder) {}
 
     /**
      * Handle a successful sign in.

--- a/app/Models/AuditActivity.php
+++ b/app/Models/AuditActivity.php
@@ -28,6 +28,7 @@ class AuditActivity extends Activity
     /**
      * Guard against any mutation after creation so the log stays append-only.
      */
+    #[\Override]
     protected static function booted(): void
     {
         static::updating(function (): never {

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -155,6 +155,7 @@ class Channel extends Model
     /**
      * Get the route key for the model.
      */
+    #[\Override]
     public function getRouteKeyName(): string
     {
         return 'slug';
@@ -165,6 +166,7 @@ class Channel extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/ChannelMember.php
+++ b/app/Models/ChannelMember.php
@@ -40,6 +40,7 @@ class ChannelMember extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/ChannelSection.php
+++ b/app/Models/ChannelSection.php
@@ -36,6 +36,7 @@ class ChannelSection extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/DataExport.php
+++ b/app/Models/DataExport.php
@@ -63,6 +63,7 @@ class DataExport extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/Membership.php
+++ b/app/Models/Membership.php
@@ -66,6 +66,7 @@ class Membership extends Pivot
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -75,7 +75,7 @@ class Message extends Model
      *
      * @var list<string>
      */
-    private const MESSAGE_DATA_RELATIONS = [
+    private const array MESSAGE_DATA_RELATIONS = [
         'user',
         'mentionedUsers',
         'linkPreviews',
@@ -202,7 +202,7 @@ class Message extends Model
      */
     public function reactions(): HasMany
     {
-        return $this->hasMany(MessageReaction::class)->orderBy('created_at')->orderBy('id');
+        return $this->hasMany(MessageReaction::class)->oldest()->orderBy('id');
     }
 
     /**
@@ -211,7 +211,7 @@ class Message extends Model
      * or were @mentioned anywhere in it — the Slack-style auto-follow rule.
      * Binds the user id twice.
      */
-    private const THREAD_FOLLOWED_SQL = '(exists (
+    private const string THREAD_FOLLOWED_SQL = '(exists (
         select 1 from messages tm
         where (tm.id = messages.id or tm.thread_root_id = messages.id)
           and (
@@ -229,7 +229,7 @@ class Message extends Model
      * query gets per-channel muting for free. Binds the user id three times, then
      * the "all" notification level.
      */
-    private const THREAD_HAS_UNREAD_SQL = '(exists (
+    private const string THREAD_HAS_UNREAD_SQL = '(exists (
         select 1 from messages r
         left join thread_reads tr on tr.thread_root_id = messages.id and tr.user_id = ?
         where r.thread_root_id = messages.id
@@ -249,7 +249,7 @@ class Message extends Model
      *
      * @param  Builder<Message>  $query
      */
-    public function scopeWithThreadReadState(Builder $query, User $user): void
+    protected function scopeWithThreadReadState(Builder $query, User $user): void
     {
         $query->addSelect('messages.*')
             ->selectRaw(self::THREAD_FOLLOWED_SQL.'::int as thread_followed', [$user->id, $user->id])
@@ -264,7 +264,7 @@ class Message extends Model
      *
      * @param  Builder<Message>  $query
      */
-    public function scopeFollowedBy(Builder $query, User $user): void
+    protected function scopeFollowedBy(Builder $query, User $user): void
     {
         $query->whereRaw(self::THREAD_FOLLOWED_SQL, [$user->id, $user->id]);
     }
@@ -275,7 +275,7 @@ class Message extends Model
      *
      * @param  Builder<Message>  $query
      */
-    public function scopeWhereThreadUnreadFor(Builder $query, User $user): void
+    protected function scopeWhereThreadUnreadFor(Builder $query, User $user): void
     {
         $query->whereRaw(self::THREAD_HAS_UNREAD_SQL, [$user->id, $user->id, $user->id, NotificationLevel::All->value]);
     }
@@ -289,7 +289,7 @@ class Message extends Model
      *
      * @param  Builder<Message>  $query
      */
-    public function scopeWithMessageDataRelations(Builder $query): void
+    protected function scopeWithMessageDataRelations(Builder $query): void
     {
         $query->with(self::MESSAGE_DATA_RELATIONS);
     }
@@ -327,6 +327,7 @@ class Message extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/MessageLinkPreview.php
+++ b/app/Models/MessageLinkPreview.php
@@ -46,6 +46,7 @@ class MessageLinkPreview extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/MessageReminder.php
+++ b/app/Models/MessageReminder.php
@@ -68,7 +68,7 @@ class MessageReminder extends Model
      *
      * @param  Builder<MessageReminder>  $query
      */
-    public function scopePending(Builder $query): void
+    protected function scopePending(Builder $query): void
     {
         $query->where('status', MessageReminderStatus::Pending);
     }
@@ -78,7 +78,7 @@ class MessageReminder extends Model
      *
      * @param  Builder<MessageReminder>  $query
      */
-    public function scopeDue(Builder $query): void
+    protected function scopeDue(Builder $query): void
     {
         $query->pending()->where('remind_at', '<=', now());
     }
@@ -88,6 +88,7 @@ class MessageReminder extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/ScheduledMessage.php
+++ b/app/Models/ScheduledMessage.php
@@ -84,7 +84,7 @@ class ScheduledMessage extends Model
      *
      * @param  Builder<ScheduledMessage>  $query
      */
-    public function scopePending(Builder $query): void
+    protected function scopePending(Builder $query): void
     {
         $query->where('status', ScheduledMessageStatus::Pending);
     }
@@ -94,7 +94,7 @@ class ScheduledMessage extends Model
      *
      * @param  Builder<ScheduledMessage>  $query
      */
-    public function scopeDue(Builder $query): void
+    protected function scopeDue(Builder $query): void
     {
         $query->pending()->where('send_at', '<=', now());
     }
@@ -104,6 +104,7 @@ class ScheduledMessage extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/SecurityEvent.php
+++ b/app/Models/SecurityEvent.php
@@ -47,6 +47,7 @@ class SecurityEvent extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -37,17 +37,18 @@ class Team extends Model
     /**
      * Bootstrap the model and its traits.
      */
+    #[\Override]
     protected static function boot(): void
     {
         parent::boot();
 
-        static::creating(function (Team $team) {
+        static::creating(function (Team $team): void {
             if (empty($team->slug)) {
                 $team->slug = static::generateUniqueTeamSlug($team->name);
             }
         });
 
-        static::updating(function (Team $team) {
+        static::updating(function (Team $team): void {
             if ($team->isDirty('name')) {
                 $team->slug = static::generateUniqueTeamSlug($team->name, $team->id);
             }
@@ -112,6 +113,7 @@ class Team extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [
@@ -122,6 +124,7 @@ class Team extends Model
     /**
      * Get the route key for the model.
      */
+    #[\Override]
     public function getRouteKeyName(): string
     {
         return 'slug';

--- a/app/Models/TeamInvitation.php
+++ b/app/Models/TeamInvitation.php
@@ -35,11 +35,12 @@ class TeamInvitation extends Model
     /**
      * Bootstrap the model and its traits.
      */
+    #[\Override]
     protected static function boot(): void
     {
         parent::boot();
 
-        static::creating(function (TeamInvitation $invitation) {
+        static::creating(function (TeamInvitation $invitation): void {
             if (empty($invitation->code)) {
                 $invitation->code = Str::random(64);
             }
@@ -95,6 +96,7 @@ class TeamInvitation extends Model
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [
@@ -107,6 +109,7 @@ class TeamInvitation extends Model
     /**
      * Get the route key for the model.
      */
+    #[\Override]
     public function getRouteKeyName(): string
     {
         return 'code';

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -75,6 +75,7 @@ class User extends Authenticatable implements HasLocalePreference
      *
      * @return array<string, string>
      */
+    #[\Override]
     protected function casts(): array
     {
         return [

--- a/app/Observers/MembershipObserver.php
+++ b/app/Observers/MembershipObserver.php
@@ -11,8 +11,8 @@ use App\Models\Membership;
 class MembershipObserver
 {
     public function __construct(
-        private CreateChannel $createChannel,
-        private JoinChannel $joinChannel,
+        private readonly CreateChannel $createChannel,
+        private readonly JoinChannel $joinChannel,
     ) {}
 
     /**

--- a/app/Policies/ChannelPolicy.php
+++ b/app/Policies/ChannelPolicy.php
@@ -165,9 +165,11 @@ class ChannelPolicy
         if (! $user->belongsToTeam($channel->team)) {
             return false;
         }
+        if ($channel->members()->whereKey($user->id)->exists()) {
+            return true;
+        }
 
-        return $channel->members()->whereKey($user->id)->exists()
-            || ($user->teamRole($channel->team)?->isAtLeast(TeamRole::Admin) ?? false);
+        return $user->teamRole($channel->team)?->isAtLeast(TeamRole::Admin) ?? false;
     }
 
     /**

--- a/app/Policies/ChannelSectionPolicy.php
+++ b/app/Policies/ChannelSectionPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Policies;
 
 use App\Models\ChannelSection;

--- a/app/Policies/MessageReminderPolicy.php
+++ b/app/Policies/MessageReminderPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Policies;
 
 use App\Models\MessageReminder;

--- a/app/Policies/ScheduledMessagePolicy.php
+++ b/app/Policies/ScheduledMessagePolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Policies;
 
 use App\Enums\ScheduledMessageStatus;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,6 +14,7 @@ class AppServiceProvider extends ServiceProvider
     /**
      * Register any application services.
      */
+    #[\Override]
     public function register(): void
     {
         $this->app->singleton(Client::class, fn (): Client => new Client(

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -25,6 +25,7 @@ class FortifyServiceProvider extends ServiceProvider
     /**
      * Register any application services.
      */
+    #[\Override]
     public function register(): void
     {
         $this->app->singleton(LoginResponseContract::class, LoginResponse::class);

--- a/app/Providers/TypeScriptTransformerServiceProvider.php
+++ b/app/Providers/TypeScriptTransformerServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Providers;
 
 use Spatie\LaravelTypeScriptTransformer\TypeScriptTransformerApplicationServiceProvider as BaseTypeScriptTransformerServiceProvider;

--- a/app/Rules/TeamName.php
+++ b/app/Rules/TeamName.php
@@ -17,7 +17,7 @@ class TeamName implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $name = strtolower(trim($value));
+        $name = strtolower(trim((string) $value));
 
         if (in_array($name, $this->reservedNames(), true)) {
             $fail(__('This team name is reserved and cannot be used.'));
@@ -377,9 +377,9 @@ class TeamName implements ValidationRule
     {
         return collect(Route::getRoutes()->getRoutes())
             ->map(fn (RouteElement $route) => $route->uri)
-            ->map(fn (string $uri) => explode('/', $uri)[0])
-            ->reject(fn (string $uri) => str_contains($uri, '{'))
-            ->filter(fn (string $uri) => $uri !== '')
+            ->map(fn (string $uri): string => explode('/', $uri)[0])
+            ->reject(fn (string $uri): bool => str_contains($uri, '{'))
+            ->filter(fn (string $uri): bool => $uri !== '')
             ->unique()
             ->sort()
             ->values()

--- a/app/Rules/UniqueTeamInvitation.php
+++ b/app/Rules/UniqueTeamInvitation.php
@@ -22,7 +22,7 @@ class UniqueTeamInvitation implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $email = strtolower($value);
+        $email = strtolower((string) $value);
 
         $isMember = $this->team->members()
             ->whereRaw('LOWER(email) = ?', [$email])
@@ -37,7 +37,7 @@ class UniqueTeamInvitation implements ValidationRule
         $hasPendingInvitation = TeamInvitation::where('team_id', $this->team->id)
             ->whereRaw('LOWER(email) = ?', [$email])
             ->whereNull('accepted_at')
-            ->where(function ($query) {
+            ->where(function ($query): void {
                 $query->whereNull('expires_at')
                     ->orWhere('expires_at', '>', now());
             })

--- a/app/Support/AccountDeleter.php
+++ b/app/Support/AccountDeleter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Support;
 
 use App\Http\Requests\Settings\ProfileDeleteRequest;

--- a/app/Support/AuditRecorder.php
+++ b/app/Support/AuditRecorder.php
@@ -40,7 +40,7 @@ class AuditRecorder
                 $activity->team_id = $team->id;
             });
 
-        if ($target !== null) {
+        if ($target instanceof Model) {
             $logger->performedOn($target);
         }
 

--- a/app/Support/ChannelTimelineWindow.php
+++ b/app/Support/ChannelTimelineWindow.php
@@ -119,7 +119,7 @@ class ChannelTimelineWindow
             ->when($ceilingId, fn (Builder $query) => $query->where('id', '<=', $ceilingId))
             ->orderByDesc('id')
             ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
-            ->through(fn (Message $message) => MessageData::fromMessage($message));
+            ->through(fn (Message $message): MessageData => MessageData::fromMessage($message));
     }
 
     /**
@@ -135,7 +135,7 @@ class ChannelTimelineWindow
     {
         $root = $this->resolveThreadRoot();
 
-        if ($root === null) {
+        if (! $root instanceof Message) {
             return null;
         }
 
@@ -157,14 +157,14 @@ class ChannelTimelineWindow
     {
         $root = $this->resolveThreadRoot();
 
-        $query = $root !== null
+        $query = $root instanceof Message
             ? $root->threadReplies()->withTrashed()->withMessageDataRelations()
             : Message::query()->whereRaw('1 = 0');
 
         return $query
             ->orderByDesc('id')
             ->cursorPaginate(self::THREAD_PAGE_SIZE, ['*'], 'thread_cursor')
-            ->through(fn (Message $message) => MessageData::fromMessage($message));
+            ->through(fn (Message $message): MessageData => MessageData::fromMessage($message));
     }
 
     /**

--- a/app/Support/FetchLinkPreview.php
+++ b/app/Support/FetchLinkPreview.php
@@ -35,7 +35,7 @@ class FetchLinkPreview
      */
     private const string FAILED = '__failed__';
 
-    public function __construct(private HostResolver $resolver) {}
+    public function __construct(private readonly HostResolver $resolver) {}
 
     /**
      * Unfurl a URL into its Open Graph preview, or null when it can't be fetched.
@@ -50,7 +50,7 @@ class FetchLinkPreview
         $result = Cache::remember(
             'link-preview:'.sha1($url),
             now()->addSeconds(self::CACHE_TTL_SECONDS),
-            fn () => $this->unfurl($url) ?? self::FAILED,
+            fn (): array|string => $this->unfurl($url) ?? self::FAILED,
         );
 
         return $result === self::FAILED ? null : $result;

--- a/app/Support/HostResolver.php
+++ b/app/Support/HostResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Support;
 
 class HostResolver

--- a/app/Support/ReverbConfig.php
+++ b/app/Support/ReverbConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Support;
 
 class ReverbConfig

--- a/app/Support/SecurityEventRecorder.php
+++ b/app/Support/SecurityEventRecorder.php
@@ -14,7 +14,7 @@ use Illuminate\Http\Request;
  */
 class SecurityEventRecorder
 {
-    public function __construct(private Request $request) {}
+    public function __construct(private readonly Request $request) {}
 
     /**
      * Record a security event for the given user against the current request.

--- a/app/Support/UserAgentParser.php
+++ b/app/Support/UserAgentParser.php
@@ -12,7 +12,7 @@ class UserAgentParser
      *
      * @var array<string, string>
      */
-    private const BROWSERS = [
+    private const array BROWSERS = [
         'Edge' => '/\bEdg/i',
         'Opera' => '/\bOPR\b|\bOpera\b/i',
         'Firefox' => '/\bFirefox\b|\bFxiOS\b/i',
@@ -28,7 +28,7 @@ class UserAgentParser
      *
      * @var array<string, string>
      */
-    private const PLATFORMS = [
+    private const array PLATFORMS = [
         'Windows' => '/\bWindows\b/i',
         'iOS' => '/\biPhone\b|\biPad\b|\biPod\b/i',
         'Android' => '/\bAndroid\b/i',

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\SetLocale;
@@ -32,7 +34,7 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(
-            fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
+            fn (Request $request): bool => $request->is('api/*') || $request->expectsJson(),
         );
 
         // Render branded "The Desk" Inertia error pages for the common HTTP

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "symfony/dom-crawler": "^8.1"
     },
     "require-dev": {
+        "driftingly/rector-laravel": "^2.5",
         "fakerphp/faker": "^1.24",
         "larastan/larastan": "^3.9",
         "laravel/boost": "^2.2",
@@ -35,7 +36,8 @@
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.9.3",
         "pestphp/pest": "^4.7",
-        "pestphp/pest-plugin-laravel": "^4.1"
+        "pestphp/pest-plugin-laravel": "^4.1",
+        "rector/rector": "^2.5"
     },
     "autoload": {
         "psr-4": {
@@ -68,6 +70,12 @@
         "lint:check": [
             "pint --parallel --test"
         ],
+        "refactor": [
+            "rector process"
+        ],
+        "refactor:check": [
+            "rector process --dry-run"
+        ],
         "ci:check": [
             "Composer\\Config::disableProcessTimeout",
             "npm run lint:check",
@@ -83,6 +91,7 @@
             "@php artisan config:clear --ansi",
             "@lint:check",
             "@types:check",
+            "@refactor:check",
             "@php artisan test --coverage --min=100"
         ],
         "post-autoload-dump": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e740ffe5227e1614568bf09db995630",
+    "content-hash": "9d424c71b47176def7678cac1dec570a",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -9729,6 +9729,42 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "driftingly/rector-laravel",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/driftingly/rector-laravel.git",
+                "reference": "0dbdd842dfdbc821cfe5f47ca7326e2502b2a107"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/driftingly/rector-laravel/zipball/0dbdd842dfdbc821cfe5f47ca7326e2502b2a107",
+                "reference": "0dbdd842dfdbc821cfe5f47ca7326e2502b2a107",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "rector/rector": "^2.2.7",
+                "webmozart/assert": "^1.11 || ^2.0"
+            },
+            "type": "rector-extension",
+            "autoload": {
+                "psr-4": {
+                    "RectorLaravel\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Rector upgrades rules for Laravel Framework",
+            "support": {
+                "issues": "https://github.com/driftingly/rector-laravel/issues",
+                "source": "https://github.com/driftingly/rector-laravel/tree/2.5.0"
+            },
+            "time": "2026-06-02T16:22:14+00:00"
+        },
+        {
             "name": "fakerphp/faker",
             "version": "v1.24.1",
             "source": {
@@ -12044,6 +12080,66 @@
                 }
             ],
             "time": "2026-06-15T13:12:30+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "9718a72e7f1aacacbdcb6eeed07a47147bce802e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/9718a72e7f1aacacbdcb6eeed07a47147bce802e",
+                "reference": "9718a72e7f1aacacbdcb6eeed07a47147bce802e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.2"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.5.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-09T09:48:44+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Models\AuditActivity;
 use Spatie\Activitylog\Actions\CleanActivityLogAction;
 use Spatie\Activitylog\Actions\LogActivityAction;

--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Models\User;
 
 return [

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Str;
 
 return [

--- a/config/data.php
+++ b/config/data.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Contracts\Support\Arrayable;
 use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Casts\EnumCast;

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Str;
 use Pdo\Mysql;
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Fortify\Features;
 
 return [

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;

--- a/config/mail.php
+++ b/config/mail.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/queue.php
+++ b/config/queue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/scout.php
+++ b/config/scout.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/services.php
+++ b/config/services.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/session.php
+++ b/config/session.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Str;
 
 return [

--- a/database/factories/ChannelFactory.php
+++ b/database/factories/ChannelFactory.php
@@ -41,7 +41,7 @@ class ChannelFactory extends Factory
      */
     public function private(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'visibility' => ChannelVisibility::Private,
         ]);
     }
@@ -51,7 +51,7 @@ class ChannelFactory extends Factory
      */
     public function archived(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'archived_at' => now(),
         ]);
     }
@@ -64,7 +64,7 @@ class ChannelFactory extends Factory
      */
     public function direct(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'name' => null,
             'slug' => 'dm-'.Str::lower(Str::random(12)),
             'visibility' => ChannelVisibility::Private,

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -33,7 +33,7 @@ class MessageFactory extends Factory
      */
     public function edited(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'edited_at' => now(),
         ]);
     }
@@ -43,7 +43,7 @@ class MessageFactory extends Factory
      */
     public function replyTo(Message $parent): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'reply_to_id' => $parent->id,
         ]);
     }
@@ -53,7 +53,7 @@ class MessageFactory extends Factory
      */
     public function forwardedFrom(Message $source): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'forwarded_from_id' => $source->id,
         ]);
     }
@@ -66,7 +66,7 @@ class MessageFactory extends Factory
      */
     public function inThread(Message $root): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'thread_root_id' => $root->id,
             'channel_id' => $root->channel_id,
         ]);
@@ -77,7 +77,7 @@ class MessageFactory extends Factory
      */
     public function sentToChannel(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'sent_to_channel' => true,
         ]);
     }

--- a/database/factories/MessageLinkPreviewFactory.php
+++ b/database/factories/MessageLinkPreviewFactory.php
@@ -36,7 +36,7 @@ class MessageLinkPreviewFactory extends Factory
      */
     public function ready(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'status' => LinkPreviewStatus::Ready,
             'title' => fake()->sentence(4),
             'description' => fake()->sentence(10),
@@ -50,7 +50,7 @@ class MessageLinkPreviewFactory extends Factory
      */
     public function failed(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'status' => LinkPreviewStatus::Failed,
         ]);
     }

--- a/database/factories/MessageReactionFactory.php
+++ b/database/factories/MessageReactionFactory.php
@@ -31,7 +31,7 @@ class MessageReactionFactory extends Factory
      */
     public function emoji(string $emoji): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'emoji' => $emoji,
         ]);
     }

--- a/database/factories/MessageReminderFactory.php
+++ b/database/factories/MessageReminderFactory.php
@@ -34,7 +34,7 @@ class MessageReminderFactory extends Factory
      */
     public function due(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'remind_at' => now()->subMinute(),
         ]);
     }
@@ -44,7 +44,7 @@ class MessageReminderFactory extends Factory
      */
     public function fired(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'status' => MessageReminderStatus::Fired,
             'fired_at' => now(),
         ]);

--- a/database/factories/ScheduledMessageFactory.php
+++ b/database/factories/ScheduledMessageFactory.php
@@ -41,7 +41,7 @@ class ScheduledMessageFactory extends Factory
      */
     public function replyTo(Message $parent): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'reply_to_id' => $parent->id,
         ]);
     }
@@ -51,7 +51,7 @@ class ScheduledMessageFactory extends Factory
      */
     public function sent(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'status' => ScheduledMessageStatus::Sent,
             'sent_at' => now(),
         ]);
@@ -62,7 +62,7 @@ class ScheduledMessageFactory extends Factory
      */
     public function cancelled(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'status' => ScheduledMessageStatus::Cancelled,
             'cancelled_at' => now(),
         ]);

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -32,7 +32,7 @@ class TeamFactory extends Factory
      */
     public function personal(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'is_personal' => true,
         ]);
     }
@@ -42,7 +42,7 @@ class TeamFactory extends Factory
      */
     public function trashed(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'deleted_at' => now(),
         ]);
     }

--- a/database/factories/TeamInvitationFactory.php
+++ b/database/factories/TeamInvitationFactory.php
@@ -35,7 +35,7 @@ class TeamInvitationFactory extends Factory
      */
     public function accepted(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'accepted_at' => now(),
         ]);
     }
@@ -45,7 +45,7 @@ class TeamInvitationFactory extends Factory
      */
     public function expired(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'expires_at' => now()->subDay(),
         ]);
     }
@@ -55,7 +55,7 @@ class TeamInvitationFactory extends Factory
      */
     public function expiresIn(int $value, string $unit = 'days'): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'expires_at' => now()->add($unit, $value),
         ]);
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -50,9 +50,10 @@ class UserFactory extends Factory
     /**
      * Configure the model factory.
      */
+    #[\Override]
     public function configure(): static
     {
-        return $this->afterCreating(function ($user) {
+        return $this->afterCreating(function ($user): void {
             $team = Team::factory()->personal()->create([
                 'name' => $user->name."'s Team",
             ]);
@@ -70,7 +71,7 @@ class UserFactory extends Factory
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'email_verified_at' => null,
         ]);
     }
@@ -80,7 +81,7 @@ class UserFactory extends Factory
      */
     public function withoutReadReceipts(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'share_read_receipts' => false,
         ]);
     }
@@ -90,7 +91,7 @@ class UserFactory extends Factory
      */
     public function notOnboarded(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'onboarding_completed_at' => null,
         ]);
     }
@@ -100,7 +101,7 @@ class UserFactory extends Factory
      */
     public function withTwoFactor(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $attributes): array => [
             'two_factor_secret' => encrypt('secret'),
             'two_factor_recovery_codes' => encrypt(json_encode(['recovery-code-1'])),
             'two_factor_confirmed_at' => now(),

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('users', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->string('name');
             $table->string('email')->unique();
@@ -25,13 +25,13 @@ return new class extends Migration
             $table->timestamps();
         });
 
-        Schema::create('password_reset_tokens', function (Blueprint $table) {
+        Schema::create('password_reset_tokens', function (Blueprint $table): void {
             $table->string('email')->primary();
             $table->string('token');
             $table->timestamp('created_at')->nullable();
         });
 
-        Schema::create('sessions', function (Blueprint $table) {
+        Schema::create('sessions', function (Blueprint $table): void {
             $table->string('id')->primary();
             $table->foreignUuid('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();

--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -11,13 +11,13 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('cache', function (Blueprint $table) {
+        Schema::create('cache', function (Blueprint $table): void {
             $table->string('key')->primary();
             $table->mediumText('value');
             $table->bigInteger('expiration')->index();
         });
 
-        Schema::create('cache_locks', function (Blueprint $table) {
+        Schema::create('cache_locks', function (Blueprint $table): void {
             $table->string('key')->primary();
             $table->string('owner');
             $table->bigInteger('expiration')->index();

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('jobs', function (Blueprint $table) {
+        Schema::create('jobs', function (Blueprint $table): void {
             $table->id();
             $table->string('queue')->index();
             $table->longText('payload');
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->unsignedInteger('created_at');
         });
 
-        Schema::create('job_batches', function (Blueprint $table) {
+        Schema::create('job_batches', function (Blueprint $table): void {
             $table->string('id')->primary();
             $table->string('name');
             $table->integer('total_jobs');
@@ -34,7 +34,7 @@ return new class extends Migration
             $table->integer('finished_at')->nullable();
         });
 
-        Schema::create('failed_jobs', function (Blueprint $table) {
+        Schema::create('failed_jobs', function (Blueprint $table): void {
             $table->id();
             $table->string('uuid')->unique();
             $table->string('connection');

--- a/database/migrations/2026_01_27_000001_create_teams_table.php
+++ b/database/migrations/2026_01_27_000001_create_teams_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('teams', function (Blueprint $table) {
+        Schema::create('teams', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->string('name');
             $table->string('slug')->unique();
@@ -21,7 +21,7 @@ return new class extends Migration
             $table->softDeletes();
         });
 
-        Schema::create('team_members', function (Blueprint $table) {
+        Schema::create('team_members', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
@@ -31,7 +31,7 @@ return new class extends Migration
             $table->unique(['team_id', 'user_id']);
         });
 
-        Schema::create('team_invitations', function (Blueprint $table) {
+        Schema::create('team_invitations', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->string('code', 64)->unique();
             $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2026_01_27_000002_add_current_team_id_to_users_table.php
+++ b/database/migrations/2026_01_27_000002_add_current_team_id_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->foreignUuid('current_team_id')
                 ->nullable()
                 ->after('password')
@@ -25,7 +25,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropConstrainedForeignId('current_team_id');
         });
     }

--- a/database/migrations/2026_07_08_003228_create_channels_table.php
+++ b/database/migrations/2026_07_08_003228_create_channels_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('channels', function (Blueprint $table) {
+        Schema::create('channels', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
             $table->string('name');

--- a/database/migrations/2026_07_08_003229_create_channel_members_table.php
+++ b/database/migrations/2026_07_08_003229_create_channel_members_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('channel_members', function (Blueprint $table) {
+        Schema::create('channel_members', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('channel_id')->constrained()->cascadeOnDelete();
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2026_07_08_140440_create_messages_table.php
+++ b/database/migrations/2026_07_08_140440_create_messages_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('messages', function (Blueprint $table) {
+        Schema::create('messages', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('channel_id')->constrained()->cascadeOnDelete();
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2026_07_08_192231_create_mentions_table.php
+++ b/database/migrations/2026_07_08_192231_create_mentions_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('mentions', function (Blueprint $table) {
+        Schema::create('mentions', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('message_id')->constrained()->cascadeOnDelete();
             $table->foreignUuid('mentioned_user_id')->constrained('users')->cascadeOnDelete();

--- a/database/migrations/2026_07_09_021715_add_preferences_to_channel_members_table.php
+++ b/database/migrations/2026_07_09_021715_add_preferences_to_channel_members_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             // Per-member notification preferences for the channel. `muted` dims the
             // channel and is the strongest silence; `notification_level` tunes which
             // arrivals raise a badge (see App\Enums\NotificationLevel).
@@ -26,7 +26,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             $table->dropColumn(['muted', 'notification_level']);
         });
     }

--- a/database/migrations/2026_07_09_030947_add_reply_to_id_to_messages_table.php
+++ b/database/migrations/2026_07_09_030947_add_reply_to_id_to_messages_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('messages', function (Blueprint $table) {
+        Schema::table('messages', function (Blueprint $table): void {
             // The parent this message quotes inline, or null for a normal
             // message. A quoted parent that is later force-deleted nulls the
             // reference; a soft-deleted parent keeps it so the client renders a
@@ -29,7 +29,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('messages', function (Blueprint $table) {
+        Schema::table('messages', function (Blueprint $table): void {
             $table->dropConstrainedForeignId('reply_to_id');
         });
     }

--- a/database/migrations/2026_07_09_113300_add_chime_sound_to_users_table.php
+++ b/database/migrations/2026_07_09_113300_add_chime_sound_to_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             // The account-wide notification chime the client plays for a qualifying
             // incoming message. `off` disables chimes entirely (see App\Enums\ChimeSound).
             $table->string('chime_sound')->default(ChimeSound::Ping->value)->after('current_team_id');
@@ -24,7 +24,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('chime_sound');
         });
     }

--- a/database/migrations/2026_07_09_120000_add_threading_to_messages_table.php
+++ b/database/migrations/2026_07_09_120000_add_threading_to_messages_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('messages', function (Blueprint $table) {
+        Schema::table('messages', function (Blueprint $table): void {
             // The thread this reply belongs to, pointing at the thread's root
             // message, or null for a root/normal message. Force-deleting the root
             // nulls the reference; a soft-deleted root keeps it so the thread
@@ -50,7 +50,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('messages', function (Blueprint $table) {
+        Schema::table('messages', function (Blueprint $table): void {
             $table->dropIndex(['thread_root_id', 'id']);
             $table->dropConstrainedForeignId('thread_root_id');
             $table->dropColumn(['sent_to_channel', 'reply_count', 'last_reply_at']);

--- a/database/migrations/2026_07_09_134136_create_thread_reads_table.php
+++ b/database/migrations/2026_07_09_134136_create_thread_reads_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('thread_reads', function (Blueprint $table) {
+        Schema::create('thread_reads', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             // The thread's root message. Force-deleting the root cascades this
             // pointer away; a soft-deleted root keeps its row so the thread — and

--- a/database/migrations/2026_07_09_195709_add_draft_to_channel_members_table.php
+++ b/database/migrations/2026_07_09_195709_add_draft_to_channel_members_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             // The member's unsent composer text for the channel, persisted so it
             // survives navigation, reloads and other devices. Null means no
             // pending draft (the sidebar shows no draft cue).
@@ -24,7 +24,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             $table->dropColumn('draft');
         });
     }

--- a/database/migrations/2026_07_09_202754_add_starred_to_channel_members_table.php
+++ b/database/migrations/2026_07_09_202754_add_starred_to_channel_members_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             // Whether the member has starred (favorited) the channel, pinning it to
             // the sidebar's "Starred" section. Per member, so each user curates
             // their own favorites independently.
@@ -24,7 +24,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             $table->dropColumn('starred');
         });
     }

--- a/database/migrations/2026_07_09_202755_add_collapsed_channel_sections_to_users_table.php
+++ b/database/migrations/2026_07_09_202755_add_collapsed_channel_sections_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             // The sidebar section keys the user has collapsed (e.g. ["starred"]),
             // persisted so the collapsed/expanded layout follows them across
             // reloads and devices. Null is treated as "nothing collapsed".
@@ -28,7 +28,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('collapsed_channel_sections');
         });
     }

--- a/database/migrations/2026_07_09_205710_create_channel_sections_table.php
+++ b/database/migrations/2026_07_09_205710_create_channel_sections_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('channel_sections', function (Blueprint $table) {
+        Schema::create('channel_sections', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             // A custom section is owned by one user within one team, so each user
             // curates their own sidebar grouping independently. Both cascade so a

--- a/database/migrations/2026_07_09_205711_add_section_to_channel_members_table.php
+++ b/database/migrations/2026_07_09_205711_add_section_to_channel_members_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             // The custom section the member has filed this channel under, or null
             // for the default "Channels" group. Deleting the section returns the
             // channel to the default group rather than dropping the membership.
@@ -29,7 +29,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             $table->dropConstrainedForeignId('section_id');
             $table->dropColumn('position');
         });

--- a/database/migrations/2026_07_09_213037_add_forwarded_from_id_to_messages_table.php
+++ b/database/migrations/2026_07_09_213037_add_forwarded_from_id_to_messages_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('messages', function (Blueprint $table) {
+        Schema::table('messages', function (Blueprint $table): void {
             // The message this one forwards into its channel, or null for a
             // normal message. Unlike reply_to_id, the source lives in another
             // channel (any the author belongs to). A force-deleted source nulls
@@ -30,7 +30,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('messages', function (Blueprint $table) {
+        Schema::table('messages', function (Blueprint $table): void {
             $table->dropConstrainedForeignId('forwarded_from_id');
         });
     }

--- a/database/migrations/2026_07_09_233832_add_share_read_receipts_to_users_table.php
+++ b/database/migrations/2026_07_09_233832_add_share_read_receipts_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             // Whether the user shares their read position with channel peers, powering
             // the "Seen by" affordance. Default on; turning it off stops the user from
             // broadcasting or exposing where they've read up to (they can still see others').
@@ -24,7 +24,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('share_read_receipts');
         });
     }

--- a/database/migrations/2026_07_10_000255_create_message_link_previews_table.php
+++ b/database/migrations/2026_07_10_000255_create_message_link_previews_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('message_link_previews', function (Blueprint $table) {
+        Schema::create('message_link_previews', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('message_id')->constrained()->cascadeOnDelete();
             $table->text('url');

--- a/database/migrations/2026_07_10_113254_add_profile_fields_to_users_table.php
+++ b/database/migrations/2026_07_10_113254_add_profile_fields_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             // Optional self-service identity fields surfaced on the member profile.
             $table->string('pronouns')->nullable()->after('email');
             $table->string('title')->nullable()->after('pronouns');
@@ -24,7 +24,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn(['pronouns', 'title', 'phone']);
         });
     }

--- a/database/migrations/2026_07_10_114141_add_timezone_to_users_table.php
+++ b/database/migrations/2026_07_10_114141_add_timezone_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             // IANA timezone identifier (e.g. "America/New_York"), auto-detected on
             // first login and overridable in settings. Null until first detected.
             $table->string('timezone')->nullable()->after('phone');
@@ -23,7 +23,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('timezone');
         });
     }

--- a/database/migrations/2026_07_10_123909_create_security_events_table.php
+++ b/database/migrations/2026_07_10_123909_create_security_events_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('security_events', function (Blueprint $table) {
+        Schema::create('security_events', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
             // The kind of security-relevant action (see App\Enums\SecurityEventType).

--- a/database/migrations/2026_07_10_130825_create_data_exports_table.php
+++ b/database/migrations/2026_07_10_130825_create_data_exports_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('data_exports', function (Blueprint $table) {
+        Schema::create('data_exports', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
             // The lifecycle state of the export (see App\Enums\DataExportStatus).

--- a/database/migrations/2026_07_10_130828_add_is_tombstone_to_users_table.php
+++ b/database/migrations/2026_07_10_130828_add_is_tombstone_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             // Marks the single retained "Deleted User" account that authored
             // messages are reassigned to when their real author deletes their
             // account, so channel history stays coherent (see App\Support\AccountDeleter).
@@ -24,7 +24,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('is_tombstone');
         });
     }

--- a/database/migrations/2026_07_10_140000_create_activity_log_table.php
+++ b/database/migrations/2026_07_10_140000_create_activity_log_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('activity_log', function (Blueprint $table) {
+        Schema::create('activity_log', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             // Groups entries by feature; always 'audit' for this application.
             $table->string('log_name')->nullable();

--- a/database/migrations/2026_07_10_142309_create_message_reactions_table.php
+++ b/database/migrations/2026_07_10_142309_create_message_reactions_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('message_reactions', function (Blueprint $table) {
+        Schema::create('message_reactions', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('message_id')->constrained()->cascadeOnDelete();
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2026_07_10_154701_create_scheduled_messages_table.php
+++ b/database/migrations/2026_07_10_154701_create_scheduled_messages_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('scheduled_messages', function (Blueprint $table) {
+        Schema::create('scheduled_messages', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('channel_id')->constrained()->cascadeOnDelete();
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();

--- a/database/migrations/2026_07_11_022843_add_locale_to_users_table.php
+++ b/database/migrations/2026_07_11_022843_add_locale_to_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->string('locale')->default(AppLocale::English->value)->after('timezone');
         });
     }
@@ -22,7 +22,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('locale');
         });
     }

--- a/database/migrations/2026_07_11_121629_add_direct_message_columns_to_channels_table.php
+++ b/database/migrations/2026_07_11_121629_add_direct_message_columns_to_channels_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('channels', function (Blueprint $table) {
+        Schema::table('channels', function (Blueprint $table): void {
             // Distinguishes ordinary channels from 1:1 direct messages (with
             // `group_direct` reserved for a future group-DM issue). Defaulting to
             // `standard` keeps every existing row a normal channel.
@@ -33,7 +33,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('channels', function (Blueprint $table) {
+        Schema::table('channels', function (Blueprint $table): void {
             $table->dropUnique(['team_id', 'dm_key']);
             $table->dropColumn(['type', 'dm_key']);
             $table->string('name')->nullable(false)->change();

--- a/database/migrations/2026_07_11_135322_add_hidden_at_to_channel_members_table.php
+++ b/database/migrations/2026_07_11_135322_add_hidden_at_to_channel_members_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             // When the member closed (hid) this direct message from their sidebar.
             // A DM stays hidden only until a message arrives after this instant, so
             // a fresh reply re-surfaces it without any write on the message path.
@@ -25,7 +25,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('channel_members', function (Blueprint $table) {
+        Schema::table('channel_members', function (Blueprint $table): void {
             $table->dropColumn('hidden_at');
         });
     }

--- a/database/migrations/2026_07_11_150000_add_onboarding_completed_at_to_users_table.php
+++ b/database/migrations/2026_07_11_150000_add_onboarding_completed_at_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             // When the user finished (or dismissed) the first-run onboarding tour.
             // Null means they have never completed it, which gates the auto-starting
             // tour and the brand-new-workspace welcome empty state.
@@ -24,7 +24,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table): void {
             $table->dropColumn('onboarding_completed_at');
         });
     }

--- a/database/migrations/2026_07_11_162848_create_message_reminders_table.php
+++ b/database/migrations/2026_07_11_162848_create_message_reminders_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('message_reminders', function (Blueprint $table) {
+        Schema::create('message_reminders', function (Blueprint $table): void {
             $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
             $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
             $table->foreignUuid('message_id')->constrained('messages')->cascadeOnDelete();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;

--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -284,7 +284,7 @@ class WorkspaceSeeder extends Seeder
      */
     private function backdateMemberships(Team $team): void
     {
-        $memberships = $team->memberships()->orderBy('created_at')->orderBy('id')->get();
+        $memberships = $team->memberships()->oldest()->orderBy('id')->get();
         $lastIndex = max(1, $memberships->count() - 1);
 
         foreach ($memberships->values() as $index => $membership) {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use RectorLaravel\Rector\ArrayDimFetch\EnvVariableToEnvHelperRector;
+use RectorLaravel\Rector\FuncCall\AppToResolveRector;
+use RectorLaravel\Rector\StaticCall\CarbonToDateFacadeRector;
+use RectorLaravel\Set\LaravelSetList;
+
+return RectorConfig::configure()
+    // Mirror the paths analyzed by PHPStan (see phpstan.neon), plus tests/.
+    ->withPaths([
+        __DIR__.'/app',
+        __DIR__.'/bootstrap/app.php',
+        __DIR__.'/config',
+        __DIR__.'/database',
+        __DIR__.'/routes',
+        __DIR__.'/tests',
+    ])
+    // Apply the PHP level set matching the version declared in composer.json.
+    ->withPhpSets()
+    // Import namespaced class references instead of emitting redundant
+    // fully-qualified names when a `use` statement already exists. Global
+    // short classes (e.g. `\Override`) stay qualified as PHP requires.
+    ->withImportNames(importShortClasses: false)
+    // Conservative, high-signal rule sets. Structural refactors that complement
+    // Pint (style) and PHPStan (detection) without changing behaviour.
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+        earlyReturn: true,
+    )
+    // Laravel-aware refactors that modernise framework idioms safely.
+    ->withSets([
+        LaravelSetList::LARAVEL_CODE_QUALITY,
+        LaravelSetList::LARAVEL_IF_HELPERS,
+    ])
+    // Opt out of rules that are noisy or conflict with our conventions. Revisit
+    // and trim this list as the codebase adopts more of Rector's suggestions.
+    ->withSkip([
+        // Keep explicit constructor bodies readable; do not inline defaults.
+        InlineConstructorDefaultToPropertyRector::class,
+        // `app()` and `resolve()` are equivalent; don't churn the codebase over
+        // a purely stylistic preference.
+        AppToResolveRector::class,
+        // The `Date` facade resolves to CarbonImmutable under Larastan, which
+        // clashes with our explicit `Illuminate\Support\Carbon` type hints.
+        CarbonToDateFacadeRector::class,
+        // Unsafe in write contexts: rewrites `unset($_ENV[...])` into
+        // `unset(Env::get(...))`, which is not valid PHP.
+        EnvVariableToEnvHelperRector::class,
+    ]);

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -24,9 +24,7 @@ Broadcast::channel('channel.{channelId}', function (User $user, string $channelI
  * personal signals such as a brand-new direct message appearing in their
  * sidebar. No other member of the team can listen in.
  */
-Broadcast::channel('user.{userId}', function (User $user, string $userId): bool {
-    return $user->id === $userId;
-});
+Broadcast::channel('user.{userId}', fn (User $user, string $userId): bool => $user->id === $userId);
 
 /**
  * Track which team members are currently online.

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Actions\Channels\DispatchDueMessageReminders;
 use App\Actions\Channels\DispatchDueScheduledMessages;
 use App\Models\TeamInvitation;
 use Illuminate\Support\Facades\Schedule;
 
-Schedule::call(function () {
+Schedule::call(function (): void {
     TeamInvitation::query()
         ->whereNotNull('expires_at')
         ->where('expires_at', '<', now())

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -17,7 +17,7 @@ use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth'])->group(function (): void {
     Route::redirect('settings', '/settings/profile');
 
     Route::get('settings/profile', [ProfileController::class, 'edit'])->name('profile.edit');
@@ -26,7 +26,7 @@ Route::middleware(['auth'])->group(function () {
     Route::patch('settings/timezone', [TimezoneController::class, 'update'])->name('timezone.update');
 });
 
-Route::middleware(['auth', 'verified'])->group(function () {
+Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::delete('settings/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
     Route::get('settings/data-export', [DataExportController::class, 'edit'])->name('data-export.edit');
@@ -57,7 +57,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('settings/teams', [TeamController::class, 'index'])->name('teams.index');
     Route::post('settings/teams', [TeamController::class, 'store'])->name('teams.store');
 
-    Route::middleware(EnsureTeamMembership::class)->group(function () {
+    Route::middleware(EnsureTeamMembership::class)->group(function (): void {
         Route::get('settings/teams/{team}', [TeamController::class, 'edit'])->name('teams.edit');
         Route::patch('settings/teams/{team}', [TeamController::class, 'update'])->name('teams.update');
         Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,7 @@ Route::get('locales/{locale}.json', [LocaleCatalogController::class, 'show'])
     ->where('locale', '[a-z]{2}')
     ->name('locales.show');
 
-Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(function () {
+Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(function (): void {
     Route::get('t/{team}', [ChannelController::class, 'index'])->name('channels.index');
     Route::post('t/{team}/channels', [ChannelController::class, 'store'])->name('channels.store');
     Route::post('t/{team}/dm', [DirectMessageController::class, 'store'])->name('channels.dm.store');
@@ -110,7 +110,7 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
         ->name('channels.members.destroy');
 });
 
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth'])->group(function (): void {
     Route::patch('sidebar/sections', [SidebarSectionController::class, 'update'])->name('sidebar.sections.update');
 
     Route::patch('onboarding', [OnboardingController::class, 'update'])->name('onboarding.update');

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -8,13 +8,13 @@ use Illuminate\Support\Facades\RateLimiter;
 use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 
-test('login screen can be rendered', function () {
+test('login screen can be rendered', function (): void {
     $response = $this->get(route('login'));
 
     $response->assertOk();
 });
 
-test('login screen includes team invitation context', function () {
+test('login screen includes team invitation context', function (): void {
     $owner = User::factory()->create();
     $team = Team::factory()->create(['name' => 'Laravel Team']);
     $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
@@ -28,14 +28,14 @@ test('login screen includes team invitation context', function () {
     $response = $this->get(route('login', ['invitation' => $invitation->code]));
 
     $response->assertOk();
-    $response->assertInertia(fn (Assert $page) => $page
+    $response->assertInertia(fn (Assert $page): Assert => $page
         ->component('auth/Login')
         ->where('teamInvitation.code', $invitation->code)
         ->where('teamInvitation.teamName', 'Laravel Team'),
     );
 });
 
-test('users can authenticate using the login screen and land in the workspace', function () {
+test('users can authenticate using the login screen and land in the workspace', function (): void {
     $user = User::factory()->create();
 
     $response = $this->post(route('login.store'), [
@@ -47,7 +47,7 @@ test('users can authenticate using the login screen and land in the workspace', 
     $response->assertRedirect(route('channels.index', ['team' => $user->currentTeam->slug]));
 });
 
-test('users with two factor enabled are redirected to two factor challenge', function () {
+test('users with two factor enabled are redirected to two factor challenge', function (): void {
     if (! Features::canManageTwoFactorAuthentication()) {
         $this->markTestSkipped('Two-factor authentication is not enabled.');
     }
@@ -69,7 +69,7 @@ test('users with two factor enabled are redirected to two factor challenge', fun
     $this->assertGuest();
 });
 
-test('users can not authenticate with invalid password', function () {
+test('users can not authenticate with invalid password', function (): void {
     $user = User::factory()->create();
 
     $this->post(route('login.store'), [
@@ -80,7 +80,7 @@ test('users can not authenticate with invalid password', function () {
     $this->assertGuest();
 });
 
-test('users can logout', function () {
+test('users can logout', function (): void {
     $user = User::factory()->create();
 
     $response = $this->actingAs($user)->post(route('logout'));
@@ -89,7 +89,7 @@ test('users can logout', function () {
     $response->assertRedirect(route('home'));
 });
 
-test('users are rate limited', function () {
+test('users are rate limited', function (): void {
     $user = User::factory()->create();
 
     RateLimiter::increment(md5('login'.implode('|', [$user->email, '127.0.0.1'])), amount: 5);

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -5,7 +5,7 @@ use Illuminate\Auth\Events\Verified;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
 
-test('email verification screen can be rendered', function () {
+test('email verification screen can be rendered', function (): void {
     $user = User::factory()->unverified()->create();
 
     $response = $this->actingAs($user)->get(route('verification.notice'));
@@ -13,7 +13,7 @@ test('email verification screen can be rendered', function () {
     $response->assertOk();
 });
 
-test('email can be verified', function () {
+test('email can be verified', function (): void {
     $user = User::factory()->unverified()->create();
     $team = $user->personalTeam();
 
@@ -32,7 +32,7 @@ test('email can be verified', function () {
     $response->assertRedirect(route('channels.index', ['team' => $team->slug]).'?verified=1');
 });
 
-test('email is not verified with invalid hash', function () {
+test('email is not verified with invalid hash', function (): void {
     $user = User::factory()->unverified()->create();
 
     Event::fake();
@@ -49,7 +49,7 @@ test('email is not verified with invalid hash', function () {
     expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
 });
 
-test('email is not verified with invalid user id', function () {
+test('email is not verified with invalid user id', function (): void {
     $user = User::factory()->unverified()->create();
 
     Event::fake();
@@ -66,7 +66,7 @@ test('email is not verified with invalid user id', function () {
     expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
 });
 
-test('verified user is redirected home from verification prompt', function () {
+test('verified user is redirected home from verification prompt', function (): void {
     $user = User::factory()->create();
 
     Event::fake();
@@ -77,7 +77,7 @@ test('verified user is redirected home from verification prompt', function () {
     $response->assertRedirect('/');
 });
 
-test('already verified user visiting verification link is redirected without firing event again', function () {
+test('already verified user visiting verification link is redirected without firing event again', function (): void {
     $user = User::factory()->create();
     $team = $user->personalTeam();
 

--- a/tests/Feature/Auth/IntendedRedirectTest.php
+++ b/tests/Feature/Auth/IntendedRedirectTest.php
@@ -20,7 +20,7 @@ function loginWithIntended(User $user, ?string $intended = null): TestResponse
     ]);
 }
 
-test('login with no intended URL lands on the current team general channel', function () {
+test('login with no intended URL lands on the current team general channel', function (): void {
     $user = User::factory()->create();
 
     loginWithIntended($user)->assertRedirect(
@@ -28,7 +28,7 @@ test('login with no intended URL lands on the current team general channel', fun
     );
 });
 
-test('login honours an intended URL the user can view', function () {
+test('login honours an intended URL the user can view', function (): void {
     $user = User::factory()->create();
     $channel = Channel::factory()->create([
         'team_id' => $user->currentTeam->id,
@@ -40,7 +40,7 @@ test('login honours an intended URL the user can view', function () {
     loginWithIntended($user, $intended)->assertRedirect($intended);
 });
 
-test('login honours an intended URL pointing at a team the user belongs to', function () {
+test('login honours an intended URL pointing at a team the user belongs to', function (): void {
     $user = User::factory()->create();
 
     $intended = route('channels.index', ['team' => $user->currentTeam->slug]);
@@ -48,7 +48,7 @@ test('login honours an intended URL pointing at a team the user belongs to', fun
     loginWithIntended($user, $intended)->assertRedirect($intended);
 });
 
-test('login honours a non-workspace intended URL as-is', function () {
+test('login honours a non-workspace intended URL as-is', function (): void {
     $user = User::factory()->create();
 
     $intended = route('profile.edit');
@@ -56,7 +56,7 @@ test('login honours a non-workspace intended URL as-is', function () {
     loginWithIntended($user, $intended)->assertRedirect($intended);
 });
 
-test('login falls back when the intended channel no longer exists in the team', function () {
+test('login falls back when the intended channel no longer exists in the team', function (): void {
     $user = User::factory()->create();
 
     $intended = route('channels.show', ['team' => $user->currentTeam->slug, 'channel' => 'random']);
@@ -66,7 +66,7 @@ test('login falls back when the intended channel no longer exists in the team', 
     );
 });
 
-test('login falls back when the intended team does not exist', function () {
+test('login falls back when the intended team does not exist', function (): void {
     $user = User::factory()->create();
 
     loginWithIntended($user, url('/t/does-not-exist'))->assertRedirect(
@@ -74,7 +74,7 @@ test('login falls back when the intended team does not exist', function () {
     );
 });
 
-test('login falls back when the intended team is one the user does not belong to', function () {
+test('login falls back when the intended team is one the user does not belong to', function (): void {
     $user = User::factory()->create();
     $otherTeam = Team::factory()->create();
     $otherOwner = User::factory()->create();
@@ -87,7 +87,7 @@ test('login falls back when the intended team is one the user does not belong to
     );
 });
 
-test('login falls back when the intended URL has no path', function () {
+test('login falls back when the intended URL has no path', function (): void {
     $user = User::factory()->create();
 
     loginWithIntended($user, 'http://localhost')->assertRedirect(

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -3,19 +3,19 @@
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('confirm password screen can be rendered', function () {
+test('confirm password screen can be rendered', function (): void {
     $user = User::factory()->create();
 
     $response = $this->actingAs($user)->get(route('password.confirm'));
 
     $response->assertOk();
 
-    $response->assertInertia(fn (Assert $page) => $page
+    $response->assertInertia(fn (Assert $page): Assert => $page
         ->component('auth/ConfirmPassword'),
     );
 });
 
-test('password confirmation requires authentication', function () {
+test('password confirmation requires authentication', function (): void {
     $response = $this->get(route('password.confirm'));
 
     $response->assertRedirect(route('login'));

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -5,17 +5,17 @@ use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Fortify\Features;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->skipUnlessFortifyHas(Features::resetPasswords());
 });
 
-test('reset password link screen can be rendered', function () {
+test('reset password link screen can be rendered', function (): void {
     $response = $this->get(route('password.request'));
 
     $response->assertOk();
 });
 
-test('reset password link can be requested', function () {
+test('reset password link can be requested', function (): void {
     Notification::fake();
 
     $user = User::factory()->create();
@@ -25,14 +25,14 @@ test('reset password link can be requested', function () {
     Notification::assertSentTo($user, ResetPassword::class);
 });
 
-test('reset password screen can be rendered', function () {
+test('reset password screen can be rendered', function (): void {
     Notification::fake();
 
     $user = User::factory()->create();
 
     $this->post(route('password.email'), ['email' => $user->email]);
 
-    Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification): true {
         $response = $this->get(route('password.reset', $notification->token));
 
         $response->assertOk();
@@ -41,14 +41,14 @@ test('reset password screen can be rendered', function () {
     });
 });
 
-test('password can be reset with valid token', function () {
+test('password can be reset with valid token', function (): void {
     Notification::fake();
 
     $user = User::factory()->create();
 
     $this->post(route('password.email'), ['email' => $user->email]);
 
-    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user) {
+    Notification::assertSentTo($user, ResetPassword::class, function ($notification) use ($user): true {
         $response = $this->post(route('password.update'), [
             'token' => $notification->token,
             'email' => $user->email,
@@ -64,7 +64,7 @@ test('password can be reset with valid token', function () {
     });
 });
 
-test('password cannot be reset with invalid token', function () {
+test('password cannot be reset with invalid token', function (): void {
     $user = User::factory()->create();
 
     $response = $this->post(route('password.update'), [

--- a/tests/Feature/Auth/RegistrationFlagTest.php
+++ b/tests/Feature/Auth/RegistrationFlagTest.php
@@ -2,12 +2,12 @@
 
 use Inertia\Testing\AssertableInertia as Assert;
 
-afterEach(function () {
+afterEach(function (): void {
     putenv('REGISTRATION_ENABLED');
     unset($_ENV['REGISTRATION_ENABLED'], $_SERVER['REGISTRATION_ENABLED']);
 });
 
-test('registration routes respond when registration is enabled', function () {
+test('registration routes respond when registration is enabled', function (): void {
     $this->reloadWithRegistrationEnabled(true);
 
     $this->get('/register')->assertOk();
@@ -23,7 +23,7 @@ test('registration routes respond when registration is enabled', function () {
     $response->assertRedirect();
 });
 
-test('registration routes return 404 when registration is disabled', function () {
+test('registration routes return 404 when registration is disabled', function (): void {
     $this->reloadWithRegistrationEnabled(false);
 
     $this->get('/register')->assertNotFound();
@@ -37,29 +37,29 @@ test('registration routes return 404 when registration is disabled', function ()
     $this->assertGuest();
 });
 
-test('the shared registrationEnabled prop is true when registration is enabled', function () {
+test('the shared registrationEnabled prop is true when registration is enabled', function (): void {
     $this->reloadWithRegistrationEnabled(true);
 
-    $this->get(route('home'))->assertInertia(fn (Assert $page) => $page
+    $this->get(route('home'))->assertInertia(fn (Assert $page): Assert => $page
         ->component('Welcome')
         ->where('registrationEnabled', true),
     );
 
-    $this->get(route('login'))->assertInertia(fn (Assert $page) => $page
+    $this->get(route('login'))->assertInertia(fn (Assert $page): Assert => $page
         ->component('auth/Login')
         ->where('registrationEnabled', true),
     );
 });
 
-test('the shared registrationEnabled prop is false when registration is disabled', function () {
+test('the shared registrationEnabled prop is false when registration is disabled', function (): void {
     $this->reloadWithRegistrationEnabled(false);
 
-    $this->get(route('home'))->assertInertia(fn (Assert $page) => $page
+    $this->get(route('home'))->assertInertia(fn (Assert $page): Assert => $page
         ->component('Welcome')
         ->where('registrationEnabled', false),
     );
 
-    $this->get(route('login'))->assertInertia(fn (Assert $page) => $page
+    $this->get(route('login'))->assertInertia(fn (Assert $page): Assert => $page
         ->component('auth/Login')
         ->where('registrationEnabled', false),
     );

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -6,13 +6,13 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('registration screen can be rendered', function () {
+test('registration screen can be rendered', function (): void {
     $response = $this->get(route('register'));
 
     $response->assertOk();
 });
 
-test('registration screen includes team invitation context', function () {
+test('registration screen includes team invitation context', function (): void {
     $owner = User::factory()->create();
     $team = Team::factory()->create(['name' => 'Laravel Team']);
     $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
@@ -26,14 +26,14 @@ test('registration screen includes team invitation context', function () {
     $response = $this->get(route('register', ['invitation' => $invitation->code]));
 
     $response->assertOk();
-    $response->assertInertia(fn (Assert $page) => $page
+    $response->assertInertia(fn (Assert $page): Assert => $page
         ->component('auth/Register')
         ->where('teamInvitation.code', $invitation->code)
         ->where('teamInvitation.teamName', 'Laravel Team'),
     );
 });
 
-test('new users can register', function () {
+test('new users can register', function (): void {
     $response = $this->post(route('register.store'), [
         'name' => 'Test User',
         'email' => 'test@example.com',

--- a/tests/Feature/Auth/VerificationNotificationTest.php
+++ b/tests/Feature/Auth/VerificationNotificationTest.php
@@ -4,7 +4,7 @@ use App\Models\User;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Support\Facades\Notification;
 
-test('sends verification notification', function () {
+test('sends verification notification', function (): void {
     Notification::fake();
 
     $user = User::factory()->unverified()->create();
@@ -16,7 +16,7 @@ test('sends verification notification', function () {
     Notification::assertSentTo($user, VerifyEmail::class);
 });
 
-test('does not send verification notification if email is verified', function () {
+test('does not send verification notification if email is verified', function (): void {
     Notification::fake();
 
     $user = User::factory()->create();

--- a/tests/Feature/Channels/ArchiveChannelTest.php
+++ b/tests/Feature/Channels/ArchiveChannelTest.php
@@ -7,7 +7,7 @@ use App\Models\Message;
 use App\Models\User;
 use Illuminate\Support\Str;
 
-test('a channel creator can archive their channel and is redirected to #general', function () {
+test('a channel creator can archive their channel and is redirected to #general', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
@@ -20,7 +20,7 @@ test('a channel creator can archive their channel and is redirected to #general'
     expect($channel->fresh()->isArchived())->toBeTrue();
 });
 
-test('a team admin can archive a channel they did not create', function () {
+test('a team admin can archive a channel they did not create', function (): void {
     $owner = User::factory()->create();
     $admin = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -34,7 +34,7 @@ test('a team admin can archive a channel they did not create', function () {
     expect($channel->fresh()->isArchived())->toBeTrue();
 });
 
-test('a plain member who did not create a channel cannot archive it', function () {
+test('a plain member who did not create a channel cannot archive it', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -48,7 +48,7 @@ test('a plain member who did not create a channel cannot archive it', function (
     expect($channel->fresh()->isArchived())->toBeFalse();
 });
 
-test('the #general channel cannot be archived', function () {
+test('the #general channel cannot be archived', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
@@ -60,7 +60,7 @@ test('the #general channel cannot be archived', function () {
     expect($general->fresh()->isArchived())->toBeFalse();
 });
 
-test('an already-archived channel cannot be archived again', function () {
+test('an already-archived channel cannot be archived again', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->archived()->create(['created_by' => $owner->id]);
@@ -70,7 +70,7 @@ test('an already-archived channel cannot be archived again', function () {
         ->assertForbidden();
 });
 
-test('archiving keeps the channel and its messages, only setting archived_at', function () {
+test('archiving keeps the channel and its messages, only setting archived_at', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
@@ -83,7 +83,7 @@ test('archiving keeps the channel and its messages, only setting archived_at', f
         ->and($channel->fresh()->messages()->count())->toBe(1);
 });
 
-test('an archived channel is hidden from the active sidebar channel list', function () {
+test('an archived channel is hidden from the active sidebar channel list', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $active = Channel::factory()->for($team)->create(['name' => 'Announcements', 'slug' => 'announcements', 'created_by' => $owner->id]);
@@ -99,7 +99,7 @@ test('an archived channel is hidden from the active sidebar channel list', funct
             ->where('channels.1.slug', Channel::GENERAL_SLUG));
 });
 
-test('the archive control is offered to a user who may archive the channel', function () {
+test('the archive control is offered to a user who may archive the channel', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
@@ -110,7 +110,7 @@ test('the archive control is offered to a user who may archive the channel', fun
         ->assertInertia(fn ($page) => $page->where('canArchive', true));
 });
 
-test('the archive control is withheld from a user who may not archive the channel', function () {
+test('the archive control is withheld from a user who may not archive the channel', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
@@ -120,7 +120,7 @@ test('the archive control is withheld from a user who may not archive the channe
         ->assertInertia(fn ($page) => $page->where('canArchive', false));
 });
 
-test('a user who cannot post to an archived channel is forbidden', function () {
+test('a user who cannot post to an archived channel is forbidden', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->archived()->create(['created_by' => $owner->id]);

--- a/tests/Feature/Channels/BrowseAndJoinChannelTest.php
+++ b/tests/Feature/Channels/BrowseAndJoinChannelTest.php
@@ -6,7 +6,7 @@ use App\Models\Channel;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('browsing lists joinable public channels only', function () {
+test('browsing lists joinable public channels only', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
 
@@ -19,14 +19,14 @@ test('browsing lists joinable public channels only', function () {
     $this->actingAs($user)
         ->get(route('channels.browse', ['team' => $team->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Browse')
             ->has('joinableChannels', 1)
             ->where('joinableChannels.0.slug', 'marketing')
         );
 });
 
-test('browsing does not leak channels from other teams', function () {
+test('browsing does not leak channels from other teams', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $otherTeam = app(CreateTeam::class)->handle(User::factory()->create(), 'Globex');
@@ -35,10 +35,10 @@ test('browsing does not leak channels from other teams', function () {
     $this->actingAs($user)
         ->get(route('channels.browse', ['team' => $team->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page->has('joinableChannels', 0));
+        ->assertInertia(fn (Assert $page): Assert => $page->has('joinableChannels', 0));
 });
 
-test('a team member can join a public channel', function () {
+test('a team member can join a public channel', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $channel = Channel::factory()->for($team)->create(['name' => 'Marketing', 'slug' => 'marketing']);
@@ -50,7 +50,7 @@ test('a team member can join a public channel', function () {
     expect($channel->members()->whereKey($user->id)->exists())->toBeTrue();
 });
 
-test('joining a channel is idempotent', function () {
+test('joining a channel is idempotent', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $channel = Channel::factory()->for($team)->create(['slug' => 'marketing']);
@@ -63,7 +63,7 @@ test('joining a channel is idempotent', function () {
     expect($channel->channelMembers()->where('user_id', $user->id)->count())->toBe(1);
 });
 
-test('a private channel cannot be joined by browsing', function () {
+test('a private channel cannot be joined by browsing', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
@@ -75,7 +75,7 @@ test('a private channel cannot be joined by browsing', function () {
     expect($channel->members()->whereKey($user->id)->exists())->toBeFalse();
 });
 
-test('an archived channel cannot be joined', function () {
+test('an archived channel cannot be joined', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $channel = Channel::factory()->for($team)->archived()->create(['slug' => 'old']);
@@ -85,7 +85,7 @@ test('an archived channel cannot be joined', function () {
         ->assertForbidden();
 });
 
-test('a non-team-member cannot join a channel', function () {
+test('a non-team-member cannot join a channel', function (): void {
     $owner = User::factory()->create();
     $outsider = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');

--- a/tests/Feature/Channels/ChannelDraftTest.php
+++ b/tests/Feature/Channels/ChannelDraftTest.php
@@ -64,7 +64,7 @@ function saveDraft(User $user, Team $team, Channel $channel, ?string $body): Tes
     ]), ['body' => $body]);
 }
 
-test('a member can save a draft for a channel', function () {
+test('a member can save a draft for a channel', function (): void {
     [, $team, $general] = draftTeamWithGeneral();
     $member = draftMember($team, $general);
 
@@ -78,7 +78,7 @@ test('a member can save a draft for a channel', function () {
     ]);
 });
 
-test('saving a blank draft clears it', function () {
+test('saving a blank draft clears it', function (): void {
     [, $team, $general] = draftTeamWithGeneral();
     $member = draftMember($team, $general);
     $member->channels()->updateExistingPivot($general->id, ['draft' => 'stale text']);
@@ -96,7 +96,7 @@ test('saving a blank draft clears it', function () {
     'null body' => [null],
 ]);
 
-test('a non-member cannot save a draft for a channel', function () {
+test('a non-member cannot save a draft for a channel', function (): void {
     [$owner, $team] = draftTeamWithGeneral();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
@@ -114,7 +114,7 @@ test('a non-member cannot save a draft for a channel', function () {
     ]);
 });
 
-test('a draft cannot exceed the message length limit', function () {
+test('a draft cannot exceed the message length limit', function (): void {
     [, $team, $general] = draftTeamWithGeneral();
     $member = draftMember($team, $general);
 
@@ -122,7 +122,7 @@ test('a draft cannot exceed the message length limit', function () {
         ->assertSessionHasErrors('body');
 });
 
-test('the channel view restores the members saved draft', function () {
+test('the channel view restores the members saved draft', function (): void {
     [, $team, $general] = draftTeamWithGeneral();
     $member = draftMember($team, $general);
     $member->channels()->updateExistingPivot($general->id, ['draft' => 'unsent words']);
@@ -136,7 +136,7 @@ test('the channel view restores the members saved draft', function () {
         ->toMatchArray(['draft' => 'unsent words', 'hasDraft' => true]);
 });
 
-test('a member without a draft opens the channel with an empty composer', function () {
+test('a member without a draft opens the channel with an empty composer', function (): void {
     [, $team, $general] = draftTeamWithGeneral();
     $member = draftMember($team, $general);
 
@@ -149,7 +149,7 @@ test('a member without a draft opens the channel with an empty composer', functi
         ->toMatchArray(['draft' => null, 'hasDraft' => false]);
 });
 
-test('the sidebar flags a channel with a draft without shipping the draft text', function () {
+test('the sidebar flags a channel with a draft without shipping the draft text', function (): void {
     [, $team, $general] = draftTeamWithGeneral();
     $member = draftMember($team, $general);
     $member->channels()->updateExistingPivot($general->id, ['draft' => 'secret sauce']);
@@ -158,7 +158,7 @@ test('the sidebar flags a channel with a draft without shipping the draft text',
         ->toMatchArray(['hasDraft' => true, 'draft' => null]);
 });
 
-test('the sidebar shows no draft cue when the channel has none', function () {
+test('the sidebar shows no draft cue when the channel has none', function (): void {
     [, $team, $general] = draftTeamWithGeneral();
     $member = draftMember($team, $general);
 
@@ -166,7 +166,7 @@ test('the sidebar shows no draft cue when the channel has none', function () {
         ->toMatchArray(['hasDraft' => false, 'draft' => null]);
 });
 
-test('posting a message from the main composer clears the channel draft', function () {
+test('posting a message from the main composer clears the channel draft', function (): void {
     [, $team, $general] = draftTeamWithGeneral();
     $member = draftMember($team, $general);
     $member->channels()->updateExistingPivot($general->id, ['draft' => 'about to send this']);

--- a/tests/Feature/Channels/ChannelMemberTest.php
+++ b/tests/Feature/Channels/ChannelMemberTest.php
@@ -22,7 +22,7 @@ function teamWithMember(TeamRole $role = TeamRole::Member): array
     return [$owner, $member, $team];
 }
 
-test('a private channel member can add another team member', function () {
+test('a private channel member can add another team member', function (): void {
     [$owner, $member, $team] = teamWithMember();
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
     app(JoinChannel::class)->handle($channel, $owner);
@@ -36,7 +36,7 @@ test('a private channel member can add another team member', function () {
     expect($channel->members()->whereKey($member->id)->exists())->toBeTrue();
 });
 
-test('a team admin who is not a channel member can add a member to a private channel', function () {
+test('a team admin who is not a channel member can add a member to a private channel', function (): void {
     [$owner, $admin, $team] = teamWithMember(TeamRole::Admin);
     $target = User::factory()->create();
     $team->memberships()->create(['user_id' => $target->id, 'role' => TeamRole::Member]);
@@ -51,7 +51,7 @@ test('a team admin who is not a channel member can add a member to a private cha
     expect($channel->members()->whereKey($target->id)->exists())->toBeTrue();
 });
 
-test('a plain member who is not in the private channel cannot add members', function () {
+test('a plain member who is not in the private channel cannot add members', function (): void {
     [$owner, $member, $team] = teamWithMember();
     $target = User::factory()->create();
     $team->memberships()->create(['user_id' => $target->id, 'role' => TeamRole::Member]);
@@ -67,7 +67,7 @@ test('a plain member who is not in the private channel cannot add members', func
     expect($channel->members()->whereKey($target->id)->exists())->toBeFalse();
 });
 
-test('members cannot be managed on a public channel through the members endpoint', function () {
+test('members cannot be managed on a public channel through the members endpoint', function (): void {
     [$owner, $member, $team] = teamWithMember();
     $channel = Channel::factory()->for($team)->create(['slug' => 'marketing']);
     app(JoinChannel::class)->handle($channel, $owner);
@@ -79,7 +79,7 @@ test('members cannot be managed on a public channel through the members endpoint
         ->assertForbidden();
 });
 
-test('a user who is not a team member cannot be added to a channel', function () {
+test('a user who is not a team member cannot be added to a channel', function (): void {
     [$owner, $member, $team] = teamWithMember();
     $outsider = User::factory()->create();
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
@@ -94,7 +94,7 @@ test('a user who is not a team member cannot be added to a channel', function ()
     expect($channel->members()->whereKey($outsider->id)->exists())->toBeFalse();
 });
 
-test('a private channel member can remove another member', function () {
+test('a private channel member can remove another member', function (): void {
     [$owner, $member, $team] = teamWithMember();
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
     app(JoinChannel::class)->handle($channel, $owner);
@@ -109,7 +109,7 @@ test('a private channel member can remove another member', function () {
     expect($channel->members()->whereKey($member->id)->exists())->toBeFalse();
 });
 
-test('a plain non-member cannot remove members from a private channel', function () {
+test('a plain non-member cannot remove members from a private channel', function (): void {
     [$owner, $member, $team] = teamWithMember();
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
     app(JoinChannel::class)->handle($channel, $owner);

--- a/tests/Feature/Channels/ChannelModelTest.php
+++ b/tests/Feature/Channels/ChannelModelTest.php
@@ -5,7 +5,7 @@ use App\Models\Channel;
 use App\Models\ChannelMember;
 use App\Models\User;
 
-test('a channel belongs to its creator', function () {
+test('a channel belongs to its creator', function (): void {
     $creator = User::factory()->create();
     $channel = Channel::factory()->create(['created_by' => $creator->id]);
 
@@ -13,7 +13,7 @@ test('a channel belongs to its creator', function () {
         ->and($channel->creator->is($creator))->toBeTrue();
 });
 
-test('a channel member belongs to a channel and a user', function () {
+test('a channel member belongs to a channel and a user', function (): void {
     $channel = Channel::factory()->create();
     $user = User::factory()->create();
     $member = ChannelMember::factory()->create([
@@ -25,7 +25,7 @@ test('a channel member belongs to a channel and a user', function () {
         ->and($member->user->is($user))->toBeTrue();
 });
 
-test('channel visibility exposes a human label', function () {
+test('channel visibility exposes a human label', function (): void {
     expect(ChannelVisibility::Public->label())->toBe('Public')
         ->and(ChannelVisibility::Private->label())->toBe('Private');
 });

--- a/tests/Feature/Channels/ChannelPlacementTest.php
+++ b/tests/Feature/Channels/ChannelPlacementTest.php
@@ -69,7 +69,7 @@ function placementSidebar(User $user, Team $team, Channel $channel): Collection
     return collect($response->viewData('page')['props']['channels'])->keyBy('slug');
 }
 
-test('a member can move a channel into a custom section', function () {
+test('a member can move a channel into a custom section', function (): void {
     [$owner, $team, $general] = placementTeam();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
 
@@ -89,7 +89,7 @@ test('a member can move a channel into a custom section', function () {
         ->toMatchArray(['sectionId' => $section->id, 'position' => 0]);
 });
 
-test('a member can move a channel back to the default group with a null section', function () {
+test('a member can move a channel back to the default group with a null section', function (): void {
     [$owner, $team, $general] = placementTeam();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
     $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
@@ -106,7 +106,7 @@ test('a member can move a channel back to the default group with a null section'
     ]);
 });
 
-test('a pure reorder leaves the section assignment untouched', function () {
+test('a pure reorder leaves the section assignment untouched', function (): void {
     [$owner, $team, $general] = placementTeam();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
     $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
@@ -123,7 +123,7 @@ test('a pure reorder leaves the section assignment untouched', function () {
     ]);
 });
 
-test('reordering persists channel positions and drives the sidebar order', function () {
+test('reordering persists channel positions and drives the sidebar order', function (): void {
     [$owner, $team, $general] = placementTeam();
     $alpha = placementChannel($owner, $team, 'Alpha');
     $beta = placementChannel($owner, $team, 'Beta');
@@ -141,7 +141,7 @@ test('reordering persists channel positions and drives the sidebar order', funct
     expect($order)->toBe(['beta', 'alpha', 'general']);
 });
 
-test('placement only touches the acting user own rows', function () {
+test('placement only touches the acting user own rows', function (): void {
     [$owner, $team, $general] = placementTeam();
     $member = User::factory()->create();
     $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
@@ -156,7 +156,7 @@ test('placement only touches the acting user own rows', function () {
     expect($general->channelMembers()->where('user_id', $member->id)->value('position'))->toBe(0);
 });
 
-test('a member cannot place a channel into another user section', function () {
+test('a member cannot place a channel into another user section', function (): void {
     [$owner, $team, $general] = placementTeam();
     $other = User::factory()->create();
     $theirs = ChannelSection::factory()->for($other)->for($team)->create();
@@ -167,7 +167,7 @@ test('a member cannot place a channel into another user section', function () {
     ])->assertSessionHasErrors('section_id');
 });
 
-test('a non-member cannot place a channel', function () {
+test('a non-member cannot place a channel', function (): void {
     [$owner, $team] = placementTeam();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
@@ -181,13 +181,13 @@ test('a non-member cannot place a channel', function () {
     ])->assertForbidden();
 });
 
-test('placement requires the ordered ids payload', function () {
+test('placement requires the ordered ids payload', function (): void {
     [$owner, $team, $general] = placementTeam();
 
     placeChannel($owner, $team, $general, [])->assertSessionHasErrors('ordered_ids');
 });
 
-test('placement rejects a channel id the user does not belong to', function () {
+test('placement rejects a channel id the user does not belong to', function (): void {
     [$owner, $team, $general] = placementTeam();
     $foreign = Channel::factory()->for($team)->create();
 
@@ -196,7 +196,7 @@ test('placement rejects a channel id the user does not belong to', function () {
     ])->assertSessionHasErrors('ordered_ids.0');
 });
 
-test('a guest cannot place a channel', function () {
+test('a guest cannot place a channel', function (): void {
     [$owner, $team, $general] = placementTeam();
 
     $this->patch(route('channels.placement.update', ['team' => $team->slug, 'channel' => $general->slug]), [

--- a/tests/Feature/Channels/ChannelPolicyTest.php
+++ b/tests/Feature/Channels/ChannelPolicyTest.php
@@ -5,7 +5,7 @@ use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\User;
 
-test('the #general channel cannot be archived by anyone', function () {
+test('the #general channel cannot be archived by anyone', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -13,7 +13,7 @@ test('the #general channel cannot be archived by anyone', function () {
     expect($owner->can('archive', $general))->toBeFalse();
 });
 
-test('the channel creator can archive a regular channel', function () {
+test('the channel creator can archive a regular channel', function (): void {
     $creator = User::factory()->create();
     $team = app(CreateTeam::class)->handle($creator, 'Acme');
     $channel = Channel::factory()->for($team)->create([
@@ -24,7 +24,7 @@ test('the channel creator can archive a regular channel', function () {
     expect($creator->can('archive', $channel))->toBeTrue();
 });
 
-test('a plain member who did not create a channel cannot archive it', function () {
+test('a plain member who did not create a channel cannot archive it', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -38,7 +38,7 @@ test('a plain member who did not create a channel cannot archive it', function (
     expect($member->can('archive', $channel))->toBeFalse();
 });
 
-test('the #general channel cannot be deleted by anyone', function () {
+test('the #general channel cannot be deleted by anyone', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -46,7 +46,7 @@ test('the #general channel cannot be deleted by anyone', function () {
     expect($owner->can('delete', $general))->toBeFalse();
 });
 
-test('a team admin can delete a regular channel they did not create', function () {
+test('a team admin can delete a regular channel they did not create', function (): void {
     $owner = User::factory()->create();
     $admin = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -57,7 +57,7 @@ test('a team admin can delete a regular channel they did not create', function (
     expect($admin->can('delete', $channel))->toBeTrue();
 });
 
-test('a user who is not a team member cannot archive a channel', function () {
+test('a user who is not a team member cannot archive a channel', function (): void {
     $owner = User::factory()->create();
     $outsider = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -66,7 +66,7 @@ test('a user who is not a team member cannot archive a channel', function () {
     expect($outsider->can('archive', $channel))->toBeFalse();
 });
 
-test('an already-archived channel cannot be archived again', function () {
+test('an already-archived channel cannot be archived again', function (): void {
     $creator = User::factory()->create();
     $team = app(CreateTeam::class)->handle($creator, 'Acme');
     $channel = Channel::factory()->for($team)->archived()->create(['created_by' => $creator->id]);
@@ -74,7 +74,7 @@ test('an already-archived channel cannot be archived again', function () {
     expect($creator->can('archive', $channel))->toBeFalse();
 });
 
-test('a team member can view a public channel but a non-member cannot', function () {
+test('a team member can view a public channel but a non-member cannot', function (): void {
     $owner = User::factory()->create();
     $outsider = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -84,7 +84,7 @@ test('a team member can view a public channel but a non-member cannot', function
         ->and($outsider->can('view', $general))->toBeFalse();
 });
 
-test('a private channel is only viewable by its members', function () {
+test('a private channel is only viewable by its members', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -97,7 +97,7 @@ test('a private channel is only viewable by its members', function () {
         ->and($member->can('view', $private))->toBeFalse();
 });
 
-test('any team member can create a channel but an outsider cannot', function () {
+test('any team member can create a channel but an outsider cannot', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $outsider = User::factory()->create();
@@ -108,7 +108,7 @@ test('any team member can create a channel but an outsider cannot', function () 
         ->and($outsider->can('create', [Channel::class, $team]))->toBeFalse();
 });
 
-test('a public channel is joinable by a team member but a private one is not', function () {
+test('a public channel is joinable by a team member but a private one is not', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $public = Channel::factory()->for($team)->create();
@@ -118,7 +118,7 @@ test('a public channel is joinable by a team member but a private one is not', f
         ->and($owner->can('join', $private))->toBeFalse();
 });
 
-test('an archived public channel is not joinable', function () {
+test('an archived public channel is not joinable', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $archived = Channel::factory()->for($team)->archived()->create();
@@ -126,7 +126,7 @@ test('an archived public channel is not joinable', function () {
     expect($owner->can('join', $archived))->toBeFalse();
 });
 
-test('a private channel member or admin may manage its membership', function () {
+test('a private channel member or admin may manage its membership', function (): void {
     $owner = User::factory()->create();
     $channelMember = User::factory()->create();
     $admin = User::factory()->create();
@@ -146,7 +146,7 @@ test('a private channel member or admin may manage its membership', function () 
         ->and($plainMember->can('removeMember', $private))->toBeFalse();
 });
 
-test('only channel members may post a message', function () {
+test('only channel members may post a message', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -160,7 +160,7 @@ test('only channel members may post a message', function () {
         ->and($member->can('postMessage', $channel))->toBeFalse();
 });
 
-test('a channel member cannot post to an archived channel', function () {
+test('a channel member cannot post to an archived channel', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->archived()->create();
@@ -169,7 +169,7 @@ test('a channel member cannot post to an archived channel', function () {
     expect($owner->can('postMessage', $channel))->toBeFalse();
 });
 
-test('membership cannot be managed on a public channel', function () {
+test('membership cannot be managed on a public channel', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $public = Channel::factory()->for($team)->create();
@@ -179,7 +179,7 @@ test('membership cannot be managed on a public channel', function () {
         ->and($owner->can('removeMember', $public))->toBeFalse();
 });
 
-test('a non-team-member cannot manage a private channel membership', function () {
+test('a non-team-member cannot manage a private channel membership', function (): void {
     $owner = User::factory()->create();
     $outsider = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -189,7 +189,7 @@ test('a non-team-member cannot manage a private channel membership', function ()
         ->and($outsider->can('removeMember', $private))->toBeFalse();
 });
 
-test('the pivot-preference abilities are granted only to channel members', function (string $ability) {
+test('the pivot-preference abilities are granted only to channel members', function (string $ability): void {
     $channelMember = User::factory()->create();
     $team = app(CreateTeam::class)->handle($channelMember, 'Acme');
     $channel = Channel::factory()->for($team)->create();

--- a/tests/Feature/Channels/ChannelPreferenceTest.php
+++ b/tests/Feature/Channels/ChannelPreferenceTest.php
@@ -42,11 +42,11 @@ function prefMember(Team $team, Channel $channel, ?string $name = null): User
  */
 function prefPost(Channel $channel, User $author, ?User $mention = null): Message
 {
-    $body = $mention ? "hey @[{$mention->name}]({$mention->id})" : fake()->sentence();
+    $body = $mention instanceof User ? "hey @[{$mention->name}]({$mention->id})" : fake()->sentence();
 
     $message = Message::factory()->for($channel)->for($author)->create(['body' => $body]);
 
-    if ($mention) {
+    if ($mention instanceof User) {
         $message->mentionedUsers()->attach($mention->id);
     }
 
@@ -81,7 +81,7 @@ function updatePreferences(User $user, Team $team, Channel $channel, bool $muted
     ]), ['muted' => $muted, 'notification_level' => $level]);
 }
 
-test('joining a channel applies the default notification preferences', function () {
+test('joining a channel applies the default notification preferences', function (): void {
     [$owner, $team] = prefTeamWithGeneral();
     $channel = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Public,
@@ -100,7 +100,7 @@ test('joining a channel applies the default notification preferences', function 
     ]);
 });
 
-test('a member can update their notification preferences', function () {
+test('a member can update their notification preferences', function (): void {
     [, $team, $general] = prefTeamWithGeneral();
     $member = prefMember($team, $general);
 
@@ -115,7 +115,7 @@ test('a member can update their notification preferences', function () {
     ]);
 });
 
-test('a non-member cannot update preferences for a channel', function () {
+test('a non-member cannot update preferences for a channel', function (): void {
     [$owner, $team] = prefTeamWithGeneral();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
@@ -133,7 +133,7 @@ test('a non-member cannot update preferences for a channel', function () {
     ]);
 });
 
-test('the notification level must be one of the allowed values', function () {
+test('the notification level must be one of the allowed values', function (): void {
     [, $team, $general] = prefTeamWithGeneral();
     $member = prefMember($team, $general);
 
@@ -141,7 +141,7 @@ test('the notification level must be one of the allowed values', function () {
         ->assertSessionHasErrors('notification_level');
 });
 
-test('the muted flag must be a boolean', function () {
+test('the muted flag must be a boolean', function (): void {
     [, $team, $general] = prefTeamWithGeneral();
     $member = prefMember($team, $general);
 
@@ -152,7 +152,7 @@ test('the muted flag must be a boolean', function () {
         ->assertSessionHasErrors('muted');
 });
 
-test('the channel view exposes the members own preferences and the level options', function () {
+test('the channel view exposes the members own preferences and the level options', function (): void {
     [, $team, $general] = prefTeamWithGeneral();
     $member = prefMember($team, $general);
     $member->channels()->updateExistingPivot($general->id, [
@@ -177,7 +177,7 @@ test('the channel view exposes the members own preferences and the level options
         ]);
 });
 
-test('a non-member viewing a public channel cannot manage preferences and sees defaults', function () {
+test('a non-member viewing a public channel cannot manage preferences and sees defaults', function (): void {
     [$owner, $team] = prefTeamWithGeneral();
     $public = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Public,
@@ -198,7 +198,7 @@ test('a non-member viewing a public channel cannot manage preferences and sees d
         ->and($props['canManagePreferences'])->toBeFalse();
 });
 
-test('the notification level and mute suppress the sidebar badges', function (bool $muted, string $level, int $expectedUnread, int $expectedMention) {
+test('the notification level and mute suppress the sidebar badges', function (bool $muted, string $level, int $expectedUnread, int $expectedMention): void {
     [$owner, $team, $general] = prefTeamWithGeneral();
     $member = prefMember($team, $general, 'Ada Lovelace');
 

--- a/tests/Feature/Channels/ChannelStarTest.php
+++ b/tests/Feature/Channels/ChannelStarTest.php
@@ -62,7 +62,7 @@ function setStar(User $user, Team $team, Channel $channel, bool $starred): TestR
     ]), ['starred' => $starred]);
 }
 
-test('a member can star a channel', function () {
+test('a member can star a channel', function (): void {
     [, $team, $general] = starTeamWithGeneral();
     $member = starMember($team, $general);
 
@@ -75,7 +75,7 @@ test('a member can star a channel', function () {
     ]);
 });
 
-test('a member can unstar a channel', function () {
+test('a member can unstar a channel', function (): void {
     [, $team, $general] = starTeamWithGeneral();
     $member = starMember($team, $general);
     $member->channels()->updateExistingPivot($general->id, ['starred' => true]);
@@ -89,7 +89,7 @@ test('a member can unstar a channel', function () {
     ]);
 });
 
-test('the sidebar reflects a channel star flag', function () {
+test('the sidebar reflects a channel star flag', function (): void {
     [, $team, $general] = starTeamWithGeneral();
     $member = starMember($team, $general);
 
@@ -102,7 +102,7 @@ test('the sidebar reflects a channel star flag', function () {
         ->toMatchArray(['starred' => true]);
 });
 
-test('one member starring a channel does not star it for another', function () {
+test('one member starring a channel does not star it for another', function (): void {
     [$owner, $team, $general] = starTeamWithGeneral();
     $member = starMember($team, $general);
 
@@ -112,7 +112,7 @@ test('one member starring a channel does not star it for another', function () {
     expect(starSidebarEntry($member, $team, $general))->toMatchArray(['starred' => true]);
 });
 
-test('a non-member cannot star a channel', function () {
+test('a non-member cannot star a channel', function (): void {
     [$owner, $team] = starTeamWithGeneral();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
@@ -129,7 +129,7 @@ test('a non-member cannot star a channel', function () {
     ]);
 });
 
-test('starring requires a boolean flag', function () {
+test('starring requires a boolean flag', function (): void {
     [, $team, $general] = starTeamWithGeneral();
     $member = starMember($team, $general);
 

--- a/tests/Feature/Channels/ChannelTest.php
+++ b/tests/Feature/Channels/ChannelTest.php
@@ -10,7 +10,7 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('creating a team auto-creates a #general channel', function () {
+test('creating a team auto-creates a #general channel', function (): void {
     $user = User::factory()->create();
 
     $team = app(CreateTeam::class)->handle($user, 'Acme');
@@ -23,7 +23,7 @@ test('creating a team auto-creates a #general channel', function () {
         ->and($general->created_by)->toBe($user->id);
 });
 
-test('the team owner is auto-joined to #general on team creation', function () {
+test('the team owner is auto-joined to #general on team creation', function (): void {
     $user = User::factory()->create();
 
     $team = app(CreateTeam::class)->handle($user, 'Acme');
@@ -33,7 +33,7 @@ test('the team owner is auto-joined to #general on team creation', function () {
     expect($general->members()->whereKey($user->id)->exists())->toBeTrue();
 });
 
-test('a new team member is auto-joined to #general when accepting an invitation', function () {
+test('a new team member is auto-joined to #general when accepting an invitation', function (): void {
     $owner = User::factory()->create();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -52,7 +52,7 @@ test('a new team member is auto-joined to #general when accepting an invitation'
     expect($general->members()->whereKey($invitedUser->id)->exists())->toBeTrue();
 });
 
-test('the channel page lists the current user\'s channels in the sidebar', function () {
+test('the channel page lists the current user\'s channels in the sidebar', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -60,7 +60,7 @@ test('the channel page lists the current user\'s channels in the sidebar', funct
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Show')
             ->has('channels', 1)
             ->where('channels.0.slug', 'general')
@@ -69,7 +69,7 @@ test('the channel page lists the current user\'s channels in the sidebar', funct
         );
 });
 
-test('the CreateChannel action creates a channel, strips a leading # and joins the creator', function () {
+test('the CreateChannel action creates a channel, strips a leading # and joins the creator', function (): void {
     $creator = User::factory()->create();
     $team = app(CreateTeam::class)->handle($creator, 'Acme');
 
@@ -82,7 +82,7 @@ test('the CreateChannel action creates a channel, strips a leading # and joins t
         ->and($channel->members()->whereKey($creator->id)->exists())->toBeTrue();
 });
 
-test('a bare team URL redirects to the #general channel', function () {
+test('a bare team URL redirects to the #general channel', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
 
@@ -91,7 +91,7 @@ test('a bare team URL redirects to the #general channel', function () {
         ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => 'general']));
 });
 
-test('a user who is not a team member cannot view the team\'s channels', function () {
+test('a user who is not a team member cannot view the team\'s channels', function (): void {
     $owner = User::factory()->create();
     $outsider = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -101,7 +101,7 @@ test('a user who is not a team member cannot view the team\'s channels', functio
         ->assertForbidden();
 });
 
-test('the channel page exposes the viewer\'s read pointer for the new-messages divider', function () {
+test('the channel page exposes the viewer\'s read pointer for the new-messages divider', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -112,12 +112,12 @@ test('the channel page exposes the viewer\'s read pointer for the new-messages d
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('lastReadMessageId', (string) $messages[1]->id)
         );
 });
 
-test('the read pointer is null on a channel the viewer has never read', function () {
+test('the read pointer is null on a channel the viewer has never read', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -127,10 +127,10 @@ test('the read pointer is null on a channel the viewer has never read', function
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page->where('lastReadMessageId', null));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('lastReadMessageId', null));
 });
 
-test('opening a channel with more unread than a page windows the initial page around the read boundary', function () {
+test('opening a channel with more unread than a page windows the initial page around the read boundary', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -146,7 +146,7 @@ test('opening a channel with more unread than a page windows the initial page ar
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             // The window is capped 39 messages past the boundary (message 71) and
             // holds the newest 50 rows at or below that cap — messages 22..71 —
             // so the boundary (message 31) is loaded while the newest history
@@ -157,7 +157,7 @@ test('opening a channel with more unread than a page windows the initial page ar
         );
 });
 
-test('opening a channel with unread within a page keeps the default newest window', function () {
+test('opening a channel with unread within a page keeps the default newest window', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -172,7 +172,7 @@ test('opening a channel with unread within a page keeps the default newest windo
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             // No window: the boundary already sits in the newest page, so the view
             // opens at newest (messages 11..60) with the boundary (message 21) loaded.
             ->has('messages.data', 50)
@@ -181,7 +181,7 @@ test('opening a channel with unread within a page keeps the default newest windo
         );
 });
 
-test('a never-read channel with a long backlog still opens at newest', function () {
+test('a never-read channel with a long backlog still opens at newest', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -196,14 +196,14 @@ test('a never-read channel with a long backlog still opens at newest', function 
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('messages.data', 50)
             ->where('messages.data.0.body', 'message 60')
             ->where('messages.data.49.body', 'message 11')
         );
 });
 
-test('a fully-read channel opens at newest without a window', function () {
+test('a fully-read channel opens at newest without a window', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
@@ -218,7 +218,7 @@ test('a fully-read channel opens at newest without a window', function () {
     $this->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('messages.data', 50)
             ->where('messages.data.0.body', 'message 60')
             ->where('messages.data.49.body', 'message 11')

--- a/tests/Feature/Channels/ChannelTimelineWindowTest.php
+++ b/tests/Feature/Channels/ChannelTimelineWindowTest.php
@@ -45,16 +45,16 @@ function windowMessages(Channel $channel, User $author, int $count): Collection
 function bodiesOf(ChannelTimelineWindow $window): array
 {
     return collect($window->messages()->items())
-        ->map(fn (MessageData $message) => $message->body)
+        ->map(fn (MessageData $message): string => $message->body)
         ->all();
 }
 
-it('opens at newest with no ceiling on a never-read channel', function () {
+it('opens at newest with no ceiling on a never-read channel', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     windowMessages($general, $user, 60);
 
     // Null read pointer: nothing to anchor, so the default newest window holds.
-    $window = new ChannelTimelineWindow(channel: $general, viewer: $user, lastReadMessageId: null);
+    $window = new ChannelTimelineWindow(channel: $general, viewer: $user);
 
     expect($window->ceilingId())->toBeNull()
         ->and($window->jumpToMessageId())->toBeNull();
@@ -65,7 +65,7 @@ it('opens at newest with no ceiling on a never-read channel', function () {
         ->and($bodies[49])->toBe('message 11');
 });
 
-it('opens at newest with no ceiling on a fully-read channel', function () {
+it('opens at newest with no ceiling on a fully-read channel', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     $messages = windowMessages($general, $user, 60);
 
@@ -80,7 +80,7 @@ it('opens at newest with no ceiling on a fully-read channel', function () {
     expect(bodiesOf($window))->toHaveCount(50);
 });
 
-it('keeps the newest window when unread fits within a page', function () {
+it('keeps the newest window when unread fits within a page', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     $messages = windowMessages($general, $user, 60);
 
@@ -98,7 +98,7 @@ it('keeps the newest window when unread fits within a page', function () {
         ->and($bodies[49])->toBe('message 11');
 });
 
-it('anchors the window around the boundary when unread exceeds a page', function () {
+it('anchors the window around the boundary when unread exceeds a page', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     $messages = windowMessages($general, $user, 100);
 
@@ -118,7 +118,7 @@ it('anchors the window around the boundary when unread exceeds a page', function
         ->and($bodies[49])->toBe('message 22');
 });
 
-it('windows a jump target with newer context below it', function () {
+it('windows a jump target with newer context below it', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     $messages = windowMessages($general, $user, 30);
     $target = $messages[4]; // message 5
@@ -138,7 +138,7 @@ it('windows a jump target with newer context below it', function () {
         ->and($bodies[0])->toBe('message 20');
 });
 
-it('leaves a jump near the newest message uncapped', function () {
+it('leaves a jump near the newest message uncapped', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     $messages = windowMessages($general, $user, 5);
     $target = $messages[4]; // the newest
@@ -155,7 +155,7 @@ it('leaves a jump near the newest message uncapped', function () {
     expect(bodiesOf($window))->toHaveCount(5);
 });
 
-it('ignores a jump target from another channel', function () {
+it('ignores a jump target from another channel', function (): void {
     ['user' => $user, 'team' => $team, 'general' => $general] = windowFixture();
     windowMessages($general, $user, 3);
     $other = Channel::factory()->for($team)->create(['created_by' => $user->id]);
@@ -171,7 +171,7 @@ it('ignores a jump target from another channel', function () {
         ->and($window->ceilingId())->toBeNull();
 });
 
-it('ignores an absent or non-string jump target', function () {
+it('ignores an absent or non-string jump target', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     windowMessages($general, $user, 3);
 
@@ -183,7 +183,7 @@ it('ignores an absent or non-string jump target', function () {
         ->toBeNull();
 });
 
-it('includes thread replies sent to the channel and excludes those that are not', function () {
+it('includes thread replies sent to the channel and excludes those that are not', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     $root = Message::factory()->for($general)->for($user)->create(['body' => 'root']);
     Message::factory()->for($user)->inThread($root)->sentToChannel()->create(['body' => 'echoed reply']);
@@ -197,7 +197,7 @@ it('includes thread replies sent to the channel and excludes those that are not'
         ->and($bodies)->not->toContain('thread-only reply');
 });
 
-it('resolves the open thread root and its replies', function () {
+it('resolves the open thread root and its replies', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     $root = Message::factory()->for($general)->for($user)->create(['body' => 'root']);
     Message::factory()->for($user)->inThread($root)->create(['body' => 'reply one']);
@@ -214,12 +214,12 @@ it('resolves the open thread root and its replies', function () {
         ->and($thread['root']->id)->toBe($root->id);
 
     $replyBodies = collect($window->threadReplies()->items())
-        ->map(fn (MessageData $message) => $message->body)
+        ->map(fn (MessageData $message): string => $message->body)
         ->all();
     expect($replyBodies)->toBe(['reply one']);
 });
 
-it('returns no thread and an empty replies page without a thread param', function () {
+it('returns no thread and an empty replies page without a thread param', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     windowMessages($general, $user, 2);
 
@@ -229,7 +229,7 @@ it('returns no thread and an empty replies page without a thread param', functio
         ->and($window->threadReplies()->items())->toBe([]);
 });
 
-it('returns no thread for a non-string or foreign thread param', function () {
+it('returns no thread for a non-string or foreign thread param', function (): void {
     ['user' => $user, 'team' => $team, 'general' => $general] = windowFixture();
     $other = Channel::factory()->for($team)->create(['created_by' => $user->id]);
     $foreignRoot = Message::factory()->for($other)->for($user)->create();

--- a/tests/Feature/Channels/ClearMessageReminderTest.php
+++ b/tests/Feature/Channels/ClearMessageReminderTest.php
@@ -21,7 +21,7 @@ function reminderClearTeamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('a user can clear one of their reminders', function () {
+test('a user can clear one of their reminders', function (): void {
     [$owner, $team, $general] = reminderClearTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
     $reminder = MessageReminder::factory()->for($owner)->for($message)->create();
@@ -33,7 +33,7 @@ test('a user can clear one of their reminders', function () {
     expect(MessageReminder::find($reminder->id))->toBeNull();
 });
 
-test('a user cannot clear someone else reminder', function () {
+test('a user cannot clear someone else reminder', function (): void {
     [$owner, $team, $general] = reminderClearTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
 
@@ -47,7 +47,7 @@ test('a user cannot clear someone else reminder', function () {
     expect(MessageReminder::find($reminder->id))->not->toBeNull();
 });
 
-test('a user can clear all their pending reminders in the team at once', function () {
+test('a user can clear all their pending reminders in the team at once', function (): void {
     [$owner, $team, $general] = reminderClearTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
     $secondMessage = Message::factory()->for($general)->for($owner)->create();
@@ -64,7 +64,7 @@ test('a user can clear all their pending reminders in the team at once', functio
         ->and(MessageReminder::first()->is($fired))->toBeTrue();
 });
 
-test('clearing all leaves another team reminders untouched', function () {
+test('clearing all leaves another team reminders untouched', function (): void {
     [$owner, $team, $general] = reminderClearTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
     MessageReminder::factory()->for($owner)->for($message)->create();

--- a/tests/Feature/Channels/CreateChannelTest.php
+++ b/tests/Feature/Channels/CreateChannelTest.php
@@ -6,7 +6,7 @@ use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\User;
 
-test('a team member can create a channel and is redirected to it', function () {
+test('a team member can create a channel and is redirected to it', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
@@ -28,7 +28,7 @@ test('a team member can create a channel and is redirected to it', function () {
         ->and($channel->members()->whereKey($owner->id)->exists())->toBeTrue();
 });
 
-test('a plain team member can create a channel', function () {
+test('a plain team member can create a channel', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
@@ -44,7 +44,7 @@ test('a plain team member can create a channel', function () {
     expect(Channel::where('team_id', $team->id)->where('slug', 'random')->exists())->toBeTrue();
 });
 
-test('a channel name must be unique within the team', function () {
+test('a channel name must be unique within the team', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     Channel::factory()->for($team)->create(['name' => 'Marketing', 'slug' => 'marketing']);
@@ -59,7 +59,7 @@ test('a channel name must be unique within the team', function () {
     expect(Channel::where('team_id', $team->id)->where('slug', 'marketing')->count())->toBe(1);
 });
 
-test('the same channel name may exist in different teams', function () {
+test('the same channel name may exist in different teams', function (): void {
     $owner = User::factory()->create();
     $teamA = app(CreateTeam::class)->handle($owner, 'Acme');
     $teamB = app(CreateTeam::class)->handle($owner, 'Globex');
@@ -75,7 +75,7 @@ test('the same channel name may exist in different teams', function () {
     expect(Channel::where('team_id', $teamB->id)->where('slug', 'marketing')->exists())->toBeTrue();
 });
 
-test('creating a channel requires a valid visibility', function () {
+test('creating a channel requires a valid visibility', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
@@ -87,7 +87,7 @@ test('creating a channel requires a valid visibility', function () {
         ->assertSessionHasErrors('visibility');
 });
 
-test('creating a channel requires a name', function () {
+test('creating a channel requires a name', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
@@ -99,7 +99,7 @@ test('creating a channel requires a name', function () {
         ->assertSessionHasErrors('name');
 });
 
-test('a user who is not a team member cannot create a channel', function () {
+test('a user who is not a team member cannot create a channel', function (): void {
     $owner = User::factory()->create();
     $outsider = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');

--- a/tests/Feature/Channels/DirectMessageChannelDataTest.php
+++ b/tests/Feature/Channels/DirectMessageChannelDataTest.php
@@ -7,14 +7,14 @@ use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\User;
 
-test('a standard channel has no direct participant', function () {
+test('a standard channel has no direct participant', function (): void {
     $viewer = User::factory()->create();
     $channel = Channel::factory()->create();
 
     expect($channel->directParticipantFor($viewer))->toBeNull();
 });
 
-test('a direct channel renders the other participant viewer-relatively', function () {
+test('a direct channel renders the other participant viewer-relatively', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = User::factory()->create();
@@ -36,7 +36,7 @@ test('a direct channel renders the other participant viewer-relatively', functio
         ->and($otherView->dmUserId)->toBe($owner->id);
 });
 
-test('a self direct channel resolves the viewer as the participant', function () {
+test('a self direct channel resolves the viewer as the participant', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
 

--- a/tests/Feature/Channels/DirectMessageGuardsTest.php
+++ b/tests/Feature/Channels/DirectMessageGuardsTest.php
@@ -21,7 +21,7 @@ function openDmWithNewMember(Team $team, User $owner): array
     return [app(OpenDirectMessage::class)->handle($team, $owner, $other), $owner, $other];
 }
 
-test('a channel created through the store endpoint is always a standard channel', function () {
+test('a channel created through the store endpoint is always a standard channel', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
@@ -36,7 +36,7 @@ test('a channel created through the store endpoint is always a standard channel'
         ->and($channel->isDirect())->toBeFalse();
 });
 
-test('a direct message cannot be archived', function () {
+test('a direct message cannot be archived', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     [$dm] = openDmWithNewMember($team, $owner);
@@ -48,7 +48,7 @@ test('a direct message cannot be archived', function () {
     expect($dm->fresh()->isArchived())->toBeFalse();
 });
 
-test('direct messages are excluded from the browse directory', function () {
+test('direct messages are excluded from the browse directory', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     [$dm] = openDmWithNewMember($team, $owner);

--- a/tests/Feature/Channels/DirectMessageRealtimeTest.php
+++ b/tests/Feature/Channels/DirectMessageRealtimeTest.php
@@ -44,7 +44,7 @@ function postDmMessage(User $author, Team $team, Channel $dm, string $body): voi
     ]), ['body' => $body, 'client_uuid' => (string) Str::uuid7()]);
 }
 
-test('the first message in a direct message announces to the recipient user channel', function () {
+test('the first message in a direct message announces to the recipient user channel', function (): void {
     Event::fake([DirectMessageStarted::class]);
 
     [$owner, $team, $other] = realtimeTeamWithMember();
@@ -52,7 +52,7 @@ test('the first message in a direct message announces to the recipient user chan
 
     postDmMessage($owner, $team, $dm, 'Hey there');
 
-    Event::assertDispatched(DirectMessageStarted::class, function (DirectMessageStarted $event) use ($dm, $other) {
+    Event::assertDispatched(DirectMessageStarted::class, function (DirectMessageStarted $event) use ($dm, $other): bool {
         $target = $event->broadcastOn()[0];
 
         expect($target)->toBeInstanceOf(PrivateChannel::class)
@@ -64,7 +64,7 @@ test('the first message in a direct message announces to the recipient user chan
     });
 });
 
-test('only the first direct message announces; later messages do not', function () {
+test('only the first direct message announces; later messages do not', function (): void {
     Event::fake([DirectMessageStarted::class]);
 
     [$owner, $team, $other] = realtimeTeamWithMember();
@@ -77,7 +77,7 @@ test('only the first direct message announces; later messages do not', function 
     Event::assertDispatchedTimes(DirectMessageStarted::class, 1);
 });
 
-test('a self direct message announces to no one', function () {
+test('a self direct message announces to no one', function (): void {
     Event::fake([DirectMessageStarted::class]);
 
     $owner = User::factory()->create();
@@ -89,7 +89,7 @@ test('a self direct message announces to no one', function () {
     Event::assertNotDispatched(DirectMessageStarted::class);
 });
 
-test('a message in a standard channel never announces a direct message', function () {
+test('a message in a standard channel never announces a direct message', function (): void {
     Event::fake([DirectMessageStarted::class]);
 
     [$owner, $team] = realtimeTeamWithMember();
@@ -100,7 +100,7 @@ test('a message in a standard channel never announces a direct message', functio
     Event::assertNotDispatched(DirectMessageStarted::class);
 });
 
-test('a user may subscribe to their own user channel', function () {
+test('a user may subscribe to their own user channel', function (): void {
     useRealBroadcasterForDm();
 
     $user = User::factory()->create();
@@ -113,7 +113,7 @@ test('a user may subscribe to their own user channel', function () {
         ->assertOk();
 });
 
-test('a user cannot subscribe to another user channel', function () {
+test('a user cannot subscribe to another user channel', function (): void {
     useRealBroadcasterForDm();
 
     $user = User::factory()->create();

--- a/tests/Feature/Channels/DispatchMessageReminderTest.php
+++ b/tests/Feature/Channels/DispatchMessageReminderTest.php
@@ -31,7 +31,7 @@ function fireDueReminders(): void
     app(DispatchDueMessageReminders::class)->handle();
 }
 
-test('a due reminder fires and signals its owner', function () {
+test('a due reminder fires and signals its owner', function (): void {
     Event::fake([MessageReminderDue::class]);
 
     [$owner, $team, $general] = reminderDispatchTeamWithGeneral();
@@ -45,13 +45,11 @@ test('a due reminder fires and signals its owner', function () {
     expect($reminder->status)->toBe(MessageReminderStatus::Fired)
         ->and($reminder->fired_at)->not->toBeNull();
 
-    Event::assertDispatched(MessageReminderDue::class, function (MessageReminderDue $event) use ($owner) {
-        return $event->userId === $owner->id
-            && $event->broadcastOn()[0]->name === 'private-user.'.$owner->id;
-    });
+    Event::assertDispatched(MessageReminderDue::class, fn (MessageReminderDue $event): bool => $event->userId === $owner->id
+        && $event->broadcastOn()[0]->name === 'private-user.'.$owner->id);
 });
 
-test('a reminder whose time has not arrived is left pending', function () {
+test('a reminder whose time has not arrived is left pending', function (): void {
     Event::fake([MessageReminderDue::class]);
 
     [$owner, $team, $general] = reminderDispatchTeamWithGeneral();
@@ -66,7 +64,7 @@ test('a reminder whose time has not arrived is left pending', function () {
     Event::assertNotDispatched(MessageReminderDue::class);
 });
 
-test('an already-fired reminder never fires twice', function () {
+test('an already-fired reminder never fires twice', function (): void {
     Event::fake([MessageReminderDue::class]);
 
     [$owner, $team, $general] = reminderDispatchTeamWithGeneral();

--- a/tests/Feature/Channels/DispatchScheduledMessageTest.php
+++ b/tests/Feature/Channels/DispatchScheduledMessageTest.php
@@ -33,7 +33,7 @@ function dispatchDue(): void
     app(DispatchDueScheduledMessages::class)->handle();
 }
 
-test('a due scheduled message is delivered through the normal send path and broadcasts', function () {
+test('a due scheduled message is delivered through the normal send path and broadcasts', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = dispatchTeamWithGeneral();
@@ -52,13 +52,11 @@ test('a due scheduled message is delivered through the normal send path and broa
         ->and($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Sent)
         ->and($scheduled->fresh()->sent_at)->not->toBeNull();
 
-    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($general, $message) {
-        return $event->broadcastOn()[0]->name === 'private-channel.'.$general->id
-            && $event->broadcastWith() === MessageData::fromMessage($message->fresh()->load('user'))->toArray();
-    });
+    Event::assertDispatched(MessageSent::class, fn (MessageSent $event): bool => $event->broadcastOn()[0]->name === 'private-channel.'.$general->id
+        && $event->broadcastWith() === MessageData::fromMessage($message->fresh()->load('user'))->toArray());
 });
 
-test('a scheduled message not yet due is left pending', function () {
+test('a scheduled message not yet due is left pending', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = dispatchTeamWithGeneral();
@@ -73,7 +71,7 @@ test('a scheduled message not yet due is left pending', function () {
     Event::assertNotDispatched(MessageSent::class);
 });
 
-test('a cancelled scheduled message is never delivered', function () {
+test('a cancelled scheduled message is never delivered', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = dispatchTeamWithGeneral();
@@ -87,7 +85,7 @@ test('a cancelled scheduled message is never delivered', function () {
     Event::assertNotDispatched(MessageSent::class);
 });
 
-test('a due message is delivered at most once across overlapping runs', function () {
+test('a due message is delivered at most once across overlapping runs', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = dispatchTeamWithGeneral();
@@ -102,7 +100,7 @@ test('a due message is delivered at most once across overlapping runs', function
     Event::assertDispatchedTimes(MessageSent::class, 1);
 });
 
-test('a due message preserves the inline reply quote when its target is still live', function () {
+test('a due message preserves the inline reply quote when its target is still live', function (): void {
     [$owner, $team, $general] = dispatchTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create([
@@ -117,7 +115,7 @@ test('a due message preserves the inline reply quote when its target is still li
         ->and($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Sent);
 });
 
-test('a due message drops a since-deleted reply target but still sends', function () {
+test('a due message drops a since-deleted reply target but still sends', function (): void {
     [$owner, $team, $general] = dispatchTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create([
@@ -135,7 +133,7 @@ test('a due message drops a since-deleted reply target but still sends', functio
         ->and($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Sent);
 });
 
-test('a due message for an archived channel fails instead of delivering', function () {
+test('a due message for an archived channel fails instead of delivering', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team] = dispatchTeamWithGeneral();
@@ -155,7 +153,7 @@ test('a due message for an archived channel fails instead of delivering', functi
     Event::assertNotDispatched(MessageSent::class);
 });
 
-test('a due message fails when its author is no longer a channel member', function () {
+test('a due message fails when its author is no longer a channel member', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = dispatchTeamWithGeneral();
@@ -174,7 +172,7 @@ test('a due message fails when its author is no longer a channel member', functi
     Event::assertNotDispatched(MessageSent::class);
 });
 
-test('delivering a scheduled message leaves the author current draft untouched', function () {
+test('delivering a scheduled message leaves the author current draft untouched', function (): void {
     [$owner, $team, $general] = dispatchTeamWithGeneral();
     $owner->channels()->updateExistingPivot($general->id, ['draft' => 'a fresh draft']);
     ScheduledMessage::factory()->for($general)->for($owner)->create([
@@ -187,7 +185,7 @@ test('delivering a scheduled message leaves the author current draft untouched',
         ->toBe('a fresh draft');
 });
 
-test('the send time is honored as a UTC instant regardless of when the scan runs', function () {
+test('the send time is honored as a UTC instant regardless of when the scan runs', function (): void {
     [$owner, $team, $general] = dispatchTeamWithGeneral();
     $sendAt = now()->addMinutes(30);
     ScheduledMessage::factory()->for($general)->for($owner)->create(['send_at' => $sendAt]);

--- a/tests/Feature/Channels/EditDeleteMessageTest.php
+++ b/tests/Feature/Channels/EditDeleteMessageTest.php
@@ -22,7 +22,7 @@ function editTeamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('the author can edit their own message and edited_at is set', function () {
+test('the author can edit their own message and edited_at is set', function (): void {
     [$owner, $team, $general] = editTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
 
@@ -40,7 +40,7 @@ test('the author can edit their own message and edited_at is set', function () {
         ->and($message->edited_at)->not->toBeNull();
 });
 
-test('the message body is trimmed and required on edit', function () {
+test('the message body is trimmed and required on edit', function (): void {
     [$owner, $team, $general] = editTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
 
@@ -55,7 +55,7 @@ test('the message body is trimmed and required on edit', function () {
     expect($message->refresh()->body)->toBe('original');
 });
 
-test('a user cannot edit another members message', function () {
+test('a user cannot edit another members message', function (): void {
     [$owner, $team, $general] = editTeamWithGeneral();
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
@@ -73,7 +73,7 @@ test('a user cannot edit another members message', function () {
     expect($message->refresh()->body)->toBe('original');
 });
 
-test('the author can delete their own message', function () {
+test('the author can delete their own message', function (): void {
     [$owner, $team, $general] = editTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
 
@@ -88,7 +88,7 @@ test('the author can delete their own message', function () {
     expect($message->fresh()->deleted_at)->not->toBeNull();
 });
 
-test('a team admin can delete another members message', function () {
+test('a team admin can delete another members message', function (): void {
     [$owner, $team, $general] = editTeamWithGeneral();
     $admin = User::factory()->create();
     $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
@@ -106,7 +106,7 @@ test('a team admin can delete another members message', function () {
     expect($message->fresh()->deleted_at)->not->toBeNull();
 });
 
-test('a plain member cannot delete another members message', function () {
+test('a plain member cannot delete another members message', function (): void {
     [$owner, $team, $general] = editTeamWithGeneral();
     $member = User::factory()->create();
     $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
@@ -124,7 +124,7 @@ test('a plain member cannot delete another members message', function () {
     expect($message->fresh()->deleted_at)->toBeNull();
 });
 
-test('the channel page includes deleted messages as tombstones with a blanked body', function () {
+test('the channel page includes deleted messages as tombstones with a blanked body', function (): void {
     [$owner, $team, $general] = editTeamWithGeneral();
     Message::factory()->for($general)->for($owner)->create(['body' => 'kept']);
     $deleted = Message::factory()->for($general)->for($owner)->create(['body' => 'secret']);
@@ -132,7 +132,7 @@ test('the channel page includes deleted messages as tombstones with a blanked bo
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('messages.data', 2)
             ->where('messages.data.0.isDeleted', true)
             ->where('messages.data.0.body', '')

--- a/tests/Feature/Channels/ForwardMessageTest.php
+++ b/tests/Feature/Channels/ForwardMessageTest.php
@@ -42,7 +42,7 @@ function forwardRoute(Team $team, Channel $source, Message $message): string
     ]);
 }
 
-test('a message can be forwarded into another channel with a note', function () {
+test('a message can be forwarded into another channel with a note', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
     $clientUuid = (string) Str::uuid7();
 
@@ -63,7 +63,7 @@ test('a message can be forwarded into another channel with a note', function () 
     ]);
 });
 
-test('a message can be forwarded with no note, leaving an empty body', function () {
+test('a message can be forwarded with no note, leaving an empty body', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
     $clientUuid = (string) Str::uuid7();
 
@@ -80,7 +80,7 @@ test('a message can be forwarded with no note, leaving an empty body', function 
     ]);
 });
 
-test('the target channel renders a forwarded message with source attribution', function () {
+test('the target channel renders a forwarded message with source attribution', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     // A mention on the source rides along in the forwarded quote's mentions.
@@ -92,7 +92,7 @@ test('the target channel renders a forwarded message with source attribution', f
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $target->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('messages.data.0.body', 'fyi')
             ->where('messages.data.0.forwardedFrom.id', $source->id)
             ->where('messages.data.0.forwardedFrom.body', 'the original')
@@ -103,7 +103,7 @@ test('the target channel renders a forwarded message with source attribution', f
         );
 });
 
-test('a message forwarded from a direct message carries a null source channel name', function () {
+test('a message forwarded from a direct message carries a null source channel name', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     $friend = User::factory()->create();
@@ -117,13 +117,13 @@ test('a message forwarded from a direct message carries a null source channel na
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $target->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('messages.data.0.forwardedFrom.id', $dmMessage->id)
             ->where('messages.data.0.forwardedFrom.channelName', null)
         );
 });
 
-test('a forward whose source was later deleted renders a deleted stub', function () {
+test('a forward whose source was later deleted renders a deleted stub', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     Message::factory()->for($target)->for($owner)->forwardedFrom($source)->create(['body' => 'fyi']);
@@ -131,14 +131,14 @@ test('a forward whose source was later deleted renders a deleted stub', function
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $target->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('messages.data.0.forwardedFrom.id', $source->id)
             ->where('messages.data.0.forwardedFrom.isDeleted', true)
             ->where('messages.data.0.forwardedFrom.body', '')
         );
 });
 
-test('a deleted forwarded message carries no source reference', function () {
+test('a deleted forwarded message carries no source reference', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     $forward = Message::factory()->for($target)->for($owner)->forwardedFrom($source)->create(['body' => 'fyi']);
@@ -146,13 +146,13 @@ test('a deleted forwarded message carries no source reference', function () {
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $target->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('messages.data.0.isDeleted', true)
             ->where('messages.data.0.forwardedFrom', null)
         );
 });
 
-test('forwarding broadcasts the source quote in the target channel payload', function () {
+test('forwarding broadcasts the source quote in the target channel payload', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general, $target, $source] = forwardFixture();
@@ -163,7 +163,7 @@ test('forwarding broadcasts the source quote in the target channel payload', fun
         'target_channel_id' => $target->id,
     ]);
 
-    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($target, $source, $general) {
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($target, $source, $general): bool {
         $payload = $event->message->toArray();
 
         return $event->channel->is($target)
@@ -173,7 +173,7 @@ test('forwarding broadcasts the source quote in the target channel payload', fun
     });
 });
 
-test('a message cannot be forwarded to a channel the user is not a member of', function () {
+test('a message cannot be forwarded to a channel the user is not a member of', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
     $stranger = Channel::factory()->for($team)->create();
 
@@ -186,7 +186,7 @@ test('a message cannot be forwarded to a channel the user is not a member of', f
     expect(Message::where('channel_id', $stranger->id)->count())->toBe(0);
 });
 
-test('a message cannot be forwarded to an archived channel', function () {
+test('a message cannot be forwarded to an archived channel', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
     $archived = Channel::factory()->for($team)->archived()->create();
     $archived->members()->attach($owner->id);
@@ -198,7 +198,7 @@ test('a message cannot be forwarded to an archived channel', function () {
     ])->assertInvalid(['target_channel_id']);
 });
 
-test('a message cannot be forwarded to a channel in another team', function () {
+test('a message cannot be forwarded to a channel in another team', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     $otherOwner = User::factory()->create();
@@ -217,7 +217,7 @@ test('a message cannot be forwarded to a channel in another team', function () {
     ])->assertInvalid(['target_channel_id']);
 });
 
-test('a user cannot forward a message from a private channel they cannot view', function () {
+test('a user cannot forward a message from a private channel they cannot view', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     $private = Channel::factory()->for($team)->create(['visibility' => ChannelVisibility::Private]);
@@ -234,7 +234,7 @@ test('a user cannot forward a message from a private channel they cannot view', 
     ])->assertForbidden();
 });
 
-test('a deleted source message cannot be forwarded', function () {
+test('a deleted source message cannot be forwarded', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
     $source->delete();
 
@@ -245,7 +245,7 @@ test('a deleted source message cannot be forwarded', function () {
     ])->assertNotFound();
 });
 
-test('forwarding is idempotent on a resent client uuid', function () {
+test('forwarding is idempotent on a resent client uuid', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
     $clientUuid = (string) Str::uuid7();
 
@@ -261,7 +261,7 @@ test('forwarding is idempotent on a resent client uuid', function () {
     expect(Message::where('client_uuid', $clientUuid)->count())->toBe(1);
 });
 
-test('a message can be forwarded into an existing direct message', function () {
+test('a message can be forwarded into an existing direct message', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     $friend = User::factory()->create();
@@ -284,7 +284,7 @@ test('a message can be forwarded into an existing direct message', function () {
     ]);
 });
 
-test('forwarding to a person with no existing direct message opens one', function () {
+test('forwarding to a person with no existing direct message opens one', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     $friend = User::factory()->create();
@@ -310,7 +310,7 @@ test('forwarding to a person with no existing direct message opens one', functio
     ]);
 });
 
-test('a message can be forwarded to yourself as a self note', function () {
+test('a message can be forwarded to yourself as a self note', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
     $clientUuid = (string) Str::uuid7();
 
@@ -328,7 +328,7 @@ test('a message can be forwarded to yourself as a self note', function () {
     ]);
 });
 
-test('a message cannot be forwarded to a non-member of the team', function () {
+test('a message cannot be forwarded to a non-member of the team', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
     $outsider = User::factory()->create();
 
@@ -338,7 +338,7 @@ test('a message cannot be forwarded to a non-member of the team', function () {
     ])->assertInvalid(['target_user_id']);
 });
 
-test('a forward must name either a target channel or a target user', function () {
+test('a forward must name either a target channel or a target user', function (): void {
     [$owner, $team, $general, $target, $source] = forwardFixture();
 
     $this->actingAs($owner)->post(forwardRoute($team, $general, $source), [

--- a/tests/Feature/Channels/HideDirectMessageTest.php
+++ b/tests/Feature/Channels/HideDirectMessageTest.php
@@ -32,14 +32,14 @@ function hideSidebarChannels(User $viewer, Team $team): array
 
     test()->actingAs($viewer)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
-        ->assertInertia(function (Assert $page) use (&$channels) {
+        ->assertInertia(function (Assert $page) use (&$channels): void {
             $channels = collect($page->toArray()['props']['channels'])->keyBy('slug')->all();
         });
 
     return $channels;
 }
 
-test('hiding a direct message removes it from the sidebar', function () {
+test('hiding a direct message removes it from the sidebar', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = hideTeamMember($team);
@@ -56,7 +56,7 @@ test('hiding a direct message removes it from the sidebar', function () {
     expect(hideSidebarChannels($owner, $team))->not->toHaveKey($dm->slug);
 });
 
-test('hiding an empty direct message the creator opened removes it from the sidebar', function () {
+test('hiding an empty direct message the creator opened removes it from the sidebar', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = hideTeamMember($team);
@@ -73,7 +73,7 @@ test('hiding an empty direct message the creator opened removes it from the side
     expect(hideSidebarChannels($owner, $team))->not->toHaveKey($dm->slug);
 });
 
-test('a message after hiding re-surfaces the direct message with an unread badge', function () {
+test('a message after hiding re-surfaces the direct message with an unread badge', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = hideTeamMember($team);
@@ -94,7 +94,7 @@ test('a message after hiding re-surfaces the direct message with an unread badge
         ->and($channels[$dm->slug]['unreadCount'])->toBe(1);
 });
 
-test('reopening a hidden direct message un-hides it', function () {
+test('reopening a hidden direct message un-hides it', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = hideTeamMember($team);
@@ -113,7 +113,7 @@ test('reopening a hidden direct message un-hides it', function () {
     expect(hideSidebarChannels($owner, $team))->toHaveKey($dm->slug);
 });
 
-test('hiding is per member and does not hide the direct message for the other participant', function () {
+test('hiding is per member and does not hide the direct message for the other participant', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = hideTeamMember($team);
@@ -128,7 +128,7 @@ test('hiding is per member and does not hide the direct message for the other pa
     expect(hideSidebarChannels($other, $team))->toHaveKey($dm->slug);
 });
 
-test('closing the direct message being viewed redirects home', function () {
+test('closing the direct message being viewed redirects home', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = hideTeamMember($team);
@@ -143,7 +143,7 @@ test('closing the direct message being viewed redirects home', function () {
     expect(hideSidebarChannels($owner, $team))->not->toHaveKey($dm->slug);
 });
 
-test('a standard channel cannot be hidden', function () {
+test('a standard channel cannot be hidden', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
@@ -153,7 +153,7 @@ test('a standard channel cannot be hidden', function () {
         ->assertForbidden();
 });
 
-test('a non-member cannot hide a direct message', function () {
+test('a non-member cannot hide a direct message', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = hideTeamMember($team);

--- a/tests/Feature/Channels/InlineReplyTest.php
+++ b/tests/Feature/Channels/InlineReplyTest.php
@@ -24,7 +24,7 @@ function replyTeamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('a message can reply to another message in the same channel', function () {
+test('a message can reply to another message in the same channel', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'parent']);
     $clientUuid = (string) Str::uuid7();
@@ -44,7 +44,7 @@ test('a message can reply to another message in the same channel', function () {
     ]);
 });
 
-test('a message without a reply target persists a null reply reference', function () {
+test('a message without a reply target persists a null reply reference', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $clientUuid = (string) Str::uuid7();
 
@@ -60,7 +60,7 @@ test('a message without a reply target persists a null reply reference', functio
     ]);
 });
 
-test('the reply target must belong to the same channel', function () {
+test('the reply target must belong to the same channel', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
@@ -77,7 +77,7 @@ test('the reply target must belong to the same channel', function () {
     expect(Message::where('channel_id', $general->id)->count())->toBe(0);
 });
 
-test('a reply cannot target a deleted message', function () {
+test('a reply cannot target a deleted message', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $parent->delete();
@@ -91,7 +91,7 @@ test('a reply cannot target a deleted message', function () {
         ->assertInvalid(['reply_to_id']);
 });
 
-test('a non-uuid reply target is rejected', function () {
+test('a non-uuid reply target is rejected', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
 
     $this->actingAs($owner)
@@ -103,14 +103,14 @@ test('a non-uuid reply target is rejected', function () {
         ->assertInvalid(['reply_to_id']);
 });
 
-test('the channel page renders a reply as a compact quote of its parent', function () {
+test('the channel page renders a reply as a compact quote of its parent', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'the original']);
     Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'the answer']);
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             // Newest-first: the reply is data.0, its parent data.1.
             ->where('messages.data.0.body', 'the answer')
             ->where('messages.data.0.replyTo.id', $parent->id)
@@ -121,7 +121,7 @@ test('the channel page renders a reply as a compact quote of its parent', functi
         );
 });
 
-test('a reply to a deleted parent renders a deleted quote stub with a blanked body', function () {
+test('a reply to a deleted parent renders a deleted quote stub with a blanked body', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'secret original']);
     Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'still here']);
@@ -129,7 +129,7 @@ test('a reply to a deleted parent renders a deleted quote stub with a blanked bo
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('messages.data.0.body', 'still here')
             ->where('messages.data.0.replyTo.id', $parent->id)
             ->where('messages.data.0.replyTo.isDeleted', true)
@@ -137,7 +137,7 @@ test('a reply to a deleted parent renders a deleted quote stub with a blanked bo
         );
 });
 
-test('a deleted reply carries no quote of its own', function () {
+test('a deleted reply carries no quote of its own', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'original']);
     $reply = Message::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'answer']);
@@ -145,13 +145,13 @@ test('a deleted reply carries no quote of its own', function () {
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('messages.data.0.isDeleted', true)
             ->where('messages.data.0.replyTo', null)
         );
 });
 
-test('posting a reply broadcasts the parent quote in the MessageSent payload', function () {
+test('posting a reply broadcasts the parent quote in the MessageSent payload', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = replyTeamWithGeneral();
@@ -167,7 +167,7 @@ test('posting a reply broadcasts the parent quote in the MessageSent payload', f
         'reply_to_id' => $parent->id,
     ]);
 
-    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($parent) {
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($parent): bool {
         $payload = $event->message->toArray();
 
         return $payload['replyTo']['id'] === $parent->id
@@ -175,7 +175,7 @@ test('posting a reply broadcasts the parent quote in the MessageSent payload', f
     });
 });
 
-test('the reply reference survives an idempotent resend', function () {
+test('the reply reference survives an idempotent resend', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $clientUuid = (string) Str::uuid7();

--- a/tests/Feature/Channels/LinkPreviewFetchTest.php
+++ b/tests/Feature/Channels/LinkPreviewFetchTest.php
@@ -19,7 +19,7 @@ function resolverReturning(array $map = [], array $default = ['93.184.216.34']):
          * @param  array<string, array<int, string>>  $map
          * @param  array<int, string>  $default
          */
-        public function __construct(private array $map, private array $default) {}
+        public function __construct(private array $map, private readonly array $default) {}
 
         public function resolve(string $host): array
         {
@@ -33,7 +33,7 @@ function fetcherWith(HostResolver $resolver): FetchLinkPreview
     return new FetchLinkPreview($resolver);
 }
 
-test('unfurls Open Graph metadata from a public URL', function () {
+test('unfurls Open Graph metadata from a public URL', function (): void {
     Http::fake(['https://example.com' => Http::response(
         '<html><head>'
         .'<meta property="og:title" content="Hello">'
@@ -53,7 +53,7 @@ test('unfurls Open Graph metadata from a public URL', function () {
     ]);
 });
 
-test('falls back to the title tag and host when og tags are absent', function () {
+test('falls back to the title tag and host when og tags are absent', function (): void {
     Http::fake(['https://example.com' => Http::response(
         '<html><head><title>Just a title</title></head></html>',
         200,
@@ -68,7 +68,7 @@ test('falls back to the title tag and host when og tags are absent', function ()
     ]);
 });
 
-test('ignores whitespace-only meta content', function () {
+test('ignores whitespace-only meta content', function (): void {
     Http::fake(['https://example.com' => Http::response(
         '<html><head><title>T</title><meta property="og:description" content="   "></head></html>',
         200,
@@ -78,7 +78,7 @@ test('ignores whitespace-only meta content', function () {
     expect(fetcherWith(resolverReturning())->handle('https://example.com')['description'])->toBeNull();
 });
 
-test('returns null when the page has no title at all', function () {
+test('returns null when the page has no title at all', function (): void {
     Http::fake(['https://example.com' => Http::response(
         '<html><body><p>nothing to see</p></body></html>',
         200,
@@ -88,13 +88,13 @@ test('returns null when the page has no title at all', function () {
     expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
 });
 
-test('returns null for an empty body', function () {
+test('returns null for an empty body', function (): void {
     Http::fake(['https://example.com' => Http::response('   ', 200, ['Content-Type' => 'text/html'])]);
 
     expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
 });
 
-test('resolves a protocol-relative og:image against the base scheme', function () {
+test('resolves a protocol-relative og:image against the base scheme', function (): void {
     Http::fake(['https://example.com' => Http::response(
         '<html><head><title>T</title><meta property="og:image" content="//cdn.example.com/i.png"></head></html>',
         200,
@@ -105,7 +105,7 @@ test('resolves a protocol-relative og:image against the base scheme', function (
         ->toBe('https://cdn.example.com/i.png');
 });
 
-test('resolves a root-relative og:image against the base origin', function () {
+test('resolves a root-relative og:image against the base origin', function (): void {
     Http::fake(['https://example.com' => Http::response(
         '<html><head><title>T</title><meta property="og:image" content="/img/a.png"></head></html>',
         200,
@@ -116,7 +116,7 @@ test('resolves a root-relative og:image against the base origin', function () {
         ->toBe('https://example.com/img/a.png');
 });
 
-test('blocks a private, loopback, link-local or reserved host', function (string $ip) {
+test('blocks a private, loopback, link-local or reserved host', function (string $ip): void {
     Http::fake();
 
     expect(fetcherWith(resolverReturning(default: [$ip]))->handle('https://internal.test'))->toBeNull();
@@ -124,7 +124,7 @@ test('blocks a private, loopback, link-local or reserved host', function (string
     Http::assertNothingSent();
 })->with(['10.0.0.5', '127.0.0.1', '169.254.169.254', '192.168.1.1', '172.16.0.1']);
 
-test('rejects a non-http(s) scheme', function () {
+test('rejects a non-http(s) scheme', function (): void {
     Http::fake();
 
     expect(fetcherWith(resolverReturning())->handle('ftp://example.com'))->toBeNull();
@@ -132,7 +132,7 @@ test('rejects a non-http(s) scheme', function () {
     Http::assertNothingSent();
 });
 
-test('rejects a malformed URL', function () {
+test('rejects a malformed URL', function (): void {
     Http::fake();
 
     expect(fetcherWith(resolverReturning())->handle('http://foo:bar'))->toBeNull();
@@ -140,7 +140,7 @@ test('rejects a malformed URL', function () {
     Http::assertNothingSent();
 });
 
-test('rejects a URL with no host', function () {
+test('rejects a URL with no host', function (): void {
     Http::fake();
 
     expect(fetcherWith(resolverReturning())->handle('http:///just/a/path'))->toBeNull();
@@ -148,7 +148,7 @@ test('rejects a URL with no host', function () {
     Http::assertNothingSent();
 });
 
-test('rejects a host that does not resolve', function () {
+test('rejects a host that does not resolve', function (): void {
     Http::fake();
 
     expect(fetcherWith(resolverReturning(default: []))->handle('https://ghost.example'))->toBeNull();
@@ -156,7 +156,7 @@ test('rejects a host that does not resolve', function () {
     Http::assertNothingSent();
 });
 
-test('follows a safe redirect to the final page', function () {
+test('follows a safe redirect to the final page', function (): void {
     Http::fake([
         'https://example.com/start' => Http::response('', 301, ['Location' => 'https://example.com/final']),
         'https://example.com/final' => Http::response(
@@ -169,13 +169,13 @@ test('follows a safe redirect to the final page', function () {
     expect(fetcherWith(resolverReturning())->handle('https://example.com/start')['title'])->toBe('Final');
 });
 
-test('rejects a redirect with no Location', function () {
+test('rejects a redirect with no Location', function (): void {
     Http::fake(['https://example.com/go' => Http::response('', 302, [])]);
 
     expect(fetcherWith(resolverReturning())->handle('https://example.com/go'))->toBeNull();
 });
 
-test('re-validates the host on each redirect hop', function () {
+test('re-validates the host on each redirect hop', function (): void {
     Http::fake(['https://safe.test/go' => Http::response('', 302, ['Location' => 'https://internal.test/secret'])]);
 
     $resolver = resolverReturning([
@@ -186,25 +186,25 @@ test('re-validates the host on each redirect hop', function () {
     expect(fetcherWith($resolver)->handle('https://safe.test/go'))->toBeNull();
 });
 
-test('gives up after too many redirects', function () {
+test('gives up after too many redirects', function (): void {
     Http::fake(['https://example.com/loop' => Http::response('', 302, ['Location' => 'https://example.com/loop'])]);
 
     expect(fetcherWith(resolverReturning())->handle('https://example.com/loop'))->toBeNull();
 });
 
-test('rejects an unsuccessful response', function () {
+test('rejects an unsuccessful response', function (): void {
     Http::fake(['https://example.com' => Http::response('nope', 404)]);
 
     expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
 });
 
-test('rejects a non-html response', function () {
+test('rejects a non-html response', function (): void {
     Http::fake(['https://example.com' => Http::response('{"a":1}', 200, ['Content-Type' => 'application/json'])]);
 
     expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
 });
 
-test('rejects an oversized response', function () {
+test('rejects an oversized response', function (): void {
     Http::fake(['https://example.com' => Http::response(
         '<html><head><title>Huge</title></head></html>',
         200,
@@ -214,7 +214,7 @@ test('rejects an oversized response', function () {
     expect(fetcherWith(resolverReturning())->handle('https://example.com'))->toBeNull();
 });
 
-test('caches the result so the same URL is only fetched once', function () {
+test('caches the result so the same URL is only fetched once', function (): void {
     Http::fake(['https://example.com' => Http::response(
         '<html><head><title>Cached</title></head></html>',
         200,

--- a/tests/Feature/Channels/LinkUnfurlTest.php
+++ b/tests/Feature/Channels/LinkUnfurlTest.php
@@ -55,7 +55,7 @@ function fakeFetcher(?array $result): FetchLinkPreview
         /**
          * @param  array{title: string, description: string|null, image: string|null, siteName: string|null}|null  $result
          */
-        public function __construct(private ?array $result) {}
+        public function __construct(private readonly ?array $result) {}
 
         public function handle(string $url): ?array
         {
@@ -64,7 +64,7 @@ function fakeFetcher(?array $result): FetchLinkPreview
     };
 }
 
-test('posting a message with URLs creates ordered pending previews and queues the unfurl', function () {
+test('posting a message with URLs creates ordered pending previews and queues the unfurl', function (): void {
     Bus::fake();
 
     [$owner, $team, $general] = unfurlTeam();
@@ -83,7 +83,7 @@ test('posting a message with URLs creates ordered pending previews and queues th
     Bus::assertDispatched(UnfurlMessageLinks::class);
 });
 
-test('link extraction caps at three URLs and dedupes', function () {
+test('link extraction caps at three URLs and dedupes', function (): void {
     Bus::fake();
 
     [$owner, $team, $general] = unfurlTeam();
@@ -94,7 +94,7 @@ test('link extraction caps at three URLs and dedupes', function () {
         ->toBe(['https://a.test', 'https://b.test', 'https://c.test']);
 });
 
-test('a trailing punctuation mark is not part of the extracted URL', function () {
+test('a trailing punctuation mark is not part of the extracted URL', function (): void {
     Bus::fake();
 
     [$owner, $team, $general] = unfurlTeam();
@@ -104,7 +104,7 @@ test('a trailing punctuation mark is not part of the extracted URL', function ()
     expect($message->linkPreviews()->value('url'))->toBe('https://example.com/page');
 });
 
-test('a message without URLs creates no previews and queues no job', function () {
+test('a message without URLs creates no previews and queues no job', function (): void {
     Bus::fake();
 
     [$owner, $team, $general] = unfurlTeam();
@@ -116,7 +116,7 @@ test('a message without URLs creates no previews and queues no job', function ()
     Bus::assertNotDispatched(UnfurlMessageLinks::class);
 });
 
-test('the initial MessageSent broadcast carries the pending previews', function () {
+test('the initial MessageSent broadcast carries the pending previews', function (): void {
     Bus::fake();
     Event::fake([MessageSent::class]);
 
@@ -124,7 +124,7 @@ test('the initial MessageSent broadcast carries the pending previews', function 
 
     postBody($owner, $team, $general, 'Read https://example.com now');
 
-    Event::assertDispatched(MessageSent::class, function (MessageSent $event) {
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event): bool {
         $previews = $event->broadcastWith()['linkPreviews'];
 
         return count($previews) === 1
@@ -133,7 +133,7 @@ test('the initial MessageSent broadcast carries the pending previews', function 
     });
 });
 
-test('the unfurl job resolves pending previews and broadcasts the enriched message', function () {
+test('the unfurl job resolves pending previews and broadcasts the enriched message', function (): void {
     Event::fake([MessageUpdated::class]);
 
     [$owner, , $general] = unfurlTeam();
@@ -155,7 +155,7 @@ test('the unfurl job resolves pending previews and broadcasts the enriched messa
         ->and($preview->image_url)->toBe('https://example.com/i.png')
         ->and($preview->site_name)->toBe('Example');
 
-    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event) {
+    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event): bool {
         $previews = $event->broadcastWith()['linkPreviews'];
 
         return count($previews) === 1
@@ -164,7 +164,7 @@ test('the unfurl job resolves pending previews and broadcasts the enriched messa
     });
 });
 
-test('the unfurl job marks a preview failed when it cannot be fetched', function () {
+test('the unfurl job marks a preview failed when it cannot be fetched', function (): void {
     Event::fake([MessageUpdated::class]);
 
     [$owner, , $general] = unfurlTeam();
@@ -176,12 +176,10 @@ test('the unfurl job marks a preview failed when it cannot be fetched', function
     expect($message->linkPreviews()->value('status'))->toBe(LinkPreviewStatus::Failed);
 
     // A failed preview is dropped from the payload, so no broken card renders.
-    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event) {
-        return $event->broadcastWith()['linkPreviews'] === [];
-    });
+    Event::assertDispatched(MessageUpdated::class, fn (MessageUpdated $event): bool => $event->broadcastWith()['linkPreviews'] === []);
 });
 
-test('the unfurl job bails quietly when the message is gone or deleted', function (bool $delete) {
+test('the unfurl job bails quietly when the message is gone or deleted', function (bool $delete): void {
     Event::fake([MessageUpdated::class]);
 
     [$owner, , $general] = unfurlTeam();
@@ -203,7 +201,7 @@ test('the unfurl job bails quietly when the message is gone or deleted', functio
     Event::assertNotDispatched(MessageUpdated::class);
 })->with([true, false]);
 
-test('the unfurl job does nothing when no previews are pending', function () {
+test('the unfurl job does nothing when no previews are pending', function (): void {
     Event::fake([MessageUpdated::class]);
 
     [$owner, , $general] = unfurlTeam();
@@ -215,7 +213,7 @@ test('the unfurl job does nothing when no previews are pending', function () {
     Event::assertNotDispatched(MessageUpdated::class);
 });
 
-test('editing a message drops previews for removed URLs and queues the new ones', function () {
+test('editing a message drops previews for removed URLs and queues the new ones', function (): void {
     Bus::fake();
 
     [$owner, $team, $general] = unfurlTeam();
@@ -232,7 +230,7 @@ test('editing a message drops previews for removed URLs and queues the new ones'
     Bus::assertDispatchedTimes(UnfurlMessageLinks::class, 2);
 });
 
-test('editing preserves an already-resolved preview and queues nothing new', function () {
+test('editing preserves an already-resolved preview and queues nothing new', function (): void {
     Bus::fake();
 
     [$owner, $team, $general] = unfurlTeam();
@@ -254,7 +252,7 @@ test('editing preserves an already-resolved preview and queues nothing new', fun
     Bus::assertDispatchedTimes(UnfurlMessageLinks::class, 1);
 });
 
-test('editing to reorder links reassigns positions without collision', function () {
+test('editing to reorder links reassigns positions without collision', function (): void {
     Bus::fake();
 
     [$owner, $team, $general] = unfurlTeam();
@@ -270,7 +268,7 @@ test('editing to reorder links reassigns positions without collision', function 
         ->toBe(['https://two.test', 'https://one.test']);
 });
 
-test('editing to remove every link clears the previews', function () {
+test('editing to remove every link clears the previews', function (): void {
     Bus::fake();
 
     [$owner, $team, $general] = unfurlTeam();
@@ -285,7 +283,7 @@ test('editing to remove every link clears the previews', function () {
     expect($message->linkPreviews()->count())->toBe(0);
 });
 
-test('a preview belongs to its message', function () {
+test('a preview belongs to its message', function (): void {
     [$owner, , $general] = unfurlTeam();
     $message = Message::factory()->for($general)->for($owner)->create();
     $preview = $message->linkPreviews()->create(['url' => 'https://example.com', 'position' => 0]);
@@ -293,7 +291,7 @@ test('a preview belongs to its message', function () {
     expect($preview->message->is($message))->toBeTrue();
 });
 
-test('a deleted message carries no link previews in its payload', function () {
+test('a deleted message carries no link previews in its payload', function (): void {
     [$owner, , $general] = unfurlTeam();
     $message = Message::factory()->for($general)->for($owner)->create();
     $message->linkPreviews()->create(['url' => 'https://example.com', 'position' => 0, 'status' => LinkPreviewStatus::Ready]);

--- a/tests/Feature/Channels/MentionMembersPropTest.php
+++ b/tests/Feature/Channels/MentionMembersPropTest.php
@@ -7,7 +7,7 @@ use App\Models\Channel;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('a standard channel ships the whole team for mention autocomplete', function () {
+test('a standard channel ships the whole team for mention autocomplete', function (): void {
     $owner = User::factory()->create(['name' => 'Zoe Owner']);
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $member = User::factory()->create(['name' => 'Amy Member']);
@@ -15,14 +15,14 @@ test('a standard channel ships the whole team for mention autocomplete', functio
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('members', 2)
             ->where('members.0.name', 'Amy Member')
             ->where('members.1.name', 'Zoe Owner')
         );
 });
 
-test('a direct message scopes mention autocomplete to its participants', function () {
+test('a direct message scopes mention autocomplete to its participants', function (): void {
     $owner = User::factory()->create(['name' => 'Zoe Owner']);
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = User::factory()->create(['name' => 'Amy Member']);
@@ -35,7 +35,7 @@ test('a direct message scopes mention autocomplete to its participants', functio
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('members', 2)
             // Only the two DM participants, ordered by name; the bystander is excluded.
             ->where('members.0.name', 'Amy Member')

--- a/tests/Feature/Channels/MentionTest.php
+++ b/tests/Feature/Channels/MentionTest.php
@@ -43,7 +43,7 @@ function mentionToken(User $user): string
     return "@[{$user->name}]({$user->id})";
 }
 
-test('posting a message persists a mention row for a real team member', function () {
+test('posting a message persists a mention row for a real team member', function (): void {
     [$owner, $team, $general] = mentionTeamWithGeneral();
     $mentioned = teamMember($team, 'Ada Lovelace');
 
@@ -63,7 +63,7 @@ test('posting a message persists a mention row for a real team member', function
     expect($message->mentionedUsers)->toHaveCount(1);
 });
 
-test('parsing resolves only real team members, ignoring non-members and unknown ids', function () {
+test('parsing resolves only real team members, ignoring non-members and unknown ids', function (): void {
     [$owner, $team, $general] = mentionTeamWithGeneral();
     $member = teamMember($team, 'Real Member');
     $stranger = User::factory()->create(['name' => 'Outsider']);
@@ -84,7 +84,7 @@ test('parsing resolves only real team members, ignoring non-members and unknown 
     $this->assertDatabaseMissing('mentions', ['mentioned_user_id' => $stranger->id]);
 });
 
-test('a user mentioned twice in one message is persisted once', function () {
+test('a user mentioned twice in one message is persisted once', function (): void {
     [$owner, $team, $general] = mentionTeamWithGeneral();
     $mentioned = teamMember($team);
 
@@ -98,7 +98,7 @@ test('a user mentioned twice in one message is persisted once', function () {
     expect(Message::firstOrFail()->mentionedUsers)->toHaveCount(1);
 });
 
-test('editing a message re-syncs mentions: adds new and removes stale', function () {
+test('editing a message re-syncs mentions: adds new and removes stale', function (): void {
     [$owner, $team, $general] = mentionTeamWithGeneral();
     $first = teamMember($team, 'First Person');
     $second = teamMember($team, 'Second Person');
@@ -121,7 +121,7 @@ test('editing a message re-syncs mentions: adds new and removes stale', function
     $this->assertDatabaseHas('mentions', ['mentioned_user_id' => $second->id]);
 });
 
-test('the mention payload rides the MessageData on the channel page', function () {
+test('the mention payload rides the MessageData on the channel page', function (): void {
     [$owner, $team, $general] = mentionTeamWithGeneral();
     $mentioned = teamMember($team, 'Grace Hopper');
 
@@ -132,14 +132,14 @@ test('the mention payload rides the MessageData on the channel page', function (
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('messages.data.0.mentions', 1)
             ->where('messages.data.0.mentions.0.id', $mentioned->id)
             ->where('messages.data.0.mentions.0.name', 'Grace Hopper')
         );
 });
 
-test('the mention payload rides the broadcast MessageData', function () {
+test('the mention payload rides the broadcast MessageData', function (): void {
     [$owner, $team, $general] = mentionTeamWithGeneral();
     $mentioned = teamMember($team, 'Alan Turing');
     $clientUuid = (string) Str::uuid7();
@@ -158,7 +158,7 @@ test('the mention payload rides the broadcast MessageData', function () {
     expect($payload['mentions'])->toBe([['id' => $mentioned->id, 'name' => 'Alan Turing']]);
 });
 
-test('a deleted message blanks its mentions in the tombstone payload', function () {
+test('a deleted message blanks its mentions in the tombstone payload', function (): void {
     [$owner, $team, $general] = mentionTeamWithGeneral();
     $mentioned = teamMember($team);
 
@@ -172,15 +172,15 @@ test('a deleted message blanks its mentions in the tombstone payload', function 
         ->and($payload['mentions'])->toBe([]);
 });
 
-test('the channel page exposes team members for the composer autocomplete', function () {
+test('the channel page exposes team members for the composer autocomplete', function (): void {
     [$owner, $team, $general] = mentionTeamWithGeneral();
     teamMember($team, 'Bea Member');
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('members', 2)
-            ->where('members', fn ($members) => collect($members)->pluck('name')->contains('Bea Member')
+            ->where('members', fn ($members): bool => collect($members)->pluck('name')->contains('Bea Member')
                 && collect($members)->pluck('name')->contains($owner->name))
         );
 });

--- a/tests/Feature/Channels/MessageBroadcastTest.php
+++ b/tests/Feature/Channels/MessageBroadcastTest.php
@@ -42,7 +42,7 @@ function useRealBroadcaster(): void
     require base_path('routes/channels.php');
 }
 
-test('posting a message broadcasts MessageSent on the channel private channel with the MessageData payload', function () {
+test('posting a message broadcasts MessageSent on the channel private channel with the MessageData payload', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = broadcastTeamWithGeneral();
@@ -58,7 +58,7 @@ test('posting a message broadcasts MessageSent on the channel private channel wi
 
     $message = Message::where('client_uuid', $clientUuid)->with('user')->firstOrFail();
 
-    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($general, $message) {
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($general, $message): bool {
         $target = $event->broadcastOn()[0];
 
         expect($target)->toBeInstanceOf(PrivateChannel::class)
@@ -68,7 +68,7 @@ test('posting a message broadcasts MessageSent on the channel private channel wi
     });
 });
 
-test('a resent message with the same client uuid broadcasts only once', function () {
+test('a resent message with the same client uuid broadcasts only once', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = broadcastTeamWithGeneral();
@@ -92,7 +92,7 @@ test('a resent message with the same client uuid broadcasts only once', function
     Event::assertDispatchedTimes(MessageSent::class, 1);
 });
 
-test('editing a message broadcasts MessageUpdated on the channel private channel with the MessageData payload', function () {
+test('editing a message broadcasts MessageUpdated on the channel private channel with the MessageData payload', function (): void {
     Event::fake([MessageUpdated::class]);
 
     [$owner, $team, $general] = broadcastTeamWithGeneral();
@@ -106,7 +106,7 @@ test('editing a message broadcasts MessageUpdated on the channel private channel
 
     $updated = Message::where('id', $message->id)->with('user')->firstOrFail();
 
-    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event) use ($general, $updated) {
+    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event) use ($general, $updated): bool {
         $target = $event->broadcastOn()[0];
 
         expect($target)->toBeInstanceOf(PrivateChannel::class)
@@ -116,7 +116,7 @@ test('editing a message broadcasts MessageUpdated on the channel private channel
     });
 });
 
-test('deleting a message broadcasts MessageDeleted as a tombstone with a blanked body', function () {
+test('deleting a message broadcasts MessageDeleted as a tombstone with a blanked body', function (): void {
     Event::fake([MessageDeleted::class]);
 
     [$owner, $team, $general] = broadcastTeamWithGeneral();
@@ -128,7 +128,7 @@ test('deleting a message broadcasts MessageDeleted as a tombstone with a blanked
         'message' => $message->id,
     ]));
 
-    Event::assertDispatched(MessageDeleted::class, function (MessageDeleted $event) use ($general) {
+    Event::assertDispatched(MessageDeleted::class, function (MessageDeleted $event) use ($general): bool {
         $target = $event->broadcastOn()[0];
         $payload = $event->broadcastWith();
 
@@ -139,7 +139,7 @@ test('deleting a message broadcasts MessageDeleted as a tombstone with a blanked
     });
 });
 
-test('a channel member is authorized to subscribe to the channel', function () {
+test('a channel member is authorized to subscribe to the channel', function (): void {
     useRealBroadcaster();
 
     [$owner, $team, $general] = broadcastTeamWithGeneral();
@@ -152,7 +152,7 @@ test('a channel member is authorized to subscribe to the channel', function () {
         ->assertOk();
 });
 
-test('a non-member cannot subscribe to the channel', function () {
+test('a non-member cannot subscribe to the channel', function (): void {
     useRealBroadcaster();
 
     [$owner, $team] = broadcastTeamWithGeneral();
@@ -171,7 +171,7 @@ test('a non-member cannot subscribe to the channel', function () {
         ->assertForbidden();
 });
 
-test('subscribing to an unknown channel is denied', function () {
+test('subscribing to an unknown channel is denied', function (): void {
     useRealBroadcaster();
 
     $user = User::factory()->create();

--- a/tests/Feature/Channels/MessageLoadSetScopeTest.php
+++ b/tests/Feature/Channels/MessageLoadSetScopeTest.php
@@ -42,7 +42,7 @@ function decoratedMessage(): string
     return $root->id;
 }
 
-it('builds MessageData with no follow-up queries when loaded through the scope', function () {
+it('builds MessageData with no follow-up queries when loaded through the scope', function (): void {
     $id = decoratedMessage();
 
     $message = Message::query()->withMessageDataRelations()->findOrFail($id);

--- a/tests/Feature/Channels/MessagePolicyTest.php
+++ b/tests/Feature/Channels/MessagePolicyTest.php
@@ -24,14 +24,14 @@ function teamWithMessage(User $author): array
     return [$owner, $team, $general, $message];
 }
 
-test('the author can edit their own message', function () {
+test('the author can edit their own message', function (): void {
     $author = User::factory()->create();
     [, , , $message] = teamWithMessage($author);
 
     expect($author->can('update', $message))->toBeTrue();
 });
 
-test('a non-author cannot edit a message even as an admin', function () {
+test('a non-author cannot edit a message even as an admin', function (): void {
     $author = User::factory()->create();
     [$owner, $team, , $message] = teamWithMessage($author);
 
@@ -42,14 +42,14 @@ test('a non-author cannot edit a message even as an admin', function () {
         ->and($owner->can('update', $message))->toBeFalse();
 });
 
-test('the author can delete their own message', function () {
+test('the author can delete their own message', function (): void {
     $author = User::factory()->create();
     [, , , $message] = teamWithMessage($author);
 
     expect($author->can('delete', $message))->toBeTrue();
 });
 
-test('a team admin can delete another members message', function () {
+test('a team admin can delete another members message', function (): void {
     $author = User::factory()->create();
     [$owner, $team, , $message] = teamWithMessage($author);
 
@@ -60,7 +60,7 @@ test('a team admin can delete another members message', function () {
         ->and($owner->can('delete', $message))->toBeTrue();
 });
 
-test('a plain member cannot delete another members message', function () {
+test('a plain member cannot delete another members message', function (): void {
     $author = User::factory()->create();
     [, $team, , $message] = teamWithMessage($author);
 

--- a/tests/Feature/Channels/MessageReactionTest.php
+++ b/tests/Feature/Channels/MessageReactionTest.php
@@ -38,7 +38,7 @@ function toggleReaction($actor, $team, $channel, $message, string $emoji)
     ]), ['emoji' => $emoji]);
 }
 
-test('reacting adds the reaction, and reacting again with the same emoji removes it', function () {
+test('reacting adds the reaction, and reacting again with the same emoji removes it', function (): void {
     [$owner, $team, $general] = reactionTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
 
@@ -51,7 +51,7 @@ test('reacting adds the reaction, and reacting again with the same emoji removes
     expect(MessageReaction::where('message_id', $message->id)->exists())->toBeFalse();
 });
 
-test('a user holds at most one row per distinct emoji and can react with several emoji', function () {
+test('a user holds at most one row per distinct emoji and can react with several emoji', function (): void {
     [$owner, $team, $general] = reactionTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
 
@@ -69,7 +69,7 @@ test('a user holds at most one row per distinct emoji and can react with several
         ->and($remaining->first()->emoji)->toBe('🎉');
 });
 
-test('a non-member of a private channel cannot react', function () {
+test('a non-member of a private channel cannot react', function (): void {
     [$owner, $team] = reactionTeamWithGeneral();
 
     $stranger = User::factory()->create();
@@ -84,7 +84,7 @@ test('a non-member of a private channel cannot react', function () {
     expect(MessageReaction::where('message_id', $message->id)->exists())->toBeFalse();
 });
 
-test('reactions cannot be added in an archived channel', function () {
+test('reactions cannot be added in an archived channel', function (): void {
     [$owner, $team, $general] = reactionTeamWithGeneral();
     $channel = Channel::factory()->for($team)->create(['archived_at' => now()]);
     $channel->channelMembers()->create(['user_id' => $owner->id]);
@@ -95,7 +95,7 @@ test('reactions cannot be added in an archived channel', function () {
     expect(MessageReaction::where('message_id', $message->id)->exists())->toBeFalse();
 });
 
-test('the emoji is required', function () {
+test('the emoji is required', function (): void {
     [$owner, $team, $general] = reactionTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
 
@@ -106,7 +106,7 @@ test('the emoji is required', function () {
     ]), [])->assertInvalid(['emoji']);
 });
 
-test('a message aggregates its reactions per emoji with reactor sets', function () {
+test('a message aggregates its reactions per emoji with reactor sets', function (): void {
     [$owner, $team, $general] = reactionTeamWithGeneral();
     $alice = User::factory()->create(['name' => 'Alice']);
     $team->memberships()->create(['user_id' => $alice->id, 'role' => TeamRole::Member]);
@@ -131,7 +131,7 @@ test('a message aggregates its reactions per emoji with reactor sets', function 
         ->and($party->reactors[0]->name)->toBe('Alice');
 });
 
-test('toggling a reaction broadcasts MessageReactionChanged on the channel with the fresh summary', function () {
+test('toggling a reaction broadcasts MessageReactionChanged on the channel with the fresh summary', function (): void {
     Event::fake([MessageReactionChanged::class]);
 
     [$owner, $team, $general] = reactionTeamWithGeneral();
@@ -140,7 +140,7 @@ test('toggling a reaction broadcasts MessageReactionChanged on the channel with 
     // Add.
     toggleReaction($owner, $team, $general, $message, '👍');
 
-    Event::assertDispatched(MessageReactionChanged::class, function (MessageReactionChanged $event) use ($general, $message) {
+    Event::assertDispatched(MessageReactionChanged::class, function (MessageReactionChanged $event) use ($general, $message): bool {
         $target = $event->broadcastOn()[0];
         $payload = $event->broadcastWith();
 
@@ -157,10 +157,10 @@ test('toggling a reaction broadcasts MessageReactionChanged on the channel with 
     toggleReaction($owner, $team, $general, $message, '👍');
 
     Event::assertDispatchedTimes(MessageReactionChanged::class, 2);
-    Event::assertDispatched(MessageReactionChanged::class, fn (MessageReactionChanged $event) => $event->broadcastWith()['reactions'] === []);
+    Event::assertDispatched(MessageReactionChanged::class, fn (MessageReactionChanged $event): bool => $event->broadcastWith()['reactions'] === []);
 });
 
-test('deleting a message removes its reactions and emits none in the tombstone payload', function () {
+test('deleting a message removes its reactions and emits none in the tombstone payload', function (): void {
     [$owner, $team, $general] = reactionTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
     MessageReaction::factory()->for($message)->for($owner)->emoji('👍')->create();
@@ -177,7 +177,7 @@ test('deleting a message removes its reactions and emits none in the tombstone p
     expect(MessageData::fromMessage($message)->reactions)->toBe([]);
 });
 
-test('deleting a reacting user drops their reactions via the cascade', function () {
+test('deleting a reacting user drops their reactions via the cascade', function (): void {
     [$owner, $team, $general] = reactionTeamWithGeneral();
     $alice = User::factory()->create();
     $team->memberships()->create(['user_id' => $alice->id, 'role' => TeamRole::Member]);

--- a/tests/Feature/Channels/MessageReminderListTest.php
+++ b/tests/Feature/Channels/MessageReminderListTest.php
@@ -22,7 +22,7 @@ function reminderListTeamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('the workspace shares the viewer pending reminders, soonest first', function () {
+test('the workspace shares the viewer pending reminders, soonest first', function (): void {
     [$owner, $team, $general] = reminderListTeamWithGeneral();
 
     $laterMessage = Message::factory()->for($general)->for($owner)->create(['body' => 'the later one']);
@@ -33,7 +33,7 @@ test('the workspace shares the viewer pending reminders, soonest first', functio
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('reminders', 2)
             ->where('reminders.0.id', $sooner->id)
             ->where('reminders.0.messageId', $soonerMessage->id)
@@ -45,7 +45,7 @@ test('the workspace shares the viewer pending reminders, soonest first', functio
         );
 });
 
-test('fired reminders are shared separately from pending ones', function () {
+test('fired reminders are shared separately from pending ones', function (): void {
     [$owner, $team, $general] = reminderListTeamWithGeneral();
 
     $pendingMessage = Message::factory()->for($general)->for($owner)->create(['body' => 'still pending']);
@@ -56,7 +56,7 @@ test('fired reminders are shared separately from pending ones', function () {
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('reminders', 1)
             ->where('reminders.0.body', 'still pending')
             ->has('firedReminders', 1)
@@ -64,7 +64,7 @@ test('fired reminders are shared separately from pending ones', function () {
         );
 });
 
-test('a reminder on a since-deleted message blanks its body but keeps the link', function () {
+test('a reminder on a since-deleted message blanks its body but keeps the link', function (): void {
     [$owner, $team, $general] = reminderListTeamWithGeneral();
 
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'secret plan']);
@@ -73,7 +73,7 @@ test('a reminder on a since-deleted message blanks its body but keeps the link',
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('reminders.0.isDeleted', true)
             ->where('reminders.0.body', '')
             ->where('reminders.0.messageId', $message->id)
@@ -81,7 +81,7 @@ test('a reminder on a since-deleted message blanks its body but keeps the link',
         );
 });
 
-test('reminders are scoped to the current team', function () {
+test('reminders are scoped to the current team', function (): void {
     [$owner, $team, $general] = reminderListTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'in acme']);
     MessageReminder::factory()->for($owner)->for($message)->create();
@@ -93,7 +93,7 @@ test('reminders are scoped to the current team', function () {
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('reminders', 1)
             ->where('reminders.0.body', 'in acme')
         );

--- a/tests/Feature/Channels/MessageSearchTest.php
+++ b/tests/Feature/Channels/MessageSearchTest.php
@@ -51,7 +51,7 @@ function performSuggest(User $user, Team $team, string $query): TestResponse
     return test()->actingAs($user)->getJson(route('search.suggest', ['team' => $team->slug, 'q' => $query]));
 }
 
-test('a member searches messages in their channels', function () {
+test('a member searches messages in their channels', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general, 'Ada Lovelace');
     Message::factory()->for($general)->for($member)->create(['body' => 'the quokka danced at dawn']);
@@ -59,7 +59,7 @@ test('a member searches messages in their channels', function () {
 
     performSearch($member, $team, 'quokka')
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Search')
             ->where('query', 'quokka')
             ->has('results', 1)
@@ -70,7 +70,7 @@ test('a member searches messages in their channels', function () {
         );
 });
 
-test('the search page shares the workspace sidebar props', function () {
+test('the search page shares the workspace sidebar props', function (): void {
     [, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general, 'Ada Lovelace');
 
@@ -78,7 +78,7 @@ test('the search page shares the workspace sidebar props', function () {
     // route lives outside the channels.* name prefix, so it must be covered too.
     performSearch($member, $team, '')
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Search')
             ->has('channels', 1)
             ->where('channels.0.slug', 'general')
@@ -86,7 +86,7 @@ test('the search page shares the workspace sidebar props', function () {
         );
 });
 
-test('search does not leak messages from channels the user is not a member of', function () {
+test('search does not leak messages from channels the user is not a member of', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
     $private = Channel::factory()->for($team)->private()->create(['created_by' => $owner->id]);
@@ -94,10 +94,10 @@ test('search does not leak messages from channels the user is not a member of', 
 
     performSearch($member, $team, 'zephyr')
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+        ->assertInertia(fn (Assert $page): Assert => $page->has('results', 0));
 });
 
-test('search does not leak messages from other teams the member also belongs to', function () {
+test('search does not leak messages from other teams the member also belongs to', function (): void {
     [, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
 
@@ -110,20 +110,20 @@ test('search does not leak messages from other teams the member also belongs to'
     Message::factory()->for($otherGeneral)->for($otherOwner)->create(['body' => 'crossteam zephyr note']);
 
     performSearch($member, $team, 'zephyr')
-        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+        ->assertInertia(fn (Assert $page): Assert => $page->has('results', 0));
 });
 
-test('soft-deleted messages are excluded from search results', function () {
+test('soft-deleted messages are excluded from search results', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'deletable zephyr note']);
     $message->delete();
 
     performSearch($member, $team, 'zephyr')
-        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+        ->assertInertia(fn (Assert $page): Assert => $page->has('results', 0));
 });
 
-test('editing a message changes what search matches', function () {
+test('editing a message changes what search matches', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'original zephyr wording']);
@@ -131,26 +131,26 @@ test('editing a message changes what search matches', function () {
     $message->update(['body' => 'reworded qibble wording']);
 
     performSearch($member, $team, 'zephyr')
-        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+        ->assertInertia(fn (Assert $page): Assert => $page->has('results', 0));
     performSearch($member, $team, 'qibble')
-        ->assertInertia(fn (Assert $page) => $page->has('results', 1));
+        ->assertInertia(fn (Assert $page): Assert => $page->has('results', 1));
 });
 
-test('an empty query renders the page without touching the search engine', function () {
+test('an empty query renders the page without touching the search engine', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr']);
 
     performSearch($member, $team, '')
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Search')
             ->where('query', '')
             ->has('results', 0)
         );
 });
 
-test('a team member who belongs to no channel gets no results', function () {
+test('a team member who belongs to no channel gets no results', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $loner = User::factory()->create();
     $team->memberships()->create(['user_id' => $loner->id, 'role' => TeamRole::Member]);
@@ -160,17 +160,17 @@ test('a team member who belongs to no channel gets no results', function () {
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr']);
 
     performSearch($loner, $team, 'zephyr')
-        ->assertInertia(fn (Assert $page) => $page->has('results', 0));
+        ->assertInertia(fn (Assert $page): Assert => $page->has('results', 0));
 });
 
-test('a non-member of the team cannot search it', function () {
+test('a non-member of the team cannot search it', function (): void {
     [, $team] = searchTeamWithGeneral();
     $outsider = User::factory()->create();
 
     performSearch($outsider, $team, 'zephyr')->assertForbidden();
 });
 
-test('the search query cannot exceed 255 characters', function () {
+test('the search query cannot exceed 255 characters', function (): void {
     [, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
 
@@ -178,7 +178,7 @@ test('the search query cannot exceed 255 characters', function () {
         ->assertSessionHasErrors('q');
 });
 
-test('a jump windows the messages around the target with newer context below', function () {
+test('a jump windows the messages around the target with newer context below', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $messages = collect(range(1, 30))->map(
         fn (int $i) => Message::factory()->for($general)->for($owner)->create(['body' => "message {$i}"])
@@ -189,7 +189,7 @@ test('a jump windows the messages around the target with newer context below', f
         'team' => $team->slug,
         'channel' => $general->slug,
         'message' => $target->id,
-    ]))->assertInertia(fn (Assert $page) => $page
+    ]))->assertInertia(fn (Assert $page): Assert => $page
         ->where('jumpToMessageId', $target->id)
         // 15 messages newer than the target cap the window (message 20), so the
         // window is messages 1..20 newest-first and messages 21..30 are excluded.
@@ -198,7 +198,7 @@ test('a jump windows the messages around the target with newer context below', f
     );
 });
 
-test('a jump to the newest message keeps it at the bottom of the window', function () {
+test('a jump to the newest message keeps it at the bottom of the window', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $messages = collect(range(1, 5))->map(
         fn (int $i) => Message::factory()->for($general)->for($owner)->create(['body' => "message {$i}"])
@@ -209,14 +209,14 @@ test('a jump to the newest message keeps it at the bottom of the window', functi
         'team' => $team->slug,
         'channel' => $general->slug,
         'message' => $target->id,
-    ]))->assertInertia(fn (Assert $page) => $page
+    ]))->assertInertia(fn (Assert $page): Assert => $page
         ->where('jumpToMessageId', $target->id)
         ->has('messages.data', 5)
         ->where('messages.data.0.body', 'message 5')
     );
 });
 
-test('a message param from another channel is ignored', function () {
+test('a message param from another channel is ignored', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     Message::factory()->for($general)->for($owner)->create(['body' => 'only message here']);
     $other = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
@@ -226,13 +226,13 @@ test('a message param from another channel is ignored', function () {
         'team' => $team->slug,
         'channel' => $general->slug,
         'message' => $foreign->id,
-    ]))->assertInertia(fn (Assert $page) => $page
+    ]))->assertInertia(fn (Assert $page): Assert => $page
         ->where('jumpToMessageId', null)
         ->has('messages.data', 1)
     );
 });
 
-test('the suggest endpoint returns matching messages as JSON', function () {
+test('the suggest endpoint returns matching messages as JSON', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general, 'Ada Lovelace');
     Message::factory()->for($general)->for($member)->create(['body' => 'the quokka danced at dawn']);
@@ -247,7 +247,7 @@ test('the suggest endpoint returns matching messages as JSON', function () {
         ->assertJsonPath('results.0.channelSlug', $general->slug);
 });
 
-test('the suggest endpoint caps results at the preview limit', function () {
+test('the suggest endpoint caps results at the preview limit', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
     collect(range(1, 8))->each(
@@ -259,7 +259,7 @@ test('the suggest endpoint caps results at the preview limit', function () {
         ->assertJsonCount(5, 'results');
 });
 
-test('the suggest endpoint is ACL-filtered to the user channels', function () {
+test('the suggest endpoint is ACL-filtered to the user channels', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
     $private = Channel::factory()->for($team)->private()->create(['created_by' => $owner->id]);
@@ -270,7 +270,7 @@ test('the suggest endpoint is ACL-filtered to the user channels', function () {
         ->assertJsonCount(0, 'results');
 });
 
-test('an empty suggest query returns no results without touching the engine', function () {
+test('an empty suggest query returns no results without touching the engine', function (): void {
     [$owner, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
     Message::factory()->for($general)->for($owner)->create(['body' => 'zephyr']);
@@ -280,14 +280,14 @@ test('an empty suggest query returns no results without touching the engine', fu
         ->assertJsonCount(0, 'results');
 });
 
-test('a non-member of the team cannot use suggest', function () {
+test('a non-member of the team cannot use suggest', function (): void {
     [, $team] = searchTeamWithGeneral();
     $outsider = User::factory()->create();
 
     performSuggest($outsider, $team, 'zephyr')->assertForbidden();
 });
 
-test('the suggest query cannot exceed 255 characters', function () {
+test('the suggest query cannot exceed 255 characters', function (): void {
     [, $team, $general] = searchTeamWithGeneral();
     $member = searchMember($team, $general);
 
@@ -295,7 +295,7 @@ test('the suggest query cannot exceed 255 characters', function () {
         ->assertJsonValidationErrorFor('q');
 });
 
-test('soft-deleted messages report that they should not be searchable', function () {
+test('soft-deleted messages report that they should not be searchable', function (): void {
     $message = Message::factory()->create();
 
     expect($message->shouldBeSearchable())->toBeTrue();

--- a/tests/Feature/Channels/MessageTest.php
+++ b/tests/Feature/Channels/MessageTest.php
@@ -23,7 +23,7 @@ function teamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('a channel member can post a message', function () {
+test('a channel member can post a message', function (): void {
     [$owner, $team, $general] = teamWithGeneral();
     $clientUuid = (string) Str::uuid7();
 
@@ -42,7 +42,7 @@ test('a channel member can post a message', function () {
     ]);
 });
 
-test('the message body is trimmed and required', function () {
+test('the message body is trimmed and required', function (): void {
     [$owner, $team, $general] = teamWithGeneral();
 
     $this->actingAs($owner)
@@ -55,7 +55,7 @@ test('the message body is trimmed and required', function () {
     expect(Message::count())->toBe(0);
 });
 
-test('a team member who is not a channel member cannot post', function () {
+test('a team member who is not a channel member cannot post', function (): void {
     [$owner, $team] = teamWithGeneral();
     $stranger = User::factory()->create();
     $team->memberships()->create(['user_id' => $stranger->id, 'role' => TeamRole::Member]);
@@ -73,7 +73,7 @@ test('a team member who is not a channel member cannot post', function () {
     expect(Message::count())->toBe(0);
 });
 
-test('nobody can post to an archived channel', function () {
+test('nobody can post to an archived channel', function (): void {
     [$owner, $team] = teamWithGeneral();
     $archived = Channel::factory()->for($team)->archived()->create();
     $archived->channelMembers()->create(['user_id' => $owner->id]);
@@ -86,7 +86,7 @@ test('nobody can post to an archived channel', function () {
         ->assertForbidden();
 });
 
-test('resending a message with the same client uuid is idempotent', function () {
+test('resending a message with the same client uuid is idempotent', function (): void {
     [$owner, $team, $general] = teamWithGeneral();
     $clientUuid = (string) Str::uuid7();
 
@@ -108,7 +108,7 @@ test('resending a message with the same client uuid is idempotent', function () 
     expect(Message::where('channel_id', $general->id)->count())->toBe(1);
 });
 
-test('the channel page returns the newest 50 messages, newest first', function () {
+test('the channel page returns the newest 50 messages, newest first', function (): void {
     [$owner, $team, $general] = teamWithGeneral();
 
     // 60 messages, created oldest-to-newest so ordered ids match creation order.
@@ -118,7 +118,7 @@ test('the channel page returns the newest 50 messages, newest first', function (
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Show')
             ->has('messages.data', 50)
             ->where('messages.data.0.body', 'message 60')
@@ -128,7 +128,7 @@ test('the channel page returns the newest 50 messages, newest first', function (
         );
 });
 
-test('older messages load through the cursor', function () {
+test('older messages load through the cursor', function (): void {
     [$owner, $team, $general] = teamWithGeneral();
 
     collect(range(1, 60))->each(fn (int $i) => Message::factory()->for($general)->for($owner)->create([
@@ -139,13 +139,13 @@ test('older messages load through the cursor', function () {
 
     $cursor = null;
     $this->actingAs($owner)->get($showUrl)
-        ->assertInertia(function (Assert $page) use (&$cursor) {
+        ->assertInertia(function (Assert $page) use (&$cursor): void {
             $cursor = $page->toArray()['props']['messages']['next_cursor'];
         });
 
     $this->actingAs($owner)
         ->get($showUrl.'?'.http_build_query(['cursor' => $cursor]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('messages.data', 10)
             ->where('messages.data.0.body', 'message 10')
             ->where('messages.data.9.body', 'message 1')
@@ -153,12 +153,12 @@ test('older messages load through the cursor', function () {
         );
 });
 
-test('an empty channel returns no messages', function () {
+test('an empty channel returns no messages', function (): void {
     [$owner, $team, $general] = teamWithGeneral();
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('messages.data', 0)
             ->where('messages.next_cursor', null)
         );

--- a/tests/Feature/Channels/OpenDirectMessageTest.php
+++ b/tests/Feature/Channels/OpenDirectMessageTest.php
@@ -20,7 +20,7 @@ function dmTeamMember(Team $team): User
     return $user;
 }
 
-test('opening a direct message creates a private direct channel with both members', function () {
+test('opening a direct message creates a private direct channel with both members', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = dmTeamMember($team);
@@ -42,7 +42,7 @@ test('opening a direct message creates a private direct channel with both member
         ->toBe(NotificationLevel::All);
 });
 
-test('opening a direct message redirects to the channel via its synthetic slug', function () {
+test('opening a direct message redirects to the channel via its synthetic slug', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = dmTeamMember($team);
@@ -55,7 +55,7 @@ test('opening a direct message redirects to the channel via its synthetic slug',
     $response->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]));
 });
 
-test('opening a direct message twice in either direction yields the same channel', function () {
+test('opening a direct message twice in either direction yields the same channel', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = dmTeamMember($team);
@@ -68,7 +68,7 @@ test('opening a direct message twice in either direction yields the same channel
     expect(Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->count())->toBe(1);
 });
 
-test('a user can open a self direct message rendering a single member', function () {
+test('a user can open a self direct message rendering a single member', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
@@ -83,7 +83,7 @@ test('a user can open a self direct message rendering a single member', function
         ->and($dm->members()->whereKey($owner->id)->exists())->toBeTrue();
 });
 
-test('opening a self direct message twice yields the same channel', function () {
+test('opening a self direct message twice yields the same channel', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
@@ -93,7 +93,7 @@ test('opening a self direct message twice yields the same channel', function () 
     expect(Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->count())->toBe(1);
 });
 
-test('a direct message cannot be opened with a non-team-member', function () {
+test('a direct message cannot be opened with a non-team-member', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $outsider = User::factory()->create();
@@ -105,7 +105,7 @@ test('a direct message cannot be opened with a non-team-member', function () {
     expect(Channel::where('team_id', $team->id)->where('type', ChannelType::Direct)->exists())->toBeFalse();
 });
 
-test('opening a direct message requires an existing user', function () {
+test('opening a direct message requires an existing user', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
 
@@ -114,7 +114,7 @@ test('opening a direct message requires an existing user', function () {
         ->assertSessionHasErrors('user_id');
 });
 
-test('a non-team-member cannot open a direct message in the team', function () {
+test('a non-team-member cannot open a direct message in the team', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $outsider = User::factory()->create();
@@ -124,7 +124,7 @@ test('a non-team-member cannot open a direct message in the team', function () {
         ->assertForbidden();
 });
 
-test('a direct channel resolves through the existing channel show route', function () {
+test('a direct channel resolves through the existing channel show route', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = dmTeamMember($team);
@@ -137,7 +137,7 @@ test('a direct channel resolves through the existing channel show route', functi
         ->assertOk();
 });
 
-test('a team member who is not a participant cannot view a direct message', function () {
+test('a team member who is not a participant cannot view a direct message', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = dmTeamMember($team);

--- a/tests/Feature/Channels/ReadReceiptsTest.php
+++ b/tests/Feature/Channels/ReadReceiptsTest.php
@@ -38,7 +38,7 @@ function receiptsMember(Team $team, Channel $channel, User $user): User
     return $user;
 }
 
-test('MarkChannelRead broadcasts the advance for a user who shares read receipts', function () {
+test('MarkChannelRead broadcasts the advance for a user who shares read receipts', function (): void {
     Event::fake([MessageRead::class]);
 
     [$owner, $team, $general] = receiptsTeamWithGeneral();
@@ -49,15 +49,13 @@ test('MarkChannelRead broadcasts the advance for a user who shares read receipts
 
     app(MarkChannelRead::class)->handle($general, $member);
 
-    Event::assertDispatched(MessageRead::class, function (MessageRead $event) use ($general, $member, $latest) {
-        return $event->channel->is($general)
-            && $event->reader->id === $member->id
-            && $event->reader->name === 'Ada Lovelace'
-            && $event->lastReadMessageId === $latest->id;
-    });
+    Event::assertDispatched(MessageRead::class, fn (MessageRead $event): bool => $event->channel->is($general)
+        && $event->reader->id === $member->id
+        && $event->reader->name === 'Ada Lovelace'
+        && $event->lastReadMessageId === $latest->id);
 });
 
-test('MarkChannelRead does not broadcast for a user who opted out of read receipts', function () {
+test('MarkChannelRead does not broadcast for a user who opted out of read receipts', function (): void {
     Event::fake([MessageRead::class]);
 
     [$owner, $team, $general] = receiptsTeamWithGeneral();
@@ -78,7 +76,7 @@ test('MarkChannelRead does not broadcast for a user who opted out of read receip
     Event::assertNotDispatched(MessageRead::class);
 });
 
-test('MarkChannelRead does not re-broadcast when the pointer is already at the tail', function () {
+test('MarkChannelRead does not re-broadcast when the pointer is already at the tail', function (): void {
     Event::fake([MessageRead::class]);
 
     [$owner, $team, $general] = receiptsTeamWithGeneral();
@@ -94,7 +92,7 @@ test('MarkChannelRead does not re-broadcast when the pointer is already at the t
     Event::assertDispatchedTimes(MessageRead::class, 1);
 });
 
-test('MarkChannelRead does not broadcast on an empty channel', function () {
+test('MarkChannelRead does not broadcast on an empty channel', function (): void {
     Event::fake([MessageRead::class]);
 
     [, $team, $general] = receiptsTeamWithGeneral();
@@ -105,7 +103,7 @@ test('MarkChannelRead does not broadcast on an empty channel', function () {
     Event::assertNotDispatched(MessageRead::class);
 });
 
-test('MarkChannelRead does not broadcast for a non-member', function () {
+test('MarkChannelRead does not broadcast for a non-member', function (): void {
     Event::fake([MessageRead::class]);
 
     [$owner, $team, $general] = receiptsTeamWithGeneral();
@@ -120,7 +118,7 @@ test('MarkChannelRead does not broadcast for a non-member', function () {
     Event::assertNotDispatched(MessageRead::class);
 });
 
-test('the read endpoint broadcasts the advance for a sharing member', function () {
+test('the read endpoint broadcasts the advance for a sharing member', function (): void {
     Event::fake([MessageRead::class]);
 
     [$owner, $team, $general] = receiptsTeamWithGeneral();
@@ -132,10 +130,10 @@ test('the read endpoint broadcasts the advance for a sharing member', function (
         ->post(route('channels.read', ['team' => $team->slug, 'channel' => $general->slug]))
         ->assertRedirect();
 
-    Event::assertDispatched(MessageRead::class, fn (MessageRead $event) => $event->lastReadMessageId === $latest->id);
+    Event::assertDispatched(MessageRead::class, fn (MessageRead $event): bool => $event->lastReadMessageId === $latest->id);
 });
 
-test('MessageRead broadcasts on the channel private channel with the reader and pointer', function () {
+test('MessageRead broadcasts on the channel private channel with the reader and pointer', function (): void {
     [$owner, $team, $general] = receiptsTeamWithGeneral();
 
     $message = Message::factory()->for($general)->for($owner)->create();
@@ -148,7 +146,7 @@ test('MessageRead broadcasts on the channel private channel with the reader and 
     ]);
 });
 
-test('the channel page seeds channelReaders with sharing members, excluding the viewer and opt-outs', function () {
+test('the channel page seeds channelReaders with sharing members, excluding the viewer and opt-outs', function (): void {
     [$owner, $team, $general] = receiptsTeamWithGeneral();
     $viewer = receiptsMember($team, $general, User::factory()->create(['name' => 'Viewer']));
     $sharer = receiptsMember($team, $general, User::factory()->create(['name' => 'Sharer']));
@@ -162,9 +160,9 @@ test('the channel page seeds channelReaders with sharing members, excluding the 
         'channel' => $general->slug,
     ]))->assertOk();
 
-    $response->assertInertia(fn (Assert $page) => $page
+    $response->assertInertia(fn (Assert $page): Assert => $page
         ->has('channelReaders')
-        ->where('channelReaders', fn ($readers) => collect($readers)->pluck('user.id')->contains($sharer->id)
+        ->where('channelReaders', fn ($readers): bool => collect($readers)->pluck('user.id')->contains($sharer->id)
             && ! collect($readers)->pluck('user.id')->contains($viewer->id)
             && ! collect($readers)->pluck('user.id')->contains($optedOut->id))
     );

--- a/tests/Feature/Channels/ScheduleMessageTest.php
+++ b/tests/Feature/Channels/ScheduleMessageTest.php
@@ -26,7 +26,7 @@ function scheduleTeamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('a member can schedule a message for a future time', function () {
+test('a member can schedule a message for a future time', function (): void {
     Event::fake([MessageSent::class]);
 
     [$owner, $team, $general] = scheduleTeamWithGeneral();
@@ -55,7 +55,7 @@ test('a member can schedule a message for a future time', function () {
     Event::assertNotDispatched(MessageSent::class);
 });
 
-test('scheduling clears the author composer draft for the channel', function () {
+test('scheduling clears the author composer draft for the channel', function (): void {
     [$owner, $team, $general] = scheduleTeamWithGeneral();
     $owner->channels()->updateExistingPivot($general->id, ['draft' => 'half-typed']);
 
@@ -69,7 +69,7 @@ test('scheduling clears the author composer draft for the channel', function () 
     expect($owner->channels()->where('channels.id', $general->id)->first()->pivot->draft)->toBeNull();
 });
 
-test('a scheduled message can quote a live message in the same channel', function () {
+test('a scheduled message can quote a live message in the same channel', function (): void {
     [$owner, $team, $general] = scheduleTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create();
 
@@ -84,7 +84,7 @@ test('a scheduled message can quote a live message in the same channel', functio
     expect(ScheduledMessage::firstOrFail()->reply_to_id)->toBe($parent->id);
 });
 
-test('a non-future send time is rejected', function () {
+test('a non-future send time is rejected', function (): void {
     [$owner, $team, $general] = scheduleTeamWithGeneral();
 
     $this->actingAs($owner)
@@ -98,7 +98,7 @@ test('a non-future send time is rejected', function () {
     expect(ScheduledMessage::count())->toBe(0);
 });
 
-test('a missing send time is rejected', function () {
+test('a missing send time is rejected', function (): void {
     [$owner, $team, $general] = scheduleTeamWithGeneral();
 
     $this->actingAs($owner)
@@ -109,7 +109,7 @@ test('a missing send time is rejected', function () {
         ->assertInvalid(['send_at']);
 });
 
-test('an empty body is rejected', function () {
+test('an empty body is rejected', function (): void {
     [$owner, $team, $general] = scheduleTeamWithGeneral();
 
     $this->actingAs($owner)
@@ -121,7 +121,7 @@ test('an empty body is rejected', function () {
         ->assertInvalid(['body']);
 });
 
-test('the reply target must belong to the same channel', function () {
+test('the reply target must belong to the same channel', function (): void {
     [$owner, $team, $general] = scheduleTeamWithGeneral();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
@@ -137,7 +137,7 @@ test('the reply target must belong to the same channel', function () {
         ->assertInvalid(['reply_to_id']);
 });
 
-test('the reply target cannot be a deleted message', function () {
+test('the reply target cannot be a deleted message', function (): void {
     [$owner, $team, $general] = scheduleTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create();
     $parent->delete();
@@ -152,7 +152,7 @@ test('the reply target cannot be a deleted message', function () {
         ->assertInvalid(['reply_to_id']);
 });
 
-test('a non-member cannot schedule a message', function () {
+test('a non-member cannot schedule a message', function (): void {
     [$owner, $team] = scheduleTeamWithGeneral();
     // A private channel the team member is not a member of: the postMessage gate
     // rejects scheduling just as it would an immediate send.
@@ -173,7 +173,7 @@ test('a non-member cannot schedule a message', function () {
     expect(ScheduledMessage::count())->toBe(0);
 });
 
-test('a message cannot be scheduled to an archived channel', function () {
+test('a message cannot be scheduled to an archived channel', function (): void {
     [$owner, $team, $general] = scheduleTeamWithGeneral();
     $channel = Channel::factory()->for($team)->archived()->create();
     $channel->channelMembers()->create(['user_id' => $owner->id]);

--- a/tests/Feature/Channels/ScheduledMessageListTest.php
+++ b/tests/Feature/Channels/ScheduledMessageListTest.php
@@ -23,7 +23,7 @@ function scheduledListTeamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('the channel page lists the viewer own pending scheduled messages, soonest first', function () {
+test('the channel page lists the viewer own pending scheduled messages, soonest first', function (): void {
     [$owner, $team, $general] = scheduledListTeamWithGeneral();
 
     $later = ScheduledMessage::factory()->for($general)->for($owner)->create([
@@ -37,7 +37,7 @@ test('the channel page lists the viewer own pending scheduled messages, soonest 
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('scheduledMessages', 2)
             ->where('scheduledMessages.0.id', $sooner->id)
             ->where('scheduledMessages.0.body', 'the sooner one')
@@ -45,7 +45,7 @@ test('the channel page lists the viewer own pending scheduled messages, soonest 
         );
 });
 
-test('the list excludes other members scheduled messages', function () {
+test('the list excludes other members scheduled messages', function (): void {
     [$owner, $team, $general] = scheduledListTeamWithGeneral();
 
     $other = User::factory()->create();
@@ -56,13 +56,13 @@ test('the list excludes other members scheduled messages', function () {
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('scheduledMessages', 1)
             ->where('scheduledMessages.0.body', 'mine')
         );
 });
 
-test('the list excludes sent and cancelled scheduled messages', function () {
+test('the list excludes sent and cancelled scheduled messages', function (): void {
     [$owner, $team, $general] = scheduledListTeamWithGeneral();
 
     ScheduledMessage::factory()->for($general)->for($owner)->create(['body' => 'still pending']);
@@ -71,13 +71,13 @@ test('the list excludes sent and cancelled scheduled messages', function () {
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('scheduledMessages', 1)
             ->where('scheduledMessages.0.body', 'still pending')
         );
 });
 
-test('the list is scoped to the current channel', function () {
+test('the list is scoped to the current channel', function (): void {
     [$owner, $team, $general] = scheduledListTeamWithGeneral();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
@@ -87,20 +87,20 @@ test('the list is scoped to the current channel', function () {
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('scheduledMessages', 1)
             ->where('scheduledMessages.0.body', 'in general')
         );
 });
 
-test('a scheduled message carries its inline reply quote', function () {
+test('a scheduled message carries its inline reply quote', function (): void {
     [$owner, $team, $general] = scheduledListTeamWithGeneral();
     $parent = Message::factory()->for($general)->for($owner)->create(['body' => 'the original']);
     ScheduledMessage::factory()->for($general)->for($owner)->replyTo($parent)->create(['body' => 'scheduled answer']);
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('scheduledMessages.0.replyTo.id', $parent->id)
             ->where('scheduledMessages.0.replyTo.body', 'the original')
             ->where('scheduledMessages.0.replyTo.authorName', $owner->name)

--- a/tests/Feature/Channels/SetMessageReminderTest.php
+++ b/tests/Feature/Channels/SetMessageReminderTest.php
@@ -23,7 +23,7 @@ function reminderTeamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('a member can set a reminder on a message they can see', function () {
+test('a member can set a reminder on a message they can see', function (): void {
     [$owner, $team, $general] = reminderTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
     $remindAt = now()->addHour();
@@ -44,7 +44,7 @@ test('a member can set a reminder on a message they can see', function () {
         ->and($reminder->remind_at->toIso8601String())->toBe($remindAt->toIso8601String());
 });
 
-test('setting a reminder again re-arms the same row rather than stacking', function () {
+test('setting a reminder again re-arms the same row rather than stacking', function (): void {
     [$owner, $team, $general] = reminderTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
     $existing = MessageReminder::factory()->for($owner)->for($message)->fired()->create([
@@ -67,7 +67,7 @@ test('setting a reminder again re-arms the same row rather than stacking', funct
         ->and($existing->remind_at->toIso8601String())->toBe($newTime->toIso8601String());
 });
 
-test('a non-future remind time is rejected', function () {
+test('a non-future remind time is rejected', function (): void {
     [$owner, $team, $general] = reminderTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
 
@@ -81,7 +81,7 @@ test('a non-future remind time is rejected', function () {
     expect(MessageReminder::count())->toBe(0);
 });
 
-test('a missing remind time is rejected', function () {
+test('a missing remind time is rejected', function (): void {
     [$owner, $team, $general] = reminderTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
 
@@ -92,7 +92,7 @@ test('a missing remind time is rejected', function () {
         ->assertInvalid(['remind_at']);
 });
 
-test('a reminder cannot target a deleted message', function () {
+test('a reminder cannot target a deleted message', function (): void {
     [$owner, $team, $general] = reminderTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create();
     $message->delete();
@@ -109,7 +109,7 @@ test('a reminder cannot target a deleted message', function () {
     expect(MessageReminder::count())->toBe(0);
 });
 
-test('a user cannot set a reminder on a message in a channel they cannot see', function () {
+test('a user cannot set a reminder on a message in a channel they cannot see', function (): void {
     [$owner, $team, $general] = reminderTeamWithGeneral();
     $private = Channel::factory()->for($team)->private()->create();
     $private->channelMembers()->create(['user_id' => $owner->id]);
@@ -128,7 +128,7 @@ test('a user cannot set a reminder on a message in a channel they cannot see', f
     expect(MessageReminder::count())->toBe(0);
 });
 
-test('a reminder cannot target a message in a different team', function () {
+test('a reminder cannot target a message in a different team', function (): void {
     [$owner, $team, $general] = reminderTeamWithGeneral();
 
     $otherOwner = User::factory()->create();

--- a/tests/Feature/Channels/SidebarDirectMessagesTest.php
+++ b/tests/Feature/Channels/SidebarDirectMessagesTest.php
@@ -33,14 +33,14 @@ function sidebarChannelSlugs(User $viewer, Team $team): array
 
     test()->actingAs($viewer)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
-        ->assertInertia(function (Assert $page) use (&$slugs) {
+        ->assertInertia(function (Assert $page) use (&$slugs): void {
             $slugs = collect($page->toArray()['props']['channels'])->pluck('slug')->all();
         });
 
     return $slugs;
 }
 
-test('the creator sees an empty direct message they opened', function () {
+test('the creator sees an empty direct message they opened', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = sidebarTeamMember($team);
@@ -50,7 +50,7 @@ test('the creator sees an empty direct message they opened', function () {
     expect(sidebarChannelSlugs($owner, $team))->toContain($dm->slug);
 });
 
-test('the recipient does not see an empty direct message', function () {
+test('the recipient does not see an empty direct message', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = sidebarTeamMember($team);
@@ -60,7 +60,7 @@ test('the recipient does not see an empty direct message', function () {
     expect(sidebarChannelSlugs($other, $team))->not->toContain($dm->slug);
 });
 
-test('the recipient sees a direct message once it has a message', function () {
+test('the recipient sees a direct message once it has a message', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = sidebarTeamMember($team);
@@ -71,7 +71,7 @@ test('the recipient sees a direct message once it has a message', function () {
     expect(sidebarChannelSlugs($other, $team))->toContain($dm->slug);
 });
 
-test('the recipient sees an empty direct message while actively viewing it', function () {
+test('the recipient sees an empty direct message while actively viewing it', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = sidebarTeamMember($team);
@@ -81,14 +81,14 @@ test('the recipient sees an empty direct message while actively viewing it', fun
     $slugs = [];
     $this->actingAs($other)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $dm->slug]))
-        ->assertInertia(function (Assert $page) use (&$slugs) {
+        ->assertInertia(function (Assert $page) use (&$slugs): void {
             $slugs = collect($page->toArray()['props']['channels'])->pluck('slug')->all();
         });
 
     expect($slugs)->toContain($dm->slug);
 });
 
-test('a direct message carries its viewer-relative identity in the sidebar prop', function () {
+test('a direct message carries its viewer-relative identity in the sidebar prop', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = sidebarTeamMember($team);
@@ -97,10 +97,10 @@ test('a direct message carries its viewer-relative identity in the sidebar prop'
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('channels', 2)
             ->where('channels', fn ($channels) => collect($channels)->contains(
-                fn ($channel) => $channel['slug'] === $dm->slug
+                fn ($channel): bool => $channel['slug'] === $dm->slug
                     && $channel['isDirect'] === true
                     && $channel['name'] === $other->name
                     && $channel['dmUserId'] === $other->id
@@ -108,7 +108,7 @@ test('a direct message carries its viewer-relative identity in the sidebar prop'
         );
 });
 
-test('a direct message orders on its latest message activity', function () {
+test('a direct message orders on its latest message activity', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $other = sidebarTeamMember($team);
@@ -119,7 +119,7 @@ test('a direct message orders on its latest message activity', function () {
     $activity = null;
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
-        ->assertInertia(function (Assert $page) use (&$activity, $dm) {
+        ->assertInertia(function (Assert $page) use (&$activity, $dm): void {
             $activity = collect($page->toArray()['props']['channels'])
                 ->firstWhere('slug', $dm->slug)['lastActivityAt'];
         });

--- a/tests/Feature/Channels/TeamMembersPropTest.php
+++ b/tests/Feature/Channels/TeamMembersPropTest.php
@@ -6,7 +6,7 @@ use App\Models\Channel;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('the workspace ships the team members for the DM entry points', function () {
+test('the workspace ships the team members for the DM entry points', function (): void {
     $owner = User::factory()->create(['name' => 'Zoe Owner']);
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $member = User::factory()->create(['name' => 'Amy Member']);
@@ -14,7 +14,7 @@ test('the workspace ships the team members for the DM entry points', function ()
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('teamMembers', 2)
             // Ordered by name: Amy before Zoe.
             ->where('teamMembers.0.name', 'Amy Member')
@@ -23,13 +23,13 @@ test('the workspace ships the team members for the DM entry points', function ()
         );
 });
 
-test('the team members prop is absent off the channel workspace', function () {
+test('the team members prop is absent off the channel workspace', function (): void {
     $owner = User::factory()->create();
     app(CreateTeam::class)->handle($owner, 'Acme');
 
     $this->actingAs($owner)
         ->get(route('profile.edit'))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('teamMembers', [])
         );
 });

--- a/tests/Feature/Channels/ThreadReadTest.php
+++ b/tests/Feature/Channels/ThreadReadTest.php
@@ -50,7 +50,7 @@ function rootPayload(User $viewer, Team $team, Channel $channel, Message $root):
 
     test()->actingAs($viewer)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]))
-        ->assertInertia(function (Assert $page) use (&$captured, $root) {
+        ->assertInertia(function (Assert $page) use (&$captured, $root): void {
             $page->has('messages.data');
             $data = $page->toArray()['props']['messages']['data'];
             $captured = collect($data)->firstWhere('id', $root->id);
@@ -59,7 +59,7 @@ function rootPayload(User $viewer, Team $team, Channel $channel, Message $root):
     return $captured;
 }
 
-test('a followed thread with an unseen reply raises the root unread flag', function () {
+test('a followed thread with an unseen reply raises the root unread flag', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
 
@@ -72,7 +72,7 @@ test('a followed thread with an unseen reply raises the root unread flag', funct
         ->and($payload['threadUnread'])->toBeTrue();
 });
 
-test('a non-participant who was never mentioned does not follow the thread', function () {
+test('a non-participant who was never mentioned does not follow the thread', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
     $bob = threadReadMember($team, $general);
@@ -86,7 +86,7 @@ test('a non-participant who was never mentioned does not follow the thread', fun
         ->and($payload['threadUnread'])->toBeFalse();
 });
 
-test('replying in a thread makes the user a follower', function () {
+test('replying in a thread makes the user a follower', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
     $bob = threadReadMember($team, $general);
@@ -101,7 +101,7 @@ test('replying in a thread makes the user a follower', function () {
         ->and($payload['threadUnread'])->toBeTrue();
 });
 
-test('a mention inside a reply makes the user a follower', function () {
+test('a mention inside a reply makes the user a follower', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
     $bob = threadReadMember($team, $general);
@@ -116,7 +116,7 @@ test('a mention inside a reply makes the user a follower', function () {
         ->and($payload['threadUnread'])->toBeTrue();
 });
 
-test('a user\'s own replies never raise their unread flag', function () {
+test('a user\'s own replies never raise their unread flag', function (): void {
     [$owner, $team, $general] = threadReadSetup();
 
     $root = Message::factory()->for($general)->for($owner)->create();
@@ -128,7 +128,7 @@ test('a user\'s own replies never raise their unread flag', function () {
         ->and($payload['threadUnread'])->toBeFalse();
 });
 
-test('a soft-deleted reply does not count as unread', function () {
+test('a soft-deleted reply does not count as unread', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
 
@@ -141,7 +141,7 @@ test('a soft-deleted reply does not count as unread', function () {
         ->and($payload['threadUnread'])->toBeFalse();
 });
 
-test('marking the thread read clears the unread flag and persists the pointer', function () {
+test('marking the thread read clears the unread flag and persists the pointer', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
 
@@ -160,7 +160,7 @@ test('marking the thread read clears the unread flag and persists the pointer', 
     expect($payload['threadUnread'])->toBeFalse();
 });
 
-test('a newer reply after the read pointer raises the flag again', function () {
+test('a newer reply after the read pointer raises the flag again', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
 
@@ -177,7 +177,7 @@ test('a newer reply after the read pointer raises the flag again', function () {
     expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeTrue();
 });
 
-test('thread read state is independent of the channel read pointer', function () {
+test('thread read state is independent of the channel read pointer', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
 
@@ -198,7 +198,7 @@ test('thread read state is independent of the channel read pointer', function ()
         ->toBe($channelPointer);
 });
 
-test('a muted channel suppresses the thread unread flag', function () {
+test('a muted channel suppresses the thread unread flag', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
 
@@ -213,7 +213,7 @@ test('a muted channel suppresses the thread unread flag', function () {
         ->and($payload['threadUnread'])->toBeFalse();
 });
 
-test('a notification level below all suppresses the thread unread flag', function () {
+test('a notification level below all suppresses the thread unread flag', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
 
@@ -226,7 +226,7 @@ test('a notification level below all suppresses the thread unread flag', functio
     expect(rootPayload($owner, $team, $general, $root)['threadUnread'])->toBeFalse();
 });
 
-test('the thread panel root carries the viewer follow and unread state', function () {
+test('the thread panel root carries the viewer follow and unread state', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $alice = threadReadMember($team, $general);
 
@@ -235,12 +235,12 @@ test('the thread panel root carries the viewer follow and unread state', functio
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $root->id]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('thread.root.threadFollowed', true)
             ->where('thread.root.threadUnread', true));
 });
 
-test('marking read is a no-op for a thread with no replies', function () {
+test('marking read is a no-op for a thread with no replies', function (): void {
     [$owner, $team, $general] = threadReadSetup();
 
     $root = Message::factory()->for($general)->for($owner)->create();
@@ -250,7 +250,7 @@ test('marking read is a no-op for a thread with no replies', function () {
     expect(ThreadRead::where('thread_root_id', $root->id)->exists())->toBeFalse();
 });
 
-test('marking a thread read requires permission to view the channel', function () {
+test('marking a thread read requires permission to view the channel', function (): void {
     [$owner, $team, $general] = threadReadSetup();
     $root = Message::factory()->for($general)->for($owner)->create();
 

--- a/tests/Feature/Channels/ThreadTest.php
+++ b/tests/Feature/Channels/ThreadTest.php
@@ -54,7 +54,7 @@ function postThreadReply(Team $team, Channel $channel, User $author, Message $ro
     );
 }
 
-test('a reply persists against its thread root and bumps the root aggregates', function () {
+test('a reply persists against its thread root and bumps the root aggregates', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
     $clientUuid = (string) Str::uuid7();
@@ -74,7 +74,7 @@ test('a reply persists against its thread root and bumps the root aggregates', f
         ->and($root->last_reply_at)->not->toBeNull();
 });
 
-test('a second reply increments the root reply count', function () {
+test('a second reply increments the root reply count', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create();
 
@@ -84,7 +84,7 @@ test('a second reply increments the root reply count', function () {
     expect($root->refresh()->reply_count)->toBe(2);
 });
 
-test('a reply cannot target another reply (threads are one level deep)', function () {
+test('a reply cannot target another reply (threads are one level deep)', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create();
     $reply = Message::factory()->for($owner)->inThread($root)->create();
@@ -93,7 +93,7 @@ test('a reply cannot target another reply (threads are one level deep)', functio
         ->assertInvalid(['thread_root_id']);
 });
 
-test('the thread root must belong to the same channel', function () {
+test('the thread root must belong to the same channel', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);
@@ -103,7 +103,7 @@ test('the thread root must belong to the same channel', function () {
         ->assertInvalid(['thread_root_id']);
 });
 
-test('a reply cannot start on a deleted root', function () {
+test('a reply cannot start on a deleted root', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create();
     $root->delete();
@@ -112,7 +112,7 @@ test('a reply cannot start on a deleted root', function () {
         ->assertInvalid(['thread_root_id']);
 });
 
-test('a non-uuid thread root is rejected', function () {
+test('a non-uuid thread root is rejected', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create();
 
@@ -120,7 +120,7 @@ test('a non-uuid thread root is rejected', function () {
         ->assertInvalid(['thread_root_id']);
 });
 
-test('sent_to_channel is ignored without a thread root', function () {
+test('sent_to_channel is ignored without a thread root', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $clientUuid = (string) Str::uuid7();
 
@@ -136,7 +136,7 @@ test('sent_to_channel is ignored without a thread root', function () {
     ]);
 });
 
-test('the main timeline hides thread-only replies but keeps sent-to-channel replies', function () {
+test('the main timeline hides thread-only replies but keeps sent-to-channel replies', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
     Message::factory()->for($owner)->inThread($root)->create(['body' => 'thread only']);
@@ -144,7 +144,7 @@ test('the main timeline hides thread-only replies but keeps sent-to-channel repl
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('messages.data', 2)
             // Newest-first: the sent-to-channel reply, then the root.
             ->where('messages.data.0.body', 'also in channel')
@@ -153,7 +153,7 @@ test('the main timeline hides thread-only replies but keeps sent-to-channel repl
         );
 });
 
-test('the thread prop returns the root and paginated replies newest-first, tombstones included', function () {
+test('the thread prop returns the root and paginated replies newest-first, tombstones included', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create(['body' => 'root']);
     Message::factory()->for($owner)->inThread($root)->create(['body' => 'first reply']);
@@ -164,7 +164,7 @@ test('the thread prop returns the root and paginated replies newest-first, tombs
     // first (the client reverses for display); the root stays on `thread`.
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $root->id]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('thread.root.id', $root->id)
             ->has('threadReplies.data', 2)
             ->where('threadReplies.data.0.isDeleted', true)
@@ -173,17 +173,17 @@ test('the thread prop returns the root and paginated replies newest-first, tombs
         );
 });
 
-test('the thread prop is null and replies are empty for a normal visit', function () {
+test('the thread prop is null and replies are empty for a normal visit', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('thread', null)
             ->has('threadReplies.data', 0));
 });
 
-test('a long thread caps the first page of replies and offers more', function () {
+test('a long thread caps the first page of replies and offers more', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create();
     Message::factory()->count(51)->for($owner)->inThread($root)->create();
@@ -192,13 +192,13 @@ test('a long thread caps the first page of replies and offers more', function ()
     // in on scroll, so the cursor to fetch it is present.
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $root->id]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('threadReplies.data', 50)
-            ->where('threadReplies.next_cursor', fn (?string $cursor) => $cursor !== null)
+            ->where('threadReplies.next_cursor', fn (?string $cursor): bool => $cursor !== null)
             ->etc());
 });
 
-test('the thread prop is null when the param is blank or points elsewhere', function () {
+test('the thread prop is null when the param is blank or points elsewhere', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $reply = Message::factory()->for($owner)->inThread(
         Message::factory()->for($general)->for($owner)->create(),
@@ -207,15 +207,15 @@ test('the thread prop is null when the param is blank or points elsewhere', func
     // Blank param.
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => '']))
-        ->assertInertia(fn (Assert $page) => $page->where('thread', null));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('thread', null));
 
     // A reply id is not a root, so it resolves to no thread.
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug, 'thread' => $reply->id]))
-        ->assertInertia(fn (Assert $page) => $page->where('thread', null));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('thread', null));
 });
 
-test('a root exposes its distinct thread participants and survives deletion', function () {
+test('a root exposes its distinct thread participants and survives deletion', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $ada = threadMember($team, $general, 'Ada');
     $grace = threadMember($team, $general, 'Grace');
@@ -231,7 +231,7 @@ test('a root exposes its distinct thread participants and survives deletion', fu
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('messages.data', 1)
             ->where('messages.data.0.isDeleted', true)
             ->where('messages.data.0.body', '')
@@ -240,7 +240,7 @@ test('a root exposes its distinct thread participants and survives deletion', fu
         );
 });
 
-test('posting a reply broadcasts the reply and the updated root aggregate', function () {
+test('posting a reply broadcasts the reply and the updated root aggregate', function (): void {
     Event::fake([MessageSent::class, MessageUpdated::class]);
 
     [$owner, $team, $general] = threadTeamWithGeneral();
@@ -249,21 +249,21 @@ test('posting a reply broadcasts the reply and the updated root aggregate', func
 
     postThreadReply($team, $general, $owner, $root, ['body' => 'broadcast reply', 'client_uuid' => $clientUuid]);
 
-    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($root, $clientUuid) {
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($root, $clientUuid): bool {
         $payload = $event->message->toArray();
 
         return $payload['clientUuid'] === $clientUuid
             && $payload['threadRootId'] === $root->id;
     });
 
-    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event) use ($root) {
+    Event::assertDispatched(MessageUpdated::class, function (MessageUpdated $event) use ($root): bool {
         $payload = $event->message->toArray();
 
         return $payload['id'] === $root->id && $payload['threadReplyCount'] === 1;
     });
 });
 
-test('a thread-only reply does not raise the channel unread badge', function () {
+test('a thread-only reply does not raise the channel unread badge', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $member = threadMember($team, $general, 'Reader');
     $root = Message::factory()->for($general)->for($owner)->create();
@@ -278,7 +278,7 @@ test('a thread-only reply does not raise the channel unread badge', function () 
     expect($entry['unreadCount'])->toBe(2);
 });
 
-test('a sent-to-channel reply raises the channel unread badge', function () {
+test('a sent-to-channel reply raises the channel unread badge', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $member = threadMember($team, $general, 'Reader');
     $root = Message::factory()->for($general)->for($owner)->create();
@@ -288,7 +288,7 @@ test('a sent-to-channel reply raises the channel unread badge', function () {
     expect(threadSidebarEntry($member, $team, $general)['unreadCount'])->toBe(2);
 });
 
-test('a mention inside a thread still badges the channel', function () {
+test('a mention inside a thread still badges the channel', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $member = threadMember($team, $general, 'Reader');
     $root = Message::factory()->for($general)->for($owner)->create();

--- a/tests/Feature/Channels/ThreadsInboxTest.php
+++ b/tests/Feature/Channels/ThreadsInboxTest.php
@@ -60,7 +60,7 @@ function inboxRows(User $viewer, Team $team): array
 
     test()->actingAs($viewer)
         ->get(route('channels.threads.index', ['team' => $team->slug]))
-        ->assertInertia(function (Assert $page) use (&$captured) {
+        ->assertInertia(function (Assert $page) use (&$captured): void {
             $page->component('channels/Threads');
             $captured = $page->toArray()['props']['threads']['data'];
         });
@@ -68,7 +68,7 @@ function inboxRows(User $viewer, Team $team): array
     return $captured;
 }
 
-test('the inbox lists a thread the user authored the root of', function () {
+test('the inbox lists a thread the user authored the root of', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -83,7 +83,7 @@ test('the inbox lists a thread the user authored the root of', function () {
         ->and($rows[0]['root']['threadUnread'])->toBeTrue();
 });
 
-test('the inbox lists a thread the user replied in', function () {
+test('the inbox lists a thread the user replied in', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -99,7 +99,7 @@ test('the inbox lists a thread the user replied in', function () {
         ->and($rows[0]['root']['threadUnread'])->toBeFalse();
 });
 
-test('the inbox lists a thread the user was mentioned in', function () {
+test('the inbox lists a thread the user was mentioned in', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
     $bob = inboxMember($team, $general);
@@ -115,7 +115,7 @@ test('the inbox lists a thread the user was mentioned in', function () {
         ->and($rows[0]['root']['threadUnread'])->toBeTrue();
 });
 
-test('the inbox excludes threads the user does not follow', function () {
+test('the inbox excludes threads the user does not follow', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
     $bob = inboxMember($team, $general);
@@ -127,7 +127,7 @@ test('the inbox excludes threads the user does not follow', function () {
     expect(inboxRows($bob, $team))->toBeEmpty();
 });
 
-test('the inbox excludes roots with no replies and deleted roots', function () {
+test('the inbox excludes roots with no replies and deleted roots', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -141,7 +141,7 @@ test('the inbox excludes roots with no replies and deleted roots', function () {
     expect(inboxRows($owner, $team))->toBeEmpty();
 });
 
-test('the inbox only lists threads in channels the user belongs to', function () {
+test('the inbox only lists threads in channels the user belongs to', function (): void {
     [$owner, $team, $general] = inboxSetup();
 
     // A private channel the owner is NOT a member of, with a thread they were
@@ -155,7 +155,7 @@ test('the inbox only lists threads in channels the user belongs to', function ()
     expect(inboxRows($owner, $team))->toBeEmpty();
 });
 
-test('the inbox orders threads by most recent reply first', function () {
+test('the inbox orders threads by most recent reply first', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -171,7 +171,7 @@ test('the inbox orders threads by most recent reply first', function () {
         ->and($rows[1]['root']['id'])->toBe($older->id);
 });
 
-test('a muted channel lists its threads without an unread dot', function () {
+test('a muted channel lists its threads without an unread dot', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -186,7 +186,7 @@ test('a muted channel lists its threads without an unread dot', function () {
         ->and($rows[0]['root']['threadUnread'])->toBeFalse();
 });
 
-test('opening and reading a thread clears its unread dot in the inbox', function () {
+test('opening and reading a thread clears its unread dot in the inbox', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -200,13 +200,13 @@ test('opening and reading a thread clears its unread dot in the inbox', function
     expect(inboxRows($owner, $team)[0]['root']['threadUnread'])->toBeFalse();
 });
 
-test('the inbox is empty when the user follows no threads', function () {
+test('the inbox is empty when the user follows no threads', function (): void {
     [$owner, $team, $general] = inboxSetup();
 
     expect(inboxRows($owner, $team))->toBeEmpty();
 });
 
-test('hasUnreadThreads flags an unread followed thread and clears when read', function () {
+test('hasUnreadThreads flags an unread followed thread and clears when read', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -215,16 +215,16 @@ test('hasUnreadThreads flags an unread followed thread and clears when read', fu
 
     $this->actingAs($owner)
         ->get(route('channels.threads.index', ['team' => $team->slug]))
-        ->assertInertia(fn (Assert $page) => $page->where('hasUnreadThreads', true));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('hasUnreadThreads', true));
 
     app(MarkThreadRead::class)->handle($root, $owner);
 
     $this->actingAs($owner)
         ->get(route('channels.threads.index', ['team' => $team->slug]))
-        ->assertInertia(fn (Assert $page) => $page->where('hasUnreadThreads', false));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('hasUnreadThreads', false));
 });
 
-test('hasUnreadThreads ignores threads the user does not follow', function () {
+test('hasUnreadThreads ignores threads the user does not follow', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
     $bob = inboxMember($team, $general);
@@ -234,10 +234,10 @@ test('hasUnreadThreads ignores threads the user does not follow', function () {
 
     $this->actingAs($bob)
         ->get(route('channels.threads.index', ['team' => $team->slug]))
-        ->assertInertia(fn (Assert $page) => $page->where('hasUnreadThreads', false));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('hasUnreadThreads', false));
 });
 
-test('hasUnreadThreads respects channel mute', function () {
+test('hasUnreadThreads respects channel mute', function (): void {
     [$owner, $team, $general] = inboxSetup();
     $alice = inboxMember($team, $general);
 
@@ -249,5 +249,5 @@ test('hasUnreadThreads respects channel mute', function () {
 
     $this->actingAs($owner)
         ->get(route('channels.threads.index', ['team' => $team->slug]))
-        ->assertInertia(fn (Assert $page) => $page->where('hasUnreadThreads', false));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('hasUnreadThreads', false));
 });

--- a/tests/Feature/Channels/UnreadBadgeTest.php
+++ b/tests/Feature/Channels/UnreadBadgeTest.php
@@ -42,11 +42,11 @@ function unreadChannelMember(Team $team, Channel $channel, ?string $name = null)
  */
 function unreadPost(Channel $channel, User $author, ?User $mention = null): Message
 {
-    $body = $mention ? "hey @[{$mention->name}]({$mention->id})" : fake()->sentence();
+    $body = $mention instanceof User ? "hey @[{$mention->name}]({$mention->id})" : fake()->sentence();
 
     $message = Message::factory()->for($channel)->for($author)->create(['body' => $body]);
 
-    if ($mention) {
+    if ($mention instanceof User) {
         $message->mentionedUsers()->attach($mention->id);
     }
 
@@ -80,27 +80,27 @@ function sidebarChannel(User $user, Team $team, Channel $channel): array
     return ['unreadCount' => $entry['unreadCount'], 'mentionCount' => $entry['mentionCount']];
 }
 
-test('unread count reflects only the messages posted after last_read', function () {
+test('unread count reflects only the messages posted after last_read', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general, 'Ada Lovelace');
 
-    $messages = collect(range(1, 5))->map(fn () => unreadPost($general, $owner));
+    $messages = collect(range(1, 5))->map(fn (): Message => unreadPost($general, $owner));
     markReadUpTo($member, $general, $messages[2]);
 
     expect(sidebarChannel($member, $team, $general))
         ->toMatchArray(['unreadCount' => 2, 'mentionCount' => 0]);
 });
 
-test('a null last_read means every message in the channel is unread', function () {
+test('a null last_read means every message in the channel is unread', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general);
 
-    collect(range(1, 3))->each(fn () => unreadPost($general, $owner));
+    collect(range(1, 3))->each(fn (): Message => unreadPost($general, $owner));
 
     expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(3);
 });
 
-test('a member does not see their own messages as unread', function () {
+test('a member does not see their own messages as unread', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general);
 
@@ -111,7 +111,7 @@ test('a member does not see their own messages as unread', function () {
     expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(1);
 });
 
-test('soft-deleted messages are excluded from the unread count', function () {
+test('soft-deleted messages are excluded from the unread count', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general);
 
@@ -122,7 +122,7 @@ test('soft-deleted messages are excluded from the unread count', function () {
     expect(sidebarChannel($member, $team, $general)['unreadCount'])->toBe(1);
 });
 
-test('the mention count only counts unread messages that mention the user', function () {
+test('the mention count only counts unread messages that mention the user', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general, 'Grace Hopper');
 
@@ -137,7 +137,7 @@ test('the mention count only counts unread messages that mention the user', func
         ->toMatchArray(['unreadCount' => 3, 'mentionCount' => 2]);
 });
 
-test('a mention of another member does not inflate the users mention count', function () {
+test('a mention of another member does not inflate the users mention count', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general);
     $other = unreadChannelMember($team, $general, 'Someone Else');
@@ -147,7 +147,7 @@ test('a mention of another member does not inflate the users mention count', fun
     expect(sidebarChannel($member, $team, $general)['mentionCount'])->toBe(0);
 });
 
-test('MarkChannelRead advances last_read to the latest message and clears the badge', function () {
+test('MarkChannelRead advances last_read to the latest message and clears the badge', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general, 'Alan Turing');
 
@@ -166,7 +166,7 @@ test('MarkChannelRead advances last_read to the latest message and clears the ba
         ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
 });
 
-test('MarkChannelRead leaves the pointer untouched when the channel has no messages', function () {
+test('MarkChannelRead leaves the pointer untouched when the channel has no messages', function (): void {
     [, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general);
 
@@ -179,7 +179,7 @@ test('MarkChannelRead leaves the pointer untouched when the channel has no messa
     ]);
 });
 
-test('MarkChannelRead is a no-op for a user who is not a channel member', function () {
+test('MarkChannelRead is a no-op for a user who is not a channel member', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,
@@ -198,7 +198,7 @@ test('MarkChannelRead is a no-op for a user who is not a channel member', functi
     ]);
 });
 
-test('hitting the read endpoint advances the pointer and clears the badges', function () {
+test('hitting the read endpoint advances the pointer and clears the badges', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general, 'Katherine Johnson');
 
@@ -223,7 +223,7 @@ test('hitting the read endpoint advances the pointer and clears the badges', fun
         ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
 });
 
-test('the read endpoint is forbidden on a private channel the user cannot view', function () {
+test('the read endpoint is forbidden on a private channel the user cannot view', function (): void {
     [$owner, $team] = unreadTeamWithGeneral();
     $private = Channel::factory()->for($team)->create([
         'visibility' => ChannelVisibility::Private,

--- a/tests/Feature/Channels/UpdateScheduledMessageTest.php
+++ b/tests/Feature/Channels/UpdateScheduledMessageTest.php
@@ -22,7 +22,7 @@ function updateScheduledTeamWithGeneral(): array
     return [$owner, $team, $general];
 }
 
-test('the author can edit the body and send time of a pending scheduled message', function () {
+test('the author can edit the body and send time of a pending scheduled message', function (): void {
     [$owner, $team, $general] = updateScheduledTeamWithGeneral();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create([
         'body' => 'first draft',
@@ -48,7 +48,7 @@ test('the author can edit the body and send time of a pending scheduled message'
         ->and($scheduled->status)->toBe(ScheduledMessageStatus::Pending);
 });
 
-test('editing rejects a non-future send time', function () {
+test('editing rejects a non-future send time', function (): void {
     [$owner, $team, $general] = updateScheduledTeamWithGeneral();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
 
@@ -64,7 +64,7 @@ test('editing rejects a non-future send time', function () {
         ->assertInvalid(['send_at']);
 });
 
-test('editing rejects an empty body', function () {
+test('editing rejects an empty body', function (): void {
     [$owner, $team, $general] = updateScheduledTeamWithGeneral();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
 
@@ -80,7 +80,7 @@ test('editing rejects an empty body', function () {
         ->assertInvalid(['body']);
 });
 
-test('a non-author cannot edit a scheduled message', function () {
+test('a non-author cannot edit a scheduled message', function (): void {
     [$owner, $team, $general] = updateScheduledTeamWithGeneral();
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
@@ -100,7 +100,7 @@ test('a non-author cannot edit a scheduled message', function () {
     expect($scheduled->fresh()->body)->toBe('not yours');
 });
 
-test('an already-sent scheduled message cannot be edited', function () {
+test('an already-sent scheduled message cannot be edited', function (): void {
     [$owner, $team, $general] = updateScheduledTeamWithGeneral();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->sent()->create();
 
@@ -116,7 +116,7 @@ test('an already-sent scheduled message cannot be edited', function () {
         ->assertForbidden();
 });
 
-test('the author can cancel a pending scheduled message', function () {
+test('the author can cancel a pending scheduled message', function (): void {
     [$owner, $team, $general] = updateScheduledTeamWithGeneral();
     $scheduled = ScheduledMessage::factory()->for($general)->for($owner)->create();
 
@@ -134,7 +134,7 @@ test('the author can cancel a pending scheduled message', function () {
         ->and($scheduled->cancelled_at)->not->toBeNull();
 });
 
-test('a non-author cannot cancel a scheduled message', function () {
+test('a non-author cannot cancel a scheduled message', function (): void {
     [$owner, $team, $general] = updateScheduledTeamWithGeneral();
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
@@ -151,7 +151,7 @@ test('a non-author cannot cancel a scheduled message', function () {
     expect($scheduled->fresh()->status)->toBe(ScheduledMessageStatus::Pending);
 });
 
-test('a scheduled message id from another channel is not resolvable', function () {
+test('a scheduled message id from another channel is not resolvable', function (): void {
     [$owner, $team, $general] = updateScheduledTeamWithGeneral();
     $other = Channel::factory()->for($team)->create();
     $other->channelMembers()->create(['user_id' => $owner->id]);

--- a/tests/Feature/Channels/VisibleChannelsAclTest.php
+++ b/tests/Feature/Channels/VisibleChannelsAclTest.php
@@ -43,7 +43,7 @@ function aclFixture(): array
     ];
 }
 
-it('returns exactly the channels a user has joined in the team', function () {
+it('returns exactly the channels a user has joined in the team', function (): void {
     ['user' => $user, 'team' => $team, 'visible' => $visible, 'hidden' => $hidden] = aclFixture();
 
     $ids = $user->visibleChannelIds($team)->all();
@@ -52,7 +52,7 @@ it('returns exactly the channels a user has joined in the team', function () {
         ->and($ids)->not->toContain(...$hidden);
 });
 
-it('excludes channels in other teams even when the user is a member', function () {
+it('excludes channels in other teams even when the user is a member', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $otherTeam = app(CreateTeam::class)->handle($user, 'Globex');
@@ -62,7 +62,7 @@ it('excludes channels in other teams even when the user is a member', function (
     expect($user->visibleChannelIds($team)->all())->not->toContain($otherChannel->id);
 });
 
-it('excludes channels in the team the user never joined', function () {
+it('excludes channels in the team the user never joined', function (): void {
     $user = User::factory()->create();
     $team = app(CreateTeam::class)->handle($user, 'Acme');
     $stranger = User::factory()->create();

--- a/tests/Feature/Channels/WorkspaceShellTest.php
+++ b/tests/Feature/Channels/WorkspaceShellTest.php
@@ -26,7 +26,7 @@ function reloadPendingInvitations(User $user)
     );
 }
 
-test('the removed dashboard route returns 404', function () {
+test('the removed dashboard route returns 404', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -34,7 +34,7 @@ test('the removed dashboard route returns 404', function () {
         ->assertNotFound();
 });
 
-test('a logged in user lands in the #general workspace', function () {
+test('a logged in user lands in the #general workspace', function (): void {
     $user = User::factory()->create();
 
     $this->post(route('login.store'), [
@@ -54,7 +54,7 @@ test('a logged in user lands in the #general workspace', function () {
         'channel' => Channel::GENERAL_SLUG,
     ]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Show')
             ->where('channel.slug', 'general')
             ->has('channels', 1)
@@ -62,7 +62,7 @@ test('a logged in user lands in the #general workspace', function () {
         );
 });
 
-test('the workspace shell shares the dock header affordances', function () {
+test('the workspace shell shares the dock header affordances', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -71,7 +71,7 @@ test('the workspace shell shares the dock header affordances', function () {
             'channel' => Channel::GENERAL_SLUG,
         ]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('currentTeam.membersCount', 1)
             ->where('canInviteToCurrentTeam', true)
             ->has('invitableRoles')
@@ -79,7 +79,7 @@ test('the workspace shell shares the dock header affordances', function () {
         );
 });
 
-test('login to workspace smoke: land in #general, create a channel, then browse', function () {
+test('login to workspace smoke: land in #general, create a channel, then browse', function (): void {
     $user = User::factory()->create();
     $slug = $user->currentTeam->slug;
 
@@ -99,20 +99,20 @@ test('login to workspace smoke: land in #general, create a channel, then browse'
     // The new channel is now part of the shared sidebar list.
     $this->get(route('channels.show', ['team' => $slug, 'channel' => 'marketing']))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Show')
             ->has('channels', 2)
         );
 
     $this->get(route('channels.browse', ['team' => $slug]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('channels/Browse')
             ->has('joinableChannels')
         );
 });
 
-test('pending invitations are not eagerly shared on a full workspace load', function () {
+test('pending invitations are not eagerly shared on a full workspace load', function (): void {
     $owner = User::factory()->create();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = Team::factory()->create();
@@ -130,10 +130,10 @@ test('pending invitations are not eagerly shared on a full workspace load', func
             'channel' => Channel::GENERAL_SLUG,
         ]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page->missing('pendingInvitations'));
+        ->assertInertia(fn (Assert $page): Assert => $page->missing('pendingInvitations'));
 });
 
-test('pending invitations are shared lazily to the workspace', function () {
+test('pending invitations are shared lazily to the workspace', function (): void {
     $owner = User::factory()->create(['name' => 'Taylor Otwell']);
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = Team::factory()->create(['name' => 'Laravel Team']);
@@ -156,7 +156,7 @@ test('pending invitations are shared lazily to the workspace', function () {
     $response->assertJsonMissingPath('props.pendingInvitations.0.teamName');
 });
 
-test('the lazily shared invitations exclude accepted, expired, and other users invitations', function () {
+test('the lazily shared invitations exclude accepted, expired, and other users invitations', function (): void {
     $owner = User::factory()->create();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = Team::factory()->create();

--- a/tests/Feature/Concerns/GeneratesUniqueTeamSlugsTest.php
+++ b/tests/Feature/Concerns/GeneratesUniqueTeamSlugsTest.php
@@ -2,7 +2,7 @@
 
 use App\Models\Team;
 
-test('non numeric slug suffixes are ignored when choosing the next suffix', function () {
+test('non numeric slug suffixes are ignored when choosing the next suffix', function (): void {
     // Matches the "acme-%" LIKE clause but not the numeric pattern, exercising the
     // null branch in the suffix mapper.
     Team::factory()->create(['name' => 'Acme Beta', 'slug' => 'acme-beta']);
@@ -12,7 +12,7 @@ test('non numeric slug suffixes are ignored when choosing the next suffix', func
     expect($team->slug)->toBe('acme-1');
 });
 
-test('a fresh name keeps its bare slug', function () {
+test('a fresh name keeps its bare slug', function (): void {
     $team = Team::factory()->create(['name' => 'Unique Co', 'slug' => '']);
 
     expect($team->slug)->toBe('unique-co');

--- a/tests/Feature/Concerns/HasTeamsTest.php
+++ b/tests/Feature/Concerns/HasTeamsTest.php
@@ -4,7 +4,7 @@ use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 
-test('personal team returns the users personal team', function () {
+test('personal team returns the users personal team', function (): void {
     $user = User::factory()->create();
 
     $personal = $user->personalTeam();
@@ -14,7 +14,7 @@ test('personal team returns the users personal team', function () {
         ->and($personal->id)->toBe($user->currentTeam->id);
 });
 
-test('owned teams returns only teams the user owns', function () {
+test('owned teams returns only teams the user owns', function (): void {
     $user = User::factory()->create();
     $personal = $user->currentTeam;
 
@@ -31,7 +31,7 @@ test('owned teams returns only teams the user owns', function () {
         ->not->toContain($memberTeam->id);
 });
 
-test('switching to a team the user does not belong to returns false', function () {
+test('switching to a team the user does not belong to returns false', function (): void {
     $user = User::factory()->create();
     $current = $user->currentTeam;
 
@@ -41,7 +41,7 @@ test('switching to a team the user does not belong to returns false', function (
         ->and($user->refresh()->current_team_id)->toBe($current->id);
 });
 
-test('fallback team returns the first team ordered by name', function () {
+test('fallback team returns the first team ordered by name', function (): void {
     // Name the user last so their personal team never wins the ordering.
     $user = User::factory()->create(['name' => 'Zzz']);
 
@@ -55,7 +55,7 @@ test('fallback team returns the first team ordered by name', function () {
     expect($user->fallbackTeam()->id)->toBe($alpha->id);
 });
 
-test('user team dto carries the team member count', function () {
+test('user team dto carries the team member count', function (): void {
     $user = User::factory()->create();
 
     $team = Team::factory()->create();
@@ -65,7 +65,7 @@ test('user team dto carries the team member count', function () {
     expect($user->toUserTeam($team)->membersCount)->toBe(2);
 });
 
-test('fallback team can exclude a given team', function () {
+test('fallback team can exclude a given team', function (): void {
     $user = User::factory()->create(['name' => 'Zzz']);
 
     $alpha = Team::factory()->create(['name' => 'Alpha']);

--- a/tests/Feature/DatabaseSeederTest.php
+++ b/tests/Feature/DatabaseSeederTest.php
@@ -10,18 +10,18 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use Database\Seeders\WorkspaceSeeder;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->seed();
 
     $this->demo = User::where('email', WorkspaceSeeder::DEMO_EMAIL)->firstOrFail();
 });
 
-test('it seeds a verified demo user with the documented credentials', function () {
+test('it seeds a verified demo user with the documented credentials', function (): void {
     expect($this->demo->email_verified_at)->not->toBeNull()
         ->and(Hash::check('password', $this->demo->password))->toBeTrue();
 });
 
-test('the demo user owns, administers and is a plain member across shared teams', function () {
+test('the demo user owns, administers and is a plain member across shared teams', function (): void {
     $acme = Team::where('name', 'Acme Corp')->firstOrFail();
     $globex = Team::where('name', 'Globex')->firstOrFail();
     $initech = Team::where('name', 'Initech')->firstOrFail();
@@ -32,7 +32,7 @@ test('the demo user owns, administers and is a plain member across shared teams'
         ->and($this->demo->isCurrentTeam($acme))->toBeTrue();
 });
 
-test('every team role is represented in the membership table', function () {
+test('every team role is represented in the membership table', function (): void {
     $roles = DB::table('team_members')->distinct()->pluck('role')->all();
 
     foreach (TeamRole::cases() as $role) {
@@ -40,17 +40,17 @@ test('every team role is represented in the membership table', function () {
     }
 });
 
-test('it covers the unverified and two-factor user states', function () {
+test('it covers the unverified and two-factor user states', function (): void {
     expect(User::whereNull('email_verified_at')->exists())->toBeTrue()
         ->and(User::whereNotNull('two_factor_confirmed_at')->exists())->toBeTrue();
 });
 
-test('every active team has a #general channel with member rows', function () {
+test('every active team has a #general channel with member rows', function (): void {
     $teams = Team::all();
 
     expect($teams)->not->toBeEmpty();
 
-    $teams->each(function (Team $team) {
+    $teams->each(function (Team $team): void {
         $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->first();
 
         expect($general)->not->toBeNull()
@@ -58,13 +58,13 @@ test('every active team has a #general channel with member rows', function () {
     });
 });
 
-test('it seeds a soft-deleted team that still keeps its #general', function () {
+test('it seeds a soft-deleted team that still keeps its #general', function (): void {
     $ghost = Team::onlyTrashed()->firstOrFail();
 
     expect($ghost->channels()->where('slug', Channel::GENERAL_SLUG)->exists())->toBeTrue();
 });
 
-test('it seeds public, private, archived and topic-bearing channels', function () {
+test('it seeds public, private, archived and topic-bearing channels', function (): void {
     expect(Channel::where('visibility', ChannelVisibility::Public)->exists())->toBeTrue()
         ->and(Channel::where('visibility', ChannelVisibility::Private)->count())->toBeGreaterThanOrEqual(2)
         ->and(Channel::whereNotNull('archived_at')->exists())->toBeTrue()
@@ -72,7 +72,7 @@ test('it seeds public, private, archived and topic-bearing channels', function (
         ->and(Channel::whereNull('topic')->exists())->toBeTrue();
 });
 
-test('the demo user is inside some private channels but excluded from others', function () {
+test('the demo user is inside some private channels but excluded from others', function (): void {
     $memberOf = $this->demo->channels()->where('visibility', ChannelVisibility::Private)->exists();
 
     $excludedFrom = Channel::where('visibility', ChannelVisibility::Private)
@@ -83,13 +83,13 @@ test('the demo user is inside some private channels but excluded from others', f
         ->and($excludedFrom)->toBeTrue();
 });
 
-test('it backfills a busy channel to make pagination meaningful', function () {
+test('it backfills a busy channel to make pagination meaningful', function (): void {
     $busiest = Channel::withCount('messages')->orderByDesc('messages_count')->firstOrFail();
 
     expect($busiest->messages_count)->toBeGreaterThanOrEqual(50);
 });
 
-test('backfilled messages carry time-ordered ids so a newly sent message sorts newest', function () {
+test('backfilled messages carry time-ordered ids so a newly sent message sorts newest', function (): void {
     $busiest = Channel::withCount('messages')->orderByDesc('messages_count')->firstOrFail();
 
     // The timeline orders by `id DESC` and relies on ids being time-ordered
@@ -108,13 +108,13 @@ test('backfilled messages carry time-ordered ids so a newly sent message sorts n
     expect($busiest->messages()->orderByDesc('id')->value('id'))->toBe($sent->id);
 });
 
-test('it seeds edited, soft-deleted and mention-bearing messages', function () {
+test('it seeds edited, soft-deleted and mention-bearing messages', function (): void {
     expect(Message::whereNotNull('edited_at')->exists())->toBeTrue()
         ->and(Message::onlyTrashed()->exists())->toBeTrue()
         ->and(DB::table('mentions')->count())->toBeGreaterThan(0);
 });
 
-test('it varies the demo user unread state across channels', function () {
+test('it varies the demo user unread state across channels', function (): void {
     $pivots = $this->demo->channels()->get()
         ->map(fn (Channel $channel) => $channel->getRelationValue('pivot')->last_read_message_id);
 
@@ -122,19 +122,19 @@ test('it varies the demo user unread state across channels', function () {
         ->and($pivots->contains(null))->toBeTrue();
 });
 
-test('it seeds direct messages covering the self, empty and excluded shapes', function () {
+test('it seeds direct messages covering the self, empty and excluded shapes', function (): void {
     $directChannels = Channel::where('type', ChannelType::Direct)->get();
 
     // The demo participates in several DMs.
     expect($this->demo->channels()->where('type', ChannelType::Direct)->exists())->toBeTrue();
 
     // A self-DM: a single-member direct channel whose member is the demo.
-    $selfDm = $directChannels->first(fn (Channel $channel) => $channel->members()->count() === 1
+    $selfDm = $directChannels->first(fn (Channel $channel): bool => $channel->members()->count() === 1
         && $channel->members()->whereKey($this->demo->id)->exists());
     expect($selfDm)->not->toBeNull();
 
     // An empty DM the demo opened (no messages) — visible to them as the creator.
-    $emptyOwned = $directChannels->first(fn (Channel $channel) => $channel->created_by === $this->demo->id
+    $emptyOwned = $directChannels->first(fn (Channel $channel): bool => $channel->created_by === $this->demo->id
         && $channel->messages()->doesntExist());
     expect($emptyOwned)->not->toBeNull();
 
@@ -143,12 +143,12 @@ test('it seeds direct messages covering the self, empty and excluded shapes', fu
     expect($excluded)->not->toBeNull();
 });
 
-test('it seeds pending, accepted and expired invitations across roles on an admin team', function () {
+test('it seeds pending, accepted and expired invitations across roles on an admin team', function (): void {
     $acme = Team::where('name', 'Acme Corp')->firstOrFail();
     $invitations = $acme->invitations()->get();
 
-    expect($invitations->contains(fn (TeamInvitation $invitation) => $invitation->isPending()))->toBeTrue()
-        ->and($invitations->contains(fn (TeamInvitation $invitation) => $invitation->isAccepted()))->toBeTrue()
-        ->and($invitations->contains(fn (TeamInvitation $invitation) => $invitation->isExpired()))->toBeTrue()
+    expect($invitations->contains(fn (TeamInvitation $invitation): bool => $invitation->isPending()))->toBeTrue()
+        ->and($invitations->contains(fn (TeamInvitation $invitation): bool => $invitation->isAccepted()))->toBeTrue()
+        ->and($invitations->contains(fn (TeamInvitation $invitation): bool => $invitation->isExpired()))->toBeTrue()
         ->and($invitations->pluck('role')->unique()->count())->toBeGreaterThan(1);
 });

--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -17,10 +17,10 @@ function abortingRoute(int $status): string
     return '/'.$path;
 }
 
-test('the 404 fallback renders the branded Inertia error page', function () {
+test('the 404 fallback renders the branded Inertia error page', function (): void {
     $this->get('/this-route-does-not-exist')
         ->assertStatus(404)
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('Error')
             ->where('status', 404)
             // Shared data resolved via withSharedData() — proves the page
@@ -31,16 +31,16 @@ test('the 404 fallback renders the branded Inertia error page', function () {
         );
 });
 
-test('the common HTTP statuses each render the Inertia error page', function (int $status) {
+test('the common HTTP statuses each render the Inertia error page', function (int $status): void {
     $this->get(abortingRoute($status))
         ->assertStatus($status)
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('Error')
             ->where('status', $status)
         );
 })->with([403, 419, 429]);
 
-test('API requests still receive JSON, not the Inertia error page', function () {
+test('API requests still receive JSON, not the Inertia error page', function (): void {
     $response = $this->getJson('/this-route-does-not-exist')
         ->assertStatus(404)
         ->assertHeader('content-type', 'application/json');
@@ -49,16 +49,16 @@ test('API requests still receive JSON, not the Inertia error page', function () 
     expect($response->getContent())->not->toContain('"component":"Error"');
 });
 
-test('expectsJson requests fall through to the JSON response', function () {
+test('expectsJson requests fall through to the JSON response', function (): void {
     $this->get(abortingRoute(403), ['Accept' => 'application/json'])
         ->assertStatus(403)
         ->assertHeader('content-type', 'application/json');
 });
 
-test('the 500 fallback renders a self-contained branded Blade page', function () {
+test('the 500 fallback renders a self-contained branded Blade page', function (): void {
     config(['app.debug' => false]);
 
-    Route::middleware('web')->get('_test/boom', function () {
+    Route::middleware('web')->get('_test/boom', function (): void {
         throw new RuntimeException('boom');
     });
 
@@ -77,7 +77,7 @@ test('the 500 fallback renders a self-contained branded Blade page', function ()
         ->not->toContain('<script');
 });
 
-test('the 503 fallback renders the branded maintenance Blade page', function () {
+test('the 503 fallback renders the branded maintenance Blade page', function (): void {
     config(['app.debug' => false]);
 
     $response = $this->get(abortingRoute(503));

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-test('returns a successful response', function () {
+test('returns a successful response', function (): void {
     $response = $this->get(route('home'));
 
     $response->assertOk();

--- a/tests/Feature/Http/Responses/AuthResponsesTest.php
+++ b/tests/Feature/Http/Responses/AuthResponsesTest.php
@@ -21,26 +21,26 @@ function requestForUser(?User $user, bool $wantsJson): Request
         $request->headers->set('Accept', 'application/json');
     }
 
-    $request->setUserResolver(fn () => $user);
+    $request->setUserResolver(fn (): ?User => $user);
 
     return $request;
 }
 
 dataset('auth responses', [
-    'login' => [fn () => new LoginResponse, 200],
-    'register' => [fn () => new RegisterResponse, 201],
-    'two factor login' => [fn () => new TwoFactorLoginResponse, 200],
-    'verify email' => [fn () => new VerifyEmailResponse, 204],
+    'login' => [fn (): LoginResponse => new LoginResponse, 200],
+    'register' => [fn (): RegisterResponse => new RegisterResponse, 201],
+    'two factor login' => [fn (): TwoFactorLoginResponse => new TwoFactorLoginResponse, 200],
+    'verify email' => [fn (): VerifyEmailResponse => new VerifyEmailResponse, 204],
 ]);
 
-test('json requests receive a json response', function (Closure $make, int $status) {
+test('json requests receive a json response', function (Closure $make, int $status): void {
     $response = $make()->toResponse(requestForUser(User::factory()->create(), wantsJson: true));
 
     expect($response)->toBeInstanceOf(JsonResponse::class)
         ->and($response->getStatusCode())->toBe($status);
 })->with('auth responses');
 
-test('browser requests redirect to the current team path', function (Closure $make) {
+test('browser requests redirect to the current team path', function (Closure $make): void {
     $user = User::factory()->create();
     $slug = $user->currentTeam->slug;
 
@@ -50,7 +50,7 @@ test('browser requests redirect to the current team path', function (Closure $ma
         ->and($response->getTargetUrl())->toContain("/{$slug}");
 })->with('auth responses');
 
-test('the verify email redirect marks the address as verified', function () {
+test('the verify email redirect marks the address as verified', function (): void {
     $user = User::factory()->create();
 
     $response = (new VerifyEmailResponse)->toResponse(requestForUser($user, wantsJson: false));
@@ -58,7 +58,7 @@ test('the verify email redirect marks the address as verified', function () {
     expect($response->getTargetUrl())->toContain('verified=1');
 });
 
-test('a request without a user is forbidden', function () {
+test('a request without a user is forbidden', function (): void {
     $this->expectException(HttpException::class);
 
     (new LoginResponse)->toResponse(requestForUser(null, wantsJson: false));

--- a/tests/Feature/LocaleCatalogTest.php
+++ b/tests/Feature/LocaleCatalogTest.php
@@ -1,6 +1,6 @@
 <?php
 
-test('the catalog endpoint returns the locale messages as cacheable json', function () {
+test('the catalog endpoint returns the locale messages as cacheable json', function (): void {
     $response = $this->get('/locales/fr.json');
 
     $response->assertOk();
@@ -10,6 +10,6 @@ test('the catalog endpoint returns the locale messages as cacheable json', funct
     expect($response->headers->get('ETag'))->not->toBeNull();
 });
 
-test('the catalog endpoint rejects an unknown locale', function () {
+test('the catalog endpoint rejects an unknown locale', function (): void {
     $this->get('/locales/xx.json')->assertNotFound();
 });

--- a/tests/Feature/LocaleSharingTest.php
+++ b/tests/Feature/LocaleSharingTest.php
@@ -4,30 +4,30 @@ use App\Enums\AppLocale;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('the active locale is shared to inertia from the user preference', function () {
+test('the active locale is shared to inertia from the user preference', function (): void {
     $user = User::factory()->create(['locale' => AppLocale::French->value]);
 
     $this
         ->actingAs($user)
         ->get(route('locale.edit'))
-        ->assertInertia(fn (Assert $page) => $page->where('locale', 'fr'));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('locale', 'fr'));
 
     expect(app()->getLocale())->toBe('fr');
 });
 
-test('guests fall back to the application default locale', function () {
+test('guests fall back to the application default locale', function (): void {
     $this
         ->get(route('home'))
-        ->assertInertia(fn (Assert $page) => $page->where('locale', 'en'));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('locale', 'en'));
 });
 
-test('the active catalog rides the initial response as a once prop', function () {
+test('the active catalog rides the initial response as a once prop', function (): void {
     $user = User::factory()->create(['locale' => AppLocale::French->value]);
 
     $this
         ->actingAs($user)
         ->get(route('locale.edit'))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('locale', 'fr')
             ->has('translations')
         );

--- a/tests/Feature/Mail/BrandedTransactionalEmailTest.php
+++ b/tests/Feature/Mail/BrandedTransactionalEmailTest.php
@@ -5,13 +5,13 @@ use App\Mail\DataExportReady;
 use App\Models\DataExport;
 use App\Models\User;
 
-test('a user exposes their stored locale as the mail preference', function () {
+test('a user exposes their stored locale as the mail preference', function (): void {
     $user = User::factory()->make(['locale' => AppLocale::French->value]);
 
     expect($user->preferredLocale())->toBe('fr');
 });
 
-test('transactional mail carries The Desk branding without external asset requests', function () {
+test('transactional mail carries The Desk branding without external asset requests', function (): void {
     $export = DataExport::factory()->ready()->create();
 
     $html = (new DataExportReady($export))->render();
@@ -24,7 +24,7 @@ test('transactional mail carries The Desk branding without external asset reques
         ->not->toContain('<img');            // no embedded/remote images at all
 });
 
-test('the ready-export mail renders in the recipient stored locale', function () {
+test('the ready-export mail renders in the recipient stored locale', function (): void {
     $user = User::factory()->create(['locale' => AppLocale::French->value]);
     $export = DataExport::factory()->ready()->create(['user_id' => $user->id]);
 
@@ -34,7 +34,7 @@ test('the ready-export mail renders in the recipient stored locale', function ()
     $mail->assertSeeInHtml('Télécharger vos données');
 });
 
-test('the ready-export mail defaults to English for a user without a French locale', function () {
+test('the ready-export mail defaults to English for a user without a French locale', function (): void {
     $user = User::factory()->create(['locale' => AppLocale::English->value]);
     $export = DataExport::factory()->ready()->create(['user_id' => $user->id]);
 

--- a/tests/Feature/Middleware/EnsureTeamMembershipTest.php
+++ b/tests/Feature/Middleware/EnsureTeamMembershipTest.php
@@ -4,6 +4,8 @@ use App\Enums\TeamRole;
 use App\Http\Middleware\EnsureTeamMembership;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Contracts\Routing\ResponseFactory;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 
 /**
@@ -18,12 +20,12 @@ function gatedTeamUrl(string $slug, ?string $role = null): string
         : EnsureTeamMembership::class.':'.$role;
 
     Route::middleware($middleware)
-        ->get('_test/gated/'.$suffix.'/{current_team}', fn () => response('ok'));
+        ->get('_test/gated/'.$suffix.'/{current_team}', fn (): ResponseFactory|Response => response('ok'));
 
     return '/_test/gated/'.$suffix.'/'.$slug;
 }
 
-test('members are allowed through', function () {
+test('members are allowed through', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -31,7 +33,7 @@ test('members are allowed through', function () {
         ->assertOk();
 });
 
-test('non members are forbidden', function () {
+test('non members are forbidden', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -40,7 +42,7 @@ test('non members are forbidden', function () {
         ->assertForbidden();
 });
 
-test('unknown team slug is forbidden', function () {
+test('unknown team slug is forbidden', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -48,7 +50,7 @@ test('unknown team slug is forbidden', function () {
         ->assertForbidden();
 });
 
-test('members with a sufficient role are allowed through', function () {
+test('members with a sufficient role are allowed through', function (): void {
     $user = User::factory()->create();
 
     // Personal-team owners outrank the admin requirement.
@@ -57,7 +59,7 @@ test('members with a sufficient role are allowed through', function () {
         ->assertOk();
 });
 
-test('members with an insufficient role are forbidden', function () {
+test('members with an insufficient role are forbidden', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -70,7 +72,7 @@ test('members with an insufficient role are forbidden', function () {
         ->assertForbidden();
 });
 
-test('an unknown minimum role is forbidden', function () {
+test('an unknown minimum role is forbidden', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -78,7 +80,7 @@ test('an unknown minimum role is forbidden', function () {
         ->assertForbidden();
 });
 
-test('visiting a team route switches the current team', function () {
+test('visiting a team route switches the current team', function (): void {
     $user = User::factory()->create();
     $current = $user->currentTeam;
 

--- a/tests/Feature/Models/TeamInvitationTest.php
+++ b/tests/Feature/Models/TeamInvitationTest.php
@@ -2,7 +2,7 @@
 
 use App\Models\TeamInvitation;
 
-test('a fresh invitation is pending', function () {
+test('a fresh invitation is pending', function (): void {
     $invitation = TeamInvitation::factory()->create();
 
     expect($invitation->isPending())->toBeTrue()
@@ -10,21 +10,21 @@ test('a fresh invitation is pending', function () {
         ->and($invitation->isExpired())->toBeFalse();
 });
 
-test('an accepted invitation is not pending', function () {
+test('an accepted invitation is not pending', function (): void {
     $invitation = TeamInvitation::factory()->accepted()->create();
 
     expect($invitation->isPending())->toBeFalse()
         ->and($invitation->isAccepted())->toBeTrue();
 });
 
-test('an expired invitation is not pending', function () {
+test('an expired invitation is not pending', function (): void {
     $invitation = TeamInvitation::factory()->expired()->create();
 
     expect($invitation->isPending())->toBeFalse()
         ->and($invitation->isExpired())->toBeTrue();
 });
 
-test('a generated code is assigned on creation', function () {
+test('a generated code is assigned on creation', function (): void {
     $invitation = TeamInvitation::factory()->create();
 
     expect($invitation->code)->toHaveLength(64);

--- a/tests/Feature/Notifications/TeamInvitationNotificationTest.php
+++ b/tests/Feature/Notifications/TeamInvitationNotificationTest.php
@@ -6,7 +6,7 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->team = Team::factory()->create(['name' => 'Laravel Team']);
     $this->inviter = User::factory()->create(['name' => 'Taylor Otwell']);
 
@@ -17,13 +17,13 @@ beforeEach(function () {
     ]);
 });
 
-test('it is delivered over mail', function () {
+test('it is delivered over mail', function (): void {
     $notification = new TeamInvitationNotification($this->invitation);
 
     expect($notification->via(new stdClass))->toBe(['mail']);
 });
 
-test('the mail message links to the login page with the invitation code', function () {
+test('the mail message links to the login page with the invitation code', function (): void {
     $notification = new TeamInvitationNotification($this->invitation);
 
     $mail = $notification->toMail(new stdClass);
@@ -37,7 +37,7 @@ test('the mail message links to the login page with the invitation code', functi
     expect($mail->outroLines)->toContain("Didn't expect this invitation? You can safely ignore this email.");
 });
 
-test('the array representation carries the invitation context', function () {
+test('the array representation carries the invitation context', function (): void {
     $notification = new TeamInvitationNotification($this->invitation);
 
     expect($notification->toArray(new stdClass))->toBe([

--- a/tests/Feature/Onboarding/OnboardingTest.php
+++ b/tests/Feature/Onboarding/OnboardingTest.php
@@ -3,12 +3,12 @@
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('a guest cannot complete onboarding', function () {
+test('a guest cannot complete onboarding', function (): void {
     $this->patch(route('onboarding.update'))
         ->assertRedirect(route('login'));
 });
 
-test('completing onboarding records the completion time', function () {
+test('completing onboarding records the completion time', function (): void {
     $user = User::factory()->notOnboarded()->create();
 
     expect($user->onboarding_completed_at)->toBeNull();
@@ -21,7 +21,7 @@ test('completing onboarding records the completion time', function () {
     expect($user->refresh()->onboarding_completed_at)->not->toBeNull();
 });
 
-test('completing onboarding again keeps the original completion time', function () {
+test('completing onboarding again keeps the original completion time', function (): void {
     $completedAt = now()->subWeek();
     $user = User::factory()->create(['onboarding_completed_at' => $completedAt]);
 
@@ -34,13 +34,13 @@ test('completing onboarding again keeps the original completion time', function 
         ->toBe($completedAt->timestamp);
 });
 
-test('the onboarding completion flag is shared with the frontend', function () {
+test('the onboarding completion flag is shared with the frontend', function (): void {
     $user = User::factory()->notOnboarded()->create();
     $team = $user->currentTeam;
 
     $this
         ->actingAs($user)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => 'general']))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('auth.user.onboarding_completed_at', null));
 });

--- a/tests/Feature/Policies/TeamPolicyTest.php
+++ b/tests/Feature/Policies/TeamPolicyTest.php
@@ -5,18 +5,18 @@ use App\Models\Team;
 use App\Models\User;
 use App\Policies\TeamPolicy;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->policy = new TeamPolicy;
 });
 
-test('any user can view the team index and create teams', function () {
+test('any user can view the team index and create teams', function (): void {
     $user = User::factory()->create();
 
     expect($this->policy->viewAny($user))->toBeTrue()
         ->and($this->policy->create($user))->toBeTrue();
 });
 
-test('only members can view a team', function () {
+test('only members can view a team', function (): void {
     $member = User::factory()->create();
     $outsider = User::factory()->create();
 
@@ -27,7 +27,7 @@ test('only members can view a team', function () {
         ->and($this->policy->view($outsider, $team))->toBeFalse();
 });
 
-test('adding members requires the add member permission', function () {
+test('adding members requires the add member permission', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
 

--- a/tests/Feature/Providers/AppServiceProviderTest.php
+++ b/tests/Feature/Providers/AppServiceProviderTest.php
@@ -5,8 +5,8 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
 
-test('production enforces a strong default password policy', function () {
-    $this->app->detectEnvironment(fn () => 'production');
+test('production enforces a strong default password policy', function (): void {
+    $this->app->detectEnvironment(fn (): string => 'production');
 
     try {
         (new AppServiceProvider($this->app))->boot();
@@ -21,6 +21,6 @@ test('production enforces a strong default password policy', function () {
     } finally {
         // Restore non-destructive defaults so the test database can be torn down.
         DB::prohibitDestructiveCommands(false);
-        Password::defaults(fn () => null);
+        Password::defaults(fn (): null => null);
     }
 });

--- a/tests/Feature/Providers/FortifyServiceProviderTest.php
+++ b/tests/Feature/Providers/FortifyServiceProviderTest.php
@@ -5,7 +5,7 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('the login page exposes a pending invitation when the code is valid', function () {
+test('the login page exposes a pending invitation when the code is valid', function (): void {
     $team = Team::factory()->create(['name' => 'Laravel Team']);
     $invitation = TeamInvitation::factory()->create([
         'team_id' => $team->id,
@@ -13,16 +13,16 @@ test('the login page exposes a pending invitation when the code is valid', funct
     ]);
 
     $this->get(route('login', ['invitation' => $invitation->code]))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('auth/Login')
             ->where('teamInvitation.code', $invitation->code)
             ->where('teamInvitation.teamName', 'Laravel Team'),
         );
 });
 
-test('the login page ignores an unknown invitation code', function () {
+test('the login page ignores an unknown invitation code', function (): void {
     $this->get(route('login', ['invitation' => 'unknown-code']))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('auth/Login')
             ->where('teamInvitation', null),
         );

--- a/tests/Feature/Providers/TypeScriptTransformerServiceProviderTest.php
+++ b/tests/Feature/Providers/TypeScriptTransformerServiceProviderTest.php
@@ -4,7 +4,7 @@ use App\Providers\TypeScriptTransformerServiceProvider;
 use Illuminate\Support\Facades\File;
 use Spatie\TypeScriptTransformer\TypeScriptTransformerConfig;
 
-test('it configures the typescript transformer', function () {
+test('it configures the typescript transformer', function (): void {
     // Building the config validates that the output directory exists; it is not
     // committed to the repo, so ensure it is present before resolving.
     File::ensureDirectoryExists(resource_path('js/generated'));

--- a/tests/Feature/ReverbConfigSharingTest.php
+++ b/tests/Feature/ReverbConfigSharingTest.php
@@ -2,7 +2,7 @@
 
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('the browser-facing reverb config is shared to the frontend at runtime', function () {
+test('the browser-facing reverb config is shared to the frontend at runtime', function (): void {
     config([
         'app.name' => 'The Desk',
         'app.url' => 'https://chat.example.test',
@@ -13,7 +13,7 @@ test('the browser-facing reverb config is shared to the frontend at runtime', fu
     ]);
 
     $this->get(route('home'))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('name', 'The Desk')
             ->where('reverb.key', 'demo-key')
             ->where('reverb.host', 'chat.example.test')
@@ -22,7 +22,7 @@ test('the browser-facing reverb config is shared to the frontend at runtime', fu
         );
 });
 
-test('browser-facing host, port, and scheme can each override the server-facing values', function () {
+test('browser-facing host, port, and scheme can each override the server-facing values', function (): void {
     // A TLS-terminating reverse proxy: the container speaks http on 8080, but the
     // browser reaches Reverb as wss on 443 at a dedicated WebSocket host.
     config([
@@ -35,7 +35,7 @@ test('browser-facing host, port, and scheme can each override the server-facing 
     ]);
 
     $this->get(route('home'))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('reverb.host', 'ws.example.test')
             ->where('reverb.port', 443)
             ->where('reverb.scheme', 'https')

--- a/tests/Feature/Rules/TeamNameTest.php
+++ b/tests/Feature/Rules/TeamNameTest.php
@@ -3,7 +3,7 @@
 use App\Rules\TeamName;
 use Illuminate\Support\Facades\Validator;
 
-test('reserved team names fail validation', function () {
+test('reserved team names fail validation', function (): void {
     $validator = Validator::make(
         ['name' => 'Settings'],
         ['name' => new TeamName],
@@ -14,7 +14,7 @@ test('reserved team names fail validation', function () {
         ->toBe('This team name is reserved and cannot be used.');
 });
 
-test('ordinary team names pass validation', function () {
+test('ordinary team names pass validation', function (): void {
     $validator = Validator::make(
         ['name' => 'Marketing Wizards'],
         ['name' => new TeamName],

--- a/tests/Feature/Rules/ValidTeamInvitationTest.php
+++ b/tests/Feature/Rules/ValidTeamInvitationTest.php
@@ -11,28 +11,28 @@ function runInvitationRule(?User $user, mixed $value): ?string
 {
     $message = null;
 
-    (new ValidTeamInvitation($user))->validate('invitation', $value, function (string $failure) use (&$message) {
+    (new ValidTeamInvitation($user))->validate('invitation', $value, function (string $failure) use (&$message): void {
         $message ??= $failure;
     });
 
     return $message;
 }
 
-test('a missing invitation fails', function () {
+test('a missing invitation fails', function (): void {
     $user = User::factory()->create();
 
     expect(runInvitationRule($user, null))
         ->toBe('This invitation was sent to a different email address.');
 });
 
-test('a missing user fails', function () {
+test('a missing user fails', function (): void {
     $invitation = TeamInvitation::factory()->create();
 
     expect(runInvitationRule(null, $invitation))
         ->toBe('This invitation was sent to a different email address.');
 });
 
-test('an accepted invitation fails', function () {
+test('an accepted invitation fails', function (): void {
     $user = User::factory()->create();
     $invitation = TeamInvitation::factory()->accepted()->create(['email' => $user->email]);
 
@@ -40,7 +40,7 @@ test('an accepted invitation fails', function () {
         ->toBe('This invitation has already been accepted.');
 });
 
-test('an expired invitation fails', function () {
+test('an expired invitation fails', function (): void {
     $user = User::factory()->create();
     $invitation = TeamInvitation::factory()->expired()->create(['email' => $user->email]);
 
@@ -48,7 +48,7 @@ test('an expired invitation fails', function () {
         ->toBe('This invitation has expired.');
 });
 
-test('an invitation for another email fails', function () {
+test('an invitation for another email fails', function (): void {
     $user = User::factory()->create();
     $invitation = TeamInvitation::factory()->create(['email' => 'someone-else@example.com']);
 
@@ -56,7 +56,7 @@ test('an invitation for another email fails', function () {
         ->toBe('This invitation was sent to a different email address.');
 });
 
-test('a valid invitation passes', function () {
+test('a valid invitation passes', function (): void {
     $user = User::factory()->create();
     $invitation = TeamInvitation::factory()->create(['email' => $user->email]);
 

--- a/tests/Feature/Settings/AccountDeletionTest.php
+++ b/tests/Feature/Settings/AccountDeletionTest.php
@@ -18,7 +18,7 @@ function attachToSharedTeam(User $user, TeamRole $role, ?Team $team = null): Tea
     return $team;
 }
 
-test('authored messages are reassigned to the deleted-user tombstone', function () {
+test('authored messages are reassigned to the deleted-user tombstone', function (): void {
     $user = User::factory()->create();
     $channel = Channel::factory()->create();
     $message = Message::factory()->create([
@@ -38,7 +38,7 @@ test('authored messages are reassigned to the deleted-user tombstone', function 
     expect($tombstone->name)->toBe('Deleted User');
 });
 
-test('the personal team is soft-deleted with the account', function () {
+test('the personal team is soft-deleted with the account', function (): void {
     $user = User::factory()->create();
     $personalTeam = $user->personalTeam();
 
@@ -50,7 +50,7 @@ test('the personal team is soft-deleted with the account', function () {
     expect(Team::withTrashed()->find($personalTeam->id)->trashed())->toBeTrue();
 });
 
-test('the sole owner of a shared team cannot delete their account', function () {
+test('the sole owner of a shared team cannot delete their account', function (): void {
     $user = User::factory()->create();
     $team = attachToSharedTeam($user, TeamRole::Owner);
 
@@ -64,7 +64,7 @@ test('the sole owner of a shared team cannot delete their account', function () 
     expect(Team::find($team->id))->not->toBeNull();
 });
 
-test('a blocked sole owner can transfer ownership then delete their account', function () {
+test('a blocked sole owner can transfer ownership then delete their account', function (): void {
     $user = User::factory()->create();
     $member = User::factory()->create();
     $team = attachToSharedTeam($user, TeamRole::Owner);
@@ -83,7 +83,7 @@ test('a blocked sole owner can transfer ownership then delete their account', fu
     expect($team->fresh()->owner()->is($member))->toBeTrue();
 });
 
-test('a co-owned shared team does not block deletion', function () {
+test('a co-owned shared team does not block deletion', function (): void {
     $user = User::factory()->create();
     $coOwner = User::factory()->create();
     $team = attachToSharedTeam($user, TeamRole::Owner);
@@ -98,7 +98,7 @@ test('a co-owned shared team does not block deletion', function () {
     expect($team->fresh()->owner()->is($coOwner))->toBeTrue();
 });
 
-test('membership of a shared team is dropped when the account is deleted', function () {
+test('membership of a shared team is dropped when the account is deleted', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = attachToSharedTeam($owner, TeamRole::Owner);
@@ -113,7 +113,7 @@ test('membership of a shared team is dropped when the account is deleted', funct
     expect($team->fresh()->members()->whereKey($member->id)->exists())->toBeFalse();
 });
 
-test('the deleted-user tombstone is a reused singleton', function () {
+test('the deleted-user tombstone is a reused singleton', function (): void {
     $first = User::tombstone();
     $second = User::tombstone();
 

--- a/tests/Feature/Settings/DataExportTest.php
+++ b/tests/Feature/Settings/DataExportTest.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('requesting an export queues the job and records a pending export', function () {
+test('requesting an export queues the job and records a pending export', function (): void {
     Queue::fake();
 
     $user = User::factory()->create();
@@ -33,7 +33,7 @@ test('requesting an export queues the job and records a pending export', functio
     expect($export->status)->toBe(DataExportStatus::Pending);
 });
 
-test('the export job builds a downloadable archive and emails the user', function () {
+test('the export job builds a downloadable archive and emails the user', function (): void {
     Storage::fake('local');
     Mail::fake();
 
@@ -70,7 +70,7 @@ test('the export job builds a downloadable archive and emails the user', functio
     Mail::assertSent(DataExportReady::class, fn (DataExportReady $mail): bool => $mail->hasTo($user->email));
 });
 
-test('the job bails quietly when the export no longer exists', function () {
+test('the job bails quietly when the export no longer exists', function (): void {
     Mail::fake();
 
     $export = DataExport::factory()->create();
@@ -82,7 +82,7 @@ test('the job bails quietly when the export no longer exists', function () {
     Mail::assertNothingSent();
 });
 
-test('the failed hook marks the export failed', function () {
+test('the failed hook marks the export failed', function (): void {
     $export = DataExport::factory()->create();
 
     (new ExportUserData($export->id))->failed(new RuntimeException('boom'));
@@ -90,7 +90,7 @@ test('the failed hook marks the export failed', function () {
     expect($export->refresh()->status)->toBe(DataExportStatus::Failed);
 });
 
-test('the owner can download a ready export', function () {
+test('the owner can download a ready export', function (): void {
     Storage::fake('local');
 
     $user = User::factory()->create();
@@ -103,7 +103,7 @@ test('the owner can download a ready export', function () {
         ->assertDownload('data-export.zip');
 });
 
-test('another user cannot download an export', function () {
+test('another user cannot download an export', function (): void {
     Storage::fake('local');
 
     $export = DataExport::factory()->ready()->create();
@@ -114,7 +114,7 @@ test('another user cannot download an export', function () {
         ->assertForbidden();
 });
 
-test('a pending export cannot be downloaded', function () {
+test('a pending export cannot be downloaded', function (): void {
     $user = User::factory()->create();
     $export = DataExport::factory()->for($user)->create();
 
@@ -123,7 +123,7 @@ test('a pending export cannot be downloaded', function () {
         ->assertNotFound();
 });
 
-test('an expired export cannot be downloaded', function () {
+test('an expired export cannot be downloaded', function (): void {
     Storage::fake('local');
 
     $user = User::factory()->create();
@@ -135,29 +135,29 @@ test('an expired export cannot be downloaded', function () {
         ->assertNotFound();
 });
 
-test('the data & privacy page carries the latest export', function () {
+test('the data & privacy page carries the latest export', function (): void {
     $user = User::factory()->create();
     DataExport::factory()->for($user)->ready()->create();
 
     $this->actingAs($user)
         ->get(route('data-export.edit'))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/DataPrivacy')
             ->where('dataExport.status', 'ready')
             ->where('dataExport.isReady', true));
 });
 
-test('the data & privacy page carries a null export when none has been requested', function () {
+test('the data & privacy page carries a null export when none has been requested', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)
         ->get(route('data-export.edit'))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/DataPrivacy')
             ->where('dataExport', null));
 });
 
-test('the DTO maps a ready export', function () {
+test('the DTO maps a ready export', function (): void {
     $export = DataExport::factory()->ready()->create();
 
     $data = DataExportData::fromExport($export);
@@ -169,7 +169,7 @@ test('the DTO maps a ready export', function () {
     expect($data->requestedAt)->not->toBeNull();
 });
 
-test('the DTO maps a pending export', function () {
+test('the DTO maps a pending export', function (): void {
     $export = DataExport::factory()->create();
 
     $data = DataExportData::fromExport($export);
@@ -180,7 +180,7 @@ test('the DTO maps a pending export', function () {
     expect($data->expiresAt)->toBeNull();
 });
 
-test('the ready-export mail renders the download link', function () {
+test('the ready-export mail renders the download link', function (): void {
     $export = DataExport::factory()->ready()->create();
 
     $mail = new DataExportReady($export);

--- a/tests/Feature/Settings/LocaleSettingsTest.php
+++ b/tests/Feature/Settings/LocaleSettingsTest.php
@@ -4,21 +4,21 @@ use App\Enums\AppLocale;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('localization settings page is displayed with the selectable locales', function () {
+test('localization settings page is displayed with the selectable locales', function (): void {
     $user = User::factory()->create();
 
     $this
         ->actingAs($user)
         ->get(route('locale.edit'))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/Localization')
             ->has('locales', count(AppLocale::cases()))
             ->where('locales.0', ['value' => AppLocale::English->value, 'label' => 'English'])
         );
 });
 
-test('the locale can be updated', function () {
+test('the locale can be updated', function (): void {
     $user = User::factory()->create(['locale' => AppLocale::English->value]);
 
     $this
@@ -32,7 +32,7 @@ test('the locale can be updated', function () {
     expect($user->refresh()->locale)->toBe(AppLocale::French);
 });
 
-test('an unknown locale is rejected', function () {
+test('an unknown locale is rejected', function (): void {
     $user = User::factory()->create(['locale' => AppLocale::English->value]);
 
     $this
@@ -47,7 +47,7 @@ test('an unknown locale is rejected', function () {
     expect($user->refresh()->locale)->toBe(AppLocale::English);
 });
 
-test('a locale is required', function () {
+test('a locale is required', function (): void {
     $user = User::factory()->create();
 
     $this
@@ -57,6 +57,6 @@ test('a locale is required', function () {
         ->assertSessionHasErrors('locale');
 });
 
-test('guests cannot view the localization settings page', function () {
+test('guests cannot view the localization settings page', function (): void {
     $this->get(route('locale.edit'))->assertRedirect(route('login'));
 });

--- a/tests/Feature/Settings/NotificationSettingsTest.php
+++ b/tests/Feature/Settings/NotificationSettingsTest.php
@@ -4,21 +4,21 @@ use App\Enums\ChimeSound;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('notification settings page is displayed with the selectable chime sounds', function () {
+test('notification settings page is displayed with the selectable chime sounds', function (): void {
     $user = User::factory()->create();
 
     $this
         ->actingAs($user)
         ->get(route('notifications.edit'))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/Notifications')
             ->has('chimeSounds', count(ChimeSound::cases()))
             ->where('chimeSounds.0', ['value' => ChimeSound::Off->value, 'label' => 'Off'])
         );
 });
 
-test('the chime sound can be updated', function () {
+test('the chime sound can be updated', function (): void {
     $user = User::factory()->create();
 
     $this
@@ -32,7 +32,7 @@ test('the chime sound can be updated', function () {
     expect($user->refresh()->chime_sound)->toBe(ChimeSound::Knock);
 });
 
-test('chimes can be disabled entirely', function () {
+test('chimes can be disabled entirely', function (): void {
     $user = User::factory()->create(['chime_sound' => ChimeSound::Ping->value]);
 
     $this
@@ -45,7 +45,7 @@ test('chimes can be disabled entirely', function () {
     expect($user->refresh()->chime_sound)->toBe(ChimeSound::Off);
 });
 
-test('an unknown chime sound is rejected', function () {
+test('an unknown chime sound is rejected', function (): void {
     $user = User::factory()->create(['chime_sound' => ChimeSound::Ping->value]);
 
     $this
@@ -60,7 +60,7 @@ test('an unknown chime sound is rejected', function () {
     expect($user->refresh()->chime_sound)->toBe(ChimeSound::Ping);
 });
 
-test('a chime sound is required', function () {
+test('a chime sound is required', function (): void {
     $user = User::factory()->create();
 
     $this
@@ -70,6 +70,6 @@ test('a chime sound is required', function () {
         ->assertSessionHasErrors('chime_sound');
 });
 
-test('guests cannot view the notification settings page', function () {
+test('guests cannot view the notification settings page', function (): void {
     $this->get(route('notifications.edit'))->assertRedirect(route('login'));
 });

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -2,7 +2,7 @@
 
 use App\Models\User;
 
-test('profile page is displayed', function () {
+test('profile page is displayed', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -12,7 +12,7 @@ test('profile page is displayed', function () {
     $response->assertOk();
 });
 
-test('profile information can be updated', function () {
+test('profile information can be updated', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -33,7 +33,7 @@ test('profile information can be updated', function () {
     expect($user->email_verified_at)->toBeNull();
 });
 
-test('optional profile fields can be updated', function () {
+test('optional profile fields can be updated', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -57,7 +57,7 @@ test('optional profile fields can be updated', function () {
     expect($user->phone)->toBe('+1 555 010 1234');
 });
 
-test('optional profile fields degrade to null when cleared', function () {
+test('optional profile fields degrade to null when cleared', function (): void {
     $user = User::factory()->create([
         'pronouns' => 'she/her',
         'title' => 'Designer',
@@ -83,7 +83,7 @@ test('optional profile fields degrade to null when cleared', function () {
     expect($user->phone)->toBeNull();
 });
 
-test('optional profile fields are rejected when too long', function () {
+test('optional profile fields are rejected when too long', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -99,7 +99,7 @@ test('optional profile fields are rejected when too long', function () {
     $response->assertSessionHasErrors(['pronouns', 'title', 'phone']);
 });
 
-test('email verification status is unchanged when the email address is unchanged', function () {
+test('email verification status is unchanged when the email address is unchanged', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -116,7 +116,7 @@ test('email verification status is unchanged when the email address is unchanged
     expect($user->refresh()->email_verified_at)->not->toBeNull();
 });
 
-test('user can delete their account', function () {
+test('user can delete their account', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -133,7 +133,7 @@ test('user can delete their account', function () {
     expect($user->fresh())->toBeNull();
 });
 
-test('correct password must be provided to delete account', function () {
+test('correct password must be provided to delete account', function (): void {
     $user = User::factory()->create();
 
     $response = $this

--- a/tests/Feature/Settings/ReadReceiptsSettingsTest.php
+++ b/tests/Feature/Settings/ReadReceiptsSettingsTest.php
@@ -2,7 +2,7 @@
 
 use App\Models\User;
 
-test('read receipt sharing can be turned off', function () {
+test('read receipt sharing can be turned off', function (): void {
     $user = User::factory()->create(['share_read_receipts' => true]);
 
     $this
@@ -15,7 +15,7 @@ test('read receipt sharing can be turned off', function () {
     expect($user->refresh()->share_read_receipts)->toBeFalse();
 });
 
-test('read receipt sharing can be turned back on', function () {
+test('read receipt sharing can be turned back on', function (): void {
     $user = User::factory()->withoutReadReceipts()->create();
 
     $this
@@ -26,7 +26,7 @@ test('read receipt sharing can be turned back on', function () {
     expect($user->refresh()->share_read_receipts)->toBeTrue();
 });
 
-test('the share_read_receipts value is required', function () {
+test('the share_read_receipts value is required', function (): void {
     $user = User::factory()->create();
 
     $this
@@ -36,7 +36,7 @@ test('the share_read_receipts value is required', function () {
         ->assertSessionHasErrors('share_read_receipts');
 });
 
-test('the share_read_receipts value must be a boolean', function () {
+test('the share_read_receipts value must be a boolean', function (): void {
     $user = User::factory()->create();
 
     $this
@@ -45,7 +45,7 @@ test('the share_read_receipts value must be a boolean', function () {
         ->assertSessionHasErrors('share_read_receipts');
 });
 
-test('guests cannot update read receipt sharing', function () {
+test('guests cannot update read receipt sharing', function (): void {
     $this->patch(route('read-receipts.update'), ['share_read_receipts' => false])
         ->assertRedirect(route('login'));
 });

--- a/tests/Feature/Settings/SecurityActivityTest.php
+++ b/tests/Feature/Settings/SecurityActivityTest.php
@@ -11,7 +11,7 @@ use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
 use Laravel\Fortify\Events\TwoFactorAuthenticationDisabled;
 use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
 
-test('signing in records a security event with request context', function () {
+test('signing in records a security event with request context', function (): void {
     $user = User::factory()->create();
 
     $this->post(route('login.store'), [
@@ -28,7 +28,7 @@ test('signing in records a security event with request context', function () {
     expect($event->is_new_device)->toBeTrue();
 });
 
-test('a repeat sign in from the same device is not flagged as new', function () {
+test('a repeat sign in from the same device is not flagged as new', function (): void {
     $user = User::factory()->create();
 
     $credentials = ['email' => $user->email, 'password' => 'password'];
@@ -45,7 +45,7 @@ test('a repeat sign in from the same device is not flagged as new', function () 
     expect((clone $logins)->where('is_new_device', true)->count())->toBe(1);
 });
 
-test('signing out records a security event', function () {
+test('signing out records a security event', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)->post(route('logout'));
@@ -56,13 +56,13 @@ test('signing out records a security event', function () {
         ->exists())->toBeTrue();
 });
 
-test('signing out as a guest records nothing', function () {
+test('signing out as a guest records nothing', function (): void {
     event(new Logout('web', null));
 
     expect(SecurityEvent::query()->count())->toBe(0);
 });
 
-test('changing the password records a security event', function () {
+test('changing the password records a security event', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -80,7 +80,7 @@ test('changing the password records a security event', function () {
         ->exists())->toBeTrue();
 });
 
-test('resetting the password records a security event', function () {
+test('resetting the password records a security event', function (): void {
     $user = User::factory()->create();
 
     event(new PasswordReset($user));
@@ -91,7 +91,7 @@ test('resetting the password records a security event', function () {
         ->exists())->toBeTrue();
 });
 
-test('two factor changes are recorded', function () {
+test('two factor changes are recorded', function (): void {
     $user = User::factory()->create();
 
     event(new TwoFactorAuthenticationEnabled($user));
@@ -112,7 +112,7 @@ test('two factor changes are recorded', function () {
     );
 });
 
-test('the security page lists recent activity newest first', function () {
+test('the security page lists recent activity newest first', function (): void {
     $user = User::factory()->create();
 
     SecurityEvent::factory()->for($user)->ofType(SecurityEventType::PasswordChanged)->create(['created_at' => now()->subMinute()]);
@@ -122,10 +122,10 @@ test('the security page lists recent activity newest first', function () {
         ->withSession(['auth.password_confirmed_at' => time()])
         ->get(route('security.edit'))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/Security')
             ->has('securityEvents', 2)
-            ->has('securityEvents.0', fn (Assert $event) => $event
+            ->has('securityEvents.0', fn (Assert $event): Assert => $event
                 ->where('isNewDevice', true)
                 ->where('label', SecurityEventType::LoggedIn->label())
                 ->hasAll(['id', 'type', 'ipAddress', 'browser', 'platform', 'occurredAt']),
@@ -133,7 +133,7 @@ test('the security page lists recent activity newest first', function () {
         );
 });
 
-test('the activity log is scoped to the authenticated user', function () {
+test('the activity log is scoped to the authenticated user', function (): void {
     $user = User::factory()->create();
     SecurityEvent::factory()->for(User::factory())->create();
 
@@ -141,5 +141,5 @@ test('the activity log is scoped to the authenticated user', function () {
         ->withSession(['auth.password_confirmed_at' => time()])
         ->get(route('security.edit'))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page->where('securityEvents', []));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('securityEvents', []));
 });

--- a/tests/Feature/Settings/SecurityTest.php
+++ b/tests/Feature/Settings/SecurityTest.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\Hash;
 use Inertia\Testing\AssertableInertia as Assert;
 use Laravel\Fortify\Features;
 
-test('security page is displayed', function () {
+test('security page is displayed', function (): void {
     $this->skipUnlessFortifyHas(Features::twoFactorAuthentication());
 
     Features::twoFactorAuthentication([
@@ -18,14 +18,14 @@ test('security page is displayed', function () {
     $this->actingAs($user)
         ->withSession(['auth.password_confirmed_at' => time()])
         ->get(route('security.edit'))
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/Security')
             ->where('canManageTwoFactor', true)
             ->where('twoFactorEnabled', false),
         );
 });
 
-test('security page requires password confirmation when enabled', function () {
+test('security page requires password confirmation when enabled', function (): void {
     $this->skipUnlessFortifyHas(Features::twoFactorAuthentication());
 
     $user = User::factory()->create();
@@ -41,7 +41,7 @@ test('security page requires password confirmation when enabled', function () {
     $response->assertRedirect(route('password.confirm'));
 });
 
-test('security page renders without two factor when feature is disabled', function () {
+test('security page renders without two factor when feature is disabled', function (): void {
     $this->skipUnlessFortifyHas(Features::twoFactorAuthentication());
 
     config(['fortify.features' => []]);
@@ -52,7 +52,7 @@ test('security page renders without two factor when feature is disabled', functi
         ->withSession(['auth.password_confirmed_at' => time()])
         ->get(route('security.edit'))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/Security')
             ->where('canManageTwoFactor', false)
             ->missing('twoFactorEnabled')
@@ -60,20 +60,20 @@ test('security page renders without two factor when feature is disabled', functi
         );
 });
 
-test('security page renders with password rules', function () {
+test('security page renders with password rules', function (): void {
     $user = User::factory()->create();
 
     $this->actingAs($user)
         ->withSession(['auth.password_confirmed_at' => time()])
         ->get(route('security.edit'))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/Security')
             ->has('passwordRules'),
         );
 });
 
-test('password can be updated', function () {
+test('password can be updated', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -92,7 +92,7 @@ test('password can be updated', function () {
     expect(Hash::check('new-password', $user->refresh()->password))->toBeTrue();
 });
 
-test('correct password must be provided to update password', function () {
+test('correct password must be provided to update password', function (): void {
     $user = User::factory()->create();
 
     $response = $this

--- a/tests/Feature/Settings/SessionManagementTest.php
+++ b/tests/Feature/Settings/SessionManagementTest.php
@@ -20,7 +20,7 @@ function seedSession(User $user, string $id, string $userAgent = 'Mozilla/5.0 (W
     ]);
 }
 
-test('active sessions are listed on the security page with the current device flagged', function () {
+test('active sessions are listed on the security page with the current device flagged', function (): void {
     $user = User::factory()->create();
     $currentId = Str::random(40);
     $otherId = Str::random(40);
@@ -33,7 +33,7 @@ test('active sessions are listed on the security page with the current device fl
         ->withCookie(config('session.cookie'), $currentId)
         ->get(route('security.edit'))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('settings/Security')
             ->has('sessions', 2)
             ->where('sessions.0.id', $currentId)
@@ -46,7 +46,7 @@ test('active sessions are listed on the security page with the current device fl
         );
 });
 
-test('a single session can be revoked', function () {
+test('a single session can be revoked', function (): void {
     $user = User::factory()->create();
     $currentId = Str::random(40);
     $otherId = Str::random(40);
@@ -65,7 +65,7 @@ test('a single session can be revoked', function () {
     $this->assertDatabaseHas('sessions', ['id' => $currentId]);
 });
 
-test('the current session cannot be revoked through the single-session route', function () {
+test('the current session cannot be revoked through the single-session route', function (): void {
     $user = User::factory()->create();
     $currentId = Str::random(40);
 
@@ -80,7 +80,7 @@ test('the current session cannot be revoked through the single-session route', f
     $this->assertDatabaseHas('sessions', ['id' => $currentId]);
 });
 
-test('a session belonging to another user cannot be revoked', function () {
+test('a session belonging to another user cannot be revoked', function (): void {
     $user = User::factory()->create();
     $otherUser = User::factory()->create();
     $currentId = Str::random(40);
@@ -98,7 +98,7 @@ test('a session belonging to another user cannot be revoked', function () {
     $this->assertDatabaseHas('sessions', ['id' => $victimId]);
 });
 
-test('logging out other devices removes other sessions but keeps the current one', function () {
+test('logging out other devices removes other sessions but keeps the current one', function (): void {
     $user = User::factory()->create();
     $currentId = Str::random(40);
     $otherId = Str::random(40);
@@ -120,7 +120,7 @@ test('logging out other devices removes other sessions but keeps the current one
     $this->assertDatabaseMissing('sessions', ['id' => $anotherId]);
 });
 
-test('revoking a session requires the correct password', function () {
+test('revoking a session requires the correct password', function (): void {
     $user = User::factory()->create();
     $currentId = Str::random(40);
     $otherId = Str::random(40);
@@ -138,7 +138,7 @@ test('revoking a session requires the correct password', function () {
     $this->assertDatabaseHas('sessions', ['id' => $otherId]);
 });
 
-test('logging out other devices requires the correct password', function () {
+test('logging out other devices requires the correct password', function (): void {
     $user = User::factory()->create();
     $currentId = Str::random(40);
     $otherId = Str::random(40);

--- a/tests/Feature/Settings/TimezoneUpdateTest.php
+++ b/tests/Feature/Settings/TimezoneUpdateTest.php
@@ -2,7 +2,7 @@
 
 use App\Models\User;
 
-test('a user can set their timezone', function () {
+test('a user can set their timezone', function (): void {
     $user = User::factory()->create(['timezone' => null]);
 
     $response = $this
@@ -19,7 +19,7 @@ test('a user can set their timezone', function () {
     expect($user->refresh()->timezone)->toBe('America/New_York');
 });
 
-test('an invalid timezone is rejected', function () {
+test('an invalid timezone is rejected', function (): void {
     $user = User::factory()->create(['timezone' => 'UTC']);
 
     $response = $this
@@ -34,7 +34,7 @@ test('an invalid timezone is rejected', function () {
     expect($user->refresh()->timezone)->toBe('UTC');
 });
 
-test('the timezone is required', function () {
+test('the timezone is required', function (): void {
     $user = User::factory()->create();
 
     $this

--- a/tests/Feature/Sidebar/ChannelSectionTest.php
+++ b/tests/Feature/Sidebar/ChannelSectionTest.php
@@ -48,7 +48,7 @@ function createSection(User $user, Team $team, string $name): TestResponse
     ]);
 }
 
-test('a member can create a custom section', function () {
+test('a member can create a custom section', function (): void {
     [$owner, $team, $general] = sectionCrudTeam();
 
     createSection($owner, $team, 'My Projects')->assertRedirect();
@@ -66,7 +66,7 @@ test('a member can create a custom section', function () {
         ->toMatchArray(['name' => 'My Projects', 'collapsed' => false]);
 });
 
-test('new sections are appended after existing ones', function () {
+test('new sections are appended after existing ones', function (): void {
     [$owner, $team] = sectionCrudTeam();
 
     createSection($owner, $team, 'First')->assertRedirect();
@@ -78,7 +78,7 @@ test('new sections are appended after existing ones', function () {
         ->and($positions[2] ?? null)->toBe('Second');
 });
 
-test('the section name is trimmed and required', function () {
+test('the section name is trimmed and required', function (): void {
     [$owner, $team] = sectionCrudTeam();
 
     createSection($owner, $team, '   Trimmed   ')->assertRedirect();
@@ -87,13 +87,13 @@ test('the section name is trimmed and required', function () {
     createSection($owner, $team, '   ')->assertSessionHasErrors('name');
 });
 
-test('a section name is capped at 50 characters', function () {
+test('a section name is capped at 50 characters', function (): void {
     [$owner, $team] = sectionCrudTeam();
 
     createSection($owner, $team, str_repeat('a', 51))->assertSessionHasErrors('name');
 });
 
-test('a non-member cannot create a section in the team', function () {
+test('a non-member cannot create a section in the team', function (): void {
     [, $team] = sectionCrudTeam();
     $stranger = User::factory()->create();
 
@@ -102,7 +102,7 @@ test('a non-member cannot create a section in the team', function () {
     $this->assertDatabaseMissing('channel_sections', ['user_id' => $stranger->id]);
 });
 
-test('a member can rename their section', function () {
+test('a member can rename their section', function (): void {
     [$owner, $team] = sectionCrudTeam();
     $section = ChannelSection::factory()->for($owner)->for($team)->create(['name' => 'Old']);
 
@@ -113,7 +113,7 @@ test('a member can rename their section', function () {
     expect($section->refresh()->name)->toBe('New');
 });
 
-test('a member can collapse their section', function () {
+test('a member can collapse their section', function (): void {
     [$owner, $team] = sectionCrudTeam();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
 
@@ -124,7 +124,7 @@ test('a member can collapse their section', function () {
     expect($section->refresh()->collapsed)->toBeTrue();
 });
 
-test('an empty section update is rejected', function () {
+test('an empty section update is rejected', function (): void {
     [$owner, $team] = sectionCrudTeam();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
 
@@ -133,7 +133,7 @@ test('an empty section update is rejected', function () {
         ->assertSessionHasErrors(['name', 'collapsed']);
 });
 
-test('a member cannot update another user section', function () {
+test('a member cannot update another user section', function (): void {
     [$owner, $team] = sectionCrudTeam();
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
@@ -146,7 +146,7 @@ test('a member cannot update another user section', function () {
     expect($section->refresh()->name)->not->toBe('Hijacked');
 });
 
-test('a section from another team cannot be updated through this team', function () {
+test('a section from another team cannot be updated through this team', function (): void {
     [$owner, $team] = sectionCrudTeam();
     $otherTeam = app(CreateTeam::class)->handle($owner, 'Other');
     $section = ChannelSection::factory()->for($owner)->for($otherTeam)->create();
@@ -156,7 +156,7 @@ test('a section from another team cannot be updated through this team', function
         ->assertForbidden();
 });
 
-test('a member can delete their section and its channels fall back to the default group', function () {
+test('a member can delete their section and its channels fall back to the default group', function (): void {
     [$owner, $team, $general] = sectionCrudTeam();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
     $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
@@ -173,7 +173,7 @@ test('a member can delete their section and its channels fall back to the defaul
     ]);
 });
 
-test('a member cannot delete another user section', function () {
+test('a member cannot delete another user section', function (): void {
     [$owner, $team] = sectionCrudTeam();
     $other = User::factory()->create();
     $team->memberships()->create(['user_id' => $other->id, 'role' => TeamRole::Member]);
@@ -186,7 +186,7 @@ test('a member cannot delete another user section', function () {
     $this->assertDatabaseHas('channel_sections', ['id' => $section->id]);
 });
 
-test('a member can reorder their sections', function () {
+test('a member can reorder their sections', function (): void {
     [$owner, $team] = sectionCrudTeam();
     $a = ChannelSection::factory()->for($owner)->for($team)->position(0)->create(['name' => 'A']);
     $b = ChannelSection::factory()->for($owner)->for($team)->position(1)->create(['name' => 'B']);
@@ -203,7 +203,7 @@ test('a member can reorder their sections', function () {
         ->and($b->refresh()->position)->toBe(2);
 });
 
-test('reordering rejects a section the user does not own', function () {
+test('reordering rejects a section the user does not own', function (): void {
     [$owner, $team] = sectionCrudTeam();
     $mine = ChannelSection::factory()->for($owner)->for($team)->create();
     $other = User::factory()->create();
@@ -216,7 +216,7 @@ test('reordering rejects a section the user does not own', function () {
         ->assertSessionHasErrors('sections.1');
 });
 
-test('the sections payload must be present to reorder', function () {
+test('the sections payload must be present to reorder', function (): void {
     [$owner, $team] = sectionCrudTeam();
 
     $this->actingAs($owner)
@@ -224,7 +224,7 @@ test('the sections payload must be present to reorder', function () {
         ->assertSessionHasErrors('sections');
 });
 
-test('sections are scoped per user in the sidebar prop', function () {
+test('sections are scoped per user in the sidebar prop', function (): void {
     [$owner, $team, $general] = sectionCrudTeam();
     ChannelSection::factory()->for($owner)->for($team)->create(['name' => 'Mine']);
     $other = User::factory()->create();
@@ -235,7 +235,7 @@ test('sections are scoped per user in the sidebar prop', function () {
     expect($names)->toContain('Mine')->not->toContain('Theirs');
 });
 
-test('a section and its channel memberships relate both ways', function () {
+test('a section and its channel memberships relate both ways', function (): void {
     [$owner, $team, $general] = sectionCrudTeam();
     $section = ChannelSection::factory()->for($owner)->for($team)->create();
     $owner->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
@@ -248,7 +248,7 @@ test('a section and its channel memberships relate both ways', function () {
         ->and($section->channelMembers->pluck('id')->all())->toContain($membership->id);
 });
 
-test('a guest cannot manage sections', function () {
+test('a guest cannot manage sections', function (): void {
     [, $team] = sectionCrudTeam();
 
     $this->post(route('channels.sections.store', ['team' => $team->slug]), ['name' => 'X'])

--- a/tests/Feature/SidebarSectionTest.php
+++ b/tests/Feature/SidebarSectionTest.php
@@ -35,7 +35,7 @@ function sidebarCollapsedProp(User $user, Team $team, Channel $channel): array
     return $response->viewData('page')['props']['collapsedChannelSections'];
 }
 
-test('a user can collapse a sidebar section', function () {
+test('a user can collapse a sidebar section', function (): void {
     [$owner, $team, $general] = sectionTeamWithGeneral();
 
     $this->actingAs($owner)
@@ -46,7 +46,7 @@ test('a user can collapse a sidebar section', function () {
     expect(sidebarCollapsedProp($owner, $team, $general))->toBe(['starred']);
 });
 
-test('an empty payload clears every collapsed section', function () {
+test('an empty payload clears every collapsed section', function (): void {
     [$owner, $team, $general] = sectionTeamWithGeneral();
     $owner->update(['collapsed_channel_sections' => ['starred', 'channels']]);
 
@@ -58,14 +58,14 @@ test('an empty payload clears every collapsed section', function () {
     expect(sidebarCollapsedProp($owner, $team, $general))->toBe([]);
 });
 
-test('collapsed sections default to empty for a fresh user', function () {
+test('collapsed sections default to empty for a fresh user', function (): void {
     [$owner, $team, $general] = sectionTeamWithGeneral();
 
     expect($owner->collapsed_channel_sections)->toBeNull();
     expect(sidebarCollapsedProp($owner, $team, $general))->toBe([]);
 });
 
-test('duplicate section keys are stored once', function () {
+test('duplicate section keys are stored once', function (): void {
     [$owner] = sectionTeamWithGeneral();
 
     $this->actingAs($owner)
@@ -75,7 +75,7 @@ test('duplicate section keys are stored once', function () {
     expect($owner->refresh()->collapsed_channel_sections)->toBe(['channels']);
 });
 
-test('unknown section keys are rejected', function () {
+test('unknown section keys are rejected', function (): void {
     [$owner] = sectionTeamWithGeneral();
 
     $this->actingAs($owner)
@@ -85,7 +85,7 @@ test('unknown section keys are rejected', function () {
     expect($owner->refresh()->collapsed_channel_sections)->toBeNull();
 });
 
-test('the collapsed payload must be present', function () {
+test('the collapsed payload must be present', function (): void {
     [$owner] = sectionTeamWithGeneral();
 
     $this->actingAs($owner)
@@ -93,7 +93,7 @@ test('the collapsed payload must be present', function () {
         ->assertSessionHasErrors('collapsed');
 });
 
-test('a guest cannot persist sidebar sections', function () {
+test('a guest cannot persist sidebar sections', function (): void {
     $this->patch(route('sidebar.sections.update'), ['collapsed' => ['starred']])
         ->assertRedirect(route('login'));
 });

--- a/tests/Feature/Teams/AuditLogTest.php
+++ b/tests/Feature/Teams/AuditLogTest.php
@@ -48,7 +48,7 @@ function auditEntry(Team $team, AuditAction $action): AuditActivity
         ->sole();
 }
 
-test('renaming a team records an audit entry with old and new names', function () {
+test('renaming a team records an audit entry with old and new names', function (): void {
     [$owner, $team] = auditTeam();
 
     $this->actingAs($owner)
@@ -62,7 +62,7 @@ test('renaming a team records an audit entry with old and new names', function (
     expect($entry->properties['new_name'])->toBe('Acme Corp');
 });
 
-test('renaming a team to the same name records nothing', function () {
+test('renaming a team to the same name records nothing', function (): void {
     [$owner, $team] = auditTeam();
 
     $this->actingAs($owner)
@@ -72,7 +72,7 @@ test('renaming a team to the same name records nothing', function () {
     expect(AuditActivity::query()->where('team_id', $team->id)->count())->toBe(0);
 });
 
-test('changing a member role records an audit entry with old and new roles', function () {
+test('changing a member role records an audit entry with old and new roles', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
 
@@ -88,7 +88,7 @@ test('changing a member role records an audit entry with old and new roles', fun
     expect($entry->properties['new_role'])->toBe(TeamRole::Admin->label());
 });
 
-test('changing a member role to the same role records nothing', function () {
+test('changing a member role to the same role records nothing', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
 
@@ -99,7 +99,7 @@ test('changing a member role to the same role records nothing', function () {
     expect(AuditActivity::query()->where('team_id', $team->id)->count())->toBe(0);
 });
 
-test('removing a member records an audit entry', function () {
+test('removing a member records an audit entry', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
 
@@ -113,7 +113,7 @@ test('removing a member records an audit entry', function () {
     expect($entry->properties['member_name'])->toBe($member->name);
 });
 
-test('transferring ownership records an audit entry', function () {
+test('transferring ownership records an audit entry', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team, TeamRole::Admin);
 
@@ -127,7 +127,7 @@ test('transferring ownership records an audit entry', function () {
     expect($entry->properties['new_owner_name'])->toBe($member->name);
 });
 
-test('creating a channel records an audit entry', function () {
+test('creating a channel records an audit entry', function (): void {
     [$owner, $team] = auditTeam();
 
     $this->actingAs($owner)
@@ -143,7 +143,7 @@ test('creating a channel records an audit entry', function () {
     expect($entry->properties['channel_name'])->toBe('marketing');
 });
 
-test('archiving a channel records an audit entry', function () {
+test('archiving a channel records an audit entry', function (): void {
     [$owner, $team] = auditTeam();
     $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
 
@@ -157,7 +157,7 @@ test('archiving a channel records an audit entry', function () {
     expect($entry->properties['channel_name'])->toBe($channel->name);
 });
 
-test('adding a channel member records an audit entry', function () {
+test('adding a channel member records an audit entry', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
@@ -176,7 +176,7 @@ test('adding a channel member records an audit entry', function () {
     expect($entry->properties['member_name'])->toBe($member->name);
 });
 
-test('removing a channel member records an audit entry', function () {
+test('removing a channel member records an audit entry', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
     $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
@@ -195,7 +195,7 @@ test('removing a channel member records an audit entry', function () {
     expect($entry->properties['member_name'])->toBe($member->name);
 });
 
-test('a moderator deleting another members message records an audit entry', function () {
+test('a moderator deleting another members message records an audit entry', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
     $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
@@ -215,7 +215,7 @@ test('a moderator deleting another members message records an audit entry', func
     expect($entry->properties['author_name'])->toBe($member->name);
 });
 
-test('a member deleting their own message records nothing', function () {
+test('a member deleting their own message records nothing', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
     $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
@@ -232,14 +232,14 @@ test('a member deleting their own message records nothing', function () {
     expect(AuditActivity::query()->where('event', AuditAction::MessageDeleted->value)->count())->toBe(0);
 });
 
-test('an audit entry belongs to its team', function () {
+test('an audit entry belongs to its team', function (): void {
     [$owner, $team] = auditTeam();
     $entry = AuditActivity::factory()->forTeam($team)->causedBy($owner)->create();
 
     expect($entry->team->id)->toBe($team->id);
 });
 
-test('an audit entry cannot be updated', function () {
+test('an audit entry cannot be updated', function (): void {
     $entry = AuditActivity::factory()->create();
 
     expect(fn () => $entry->update(['description' => 'tampered']))
@@ -248,7 +248,7 @@ test('an audit entry cannot be updated', function () {
     expect($entry->fresh()->description)->not->toBe('tampered');
 });
 
-test('an audit entry cannot be deleted', function () {
+test('an audit entry cannot be deleted', function (): void {
     $entry = AuditActivity::factory()->create();
 
     expect(fn () => $entry->delete())
@@ -257,7 +257,7 @@ test('an audit entry cannot be deleted', function () {
     expect(AuditActivity::query()->whereKey($entry->id)->exists())->toBeTrue();
 });
 
-test('an admin can view the audit log', function () {
+test('an admin can view the audit log', function (): void {
     [$owner, $team] = auditTeam();
     $admin = auditMember($team, TeamRole::Admin);
     AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
@@ -265,14 +265,14 @@ test('an admin can view the audit log', function () {
     $this->actingAs($admin)
         ->get(route('teams.audit.index', $team))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('teams/Audit')
             ->has('entries.data', 1)
             ->where('entries.data.0.action', AuditAction::ChannelCreated->value)
         );
 });
 
-test('a plain member cannot view the audit log', function () {
+test('a plain member cannot view the audit log', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
 
@@ -281,7 +281,7 @@ test('a plain member cannot view the audit log', function () {
         ->assertForbidden();
 });
 
-test('a non member cannot view the audit log', function () {
+test('a non member cannot view the audit log', function (): void {
     [$owner, $team] = auditTeam();
     $stranger = User::factory()->create();
 
@@ -290,7 +290,7 @@ test('a non member cannot view the audit log', function () {
         ->assertForbidden();
 });
 
-test('the audit log is not available for a personal team', function () {
+test('the audit log is not available for a personal team', function (): void {
     $user = User::factory()->create();
     $personal = $user->personalTeam();
 
@@ -299,7 +299,7 @@ test('the audit log is not available for a personal team', function () {
         ->assertForbidden();
 });
 
-test('the audit log only shows the current teams entries', function () {
+test('the audit log only shows the current teams entries', function (): void {
     [$owner, $team] = auditTeam();
     $otherTeam = Team::factory()->create();
 
@@ -309,13 +309,13 @@ test('the audit log only shows the current teams entries', function () {
     $this->actingAs($owner)
         ->get(route('teams.audit.index', $team))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('entries.data', 1)
             ->where('entries.data.0.action', AuditAction::ChannelCreated->value)
         );
 });
 
-test('the audit log can be filtered by action', function () {
+test('the audit log can be filtered by action', function (): void {
     [$owner, $team] = auditTeam();
 
     AuditActivity::factory()->forTeam($team)->causedBy($owner)->ofAction(AuditAction::ChannelCreated)->create();
@@ -324,13 +324,13 @@ test('the audit log can be filtered by action', function () {
     $this->actingAs($owner)
         ->get(route('teams.audit.index', ['team' => $team, 'action' => AuditAction::ChannelCreated->value]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('entries.data', 1)
             ->where('entries.data.0.action', AuditAction::ChannelCreated->value)
         );
 });
 
-test('the audit log can be filtered by actor', function () {
+test('the audit log can be filtered by actor', function (): void {
     [$owner, $team] = auditTeam();
     $admin = auditMember($team, TeamRole::Admin);
 
@@ -340,7 +340,7 @@ test('the audit log can be filtered by actor', function () {
     $this->actingAs($owner)
         ->get(route('teams.audit.index', ['team' => $team, 'actor' => $admin->id]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->has('entries.data', 1)
             ->where('entries.data.0.action', AuditAction::MemberRemoved->value)
         );

--- a/tests/Feature/Teams/MemberProfileTest.php
+++ b/tests/Feature/Teams/MemberProfileTest.php
@@ -5,7 +5,7 @@ use App\Models\Team;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('a team member can view another member profile', function () {
+test('a team member can view another member profile', function (): void {
     $viewer = User::factory()->create();
     $member = User::factory()->create([
         'name' => 'Ada Lovelace',
@@ -23,7 +23,7 @@ test('a team member can view another member profile', function () {
     $this->actingAs($viewer)
         ->get(route('teams.members.show', [$team, $member]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('teams/MemberProfile')
             ->where('team.slug', $team->slug)
             ->where('profile.id', $member->id)
@@ -40,7 +40,7 @@ test('a team member can view another member profile', function () {
         );
 });
 
-test('the profile card returns a member profile as json', function () {
+test('the profile card returns a member profile as json', function (): void {
     $viewer = User::factory()->create();
     $member = User::factory()->create([
         'name' => 'Grace Hopper',
@@ -65,7 +65,7 @@ test('the profile card returns a member profile as json', function () {
         ]);
 });
 
-test('the profile card 404s for a user outside the team', function () {
+test('the profile card 404s for a user outside the team', function (): void {
     $viewer = User::factory()->create();
     $outsider = User::factory()->create();
     $team = Team::factory()->create();
@@ -77,7 +77,7 @@ test('the profile card 404s for a user outside the team', function () {
         ->assertNotFound();
 });
 
-test('the profile card is forbidden for a non-member viewer', function () {
+test('the profile card is forbidden for a non-member viewer', function (): void {
     $outsider = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -89,7 +89,7 @@ test('the profile card is forbidden for a non-member viewer', function () {
         ->assertForbidden();
 });
 
-test('a member viewing their own profile is flagged as you', function () {
+test('a member viewing their own profile is flagged as you', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -98,10 +98,10 @@ test('a member viewing their own profile is flagged as you', function () {
     $this->actingAs($user)
         ->get(route('teams.members.show', [$team, $user]))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page->where('profile.isYou', true));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('profile.isYou', true));
 });
 
-test('viewing a user who does not belong to the team returns 404', function () {
+test('viewing a user who does not belong to the team returns 404', function (): void {
     $viewer = User::factory()->create();
     $outsider = User::factory()->create();
     $team = Team::factory()->create();
@@ -113,7 +113,7 @@ test('viewing a user who does not belong to the team returns 404', function () {
         ->assertNotFound();
 });
 
-test('a user who is not a team member cannot view profiles in that team', function () {
+test('a user who is not a team member cannot view profiles in that team', function (): void {
     $outsider = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -125,7 +125,7 @@ test('a user who is not a team member cannot view profiles in that team', functi
         ->assertForbidden();
 });
 
-test('guests cannot view member profiles', function () {
+test('guests cannot view member profiles', function (): void {
     $member = User::factory()->create();
     $team = Team::factory()->create();
 

--- a/tests/Feature/Teams/PruneExpiredTeamInvitationsTest.php
+++ b/tests/Feature/Teams/PruneExpiredTeamInvitationsTest.php
@@ -5,8 +5,8 @@ use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
 
-test('expired invitations are deleted by the scheduled cleanup', function () {
-    $this->travelTo(now()->startOfDay());
+test('expired invitations are deleted by the scheduled cleanup', function (): void {
+    $this->travelTo(today());
 
     $owner = User::factory()->create();
     $team = Team::factory()->create();

--- a/tests/Feature/Teams/TeamInvitationTest.php
+++ b/tests/Feature/Teams/TeamInvitationTest.php
@@ -7,7 +7,7 @@ use App\Models\User;
 use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
 use Illuminate\Support\Facades\Notification;
 
-test('team invitations can be created', function () {
+test('team invitations can be created', function (): void {
     Notification::fake();
 
     $owner = User::factory()->create();
@@ -31,7 +31,7 @@ test('team invitations can be created', function () {
     ]);
 });
 
-test('invitation email for existing users uses login route', function () {
+test('invitation email for existing users uses login route', function (): void {
     $owner = User::factory()->create();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = Team::factory()->create();
@@ -50,7 +50,7 @@ test('invitation email for existing users uses login route', function () {
     $this->assertStringContainsString('workspace', implode(' ', $mail->introLines));
 });
 
-test('invitation email for unknown users uses login route', function () {
+test('invitation email for unknown users uses login route', function (): void {
     $owner = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -68,7 +68,7 @@ test('invitation email for unknown users uses login route', function () {
     $this->assertStringContainsString('log in', strtolower(implode(' ', $mail->introLines)));
 });
 
-test('team invitations can be created by admins', function () {
+test('team invitations can be created by admins', function (): void {
     Notification::fake();
 
     $owner = User::factory()->create();
@@ -88,7 +88,7 @@ test('team invitations can be created by admins', function () {
     $response->assertRedirect(route('teams.edit', $team));
 });
 
-test('existing team members cannot be invited', function () {
+test('existing team members cannot be invited', function (): void {
     Notification::fake();
 
     $owner = User::factory()->create();
@@ -108,7 +108,7 @@ test('existing team members cannot be invited', function () {
     $response->assertSessionHasErrors('email');
 });
 
-test('duplicate invitations cannot be created', function () {
+test('duplicate invitations cannot be created', function (): void {
     Notification::fake();
 
     $owner = User::factory()->create();
@@ -131,7 +131,7 @@ test('duplicate invitations cannot be created', function () {
     $response->assertSessionHasErrors('email');
 });
 
-test('team invitations cannot be created by members', function () {
+test('team invitations cannot be created by members', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -149,7 +149,7 @@ test('team invitations cannot be created by members', function () {
     $response->assertForbidden();
 });
 
-test('team invitations can be cancelled by owners', function () {
+test('team invitations can be cancelled by owners', function (): void {
     $owner = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -171,7 +171,7 @@ test('team invitations can be cancelled by owners', function () {
     ]);
 });
 
-test('team invitations can be accepted', function () {
+test('team invitations can be accepted', function (): void {
     $owner = User::factory()->create();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = Team::factory()->create();
@@ -196,7 +196,7 @@ test('team invitations can be accepted', function () {
     expect($invitation->fresh()->accepted_at)->not->toBeNull();
 });
 
-test('team invitations can be declined by the invited user', function () {
+test('team invitations can be declined by the invited user', function (): void {
     $owner = User::factory()->create();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = Team::factory()->create();
@@ -220,7 +220,7 @@ test('team invitations can be declined by the invited user', function () {
     ]);
 });
 
-test('team invitations cannot be declined by uninvited user', function () {
+test('team invitations cannot be declined by uninvited user', function (): void {
     $owner = User::factory()->create();
     $uninvitedUser = User::factory()->create(['email' => 'uninvited@example.com']);
     $team = Team::factory()->create();
@@ -244,7 +244,7 @@ test('team invitations cannot be declined by uninvited user', function () {
     ]);
 });
 
-test('accepted team invitations cannot be declined', function () {
+test('accepted team invitations cannot be declined', function (): void {
     $owner = User::factory()->create();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = Team::factory()->create();
@@ -268,7 +268,7 @@ test('accepted team invitations cannot be declined', function () {
     ]);
 });
 
-test('team invitations cannot be accepted by uninvited user', function () {
+test('team invitations cannot be accepted by uninvited user', function (): void {
     $owner = User::factory()->create();
     $uninvitedUser = User::factory()->create(['email' => 'uninvited@example.com']);
     $team = Team::factory()->create();
@@ -290,7 +290,7 @@ test('team invitations cannot be accepted by uninvited user', function () {
     expect($uninvitedUser->fresh()->belongsToTeam($team))->toBeFalse();
 });
 
-test('expired invitations cannot be accepted', function () {
+test('expired invitations cannot be accepted', function (): void {
     $owner = User::factory()->create();
     $invitedUser = User::factory()->create(['email' => 'invited@example.com']);
     $team = Team::factory()->create();

--- a/tests/Feature/Teams/TeamMemberTest.php
+++ b/tests/Feature/Teams/TeamMemberTest.php
@@ -4,7 +4,7 @@ use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 
-test('team member roles can be updated by owners', function () {
+test('team member roles can be updated by owners', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -23,7 +23,7 @@ test('team member roles can be updated by owners', function () {
     expect($team->members()->where('user_id', $member->id)->first()->pivot->role->value)->toEqual(TeamRole::Admin->value);
 });
 
-test('team member roles cannot be updated by non owners', function () {
+test('team member roles cannot be updated by non owners', function (): void {
     $owner = User::factory()->create();
     $admin = User::factory()->create();
     $member = User::factory()->create();
@@ -42,7 +42,7 @@ test('team member roles cannot be updated by non owners', function () {
     $response->assertForbidden();
 });
 
-test('team members can be removed by owners', function () {
+test('team members can be removed by owners', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -59,7 +59,7 @@ test('team members can be removed by owners', function () {
     expect($member->fresh()->belongsToTeam($team))->toBeFalse();
 });
 
-test('team members cannot be removed by non owners', function () {
+test('team members cannot be removed by non owners', function (): void {
     $owner = User::factory()->create();
     $admin = User::factory()->create();
     $member = User::factory()->create();
@@ -76,7 +76,7 @@ test('team members cannot be removed by non owners', function () {
     $response->assertForbidden();
 });
 
-test('team owner cannot be removed', function () {
+test('team owner cannot be removed', function (): void {
     $owner = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -91,7 +91,7 @@ test('team owner cannot be removed', function () {
     expect($owner->fresh()->belongsToTeam($team))->toBeTrue();
 });
 
-test('team member role cannot be set to owner', function () {
+test('team member role cannot be set to owner', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -110,7 +110,7 @@ test('team member role cannot be set to owner', function () {
     expect($team->members()->where('user_id', $member->id)->first()->pivot->role->value)->toEqual(TeamRole::Member->value);
 });
 
-test('removed member current team is set to personal team', function () {
+test('removed member current team is set to personal team', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $personalTeam = $member->personalTeam();

--- a/tests/Feature/Teams/TeamOwnershipTransferTest.php
+++ b/tests/Feature/Teams/TeamOwnershipTransferTest.php
@@ -4,7 +4,7 @@ use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 
-test('an owner can transfer ownership to another member', function () {
+test('an owner can transfer ownership to another member', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -24,7 +24,7 @@ test('an owner can transfer ownership to another member', function () {
     expect($member->fresh()->teamRole($team))->toBe(TeamRole::Owner);
 });
 
-test('the single owner invariant is preserved after a transfer', function () {
+test('the single owner invariant is preserved after a transfer', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -42,7 +42,7 @@ test('the single owner invariant is preserved after a transfer', function () {
     expect($team->owner()->is($member))->toBeTrue();
 });
 
-test('a non owner cannot transfer ownership', function () {
+test('a non owner cannot transfer ownership', function (): void {
     $owner = User::factory()->create();
     $admin = User::factory()->create();
     $member = User::factory()->create();
@@ -63,7 +63,7 @@ test('a non owner cannot transfer ownership', function () {
     expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
 });
 
-test('ownership cannot be transferred to a non member', function () {
+test('ownership cannot be transferred to a non member', function (): void {
     $owner = User::factory()->create();
     $stranger = User::factory()->create();
     $team = Team::factory()->create();
@@ -81,7 +81,7 @@ test('ownership cannot be transferred to a non member', function () {
     expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
 });
 
-test('ownership cannot be transferred to yourself', function () {
+test('ownership cannot be transferred to yourself', function (): void {
     $owner = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -98,7 +98,7 @@ test('ownership cannot be transferred to yourself', function () {
     expect($owner->fresh()->teamRole($team))->toBe(TeamRole::Owner);
 });
 
-test('transferring ownership requires the current password', function () {
+test('transferring ownership requires the current password', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();

--- a/tests/Feature/Teams/TeamPresenceTest.php
+++ b/tests/Feature/Teams/TeamPresenceTest.php
@@ -20,7 +20,7 @@ function usePresenceBroadcaster(): void
     require base_path('routes/channels.php');
 }
 
-test('a team member is authorized to join the team presence channel and receives their roster identity', function () {
+test('a team member is authorized to join the team presence channel and receives their roster identity', function (): void {
     usePresenceBroadcaster();
 
     $member = User::factory()->create();
@@ -34,12 +34,12 @@ test('a team member is authorized to join the team presence channel and receives
         ])
         ->assertOk();
 
-    $channelData = json_decode($response->json('channel_data'), true);
+    $channelData = json_decode((string) $response->json('channel_data'), true);
 
     expect($channelData['user_info'])->toBe(['id' => $member->id, 'name' => $member->name]);
 });
 
-test('a non-member cannot join the team presence channel', function () {
+test('a non-member cannot join the team presence channel', function (): void {
     usePresenceBroadcaster();
 
     $team = Team::factory()->create();
@@ -53,7 +53,7 @@ test('a non-member cannot join the team presence channel', function () {
         ->assertForbidden();
 });
 
-test('joining the presence channel of an unknown team is denied', function () {
+test('joining the presence channel of an unknown team is denied', function (): void {
     usePresenceBroadcaster();
 
     $user = User::factory()->create();

--- a/tests/Feature/Teams/TeamTest.php
+++ b/tests/Feature/Teams/TeamTest.php
@@ -5,7 +5,7 @@ use App\Models\Team;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
-test('the teams index page can be rendered', function () {
+test('the teams index page can be rendered', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -15,7 +15,7 @@ test('the teams index page can be rendered', function () {
     $response->assertOk();
 });
 
-test('teams can be created', function () {
+test('teams can be created', function (): void {
     $user = User::factory()->create();
 
     $response = $this
@@ -32,7 +32,7 @@ test('teams can be created', function () {
     ]);
 });
 
-test('team slug uses next available suffix', function () {
+test('team slug uses next available suffix', function (): void {
     $user = User::factory()->create();
 
     Team::factory()->create(['name' => 'Acme', 'slug' => 'acme']);
@@ -51,7 +51,7 @@ test('team slug uses next available suffix', function () {
     ]);
 });
 
-test('the team edit page can be rendered', function () {
+test('the team edit page can be rendered', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -63,14 +63,14 @@ test('the team edit page can be rendered', function () {
 
     $response
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('teams/Edit')
             ->where('members.0.role', TeamRole::Owner->value)
             ->where('members.0.role_label', TeamRole::Owner->label()),
         );
 });
 
-test('teams can be updated by owners', function () {
+test('teams can be updated by owners', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create(['name' => 'Original Name']);
 
@@ -90,7 +90,7 @@ test('teams can be updated by owners', function () {
     ]);
 });
 
-test('teams cannot be updated by members', function () {
+test('teams cannot be updated by members', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -107,7 +107,7 @@ test('teams cannot be updated by members', function () {
     $response->assertForbidden();
 });
 
-test('teams can be deleted by owners', function () {
+test('teams can be deleted by owners', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -126,7 +126,7 @@ test('teams can be deleted by owners', function () {
     ]);
 });
 
-test('team deletion requires name confirmation', function () {
+test('team deletion requires name confirmation', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -146,7 +146,7 @@ test('team deletion requires name confirmation', function () {
     ]);
 });
 
-test('deleting current team switches to alphabetically first remaining team', function () {
+test('deleting current team switches to alphabetically first remaining team', function (): void {
     $user = User::factory()->create(['name' => 'Mike']);
 
     $zuluTeam = Team::factory()->create(['name' => 'Zulu Team']);
@@ -175,7 +175,7 @@ test('deleting current team switches to alphabetically first remaining team', fu
     expect($user->fresh()->current_team_id)->toEqual($alphaTeam->id);
 });
 
-test('deleting current team falls back to personal team when alphabetically first', function () {
+test('deleting current team falls back to personal team when alphabetically first', function (): void {
     $user = User::factory()->create();
     $personalTeam = $user->personalTeam();
     $team = Team::factory()->create(['name' => 'Zulu Team']);
@@ -198,7 +198,7 @@ test('deleting current team falls back to personal team when alphabetically firs
     expect($user->fresh()->current_team_id)->toEqual($personalTeam->id);
 });
 
-test('deleting non current team leaves current team unchanged', function () {
+test('deleting non current team leaves current team unchanged', function (): void {
     $user = User::factory()->create();
     $personalTeam = $user->personalTeam();
     $team = Team::factory()->create();
@@ -221,7 +221,7 @@ test('deleting non current team leaves current team unchanged', function () {
     expect($user->fresh()->current_team_id)->toEqual($personalTeam->id);
 });
 
-test('members can leave non personal teams', function () {
+test('members can leave non personal teams', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -239,7 +239,7 @@ test('members can leave non personal teams', function () {
     expect($member->fresh()->belongsToTeam($team))->toBeFalse();
 });
 
-test('leaving current team switches to alphabetically first remaining team', function () {
+test('leaving current team switches to alphabetically first remaining team', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create(['name' => 'Mike']);
 
@@ -265,7 +265,7 @@ test('leaving current team switches to alphabetically first remaining team', fun
     expect($member->fresh()->current_team_id)->toEqual($alphaTeam->id);
 });
 
-test('personal teams cannot be left', function () {
+test('personal teams cannot be left', function (): void {
     $user = User::factory()->create();
     $personalTeam = $user->personalTeam();
 
@@ -278,7 +278,7 @@ test('personal teams cannot be left', function () {
     expect($user->fresh()->belongsToTeam($personalTeam))->toBeTrue();
 });
 
-test('team owners cannot leave their team', function () {
+test('team owners cannot leave their team', function (): void {
     $owner = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -293,7 +293,7 @@ test('team owners cannot leave their team', function () {
     expect($owner->fresh()->belongsToTeam($team))->toBeTrue();
 });
 
-test('users cannot leave teams they dont belong to', function () {
+test('users cannot leave teams they dont belong to', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -304,7 +304,7 @@ test('users cannot leave teams they dont belong to', function () {
     $response->assertForbidden();
 });
 
-test('deleting team switches other affected users to their personal team', function () {
+test('deleting team switches other affected users to their personal team', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
 
@@ -326,7 +326,7 @@ test('deleting team switches other affected users to their personal team', funct
     expect($member->fresh()->current_team_id)->toEqual($member->personalTeam()->id);
 });
 
-test('personal teams cannot be deleted', function () {
+test('personal teams cannot be deleted', function (): void {
     $user = User::factory()->create();
 
     $personalTeam = $user->personalTeam();
@@ -345,7 +345,7 @@ test('personal teams cannot be deleted', function () {
     ]);
 });
 
-test('teams cannot be deleted by non owners', function () {
+test('teams cannot be deleted by non owners', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $team = Team::factory()->create();
@@ -362,7 +362,7 @@ test('teams cannot be deleted by non owners', function () {
     $response->assertForbidden();
 });
 
-test('users can switch teams', function () {
+test('users can switch teams', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -377,7 +377,7 @@ test('users can switch teams', function () {
     expect($user->fresh()->current_team_id)->toEqual($team->id);
 });
 
-test('users cannot switch to team they dont belong to', function () {
+test('users cannot switch to team they dont belong to', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();
 
@@ -388,7 +388,7 @@ test('users cannot switch to team they dont belong to', function () {
     $response->assertForbidden();
 });
 
-test('guests cannot access teams', function () {
+test('guests cannot access teams', function (): void {
     $response = $this->get(route('teams.index'));
 
     $response->assertRedirect(route('login'));

--- a/tests/Feature/Teams/WorkspaceAnalyticsPageTest.php
+++ b/tests/Feature/Teams/WorkspaceAnalyticsPageTest.php
@@ -32,7 +32,7 @@ function analyticsPageMember(Team $team, TeamRole $role = TeamRole::Member): Use
     return $member;
 }
 
-test('an admin can view the analytics dashboard', function () {
+test('an admin can view the analytics dashboard', function (): void {
     [$owner, $team] = analyticsPageTeam();
     $admin = analyticsPageMember($team, TeamRole::Admin);
     $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
@@ -41,7 +41,7 @@ test('an admin can view the analytics dashboard', function () {
     $this->actingAs($admin)
         ->get(route('teams.analytics.index', $team))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->component('teams/Analytics')
             ->where('range', '30d')
             ->where('analytics.messagesSent.value', 1)
@@ -51,7 +51,7 @@ test('an admin can view the analytics dashboard', function () {
         );
 });
 
-test('the owner can view the analytics dashboard', function () {
+test('the owner can view the analytics dashboard', function (): void {
     [$owner, $team] = analyticsPageTeam();
 
     $this->actingAs($owner)
@@ -59,7 +59,7 @@ test('the owner can view the analytics dashboard', function () {
         ->assertOk();
 });
 
-test('a plain member cannot view the analytics dashboard', function () {
+test('a plain member cannot view the analytics dashboard', function (): void {
     [$owner, $team] = analyticsPageTeam();
     $member = analyticsPageMember($team);
 
@@ -68,7 +68,7 @@ test('a plain member cannot view the analytics dashboard', function () {
         ->assertForbidden();
 });
 
-test('a non member cannot view the analytics dashboard', function () {
+test('a non member cannot view the analytics dashboard', function (): void {
     [$owner, $team] = analyticsPageTeam();
     $stranger = User::factory()->create();
 
@@ -77,7 +77,7 @@ test('a non member cannot view the analytics dashboard', function () {
         ->assertForbidden();
 });
 
-test('analytics is not available for a personal team', function () {
+test('analytics is not available for a personal team', function (): void {
     $user = User::factory()->create();
     $personal = $user->personalTeam();
 
@@ -86,20 +86,20 @@ test('analytics is not available for a personal team', function () {
         ->assertForbidden();
 });
 
-test('the requested range scopes the dashboard', function () {
+test('the requested range scopes the dashboard', function (): void {
     [$owner, $team] = analyticsPageTeam();
 
     $this->actingAs($owner)
         ->get(route('teams.analytics.index', [$team, 'range' => '7d']))
         ->assertOk()
-        ->assertInertia(fn (Assert $page) => $page
+        ->assertInertia(fn (Assert $page): Assert => $page
             ->where('range', '7d')
             ->where('analytics.range', '7d')
             ->has('analytics.messagesByDay', 7)
         );
 });
 
-test('an invalid range is rejected', function () {
+test('an invalid range is rejected', function (): void {
     [$owner, $team] = analyticsPageTeam();
 
     $this->actingAs($owner)

--- a/tests/Feature/Teams/WorkspaceAnalyticsTest.php
+++ b/tests/Feature/Teams/WorkspaceAnalyticsTest.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Cache;
 /**
  * Freeze the clock so day/month bucketing is deterministic.
  */
-beforeEach(function () {
+beforeEach(function (): void {
     $this->travelTo('2026-07-15 12:00:00');
 });
 
@@ -68,7 +68,7 @@ function analyticsFor(Team $team, AnalyticsRange $range = AnalyticsRange::Month)
     return app(WorkspaceAnalytics::class)->for($team, $range);
 }
 
-test('active members counts distinct authors in the window against total members', function () {
+test('active members counts distinct authors in the window against total members', function (): void {
     [$team, $owner] = analyticsTeam(members: 3);
     $channel = analyticsChannel($team);
     $members = $team->members()->where('team_members.role', TeamRole::Member->value)->get();
@@ -86,7 +86,7 @@ test('active members counts distinct authors in the window against total members
         ->and($stat->total)->toBe(4);
 });
 
-test('active members delta compares against the previous window', function () {
+test('active members delta compares against the previous window', function (): void {
     [$team, $owner] = analyticsTeam(members: 2);
     $channel = analyticsChannel($team);
     $members = $team->members()->where('team_members.role', TeamRole::Member->value)->get();
@@ -100,7 +100,7 @@ test('active members delta compares against the previous window', function () {
     expect(analyticsFor($team)->activeMembers->delta)->toBe(1);
 });
 
-test('messages per day averages volume over the window and reports percent change', function () {
+test('messages per day averages volume over the window and reports percent change', function (): void {
     [$team, $owner] = analyticsTeam();
     $channel = analyticsChannel($team);
 
@@ -119,7 +119,7 @@ test('messages per day averages volume over the window and reports percent chang
         ->and($stat->deltaPercent)->toBe(100);
 });
 
-test('messages per day percent change is null without a previous baseline', function () {
+test('messages per day percent change is null without a previous baseline', function (): void {
     [$team, $owner] = analyticsTeam();
     $channel = analyticsChannel($team);
     postMessage($channel, $owner, '2026-07-10 09:00:00');
@@ -127,7 +127,7 @@ test('messages per day percent change is null without a previous baseline', func
     expect(analyticsFor($team)->messagesPerDay->deltaPercent)->toBeNull();
 });
 
-test('messages sent totals the window and counts thread replies separately', function () {
+test('messages sent totals the window and counts thread replies separately', function (): void {
     [$team, $owner] = analyticsTeam();
     $channel = analyticsChannel($team);
 
@@ -141,7 +141,7 @@ test('messages sent totals the window and counts thread replies separately', fun
         ->and($stat->secondary)->toBe(2);
 });
 
-test('active channels counts channels with activity against live channel count', function () {
+test('active channels counts channels with activity against live channel count', function (): void {
     [$team, $owner] = analyticsTeam();
     $general = analyticsChannel($team);
     $random = analyticsChannel($team, 'random');
@@ -158,7 +158,7 @@ test('active channels counts channels with activity against live channel count',
         ->and($stat->total)->toBe(3);
 });
 
-test('the messages-by-day series is zero-filled for the whole window', function () {
+test('the messages-by-day series is zero-filled for the whole window', function (): void {
     [$team, $owner] = analyticsTeam();
     $channel = analyticsChannel($team);
 
@@ -174,7 +174,7 @@ test('the messages-by-day series is zero-filled for the whole window', function 
         ->and($series[6]->count)->toBe(0);
 });
 
-test('top channels ranks the busiest channels by message count', function () {
+test('top channels ranks the busiest channels by message count', function (): void {
     [$team, $owner] = analyticsTeam();
     $design = analyticsChannel($team, 'design');
     $general = analyticsChannel($team);
@@ -193,7 +193,7 @@ test('top channels ranks the busiest channels by message count', function () {
         ->and($top[1]->count)->toBe(1);
 });
 
-test('member growth accumulates the member total over six months', function () {
+test('member growth accumulates the member total over six months', function (): void {
     [$team, $owner] = analyticsTeam();
     $channel = analyticsChannel($team);
 
@@ -212,7 +212,7 @@ test('member growth accumulates the member total over six months', function () {
         ->and($growth[5]->total)->toBe(3);
 });
 
-test('top contributors ranks the most active members', function () {
+test('top contributors ranks the most active members', function (): void {
     [$team, $owner] = analyticsTeam(members: 1);
     $channel = analyticsChannel($team);
     $member = $team->members()->where('team_members.role', TeamRole::Member->value)->first();
@@ -229,7 +229,7 @@ test('top contributors ranks the most active members', function () {
         ->and($top[1]->id)->toBe($member->id);
 });
 
-test('analytics ignores direct messages, other teams, and soft-deleted messages', function () {
+test('analytics ignores direct messages, other teams, and soft-deleted messages', function (): void {
     [$team, $owner] = analyticsTeam();
     $channel = analyticsChannel($team);
 
@@ -250,7 +250,7 @@ test('analytics ignores direct messages, other teams, and soft-deleted messages'
     expect(analyticsFor($team)->messagesSent->value)->toBe(1);
 });
 
-test('snapshots are cached per team and range', function () {
+test('snapshots are cached per team and range', function (): void {
     [$team, $owner] = analyticsTeam();
     $channel = analyticsChannel($team);
     postMessage($channel, $owner, '2026-07-10 09:00:00');
@@ -265,7 +265,7 @@ test('snapshots are cached per team and range', function () {
     expect(analyticsFor($team)->messagesSent->value)->toBe(2);
 });
 
-test('caching is scoped to the requested range', function () {
+test('caching is scoped to the requested range', function (): void {
     [$team, $owner] = analyticsTeam();
     $channel = analyticsChannel($team);
     Cache::spy();
@@ -273,6 +273,6 @@ test('caching is scoped to the requested range', function () {
     app(WorkspaceAnalytics::class)->for($team, AnalyticsRange::Week);
 
     Cache::shouldHaveReceived('remember')
-        ->withArgs(fn (string $key) => str_contains($key, ':analytics:7d'))
+        ->withArgs(fn (string $key): bool => str_contains($key, ':analytics:7d'))
         ->once();
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -29,9 +31,7 @@ pest()->extend(TestCase::class)
 |
 */
 
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
-});
+expect()->extend('toBeOne', fn () => $this->toBe(1));
 
 /*
 |--------------------------------------------------------------------------
@@ -44,7 +44,7 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+function something(): void
 {
     // ..
 }

--- a/tests/Unit/AuditActionTest.php
+++ b/tests/Unit/AuditActionTest.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 // framework's translator, so these tests boot the application container.
 uses(TestCase::class);
 
-test('every action describes itself from context', function (AuditAction $action) {
+test('every action describes itself from context', function (AuditAction $action): void {
     $context = [
         'old_name' => 'Acme',
         'new_name' => 'Acme Corp',
@@ -22,11 +22,11 @@ test('every action describes itself from context', function (AuditAction $action
     expect($action->describe($context))->toBeString()->not->toBe('');
 })->with(AuditAction::cases());
 
-test('a missing context value falls back to a placeholder', function () {
+test('a missing context value falls back to a placeholder', function (): void {
     expect(AuditAction::ChannelCreated->describe([]))->toContain('—');
 });
 
-test('the action options expose a value and label for every case', function () {
+test('the action options expose a value and label for every case', function (): void {
     $options = AuditAction::options();
 
     expect($options)->toHaveCount(count(AuditAction::cases()));

--- a/tests/Unit/DataExportStatusTest.php
+++ b/tests/Unit/DataExportStatusTest.php
@@ -7,11 +7,11 @@ use Tests\TestCase;
 // translator, so these tests boot the application container.
 uses(TestCase::class);
 
-test('every status has a non-empty label', function (DataExportStatus $status) {
+test('every status has a non-empty label', function (DataExportStatus $status): void {
     expect($status->label())->toBeString()->not->toBeEmpty();
 })->with(DataExportStatus::cases());
 
-test('labels describe the status', function () {
+test('labels describe the status', function (): void {
     expect(DataExportStatus::Pending->label())->toBe('Preparing');
     expect(DataExportStatus::Ready->label())->toBe('Ready to download');
     expect(DataExportStatus::Failed->label())->toBe('Failed');

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,7 @@
 <?php
 
-test('that true is true', function () {
+declare(strict_types=1);
+
+test('that true is true', function (): void {
     expect(true)->toBeTrue();
 });

--- a/tests/Unit/HostResolverTest.php
+++ b/tests/Unit/HostResolverTest.php
@@ -2,16 +2,16 @@
 
 use App\Support\HostResolver;
 
-test('a literal IP resolves to itself', function () {
+test('a literal IP resolves to itself', function (): void {
     expect((new HostResolver)->resolve('93.184.216.34'))->toBe(['93.184.216.34']);
 });
 
-test('a resolvable hostname resolves to its addresses', function () {
+test('a resolvable hostname resolves to its addresses', function (): void {
     // localhost resolves from the hosts file, so this needs no live DNS.
     expect((new HostResolver)->resolve('localhost'))->toContain('127.0.0.1');
 });
 
-test('an unresolvable hostname resolves to no addresses', function () {
+test('an unresolvable hostname resolves to no addresses', function (): void {
     // The .invalid TLD is guaranteed never to resolve (RFC 6761).
     expect((new HostResolver)->resolve('nonexistent-host.invalid'))->toBe([]);
 });

--- a/tests/Unit/SecurityEventTypeTest.php
+++ b/tests/Unit/SecurityEventTypeTest.php
@@ -7,11 +7,11 @@ use Tests\TestCase;
 // translator, so these tests boot the application container.
 uses(TestCase::class);
 
-test('every event type has a non-empty label', function (SecurityEventType $type) {
+test('every event type has a non-empty label', function (SecurityEventType $type): void {
     expect($type->label())->toBeString()->not->toBeEmpty();
 })->with(SecurityEventType::cases());
 
-test('labels describe the action', function () {
+test('labels describe the action', function (): void {
     expect(SecurityEventType::LoggedIn->label())->toBe('Signed in');
     expect(SecurityEventType::TwoFactorEnabled->label())->toBe('Two-factor authentication enabled');
 });

--- a/tests/Unit/UserAgentParserTest.php
+++ b/tests/Unit/UserAgentParserTest.php
@@ -2,7 +2,7 @@
 
 use App\Support\UserAgentParser;
 
-test('it detects the browser', function (string $userAgent, string $browser) {
+test('it detects the browser', function (string $userAgent, string $browser): void {
     expect(UserAgentParser::parse($userAgent)['browser'])->toBe($browser);
 })->with([
     'Edge' => ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0', 'Edge'],
@@ -13,7 +13,7 @@ test('it detects the browser', function (string $userAgent, string $browser) {
     'unknown browser' => ['curl/8.4.0', 'Unknown browser'],
 ]);
 
-test('it detects the platform', function (string $userAgent, string $platform) {
+test('it detects the platform', function (string $userAgent, string $platform): void {
     expect(UserAgentParser::parse($userAgent)['platform'])->toBe($platform);
 })->with([
     'Windows' => ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36', 'Windows'],
@@ -24,7 +24,7 @@ test('it detects the platform', function (string $userAgent, string $platform) {
     'unknown platform' => ['curl/8.4.0', 'Unknown platform'],
 ]);
 
-test('it falls back to unknowns for a missing user agent', function (?string $userAgent) {
+test('it falls back to unknowns for a missing user agent', function (?string $userAgent): void {
     expect(UserAgentParser::parse($userAgent))->toBe([
         'browser' => 'Unknown browser',
         'platform' => 'Unknown platform',


### PR DESCRIPTION
Closes #246.

Adds [RectorPHP](https://github.com/rectorphp/rector) (with [rector-laravel](https://github.com/driftingly/rector-laravel)) as a dev-only automated-fix layer for structural PHP, complementing Pint (style) and PHPStan (detection), and wires its dry-run into the quality gate.

## Commits (kept reviewable)

1. **`build(rector)`** — config + docs + gate wiring only.
2. **`refactor`** — the mechanical `rector process` diff (294 files, PHP-only, behaviour-preserving).

## What's included

- `rector/rector` + `driftingly/rector-laravel` under `require-dev`.
- **`rector.php`** scoped to the same paths PHPStan analyzes (`app/`, `bootstrap/app.php`, `config/`, `database/`, `routes/`) plus `tests/`. Conservative, high-signal sets: `deadCode`, `codeQuality`, `typeDeclarations`, `earlyReturn`, the PHP level set (auto-detected from composer), and the Laravel code-quality / if-helper sets. Names are imported (no redundant fully-qualified qualifiers).
- **Composer scripts:** `composer refactor` (apply) and `composer refactor:check` (dry-run).
- **Gate wiring:** `refactor:check` runs inside `composer test`, and a `Run Rector` step was added to `.github/workflows/lint.yml`, so un-applied refactors fail the build.
- **Docs:** `CLAUDE.md` (new *Automated Refactoring* section + updated *Code Coverage*) and `README.md` document `composer refactor` as the semantic counterpart to Pint's formatter.

## Rules skipped (conservative first adoption)

- `AppToResolveRector` — `app()`↔`resolve()` is a lateral stylistic swap; not worth churning 50 files.
- `CarbonToDateFacadeRector` — the `Date` facade resolves to `CarbonImmutable` under Larastan and clashed with our explicit `Illuminate\Support\Carbon` type hints (broke `composer types:check`).
- `EnvVariableToEnvHelperRector` — unsafe in write contexts: it rewrote `unset($_ENV[...])` into `unset(Env::get(...))`, which is not valid PHP.
- `InlineConstructorDefaultToPropertyRector` — keep explicit constructor bodies readable.

## Verification

Full backend gate green on the final tree:

- Pint ✅ · PHPStan level 7 ✅ (`No errors`) · Rector dry-run ✅ (`Rector is done!`) · tests **777 passed, 4 skipped**, **Total: 100.0 %** coverage.
- Frontend gate unaffected — the diff is PHP-only.
