### PR TITLE
fix(security): back active sessions with a driver-agnostic index (#287)

### DIFF
--- a/app/Data/SessionData.php
+++ b/app/Data/SessionData.php
@@ -2,6 +2,7 @@
 
 namespace App\Data;
 
+use App\Support\SessionRegistry;
 use App\Support\UserAgentParser;
 use Illuminate\Support\Carbon;
 use Spatie\LaravelData\Data;
@@ -20,19 +21,21 @@ class SessionData extends Data
     ) {}
 
     /**
-     * Build the DTO from a raw `sessions` table row.
+     * Build the DTO from a {@see SessionRegistry} index entry.
+     *
+     * @param  array{id: string, ip_address: ?string, user_agent: ?string, last_activity: int}  $session
      */
-    public static function fromSession(\stdClass $session, string $currentSessionId): self
+    public static function fromRegistry(array $session, string $currentSessionId): self
     {
-        $agent = UserAgentParser::parse($session->user_agent);
+        $agent = UserAgentParser::parse($session['user_agent']);
 
         return new self(
-            id: $session->id,
-            ipAddress: $session->ip_address,
+            id: $session['id'],
+            ipAddress: $session['ip_address'],
             browser: $agent['browser'],
             platform: $agent['platform'],
-            lastActive: Carbon::createFromTimestamp((int) $session->last_activity)->toIso8601String(),
-            isCurrentDevice: $session->id === $currentSessionId,
+            lastActive: Carbon::createFromTimestamp($session['last_activity'])->toIso8601String(),
+            isCurrentDevice: $session['id'] === $currentSessionId,
         );
     }
 }

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -10,8 +10,8 @@ use App\Http\Requests\Settings\PasswordUpdateRequest;
 use App\Http\Requests\Settings\TwoFactorAuthenticationRequest;
 use App\Models\SecurityEvent;
 use App\Support\SecurityEventRecorder;
+use App\Support\SessionRegistry;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -26,11 +26,11 @@ class SecurityController extends Controller
     /**
      * Show the user's security settings page.
      */
