### PR TITLE
feat: add a loading prop to Button and migrate raw buttons onto it

### DIFF
--- a/eslint-rules/no-raw-button.js
+++ b/eslint-rules/no-raw-button.js
@@ -1,0 +1,63 @@
+/**
+ * Flags raw `<button>` elements in Vue templates outside `components/ui/`,
+ * steering shared button styling onto the `<Button>` primitive (its variants,
+ * sizes, focus ring, and `loading` affordance) rather than hand-rolled class
+ * strings that drift over time. Genuinely bespoke controls (composer keys, the
+ * reaction grid, menu items, card buttons) opt out per-occurrence with
+ * `<!-- eslint-disable-next-line local/no-raw-button -- <reason> -->`.
+ *
+ * The shadcn-owned primitives under `components/ui/` legitimately render the
+ * underlying `<button>`, so files there are exempt.
+ */
+
+const UI_DIRECTORY = 'components/ui/';
+
+/**
+ * Whether a file is exempt from the rule: the shadcn-owned `<Button>` / friends
+ * under `components/ui/`, which own the one blessed raw `<button>`.
+ *
+ * @param {string} filename
+ * @returns {boolean}
+ */
+export function isExemptFile(filename) {
+    return filename.replaceAll('\\', '/').includes(UI_DIRECTORY);
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description:
+                'Use the `<Button>` primitive instead of a raw `<button>` element outside `components/ui/`.',
+        },
+        schema: [],
+        messages: {
+            preferButton:
+                'Use the `<Button>` primitive (`@/components/ui/button`) instead of a raw `<button>`; it carries the shared variant, size, focus-ring, and loading behaviour. Genuinely bespoke controls may opt out with `<!-- eslint-disable-next-line local/no-raw-button -- reason -->`.',
+        },
+    },
+    create(context) {
+        if (isExemptFile(context.filename)) {
+            return {};
+        }
+
+        const defineTemplateBodyVisitor =
+            context.sourceCode.parserServices?.defineTemplateBodyVisitor;
+
+        if (!defineTemplateBodyVisitor) {
+            return {};
+        }
+
+        return defineTemplateBodyVisitor({
+            "VElement[rawName='button']"(node) {
+                context.report({
+                    node: node.startTag,
+                    messageId: 'preferButton',
+                });
+            },
+        });
+    },
+};
+
+export default rule;

