### PR TITLE
fix(channels): secure-context-safe UUID helper for message sends (#226)

### DIFF
--- a/resources/js/composables/useMessageActions.ts
+++ b/resources/js/composables/useMessageActions.ts
@@ -21,6 +21,7 @@ import { useTranslations } from '@/composables/useTranslations';
 import { planForward } from '@/lib/forwardPlacement';
 import type { Outbox } from '@/lib/outbox';
 import { toggleReaction } from '@/lib/reactions';
+import { generateUuid } from '@/lib/uuid';
 import type { Channel, Mention, Message } from '@/types';
 import type { ForwardTarget } from '@/types/forward';
 
@@ -176,7 +177,7 @@ export function useMessageActions(
         // in flight; otherwise it would re-persist the just-sent text.
         options.cancelDraft();
 
-        const clientUuid = crypto.randomUUID();
+        const clientUuid = generateUuid();
         const target = options.replyTarget.value;
         const replyToId = target?.id ?? null;
 
@@ -338,7 +339,7 @@ export function useMessageActions(
     ): void {
         const channel = options.channel();
         const { target, note } = payload;
-        const clientUuid = crypto.randomUUID();
+        const clientUuid = generateUuid();
         const plan = planForward({ target, channel });
 
         if (plan.toCurrentChannel) {
@@ -411,7 +412,7 @@ export function useMessageActions(
         }
 
         const channel = options.channel();
-        const clientUuid = crypto.randomUUID();
+        const clientUuid = generateUuid();
         const optimistic = optimisticMessage({
             clientUuid,
             body,
@@ -477,7 +478,7 @@ export function useMessageActions(
             }).url,
             {
                 body,
-                client_uuid: crypto.randomUUID(),
+                client_uuid: generateUuid(),
                 reply_to_id: target?.id ?? null,
                 send_at: sendAt,
             },

--- a/resources/js/lib/uuid.test.ts
+++ b/resources/js/lib/uuid.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { generateUuid } from '@/lib/uuid';
+
+const UUID_V4 =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('generateUuid', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('uses crypto.randomUUID when available', () => {
+        const randomUUID = vi
+            .fn()
+            .mockReturnValue('11111111-1111-4111-8111-111111111111');
+        vi.stubGlobal('crypto', { randomUUID });
+
+        expect(generateUuid()).toBe('11111111-1111-4111-8111-111111111111');
+        expect(randomUUID).toHaveBeenCalledOnce();
+    });
+
+    it('falls back to a valid v4 UUID when crypto.randomUUID is undefined', () => {
+        vi.stubGlobal('crypto', {
+            getRandomValues: (array: Uint8Array): Uint8Array => {
+                for (let index = 0; index < array.length; index += 1) {
+                    array[index] = index;
+                }
+
+                return array;
+            },
+        });
+
+        const uuid = generateUuid();
+
+        expect(uuid).toMatch(UUID_V4);
+    });
+
+    it('produces distinct fallback values across calls', () => {
+        let seed = 0;
+        vi.stubGlobal('crypto', {
+            getRandomValues: (array: Uint8Array): Uint8Array => {
+                for (let index = 0; index < array.length; index += 1) {
+                    array[index] = (seed + index) % 256;
+                }
+
+                seed += 1;
+
+                return array;
+            },
+        });
+
+        expect(generateUuid()).not.toBe(generateUuid());
+    });
+});

--- a/resources/js/lib/uuid.ts
+++ b/resources/js/lib/uuid.ts
@@ -1,0 +1,33 @@
+/**
+ * Generate a RFC 4122 version 4 UUID.
+ *
+ * Prefers the native `crypto.randomUUID()`, which is only available in a
+ * secure context (HTTPS, or `http://localhost` / `http://127.0.0.1`). When the
+ * app is served over plain HTTP on a custom host, `crypto.randomUUID` is
+ * `undefined`, so we fall back to a `crypto.getRandomValues()`-based v4 UUID.
+ */
+export function generateUuid(): string {
+    if (typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+
+    // Set the version (4) and variant (RFC 4122) bits.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    const hex: string[] = [];
+
+    for (let index = 0; index < bytes.length; index += 1) {
+        hex.push(bytes[index].toString(16).padStart(2, '0'));
+    }
+
+    return (
+        `${hex[0]}${hex[1]}${hex[2]}${hex[3]}-` +
+        `${hex[4]}${hex[5]}-` +
+        `${hex[6]}${hex[7]}-` +
+        `${hex[8]}${hex[9]}-` +
+        `${hex[10]}${hex[11]}${hex[12]}${hex[13]}${hex[14]}${hex[15]}`
+    );
+}


### PR DESCRIPTION
## Problem

Sending a message threw `TypeError: crypto.randomUUID is not a function`, breaking message sending entirely on any non-secure-context deployment. `crypto.randomUUID()` is only exposed in a secure context (HTTPS, or `http://localhost` / `http://127.0.0.1`); served over plain HTTP on a custom host (e.g. `http://chat.example.com`), `window.crypto.randomUUID` is `undefined` and the optimistic-send path throws. Behind an HTTPS proxy the context is secure, so this only bites plain-HTTP self-hosts (small internal/LAN instances, local prod testing).

## Change

- New `generateUuid()` helper in `resources/js/lib/uuid.ts` — prefers native `crypto.randomUUID()`, falls back to a `crypto.getRandomValues()`-based RFC 4122 v4 UUID (correct version/variant bits) otherwise.
- All four `client_uuid` call sites in `resources/js/composables/useMessageActions.ts` now route through the helper. (The issue referenced `Show.vue`, but those calls have since moved into this composable; grepped the tree to confirm no other sites.)
- Vitest covers the native path, the fallback producing a valid v4 UUID, and distinct values across calls.

## Acceptance criteria

- [x] A shared UUID helper exists with a non-secure-context fallback.
- [x] All `crypto.randomUUID()` call sites use the helper.
- [x] Sending a message works when served over plain `http://<custom-host>` (the throwing call is gone).
- [x] Unit test (Vitest) covers the fallback path.

## Verification

All four frontend gates pass (`lint:check`, `format:check`, `types:check`, `build`); full JS suite green (379 tests).

Closes #226