-    public function edit(TwoFactorAuthenticationRequest $request): Response
+    public function edit(TwoFactorAuthenticationRequest $request, SessionRegistry $registry): Response
     {
         $props = [
             'passwordRules' => Password::defaults()->toPasswordRulesString(),
-            'sessions' => $this->activeSessions($request),
+            'sessions' => $this->activeSessions($request, $registry),
             'securityEvents' => $this->recentSecurityEvents($request),
         ];
 
@@ -57,15 +57,12 @@ class SecurityController extends Controller
      *
      * @return array<int, SessionData>
      */
-    private function activeSessions(TwoFactorAuthenticationRequest $request): array
+    private function activeSessions(TwoFactorAuthenticationRequest $request, SessionRegistry $registry): array
     {
         $currentSessionId = $request->session()->getId();
 
-        return DB::table('sessions')
-            ->where('user_id', $request->user()->id)
-            ->orderByDesc('last_activity')
-            ->get()
-            ->map(fn (\stdClass $session): SessionData => SessionData::fromSession($session, $currentSessionId))
+        return collect($registry->all($request->user()->id))
+            ->map(fn (array $session): SessionData => SessionData::fromRegistry($session, $currentSessionId))
             ->sortByDesc('isCurrentDevice')
             ->values()
             ->all();

--- a/app/Http/Controllers/Settings/SessionController.php
+++ b/app/Http/Controllers/Settings/SessionController.php
@@ -6,39 +6,42 @@ namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\SessionRevokeRequest;
+use App\Support\SessionRegistry;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 
 class SessionController extends Controller
 {
+    public function __construct(private readonly SessionRegistry $registry) {}
+
     /**
      * Revoke a single session, protecting the request's own session.
+     *
+     * A success toast is shown only when a session was actually revoked, so a
+     * no-op revocation (an already-expired or unknown session) stays silent.
      */
     public function destroy(SessionRevokeRequest $request, string $session): RedirectResponse
     {
-        DB::table('sessions')
-            ->where('user_id', $request->user()->id)
-            ->where('id', $session)
-            ->where('id', '!=', $request->session()->getId())
-            ->delete();
-
-        Inertia::flash('toast', ['type' => 'success', 'message' => __('Session revoked.')]);
+        if ($session !== $request->session()->getId()
+            && $this->registry->forget($request->user()->id, $session)) {
+            Inertia::flash('toast', ['type' => 'success', 'message' => __('Session revoked.')]);
+        }
 
         return back();
     }
 
     /**
      * Revoke every session for the user except the request's own session.
+     *
+     * A success toast is shown only when at least one other session was revoked.
      */
     public function destroyOthers(SessionRevokeRequest $request): RedirectResponse
     {
-        DB::table('sessions')
-            ->where('user_id', $request->user()->id)
-            ->where('id', '!=', $request->session()->getId())
-            ->delete();
+        $revoked = $this->registry->forgetOthers($request->user()->id, $request->session()->getId());
 
-        Inertia::flash('toast', ['type' => 'success', 'message' => __('Logged out of your other devices.')]);
+        if ($revoked > 0) {
+            Inertia::flash('toast', ['type' => 'success', 'message' => __('Logged out of your other devices.')]);
+        }
 
         return back();
     }

--- a/app/Http/Middleware/TrackActiveSession.php
+++ b/app/Http/Middleware/TrackActiveSession.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Support\SessionRegistry;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Keeps the per-user {@see SessionRegistry} index in step with real requests and
+ * enforces revocation.
+ *
+ * On every authenticated request it records the current session (registering the
+ * device the first time it is seen and refreshing its activity thereafter). When
+ * a session's own id is present in the index it is left signed in; when that id
+ * has been removed from another device — i.e. revoked — the request is logged out
+ * and bounced to the login screen, so a revoked session can no longer make
+ * authenticated requests regardless of the configured session driver.
+ */
+class TrackActiveSession
+{
+    /**
+     * The session key recording the id this session was last indexed under.
+     */
+    private const string MARKER = 'active_session_id';
+
+    public function __construct(private readonly SessionRegistry $registry) {}
+
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user === null || ! $request->hasSession()) {
+            return $next($request);
+        }
+
+        $session = $request->session();
+        $sessionId = $session->getId();
+        $userId = (string) $user->getAuthIdentifier();
+        $registeredId = $session->get(self::MARKER);
+
+        if ($registeredId !== $sessionId) {
+            // A fresh login, or the session id was regenerated: move any prior
+            // index entry onto the current id and register this device.
+            if (is_string($registeredId)) {
+                $this->registry->forget($userId, $registeredId);
+            }
+
+            $this->track($request, $userId, $sessionId);
+            $session->put(self::MARKER, $sessionId);
+
+            return $next($request);
+        }
+
+        if (! $this->registry->has($userId, $sessionId)) {
+            // This session was revoked from another device.
+            Auth::guard()->logout();
+            $session->invalidate();
+            $session->regenerateToken();
+
+            return redirect()->guest(route('login'));
+        }
+
+        $this->track($request, $userId, $sessionId);
+
+        return $next($request);
+    }
+
+    /**
+     * Record the current session's activity in the index.
+     */
+    private function track(Request $request, string $userId, string $sessionId): void
+    {
+        $this->registry->record($userId, $sessionId, $request->ip(), $request->userAgent());
+    }
+}

--- a/app/Listeners/RecordSecurityEvents.php
+++ b/app/Listeners/RecordSecurityEvents.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Enums\SecurityEventType;
 use App\Support\SecurityEventRecorder;
+use App\Support\SessionRegistry;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Events\PasswordReset;
@@ -20,7 +21,10 @@ use Laravel\Fortify\Events\TwoFactorAuthenticationEnabled;
  */
 class RecordSecurityEvents
 {
-    public function __construct(private readonly SecurityEventRecorder $recorder) {}
+    public function __construct(
+        private readonly SecurityEventRecorder $recorder,
+        private readonly SessionRegistry $registry,
+    ) {}
 
     /**
      * Handle a successful sign in.
@@ -38,6 +42,8 @@ class RecordSecurityEvents
         if ($event->user === null) {
             return;
         }
+
+        $this->registry->forget((string) $event->user->getAuthIdentifier(), session()->getId());
 
         $this->recorder->record($event->user, SecurityEventType::LoggedOut);
     }

--- a/app/Support/SessionRegistry.php
+++ b/app/Support/SessionRegistry.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+/**
+ * An owned, per-user index of active sessions.
+ *
+ * The configured session store (Redis) keeps each session payload under its own
+ * key with no way to enumerate a single user's sessions, so device management
+ * (listing and revocation) is backed by this index instead. It lives in the
+ * application cache — Redis in production, the array store under tests — which
+ * makes it independent of `SESSION_DRIVER`: the list and revocation reflect
+ * reality regardless of where session payloads are stored.
+ *
+ * Entries are pruned whenever the index is read or written: any session whose
+ * last activity is older than the session lifetime is dropped, and the whole
+ * index expires from the cache once the user has been inactive that long.
+ *
+ * @phpstan-type SessionMeta array{ip_address: ?string, user_agent: ?string, last_activity: int}
+ */
+class SessionRegistry
+{
+    public function __construct(private readonly Cache $cache) {}
+
+    /**
+     * Record — or refresh the activity of — a session for the given user.
+     */
+    public function record(string $userId, string $sessionId, ?string $ipAddress, ?string $userAgent, ?int $lastActivity = null): void
+    {
+        $sessions = $this->load($userId);
+
+        $sessions[$sessionId] = [
+            'ip_address' => $ipAddress,
+            'user_agent' => $userAgent,
+            'last_activity' => $lastActivity ?? now()->getTimestamp(),
+        ];
+
+        $this->save($userId, $sessions);
+    }
+
+    /**
+     * List the user's active sessions, most recently active first.
+     *
+     * @return array<int, array{id: string, ip_address: ?string, user_agent: ?string, last_activity: int}>
+     */
+    public function all(string $userId): array
+    {
+        return collect($this->load($userId))
+            ->map(fn (array $meta, string $id): array => ['id' => $id, ...$meta])
+            ->sortByDesc('last_activity')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Determine whether the given session is still active for the user.
+     */
+    public function has(string $userId, string $sessionId): bool
+    {
+        return array_key_exists($sessionId, $this->load($userId));
+    }
+
+    /**
+     * Revoke a single session, returning whether it was present.
+     */
+    public function forget(string $userId, string $sessionId): bool
+    {
+        $sessions = $this->load($userId);
+
+        if (! array_key_exists($sessionId, $sessions)) {
+            return false;
+        }
+
+        unset($sessions[$sessionId]);
+        $this->save($userId, $sessions);
+
+        return true;
+    }
+
+    /**
+     * Revoke every session except the one to keep, returning the number removed.
+     */
+    public function forgetOthers(string $userId, string $keepSessionId): int
+    {
+        $sessions = $this->load($userId);
+
+        $removed = 0;
+
+        foreach (array_keys($sessions) as $id) {
+            if ($id !== $keepSessionId) {
+                unset($sessions[$id]);
+                $removed++;
+            }
+        }
+
+        if ($removed > 0) {
+            $this->save($userId, $sessions);
+        }
+
+        return $removed;
+    }
+
+    /**
+     * Read the user's index, dropping entries older than the session lifetime.
+     *
+     * @return array<string, SessionMeta>
+     */
+    private function load(string $userId): array
+    {
+        /** @var array<string, SessionMeta> $sessions */
+        $sessions = $this->cache->get($this->key($userId), []);
+
+        $threshold = now()->subMinutes($this->lifetime())->timestamp;
+
+        return array_filter($sessions, fn (array $meta): bool => $meta['last_activity'] >= $threshold);
+    }
+
+    /**
+     * Persist the user's index, or forget it entirely when empty.
+     *
+     * @param  array<string, SessionMeta>  $sessions
+     */
+    private function save(string $userId, array $sessions): void
+    {
+        if ($sessions === []) {
+            $this->cache->forget($this->key($userId));
+
+            return;
+        }
+
+        $this->cache->put($this->key($userId), $sessions, now()->addMinutes($this->lifetime()));
+    }
+
+    /**
+     * The cache key holding a user's session index.
+     */
+    private function key(string $userId): string
+    {
+        return "active-sessions:{$userId}";
+    }
+
+    /**
+     * The session lifetime in minutes, floored at one.
+     */
+    private function lifetime(): int
+    {
+        return max((int) config('session.lifetime'), 1);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\SetTeamUrlDefaults;
+use App\Http\Middleware\TrackActiveSession;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -30,6 +31,7 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
             SetTeamUrlDefaults::class,
+            TrackActiveSession::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/docs/src/content/docs/reference/architecture.md
+++ b/docs/src/content/docs/reference/architecture.md
@@ -39,6 +39,11 @@ Cache, session, and the queue all use the **Redis** driver
 `REDIS_HOST=redis`). Broadcasting uses **Reverb**. Redis persists to a named
 volume with `appendonly` enabled, so queued jobs survive a restart.
 
+The **Active sessions** panel (Security settings) — listing signed-in devices
+and revoking them — is backed by an owned per-user session index kept in the
+cache, so it works under the default Redis session driver with no need to switch
+`SESSION_DRIVER` to `database`.
+
 ## Persistent volumes
 
 | Volume                        | Contents                          |

--- a/tests/Feature/Settings/SessionManagementTest.php
+++ b/tests/Feature/Settings/SessionManagementTest.php
@@ -1,36 +1,58 @@
 <?php
 
 use App\Models\User;
-use Illuminate\Support\Facades\DB;
+use App\Support\SessionRegistry;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
 
 /**
- * Insert a row into the `sessions` table for the given user.
+ * The owned session index that backs device management, independent of the
+ * configured session driver.
+ */
+function sessionRegistry(): SessionRegistry
+{
+    return app(SessionRegistry::class);
+}
+
+/**
+ * Record a session in the registry for the given user.
  */
 function seedSession(User $user, string $id, string $userAgent = 'Mozilla/5.0 (Windows NT 10.0) Chrome/120.0.0.0 Safari/537.36', string $ip = '203.0.113.10', ?int $lastActivity = null): void
 {
-    DB::table('sessions')->insert([
-        'id' => $id,
-        'user_id' => $user->id,
-        'ip_address' => $ip,
-        'user_agent' => $userAgent,
-        'payload' => '',
-        'last_activity' => $lastActivity ?? now()->timestamp,
-    ]);
+    sessionRegistry()->record($user->id, $id, $ip, $userAgent, $lastActivity);
 }
 
-test('active sessions are listed on the security page with the current device flagged', function (): void {
+test('the current device is listed even with no prior index entries', function (): void {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->withCookie(config('session.cookie'), $currentId)
+        ->withHeaders(['User-Agent' => 'Mozilla/5.0 (Windows NT 10.0) Chrome/120.0.0.0 Safari/537.36'])
+        ->get(route('security.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('settings/Security')
+            ->has('sessions', 1)
+            ->where('sessions.0.id', $currentId)
+            ->where('sessions.0.isCurrentDevice', true)
+            ->where('sessions.0.browser', 'Chrome')
+            ->where('sessions.0.platform', 'Windows'),
+        );
+});
+
+test('active sessions are listed with the current device flagged first', function (): void {
     $user = User::factory()->create();
     $currentId = Str::random(40);
     $otherId = Str::random(40);
 
-    seedSession($user, $currentId, ip: '198.51.100.5', lastActivity: now()->subMinute()->timestamp);
     seedSession($user, $otherId, userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) Version/17.2 Mobile Safari/604.1', ip: '203.0.113.10', lastActivity: now()->subHour()->timestamp);
 
     $this->actingAs($user)
         ->withSession(['auth.password_confirmed_at' => time()])
         ->withCookie(config('session.cookie'), $currentId)
+        ->withHeaders(['User-Agent' => 'Mozilla/5.0 (Windows NT 10.0) Chrome/120.0.0.0 Safari/537.36'])
         ->get(route('security.edit'))
         ->assertOk()
         ->assertInertia(fn (Assert $page): Assert => $page
@@ -40,9 +62,29 @@ test('active sessions are listed on the security page with the current device fl
             ->where('sessions.0.isCurrentDevice', true)
             ->where('sessions.0.browser', 'Chrome')
             ->where('sessions.0.platform', 'Windows')
-            ->where('sessions.0.ipAddress', '198.51.100.5')
             ->where('sessions.1.id', $otherId)
-            ->where('sessions.1.isCurrentDevice', false),
+            ->where('sessions.1.isCurrentDevice', false)
+            ->where('sessions.1.browser', 'Safari')
+            ->where('sessions.1.platform', 'iOS')
+            ->where('sessions.1.ipAddress', '203.0.113.10'),
+        );
+});
+
+test('sessions inactive beyond the session lifetime are not listed', function (): void {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+    $staleId = Str::random(40);
+
+    seedSession($user, $staleId, lastActivity: now()->subMinutes((int) config('session.lifetime') + 1)->timestamp);
+
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->withCookie(config('session.cookie'), $currentId)
+        ->get(route('security.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('sessions', 1)
+            ->where('sessions.0.id', $currentId),
         );
 });
 
@@ -55,14 +97,40 @@ test('a single session can be revoked', function (): void {
     seedSession($user, $otherId);
 
     $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
         ->withCookie(config('session.cookie'), $currentId)
         ->from(route('security.edit'))
         ->delete(route('sessions.destroy', $otherId), ['password' => 'password'])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(route('security.edit'));
+        ->assertRedirect(route('security.edit'))
+        ->assertInertiaFlash('toast', ['type' => 'success', 'message' => 'Session revoked.']);
 
-    $this->assertDatabaseMissing('sessions', ['id' => $otherId]);
-    $this->assertDatabaseHas('sessions', ['id' => $currentId]);
+    expect(sessionRegistry()->has($user->id, $otherId))->toBeFalse();
+    expect(sessionRegistry()->has($user->id, $currentId))->toBeTrue();
+});
+
+test('a revoked session can no longer make authenticated requests', function (): void {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+    $otherId = Str::random(40);
+
+    seedSession($user, $currentId);
+    seedSession($user, $otherId);
+
+    $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
+        ->withCookie(config('session.cookie'), $currentId)
+        ->delete(route('sessions.destroy', $otherId), ['password' => 'password'])
+        ->assertRedirect();
+
+    // The revoked device's next request is bounced to login and left a guest.
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time(), 'active_session_id' => $otherId])
+        ->withCookie(config('session.cookie'), $otherId)
+        ->get(route('security.edit'))
+        ->assertRedirect(route('login'));
+
+    $this->assertGuest();
 });
 
 test('the current session cannot be revoked through the single-session route', function (): void {
@@ -72,12 +140,29 @@ test('the current session cannot be revoked through the single-session route', f
     seedSession($user, $currentId);
 
     $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
         ->withCookie(config('session.cookie'), $currentId)
         ->from(route('security.edit'))
         ->delete(route('sessions.destroy', $currentId), ['password' => 'password'])
-        ->assertRedirect(route('security.edit'));
+        ->assertRedirect(route('security.edit'))
+        ->assertInertiaFlashMissing('toast');
 
-    $this->assertDatabaseHas('sessions', ['id' => $currentId]);
+    expect(sessionRegistry()->has($user->id, $currentId))->toBeTrue();
+});
+
+test('revoking an unknown session flashes no success toast', function (): void {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+
+    seedSession($user, $currentId);
+
+    $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
+        ->withCookie(config('session.cookie'), $currentId)
+        ->from(route('security.edit'))
+        ->delete(route('sessions.destroy', Str::random(40)), ['password' => 'password'])
+        ->assertRedirect(route('security.edit'))
+        ->assertInertiaFlashMissing('toast');
 });
 
 test('a session belonging to another user cannot be revoked', function (): void {
@@ -90,12 +175,14 @@ test('a session belonging to another user cannot be revoked', function (): void 
     seedSession($otherUser, $victimId);
 
     $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
         ->withCookie(config('session.cookie'), $currentId)
         ->from(route('security.edit'))
         ->delete(route('sessions.destroy', $victimId), ['password' => 'password'])
-        ->assertRedirect(route('security.edit'));
+        ->assertRedirect(route('security.edit'))
+        ->assertInertiaFlashMissing('toast');
 
-    $this->assertDatabaseHas('sessions', ['id' => $victimId]);
+    expect(sessionRegistry()->has($otherUser->id, $victimId))->toBeTrue();
 });
 
 test('logging out other devices removes other sessions but keeps the current one', function (): void {
@@ -109,15 +196,51 @@ test('logging out other devices removes other sessions but keeps the current one
     seedSession($user, $anotherId);
 
     $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
         ->withCookie(config('session.cookie'), $currentId)
         ->from(route('security.edit'))
         ->delete(route('sessions.destroy-others'), ['password' => 'password'])
         ->assertSessionHasNoErrors()
-        ->assertRedirect(route('security.edit'));
+        ->assertRedirect(route('security.edit'))
+        ->assertInertiaFlash('toast', ['type' => 'success', 'message' => 'Logged out of your other devices.']);
 
-    $this->assertDatabaseHas('sessions', ['id' => $currentId]);
-    $this->assertDatabaseMissing('sessions', ['id' => $otherId]);
-    $this->assertDatabaseMissing('sessions', ['id' => $anotherId]);
+    expect(sessionRegistry()->has($user->id, $currentId))->toBeTrue();
+    expect(sessionRegistry()->has($user->id, $otherId))->toBeFalse();
+    expect(sessionRegistry()->has($user->id, $anotherId))->toBeFalse();
+});
+
+test('logging out other devices with no other devices flashes no toast', function (): void {
+    $user = User::factory()->create();
+    $currentId = Str::random(40);
+
+    seedSession($user, $currentId);
+
+    $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
+        ->withCookie(config('session.cookie'), $currentId)
+        ->from(route('security.edit'))
+        ->delete(route('sessions.destroy-others'), ['password' => 'password'])
+        ->assertRedirect(route('security.edit'))
+        ->assertInertiaFlashMissing('toast');
+
+    expect(sessionRegistry()->has($user->id, $currentId))->toBeTrue();
+});
+
+test('a regenerated session id keeps the user signed in and moves its index entry', function (): void {
+    $user = User::factory()->create();
+    $oldId = Str::random(40);
+    $newId = Str::random(40);
+
+    seedSession($user, $oldId);
+
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time(), 'active_session_id' => $oldId])
+        ->withCookie(config('session.cookie'), $newId)
+        ->get(route('security.edit'))
+        ->assertOk();
+
+    expect(sessionRegistry()->has($user->id, $oldId))->toBeFalse();
+    expect(sessionRegistry()->has($user->id, $newId))->toBeTrue();
 });
 
 test('revoking a session requires the correct password', function (): void {
@@ -129,13 +252,14 @@ test('revoking a session requires the correct password', function (): void {
     seedSession($user, $otherId);
 
     $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
         ->withCookie(config('session.cookie'), $currentId)
         ->from(route('security.edit'))
         ->delete(route('sessions.destroy', $otherId), ['password' => 'wrong-password'])
         ->assertSessionHasErrors('password')
         ->assertRedirect(route('security.edit'));
 
-    $this->assertDatabaseHas('sessions', ['id' => $otherId]);
+    expect(sessionRegistry()->has($user->id, $otherId))->toBeTrue();
 });
 
 test('logging out other devices requires the correct password', function (): void {
@@ -147,11 +271,12 @@ test('logging out other devices requires the correct password', function (): voi
     seedSession($user, $otherId);
 
     $this->actingAs($user)
+        ->withSession(['active_session_id' => $currentId])
         ->withCookie(config('session.cookie'), $currentId)
         ->from(route('security.edit'))
         ->delete(route('sessions.destroy-others'), ['password' => 'wrong-password'])
         ->assertSessionHasErrors('password')
         ->assertRedirect(route('security.edit'));
 
-    $this->assertDatabaseHas('sessions', ['id' => $otherId]);
+    expect(sessionRegistry()->has($user->id, $otherId))->toBeTrue();
 });

--- a/tests/Unit/SessionRegistryTest.php
+++ b/tests/Unit/SessionRegistryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Support\SessionRegistry;
+use Tests\TestCase;
+
+// The registry reads config('session.lifetime') and the application cache, so
+// these tests boot the container.
+uses(TestCase::class);
+
+function registry(): SessionRegistry
+{
+    return app(SessionRegistry::class);
+}
+
+test('forgetting the last session clears the index', function (): void {
+    $registry = registry();
+    $registry->record('user-1', 'session-a', '203.0.113.1', 'Chrome', now()->timestamp);
+
+    expect($registry->forget('user-1', 'session-a'))->toBeTrue();
+
+    expect($registry->has('user-1', 'session-a'))->toBeFalse();
+    expect($registry->all('user-1'))->toBe([]);
+});
+
+test('forgetting an absent session is a no-op', function (): void {
+    expect(registry()->forget('user-1', 'never-seen'))->toBeFalse();
+});


### PR DESCRIPTION
Closes #287.

## Problem

The **Active sessions** panel read and wrote the `sessions` table directly, but the app runs `SESSION_DRIVER=redis`, where session payloads live in Redis — not that table. So the list came back empty (never showing even the current device), and **Revoke** / **Log out other devices** matched zero rows: silent no-ops that still flashed a success toast. Security-relevant, because a user could believe they'd logged other devices out when they hadn't.

## Approach

Per the issue's option 2, device management is now backed by an **owned per-user session index** (`App\Support\SessionRegistry`) kept in the application **cache** (Redis in production, the array store under tests). This makes listing and revocation independent of `SESSION_DRIVER` — they reflect reality regardless of where session payloads are stored.

- **`TrackActiveSession` middleware** (appended to the web group) registers the current device on first sighting, refreshes its activity on each authenticated request, migrates the entry when the session id is regenerated, and — when a session's own id has been removed from the index (i.e. revoked from another device) — logs it out and bounces it to login. This is what makes a revoked session unable to make further authenticated requests, and it works under any driver.
- **`SecurityController` / `SessionController`** now read/revoke through the registry. A success toast is shown **only** when a session was actually revoked.
- **`RecordSecurityEvents`** prunes the current session from the index on logout. Entries older than `session.lifetime` are pruned on every read/write, and the whole index self-expires from the cache.

No new `.env`/driver requirement: the panel works with the default Redis session driver, so the docs gained a short clarifying note (no switch to `SESSION_DRIVER=database` needed).

## Acceptance criteria

- [x] Active-sessions list shows at least the current device.
- [x] Revoke / "Log out other devices" actually invalidate the targeted sessions (verified: the revoked session's next request is bounced to login and left a guest).
- [x] No success toast when nothing was actually revoked.
- [x] Covered by feature tests that run under the app's configured (test) driver, plus a unit test for the registry.
- [x] Docs updated (`reference/architecture.md`).

## Testing

- `sail composer test` — Pint, PHPStan, Rector, and **100% coverage** across 828 tests, all green.
- `sail npm run types:check` / `lint:check` / `format:check` — clean (no frontend source changed; DTO shape unchanged).
- `docs` site builds.