### PR TITLE
fix(self-hosting): make prod use Redis for cache/session/queue

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -30,6 +30,16 @@ LOG_CHANNEL=stack
 LOG_STACK=single
 LOG_LEVEL=warning
 
+# --- Feature toggles ---------------------------------------------------------
+# Set to false to close public sign-ups on a private/invite-only instance:
+# /register then returns 404 and the "sign up" links disappear. Create your own
+# account first (while this is still true), then flip it and restart the stack.
+REGISTRATION_ENABLED=true
+# Set to true to require new accounts to confirm their email before using the
+# app (needs working SMTP so the verification mail is delivered). Defaults to
+# false: registration logs the user straight in.
+EMAIL_VERIFICATION_ENABLED=false
+
 # --- Database (pgsql service) ------------------------------------------------
 DB_CONNECTION=pgsql
 DB_HOST=pgsql
@@ -39,8 +49,8 @@ DB_USERNAME=laravel
 # Required — used by both the app and the Postgres container.
 DB_PASSWORD=
 
-# --- Cache / session / queue (all on the database, no Redis needed) ----------
-SESSION_DRIVER=database
+# --- Cache / session / queue (redis service) ---------------------------------
+SESSION_DRIVER=redis
 SESSION_LIFETIME=120
 SESSION_ENCRYPT=false
 SESSION_PATH=/
@@ -48,8 +58,14 @@ SESSION_DOMAIN=null
 
 BROADCAST_CONNECTION=reverb
 FILESYSTEM_DISK=local
-QUEUE_CONNECTION=database
-CACHE_STORE=database
+QUEUE_CONNECTION=redis
+CACHE_STORE=redis
+
+# Redis connection for the drivers above (the redis service on the compose network).
+REDIS_CLIENT=phpredis
+REDIS_HOST=redis
+REDIS_PASSWORD=null
+REDIS_PORT=6379
 
 # --- Mail (external SMTP, operator-provided) ---------------------------------
 MAIL_MAILER=smtp

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,12 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS runtime
 
-# pdo_pgsql: Postgres. pcntl/posix: queue worker + Reverb signal handling.
+# pdo_pgsql: Postgres. redis: phpredis client for the cache/session/queue drivers.
+# pcntl/posix: queue worker + Reverb signal handling.
 # intl/zip/opcache: framework recommendations + performance.
 RUN install-php-extensions \
         pdo_pgsql \
+        redis \
         pcntl \
         posix \
         intl \


### PR DESCRIPTION
## Summary

Found during the clean-room install verification for the v1.0.0 self-host release (gate #1 on #290). The prod stack shipped an always-on `redis` service that every app process `depends_on`, and both the compose header and `reference/architecture.md` describe Redis-backed cache/session/queue — but the shipped config couldn't actually use it:

- `.env.prod.example` set `SESSION_DRIVER`/`QUEUE_CONNECTION`/`CACHE_STORE=database`, so Redis was dead weight.
- The runtime image never installed the **phpredis** extension (`config/database.php` defaults `REDIS_CLIENT=phpredis`, and `predis` is not a non-dev Composer dep), so flipping the drivers to `redis` would have failed to boot. This is almost certainly why the template was switched to `database`.

This aligns the shipped prod config with what compose + the architecture docs already promise.

## Changes

- **`Dockerfile`** — install the `redis` (phpredis) extension in the runtime stage.
- **`.env.prod.example`** — `SESSION_DRIVER`/`QUEUE_CONNECTION`/`CACHE_STORE=redis` plus the `REDIS_*` connection block (mirrors `.env.example`).
- **`.env.prod.example`** — add the documented `REGISTRATION_ENABLED` and `EMAIL_VERIFICATION_ENABLED` toggles. `self-hosting/first-user.md` and `reference/feature-toggles.md` instruct operators to set these, but the template omitted them (behaviour was only correct because the app config defaults matched).

## Verification

Clean-room build-from-source (native arm64) of this branch, brought up with the new template:

- `php -m` shows `redis` loaded in the runtime image.
- Effective drivers: `session=redis cache=redis queue=redis`.
- After driving traffic, `redis-cli dbsize` > 0 (cache key written); Postgres `sessions` table stays at `0`.
- App boots healthy, migrations run, first-user registration completes with no SMTP.

## Notes

- No docs changes needed — the compose header and `reference/architecture.md` already describe the Redis-backed config; this makes the shipped `.env` match.
- Separate gate-#1 findings tracked on #290 (not in this PR): the published image is `linux/amd64`-only (ARM hosts can't `pull`); `REVERB_PORT` couples the internal broadcast target with the host publish port; the Meilisearch volume name lacks the compose project prefix.

Refs #290
