### PR TITLE
feat: add a FormField module and migrate hand-built field clusters onto it

### DIFF
--- a/resources/js/components/CreateChannelModal.vue
+++ b/resources/js/components/CreateChannelModal.vue
@@ -2,7 +2,7 @@
 import { Form } from '@inertiajs/vue3';
 import { ref } from 'vue';
 import { store } from '@/actions/App/Http/Controllers/Channels/ChannelController';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -15,7 +15,6 @@ import {
     DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
     Select,
     SelectContent,
@@ -63,8 +62,12 @@ function handleOpenChange(value: boolean) {
                 </DialogHeader>
 
                 <div class="grid gap-4">
-                    <div class="grid gap-2">
-                        <Label for="name">{{ $t('Name') }}</Label>
+                    <FormField
+                        id="name"
+                        :label="$t('Name')"
+                        :error="errors.name"
+                        v-slot="{ id }"
+                    >
                         <div class="relative">
                             <span
                                 aria-hidden="true"
@@ -72,7 +75,7 @@ function handleOpenChange(value: boolean) {
                                 >#</span
                             >
                             <Input
-                                id="name"
+                                :id="id"
                                 name="name"
                                 data-test="create-channel-name"
                                 :placeholder="$t('marketing')"
@@ -80,17 +83,20 @@ function handleOpenChange(value: boolean) {
                                 required
                             />
                         </div>
-                        <InputError :message="errors.name" />
-                    </div>
+                    </FormField>
 
-                    <div class="grid gap-2">
-                        <Label for="visibility">{{ $t('Visibility') }}</Label>
+                    <FormField
+                        id="visibility"
+                        :label="$t('Visibility')"
+                        :error="errors.visibility"
+                        v-slot="{ id }"
+                    >
                         <Select
                             v-model="visibility"
                             name="visibility"
                             data-test="create-channel-visibility"
                         >
-                            <SelectTrigger class="w-full">
+                            <SelectTrigger :id="id" class="w-full">
                                 <SelectValue
                                     :placeholder="$t('Select visibility')"
                                 />
@@ -104,19 +110,21 @@ function handleOpenChange(value: boolean) {
                                 }}</SelectItem>
                             </SelectContent>
                         </Select>
-                        <InputError :message="errors.visibility" />
-                    </div>
+                    </FormField>
 
-                    <div class="grid gap-2">
-                        <Label for="topic">{{ $t('Topic (optional)') }}</Label>
+                    <FormField
+                        id="topic"
+                        :label="$t('Topic (optional)')"
+                        :error="errors.topic"
+                        v-slot="{ id }"
+                    >
                         <Input
-                            id="topic"
+                            :id="id"
                             name="topic"
                             data-test="create-channel-topic"
                             :placeholder="$t('What\'s this channel about?')"
                         />
-                        <InputError :message="errors.topic" />
-                    </div>
+                    </FormField>
                 </div>
 
                 <DialogFooter class="gap-2">

--- a/resources/js/components/CreateTeamModal.vue
+++ b/resources/js/components/CreateTeamModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Form } from '@inertiajs/vue3';
 import { ref } from 'vue';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -14,7 +14,6 @@ import {
     DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { store } from '@/routes/teams';
 
 const open = ref(false);
@@ -51,17 +50,20 @@ function handleOpenChange(value: boolean) {
                     </DialogDescription>
                 </DialogHeader>
 
-                <div class="grid gap-2">
-                    <Label for="name">{{ $t('Team name') }}</Label>
+                <FormField
+                    id="name"
+                    :label="$t('Team name')"
+                    :error="errors.name"
+                    v-slot="{ id }"
+                >
                     <Input
-                        id="name"
+                        :id="id"
                         name="name"
                         data-test="create-team-name"
                         :placeholder="$t('My team')"
                         required
                     />
-                    <InputError :message="errors.name" />
-                </div>
+                </FormField>
 
                 <DialogFooter class="gap-2">
                     <DialogClose as-child>

--- a/resources/js/components/DeleteTeamModal.vue
+++ b/resources/js/components/DeleteTeamModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Form } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -13,7 +13,6 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { destroy } from '@/routes/teams';
 import type { Team } from '@/types';
 
@@ -67,22 +66,23 @@ const handleOpenChange = (nextOpen: boolean) => {
                 </DialogHeader>
 
                 <div class="space-y-4 py-4">
-                    <div class="grid gap-2">
-                        <Label for="confirmation-name">
+                    <FormField id="confirmation-name" :error="errors.name">
+                        <template #label>
                             {{ $t('Type') }}
                             <strong>"{{ props.team.name }}"</strong>
                             {{ $t('to confirm') }}
-                        </Label>
-                        <Input
-                            id="confirmation-name"
-                            name="name"
-                            data-test="delete-team-name"
-                            v-model="confirmationName"
-                            :placeholder="$t('Enter team name')"
-                            autocomplete="off"
-                        />
-                        <InputError :message="errors.name" />
-                    </div>
+                        </template>
+                        <template #default="{ id }">
+                            <Input
+                                :id="id"
+                                name="name"
+                                data-test="delete-team-name"
+                                v-model="confirmationName"
+                                :placeholder="$t('Enter team name')"
+                                autocomplete="off"
+                            />
+                        </template>
+                    </FormField>
                 </div>
 
                 <DialogFooter class="gap-2">

--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -2,7 +2,7 @@
 import { Form } from '@inertiajs/vue3';
 import { useTemplateRef } from 'vue';
 import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import {
@@ -15,7 +15,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Label } from '@/components/ui/label';
 
 const passwordInput = useTemplateRef('passwordInput');
 </script>
@@ -55,18 +54,20 @@ const passwordInput = useTemplateRef('passwordInput');
                         </DialogDescription>
                     </DialogHeader>
 
-                    <div class="grid gap-2">
-                        <Label for="password" class="sr-only">{{
-                            $t('Password')
-                        }}</Label>
+                    <FormField
+                        id="password"
+                        :label="$t('Password')"
+                        label-class="sr-only"
+                        :error="errors.password"
+                        v-slot="{ id }"
+                    >
                         <PasswordInput
-                            id="password"
+                            :id="id"
                             name="password"
                             ref="passwordInput"
                             :placeholder="$t('Password')"
                         />
-                        <InputError :message="errors.password" />
-                    </div>
+                    </FormField>
 
                     <DialogFooter class="gap-2">
                         <DialogClose as-child>

--- a/resources/js/components/FormField.test.ts
+++ b/resources/js/components/FormField.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { createSSRApp, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import FormField from './FormField.vue';
+
+/**
+ * Renders `<FormField>` to an HTML string in the node test environment. `$t` is
+ * stubbed to echo its key so any child relying on the global translate helper
+ * resolves without the full app locale plumbing.
+ *
+ * The default slot mirrors a real call-site: it binds the scoped `id` onto an
+ * `<input>` so the test can prove the label/control coupling is decided in one
+ * place.
+ */
+async function renderField(
+    props: Record<string, unknown>,
+    slots: Record<string, (scope: { id: string }) => unknown> = {
+        default: ({ id }) => h('input', { id, name: 'email' }),
+    },
+): Promise<string> {
+    const app = createSSRApp({
+        render: () => h(FormField, props, slots),
+    });
+
+    app.config.globalProperties.$t = (key: string) => key;
+
+    return renderToString(app);
+}
+
+describe('FormField', () => {
+    it('couples the label to the control by feeding one id to both', async () => {
+        const html = await renderField({ id: 'email', label: 'Email address' });
+
+        // The label points at the control...
+        expect(html).toContain('for="email"');
+        // ...and the control the slot rendered carries that exact id.
+        expect(html).toContain('id="email"');
+        expect(html).toContain('Email address');
+    });
+
+    it('renders the error message when one is present', async () => {
+        const html = await renderField({
+            id: 'email',
+            label: 'Email address',
+            error: 'The email field is required.',
+        });
+
+        expect(html).toContain('The email field is required.');
+    });
+
+    it('omits the error text when there is no error', async () => {
+        const html = await renderField({ id: 'email', label: 'Email address' });
+
+        expect(html).not.toContain('field is required');
+        // The error slot stays hidden rather than reserving space.
+        expect(html).toContain('style="display:none;"');
+    });
+
+    it('renders the optional hint line when provided', async () => {
+        const html = await renderField({
+            id: 'locale',
+            label: 'Display language',
+            hint: 'Dates and numbers follow your language.',
+        });
+
+        expect(html).toContain('Dates and numbers follow your language.');
+    });
+
+    it('renders a rich label through the label slot, overriding the prop', async () => {
+        const html = await renderField(
+            { id: 'confirmation-name', label: 'unused' },
+            {
+                default: ({ id }) => h('input', { id, name: 'name' }),
+                label: () => [h('span', 'Type '), h('strong', '"Acme"')],
+            },
+        );
+
+        expect(html).toContain('<strong>&quot;Acme&quot;</strong>');
+        expect(html).not.toContain('unused');
+    });
+
+    it('applies labelClass to the label element', async () => {
+        const html = await renderField({
+            id: 'transfer-password',
+            label: 'Password',
+            labelClass: 'sr-only',
+        });
+
+        expect(html).toMatch(/<label[^>]*\bsr-only\b/);
+    });
+
+    it('renders trailing label content through the labelAction slot', async () => {
+        const html = await renderField(
+            { id: 'password', label: 'Password' },
+            {
+                default: ({ id }) => h('input', { id, name: 'password' }),
+                labelAction: () =>
+                    h('a', { href: '/forgot' }, 'Forgot password?'),
+            },
+        );
+
+        expect(html).toContain('Forgot password?');
+        expect(html).toContain('href="/forgot"');
+    });
+});

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { useId } from 'vue';
+import InputError from '@/components/InputError.vue';
+import { Label } from '@/components/ui/label';
+
+/**
+ * The single place a form field's shape is decided: the `grid gap-2` wrapper,
+ * the `<Label :for>` binding, the `<InputError>` placement, and an optional
+ * hint line. The control lives in the default slot and receives the field `id`
+ * via slot scope, so the label/control coupling is wired from one source and
+ * cannot drift.
+ */
+const props = defineProps<{
+    label?: string;
+    id?: string;
+    error?: string;
+    hint?: string;
+    labelClass?: string;
+}>();
+
+const fieldId = props.id ?? useId();
+</script>
+
+<template>
+    <div class="grid gap-2">
+        <div
+            v-if="$slots.labelAction"
+            class="flex items-center justify-between"
+        >
+            <Label :for="fieldId" :class="labelClass">
+                <slot name="label">{{ label }}</slot>
+            </Label>
+            <slot name="labelAction" />
+        </div>
+        <Label v-else :for="fieldId" :class="labelClass">
+            <slot name="label">{{ label }}</slot>
+        </Label>
+
+        <slot :id="fieldId" />
+
+        <InputError :message="error" />
+
+        <p v-if="hint" class="text-sm text-muted-foreground">{{ hint }}</p>
+    </div>
+</template>

--- a/resources/js/components/InviteMemberModal.vue
+++ b/resources/js/components/InviteMemberModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Form } from '@inertiajs/vue3';
 import { ref } from 'vue';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -13,7 +13,6 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
     Select,
     SelectContent,
@@ -82,27 +81,34 @@ function handleOpenChange(value: boolean) {
                 </DialogHeader>
 
                 <div class="grid gap-4">
-                    <div class="grid gap-2">
-                        <Label for="email">{{ $t('Email address') }}</Label>
+                    <FormField
+                        id="email"
+                        :label="$t('Email address')"
+                        :error="errors.email"
+                        v-slot="{ id }"
+                    >
                         <Input
-                            id="email"
+                            :id="id"
                             name="email"
                             data-test="invite-email"
                             type="email"
                             :placeholder="$t('colleague@example.com')"
                             required
                         />
-                        <InputError :message="errors.email" />
-                    </div>
+                    </FormField>
 
-                    <div class="grid gap-2">
-                        <Label for="role">{{ $t('Role') }}</Label>
+                    <FormField
+                        id="role"
+                        :label="$t('Role')"
+                        :error="errors.role"
+                        v-slot="{ id }"
+                    >
                         <Select
                             v-model="inviteRole"
                             name="role"
                             data-test="invite-role"
                         >
-                            <SelectTrigger class="w-full">
+                            <SelectTrigger :id="id" class="w-full">
                                 <SelectValue
                                     :placeholder="$t('Select a role')"
                                 />
@@ -117,8 +123,7 @@ function handleOpenChange(value: boolean) {
                                 </SelectItem>
                             </SelectContent>
                         </Select>
-                        <InputError :message="errors.role" />
-                    </div>
+                    </FormField>
                 </div>
 
                 <DialogFooter class="gap-2">

--- a/resources/js/components/LogOutOtherDevicesDialog.vue
+++ b/resources/js/components/LogOutOtherDevicesDialog.vue
@@ -2,7 +2,7 @@
 import { Form } from '@inertiajs/vue3';
 import { computed, useTemplateRef } from 'vue';
 import SessionController from '@/actions/App/Http/Controllers/Settings/SessionController';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import {
@@ -15,7 +15,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Label } from '@/components/ui/label';
 import type { ActiveSession } from '@/types';
 
 type Props = {
@@ -66,18 +65,20 @@ const hasOtherSessions = computed(() =>
                     </DialogDescription>
                 </DialogHeader>
 
-                <div class="grid gap-2">
-                    <Label for="revoke_others_password" class="sr-only">
-                        {{ $t('Password') }}
-                    </Label>
+                <FormField
+                    id="revoke_others_password"
+                    :label="$t('Password')"
+                    label-class="sr-only"
+                    :error="errors.password"
+                    v-slot="{ id }"
+                >
                     <PasswordInput
-                        id="revoke_others_password"
+                        :id="id"
                         name="password"
                         ref="revokeOthersInput"
                         :placeholder="$t('Password')"
                     />
-                    <InputError :message="errors.password" />
-                </div>
+                </FormField>
 
                 <DialogFooter class="gap-2">
                     <DialogClose as-child>

--- a/resources/js/components/ManageSessions.vue
+++ b/resources/js/components/ManageSessions.vue
@@ -3,7 +3,7 @@ import { Form } from '@inertiajs/vue3';
 import { Monitor, Smartphone } from '@lucide/vue';
 import { useTemplateRef } from 'vue';
 import SessionController from '@/actions/App/Http/Controllers/Settings/SessionController';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import {
@@ -16,7 +16,6 @@ import {
     DialogTitle,
     DialogTrigger,
 } from '@/components/ui/dialog';
-import { Label } from '@/components/ui/label';
 import { useTimezone } from '@/composables/useTimezone';
 import { formatDateTime } from '@/lib/datetime';
 import type { ActiveSession } from '@/types';
@@ -128,18 +127,20 @@ function lastActive(iso: string): string {
                             </DialogDescription>
                         </DialogHeader>
 
-                        <div class="grid gap-2">
-                            <Label for="revoke_password" class="sr-only">
-                                {{ $t('Password') }}
-                            </Label>
+                        <FormField
+                            id="revoke_password"
+                            :label="$t('Password')"
+                            label-class="sr-only"
+                            :error="errors.password"
+                            v-slot="{ id }"
+                        >
                             <PasswordInput
-                                id="revoke_password"
+                                :id="id"
                                 name="password"
                                 ref="revokeInput"
                                 :placeholder="$t('Password')"
                             />
-                            <InputError :message="errors.password" />
-                        </div>
+                        </FormField>
 
                         <DialogFooter class="gap-2">
                             <DialogClose as-child>

--- a/resources/js/components/TransferOwnershipModal.vue
+++ b/resources/js/components/TransferOwnershipModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Form } from '@inertiajs/vue3';
 import { ref, useTemplateRef } from 'vue';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import {
@@ -13,7 +13,6 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import { Label } from '@/components/ui/label';
 import { transferOwnership } from '@/routes/teams/members';
 import type { Team, TeamMember } from '@/types';
 
@@ -74,19 +73,21 @@ const handleOpenChange = (nextOpen: boolean) => {
                     </DialogDescription>
                 </DialogHeader>
 
-                <div class="grid gap-2">
-                    <Label for="transfer-password" class="sr-only">
-                        {{ $t('Password') }}
-                    </Label>
+                <FormField
+                    id="transfer-password"
+                    :label="$t('Password')"
+                    label-class="sr-only"
+                    :error="errors.password"
+                    v-slot="{ id }"
+                >
                     <PasswordInput
-                        id="transfer-password"
+                        :id="id"
                         name="password"
                         ref="passwordInput"
                         data-test="transfer-ownership-password"
                         :placeholder="$t('Password')"
                     />
-                    <InputError :message="errors.password" />
-                </div>
+                </FormField>
 
                 <DialogFooter class="gap-2">
                     <DialogClose as-child>

--- a/resources/js/pages/auth/ConfirmPassword.vue
+++ b/resources/js/pages/auth/ConfirmPassword.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
 import { translate } from '@/lib/i18n';
 import { store } from '@/routes/password/confirm';
 
@@ -27,19 +26,20 @@ defineOptions({
         v-slot="{ errors, processing }"
     >
         <div class="space-y-6">
-            <div class="grid gap-2">
-                <Label for="password">{{ $t('Password') }}</Label>
+            <FormField
+                id="password"
+                :label="$t('Password')"
+                :error="errors.password"
+                v-slot="{ id }"
+            >
                 <PasswordInput
-                    id="password"
+                    :id="id"
                     name="password"
-                    class="mt-1 block w-full"
                     required
                     autocomplete="current-password"
                     autofocus
                 />
-
-                <InputError :message="errors.password" />
-            </div>
+            </FormField>
 
             <div class="flex items-center">
                 <Button

--- a/resources/js/pages/auth/ForgotPassword.vue
+++ b/resources/js/pages/auth/ForgotPassword.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
 import AuthStatus from '@/components/AuthStatus.vue';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import TextLink from '@/components/TextLink.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { translate } from '@/lib/i18n';
 import { login } from '@/routes';
 import { email } from '@/routes/password';
@@ -31,18 +30,21 @@ defineProps<{
 
     <div class="space-y-6">
         <Form v-bind="email.form()" v-slot="{ errors, processing }">
-            <div class="grid gap-2">
-                <Label for="email">{{ $t('Email address') }}</Label>
+            <FormField
+                id="email"
+                :label="$t('Email address')"
+                :error="errors.email"
+                v-slot="{ id }"
+            >
                 <Input
-                    id="email"
+                    :id="id"
                     type="email"
                     name="email"
                     autocomplete="off"
                     autofocus
                     placeholder="email@example.com"
                 />
-                <InputError :message="errors.email" />
-            </div>
+            </FormField>
 
             <div class="my-6 flex items-center justify-start">
                 <Button

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
 import AuthStatus from '@/components/AuthStatus.vue';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import TeamInvitationAlert from '@/components/TeamInvitationAlert.vue';
 import TextLink from '@/components/TextLink.vue';
@@ -48,10 +48,14 @@ defineProps<{
             class="flex flex-col gap-6"
         >
             <div class="grid gap-6">
-                <div class="grid gap-2">
-                    <Label for="email">{{ $t('Email address') }}</Label>
+                <FormField
+                    id="email"
+                    :label="$t('Email address')"
+                    :error="errors.email"
+                    v-slot="{ id }"
+                >
                     <Input
-                        id="email"
+                        :id="id"
                         type="email"
                         name="email"
                         required
@@ -60,12 +64,14 @@ defineProps<{
                         autocomplete="email"
                         placeholder="email@example.com"
                     />
-                    <InputError :message="errors.email" />
-                </div>
+                </FormField>
 
-                <div class="grid gap-2">
-                    <div class="flex items-center justify-between">
-                        <Label for="password">{{ $t('Password') }}</Label>
+                <FormField
+                    id="password"
+                    :label="$t('Password')"
+                    :error="errors.password"
+                >
+                    <template #labelAction>
                         <TextLink
                             v-if="canResetPassword"
                             :href="request()"
@@ -74,17 +80,18 @@ defineProps<{
                         >
                             {{ $t('Forgot password?') }}
                         </TextLink>
-                    </div>
-                    <PasswordInput
-                        id="password"
-                        name="password"
-                        required
-                        :tabindex="2"
-                        autocomplete="current-password"
-                        :placeholder="$t('Password')"
-                    />
-                    <InputError :message="errors.password" />
-                </div>
+                    </template>
+                    <template #default="{ id }">
+                        <PasswordInput
+                            :id="id"
+                            name="password"
+                            required
+                            :tabindex="2"
+                            autocomplete="current-password"
+                            :placeholder="$t('Password')"
+                        />
+                    </template>
+                </FormField>
 
                 <div class="flex items-center justify-between">
                     <Label for="remember" class="flex items-center space-x-3">

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import TeamInvitationAlert from '@/components/TeamInvitationAlert.vue';
 import TextLink from '@/components/TextLink.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { translate } from '@/lib/i18n';
 import { login } from '@/routes';
 import { store } from '@/routes/register';
@@ -44,10 +43,14 @@ defineOptions({
             class="flex flex-col gap-6"
         >
             <div class="grid gap-6">
-                <div class="grid gap-2">
-                    <Label for="name">{{ $t('Name') }}</Label>
+                <FormField
+                    id="name"
+                    :label="$t('Name')"
+                    :error="errors.name"
+                    v-slot="{ id }"
+                >
                     <Input
-                        id="name"
+                        :id="id"
                         type="text"
                         required
                         autofocus
@@ -56,13 +59,16 @@ defineOptions({
                         name="name"
                         :placeholder="$t('Full name')"
                     />
-                    <InputError :message="errors.name" />
-                </div>
+                </FormField>
 
-                <div class="grid gap-2">
-                    <Label for="email">{{ $t('Email address') }}</Label>
+                <FormField
+                    id="email"
+                    :label="$t('Email address')"
+                    :error="errors.email"
+                    v-slot="{ id }"
+                >
                     <Input
-                        id="email"
+                        :id="id"
                         type="email"
                         required
                         :tabindex="2"
@@ -70,13 +76,16 @@ defineOptions({
                         name="email"
                         placeholder="email@example.com"
                     />
-                    <InputError :message="errors.email" />
-                </div>
+                </FormField>
 
-                <div class="grid gap-2">
-                    <Label for="password">{{ $t('Password') }}</Label>
+                <FormField
+                    id="password"
+                    :label="$t('Password')"
+                    :error="errors.password"
+                    v-slot="{ id }"
+                >
                     <PasswordInput
-                        id="password"
+                        :id="id"
                         required
                         :tabindex="3"
                         autocomplete="new-password"
@@ -84,15 +93,16 @@ defineOptions({
                         :placeholder="$t('Password')"
                         :passwordrules="passwordRules"
                     />
-                    <InputError :message="errors.password" />
-                </div>
+                </FormField>
 
-                <div class="grid gap-2">
-                    <Label for="password_confirmation">{{
-                        $t('Confirm password')
-                    }}</Label>
+                <FormField
+                    id="password_confirmation"
+                    :label="$t('Confirm password')"
+                    :error="errors.password_confirmation"
+                    v-slot="{ id }"
+                >
                     <PasswordInput
-                        id="password_confirmation"
+                        :id="id"
                         required
                         :tabindex="4"
                         autocomplete="new-password"
@@ -100,8 +110,7 @@ defineOptions({
                         :placeholder="$t('Confirm password')"
                         :passwordrules="passwordRules"
                     />
-                    <InputError :message="errors.password_confirmation" />
-                </div>
+                </FormField>
 
                 <Button
                     type="submit"

--- a/resources/js/pages/auth/ResetPassword.vue
+++ b/resources/js/pages/auth/ResetPassword.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
 import { ref } from 'vue';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { translate } from '@/lib/i18n';
 import { update } from '@/routes/password';
 
@@ -35,48 +34,52 @@ const inputEmail = ref(props.email);
         v-slot="{ errors, processing }"
     >
         <div class="grid gap-6">
-            <div class="grid gap-2">
-                <Label for="email">{{ $t('Email') }}</Label>
+            <FormField
+                id="email"
+                :label="$t('Email')"
+                :error="errors.email"
+                v-slot="{ id }"
+            >
                 <Input
-                    id="email"
+                    :id="id"
                     type="email"
                     name="email"
                     autocomplete="email"
                     v-model="inputEmail"
-                    class="mt-1 block w-full"
                     readonly
                 />
-                <InputError :message="errors.email" class="mt-2" />
-            </div>
+            </FormField>
 
-            <div class="grid gap-2">
-                <Label for="password">{{ $t('Password') }}</Label>
+            <FormField
+                id="password"
+                :label="$t('Password')"
+                :error="errors.password"
+                v-slot="{ id }"
+            >
                 <PasswordInput
-                    id="password"
+                    :id="id"
                     name="password"
                     autocomplete="new-password"
-                    class="mt-1 block w-full"
                     autofocus
                     :placeholder="$t('Password')"
                     :passwordrules="passwordRules"
                 />
-                <InputError :message="errors.password" />
-            </div>
+            </FormField>
 
-            <div class="grid gap-2">
-                <Label for="password_confirmation">{{
-                    $t('Confirm password')
-                }}</Label>
+            <FormField
+                id="password_confirmation"
+                :label="$t('Confirm password')"
+                :error="errors.password_confirmation"
+                v-slot="{ id }"
+            >
                 <PasswordInput
-                    id="password_confirmation"
+                    :id="id"
                     name="password_confirmation"
                     autocomplete="new-password"
-                    class="mt-1 block w-full"
                     :placeholder="$t('Confirm password')"
                     :passwordrules="passwordRules"
                 />
-                <InputError :message="errors.password_confirmation" />
-            </div>
+            </FormField>
 
             <Button
                 type="submit"

--- a/resources/js/pages/settings/Localization.vue
+++ b/resources/js/pages/settings/Localization.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3';
 import { ref } from 'vue';
+import FormField from '@/components/FormField.vue';
 import SettingsSection from '@/components/SettingsSection.vue';
-import { Label } from '@/components/ui/label';
 import {
     Select,
     SelectContent,
@@ -55,11 +55,18 @@ function onSelect(value: unknown): void {
             $t('Choose the language used across your workspace interface.')
         "
     >
-        <div class="grid gap-2">
-            <Label for="locale">{{ $t('Display language') }}</Label>
-
+        <FormField
+            id="locale"
+            :label="$t('Display language')"
+            :hint="
+                $t(
+                    'Dates, times, and numbers are formatted to match your selected language.',
+                )
+            "
+            v-slot="{ id }"
+        >
             <Select :model-value="selected" @update:model-value="onSelect">
-                <SelectTrigger id="locale" class="w-full">
+                <SelectTrigger :id="id" class="w-full">
                     <SelectValue :placeholder="$t('Select a language')" />
                 </SelectTrigger>
                 <SelectContent>
@@ -72,14 +79,6 @@ function onSelect(value: unknown): void {
                     </SelectItem>
                 </SelectContent>
             </Select>
-
-            <p class="text-sm text-muted-foreground">
-                {{
-                    $t(
-                        'Dates, times, and numbers are formatted to match your selected language.',
-                    )
-                }}
-            </p>
-        </div>
+        </FormField>
     </SettingsSection>
 </template>

--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -3,11 +3,10 @@ import { Form, Head, usePage } from '@inertiajs/vue3';
 import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import ProfileController from '@/actions/App/Http/Controllers/Settings/ProfileController';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import SettingsSection from '@/components/SettingsSection.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
     Select,
     SelectContent,
@@ -64,75 +63,85 @@ function onTimezoneSelect(value: unknown): void {
             class="space-y-6"
             v-slot="{ errors, processing, recentlySuccessful }"
         >
-            <div class="grid gap-2">
-                <Label for="name">{{ $t('Name') }}</Label>
+            <FormField
+                id="name"
+                :label="$t('Name')"
+                :error="errors.name"
+                v-slot="{ id }"
+            >
                 <Input
-                    id="name"
-                    class="mt-1 block w-full"
+                    :id="id"
                     name="name"
                     :default-value="user.name"
                     required
                     autocomplete="name"
                     :placeholder="$t('Full name')"
                 />
-                <InputError class="mt-2" :message="errors.name" />
-            </div>
+            </FormField>
 
-            <div class="grid gap-2">
-                <Label for="email">{{ $t('Email address') }}</Label>
+            <FormField
+                id="email"
+                :label="$t('Email address')"
+                :error="errors.email"
+                v-slot="{ id }"
+            >
                 <Input
-                    id="email"
+                    :id="id"
                     type="email"
-                    class="mt-1 block w-full"
                     name="email"
                     :default-value="user.email"
                     required
                     autocomplete="username"
                     :placeholder="$t('Email address')"
                 />
-                <InputError class="mt-2" :message="errors.email" />
-            </div>
+            </FormField>
 
-            <div class="grid gap-2">
-                <Label for="pronouns">{{ $t('Pronouns') }}</Label>
+            <FormField
+                id="pronouns"
+                :label="$t('Pronouns')"
+                :error="errors.pronouns"
+                v-slot="{ id }"
+            >
                 <Input
-                    id="pronouns"
-                    class="mt-1 block w-full"
+                    :id="id"
                     name="pronouns"
                     :default-value="user.pronouns ?? ''"
                     maxlength="50"
                     :placeholder="$t('e.g. she/her, they/them')"
                 />
-                <InputError class="mt-2" :message="errors.pronouns" />
-            </div>
+            </FormField>
 
-            <div class="grid gap-2">
-                <Label for="title">{{ $t('Job title') }}</Label>
+            <FormField
+                id="title"
+                :label="$t('Job title')"
+                :error="errors.title"
+                v-slot="{ id }"
+            >
                 <Input
-                    id="title"
-                    class="mt-1 block w-full"
+                    :id="id"
                     name="title"
                     :default-value="user.title ?? ''"
                     maxlength="100"
                     :placeholder="$t('e.g. Product Designer')"
                 />
-                <InputError class="mt-2" :message="errors.title" />
-            </div>
+            </FormField>
 
-            <div class="grid gap-2">
-                <Label for="phone">{{ $t('Phone') }}</Label>
+            <FormField
+                id="phone"
+                :label="$t('Phone')"
+                :error="errors.phone"
+                v-slot="{ id }"
+            >
                 <Input
-                    id="phone"
+                    :id="id"
                     type="tel"
-                    class="mt-1 block w-full"
                     name="phone"
                     :default-value="user.phone ?? ''"
                     maxlength="30"
                     autocomplete="tel"
                     :placeholder="$t('e.g. +1 555 123 4567')"
                 />
-                <InputError class="mt-2" :message="errors.phone" />
-            </div>
+            </FormField>
 
             <div
                 v-if="
@@ -197,17 +206,12 @@ function onTimezoneSelect(value: unknown): void {
             )
         "
     >
-        <div class="grid gap-2">
-            <Label for="timezone">{{ $t('Timezone') }}</Label>
+        <FormField id="timezone" :label="$t('Timezone')" v-slot="{ id }">
             <Select
                 :model-value="timezone ?? undefined"
                 @update:model-value="onTimezoneSelect"
             >
-                <SelectTrigger
-                    id="timezone"
-                    class="w-full"
-                    data-test="timezone"
-                >
+                <SelectTrigger :id="id" class="w-full" data-test="timezone">
                     <SelectValue :placeholder="$t('Select a timezone')" />
                 </SelectTrigger>
                 <SelectContent>
@@ -220,6 +224,6 @@ function onTimezoneSelect(value: unknown): void {
                     </SelectItem>
                 </SelectContent>
             </Select>
-        </div>
+        </FormField>
     </SettingsSection>
 </template>

--- a/resources/js/pages/settings/Security.vue
+++ b/resources/js/pages/settings/Security.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Form, Head } from '@inertiajs/vue3';
 import SecurityController from '@/actions/App/Http/Controllers/Settings/SecurityController';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import LogOutOtherDevicesDialog from '@/components/LogOutOtherDevicesDialog.vue';
 import ManageSessions from '@/components/ManageSessions.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
@@ -9,7 +9,6 @@ import SecurityActivity from '@/components/SecurityActivity.vue';
 import SettingsPane from '@/components/SettingsPane.vue';
 import SettingsPaneSection from '@/components/SettingsPaneSection.vue';
 import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
 import { translate } from '@/lib/i18n';
 import { edit } from '@/routes/security';
 import type { ActiveSession, SecurityActivityEvent } from '@/types';
@@ -67,47 +66,49 @@ defineOptions({
                 class="space-y-6"
                 v-slot="{ errors, processing, recentlySuccessful }"
             >
-                <div class="grid gap-2">
-                    <Label for="current_password">{{
-                        $t('Current password')
-                    }}</Label>
+                <FormField
+                    id="current_password"
+                    :label="$t('Current password')"
+                    :error="errors.current_password"
+                    v-slot="{ id }"
+                >
                     <PasswordInput
-                        id="current_password"
+                        :id="id"
                         name="current_password"
-                        class="mt-1 block w-full"
                         autocomplete="current-password"
                         :placeholder="$t('Current password')"
                     />
-                    <InputError :message="errors.current_password" />
-                </div>
+                </FormField>
 
-                <div class="grid gap-2">
-                    <Label for="password">{{ $t('New password') }}</Label>
+                <FormField
+                    id="password"
+                    :label="$t('New password')"
+                    :error="errors.password"
+                    v-slot="{ id }"
+                >
                     <PasswordInput
-                        id="password"
+                        :id="id"
                         name="password"
-                        class="mt-1 block w-full"
                         autocomplete="new-password"
                         :placeholder="$t('New password')"
                         :passwordrules="props.passwordRules"
                     />
-                    <InputError :message="errors.password" />
-                </div>
+                </FormField>
 
-                <div class="grid gap-2">
-                    <Label for="password_confirmation">{{
-                        $t('Confirm password')
-                    }}</Label>
+                <FormField
+                    id="password_confirmation"
+                    :label="$t('Confirm password')"
+                    :error="errors.password_confirmation"
+                    v-slot="{ id }"
+                >
                     <PasswordInput
-                        id="password_confirmation"
+                        :id="id"
                         name="password_confirmation"
-                        class="mt-1 block w-full"
                         autocomplete="new-password"
                         :placeholder="$t('Confirm password')"
                         :passwordrules="props.passwordRules"
                     />
-                    <InputError :message="errors.password_confirmation" />
-                </div>
+                </FormField>
 
                 <div class="flex items-center gap-4">
                     <Button

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -4,8 +4,8 @@ import { ChevronDown, Crown, Mail, Send, UserPlus, X } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import CancelInvitationModal from '@/components/CancelInvitationModal.vue';
 import DeleteTeamModal from '@/components/DeleteTeamModal.vue';
+import FormField from '@/components/FormField.vue';
 import Heading from '@/components/Heading.vue';
-import InputError from '@/components/InputError.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import RemoveMemberModal from '@/components/RemoveMemberModal.vue';
 import TransferOwnershipModal from '@/components/TransferOwnershipModal.vue';
@@ -19,7 +19,6 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
     Tooltip,
     TooltipContent,
@@ -137,17 +136,20 @@ const confirmTransferOwnership = (member: TeamMember) => {
                 class="space-y-6"
                 v-slot="{ errors, processing }"
             >
-                <div class="grid gap-2">
-                    <Label for="name">{{ $t('Team name') }}</Label>
+                <FormField
+                    id="name"
+                    :label="$t('Team name')"
+                    :error="errors.name"
+                    v-slot="{ id }"
+                >
                     <Input
-                        id="name"
+                        :id="id"
                         name="name"
                         data-test="team-name-input"
                         :default-value="team.name"
                         required
                     />
-                    <InputError :message="errors.name" />
-                </div>
+                </FormField>
 
                 <div class="flex items-center gap-4">
                     <Button


### PR DESCRIPTION
Part of #313 (frontend deepening epic). Follows #316 (Button loading prop).

## What

Adds `resources/js/components/FormField.vue` — one deep module that owns the
`grid gap-2` wrapper, the `<Label :for>` binding, `<InputError>` placement, and
an optional hint line — then migrates **all 33 hand-built clusters across 17
files** onto it. The inline `grid gap-2 → Label → control → InputError` triad no
longer appears anywhere except inside the module (grep-confirmed).

## Interface

```vue
<FormField id="email" :label="$t('Email address')" :error="errors.email" v-slot="{ id }">
    <Input :id="id" type="email" name="email" ... />
</FormField>
```

- **`id`** drives the `Label`'s `for` **and** is handed back through slot scope
  (`v-slot="{ id }"`) so the control binds the same `:id`. The label/control
  coupling is now decided in one place and cannot drift. The `id` string is
  written once (Playwright's `#email`/`#password` selectors are preserved).
- **`error`** → `InputError` (hidden, no reserved space, when empty).
- **`hint`** → optional muted line (e.g. `Localization.vue`).
- **`labelClass`** → for `sr-only` labels (the password-confirm dialogs).
- **`#label`** slot → rich label content (`DeleteTeamModal`'s `Type "name" to confirm`).
- **`#labelAction`** slot → trailing label-row content (`Login`'s "Forgot password?").

## Normalization by construction

The copies had drifted: some `Input`s carried `mt-1 block w-full`, some
`InputError`s `mt-2`, some not. Because `FormField` owns the wrapper and error
placement (and `Input`/`PasswordInput` are already `w-full`), those redundant
classes are dropped and every field now spaces identically. Two `<Select>`
triggers (`CreateChannelModal` visibility, `InviteMemberModal` role) previously
had a `<Label for=...>` pointing at a trigger with **no `id`** — the module now
wires that association correctly.

## Tests

`FormField.test.ts` renders the component via SSR `renderToString` (same harness
as `Button.test.ts`, `$t` stubbed) and proves: label↔control id coupling, error
rendering + omission, the hint line, the rich-label slot, `labelClass`, and the
`labelAction` slot. Frontend gate (lint/format/types/build/`test:js`) and backend
gate (Pint/PHPStan/Rector + 100% coverage) both green; zero new eslint warnings.

## Scope

All 33 sites migrated — none deferred. Sibling children #315 (ConfirmDialog),
#317 (ScrollableMessageList) and #323 (remaining raw `<button>`s) are out of
scope here.

Closes #314
