### PR TITLE
fix(a11y): unread affordance & marketing-page contrast meet WCAG AA (#278, #274)

### DIFF
--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -502,7 +502,7 @@ function confirmDelete(): void {
                     />
                     <span
                         aria-hidden="true"
-                        class="font-serif text-[13px] text-brass-border italic"
+                        class="font-serif text-[13px] text-brass-fill-foreground italic"
                     >
                         {{ $t('new') }}
                     </span>

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -154,32 +154,31 @@ const getStartedUrl = computed(() =>
                         >
                             Jump to&hellip;
                             <span
-                                class="ml-auto font-mono text-[9px] font-semibold text-muted-foreground/70"
+                                class="ml-auto font-mono text-[9px] font-semibold text-muted-foreground"
                                 >&#8984;K</span
                             >
                         </div>
 
                         <span
-                            class="px-1.5 py-1 text-[10px] font-bold tracking-[0.1em] text-muted-foreground/70 uppercase"
+                            class="px-1.5 py-1 text-[10px] font-bold tracking-[0.1em] text-muted-foreground uppercase"
                             >Starred</span
                         >
                         <div
                             class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] text-foreground/70"
                         >
                             <span class="text-brass">&#9733;</span>
-                            <span class="text-muted-foreground/70">#</span
-                            >general
+                            <span class="text-muted-foreground">#</span>general
                         </div>
 
                         <span
-                            class="mt-2 px-1.5 py-1 text-[10px] font-bold tracking-[0.1em] text-muted-foreground/70 uppercase"
+                            class="mt-2 px-1.5 py-1 text-[10px] font-bold tracking-[0.1em] text-muted-foreground uppercase"
                             >Channels</span
                         >
                         <div class="flex flex-col gap-px">
                             <div
                                 class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] font-semibold"
                             >
-                                <span class="text-muted-foreground/80">#</span
+                                <span class="text-muted-foreground">#</span
                                 >announcements
                                 <span
                                     class="ml-auto flex h-4 min-w-[17px] items-center justify-center rounded-full bg-brass px-1.5 text-[9.5px] font-bold text-brass-foreground"
@@ -189,7 +188,7 @@ const getStartedUrl = computed(() =>
                             <div
                                 class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] text-foreground/70"
                             >
-                                <span class="text-muted-foreground/70">#</span
+                                <span class="text-muted-foreground">#</span
                                 >leadership
                             </div>
                             <div
@@ -200,7 +199,7 @@ const getStartedUrl = computed(() =>
                             <div
                                 class="flex h-7 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] text-foreground/70"
                             >
-                                <span class="text-muted-foreground/70">#</span
+                                <span class="text-muted-foreground">#</span
                                 >support
                             </div>
                         </div>
@@ -305,7 +304,7 @@ const getStartedUrl = computed(() =>
                                     ></span>
                                 </div>
                                 <span
-                                    class="font-mono text-[9px] text-muted-foreground/70"
+                                    class="font-mono text-[9px] text-muted-foreground"
                                     >9:14</span
                                 >
                             </div>
@@ -365,7 +364,7 @@ const getStartedUrl = computed(() =>
                                 class="h-px flex-1 bg-gradient-to-r from-transparent to-brass-border"
                             ></span>
                             <span
-                                class="font-serif text-xs text-brass-border italic"
+                                class="font-serif text-xs text-brass-fill-foreground italic"
                                 >new</span
                             >
                             <span
@@ -384,7 +383,7 @@ const getStartedUrl = computed(() =>
                                     JW
                                 </div>
                                 <span
-                                    class="font-mono text-[9px] text-muted-foreground/70"
+                                    class="font-mono text-[9px] text-muted-foreground"
                                     >10:41</span
                                 >
                             </div>
@@ -410,7 +409,7 @@ const getStartedUrl = computed(() =>
                             class="mt-1.5 mb-1 flex items-center justify-end gap-1.5"
                         >
                             <span
-                                class="font-serif text-[10.5px] text-muted-foreground/70 italic"
+                                class="font-serif text-[10.5px] text-muted-foreground italic"
                                 >Seen by</span
                             >
                             <span class="flex">
@@ -492,7 +491,7 @@ const getStartedUrl = computed(() =>
                             <div class="flex items-baseline gap-1.5">
                                 <span class="text-xs font-bold">Maya Chen</span>
                                 <span
-                                    class="font-mono text-[9px] text-muted-foreground/70"
+                                    class="font-mono text-[9px] text-muted-foreground"
                                     >9:14</span
                                 >
                             </div>
@@ -516,7 +515,7 @@ const getStartedUrl = computed(() =>
                                         >Jonas Weber</span
                                     >
                                     <span
-                                        class="font-mono text-[9px] text-muted-foreground/70"
+                                        class="font-mono text-[9px] text-muted-foreground"
                                         >10:44</span
                                     >
                                 </div>
@@ -541,7 +540,7 @@ const getStartedUrl = computed(() =>
                                         >Priya Nair</span
                                     >
                                     <span
-                                        class="font-mono text-[9px] text-muted-foreground/70"
+                                        class="font-mono text-[9px] text-muted-foreground"
                                         >10:52</span
                                     >
                                 </div>
@@ -563,12 +562,11 @@ const getStartedUrl = computed(() =>
                         <div
                             class="flex items-center gap-2 rounded-full border border-input bg-card py-1.5 pr-1.5 pl-3.5"
                         >
-                            <span
-                                class="flex-1 text-xs text-muted-foreground/70"
+                            <span class="flex-1 text-xs text-muted-foreground"
                                 >Reply&hellip;</span
                             >
                             <span
-                                class="flex size-[26px] items-center justify-center rounded-full bg-muted text-muted-foreground/70"
+                                class="flex size-[26px] items-center justify-center rounded-full bg-muted text-muted-foreground"
                                 >&uarr;</span
                             >
                         </div>

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -810,7 +810,7 @@ function archive(): void {
                             v-if="showJumpToUnread"
                             type="button"
                             data-test="jump-to-unread"
-                            class="absolute top-2.5 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-rose-500 px-3 py-1 text-[12px] font-semibold text-white shadow-md hover:bg-rose-600"
+                            class="absolute top-2.5 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-rose-600 px-3 py-1 text-[12px] font-semibold text-white shadow-md hover:bg-rose-700"
                             @click="scrollToUnread"
                         >
                             <ArrowUp class="size-3.5" />

--- a/resources/js/theme/contrast.test.ts
+++ b/resources/js/theme/contrast.test.ts
@@ -160,4 +160,36 @@ describe('theme contrast (WCAG AA)', () => {
             contrast(hexToRgb(dark['brass-fill-foreground']), pill),
         ).toBeGreaterThanOrEqual(AA_TEXT);
     });
+
+    // The unread "new" divider text (MessageList) also paints --brass-fill-foreground,
+    // but as opaque text straight on the channel surface — `--card` on desktop,
+    // `--background` on the mobile full-bleed pane. It replaced --brass-border,
+    // which measured 2.94:1 (#278); lock the surfaces it renders on so the brass
+    // debt can't creep back. The channel axe audit can't guard it: to stay scoped
+    // to #268 it seeds a *read* message, so the divider never renders there.
+    const dividerSurfaces = ['card', 'background'] as const;
+
+    it.each(dividerSurfaces)(
+        'light unread-divider text (--brass-fill-foreground) meets AA on --%s',
+        (surface) => {
+            expect(
+                contrast(
+                    hexToRgb(light['brass-fill-foreground']),
+                    hexToRgb(light[surface]),
+                ),
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+        },
+    );
+
+    it.each(dividerSurfaces)(
+        'dark unread-divider text (--brass-fill-foreground) meets AA on --%s',
+        (surface) => {
+            expect(
+                contrast(
+                    hexToRgb(dark['brass-fill-foreground']),
+                    hexToRgb(dark[surface]),
+                ),
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+        },
+    );
 });

--- a/tests/Browser/A11yAuditTest.php
+++ b/tests/Browser/A11yAuditTest.php
@@ -51,3 +51,67 @@ test('the authenticated channel page has no serious accessibility violations in 
     $page->wait(0.5)
         ->assertNoAccessibilityIssues();
 });
+
+test('the unread jump-to-unread pill has no serious accessibility violations in either theme', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    // Seed one read message to anchor Alice's read pointer, then a long run of
+    // unread ones. On mount the timeline auto-scrolls to the newest message, so
+    // the unread boundary lands far above the rendered window — the state that
+    // surfaces the floating "New messages" jump pill (`showJumpToUnread`). Its
+    // white-on-rose fill carried known contrast debt (#278) and, unlike the
+    // divider token, isn't a theme variable the CSS-parse contrast spec can
+    // reach — so a rendered axe pass is the only guard for the darkened pill.
+    $read = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $bob->id,
+        'body' => 'Anchor message',
+        'created_at' => now()->subMinutes(41),
+    ]);
+
+    foreach (range(1, 40) as $i) {
+        Message::factory()->create([
+            'channel_id' => $channel->id,
+            'user_id' => $bob->id,
+            'body' => "Unread message {$i}",
+            'created_at' => now()->subMinutes(41 - $i),
+        ]);
+    }
+
+    $alice->channels()->updateExistingPivot($channel->id, [
+        'last_read_message_id' => $read->id,
+    ]);
+
+    $page = signInThroughBrowser($alice)
+        ->assertSee('Anchor message');
+
+    // The channel opens anchored on the unread divider, which keeps the pill
+    // hidden (the boundary is on-screen). Scroll the message-history region to the
+    // bottom so the virtualizer drops the divider off the top of its window — the
+    // exact condition (`dividerIndex < startIndex`) that reveals the jump pill.
+    $page->script(<<<'JS'
+    () => {
+        const region = document.querySelector('[role="region"]');
+        region.scrollTop = region.scrollHeight;
+        region.dispatchEvent(new Event('scroll'));
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertPresent('[data-test="jump-to-unread"]')
+        ->assertNoAccessibilityIssues();
+
+    // Re-audit the pill against the dark palette (see the sibling test for why the
+    // localStorage write must precede the `.dark` class).
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertPresent('[data-test="jump-to-unread"]')
+        ->assertNoAccessibilityIssues();
+});

--- a/tests/Browser/A11yMarketingTest.php
+++ b/tests/Browser/A11yMarketingTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+test('the public marketing page has no serious accessibility violations in either theme', function (): void {
+    // The page root fades in over `duration-700` (`starting:opacity-0`). Auditing
+    // before it settles reads every colour composited over the backdrop mid-fade,
+    // manufacturing contrast failures — let the entrance finish first so axe sees
+    // the opaque, shipped colours.
+    $page = visit('/')
+        ->assertSee('The Desk')
+        ->wait(0.9)
+        ->assertNoAccessibilityIssues();
+
+    // Re-audit against the dark palette. Persist 'dark' to localStorage — the
+    // source of truth `useAppearance` reads — before applying the `.dark` class,
+    // otherwise the appearance controller re-resolves 'system' → light and reverts
+    // the toggle mid-audit. The settle lets that recompute finish.
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});


### PR DESCRIPTION
Closes #278, closes #274. Refs #57.

Closes out the **"Contrast meets WCAG AA in both themes"** criterion of the accessibility pass (#57). Both fixes were found by extending the browser axe audit beyond the states #269's empty-state audit reached.

## #278 — message-timeline unread affordances
Two failures that only render when there are **unread** messages:
- **Jump-to-unread pill** (`channels/Show.vue`): white text on `bg-rose-500` measured **3.72:1** → darkened to `rose-600` (hover `rose-700`) for AA 4.5:1.
- **Unread "new" divider text** (`MessageList.vue`): `text-brass-border` measured **2.94:1** → `text-brass-fill-foreground` (the AA brass token from #269).

**Guards:**
- New `A11yAuditTest` case seeds an unread timeline and scrolls the history region to the bottom so the virtualizer surfaces the jump pill, then runs axe in **both themes**. The pill's rose fill is a Tailwind palette colour, not a theme token, so a rendered axe pass is its only guard — confirmed red at rose-500 (3.72:1), green at rose-600.
- `contrast.test.ts` locks `--brass-fill-foreground` on the `--card`/`--background` surfaces the divider paints on, both themes (the divider is aria-hidden and the #268 audit seeds a *read* message, so axe never reaches it there).

## #274 — marketing Welcome.vue
- Dropped every sub-AA `text-muted-foreground/{70,80}` opacity modifier (2.2–3.0:1); the base token is already AA after #269. Fixed the preview's `text-brass-border` "new" divider the same way as the app.
- New `A11yMarketingTest` audits the public landing page in **both themes**. It waits for the 700ms `starting:opacity-0` entrance fade to settle first — otherwise axe reads every colour composited over the backdrop mid-fade and manufactures failures. Confirmed the *settled* audit is red on the genuine defects only; `foreground/NN` avatar initials clear AA at full opacity and are left unchanged.

## Modal / dialog assessment (the other two #57 criteria)
Audited every dialog/popover for keyboard operability + ARIA. The **shadcn/reka `Dialog`/`Popover` primitives already cover the surface** — schedule, scheduled-list, forward, reminders, delete-confirm, quick-switcher, and all team/channel modals inherit name + description + focus-trap + Escape + focus-return for free. **No blanket dialog slice is warranted.** Two overlays bypass the primitives (emoji picker grid via `vue3-emoji-picker`; the hand-rolled `OnboardingTour`) — filed as a narrow follow-up in #282 rather than fixed inline.

## Verification
- Frontend gate: `lint:check`, `format:check`, `types:check`, `build`, `build:ssr` — all green; Vitest 427/427.
- Backend gate: Pint, Rector dry-run, PHPStan (new tests clean) — all green. No app PHP changed, so coverage is unaffected.
- Browser a11y suite: 9/9 green against built assets (`A11yAuditTest`, `A11yMarketingTest`, `A11yTimelineTest`).

No new user-facing strings (the `new`/`New messages` keys already exist), so no `lang/fr.json` changes.