### PR TITLE
docs: surface "self-hosted Slack alternative" on landing + add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/emmpaul/the-desk/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/emmpaul/the-desk/tests.yml?branch=master&label=tests" alt="Tests"></a>
+  <a href="https://github.com/emmpaul/the-desk/releases"><img src="https://img.shields.io/github/v/release/emmpaul/the-desk?color=c9a35c" alt="Latest release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/emmpaul/the-desk?color=c9a35c" alt="License: MIT"></a>
+</p>
+
+<p align="center">
   <a href="https://the-desk.emmanuelpaul.com">Website</a> ·
   <a href="https://the-desk.emmanuelpaul.com/docs/">Docs</a> ·
   <a href="https://the-desk.emmanuelpaul.com/docs/self-hosting/installation/">Install</a> ·

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -7,7 +7,7 @@ const installGuide = '/docs/self-hosting/installation/';
 const releaseTag = '1.0.0';
 const title = 'The Desk — Self-hosted team chat that lives on your own server';
 const description =
-	'The Desk is a calm, fast, open-source team chat app you host yourself: channels, threads, reminders, scheduled messages. One container, your hardware, your data.';
+	'The Desk is a calm, fast, open-source team chat app you host yourself — a self-hosted Slack alternative with channels, threads, reminders, and scheduled messages. One container, your hardware, your data.';
 const ogImage = `${site}/og-image.png`;
 
 // Rich-result structured data: a free, self-hostable web application.
@@ -102,9 +102,9 @@ const jsonLd = {
 					</span>
 					<h1 class="serif hero-title">Team chat that lives on your own server</h1>
 					<p class="hero-lede">
-						The Desk is a calm, fast messaging app for teams: channels, threads, reminders, scheduled
-						messages. One container, your hardware, your data. No per-seat pricing, because there's no
-						one to pay.
+						The Desk is a calm, fast, self-hosted Slack alternative: channels, threads, reminders,
+						scheduled messages. One container, your hardware, your data. No per-seat pricing, because
+						there's no one to pay.
 					</p>
 					<div class="hero-actions">
 						<a class="btn btn-dark btn-lg" href={installGuide}>


### PR DESCRIPTION
Two small WS3/WS5 polish items from #300.

## Landing page — category keyword (WS3)
The landing page ranked for "self-hosted team chat" but not the highest-intent query, **"self-hosted Slack alternative."** This weaves that phrase in naturally:
- **Meta description** (which also feeds `og:description`, `twitter:description`, and the `SoftwareApplication` JSON-LD).
- **Hero lede** — "a calm, fast, self-hosted Slack alternative: channels, threads, reminders, scheduled messages."

The distinctive H1 ("Team chat that lives on your own server") is untouched — no keyword stuffing. Verified the phrase appears in the built `dist/index.html` and the docs site builds clean.

## README — shield badges (WS5)
Added **tests / latest-release / MIT-license** badges under the intro (release + license brand-tinted; the tests badge keeps its pass/fail color).

Closes the last two in-my-lane items; remaining #300 work is human-driven (real screenshots, off-site distribution) or a manual upload (social preview).