### PR TITLE
Extract message hover-action toolbar into its own component + add icon tooltips (#171)

### DIFF
--- a/resources/js/components/EmojiPickerPopover.vue
+++ b/resources/js/components/EmojiPickerPopover.vue
@@ -6,6 +6,20 @@ import {
     PopoverTrigger,
 } from 'reka-ui';
 import { defineAsyncComponent, ref } from 'vue';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+defineProps<{
+    // Optional label shown in a tooltip above the trigger on hover and keyboard
+    // focus. When set, the trigger is composed as Tooltip → PopoverTrigger so the
+    // one button anchors both the popover (on click) and the tooltip (on
+    // hover/focus); this requires a TooltipProvider ancestor. Consumers that
+    // don't want a tooltip omit it and get the bare trigger.
+    tooltip?: string;
+}>();
 
 // The emoji picker touches `indexedDB` at module load, which doesn't exist under
 // Node SSR, so import it lazily on the client only — its loader runs when the
@@ -35,7 +49,17 @@ function onPick(payload: { i: string }): void {
 
 <template>
     <PopoverRoot v-model:open="open">
-        <PopoverTrigger as-child>
+        <Tooltip v-if="tooltip">
+            <TooltipTrigger as-child>
+                <PopoverTrigger as-child>
+                    <slot :open="open" />
+                </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="top" :side-offset="6">
+                {{ tooltip }}
+            </TooltipContent>
+        </Tooltip>
+        <PopoverTrigger v-else as-child>
             <slot :open="open" />
         </PopoverTrigger>
         <PopoverPortal>

--- a/resources/js/components/MessageActions.vue
+++ b/resources/js/components/MessageActions.vue
@@ -1,0 +1,263 @@
+<script setup lang="ts">
+import {
+    AlarmClock,
+    CornerUpLeft,
+    Forward,
+    MessageSquareText,
+    Pencil,
+    SmilePlus,
+    Trash2,
+} from '@lucide/vue';
+import { computed } from 'vue';
+import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
+import MessageReminderPopover from '@/components/MessageReminderPopover.vue';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
+    canDeleteMessage,
+    canEditMessage,
+    canForwardMessage,
+    canReactToMessage,
+    canRemindAboutMessage,
+    canReplyToMessage,
+    canStartThreadFromMessage,
+    hasAnyMessageAction,
+} from '@/lib/messageActions';
+import type { MessageActionContext } from '@/lib/messageActions';
+import type { Message } from '@/types';
+
+const props = defineProps<{
+    message: Message;
+    currentUserId: string;
+    // Whether the viewer may add/remove reactions (member of a live channel).
+    canReact?: boolean;
+    // Whether the viewer may moderate others' messages (delete them).
+    canModerate?: boolean;
+    // Rendered inside a thread panel: suppresses the reply/thread affordances.
+    inThread?: boolean;
+    // Whether this row is an optimistic send with no stable server id yet.
+    pending?: boolean;
+    // The viewer's stored zone, feeding the reminder popover's wall-clock presets.
+    viewerTimezone: string | null;
+}>();
+
+const emit = defineEmits<{
+    react: [emoji: string];
+    reply: [];
+    forward: [];
+    openThread: [];
+    remind: [remindAt: string];
+    remindCustom: [];
+    edit: [];
+    delete: [];
+}>();
+
+const context = computed<MessageActionContext>(() => ({
+    currentUserId: props.currentUserId,
+    canReact: props.canReact ?? false,
+    canModerate: props.canModerate ?? false,
+    inThread: props.inThread ?? false,
+    pending: props.pending ?? false,
+}));
+
+const showReact = computed(() =>
+    canReactToMessage(props.message, context.value),
+);
+const showStartThread = computed(() =>
+    canStartThreadFromMessage(props.message, context.value),
+);
+const showReply = computed(() =>
+    canReplyToMessage(props.message, context.value),
+);
+const showForward = computed(() =>
+    canForwardMessage(props.message, context.value),
+);
+const showRemind = computed(() =>
+    canRemindAboutMessage(props.message, context.value),
+);
+const showEdit = computed(() => canEditMessage(props.message, context.value));
+const showDelete = computed(() =>
+    canDeleteMessage(props.message, context.value),
+);
+const showBar = computed(() =>
+    hasAnyMessageAction(props.message, context.value),
+);
+
+// The hairline divider only earns its place when it sits between two clusters:
+// the react/reply group and the forward/edit/delete group.
+const showDivider = computed(
+    () =>
+        (showReact.value || showStartThread.value || showReply.value) &&
+        (showForward.value ||
+            showRemind.value ||
+            showEdit.value ||
+            showDelete.value),
+);
+
+// Shared icon-button treatment: a 30×28 hit area holding a size-3.5 glyph,
+// resting muted and lifting to foreground on hover, a legible brass focus ring
+// for keyboard users, and a reserved transparent border so the brass open-state
+// below never shifts the layout (border-box keeps the footprint fixed).
+const iconButtonClass =
+    'inline-flex h-7 w-[30px] items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none';
+
+// Delete recolors to the destructive token on hover instead of neutral.
+const deleteButtonClass =
+    'inline-flex h-7 w-[30px] items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none';
+
+// The persistent "open" state for a button anchoring a popover (react / remind):
+// brass carries the meaning that a menu is attached here, per the design's
+// deliberate brass-only-when-active call.
+const openStateClass =
+    'border-brass-border bg-brass-fill text-brass-fill-foreground';
+</script>
+
+<template>
+    <TooltipProvider
+        v-if="showBar"
+        :delay-duration="300"
+        :skip-delay-duration="150"
+    >
+        <!--
+          The bar rests hidden (opacity-0) but stays focusable, so Tab reveals it
+          via group-focus-within just as hover does — the design's "focus-within
+          mirrors group-hover". Reveal animates in (fade + zoom, 100ms); hiding is
+          instant (the animation classes simply drop) so no ghost bars trail a
+          fast scroll. An open emoji/reminder popover pins it via [data-open].
+        -->
+        <div
+            class="pointer-events-none absolute -top-4 right-3 z-10 flex items-center gap-0.5 rounded-lg border border-border bg-background p-0.5 opacity-0 shadow-md group-focus-within/message:pointer-events-auto group-focus-within/message:animate-in group-focus-within/message:opacity-100 group-focus-within/message:duration-100 group-focus-within/message:fade-in-0 group-focus-within/message:zoom-in-95 group-hover/message:pointer-events-auto group-hover/message:animate-in group-hover/message:opacity-100 group-hover/message:duration-100 group-hover/message:fade-in-0 group-hover/message:zoom-in-95 has-[[data-open]]:pointer-events-auto has-[[data-open]]:opacity-100"
+        >
+            <EmojiPickerPopover
+                v-if="showReact"
+                v-slot="{ open }"
+                :tooltip="$t('Add reaction')"
+                @select="(emoji) => emit('react', emoji)"
+            >
+                <button
+                    type="button"
+                    data-test="message-react"
+                    :data-open="open || undefined"
+                    :aria-label="$t('Add reaction')"
+                    :class="[iconButtonClass, open ? openStateClass : '']"
+                >
+                    <SmilePlus class="size-3.5" />
+                </button>
+            </EmojiPickerPopover>
+
+            <Tooltip v-if="showStartThread">
+                <TooltipTrigger as-child>
+                    <button
+                        type="button"
+                        data-test="message-thread"
+                        :aria-label="$t('Reply in thread')"
+                        :class="iconButtonClass"
+                        @click="emit('openThread')"
+                    >
+                        <MessageSquareText class="size-3.5" />
+                    </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" :side-offset="6">
+                    {{ $t('Reply in thread') }}
+                </TooltipContent>
+            </Tooltip>
+
+            <Tooltip v-if="showReply">
+                <TooltipTrigger as-child>
+                    <button
+                        type="button"
+                        data-test="message-reply"
+                        :aria-label="$t('Reply to message')"
+                        :class="iconButtonClass"
+                        @click="emit('reply')"
+                    >
+                        <CornerUpLeft class="size-3.5" />
+                    </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" :side-offset="6">
+                    {{ $t('Reply to message') }}
+                </TooltipContent>
+            </Tooltip>
+
+            <div
+                v-if="showDivider"
+                aria-hidden="true"
+                class="mx-0.5 h-4 w-px bg-border"
+            ></div>
+
+            <Tooltip v-if="showForward">
+                <TooltipTrigger as-child>
+                    <button
+                        type="button"
+                        data-test="message-forward"
+                        :aria-label="$t('Forward message')"
+                        :class="iconButtonClass"
+                        @click="emit('forward')"
+                    >
+                        <Forward class="size-3.5" />
+                    </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" :side-offset="6">
+                    {{ $t('Forward message') }}
+                </TooltipContent>
+            </Tooltip>
+
+            <MessageReminderPopover
+                v-if="showRemind"
+                v-slot="{ open }"
+                :timezone="props.viewerTimezone"
+                :tooltip="$t('Remind me about this')"
+                @set="(remindAt) => emit('remind', remindAt)"
+                @custom="emit('remindCustom')"
+            >
+                <button
+                    type="button"
+                    data-test="message-remind"
+                    :data-open="open || undefined"
+                    :aria-label="$t('Remind me about this')"
+                    :class="[iconButtonClass, open ? openStateClass : '']"
+                >
+                    <AlarmClock class="size-3.5" />
+                </button>
+            </MessageReminderPopover>
+
+            <Tooltip v-if="showEdit">
+                <TooltipTrigger as-child>
+                    <button
+                        type="button"
+                        data-test="message-edit"
+                        :aria-label="$t('Edit message')"
+                        :class="iconButtonClass"
+                        @click="emit('edit')"
+                    >
+                        <Pencil class="size-3.5" />
+                    </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" :side-offset="6">
+                    {{ $t('Edit message') }}
+                </TooltipContent>
+            </Tooltip>
+
+            <Tooltip v-if="showDelete">
+                <TooltipTrigger as-child>
+                    <button
+                        type="button"
+                        data-test="message-delete"
+                        :aria-label="$t('Delete message')"
+                        :class="deleteButtonClass"
+                        @click="emit('delete')"
+                    >
+                        <Trash2 class="size-3.5" />
+                    </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" :side-offset="6">
+                    {{ $t('Delete message') }}
+                </TooltipContent>
+            </Tooltip>
+        </div>
+    </TooltipProvider>
+</template>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1,22 +1,12 @@
 <script setup lang="ts">
 import { usePage } from '@inertiajs/vue3';
-import {
-    AlarmClock,
-    Clock,
-    CornerUpLeft,
-    Forward,
-    MessageSquareText,
-    Pencil,
-    SmilePlus,
-    Trash2,
-} from '@lucide/vue';
+import { Clock } from '@lucide/vue';
 import { computed, nextTick, ref } from 'vue';
-import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
 import LinkPreview from '@/components/LinkPreview.vue';
+import MessageActions from '@/components/MessageActions.vue';
 import MessageForward from '@/components/MessageForward.vue';
 import MessageQuote from '@/components/MessageQuote.vue';
 import MessageReactions from '@/components/MessageReactions.vue';
-import MessageReminderPopover from '@/components/MessageReminderPopover.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -36,6 +26,8 @@ import UserHoverCard from '@/components/UserHoverCard.vue';
 import { useInitials } from '@/composables/useInitials';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatTimeOfDay } from '@/lib/datetime';
