### PR TITLE
ci: regenerate TypeScript ambient types before the frontend type check (#253)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,6 +80,13 @@ jobs:
       - name: Generate Application Key
         run: php artisan key:generate
 
+      # `resources/js/generated/generated.d.ts` (the App.Data.* / App.Enums.*
+      # ambient namespace) is a git-ignored build artifact, so a fresh checkout
+      # lacks it. Regenerate it before the type check, otherwise `vue-tsc` cannot
+      # resolve the `App` namespace pages now consume.
+      - name: Generate TypeScript Types
+        run: php artisan typescript:transform
+
       - name: Build Assets
         run: npm run build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,12 @@ Vue components must have a single root element.
 - `vue-tsc` (`npm run types:check`) doesn't use those native bindings, so it can run on the host, but prefer Sail for consistency.
 - The frontend quality gate is `./vendor/bin/sail npm run lint:check`, `format:check`, `types:check`, and `build` — all four must pass before pushing. Use `sail npm run lint` / `format` (the write variants) to auto-fix violations.
 
+## Generated TypeScript Types
+
+- **Prefer the generated `App.Data.*` / `App.Enums.*` ambient types over hand-duplicating a DTO or enum in `@/types`.** They are produced from the PHP `Data` classes and enums by `spatie/laravel-typescript-transformer` (configured in `app/Providers/TypeScriptTransformerServiceProvider.php`), so the frontend stays in lockstep with the backend shape. Example: `type CustomEmoji = App.Data.CustomEmojiData`.
+- **`resources/js/generated/generated.d.ts` is a git-ignored build artifact**, not source. Regenerate it with `./vendor/bin/sail artisan typescript:transform` after adding or changing any `Data` class or enum — otherwise `vue-tsc` fails with `TS2503: Cannot find namespace 'App'`.
+- **CI regenerates it before type-checking** (the `Generate TypeScript Types` step in `.github/workflows/tests.yml`), so a fresh checkout with no `generated.d.ts` still passes — never assume the file pre-exists.
+
 ## Automated Refactoring (Rector)
 
 - **Rector is the automated-fix layer for structural PHP**, complementing Pint (style) and PHPStan (detection). It enforces our conventions (explicit return types, type hints, readonly, early returns, dead-code removal, PHP/Laravel modernization) by rewriting the code, and its config lives in `rector.php` (scoped to the same paths PHPStan analyzes, plus `tests/`).


### PR DESCRIPTION
Fixes #253. Stacked on `feat/email-verification-flag-202` (#255) so that PR's CI goes green; the same fix also unblocks `master` and the release PR.

## Problem

`resources/js/generated/generated.d.ts` — the `App.Data.*` / `App.Enums.*` ambient namespace produced by `spatie/laravel-typescript-transformer` (`php artisan typescript:transform`) — is a **git-ignored build artifact**, and nothing in CI regenerated it. On a fresh checkout the file is absent, so the `Check Frontend Types` step fails:

```
resources/js/pages/teams/Emojis.vue(27,20): error TS2503: Cannot find namespace 'App'.
```

(It passed locally in the originating PR only because the file already existed in the dev's working tree.)

## Fix

- **`.github/workflows/tests.yml`** — new `Generate TypeScript Types` step running `php artisan typescript:transform`, placed after `Generate Application Key` and before `Build Assets` / `Check Frontend Types`.
- **`CLAUDE.md`** — new "Generated TypeScript Types" section: prefer generated `App.Data.*` / `App.Enums.*` types over hand-duplicating DTOs; `generated.d.ts` is a git-ignored artifact; regenerate after changing any `Data` class/enum; CI regenerates it before type-checking.

## Verification (matches the issue's repro)

```
rm resources/js/generated/generated.d.ts
npm run types:check   # -> TS2503: Cannot find namespace 'App'   ✗
php artisan typescript:transform
npm run types:check   # -> passes                                 ✓
```