### PR TITLE
docs: comparison + FAQ pages (search intent)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -37,7 +37,11 @@ export default defineConfig({
 			sidebar: [
 				{
 					label: 'Start Here',
-					items: [{ label: 'Introduction', slug: 'docs' }],
+					items: [
+						{ label: 'Introduction', slug: 'docs' },
+						{ label: 'The Desk vs Slack, Mattermost & Rocket.Chat', slug: 'docs/comparison' },
+						{ label: 'FAQ', slug: 'docs/faq' },
+					],
 				},
 				{
 					label: 'Self-Hosting',

--- a/docs/src/content/docs/docs/comparison.md
+++ b/docs/src/content/docs/docs/comparison.md
@@ -1,0 +1,65 @@
+---
+title: The Desk vs Slack, Mattermost & Rocket.Chat
+description: How The Desk compares to Slack and other self-hosted team chat like Mattermost and Rocket.Chat — an honest look at where a calm, self-hosted, MIT-licensed Slack alternative fits.
+---
+
+If you're looking for a **self-hosted Slack alternative**, you've probably found
+that the options split into two camps: proprietary SaaS you can't run yourself,
+and large open-source platforms that can be a lot to operate. The Desk aims at a
+third spot — a small, calm, MIT-licensed chat app you run from **one compose
+file**.
+
+This page is an honest look at where it fits. It also tells you plainly where it
+*doesn't* yet, so you don't deploy it and hit a wall.
+
+## At a glance
+
+| | **The Desk** | **Slack** | **Mattermost** | **Rocket.Chat** |
+| --- | --- | --- | --- | --- |
+| Self-hostable | ✅ Yes | ❌ SaaS only | ✅ Yes | ✅ Yes |
+| License | MIT (open source) | Proprietary | Source-available / open core | MIT (open core) |
+| Price | Free — no per-seat | Free tier, then per-seat | Free tier + paid editions | Free tier + paid editions |
+| Setup | One `docker compose up -d` | Sign up | Docker / binary / Helm | Docker / Snap / Helm |
+| Data ownership | Your server, always | Slack's cloud | Your server | Your server |
+| Footprint | Deliberately small | — | Larger, enterprise-oriented | Larger, very feature-rich |
+
+Slack is the product most teams are leaving; Mattermost and Rocket.Chat are the
+established self-hosted alternatives. The Desk is the newcomer optimizing for
+*less* — fewer moving parts, less to learn, less to run.
+
+## What The Desk is good at
+
+- **Getting out of your way.** Channels, threads, and DMs plus the workflow
+  features teams actually miss: [scheduled messages](/docs/), message reminders,
+  reactions and custom emoji, and instant full-text search.
+- **Being trivial to run.** A prebuilt image and a single compose file. No
+  Kubernetes, no build step, no exotic dependencies — a small
+  [2 vCPU / 2 GB VPS](/docs/self-hosting/requirements/) comfortably hosts a team.
+- **Being yours.** MIT-licensed, auditable, self-hosted. Your messages never
+  leave your server, every user can export their data, and there's no per-seat
+  meter.
+- **Real admin basics.** Roles, invitations, a moderation audit log, workspace
+  analytics, and device/session management are built in.
+
+## When The Desk is *not* the right fit (yet)
+
+Being honest saves you a wasted afternoon. As of **v1.0.0**, The Desk does **not**
+have:
+
+- **File & image attachments** — in active development, not shipped yet.
+- **Voice or video calls** — not planned for the near term.
+- **SSO / OIDC / LDAP / SCIM** — on the roadmap, not available today. If your org
+  *requires* directory-managed logins now, Mattermost or Rocket.Chat are the
+  safer pick.
+- **Native mobile apps** — the web app is fully responsive, but there's no
+  dedicated iOS/Android app or push notifications yet.
+- **A large integration/bot marketplace** — if your workflow depends on hundreds
+  of prebuilt integrations, a bigger platform will serve you better.
+
+If none of those are dealbreakers and you want the lightest self-hosted chat that
+still feels finished, The Desk is built for you.
+
+## Ready to try it?
+
+[Deploy The Desk in about five minutes](/docs/self-hosting/installation/) — or
+skim the [requirements](/docs/self-hosting/requirements/) first.

--- a/docs/src/content/docs/docs/faq.md
+++ b/docs/src/content/docs/docs/faq.md
@@ -1,0 +1,81 @@
+---
+title: Frequently asked questions
+description: Common questions about self-hosting The Desk — cost, server requirements, backups, scaling, registration, mobile, attachments, SSO, upgrades, and data privacy.
+---
+
+Short answers to the questions people ask before self-hosting The Desk. Most link
+to the fuller docs.
+
+## Is it really free?
+
+Yes. The Desk is **MIT-licensed** and free forever. There's no per-seat pricing,
+no paywalled features, and no "open core" edition held back — because there's no
+company to pay. Members, message history, and file storage are bounded only by
+your own disk.
+
+## What do I need to run it?
+
+- A Linux host with **Docker Engine 24+** and the Compose plugin.
+- A **domain name** and a **TLS-terminating reverse proxy** (nginx, Caddy,
+  Traefik…) in front of the stack — HTTPS is your responsibility; the containers
+  speak plain HTTP.
+- Working **SMTP credentials** for invitations (and optional email verification).
+
+See [Requirements](/docs/self-hosting/requirements/) for the full list.
+
+## How much server does it need?
+
+The Desk is modest. A small **2 vCPU / 2 GB RAM** VPS comfortably hosts a team;
+scale up as message volume and the search index grow. See the
+[Architecture reference](/docs/reference/architecture/) for what each service
+does.
+
+## How do I back it up?
+
+Everything lives in **PostgreSQL** and a few **Docker volumes** (uploads and the
+Meilisearch index). Back up the Postgres database and those volumes on your normal
+schedule and you can restore the whole instance. The
+[Architecture reference](/docs/reference/architecture/) lists exactly what runs
+and where state lives.
+
+## Can people sign up themselves, or is it invite-only?
+
+Both — you choose. Open registration is controlled by the
+[`REGISTRATION_ENABLED`](/docs/reference/feature-toggles/#open-registration)
+toggle. Turn it off and the workspace is invitation-only. You can also require
+[email verification](/docs/reference/feature-toggles/#email-verification).
+
+## Is there a mobile app?
+
+Not yet. The web app is fully responsive and works well in a mobile browser, but
+there's no dedicated iOS/Android app or mobile push notifications today.
+
+## Does it support file attachments, voice, or video?
+
+**File & image attachments** are in active development but not shipped as of
+v1.0.0. **Voice and video calls** are not on the near-term roadmap. If you need
+those now, see the [comparison page](/docs/comparison/).
+
+## Does it support SSO, OIDC, or LDAP?
+
+Not today — single sign-on and directory-managed users are on the roadmap but not
+available in v1.0.0. If your organization requires them now, a larger platform is
+the safer choice for the moment. See the [comparison](/docs/comparison/).
+
+## How do upgrades work?
+
+Upgrades are **tag-based** — you move to a new release tag and pull. Database
+migrations and version-scoped search reindexing run automatically. See
+[Upgrading](/docs/self-hosting/upgrading/) for the exact steps.
+
+## Is my data private?
+
+Yes — that's the point. The Desk is **self-hosted**, so your messages never leave
+your server. There's no SaaS middleman, no analytics phoning home, and every user
+can export their own data at any time. It's your database either way.
+
+## What's the tech stack?
+
+Laravel 13, Inertia + Vue 3, Laravel Reverb (WebSockets), PostgreSQL,
+Meilisearch, and Redis — all in one compose file behind a FrankenPHP app image.
+The full picture is in the [Architecture reference](/docs/reference/architecture/).


### PR DESCRIPTION
Adds the two highest-intent discovery pages from #300 (WS3).

> **Stacked on #301** — base is `docs/seo-foundation`, so this PR's diff shows only the two new pages. GitHub will auto-retarget it to `master` once #301 merges.

## New pages
- **`/docs/comparison`** — "The Desk vs Slack, Mattermost & Rocket.Chat". Honest positioning as a small, MIT-licensed, self-hosted Slack alternative, with an at-a-glance table **and** a candid "when it's *not* the right fit yet" section (no attachments, voice/video, SSO, or native mobile as of v1.0.0). Being upfront prevents wasted deploys and builds trust.
- **`/docs/faq`** — cost, server requirements, backups, scaling, registration, mobile, attachments, SSO, upgrades, and data privacy. Every answer links to the fuller docs and is grounded in the actual requirements/feature-toggle docs.

Both carry SEO meta descriptions and are wired into the Starlight sidebar under **Start Here**.

## Verification
- `cd docs && npm run build` passes; both pages render (14 pages total) and appear in the sitemap with correct `<meta name="description">`.
- Internal links and toggle anchors (`#open-registration`, `#email-verification`) resolve.

## Also done outside this PR (GitHub repo metadata, WS5)
Set via `gh` directly — no code change: repo **description**, **homepage** → the docs site, and 12 **topics** (`self-hosted`, `slack-alternative`, `team-chat`, `laravel`, `vue`, `docker`, …).