### PR TITLE
docs: document + enforce Conventional-Commit PR titles for release-please

### DIFF
--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: open-pr
+description: Open (or retitle) a GitHub pull request in this repo the way release-please needs. This repo squash-merges with the PR title as the squash commit subject, so release-please reads the PR title — it MUST be a valid Conventional Commit or the change is silently dropped from CHANGELOG.md and the version bump. Use whenever creating, retitling, or preparing a pull request, or when the user says "open a PR", "raise a PR", "gh pr create".
+---
+
+Open a pull request that release-please can act on.
+
+## The one rule that bites here
+
+The repo **merges by squash only**, and `squash_merge_commit_title = PR_TITLE` (verify with `gh api repos/{owner}/{repo} --jq .squash_merge_commit_title`). So **the PR title becomes the commit on `master`** that release-please parses. A PR titled like a sentence ("Edit last message from the composer") is **silently dropped from `CHANGELOG.md` and the version bump**. `commitlint` does **not** catch this — it validates the PR's individual commits, not the PR title — so passing CI is no guarantee. The PR title is the thing that must be right.
+
+## Before opening
+
+1. **Not on `master`.** Work is on a feature branch; if not, branch first. Branch names are cosmetic (release-please ignores them) — mirror the type if you like (`feat/…`, `fix/…`), but the title is what matters.
+2. **The gate is green.** Don't open a PR on a red gate. Backend: `./vendor/bin/sail composer test` (Pint + PHPStan + Rector + `--min=100` coverage). Frontend: `./vendor/bin/sail npm run lint:check`, `format:check`, `types:check`, `build`. See `CLAUDE.md`.
+3. **Companion updates done** where the change requires them: `lang/fr.json` for new user-facing copy, `docs/` for operator-facing changes, tests for every change.
+4. **Branch pushed**: `git push -u origin <branch>`.
+
+## The PR title — a valid Conventional Commit
+
+Format: `type: imperative subject` — lowercase `type`, a colon-space, a concise imperative subject, **no trailing period**, aim for ≤ ~70 chars. Optional scope: `type(scope): …`. No Claude/Co-Authored-By attribution anywhere (see the global `CLAUDE.md`).
+
+Pick `type` from what the diff actually ships:
+
+| Type | Use for | In changelog? | Version bump |
+| --- | --- | --- | --- |
+| `feat` | a user-facing capability | ✅ Features | minor |
+| `fix` | a bug fix | ✅ Bug Fixes | patch |
+| `perf` | a performance improvement | ✅ Performance | patch |
+| `refactor` | internal restructure, no behaviour change | ✅ Code Refactoring | patch |
+| `docs` | docs / guidance only | ❌ | none |
+| `test` | tests only | ❌ | none |
+| `chore` / `ci` / `build` | tooling, CI, deps, build | ❌ | none |
+| `style` | formatting only | ❌ | none |
+
+(The changelog sections come from `release-please-config.json` — check it if unsure.) A **breaking change** uses `type!: …` (e.g. `feat!:`) or a `BREAKING CHANGE:` footer, forcing a major bump.
+
+If a change is a user-facing feature or fix, it must ship under `feat`/`fix` (or `perf`/`refactor`) — otherwise it won't appear in the release notes. Only use a non-changelog type when the PR genuinely ships no user-facing feature or fix.
+
+## The PR body
+
+- Reference the issue: `Closes #NNN` (or `Refs #NNN`).
+- What changed and why; how it was tested; any i18n/docs updates.
+- Never add a `Co-Authored-By` trailer or other Claude/Anthropic attribution.
+
+## Open it, then verify
+
+```bash
+gh pr create --title "feat: <imperative subject>" --body "$(cat <<'EOF'
+Closes #NNN.
+
+<what / why / testing>
+EOF
+)"
+```
+
+Then confirm the title is conventional before you consider the PR done:
+
+```bash
+gh pr view <n> --json title --jq .title
+```
+
+Ask yourself: does it start with a valid `type` (or `type!`) then `: `? Would release-please file it under the right section? If not, fix it now with `gh pr edit <n> --title "…"` — and remember GitHub appends ` (#<n>)` to the squash subject at merge time, which is fine.
+
+## Never
+
+- Hand-edit `CHANGELOG.md`, `VERSION`, or `.release-please-manifest.json` — release-please owns them.
+- Rely on the branch name or an individual commit message to carry the changelog entry — only the PR title reaches release-please on a squash merge.