+import { canReactToMessage, showsThreadSummary } from '@/lib/messageActions';
+import type { MessageActionContext } from '@/lib/messageActions';
 import { tokenizeMessageBody } from '@/lib/messageBody';
 import type { MessageBodySegment } from '@/lib/messageBody';
 import { readersForMessage } from '@/lib/readReceipts';
@@ -259,60 +251,30 @@ function isQueued(message: Message): boolean {
     return queued.value.has(message.clientUuid);
 }
 
-function isOwn(message: Message): boolean {
-    return message.user.id === props.currentUserId;
-}
-
-function canEdit(message: Message): boolean {
-    return !message.isDeleted && !isPending(message) && isOwn(message);
-}
-
-function canDelete(message: Message): boolean {
-    return (
-        !message.isDeleted &&
-        !isPending(message) &&
-        (isOwn(message) || Boolean(props.canModerate))
-    );
-}
-
-// Anyone can reply to any live message; a pending or deleted row has no stable
-// target to quote yet. Inline quoting is a main-timeline affordance — inside a
-// thread the composer answers the root, so it's suppressed.
-function canReply(message: Message): boolean {
-    return !props.inThread && !message.isDeleted && !isPending(message);
-}
-
-// Any live message can be forwarded to another channel — including from inside a
-// thread panel. A pending or deleted row has no stable target to forward yet.
-function canForward(message: Message): boolean {
-    return !message.isDeleted && !isPending(message);
+// The viewer context each per-message guard resolves against. The hover-action
+// bar (extracted to MessageActions) owns the toolbar guards; the two rules below
+// stay here because they drive non-toolbar UI — the reaction pills and the
+// thread summary — and share the same context.
+function actionContext(message: Message): MessageActionContext {
+    return {
+        currentUserId: props.currentUserId,
+        canReact: Boolean(props.canReact),
+        canModerate: Boolean(props.canModerate),
+        inThread: Boolean(props.inThread),
+        pending: isPending(message),
+    };
 }
 
 // The viewer may react to any live, confirmed message when they're a member of
-// the (non-archived) channel; a pending or deleted row has no stable target yet.
+// the (non-archived) channel; drives whether the reaction pills accept toggles.
 function canReactTo(message: Message): boolean {
-    return Boolean(props.canReact) && !message.isDeleted && !isPending(message);
-}
-
-// A reminder is personal — the viewer can set one on any live message they can
-// see, in any channel and even from inside a thread. A pending or deleted row
-// has no stable id to point back to yet.
-function canRemind(message: Message): boolean {
-    return !message.isDeleted && !isPending(message);
-}
-
-// The hover "reply in thread" action shows on live root messages in the main
-// timeline (never on replies inside a panel, nor on messages already in a thread).
-function canStartThread(message: Message): boolean {
-    return (
-        !props.inThread && canReply(message) && message.threadRootId === null
-    );
+    return canReactToMessage(message, actionContext(message));
 }
 
 // The "N replies" affordance shows on any root that has replies, even a deleted
 // one — the thread outlives its root as a tombstone.
 function showThreadSummary(message: Message): boolean {
-    return !props.inThread && message.threadReplyCount > 0;
+    return showsThreadSummary(message, actionContext(message));
 }
 
 // The message currently being edited inline, and its working draft.
@@ -728,103 +690,26 @@ function confirmDelete(): void {
                             </span>
                         </div>
 
-                        <div
-                            v-if="
-                                editingId !== message.id &&
-                                (canReactTo(message) ||
-                                    canReply(message) ||
-                                    canStartThread(message) ||
-                                    canForward(message) ||
-                                    canRemind(message) ||
-                                    canEdit(message) ||
-                                    canDelete(message))
+                        <MessageActions
+                            v-if="editingId !== message.id"
+                            :message="message"
+                            :current-user-id="props.currentUserId"
+                            :can-react="props.canReact"
+                            :can-moderate="props.canModerate"
+                            :in-thread="props.inThread"
+                            :pending="isPending(message)"
+                            :viewer-timezone="viewerTimezone"
+                            @react="(emoji) => emit('react', message, emoji)"
+                            @reply="emit('reply', message)"
+                            @forward="emit('forward', message)"
+                            @open-thread="emit('openThread', message.id)"
+                            @remind="
+                                (remindAt) => emit('remind', message, remindAt)
                             "
-                            class="absolute -top-3 right-2 hidden items-center gap-0.5 rounded-md border border-border bg-background p-0.5 shadow-sm group-hover/message:flex has-[[data-state=open]]:flex"
-                        >
-                            <EmojiPickerPopover
-                                v-if="canReactTo(message)"
-                                @select="
-                                    (emoji) => emit('react', message, emoji)
-                                "
-                            >
-                                <button
-                                    type="button"
-                                    data-test="message-react"
-                                    :aria-label="$t('Add reaction')"
-                                    class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                >
-                                    <SmilePlus class="size-3.5" />
-                                </button>
-                            </EmojiPickerPopover>
-                            <button
-                                v-if="canStartThread(message)"
-                                type="button"
-                                data-test="message-thread"
-                                :aria-label="$t('Reply in thread')"
-                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                @click="emit('openThread', message.id)"
-                            >
-                                <MessageSquareText class="size-3.5" />
-                            </button>
-                            <button
-                                v-if="canReply(message)"
-                                type="button"
-                                :data-test="'message-reply'"
-                                :aria-label="$t('Reply to message')"
-                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                @click="emit('reply', message)"
-                            >
-                                <CornerUpLeft class="size-3.5" />
-                            </button>
-                            <button
-                                v-if="canForward(message)"
-                                type="button"
-                                :data-test="'message-forward'"
-                                :aria-label="$t('Forward message')"
-                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                @click="emit('forward', message)"
-                            >
-                                <Forward class="size-3.5" />
-                            </button>
-                            <MessageReminderPopover
-                                v-if="canRemind(message)"
-                                :timezone="viewerTimezone"
-                                @set="
-                                    (remindAt) =>
-                                        emit('remind', message, remindAt)
-                                "
-                                @custom="emit('remindCustom', message)"
-                            >
-                                <button
-                                    type="button"
-                                    data-test="message-remind"
-                                    :aria-label="$t('Remind me about this')"
-                                    class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground data-[state=open]:bg-muted data-[state=open]:text-foreground"
-                                >
-                                    <AlarmClock class="size-3.5" />
-                                </button>
-                            </MessageReminderPopover>
-                            <button
-                                v-if="canEdit(message)"
-                                type="button"
-                                :data-test="'message-edit'"
-                                :aria-label="$t('Edit message')"
-                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                                @click="startEdit(message)"
-                            >
-                                <Pencil class="size-3.5" />
-                            </button>
-                            <button
-                                v-if="canDelete(message)"
-                                type="button"
-                                :data-test="'message-delete'"
-                                :aria-label="$t('Delete message')"
-                                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-destructive"
-                                @click="requestDelete(message)"
-                            >
-                                <Trash2 class="size-3.5" />
-                            </button>
-                        </div>
+                            @remind-custom="emit('remindCustom', message)"
+                            @edit="startEdit(message)"
+                            @delete="requestDelete(message)"
+                        />
                     </div>
                 </div>
             </div>

--- a/resources/js/components/MessageReminderPopover.vue
+++ b/resources/js/components/MessageReminderPopover.vue
@@ -7,12 +7,22 @@ import {
     PopoverTrigger,
 } from 'reka-ui';
 import { computed, ref } from 'vue';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { reminderPresets } from '@/lib/reminderTime';
 
 const props = defineProps<{
     // The viewer's stored IANA zone; falls back to the runtime zone when null so
     // the wall-clock presets ("Tomorrow 9am") resolve in a real zone.
     timezone: string | null;
+    // Optional label shown in a tooltip above the trigger on hover and keyboard
+    // focus. When set, the trigger is composed as Tooltip → PopoverTrigger so the
+    // one button anchors both the popover (on click) and the tooltip (on
+    // hover/focus); this requires a TooltipProvider ancestor.
+    tooltip?: string;
 }>();
 
 const emit = defineEmits<{
@@ -53,7 +63,17 @@ function chooseCustom(): void {
 
 <template>
     <PopoverRoot :open="open" @update:open="onOpenChange">
-        <PopoverTrigger as-child>
+        <Tooltip v-if="props.tooltip">
+            <TooltipTrigger as-child>
+                <PopoverTrigger as-child>
+                    <slot :open="open" />
+                </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="top" :side-offset="6">
+                {{ props.tooltip }}
+            </TooltipContent>
+        </Tooltip>
+        <PopoverTrigger v-else as-child>
             <slot :open="open" />
         </PopoverTrigger>
         <PopoverPortal>

--- a/resources/js/lib/messageActions.test.ts
+++ b/resources/js/lib/messageActions.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import {
+    canDeleteMessage,
+    canEditMessage,
+    canForwardMessage,
+    canReactToMessage,
+    canRemindAboutMessage,
+    canReplyToMessage,
+    canStartThreadFromMessage,
+    hasAnyMessageAction,
+    showsThreadSummary,
+} from '@/lib/messageActions';
+import type { MessageActionContext } from '@/lib/messageActions';
+import type { Message } from '@/types';
+
+/** A message carrying just the fields the action guards read. */
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        reactions: [],
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        ...overrides,
+    };
+}
+
+/** A viewer context, defaulting to a reacting, non-moderating member outside a thread. */
+function context(
+    overrides: Partial<MessageActionContext> = {},
+): MessageActionContext {
+    return {
+        currentUserId: 'me',
+        canReact: true,
+        canModerate: false,
+        inThread: false,
+        pending: false,
+        ...overrides,
+    };
+}
+
+describe('messageActions guards', () => {
+    describe('canEditMessage', () => {
+        it('is true only for the viewer’s own live message', () => {
+            const own = message({ user: { id: 'me', name: 'Me' } });
+
+            expect(canEditMessage(own, context())).toBe(true);
+            expect(canEditMessage(message(), context())).toBe(false);
+        });
+
+        it('is false for a deleted or pending message', () => {
+            const own = { user: { id: 'me', name: 'Me' } } as const;
+
+            expect(
+                canEditMessage(message({ ...own, isDeleted: true }), context()),
+            ).toBe(false);
+            expect(
+                canEditMessage(message(own), context({ pending: true })),
+            ).toBe(false);
+        });
+    });
+
+    describe('canDeleteMessage', () => {
+        it('allows the author, or a moderator on anyone’s message', () => {
+            expect(
+                canDeleteMessage(
+                    message({ user: { id: 'me', name: 'Me' } }),
+                    context(),
+                ),
+            ).toBe(true);
+            expect(canDeleteMessage(message(), context())).toBe(false);
+            expect(
+                canDeleteMessage(message(), context({ canModerate: true })),
+            ).toBe(true);
+        });
+
+        it('is false for a deleted or pending message even for a moderator', () => {
+            expect(
+                canDeleteMessage(
+                    message({ isDeleted: true }),
+                    context({ canModerate: true }),
+                ),
+            ).toBe(false);
+            expect(
+                canDeleteMessage(
+                    message(),
+                    context({ canModerate: true, pending: true }),
+                ),
+            ).toBe(false);
+        });
+    });
+
+    describe('canReplyToMessage', () => {
+        it('is true for a live message in the main timeline', () => {
+            expect(canReplyToMessage(message(), context())).toBe(true);
+        });
+
+        it('is suppressed inside a thread panel, or for deleted/pending rows', () => {
+            expect(
+                canReplyToMessage(message(), context({ inThread: true })),
+            ).toBe(false);
+            expect(
+                canReplyToMessage(message({ isDeleted: true }), context()),
+            ).toBe(false);
+            expect(
+                canReplyToMessage(message(), context({ pending: true })),
+            ).toBe(false);
+        });
+    });
+
+    describe('canForwardMessage', () => {
+        it('is true for any live message, including inside a thread', () => {
+            expect(
+                canForwardMessage(message(), context({ inThread: true })),
+            ).toBe(true);
+        });
+
+        it('is false for a deleted or pending message', () => {
+            expect(
+                canForwardMessage(message({ isDeleted: true }), context()),
+            ).toBe(false);
+            expect(
+                canForwardMessage(message(), context({ pending: true })),
+            ).toBe(false);
+        });
+    });
+
+    describe('canReactToMessage', () => {
+        it('requires react permission on a live message', () => {
+            expect(canReactToMessage(message(), context())).toBe(true);
+            expect(
+                canReactToMessage(message(), context({ canReact: false })),
+            ).toBe(false);
+            expect(
+                canReactToMessage(message({ isDeleted: true }), context()),
+            ).toBe(false);
+        });
+    });
+
+    describe('canRemindAboutMessage', () => {
+        it('is true for any live message, false for deleted or pending', () => {
+            expect(
+                canRemindAboutMessage(message(), context({ inThread: true })),
+            ).toBe(true);
+            expect(
+                canRemindAboutMessage(message({ isDeleted: true }), context()),
+            ).toBe(false);
+        });
+    });
+
+    describe('canStartThreadFromMessage', () => {
+        it('is true only for a live root in the main timeline', () => {
+            expect(canStartThreadFromMessage(message(), context())).toBe(true);
+        });
+
+        it('is false for a reply, inside a thread, or a deleted row', () => {
+            expect(
+                canStartThreadFromMessage(
+                    message({ threadRootId: 'root' }),
+                    context(),
+                ),
+            ).toBe(false);
+            expect(
+                canStartThreadFromMessage(
+                    message(),
+                    context({ inThread: true }),
+                ),
+            ).toBe(false);
+            expect(
+                canStartThreadFromMessage(
+                    message({ isDeleted: true }),
+                    context(),
+                ),
+            ).toBe(false);
+        });
+    });
+
+    describe('showsThreadSummary', () => {
+        it('shows for a root with replies in the main timeline, even when deleted', () => {
+            expect(
+                showsThreadSummary(
+                    message({ threadReplyCount: 2, isDeleted: true }),
+                    context(),
+                ),
+            ).toBe(true);
+        });
+
+        it('is hidden with no replies, or inside a thread panel', () => {
+            expect(showsThreadSummary(message(), context())).toBe(false);
+            expect(
+                showsThreadSummary(
+                    message({ threadReplyCount: 2 }),
+                    context({ inThread: true }),
+                ),
+            ).toBe(false);
+        });
+    });
+
+    describe('hasAnyMessageAction', () => {
+        it('is true when at least one action is available', () => {
+            expect(hasAnyMessageAction(message(), context())).toBe(true);
+        });
+
+        it('is false for a deleted message with no permissions', () => {
+            expect(
+                hasAnyMessageAction(
+                    message({ isDeleted: true }),
+                    context({ canReact: false }),
+                ),
+            ).toBe(false);
+        });
+
+        it('is true for a deleted root that still owns a thread summary’s siblings', () => {
+            // A deleted, non-own message with react turned off exposes no bar actions.
+            expect(
+                hasAnyMessageAction(
+                    message({ isDeleted: true }),
+                    context({ canReact: false, canModerate: true }),
+                ),
+            ).toBe(false);
+        });
+    });
+});

--- a/resources/js/lib/messageActions.ts
+++ b/resources/js/lib/messageActions.ts
@@ -1,0 +1,150 @@
+import type { Message } from '@/types';
+
+/**
+ * The viewer context the per-message action guards resolve against: who the
+ * viewer is, what the channel lets them do, whether they're reading inside a
+ * thread panel, and whether this specific row is still an in-flight optimistic
+ * send. Kept as a plain shape so the guards below stay pure and unit-testable,
+ * and so both `MessageList` and the extracted `MessageActions` bar can share
+ * exactly the same visibility rules.
+ */
+export type MessageActionContext = {
+    currentUserId: string;
+    // Whether the viewer may add/remove reactions (member of a live channel).
+    canReact: boolean;
+    // Whether the viewer may moderate others' messages (delete them).
+    canModerate: boolean;
+    // Rendered inside a thread panel: suppresses the reply/thread affordances.
+    inThread: boolean;
+    // Whether this row is an optimistic send with no stable server id yet.
+    pending: boolean;
+};
+
+/**
+ * Whether the message belongs to the viewer, gating the author-only affordances.
+ */
+function isOwn(message: Message, context: MessageActionContext): boolean {
+    return message.user.id === context.currentUserId;
+}
+
+/**
+ * A live, confirmed row: not a tombstone and not an in-flight optimistic send.
+ * Every stable-target action shares this precondition — a deleted or pending
+ * message has no stable id to react to, reply to, forward, remind on, or edit.
+ */
+function isActionable(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return !message.isDeleted && !context.pending;
+}
+
+/**
+ * The viewer may edit only their own live message.
+ */
+export function canEditMessage(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return isActionable(message, context) && isOwn(message, context);
+}
+
+/**
+ * The viewer may delete their own message, or anyone's when they can moderate.
+ */
+export function canDeleteMessage(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return (
+        isActionable(message, context) &&
+        (isOwn(message, context) || context.canModerate)
+    );
+}
+
+/**
+ * Anyone can reply to any live message; inline quoting is a main-timeline
+ * affordance, so it's suppressed inside a thread panel (the composer answers the
+ * root there).
+ */
+export function canReplyToMessage(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return !context.inThread && isActionable(message, context);
+}
+
+/**
+ * Any live message can be forwarded to another channel — including from inside a
+ * thread panel.
+ */
+export function canForwardMessage(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return isActionable(message, context);
+}
+
+/**
+ * The viewer may react to any live message when they're a member of the
+ * (non-archived) channel.
+ */
+export function canReactToMessage(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return context.canReact && isActionable(message, context);
+}
+
+/**
+ * A reminder is personal — the viewer can set one on any live message they can
+ * see, in any channel and even from inside a thread.
+ */
+export function canRemindAboutMessage(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return isActionable(message, context);
+}
+
+/**
+ * The "reply in thread" action shows on live root messages in the main timeline
+ * (never on replies, nor on messages already inside a thread panel).
+ */
+export function canStartThreadFromMessage(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return canReplyToMessage(message, context) && message.threadRootId === null;
+}
+
+/**
+ * The "N replies" affordance shows on any root that has replies, even a deleted
+ * one — the thread outlives its root as a tombstone. Not a toolbar action, but
+ * it shares the same viewer context, so it lives alongside the guards.
+ */
+export function showsThreadSummary(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return !context.inThread && message.threadReplyCount > 0;
+}
+
+/**
+ * Whether any toolbar action is available for this message, so the hover bar can
+ * skip rendering entirely when it would be empty.
+ */
+export function hasAnyMessageAction(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return (
+        canReactToMessage(message, context) ||
+        canReplyToMessage(message, context) ||
+        canStartThreadFromMessage(message, context) ||
+        canForwardMessage(message, context) ||
+        canRemindAboutMessage(message, context) ||
+        canEditMessage(message, context) ||
+        canDeleteMessage(message, context)
+    );
+}


### PR DESCRIPTION
Closes #171.

## What & why

The message hover-action toolbar lived inline in the already-large `MessageList.vue`, with its per-action guards embedded, and its icon-only buttons gave sighted users no hint of what each did until clicked. This extracts the toolbar and adds tooltips.

## Changes

- **`resources/js/lib/messageActions.ts`** (new) — the seven per-message action guards (`canReact/Reply/StartThread/Forward/Remind/Edit/Delete`) plus `showsThreadSummary` / `hasAnyMessageAction`, as pure functions over a small `MessageActionContext`. Shared by both consumers and fully unit-tested (`messageActions.test.ts`, 17 cases).
- **`resources/js/components/MessageActions.vue`** (new) — the extracted floating bar. Takes `message` + viewer context as props, owns the visibility guards, and re-emits `react / reply / forward / openThread / remind / remindCustom / edit / delete` — preserving `MessageList`'s existing parent contract. Each icon has a reka-ui tooltip showing its `aria-label` (via `$t()`, single source) on **hover and keyboard focus**.
- **`MessageList.vue`** — drops ~155 lines; consumes `<MessageActions>` and keeps only the two guards it still needs for non-toolbar UI (reaction pills, thread summary). `ThreadPanel.vue`'s nested `MessageList` inherits the component with no change.
- **`EmojiPickerPopover.vue` / `MessageReminderPopover.vue`** — now accept an optional `tooltip` label and compose `Tooltip → PopoverTrigger → button` internally. This is what makes a popover-anchoring button *also* show a tooltip without the fragile double-`as-child` nesting that would otherwise swallow the click/anchor. Other consumers (e.g. `MessageReactions`) omit the prop and are unaffected.

## Design

Implements `Message Action Toolbar.dc.html` from the linked Claude Design project, matching the authoritative token spec:

- Bar: `border-border bg-background shadow-md rounded-lg p-0.5 gap-0.5`, floats `-top-4 right-3`, hairline `bg-border w-px` divider between the react/reply and forward/edit/delete clusters, `focus-within` mirrors `group-hover`.
- Buttons: `30×28` `rounded-md`, `size-3.5` glyphs, resting `text-muted-foreground` → hover `bg-muted/text-foreground`, visible keyboard focus ring (`ring-ring ring-offset-2`), delete → `destructive/10 destructive` on hover.
- **Brass**: deliberately neutral at rest/hover; brass appears only in the persistent open-state of a popover-anchored button (`bg-brass-fill text-brass-fill-foreground border-brass-border`) and the focus ring.
- Tooltips: shadcn/reka default, placement top, `sideOffset 6`, one `TooltipProvider delayDuration=300 skipDelayDuration=150`.
- Motion: bar reveal `animate-in fade-in-0 zoom-in-95 duration-100`, instant hide (no ghost bars on scroll); tooltip uses reka defaults.
- Token-only, verified in light and dark.

## Testing

- New `messageActions.test.ts` covers every guard (17 cases); full JS suite 357 passing.
- Frontend gate green: `lint:check`, `format:check`, `types:check`, `build`.
- Backend gate green: Pint, PHPStan, Rector dry-run clean, and `php artisan test --coverage --min=100` → **Total: 100.0 %**.

## Notes

While running the gate I hit a pre-existing environment issue: stale root-owned cache artifacts in the sail container's `/tmp` made Rector's bundled PHPStan fail to write its compiled DI container (permission denied), which aborted `composer test` before the coverage step. Clearing the root-owned `/tmp` cache resolved it — no code change involved. Flagging in case it recurs in CI or for other contributors.