### PR TITLE
fix(a11y): color contrast & focus indicators meet WCAG AA (#269)

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -119,20 +119,26 @@
     --secondary: #eeeade;
     --secondary-foreground: #1d1a15;
     --muted: #f0ece0;
-    --muted-foreground: #9b937f;
+    /* Secondary text (timestamps, labels, placeholders). Darkened to clear WCAG
+       AA 4.5:1 on every surface — background, card, muted, sidebar (#269). */
+    --muted-foreground: #6b6355;
     --accent: #f0ece0;
     --accent-foreground: #1d1a15;
     --destructive: hsl(0 72% 45%);
     --destructive-foreground: #f3efe4;
     --border: #e3dfd5;
     --input: #e0dbcd;
-    --ring: #c9a35c;
+    /* Focus indicator — decoupled from --brass and darkened to a bronze so the
+       ring itself clears the 3:1 non-text threshold (WCAG 2.4.7/1.4.11) on the
+       sand background; --brass keeps its lighter accent value (#269). */
+    --ring: #8a6a1f;
     --brass: #c9a35c;
     /* Ink text on a solid-brass fill (unread badges); stays ink in dark too. */
     --brass-foreground: #1d1a15;
     --brass-border: #b98e3f;
     --brass-fill: rgba(201, 163, 92, 0.14);
-    --brass-fill-foreground: #7d6023;
+    /* Reaction-pill text on the translucent brass fill — AA 4.5:1 (#269). */
+    --brass-fill-foreground: #6a521e;
     --chart-1: #c9a35c;
     --chart-2: #7d6023;
     --chart-3: #8b8370;
@@ -146,7 +152,7 @@
     --sidebar-accent: #f0ece0;
     --sidebar-accent-foreground: #1d1a15;
     --sidebar-border: #e3dfd5;
-    --sidebar-ring: #c9a35c;
+    --sidebar-ring: #8a6a1f;
     --sidebar: #fbfaf7;
     --sidebar-rail: #eeeade;
 }
@@ -163,7 +169,8 @@
     --secondary: #2a271f;
     --secondary-foreground: #f3efe4;
     --muted: #2a271f;