--- a/eslint-rules/no-raw-button.test.ts
+++ b/eslint-rules/no-raw-button.test.ts
@@ -1,0 +1,62 @@
+import { RuleTester } from 'eslint';
+import { describe, expect, it } from 'vitest';
+import vueParser from 'vue-eslint-parser';
+import rule, { isExemptFile } from './no-raw-button.js';
+
+describe('isExemptFile', () => {
+    it('exempts files under components/ui/', () => {
+        expect(
+            isExemptFile('/app/resources/js/components/ui/button/Button.vue'),
+        ).toBe(true);
+    });
+
+    it('does not exempt other component files', () => {
+        expect(
+            isExemptFile('/app/resources/js/components/MessageActions.vue'),
+        ).toBe(false);
+        expect(isExemptFile('/app/resources/js/pages/channels/Show.vue')).toBe(
+            false,
+        );
+    });
+});
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parser: vueParser,
+        ecmaVersion: 2022,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('no-raw-button', rule, {
+    valid: [
+        {
+            // The `<Button>` primitive is fine anywhere.
+            filename: 'resources/js/components/MessageActions.vue',
+            code: '<template><Button variant="ghost">Go</Button></template>',
+        },
+        {
+            // Raw `<button>` is allowed inside the shadcn primitives.
+            filename: 'resources/js/components/ui/button/Button.vue',
+            code: '<template><button type="button">Go</button></template>',
+        },
+    ],
+    invalid: [
+        {
+            filename: 'resources/js/components/MessageActions.vue',
+            code: '<template><button type="button" aria-label="Pin">Pin</button></template>',
+            errors: [{ messageId: 'preferButton' }],
+        },
+        {
+            filename: 'resources/js/pages/channels/Show.vue',
+            code: '<template><div><button>One</button><button>Two</button></div></template>',
+            errors: [
+                { messageId: 'preferButton' },
+                { messageId: 'preferButton' },
+            ],
+        },
+    ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import importPlugin from 'eslint-plugin-import';
 import vue from 'eslint-plugin-vue';
 import vuejsAccessibility from 'eslint-plugin-vuejs-accessibility';
 import noArbitraryTailwindSpacing from './eslint-rules/no-arbitrary-tailwind-spacing.js';
+import noRawButton from './eslint-rules/no-raw-button.js';
 
 const controlStatements = [
     'if',
@@ -33,6 +34,7 @@ export default defineConfigWithVueTs(
             local: {
                 rules: {
                     'no-arbitrary-tailwind-spacing': noArbitraryTailwindSpacing,
+                    'no-raw-button': noRawButton,
                 },
             },
         },
@@ -71,6 +73,11 @@ export default defineConfigWithVueTs(
             // `warn` (visible, auto-fixable via `npm run lint`) so the gate stays
             // green while the existing occurrences are burned down over time.
             'local/no-arbitrary-tailwind-spacing': 'warn',
+            // Steer shared button styling onto the `<Button>` primitive: raw
+            // `<button>` outside `components/ui/` is an `error`, so CI catches
+            // new stray ones. Genuinely bespoke controls opt out per-occurrence
+            // with `<!-- eslint-disable-next-line local/no-raw-button -- reason -->`.
+            'local/no-raw-button': 'error',
         },
     },
     {

--- a/resources/js/components/AppearanceTabs.vue
+++ b/resources/js/components/AppearanceTabs.vue
@@ -20,6 +20,7 @@ const options = [
       fixed (not the active-theme tokens) — a light swatch always reads light.
     -->
     <div class="grid max-w-2xl grid-cols-3 gap-3">
+        <!-- eslint-disable-next-line local/no-raw-button -- bespoke segmented theme toggle (aria-pressed options) -->
         <button
             v-for="{ value, label } in options"
             :key="value"

--- a/resources/js/components/ChannelEmptyState.vue
+++ b/resources/js/components/ChannelEmptyState.vue
@@ -80,6 +80,7 @@ const { open: openOnboardingTour } = useOnboardingTour();
 
             <div class="mt-7 flex w-full flex-col gap-2.5">
                 <CreateChannelModal :team-slug="props.teamSlug">
+                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke welcome action card -->
                     <button
                         type="button"
                         data-test="welcome-create-channel"
@@ -105,6 +106,7 @@ const { open: openOnboardingTour } = useOnboardingTour();
                     </button>
                 </CreateChannelModal>
 
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke welcome action card -->
                 <button
                     v-if="canInviteToCurrentTeam"
                     type="button"
@@ -132,6 +134,7 @@ const { open: openOnboardingTour } = useOnboardingTour();
                     >
                 </button>
 
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke welcome action card -->
                 <button
                     type="button"
                     data-test="welcome-post-message"
@@ -161,6 +164,7 @@ const { open: openOnboardingTour } = useOnboardingTour();
 
             <p class="mt-5 text-[12.5px] text-muted-foreground">
                 {{ $t('Prefer to explore on your own?') }}
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline text-link control -->
                 <button
                     type="button"
                     data-test="welcome-take-tour"

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -258,11 +258,13 @@ const dmParticipantOnline = computed(
                  Search and options controls. -->
             <Tooltip>
                 <TooltipTrigger as-child>
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="sm"
                         type="button"
                         data-test="masthead-pins"
                         :aria-label="$t('Pinned messages')"
-                        class="inline-flex items-center gap-1 rounded px-1 py-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                        class="gap-1 px-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
                         @click="emit('openPins')"
                     >
                         <Pin
@@ -279,7 +281,7 @@ const dmParticipantOnline = computed(
                             class="text-[12px] font-semibold tabular-nums"
                             >{{ props.pinCount }}</span
                         >
-                    </button>
+                    </Button>
                 </TooltipTrigger>
                 <TooltipContent>{{ $t('Pinned messages') }}</TooltipContent>
             </Tooltip>

--- a/resources/js/components/EmojiPickerPopover.vue
+++ b/resources/js/components/EmojiPickerPopover.vue
@@ -98,6 +98,7 @@ function onPickCustom(entry: CustomEmojiEntry): void {
                     <div
                         class="grid max-h-28 grid-cols-7 gap-1 overflow-y-auto"
                     >
+                        <!-- eslint-disable-next-line local/no-raw-button -- bespoke emoji-grid cell -->
                         <button
                             v-for="entry in customEmojis"
                             :key="entry.name"

--- a/resources/js/components/ForwardMessageDialog.vue
+++ b/resources/js/components/ForwardMessageDialog.vue
@@ -160,6 +160,7 @@ function submit(): void {
                                 v-for="channel in rankedChannels"
                                 :key="channel.id"
                             >
+                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke selectable recipient row (aria-pressed) -->
                                 <button
                                     type="button"
                                     data-test="forward-channel-option"
@@ -195,6 +196,7 @@ function submit(): void {
                         </p>
                         <ul class="space-y-0.5">
                             <li v-for="person in rankedPeople" :key="person.id">
+                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke selectable recipient row (aria-pressed) -->
                                 <button
                                     type="button"
                                     data-test="forward-person-option"

--- a/resources/js/components/JoinChannelBar.vue
+++ b/resources/js/components/JoinChannelBar.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { Form } from '@inertiajs/vue3';
-import { LoaderCircle, Plus, Users } from '@lucide/vue';
+import { Plus, Users } from '@lucide/vue';
 import { join } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { Button } from '@/components/ui/button';
 
 const props = defineProps<{
     teamSlug: string;
@@ -59,25 +60,20 @@ const props = defineProps<{
                     </span>
                 </div>
 
-                <button
+                <Button
                     type="submit"
-                    :disabled="processing"
+                    :loading="processing"
                     data-test="join-channel"
-                    class="inline-flex h-10 shrink-0 items-center gap-2 rounded-full bg-primary px-5 text-[13.5px] font-semibold text-brass transition-colors hover:bg-primary/90 disabled:opacity-60 dark:text-primary-foreground"
+                    class="h-10 shrink-0 rounded-full px-5 text-[13.5px] font-semibold text-brass dark:text-primary-foreground"
                 >
-                    <LoaderCircle
-                        v-if="processing"
-                        class="size-3.5 animate-spin"
-                        aria-hidden="true"
-                    />
                     <Plus
-                        v-else
+                        v-if="!processing"
                         class="size-3.5"
                         :stroke-width="2.2"
                         aria-hidden="true"
                     />
                     {{ processing ? $t('Joining…') : $t('Join channel') }}
-                </button>
+                </Button>
             </div>
         </Form>
     </div>

--- a/resources/js/components/MessageActions.vue
+++ b/resources/js/components/MessageActions.vue
@@ -12,6 +12,7 @@ import {
 import { computed } from 'vue';
 import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
 import MessageReminderPopover from '@/components/MessageReminderPopover.vue';
+import { Button } from '@/components/ui/button';
 import {
     Tooltip,
     TooltipContent,
@@ -109,22 +110,17 @@ const showDivider = computed(
             showDelete.value),
 );
 
-// Shared icon-button treatment: a 30×28 hit area holding a size-3.5 glyph,
-// resting muted and lifting to foreground on hover, a legible brass focus ring
-// for keyboard users, and a reserved transparent border so the brass open-state
-// below never shifts the layout (border-box keeps the footprint fixed).
-const iconButtonClass =
-    'inline-flex h-7 w-7.5 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none';
+// The bar's icon buttons ride the `<Button variant="ghost" size="icon-sm">`
+// primitive; these classes only tune what the primitive doesn't own: a muted
+// resting glyph (`ghost` rests transparent), and — for the two popover triggers
+// (react / remind) — an accent-filled "open" state so it reads as active while
+// its menu is attached.
+const iconButtonClass = 'text-muted-foreground';
+const openStateClass = 'bg-accent text-accent-foreground';
 
 // Delete recolors to the destructive token on hover instead of neutral.
 const deleteButtonClass =
-    'inline-flex h-7 w-7.5 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none';
-
-// The persistent "open" state for a button anchoring a popover (react / remind):
-// brass carries the meaning that a menu is attached here, per the design's
-// deliberate brass-only-when-active call.
-const openStateClass =
-    'border-brass-border bg-brass-fill text-brass-fill-foreground';
+    'text-muted-foreground hover:bg-destructive/10 hover:text-destructive';
 </script>
 
 <template>
@@ -148,28 +144,32 @@ const openStateClass =
                 v-slot="{ open }"
                 @select="(emoji) => emit('react', emoji)"
             >
-                <button
+                <Button
+                    variant="ghost"
+                    size="icon-sm"
                     type="button"
                     data-test="message-react"
                     :data-open="open || undefined"
                     :aria-label="$t('Add reaction')"
-                    :class="[iconButtonClass, open ? openStateClass : '']"
+                    :class="open ? openStateClass : iconButtonClass"
                 >
-                    <SmilePlus class="size-3.5" />
-                </button>
+                    <SmilePlus />
+                </Button>
             </EmojiPickerPopover>
 
             <Tooltip v-if="showStartThread">
                 <TooltipTrigger as-child>
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
                         type="button"
                         data-test="message-thread"
                         :aria-label="$t('Reply in thread')"
                         :class="iconButtonClass"
                         @click="emit('openThread')"
                     >
-                        <MessageSquareText class="size-3.5" />
-                    </button>
+                        <MessageSquareText />
+                    </Button>
                 </TooltipTrigger>
                 <TooltipContent side="top" :side-offset="6">
                     {{ $t('Reply in thread') }}
@@ -178,15 +178,17 @@ const openStateClass =
 
             <Tooltip v-if="showReply">
                 <TooltipTrigger as-child>
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
                         type="button"
                         data-test="message-reply"
                         :aria-label="$t('Reply to message')"
                         :class="iconButtonClass"
                         @click="emit('reply')"
                     >
-                        <CornerUpLeft class="size-3.5" />
-                    </button>
+                        <CornerUpLeft />
+                    </Button>
                 </TooltipTrigger>
                 <TooltipContent side="top" :side-offset="6">
                     {{ $t('Reply to message') }}
@@ -201,15 +203,17 @@ const openStateClass =
 
             <Tooltip v-if="showForward">
                 <TooltipTrigger as-child>
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
                         type="button"
                         data-test="message-forward"
                         :aria-label="$t('Forward message')"
                         :class="iconButtonClass"
                         @click="emit('forward')"
                     >
-                        <Forward class="size-3.5" />
-                    </button>
+                        <Forward />
+                    </Button>
                 </TooltipTrigger>
                 <TooltipContent side="top" :side-offset="6">
                     {{ $t('Forward message') }}
@@ -218,7 +222,9 @@ const openStateClass =
 
             <Tooltip v-if="showPin">
                 <TooltipTrigger as-child>
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
                         type="button"
                         data-test="message-pin"
                         :aria-label="
@@ -229,11 +235,8 @@ const openStateClass =
                         :class="iconButtonClass"
                         @click="isPinned ? emit('unpin') : emit('pin')"
                     >
-                        <Pin
-                            class="size-3.5"
-                            :class="isPinned ? 'fill-brass text-brass' : ''"
-                        />
-                    </button>
+                        <Pin :class="isPinned ? 'fill-brass text-brass' : ''" />
+                    </Button>
                 </TooltipTrigger>
                 <TooltipContent side="top" :side-offset="6">
                     {{
@@ -251,28 +254,32 @@ const openStateClass =
                 @set="(remindAt) => emit('remind', remindAt)"
                 @custom="emit('remindCustom')"
             >
-                <button
+                <Button
+                    variant="ghost"
+                    size="icon-sm"
                     type="button"
                     data-test="message-remind"
                     :data-open="open || undefined"
                     :aria-label="$t('Remind me about this')"
-                    :class="[iconButtonClass, open ? openStateClass : '']"
+                    :class="open ? openStateClass : iconButtonClass"
                 >
-                    <AlarmClock class="size-3.5" />
-                </button>
+                    <AlarmClock />
+                </Button>
             </MessageReminderPopover>
 
             <Tooltip v-if="showEdit">
                 <TooltipTrigger as-child>
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
                         type="button"
                         data-test="message-edit"
                         :aria-label="$t('Edit message')"
                         :class="iconButtonClass"
                         @click="emit('edit')"
                     >
-                        <Pencil class="size-3.5" />
-                    </button>
+                        <Pencil />
+                    </Button>
                 </TooltipTrigger>
                 <TooltipContent side="top" :side-offset="6">
                     {{ $t('Edit message') }}
@@ -281,15 +288,17 @@ const openStateClass =
 
             <Tooltip v-if="showDelete">
                 <TooltipTrigger as-child>
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
                         type="button"
                         data-test="message-delete"
                         :aria-label="$t('Delete message')"
                         :class="deleteButtonClass"
                         @click="emit('delete')"
                     >
-                        <Trash2 class="size-3.5" />
-                    </button>
+                        <Trash2 />
+                    </Button>
                 </TooltipTrigger>
                 <TooltipContent side="top" :side-offset="6">
                     {{ $t('Delete message') }}

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -589,6 +589,7 @@ function onKeydown(event: KeyboardEvent): void {
                         :is-deleted="props.replyTarget.isDeleted"
                     />
                 </span>
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke composer chip dismiss -->
                 <button
                     type="button"
                     data-test="reply-preview-dismiss"
@@ -617,6 +618,7 @@ function onKeydown(event: KeyboardEvent): void {
                 <span class="shrink-0 text-[11.5px] text-muted-foreground">
                     {{ $t('Enter to save · Esc to cancel') }}
                 </span>
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke composer chip dismiss -->
                 <button
                     type="button"
                     data-test="composer-editing-dismiss"

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -683,6 +683,7 @@ function confirmDelete(): void {
                                     }}</span>
                                 </div>
 
+                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke quoted-reply preview control -->
                                 <button
                                     v-if="
                                         message.replyTo &&
@@ -738,20 +739,23 @@ function confirmDelete(): void {
                                     <div
                                         class="mt-1 flex items-center gap-2 text-[11.5px] text-muted-foreground"
                                     >
-                                        <button
+                                        <Button
+                                            size="sm"
                                             type="button"
-                                            class="rounded bg-primary px-2 py-1 font-medium text-primary-foreground hover:bg-primary/90"
+                                            class="h-7 px-2"
                                             @click="saveEdit(message)"
                                         >
                                             {{ $t('Save') }}
-                                        </button>
-                                        <button
+                                        </Button>
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
                                             type="button"
-                                            class="rounded border border-border px-2 py-1 font-medium text-foreground hover:bg-muted"
+                                            class="h-7 px-2"
                                             @click="cancelEdit"
                                         >
                                             {{ $t('Cancel') }}
-                                        </button>
+                                        </Button>
                                         <span>{{
                                             $t('Enter to save · Esc to cancel')
                                         }}</span>
@@ -902,6 +906,7 @@ function confirmDelete(): void {
                                     v-if="showThreadSummary(message)"
                                     class="mt-1.5 flex flex-wrap items-center gap-2"
                                 >
+                                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke thread-summary card -->
                                     <button
                                         type="button"
                                         data-test="thread-summary"

--- a/resources/js/components/MessageReactions.vue
+++ b/resources/js/components/MessageReactions.vue
@@ -76,6 +76,7 @@ function toggle(emoji: string): void {
             :close-delay="100"
         >
             <HoverCardTrigger as-child>
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke reaction pill (toggle) -->
                 <button
                     type="button"
                     data-test="reaction-pill"
@@ -135,6 +136,7 @@ function toggle(emoji: string): void {
             v-if="props.canReact"
             @select="(emoji) => emit('toggle', emoji)"
         >
+            <!-- eslint-disable-next-line local/no-raw-button -- bespoke add-reaction pill -->
             <button
                 type="button"
                 data-test="add-reaction"

--- a/resources/js/components/MessageReminderPopover.vue
+++ b/resources/js/components/MessageReminderPopover.vue
@@ -91,6 +91,7 @@ function chooseCustom(): void {
                     {{ $t('Remind me about this') }}
                 </div>
                 <div class="flex flex-col">
+                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke reminder menu item -->
                     <button
                         v-for="preset in presets"
                         :key="preset.key"
@@ -108,6 +109,7 @@ function chooseCustom(): void {
                         >
                     </button>
                     <div class="mx-2 my-1.5 h-px bg-border"></div>
+                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke reminder menu item -->
                     <button
                         type="button"
                         data-test="reminder-custom"

--- a/resources/js/components/OnboardingTour.vue
+++ b/resources/js/components/OnboardingTour.vue
@@ -178,6 +178,7 @@ onBeforeUnmount(() => {
                     />
                 </div>
 
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke control on the branded tour surface -->
                 <button
                     type="button"
                     data-test="onboarding-skip"

--- a/resources/js/components/PasswordInput.vue
+++ b/resources/js/components/PasswordInput.vue
@@ -28,6 +28,7 @@ defineExpose({
             :class="cn('pr-10', props.class)"
             v-bind="$attrs"
         />
+        <!-- eslint-disable-next-line local/no-raw-button -- bespoke show/hide toggle nested inside the input -->
         <button
             type="button"
             @click="showPassword = !showPassword"

--- a/resources/js/components/PinsPanel.vue
+++ b/resources/js/components/PinsPanel.vue
@@ -50,6 +50,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
 <template>
     <div>
         <!-- Transparent backdrop: an outside click dismisses the popover. -->
+        <!-- eslint-disable-next-line local/no-raw-button -- full-screen click-catcher backdrop -->
         <button
             type="button"
             data-test="pins-panel-backdrop"
@@ -62,7 +63,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
             role="dialog"
             :aria-label="$t('Pinned messages')"
             data-test="pins-panel"
-            class="absolute top-2 right-6 z-50 w-[392px] max-w-[calc(100vw-3rem)] overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-xl"
+            class="absolute top-2 right-6 z-50 w-98 max-w-[calc(100vw-3rem)] overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-xl"
         >
             <!-- Header: brass pin + title, with the count on the right. -->
             <div
@@ -120,6 +121,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                     :key="message.id"
                     class="group/pin relative"
                 >
+                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke pinned-message list row -->
                     <button
                         type="button"
                         data-test="pins-panel-row"
@@ -186,6 +188,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
 
                     <!-- Unpin: a floating pill revealed on row hover. Any member
                          may unpin (shared toggle); hidden read-only otherwise. -->
+                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke floating unpin pill -->
                     <button
                         v-if="props.canPin"
                         type="button"

--- a/resources/js/components/ReminderNudge.vue
+++ b/resources/js/components/ReminderNudge.vue
@@ -42,6 +42,7 @@ const channelLabel = computed(() =>
             >
                 {{ $t('Reminder · due now') }}
             </span>
+            <!-- eslint-disable-next-line local/no-raw-button -- bespoke dismiss on the branded nudge -->
             <button
                 type="button"
                 data-test="reminder-nudge-close"
@@ -89,6 +90,7 @@ const channelLabel = computed(() =>
         </div>
 
         <div class="flex items-center gap-2.5">
+            <!-- eslint-disable-next-line local/no-raw-button -- bespoke pill on the branded nudge -->
             <button
                 type="button"
                 data-test="reminder-nudge-open"
@@ -97,6 +99,7 @@ const channelLabel = computed(() =>
             >
                 {{ $t('Open message') }}
             </button>
+            <!-- eslint-disable-next-line local/no-raw-button -- bespoke pill on the branded nudge -->
             <button
                 type="button"
                 data-test="reminder-nudge-snooze"
@@ -105,6 +108,7 @@ const channelLabel = computed(() =>
             >
                 {{ $t('Snooze 20 min') }}
             </button>
+            <!-- eslint-disable-next-line local/no-raw-button -- bespoke text action on the branded nudge -->
             <button
                 type="button"
                 data-test="reminder-nudge-done"

--- a/resources/js/components/RemindersDialog.vue
+++ b/resources/js/components/RemindersDialog.vue
@@ -90,6 +90,7 @@ function openReminder(reminder: MessageReminder): void {
                             })
                         }}
                     </span>
+                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline text action -->
                     <button
                         v-if="reminders.length > 0"
                         type="button"
@@ -142,6 +143,7 @@ function openReminder(reminder: MessageReminder): void {
                             :data-reminder="reminder.id"
                             class="flex items-center gap-3 rounded-xl border border-border bg-card p-3"
                         >
+                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke reminder list row -->
                             <button
                                 type="button"
                                 data-test="reminder-open"
@@ -194,6 +196,7 @@ function openReminder(reminder: MessageReminder): void {
                                 <Clock class="size-3" />
                                 {{ whenLabel(reminder.remindAt) }}
                             </span>
+                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke row icon action -->
                             <button
                                 type="button"
                                 data-test="reminder-clear"

--- a/resources/js/components/ScheduleMessageDialog.vue
+++ b/resources/js/components/ScheduleMessageDialog.vue
@@ -185,6 +185,7 @@ function confirm(): void {
             </DialogHeader>
 
             <div class="grid grid-cols-2 gap-2" data-test="schedule-presets">
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke schedule-preset item -->
                 <button
                     v-for="preset in presets"
                     :key="preset.key"

--- a/resources/js/components/ScheduledMessagesDialog.vue
+++ b/resources/js/components/ScheduledMessagesDialog.vue
@@ -135,6 +135,7 @@ function bodyPreview(body: string): string {
                         <div
                             class="mt-2 flex items-center justify-between gap-2"
                         >
+                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke reschedule pill -->
                             <button
                                 type="button"
                                 data-test="scheduled-reschedule"
@@ -188,6 +189,7 @@ function bodyPreview(body: string): string {
                                 {{ whenLabel(scheduled.sendAt) }}
                             </span>
                             <div class="flex items-center gap-1">
+                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke row icon action -->
                                 <button
                                     type="button"
                                     :aria-label="$t('Edit scheduled message')"
@@ -197,6 +199,7 @@ function bodyPreview(body: string): string {
                                 >
                                     <Pencil class="size-4" />
                                 </button>
+                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke row icon action -->
                                 <button
                                     type="button"
                                     :aria-label="$t('Cancel scheduled message')"

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -4,6 +4,7 @@ import { ChevronDown, X } from '@lucide/vue';
 import { computed, nextTick, ref, watch } from 'vue';
 import MessageComposer from '@/components/MessageComposer.vue';
 import MessageList from '@/components/MessageList.vue';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useScrollPin } from '@/composables/useScrollPin';
 import type { Mention, Message } from '@/types';
@@ -137,15 +138,17 @@ watch(
                     >#{{ props.channelName }}
                 </p>
             </div>
-            <button
+            <Button
+                variant="outline"
+                size="icon-sm"
                 type="button"
                 data-test="thread-close"
                 :aria-label="$t('Close thread')"
-                class="flex size-6.5 shrink-0 items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-muted hover:text-foreground"
+                class="shrink-0 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground"
                 @click="emit('close')"
             >
-                <X class="size-3.5" />
-            </button>
+                <X />
+            </Button>
         </header>
 
         <div class="relative flex min-h-0 flex-1 flex-col">
@@ -221,6 +224,7 @@ watch(
                 leave-from-class="translate-y-0 opacity-100"
                 leave-to-class="translate-y-1 opacity-0"
             >
+                <!-- eslint-disable-next-line local/no-raw-button -- jump-to-latest pill, deferred to ScrollableMessageList (#316) -->
                 <button
                     v-if="!pinnedToBottom"
                     type="button"

--- a/resources/js/components/ui/button/Button.test.ts
+++ b/resources/js/components/ui/button/Button.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { createSSRApp, h } from "vue"
+import { renderToString } from "vue/server-renderer"
+import { Button } from "."
+
+/**
+ * Renders `<Button>` to an HTML string in the node test environment (no DOM
+ * needed). `$t` is stubbed to echo its key so the Spinner's `$t('Loading')`
+ * resolves without the full app locale plumbing.
+ */
+async function renderButton(props: Record<string, unknown>): Promise<string> {
+  const app = createSSRApp({
+    render: () => h(Button, props, { default: () => "Save changes" }),
+  })
+
+  app.config.globalProperties.$t = (key: string) => key
+
+  return renderToString(app)
+}
+
+describe("Button loading prop", () => {
+  it("renders the spinner and disables the button while loading", async () => {
+    const html = await renderButton({ loading: true })
+
+    // The Spinner renders a `role="status"` element (its accessible pending cue).
+    expect(html).toContain('role="status"')
+    expect(html).toContain("animate-spin")
+    // The `disabled` attribute, not the `disabled:` Tailwind utilities.
+    expect(html).toMatch(/disabled(?!:)/)
+    expect(html).toContain('aria-busy="true"')
+    expect(html).toContain("Save changes")
+  })
+
+  it("renders no spinner and stays enabled when not loading", async () => {
+    const html = await renderButton({ loading: false })
+
+    expect(html).not.toContain('role="status"')
+    expect(html).not.toContain("animate-spin")
+    expect(html).not.toMatch(/disabled(?!:)/)
+    expect(html).not.toContain("aria-busy")
+  })
+})

--- a/resources/js/components/ui/button/Button.vue
+++ b/resources/js/components/ui/button/Button.vue
@@ -3,6 +3,7 @@ import type { PrimitiveProps } from "reka-ui"
 import type { HTMLAttributes } from "vue"
 import type { ButtonVariants } from "."
 import { Primitive } from "reka-ui"
+import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "."
 
@@ -10,6 +11,10 @@ interface Props extends PrimitiveProps {
   variant?: ButtonVariants["variant"]
   size?: ButtonVariants["size"]
   class?: HTMLAttributes["class"]
+  // Renders a leading spinner and disables the control while a request is in
+  // flight, so every submit button gets consistent pending feedback without
+  // each caller re-wiring `<Spinner v-if="processing" />` by hand.
+  loading?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -24,8 +29,11 @@ const props = withDefaults(defineProps<Props>(), {
     :data-size="size"
     :as="as"
     :as-child="asChild"
+    :disabled="loading || undefined"
+    :aria-busy="loading || undefined"
     :class="cn(buttonVariants({ variant, size }), props.class)"
   >
+    <Spinner v-if="loading" />
     <slot />
   </Primitive>
 </template>

--- a/resources/js/pages/auth/ConfirmPassword.vue
+++ b/resources/js/pages/auth/ConfirmPassword.vue
@@ -4,7 +4,6 @@ import InputError from '@/components/InputError.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
-import { Spinner } from '@/components/ui/spinner';
 import { translate } from '@/lib/i18n';
 import { store } from '@/routes/password/confirm';
 
@@ -45,10 +44,9 @@ defineOptions({
             <div class="flex items-center">
                 <Button
                     class="w-full rounded-full"
-                    :disabled="processing"
+                    :loading="processing"
                     data-test="confirm-password-button"
                 >
-                    <Spinner v-if="processing" />
                     {{ $t('Confirm password') }}
                 </Button>
             </div>

--- a/resources/js/pages/auth/ForgotPassword.vue
+++ b/resources/js/pages/auth/ForgotPassword.vue
@@ -6,7 +6,6 @@ import TextLink from '@/components/TextLink.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Spinner } from '@/components/ui/spinner';
 import { translate } from '@/lib/i18n';
 import { login } from '@/routes';
 import { email } from '@/routes/password';
@@ -48,10 +47,9 @@ defineProps<{
             <div class="my-6 flex items-center justify-start">
                 <Button
                     class="w-full rounded-full"
-                    :disabled="processing"
+                    :loading="processing"
                     data-test="email-password-reset-link-button"
                 >
-                    <Spinner v-if="processing" />
                     {{ $t('Email password reset link') }}
                 </Button>
             </div>

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -9,7 +9,6 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Spinner } from '@/components/ui/spinner';
 import { translate } from '@/lib/i18n';
 import { register } from '@/routes';
 import { store } from '@/routes/login';
@@ -98,10 +97,9 @@ defineProps<{
                     type="submit"
                     class="mt-4 w-full rounded-full"
                     :tabindex="4"
-                    :disabled="processing"
+                    :loading="processing"
                     data-test="login-button"
                 >
-                    <Spinner v-if="processing" />
                     {{ $t('Log in') }}
                 </Button>
             </div>

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -7,7 +7,6 @@ import TextLink from '@/components/TextLink.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Spinner } from '@/components/ui/spinner';
 import { translate } from '@/lib/i18n';
 import { login } from '@/routes';
 import { store } from '@/routes/register';
@@ -108,10 +107,9 @@ defineOptions({
                     type="submit"
                     class="mt-2 w-full rounded-full"
                     tabindex="5"
-                    :disabled="processing"
+                    :loading="processing"
                     data-test="register-user-button"
                 >
-                    <Spinner v-if="processing" />
                     {{ $t('Create account') }}
                 </Button>
             </div>

--- a/resources/js/pages/auth/ResetPassword.vue
+++ b/resources/js/pages/auth/ResetPassword.vue
@@ -6,7 +6,6 @@ import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Spinner } from '@/components/ui/spinner';
 import { translate } from '@/lib/i18n';
 import { update } from '@/routes/password';
 
@@ -82,10 +81,9 @@ const inputEmail = ref(props.email);
             <Button
                 type="submit"
                 class="mt-4 w-full rounded-full"
-                :disabled="processing"
+                :loading="processing"
                 data-test="reset-password-button"
             >
-                <Spinner v-if="processing" />
                 {{ $t('Reset password') }}
             </Button>
         </div>

--- a/resources/js/pages/auth/VerifyEmail.vue
+++ b/resources/js/pages/auth/VerifyEmail.vue
@@ -2,7 +2,6 @@
 import { Form, Head, Link } from '@inertiajs/vue3';
 import AuthStatus from '@/components/AuthStatus.vue';
 import { Button } from '@/components/ui/button';
-import { Spinner } from '@/components/ui/spinner';
 import { translate } from '@/lib/i18n';
 import { logout } from '@/routes';
 import { send } from '@/routes/verification';
@@ -39,11 +38,10 @@ defineProps<{
         v-slot="{ processing }"
     >
         <Button
-            :disabled="processing"
+            :loading="processing"
             variant="outline"
             class="w-full rounded-full bg-muted hover:bg-accent"
         >
-            <Spinner v-if="processing" />
             {{ $t('Resend verification email') }}
         </Button>
 

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -881,6 +881,7 @@ function archive(): void {
                         leave-from-class="translate-y-0 opacity-100"
                         leave-to-class="-translate-y-1 opacity-0"
                     >
+                        <!-- eslint-disable-next-line local/no-raw-button -- bespoke jump-to-unread pill -->
                         <button
                             v-if="showJumpToUnread"
                             type="button"
@@ -1015,6 +1016,7 @@ function archive(): void {
                         leave-from-class="translate-y-0 scale-100 opacity-100"
                         leave-to-class="translate-y-3 scale-95 opacity-0"
                     >
+                        <!-- eslint-disable-next-line local/no-raw-button -- jump-to-latest pill, deferred to ScrollableMessageList (#316) -->
                         <button
                             v-if="!pinnedToBottom"
                             type="button"
@@ -1104,6 +1106,7 @@ function archive(): void {
                                       )
                             }}
                         </span>
+                        <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline text action -->
                         <button
                             type="button"
                             data-test="discard-queue"
@@ -1119,6 +1122,7 @@ function archive(): void {
                         class="mx-5 shrink-0"
                     />
 
+                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke scheduled-messages pill -->
                     <button
                         v-if="props.scheduledMessages.length > 0"
                         type="button"

--- a/resources/js/pages/settings/Appearance.vue
+++ b/resources/js/pages/settings/Appearance.vue
@@ -71,6 +71,7 @@ const { shareReadReceipts, updateShareReadReceipts } = useReadReceipts();
             "
         >
             <div class="flex flex-wrap items-center gap-2">
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke segmented chime-sound option (aria-pressed) -->
                 <button
                     v-for="option in chimeSounds"
                     :key="option.value"
@@ -87,6 +88,7 @@ const { shareReadReceipts, updateShareReadReceipts } = useReadReceipts();
                     {{ option.label }}
                 </button>
 
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline preview control -->
                 <button
                     type="button"
                     :disabled="selected === 'off'"

--- a/resources/js/pages/teams/Analytics.vue
+++ b/resources/js/pages/teams/Analytics.vue
@@ -307,6 +307,7 @@ function channelColor(indexInList: number): string {
                 :aria-label="$t('Time range')"
                 data-test="analytics-range"
             >
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke segmented range option -->
                 <button
                     v-for="option in rangeOptions"
                     :key="option.value"

--- a/resources/js/pages/teams/Emojis.vue
+++ b/resources/js/pages/teams/Emojis.vue
@@ -256,6 +256,7 @@ function addedAt(iso: string): string {
                 <span class="w-28 shrink-0 text-xs text-muted-foreground">{{
                     addedAt(emoji.createdAt)
                 }}</span>
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline remove text-link -->
                 <button
                     v-if="canRemove(emoji)"
                     type="button"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
 import { fileURLToPath } from 'node:url';
+import vue from '@vitejs/plugin-vue';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    plugins: [vue()],
     test: {
         environment: 'node',
         include: [


### PR DESCRIPTION
Closes #316. Part of #313 (frontend deepening epic).

## What

1. **`loading` prop on `<Button>`** — renders the `Spinner` and disables the control (with `aria-busy`) internally, so submit buttons get consistent pending feedback without each caller re-wiring `<Spinner v-if="processing" />`. It's a strict superset of `:disabled="processing"` (loading implies disabled).
   - The **6 auth submit buttons** (Login, Register, ForgotPassword, ConfirmPassword, VerifyEmail, ResetPassword) now use `:loading="processing"`.
   - **JoinChannelBar** adopts it too (dropping its hand-rolled `LoaderCircle`).
2. **Migrated the shared icon-button idiom** onto `<Button variant="ghost" size="icon-sm">`:
   - `MessageActions` (the 7-button hover bar — the named example in #316),
   - plus `MessageList` inline Save/Cancel, `ThreadPanel` close, and `ChannelMasthead` pins.
3. **New `no-raw-button` ESLint rule** (`error`) flags raw `<button>` outside `components/ui/`, so CI catches new stray ones. Genuinely-bespoke controls opt out per-occurrence with `<!-- eslint-disable-next-line local/no-raw-button -- <reason> -->`.

## Acceptance criteria (#316)

- [x] `Button` accepts `loading`; a paired test proves it renders the spinner and disables. The 6 auth submit buttons use it.
- [x] Raw `<button>` count outside `ui/` drops materially; the icon-button idiom uses `<Button>`.
- [x] Lint rule added + documented (config comment + rule JSDoc); CI catches new stray raw buttons.
- [x] No a11y regression (`aria-label` / `data-test` preserved); gate green; 100% coverage held.

## Bespoke controls left raw (with opt-out)

~39 genuinely-bespoke raw buttons (segmented `aria-pressed` toggles, list rows/cards, pills on branded surfaces, popover menu items, the full-screen backdrop, and the two jump-to-latest pills deferred to `ScrollableMessageList`) stay raw with an explicit one-line opt-out + reason. They don't map onto the current `<Button>` variants without a large override class or a visible design regression. **Migrating them onto a properly-styled/extended Button primitive is tracked in #323.**

## Tests

- New `Button.test.ts` renders via SSR (`renderToString`, no new deps) and asserts the spinner + `disabled` + `aria-busy` appear only when `loading`.
- New `no-raw-button.test.ts` (RuleTester + `isExemptFile` unit tests).
- `vitest.config.ts` now wires the already-present `@vitejs/plugin-vue` so `.vue` SFCs can be imported in tests.

## Gate

`sail composer test` green (Pint, PHPStan, Rector clean; **coverage 100%**); `lint:check` (0 errors), `format:check`, `types:check`, `build`, and `test:js` (472 JS tests) all pass; full Pest suite 875 passed / 4 skipped.

## Note

Frontend-only change — no PHP touched.