--- a/.claude/skills/open-pr
+++ b/.claude/skills/open-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/open-pr

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,15 @@ Vue components must have a single root element.
 
 <!-- Custom project guidance below is preserved across `boost:update` runs. -->
 
+## Commits & PR titles — Conventional Commits drive the release (non-negotiable)
+
+- **Releases are automated by release-please** (`.github/workflows/release-please.yml`, config in `release-please-config.json`). On every push to `master` it parses **Conventional Commit** prefixes to compute the next version and generate `CHANGELOG.md`. Never hand-edit `CHANGELOG.md`, `VERSION`, or `.release-please-manifest.json` — release-please owns them.
+- **The repo merges PRs by squash only, and the squash commit subject is the PR title** (`squash_merge_commit_title = PR_TITLE`). So **the PR title _is_ the commit release-please reads** — it MUST be a valid Conventional Commit (`type: imperative subject`, lower-case type, no trailing period), e.g. `feat: edit last message from the composer with ↑`. A PR titled like a sentence ("Edit last message…") is **silently dropped from the changelog and the version bump** — this is the #1 mistake here.
+- **Changelog-relevant types** (from `release-please-config.json`): `feat` → Features (minor bump), `fix` → Bug Fixes (patch), `perf` → Performance, `refactor` → Code Refactoring. A breaking change (`feat!:` / `fix!:`, or a `BREAKING CHANGE:` footer) forces a major bump. Other Conventional types are allowed (`docs`, `test`, `chore`, `ci`, `build`, `style`) but **do not appear in the changelog and do not bump the version** — only use them for PRs that genuinely ship no user-facing feature/fix.
+- **Keep individual commit messages Conventional too.** `commitlint` (config-conventional) runs on every PR and validates the PR's commits — but note it does **not** validate the PR title, so a PR can pass CI yet still land a non-Conventional squash subject. The PR title is the one that reaches release-please, so it is the one that must be right.
+- **Branch names are cosmetic** (release-please ignores them). Mirror the type if you like (`feat/…`, `fix/…`), but never rely on the branch name for the changelog — set the PR title.
+- **When opening a PR with `gh pr create`, always pass a Conventional-Commit `--title`** and reference the issue in the body (`Closes #NNN`).
+
 ## Implementing Issues (TDD)
 
 - **Always activate the `tdd` skill when implementing an issue or building a feature.** Drive the work test-first (red → green → refactor): write a failing test that captures the acceptance criterion, make it pass with the minimal change, then refactor. This pairs with the non-negotiable 100% coverage gate below.


### PR DESCRIPTION
Documents **and** enforces the convention that was missed on #319 (its squash subject landed without a `feat:` prefix, so it won't appear in the release-please changelog).

## Why

- The repo **squash-merges only**, and `squash_merge_commit_title = PR_TITLE` — so the **PR title becomes the commit release-please parses**.
- A PR titled as a plain sentence is silently dropped from `CHANGELOG.md` and the version bump. `commitlint` doesn't catch it because it validates the PR's *commits*, not the PR *title*.

## Changes

1. **`CLAUDE.md`** — new "Commits & PR titles — Conventional Commits drive the release" section: the squash-title → release-please mechanics, changelog-relevant types (`feat`/`fix`/`perf`/`refactor`) vs. non-listing types, breaking-change syntax, never hand-editing `CHANGELOG.md`/version/manifest, always passing a Conventional `--title` to `gh pr create`.
2. **`open-pr` skill** (`.agents/skills/open-pr/SKILL.md`, symlinked into `.claude/skills/open-pr` like the other authored skills) — a model-invocable skill that fires whenever a PR is being opened/retitled. It walks the pre-flight gate, the type table, and a post-create title verification so the Conventional-Commit PR-title rule is applied automatically, not just documented.

Docs/tooling only; `docs:` type intentionally stays out of the changelog.