### PR TITLE
chore: release 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bump-minor-pre-major": true,
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
Completes the **Release mechanics** of #290 — the two remaining unchecked items now that all four hard gates are green on \`master\`.

## Changes

- **\`Release-As: 1.0.0\` footer** in this commit — retitles the release-please PR from the next auto-bumped minor to **1.0.0**. (release-please won't reach 1.0.0 on its own while \`bump-minor-pre-major\` is set.)
- **Drop \`bump-minor-pre-major\`** from \`release-please-config.json\` — stale once we're at ≥ 1.0.0; normal semver applies afterward.

## After merge

release-please's PR will be retitled to 1.0.0; merging that PR tags **v1.0.0**.

Closes #290