-    --muted-foreground: #8b8370;
+    /* Lightened to clear WCAG AA 4.5:1 on the dark muted/secondary surface (#269). */
+    --muted-foreground: #9d947e;
     --accent: #2e2a21;
     --accent-foreground: #f3efe4;
     --destructive: hsl(0 72% 55%);

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -106,7 +106,7 @@ function toggleStar(): void {
                             ? 'text-brass'
                             : channel.unreadCount > 0
                               ? 'text-muted-foreground'
-                              : 'text-muted-foreground/60'
+                              : 'text-muted-foreground'
                     "
                     >#</span
                 >

--- a/resources/js/components/ForwardMessageDialog.vue
+++ b/resources/js/components/ForwardMessageDialog.vue
@@ -245,7 +245,7 @@ function submit(): void {
                     class="mb-1 block text-[12px] font-medium text-muted-foreground"
                 >
                     {{ $t('Add a note') }}
-                    <span class="font-normal text-muted-foreground/70">{{
+                    <span class="font-normal text-muted-foreground">{{
                         $t('(optional)')
                     }}</span>
                 </label>

--- a/resources/js/components/LinkPreview.vue
+++ b/resources/js/components/LinkPreview.vue
@@ -36,7 +36,7 @@ const siteLabel = computed(
         />
         <div class="px-[15px] py-[13px]">
             <p
-                class="truncate text-[10px] font-semibold tracking-[0.08em] text-muted-foreground/70 uppercase"
+                class="truncate text-[10px] font-semibold tracking-[0.08em] text-muted-foreground uppercase"
             >
                 {{ siteLabel }}
             </p>

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -452,7 +452,7 @@ function onKeydown(event: KeyboardEvent): void {
                     data-lpignore="true"
                     data-bwignore
                     data-form-type="other"
-                    class="max-h-[200px] min-w-0 flex-1 resize-none self-center bg-transparent py-1 text-sm text-foreground outline-none placeholder:text-muted-foreground/70"
+                    class="max-h-[200px] min-w-0 flex-1 resize-none self-center bg-transparent py-1 text-sm text-foreground outline-none placeholder:text-muted-foreground"
                     @input="(resize(), refreshSuggestions(), emit('typing'))"
                     @click="refreshSuggestions"
                     @keydown="onKeydown"

--- a/resources/js/components/MessageForward.vue
+++ b/resources/js/components/MessageForward.vue
@@ -33,7 +33,7 @@ const rendered = computed(() =>
             <Forward class="size-3 shrink-0" aria-hidden="true" />
             <span v-if="channelName">
                 {{ $t('Forwarded from') }}
-                <span class="text-muted-foreground/70">#</span>{{ channelName }}
+                <span class="text-muted-foreground">#</span>{{ channelName }}
             </span>
             <span v-else>
                 {{ $t('Forwarded from a direct message') }}
@@ -45,7 +45,7 @@ const rendered = computed(() =>
             <p
                 v-if="isDeleted"
                 data-test="forward-deleted"
-                class="font-serif text-[13px] text-muted-foreground/70 italic"
+                class="font-serif text-[13px] text-muted-foreground italic"
             >
                 {{ $t('Original message was deleted') }}
             </p>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -558,7 +558,7 @@ function confirmDelete(): void {
                             </div>
                         </UserHoverCard>
                         <span
-                            class="font-mono text-[9.5px] text-muted-foreground/70"
+                            class="font-mono text-[9.5px] text-muted-foreground"
                             >{{ formatTime(item.leadCreatedAt) }}</span
                         >
                     </div>
@@ -618,7 +618,7 @@ function confirmDelete(): void {
                             <p
                                 v-if="message.isDeleted"
                                 :data-test="'message-tombstone'"
-                                class="py-0.5 font-serif text-[13.5px] text-muted-foreground/70 italic"
+                                class="py-0.5 font-serif text-[13.5px] text-muted-foreground italic"
                             >
                                 {{ $t('This message was deleted') }}
                             </p>
@@ -749,7 +749,7 @@ function confirmDelete(): void {
                                 <span
                                     v-if="message.editedAt"
                                     :data-test="'message-edited'"
-                                    class="ml-1 align-baseline text-[11px] text-muted-foreground/70 select-none"
+                                    class="ml-1 align-baseline text-[11px] text-muted-foreground select-none"
                                     >{{ $t('(edited)') }}</span
                                 >
                             </p>

--- a/resources/js/components/MessageQuote.vue
+++ b/resources/js/components/MessageQuote.vue
@@ -23,7 +23,7 @@ const preview = computed(() =>
         <span
             v-if="isDeleted"
             data-test="quote-deleted"
-            class="truncate font-serif text-muted-foreground/70 italic"
+            class="truncate font-serif text-muted-foreground italic"
         >
             {{ $t('Original message was deleted') }}
         </span>

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -179,7 +179,7 @@ function openReminders(): void {
                     @select="selectChannel(channel)"
                 >
                     <span
-                        class="shrink-0 font-semibold text-muted-foreground/70 group-data-[highlighted]:text-brass"
+                        class="shrink-0 font-semibold text-muted-foreground group-data-[highlighted]:text-brass"
                         aria-hidden="true"
                         >#</span
                     >
@@ -258,12 +258,12 @@ function openReminders(): void {
                             <span class="font-semibold text-foreground">{{
                                 result.message.user.name
                             }}</span>
-                            <span class="text-muted-foreground/70"
-                                ><span class="text-muted-foreground/50">#</span
+                            <span class="text-muted-foreground"
+                                ><span class="text-muted-foreground">#</span
                                 >{{ result.channelName }}</span
                             >
                             <span
-                                class="ml-auto shrink-0 text-[10px] text-muted-foreground/60"
+                                class="ml-auto shrink-0 text-[10px] text-muted-foreground"
                                 >{{
                                     formatTimestamp(result.message.createdAt)
                                 }}</span

--- a/resources/js/components/RemindersDialog.vue
+++ b/resources/js/components/RemindersDialog.vue
@@ -131,7 +131,7 @@ function openReminder(reminder: MessageReminder): void {
                 >
                     <section v-if="group.items.length > 0" class="space-y-2">
                         <h3
-                            class="px-1 text-[11px] font-semibold tracking-[0.08em] text-muted-foreground/70 uppercase"
+                            class="px-1 text-[11px] font-semibold tracking-[0.08em] text-muted-foreground uppercase"
                         >
                             {{ group.label }}
                         </h3>

--- a/resources/js/components/SettingsNav.vue
+++ b/resources/js/components/SettingsNav.vue
@@ -104,7 +104,7 @@ const { isCurrentOrParentUrl } = useCurrentUrl();
 
         <SidebarGroup class="pt-2">
             <div
-                class="flex h-7 items-center px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/70 uppercase"
+                class="flex h-7 items-center px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground uppercase"
             >
                 {{ $t('Settings') }}
             </div>

--- a/resources/js/components/UserHoverCard.vue
+++ b/resources/js/components/UserHoverCard.vue
@@ -108,7 +108,7 @@ function onMessage(): void {
                             >
                             <span
                                 v-if="profile?.pronouns"
-                                class="font-serif text-xs text-muted-foreground/80 italic"
+                                class="font-serif text-xs text-muted-foreground italic"
                                 >{{ profile.pronouns }}</span
                             >
                         </div>

--- a/resources/js/components/ui/command/CommandGroup.vue
+++ b/resources/js/components/ui/command/CommandGroup.vue
@@ -37,7 +37,7 @@ onUnmounted(() => {
     :class="cn('text-foreground overflow-hidden p-1', props.class)"
     :hidden="isRender ? undefined : true"
   >
-    <ListboxGroupLabel v-if="heading" data-slot="command-group-heading" class="px-2.5 pt-1.5 pb-1 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/80 uppercase">
+    <ListboxGroupLabel v-if="heading" data-slot="command-group-heading" class="px-2.5 pt-1.5 pb-1 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground uppercase">
       {{ heading }}
     </ListboxGroupLabel>
     <slot />

--- a/resources/js/components/ui/dialog/DialogScrollContent.vue
+++ b/resources/js/components/ui/dialog/DialogScrollContent.vue
@@ -48,7 +48,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
         <slot />
 
         <DialogClose
-          class="absolute top-4 right-4 p-0.5 transition-colors rounded-md hover:bg-secondary"
+          class="ring-offset-background focus:ring-ring absolute top-4 right-4 rounded-md p-0.5 transition-colors hover:bg-secondary focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
         >
           <X class="w-4 h-4" />
           <span class="sr-only">{{ $t('Close') }}</span>

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -808,7 +808,7 @@ onMounted(() => {
                             <Search class="size-[13px] shrink-0" />
                             <span>{{ $t('Jump to…') }}</span>
                             <kbd
-                                class="ml-auto font-mono text-[10px] font-semibold tracking-wide text-muted-foreground/70"
+                                class="ml-auto font-mono text-[10px] font-semibold tracking-wide text-muted-foreground"
                                 >⌘K</kbd
                             >
                         </Button>
@@ -823,7 +823,7 @@ onMounted(() => {
                             variant="ghost"
                             data-test="section-toggle-starred"
                             :aria-expanded="!isSectionCollapsed('starred')"
-                            class="flex h-7 w-full items-center justify-start gap-1 rounded-md px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/70 uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                            class="flex h-7 w-full items-center justify-start gap-1 rounded-md px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
                             @click="toggleSection('starred')"
                         >
                             <ChevronRight
@@ -881,7 +881,7 @@ onMounted(() => {
                                 :data-test="`section-custom-${group.section.id}`"
                             >
                                 <div
-                                    class="group/section flex h-7 w-full items-center gap-1 rounded-md pr-1 pl-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/70 uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                                    class="group/section flex h-7 w-full items-center gap-1 rounded-md pr-1 pl-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
                                 >
                                     <Button
                                         variant="ghost"
@@ -1043,7 +1043,7 @@ onMounted(() => {
                                     </draggable>
                                     <p
                                         v-if="group.channels.length === 0"
-                                        class="px-7 pb-1 text-[12px] text-muted-foreground/50 normal-case"
+                                        class="px-7 pb-1 text-[12px] text-muted-foreground normal-case"
                                     >
                                         {{ $t('Drag channels here') }}
                                     </p>
@@ -1060,7 +1060,7 @@ onMounted(() => {
                             variant="ghost"
                             data-test="section-toggle-channels"
                             :aria-expanded="!isSectionCollapsed('channels')"
-                            class="flex h-7 w-full items-center justify-start gap-1 rounded-md px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/70 uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                            class="flex h-7 w-full items-center justify-start gap-1 rounded-md px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
                             @click="toggleSection('channels')"
                         >
                             <ChevronRight
@@ -1163,7 +1163,7 @@ onMounted(() => {
                             variant="ghost"
                             data-test="section-toggle-direct"
                             :aria-expanded="!isSectionCollapsed('direct')"
-                            class="flex h-7 w-full items-center justify-start gap-1 rounded-md px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground/70 uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+                            class="flex h-7 w-full items-center justify-start gap-1 rounded-md px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground uppercase transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
                             @click="toggleSection('direct')"
                         >
                             <ChevronRight
@@ -1206,7 +1206,7 @@ onMounted(() => {
                             <p
                                 v-if="directList.length === 0"
                                 data-test="direct-messages-empty"
-                                class="px-2 pb-1 text-[12px] text-muted-foreground/50 normal-case"
+                                class="px-2 pb-1 text-[12px] text-muted-foreground normal-case"
                             >
                                 {{ $t('No direct messages yet') }}
                             </p>

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -154,13 +154,13 @@ function jumpHref(result: MessageSearchResult): string {
                                     <span class="font-semibold text-foreground">
                                         {{ result.message.user.name }}
                                     </span>
-                                    <span class="text-muted-foreground/70">
-                                        <span class="text-muted-foreground/50"
+                                    <span class="text-muted-foreground">
+                                        <span class="text-muted-foreground"
                                             >#</span
                                         >{{ result.channelName }}
                                     </span>
                                     <span
-                                        class="ml-auto shrink-0 text-[11px] text-muted-foreground/70"
+                                        class="ml-auto shrink-0 text-[11px] text-muted-foreground"
                                     >
                                         {{
                                             formatTimestamp(

--- a/resources/js/pages/channels/Threads.vue
+++ b/resources/js/pages/channels/Threads.vue
@@ -109,14 +109,14 @@ function formatTimestamp(iso: string): string {
                                     <span class="font-semibold text-foreground">
                                         {{ item.root.user.name }}
                                     </span>
-                                    <span class="text-muted-foreground/70">
-                                        <span class="text-muted-foreground/50"
+                                    <span class="text-muted-foreground">
+                                        <span class="text-muted-foreground"
                                             >#</span
                                         >{{ item.channelName }}
                                     </span>
                                     <span
                                         v-if="item.root.threadLastReplyAt"
-                                        class="ml-auto shrink-0 text-[11px] text-muted-foreground/70"
+                                        class="ml-auto shrink-0 text-[11px] text-muted-foreground"
                                     >
                                         {{
                                             formatTimestamp(

--- a/resources/js/theme/contrast.test.ts
+++ b/resources/js/theme/contrast.test.ts
@@ -1,0 +1,163 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the theme tokens against WCAG 2.1 AA regressions (#269).
+ *
+ * The source of truth is the shipped stylesheet: we parse the real hex values
+ * out of `resources/css/app.css` and assert independently-computed contrast
+ * ratios against the WCAG constants (4.5:1 for body text, 3:1 for focus
+ * indicators). This catches the token pairs that a rendered-DOM axe audit can't
+ * reach on a natural page — the focus ring and the reaction-pill fill — as well
+ * as `--muted-foreground`, which drives secondary text app-wide.
+ */
+
+const AA_TEXT = 4.5;
+const AA_NON_TEXT = 3; // focus indicators / non-text (WCAG 1.4.11, 2.4.7)
+
+const cssPath = fileURLToPath(new URL('../../css/app.css', import.meta.url));
+const css = readFileSync(cssPath, 'utf8');
+
+type Rgb = [number, number, number];
+
+function hexToRgb(hex: string): Rgb {
+    const h = hex.replace('#', '');
+
+    return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16)) as Rgb;
+}
+
+/** Composite a translucent foreground over an opaque background. */
+function flatten(fg: Rgb, alpha: number, bg: Rgb): Rgb {
+    return fg.map((c, i) => c * alpha + bg[i] * (1 - alpha)) as Rgb;
+}
+
+function relativeLuminance([r, g, b]: Rgb): number {
+    const channel = (v: number): number => {
+        const s = v / 255;
+
+        return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+    };
+
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+    const la = relativeLuminance(a);
+    const lb = relativeLuminance(b);
+    const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Extract the `--token: #hex;` declarations from a single rule block, keyed by
+ * token name (without the leading `--`).
+ */
+function tokensFromBlock(selector: string): Record<string, string> {
+    const block = new RegExp(`${selector}\\s*\\{([^}]*)\\}`).exec(css);
+
+    expect(block, `expected a "${selector}" block in app.css`).not.toBeNull();
+
+    const tokens: Record<string, string> = {};
+
+    for (const [, name, value] of block![1].matchAll(
+        /--([\w-]+):\s*([^;]+);/g,
+    )) {
+        tokens[name] = value.trim();
+    }
+
+    return tokens;
+}
+
+const light = tokensFromBlock(':root');
+const dark = tokensFromBlock('\\.dark');
+
+/** Alpha of the translucent `--brass-fill` (`rgba(r, g, b, A)`). */
+function fillAlpha(tokens: Record<string, string>): number {
+    const alpha = /rgba\([^)]*,\s*([\d.]+)\)/.exec(tokens['brass-fill']);
+
+    expect(alpha, 'expected --brass-fill to be an rgba() value').not.toBeNull();
+
+    return Number(alpha![1]);
+}
+
+describe('theme contrast (WCAG AA)', () => {
+    // --muted-foreground styles timestamps, placeholders, and secondary labels
+    // painted directly on these surfaces, so it must clear body-text AA on each.
+    const mutedSurfaces = [
+        'background',
+        'card',
+        'muted',
+        'secondary',
+        'popover',
+        'sidebar-background',
+    ] as const;
+
+    it.each(mutedSurfaces)(
+        'light --muted-foreground meets AA on --%s',
+        (surface) => {
+            const ratio = contrast(
+                hexToRgb(light['muted-foreground']),
+                hexToRgb(light[surface]),
+            );
+
+            expect(ratio).toBeGreaterThanOrEqual(AA_TEXT);
+        },
+    );
+
+    it.each(mutedSurfaces)(
+        'dark --muted-foreground meets AA on --%s',
+        (surface) => {
+            const ratio = contrast(
+                hexToRgb(dark['muted-foreground']),
+                hexToRgb(dark[surface]),
+            );
+
+            expect(ratio).toBeGreaterThanOrEqual(AA_TEXT);
+        },
+    );
+
+    // The focus indicator (shadcn `focus-visible:border-ring`, full opacity) has
+    // to clear the 3:1 non-text threshold against the surfaces it frames.
+    it('light --ring meets the 3:1 focus-indicator threshold on --background', () => {
+        expect(
+            contrast(hexToRgb(light['ring']), hexToRgb(light['background'])),
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+    });
+
+    it('light --sidebar-ring meets the 3:1 focus-indicator threshold on the sidebar', () => {
+        expect(
+            contrast(
+                hexToRgb(light['sidebar-ring']),
+                hexToRgb(light['sidebar-background']),
+            ),
+        ).toBeGreaterThanOrEqual(AA_NON_TEXT);
+    });
+
+    // Reaction-pill text sits on the translucent brass fill composited over the
+    // page surface; it must clear body-text AA in both themes.
+    it('light --brass-fill-foreground meets AA on the reaction pill', () => {
+        const pill = flatten(
+            hexToRgb(light['brass'] ?? light['ring']),
+            fillAlpha(light),
+            hexToRgb(light['background']),
+        );
+
+        expect(
+            contrast(hexToRgb(light['brass-fill-foreground']), pill),
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+    });
+
+    it('dark --brass-fill-foreground meets AA on the reaction pill', () => {
+        const pill = flatten(
+            hexToRgb(dark['brass'] ?? light['brass']),
+            fillAlpha(dark),
+            hexToRgb(dark['background']),
+        );
+
+        expect(
+            contrast(hexToRgb(dark['brass-fill-foreground']), pill),
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+    });
+});

--- a/resources/js/theme/designTokens.test.ts
+++ b/resources/js/theme/designTokens.test.ts
@@ -36,7 +36,8 @@ describe('"The Desk" design foundation', () => {
             ['--foreground', '#1d1a15'],
             ['--primary', '#1d1a15'],
             ['--primary-foreground', '#f3efe4'],
-            ['--muted-foreground', '#9b937f'],
+            // Darkened to clear WCAG AA on every surface (#269).
+            ['--muted-foreground', '#6b6355'],
             ['--border', '#e3dfd5'],
         ])('maps %s to the warm value %s', (property, value) => {
             expect(tokenValue(':root', property)).toBe(value);
@@ -49,7 +50,8 @@ describe('"The Desk" design foundation', () => {
             ['--card', '#1e1b15'],
             ['--foreground', '#f3efe4'],
             ['--primary', '#f3efe4'],
-            ['--muted-foreground', '#8b8370'],
+            // Lightened to clear WCAG AA on the dark muted surface (#269).
+            ['--muted-foreground', '#9d947e'],
             ['--border', '#2e2a21'],
         ])('maps %s to the warm value %s', (property, value) => {
             expect(tokenValue('.dark', property)).toBe(value);
@@ -67,7 +69,7 @@ describe('"The Desk" design foundation', () => {
                 'rgba(201, 163, 92, 0.14)',
             );
             expect(tokenValue(':root', '--brass-fill-foreground')).toBe(
-                '#7d6023',
+                '#6a521e',
             );
         });
 

--- a/tests/Browser/A11yAuditTest.php
+++ b/tests/Browser/A11yAuditTest.php
@@ -2,14 +2,29 @@
 
 declare(strict_types=1);
 
-test('the authenticated channel page has no critical accessibility violations', function (): void {
+test('the authenticated channel page has no serious accessibility violations in either theme', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 
     // Runs axe-core (bundled with the browser plugin) against the real rendered
-    // DOM — the guard rail this a11y effort stands up. Level 0 is CRITICAL only:
-    // the shell still trips SERIOUS color-contrast on `--muted-foreground`
-    // (tracked in #269). Once that slice lands, raise this to the default SERIOUS
-    // level (1) by dropping the argument.
-    signInThroughBrowser($alice)
-        ->assertNoAccessibilityIssues(0);
+    // DOM — the guard rail this a11y effort stands up. The default level is
+    // SERIOUS (1), which keeps critical + serious violations; color-contrast
+    // failures surface here, so a clean run proves the WCAG AA contrast fixes
+    // (#269) hold against the shipped theme tokens.
+    $page = signInThroughBrowser($alice)
+        ->assertNoAccessibilityIssues();
+
+    // Re-audit against the dark palette. Persist 'dark' to localStorage — the
+    // source of truth `useAppearance` reads — before applying the `.dark` class,
+    // otherwise the appearance controller re-resolves 'system' → light and
+    // reverts the toggle mid-audit. The settle lets that recompute finish.
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
 });


### PR DESCRIPTION
Part of the accessibility pass (#57). Fixes color-contrast and focus-indicator failures against **WCAG 2.1 AA in both themes**. Closes #269.

## What changed

### Theme tokens (`resources/css/app.css`)
| Token | Theme | From → To | Why |
|---|---|---|---|
| `--muted-foreground` | light | `#9b937f` → `#6b6355` | ≥4.67:1 on every surface (was ~2.4–3.0) |
| `--muted-foreground` | dark | `#8b8370` → `#9d947e` | ≥4.95:1 on the dark muted surface (was 3.96) |
| `--ring` + `--sidebar-ring` | light | `#c9a35c` → `#8a6a1f` | focus indicator clears 3:1 vs the sand background (was 1.86) |
| `--brass-fill-foreground` | light | `#7d6023` → `#6a521e` | reaction-pill text ≥4.5:1 |

`--brass` keeps its accent value `#c9a35c` — only the **focus ring** decoupled and darkened, so the brand accent is unchanged.

### Stop stacking opacity on the muted token
`text-muted-foreground/{50,60,70,80}` on body-sized text can't reach 4.5:1 for any token value (even pure black `/50` tops out at 3.96), so the modifiers are removed across the authenticated app (MainLayout, channel/DM list items, message list & composer, quick switcher, search, threads, reminders, forward, dialogs). The base token is now AA-compliant, so this is just dropping the `/NN`.

- **Icon-only** usages (size-4/5 SVG buttons, drag handles, size-3 notification cues) are left as-is — non-text, so axe's color-contrast rule doesn't flag them.
- The public **marketing** `Welcome.vue` sweep is deferred to **#274** (large display text needs per-size auditing).

### Focus ring
`DialogScrollContent`'s close button gains the same `focus:ring-ring focus:ring-2 focus:ring-offset-2` as `DialogContent`.

## Tests
- **`A11yAuditTest`** now audits the channel page at the default **serious** level (was critical-only, `assertNoAccessibilityIssues(0)`) in **both themes** — proves the contrast fixes hold in the real rendered DOM. Dark is exercised by persisting `appearance=dark` to localStorage (the source of truth `useAppearance` reads) before toggling `.dark`, so the appearance controller doesn't revert it mid-audit.
- **`theme/contrast.test.ts`** (new, Vitest node) parses `app.css` and asserts WCAG ratios (4.5 text / 3.0 focus) for the token pairs axe can't reach on a natural page — the focus ring and the reaction-pill fill — plus `--muted-foreground` on all its surfaces, both themes.
- **`designTokens.test.ts`** updated to the new palette values.

## Verification
- `composer test` — Pint ✓, PHPStan 0 errors, Rector 0 changes, Pest 813 tests (0 failed), coverage **100.0%**
- `npm run lint:check` / `format:check` / `types:check` / `build` ✓; `test:js` 417 ✓
- Browser a11y suite (audit + shell + sidebar controls) 13/13 ✓

## Follow-ups filed
- **#274** — marketing `Welcome.vue` opacity sweep + optional non-text icon contrast

Refs #57.