### PR TITLE
ci: reduce GitHub Actions minutes

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - develop
-      - main
       - master
-      - workos
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,17 +4,30 @@ on:
   push:
     branches:
       - develop
-      - main
       - master
-      - workos
     tags:
       - 'v*'
+  # On PRs the image is only build-validated (never published), and an app-code
+  # change that breaks the in-image `npm run build` is already caught by tests.yml.
+  # So only rebuild on a PR when something that affects whether the image *builds*
+  # changes — the Dockerfile, its config, or the dependency manifests.
   pull_request:
     branches:
       - develop
-      - main
       - master
-      - workos
+    paths:
+      - 'Dockerfile'
+      - 'docker/**'
+      - 'docker-compose*.yml'
+      - 'composer.json'
+      - 'composer.lock'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docker.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches:
       - develop
-      - main
       - master
-      - workos
   pull_request:
     branches:
       - develop
-      - main
       - master
-      - workos
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -28,12 +28,21 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
 
-      - name: Install Dependencies
-        run: |
-          composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-          npm install
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install PHP Dependencies
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # v3.2.1
+        with:
+          composer-options: '--no-scripts'
+
+      - name: Install Node Dependencies
+        run: npm install
 
       - name: Run Pint
         run: composer lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
 
+# Serialize release runs on master but never cancel an in-flight one — cancelling
+# release-please mid-run could leave a release PR or tag half-created.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,15 +4,17 @@ on:
   push:
     branches:
       - develop
-      - main
       - master
-      - workos
   pull_request:
     branches:
       - develop
-      - main
       - master
-      - workos
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR) so we don't
+# burn Actions minutes finishing runs whose results are already stale.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -22,8 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Symfony 8 (Laravel 13) requires PHP >= 8.4, so 8.3 cannot install the locked deps.
-        php-version: ['8.4', '8.5']
+        # We develop and ship on 8.5, so CI exercises 8.5 only to keep Actions
+        # minutes down (see #260). 8.4 remains the supported composer floor via
+        # composer.json's `require`; it's just no longer tested on every run.
+        php-version: ['8.5']
 
     # The schema relies on Postgres-only defaults (gen_random_uuid()), so tests
     # run against Postgres to match the local Sail environment.
@@ -67,12 +71,17 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
+          cache: 'npm'
 
       - name: Install Node Dependencies
         run: npm i
 
+      # Caches the Composer download cache keyed on composer.lock, so unchanged
+      # dependency sets skip re-fetching packages on every run.
       - name: Install Dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # v3.2.1
+        with:
+          composer-options: '--optimize-autoloader'
 
       - name: Copy Environment File
         run: cp .env.example .env


### PR DESCRIPTION
Reduces CI Actions-minute consumption. Closes #260 and #261.

## Changes

- **Drop PHP 8.4 from the tests matrix** — the tests job now runs on PHP 8.5 only (the version we develop and ship), halving the most expensive job. 8.4 remains the supported floor via `composer.json`'s `require`; it just isn't exercised on every run. (#260)
- **Concurrency cancellation** on every workflow (`cancel-in-progress: true`) so superseded runs on the same ref stop instead of running to completion. `release-please` uses `cancel-in-progress: false` so a release is never interrupted mid-run.
- **Dependency caching** — Composer via `ramsey/composer-install` (keyed on `composer.lock`) and npm via `actions/setup-node`'s built-in cache, in both `tests.yml` and `lint.yml`.
- **Docker PR build path filter** — the build-only PR leg now runs only when the `Dockerfile`, `docker/**`, compose files, or dependency manifests change. App-code changes that could break the in-image `npm run build` are already caught by `tests.yml`, so unrelated PRs skip the expensive image build.
- **Trigger cleanup** — removed dead branches (`main`, `workos`) from all triggers; only `master`/`develop` remain. Aligned `lint.yml` to PHP 8.5.

## Trade-off

We stop exercising PHP 8.4 on every run. Acceptable given the minutes pressure; the composer floor still constrains the supported version, and 8.4 coverage can return later on a reduced trigger (nightly cron / master-only) if wanted.

## Verification

All five workflow YAML files parse cleanly. No app code changed.