### PR TITLE
fix(a11y): blocker fixes + automated-a11y tooling foundation (#266)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescri
 import prettier from 'eslint-config-prettier/flat';
 import importPlugin from 'eslint-plugin-import';
 import vue from 'eslint-plugin-vue';
+import vuejsAccessibility from 'eslint-plugin-vuejs-accessibility';
 
 const controlStatements = [
     'if',
@@ -23,6 +24,7 @@ const paddingAroundControl = [
 
 export default defineConfigWithVueTs(
     vue.configs['flat/essential'],
+    ...vuejsAccessibility.configs['flat/recommended'],
     vueTsConfigs.recommended,
     {
         plugins: {
@@ -70,6 +72,33 @@ export default defineConfigWithVueTs(
                 'error',
                 ...paddingAroundControl,
             ],
+        },
+    },
+    {
+        // Accessibility: `vuejs-accessibility/flat/recommended` is enabled above at
+        // `error`, so every currently-clean rule blocks new violations immediately.
+        // The rules below already have pre-existing violations across the shell that
+        // the a11y remediation slices burn down; they are `warn` (visible, tracked)
+        // until then, at which point each is flipped back to `error`:
+        //   - form-control-has-label / label-has-for: mostly false positives against
+        //     shadcn `<Label>` / reka-ui form composition (the control association is
+        //     established at runtime, invisible to static analysis) mixed with a few
+        //     real gaps (e.g. the composer textarea) — see #268.
+        //   - tabindex-no-positive / no-static-element-interactions /
+        //     mouse-events-have-key-events / aria-unsupported-elements: keyboard &
+        //     ARIA gaps handled in the shell (#267) and timeline/composer (#268) slices.
+        //   - no-redundant-roles: reconciled while adding list/log semantics (#268).
+        //   - no-autofocus: intentional modal/quick-switcher focus management, reviewed
+        //     alongside the focus-management work (#267).
+        rules: {
+            'vuejs-accessibility/form-control-has-label': 'warn',
+            'vuejs-accessibility/label-has-for': 'warn',
+            'vuejs-accessibility/tabindex-no-positive': 'warn',
+            'vuejs-accessibility/no-autofocus': 'warn',
+            'vuejs-accessibility/no-redundant-roles': 'warn',
+            'vuejs-accessibility/no-static-element-interactions': 'warn',
+            'vuejs-accessibility/aria-unsupported-elements': 'warn',
+            'vuejs-accessibility/mouse-events-have-key-events': 'warn',
         },
     },
     {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -296,6 +296,7 @@
   "Navigation": "Navigation",
   "New device": "Nouvel appareil",
   "New message": "Nouveau message",
+  "New message from :author: :message": "Nouveau message de :author : :message",
   "New messages": "Nouveaux messages",
   "New password": "Nouveau mot de passe",
   "New section": "Nouvelle section",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
                 "eslint-import-resolver-typescript": "^4.4.4",
                 "eslint-plugin-import": "^2.32.0",
                 "eslint-plugin-vue": "^9.32.0",
+                "eslint-plugin-vuejs-accessibility": "^2.5.0",
                 "laravel-echo": "^2.3.7",
                 "playwright": "^1.61.1",
                 "prettier": "^3.4.2",
@@ -3916,6 +3917,16 @@
                 "node": ">=10"
             }
         },
+        "node_modules/aria-query": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+            "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -6530,6 +6541,24 @@
             },
             "peerDependencies": {
                 "eslint": ">=6.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-vuejs-accessibility": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.5.0.tgz",
+            "integrity": "sha512-oZ2fL4tS91Cm/ezH3BueNP+FtpbbeS627OSqqgp9/lsN//glmoPcLBT6D53xwGocLtyBybaT99tX4ThBh8+ytA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "aria-query": "^5.3.0",
+                "vue-eslint-parser": "^9.0.0 || ^10.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+                "globals": ">= 13.12.1"
             }
         },
         "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-vue": "^9.32.0",
+        "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "laravel-echo": "^2.3.7",
         "playwright": "^1.61.1",
         "prettier": "^3.4.2",

--- a/resources/js/components/ui/sidebar/SidebarGroupAction.vue
+++ b/resources/js/components/ui/sidebar/SidebarGroupAction.vue
@@ -4,9 +4,11 @@ import type { HTMLAttributes } from "vue"
 import { Primitive } from "reka-ui"
 import { cn } from "@/lib/utils"
 
-const props = defineProps<PrimitiveProps & {
+const props = withDefaults(defineProps<PrimitiveProps & {
   class?: HTMLAttributes["class"]
-}>()
+}>(), {
+  as: "button",
+})
 </script>
 
 <template>

--- a/resources/js/composables/useMessageAnnouncer.test.ts
+++ b/resources/js/composables/useMessageAnnouncer.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import { useMessageAnnouncer } from '@/composables/useMessageAnnouncer';
+import type { Message } from '@/types';
+
+/** A message with just the fields the announcer reads. */
+function message(
+    clientUuid: string,
+    userId: string,
+    name: string,
+    body: string,
+    createdAt: string,
+): Message {
+    return {
+        clientUuid,
+        user: { id: userId, name },
+        body,
+        createdAt,
+    } as unknown as Message;
+}
+
+function withScope(messages: () => Message[], currentUserId = 'me') {
+    const scope = effectScope();
+    let announcer!: ReturnType<typeof useMessageAnnouncer>;
+
+    scope.run(() => {
+        announcer = useMessageAnnouncer({
+            messages,
+            currentUserId: () => currentUserId,
+        });
+    });
+
+    return { announcer, unmount: () => scope.stop() };
+}
+
+describe('useMessageAnnouncer', () => {
+    it('does not announce the history already present on first load', () => {
+        const { announcer } = withScope(() => [
+            message('a', 'peer', 'Bob', 'earlier', '2026-07-12T10:00:00Z'),
+            message('b', 'me', 'Me', 'mine', '2026-07-12T10:01:00Z'),
+        ]);
+
+        expect(announcer.announcement.value).toBe('');
+    });
+
+    it('announces an inbound message from another member', async () => {
+        const list = ref<Message[]>([
+            message('a', 'peer', 'Bob', 'earlier', '2026-07-12T10:00:00Z'),
+        ]);
+        const { announcer } = withScope(() => list.value);
+
+        list.value = [
+            ...list.value,
+            message('b', 'peer', 'Bob', 'hello there', '2026-07-12T10:05:00Z'),
+        ];
+        await nextTick();
+
+        expect(announcer.announcement.value).toBe(
+            'New message from Bob: hello there',
+        );
+    });
+
+    it('does not announce the viewer’s own new message', async () => {
+        const list = ref<Message[]>([
+            message('a', 'peer', 'Bob', 'earlier', '2026-07-12T10:00:00Z'),
+        ]);
+        const { announcer } = withScope(() => list.value);
+
+        list.value = [
+            ...list.value,
+            message('b', 'me', 'Me', 'my own send', '2026-07-12T10:05:00Z'),
+        ];
+        await nextTick();
+
+        expect(announcer.announcement.value).toBe('');
+    });
+
+    it('does not announce older history merged in above the pointer', async () => {
+        const list = ref<Message[]>([
+            message('c', 'peer', 'Bob', 'latest', '2026-07-12T10:05:00Z'),
+        ]);
+        const { announcer } = withScope(() => list.value);
+
+        // loadOlder prepends messages with earlier timestamps.
+        list.value = [
+            message('a', 'peer', 'Bob', 'old one', '2026-07-12T09:00:00Z'),
+            message('b', 'peer', 'Bob', 'old two', '2026-07-12T09:30:00Z'),
+            ...list.value,
+        ];
+        await nextTick();
+
+        expect(announcer.announcement.value).toBe('');
+    });
+});

--- a/resources/js/composables/useMessageAnnouncer.ts
+++ b/resources/js/composables/useMessageAnnouncer.ts
@@ -1,0 +1,75 @@
+import { ref, watch } from 'vue';
+import type { Ref } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Message } from '@/types';
+
+/**
+ * Drives a visually-hidden `aria-live="polite"` region for the message timeline.
+ *
+ * Screen readers get no signal when a broadcast message is appended, so this
+ * exposes an `announcement` string that a live region renders. It announces only
+ * *genuine inbound arrivals* — messages authored by someone other than the
+ * viewer that land at the tail of the timeline — so it never narrates the
+ * viewer's own optimistic sends, nor the block of older history that
+ * `loadOlder` prepends above the current view (which would flood the reader).
+ *
+ * @param options.messages       Getter for the rendered, chronologically sorted timeline.
+ * @param options.currentUserId  Getter for the viewing user's id.
+ */
+export function useMessageAnnouncer(options: {
+    messages: () => Message[];
+    currentUserId: () => string;
+}): { announcement: Ref<string> } {
+    const announcement = ref('');
+
+    const known = new Set<string>();
+    let latestSeen = '';
+    let seeded = false;
+
+    const rememberAll = (messages: Message[]): void => {
+        for (const message of messages) {
+            known.add(message.clientUuid);
+
+            if (message.createdAt > latestSeen) {
+                latestSeen = message.createdAt;
+            }
+        }
+    };
+
+    watch(
+        () => options.messages(),
+        (next) => {
+            // The timeline the viewer opens with is history, never announced.
+            if (!seeded) {
+                seeded = true;
+                rememberAll(next);
+
+                return;
+            }
+
+            // Genuine tail arrivals from other members, newest last. Older
+            // history merged in above the pointer (createdAt <= what we've
+            // already seen) and the viewer's own sends are never announced.
+            const inbound = next.filter(
+                (message) =>
+                    !known.has(message.clientUuid) &&
+                    message.user.id !== options.currentUserId() &&
+                    message.createdAt >= latestSeen,
+            );
+
+            const newest = inbound.at(-1);
+
+            rememberAll(next);
+
+            if (newest) {
+                announcement.value = translate(
+                    'New message from :author: :message',
+                    { author: newest.user.name, message: newest.body },
+                );
+            }
+        },
+        { immediate: true },
+    );
+
+    return { announcement };
+}

--- a/resources/js/layouts/AuthLayout.vue
+++ b/resources/js/layouts/AuthLayout.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Toaster } from '@/components/ui/sonner';
 import AuthLayout from '@/layouts/auth/AuthCardLayout.vue';
 
 const {
@@ -15,5 +16,6 @@ const {
 <template>
     <AuthLayout :title="title" :description="description" :icon="icon">
         <slot />
+        <Toaster />
     </AuthLayout>
 </template>

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -73,6 +73,7 @@ import {
     SidebarMenuItem,
     SidebarProvider,
 } from '@/components/ui/sidebar';
+import { Toaster } from '@/components/ui/sonner';
 import { adjacentSlug } from '@/composables/keyboardShortcuts';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useInitials } from '@/composables/useInitials';
@@ -1364,5 +1365,7 @@ onMounted(() => {
         </div>
 
         <OnboardingTour />
+
+        <Toaster />
     </SidebarProvider>
 </template>

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -40,6 +40,7 @@ import { useChannelRealtime } from '@/composables/useChannelRealtime';
 import { useConnectionState } from '@/composables/useConnectionState';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { useMessageActions } from '@/composables/useMessageActions';
+import { useMessageAnnouncer } from '@/composables/useMessageAnnouncer';
 import {
     optimisticMessage,
     useMessageStream,
@@ -239,6 +240,13 @@ const serverMessages = computed<Message[]>(() =>
 // patches, all merged over the server page and deduped by client uuid.
 const mainStream = useMessageStream(serverMessages);
 const displayMessages = mainStream.displayMessages;
+
+// Announce genuine inbound messages to screen readers via a polite live region;
+// the virtualized timeline itself can't be a `role="log"` (rows unmount).
+const { announcement } = useMessageAnnouncer({
+    messages: () => displayMessages.value,
+    currentUserId: () => currentUser.value.id,
+});
 const pendingUuids = mainStream.pendingUuids;
 
 const hasMessages = computed(() => displayMessages.value.length > 0);
@@ -740,6 +748,15 @@ function archive(): void {
             props.channel.isDirect ? mastheadTitle : `#${props.channel.name}`
         "
     />
+
+    <div
+        aria-live="polite"
+        aria-atomic="true"
+        class="sr-only"
+        data-test="message-announcer"
+    >
+        {{ announcement }}
+    </div>
 
     <div class="flex min-h-0 flex-1 overflow-hidden">
         <div class="flex min-w-0 flex-1 flex-col">

--- a/tests/Browser/A11yAuditTest.php
+++ b/tests/Browser/A11yAuditTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+test('the authenticated channel page has no critical accessibility violations', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // Runs axe-core (bundled with the browser plugin) against the real rendered
+    // DOM — the guard rail this a11y effort stands up. Level 0 is CRITICAL only:
+    // the shell still trips SERIOUS color-contrast on `--muted-foreground`
+    // (tracked in #269). Once that slice lands, raise this to the default SERIOUS
+    // level (1) by dropping the argument.
+    signInThroughBrowser($alice)
+        ->assertNoAccessibilityIssues(0);
+});

--- a/tests/Browser/A11yShellTest.php
+++ b/tests/Browser/A11yShellTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+test('the toast live region is mounted in the authenticated shell', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // Sonner renders its aria-live notification region only when <Toaster/> is
+    // mounted; its presence proves toasts (and their status announcements) work.
+    signInThroughBrowser($alice)
+        ->assertPresent('[data-sonner-toaster]');
+});
+
+test('the sidebar "New message" action is a keyboard-operable button', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        // A non-focusable <div> could never satisfy a `button[...]` match, so this
+        // pins the element to a real, Tab-focusable, Enter/Space-activatable button.
+        ->assertPresent('button[data-test="new-dm-trigger"]')
+        // And activating it from the keyboard opens the New Direct Message modal.
+        ->keys('@new-dm-trigger', 'Enter')
+        ->assertPresent('@new-dm-input');
+});
+
+test('the sidebar "Create channel" action is a keyboard-operable button', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->assertPresent('button[data-test="create-channel-trigger"]');
+});
+
+test('the channel timeline exposes a polite live region for inbound messages', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->assertPresent('[data-test="message-announcer"][aria-live="polite"]');
+});


### PR DESCRIPTION
Closes #266. First slice of the #57 accessibility pass — ships the functional blockers the audit surfaced and stands up the automated-a11y guard rails the later slices (#267–#269) build on.

## Blockers (were functional bugs)
- **`<Toaster>` was never mounted** — Sonner is defined but rendered nowhere, so ~30 `toast.*()` call sites (flash messages, failed sends/forwards, reminder snooze) produced **nothing on screen** and no `aria-live` status region (WCAG 4.1.3). Mounted once in `MainLayout` + `AuthLayout`.
- **Sidebar "Create channel" / "New message" weren't keyboard-operable** — `SidebarGroupAction` had dropped the `withDefaults(..., { as: "button" })` its sibling `SidebarMenuAction` keeps, rendering a non-focusable `<div>` (WCAG 2.1.1). One-line restore fixes both call sites.
- **New messages weren't announced to screen readers** — added a visually-hidden `aria-live="polite"` region driven by a new `useMessageAnnouncer` composable, scoped to *other members'* tail arrivals so the viewer's own optimistic sends and `loadOlder` history merges are never narrated (WCAG 4.1.3). The virtualized timeline can't be `role="log"` itself (rows unmount).

## Tooling foundation
- **`eslint-plugin-vuejs-accessibility`** (`flat/recommended`) wired into the existing lint gate. Clean categories stay at `error` (block new violations immediately); the 8 rules with pre-existing debt are `warn` with tracking notes, flipped back to `error` as #267/#268 remediate. Gate is green (0 errors, 87 tracked warnings).
- **axe-core browser audit** — `assertNoAccessibilityIssues()` (bundled with `pest-plugin-browser`, axe 4.10) on the authenticated channel page. Pinned to **critical** for now; the shell still trips *serious* `--muted-foreground` contrast, which **#269** fixes — then this is raised to the default *serious* level.

## Tests
- `useMessageAnnouncer` unit spec (Vitest) — history-silence, inbound announce, own-send + backfill suppression.
- `A11yShellTest` + `A11yAuditTest` (Pest browser) — Toaster live region present, sidebar triggers are keyboard-operable `<button>`s, the live region exists, and the axe guard passes.

## Gate
vitest (401) · vue-tsc · ESLint (0 errors) · Prettier · Pint · PHPStan · Rector — all green. No PHP source changed, so the 100% coverage gate is unaffected. Browser tests run in the existing `browser` CI job.

## Notes
- Part of #57. Follow-ups: #267 (shell & sidebar), #268 (timeline & composer), #269 (contrast).
- The shadcn-vue-swap directive lands in #267/#268 where the hand-rolled buttons live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)