### PR TITLE
chore(deps): update composer and npm dependencies

### DIFF
--- a/.claude/skills/laravel-best-practices/SKILL.md
+++ b/.claude/skills/laravel-best-practices/SKILL.md
@@ -8,183 +8,52 @@ metadata:
 
 # Laravel Best Practices
 
-Best practices for Laravel, prioritized by impact. Each rule teaches what to do and why. For exact API syntax, verify with `search-docs`.
+Best practices for Laravel, organized as an index of rule files. Each rule file teaches what to do and why. For exact API syntax, verify with `search-docs`.
 
 ## Consistency First
 
-Before applying any rule, check what the application already does. Laravel offers multiple valid approaches — the best choice is the one the codebase already uses, even if another pattern would be theoretically better. Inconsistency is worse than a suboptimal pattern.
+Before applying any rule, check what the application already does. Laravel offers multiple valid approaches, and the best choice is the one the codebase already uses, even if another pattern would be theoretically better. Inconsistency is worse than a suboptimal pattern.
 
-Check sibling files, related controllers, models, or tests for established patterns. If one exists, follow it — don't introduce a second way. These rules are defaults for when no pattern exists yet, not overrides.
-
-## Quick Reference
-
-### 1. Database Performance → `rules/db-performance.md`
-
-- Eager load with `with()` to prevent N+1 queries
-- Enable `Model::preventLazyLoading()` in development
-- Select only needed columns, avoid `SELECT *`
-- `chunk()` / `chunkById()` for large datasets
-- Index columns used in `WHERE`, `ORDER BY`, `JOIN`
-- `withCount()` instead of loading relations to count
-- `cursor()` for memory-efficient read-only iteration
-- Never query in Blade templates
-
-### 2. Advanced Query Patterns → `rules/advanced-queries.md`
-
-- `addSelect()` subqueries over eager-loading entire has-many for a single value
-- Dynamic relationships via subquery FK + `belongsTo`
-- Conditional aggregates (`CASE WHEN` in `selectRaw`) over multiple count queries
-- `setRelation()` to prevent circular N+1 queries
-- `whereIn` + `pluck()` over `whereHas` for better index usage
-- Two simple queries can beat one complex query
-- Compound indexes matching `orderBy` column order
-- Correlated subqueries in `orderBy` for has-many sorting (avoid joins)
-
-### 3. Security → `rules/security.md`
-
-- Define `$fillable` or `$guarded` on every model, authorize every action via policies or gates
-- No raw SQL with user input — use Eloquent or query builder
-- `{{ }}` for output escaping, `@csrf` on all POST/PUT/DELETE forms, `throttle` on auth and API routes
-- Validate MIME type, extension, and size for file uploads
-- Never commit `.env`, use `config()` for secrets, `encrypted` cast for sensitive DB fields
-
-### 4. Caching → `rules/caching.md`
-
-- `Cache::remember()` over manual get/put
-- `Cache::flexible()` for stale-while-revalidate on high-traffic data
-- `Cache::memo()` to avoid redundant cache hits within a request
-- Cache tags to invalidate related groups
-- `Cache::add()` for atomic conditional writes
-- `once()` to memoize per-request or per-object lifetime
-- `Cache::lock()` / `lockForUpdate()` for race conditions
-- Failover cache stores in production
-
-### 5. Eloquent Patterns → `rules/eloquent.md`
-
-- Correct relationship types with return type hints
-- Local scopes for reusable query constraints
-- Global scopes sparingly — document their existence
-- Attribute casts in the `casts()` method
-- Cast date columns, use Carbon instances in templates
-- `whereBelongsTo($model)` for cleaner queries
-- Never hardcode table names — use `(new Model)->getTable()` or Eloquent queries
-
-### 6. Validation & Forms → `rules/validation.md`
-
-- Form Request classes, not inline validation
-- Array notation `['required', 'email']` for new code; follow existing convention
-- `$request->validated()` only — never `$request->all()`
-- `Rule::when()` for conditional validation
-- `after()` instead of `withValidator()`
-
-### 7. Configuration → `rules/config.md`
-
-- `env()` only inside config files
-- `App::environment()` or `app()->isProduction()`
-- Config, lang files, and constants over hardcoded text
-
-### 8. Testing Patterns → `rules/testing.md`
-
-- `LazilyRefreshDatabase` over `RefreshDatabase` for speed
-- `assertModelExists()` over raw `assertDatabaseHas()`
-- Factory states and sequences over manual overrides
-- Use fakes (`Event::fake()`, `Exceptions::fake()`, etc.) — but always after factory setup, not before
-- `recycle()` to share relationship instances across factories
-
-### 9. Queue & Job Patterns → `rules/queue-jobs.md`
-
-- `retry_after` must exceed job `timeout`; use exponential backoff `[1, 5, 10]`
-- `ShouldBeUnique` to prevent duplicates; `ShouldBeUniqueUntilProcessing` for early lock release
-- Always implement `failed()`; with `retryUntil()`, set `$tries = 0`
-- `RateLimited` middleware for external API calls; `Bus::batch()` for related jobs
-- Horizon for complex multi-queue scenarios
-
-### 10. Routing & Controllers → `rules/routing.md`
-
-- Implicit route model binding
-- Scoped bindings for nested resources
-- `Route::resource()` or `apiResource()`
-- Methods under 10 lines — extract to actions/services
-- Type-hint Form Requests for auto-validation
-
-### 11. HTTP Client → `rules/http-client.md`
-
-- Explicit `timeout` and `connectTimeout` on every request
-- `retry()` with exponential backoff for external APIs
-- Check response status or use `throw()`
-- `Http::pool()` for concurrent independent requests
-- `Http::fake()` and `preventStrayRequests()` in tests
-
-### 12. Events, Notifications & Mail → `rules/events-notifications.md`, `rules/mail.md`
-
-- Event discovery over manual registration; `event:cache` in production
-- `ShouldDispatchAfterCommit` / `afterCommit()` inside transactions
-- Queue notifications and mailables with `ShouldQueue`
-- On-demand notifications for non-user recipients
-- `HasLocalePreference` on notifiable models
-- `assertQueued()` not `assertSent()` for queued mailables
-- Markdown mailables for transactional emails
-
-### 13. Error Handling → `rules/error-handling.md`
-
-- `report()`/`render()` on exception classes or in `bootstrap/app.php` — follow existing pattern
-- `ShouldntReport` for exceptions that should never log
-- Throttle high-volume exceptions to protect log sinks
-- `dontReportDuplicates()` for multi-catch scenarios
-- Force JSON rendering for API routes
-- Structured context via `context()` on exception classes
-
-### 14. Task Scheduling → `rules/scheduling.md`
-
-- `withoutOverlapping()` on variable-duration tasks
-- `onOneServer()` on multi-server deployments
-- `runInBackground()` for concurrent long tasks
-- `environments()` to restrict to appropriate environments
-- `takeUntilTimeout()` for time-bounded processing
-- Schedule groups for shared configuration
-
-### 15. Architecture → `rules/architecture.md`
-
-- Single-purpose Action classes; dependency injection over `app()` helper
-- Prefer official Laravel packages and follow conventions, don't override defaults
-- Default to `ORDER BY id DESC` or `created_at DESC`; `mb_*` for UTF-8 safety
-- `defer()` for post-response work; `Context` for request-scoped data; `Concurrency::run()` for parallel execution
-
-### 16. Migrations → `rules/migrations.md`
-
-- Generate migrations with `php artisan make:migration`
-- `constrained()` for foreign keys
-- Never modify migrations that have run in production
-- Add indexes in the migration, not as an afterthought
-- Mirror column defaults in model `$attributes`
-- Reversible `down()` by default; forward-fix migrations for intentionally irreversible changes
-- One concern per migration — never mix DDL and DML
-
-### 17. Collections → `rules/collections.md`
-
-- Higher-order messages for simple collection operations
-- `cursor()` vs. `lazy()` — choose based on relationship needs
-- `lazyById()` when updating records while iterating
-- `toQuery()` for bulk operations on collections
-
-### 18. Blade & Views → `rules/blade-views.md`
-
-- `$attributes->merge()` in component templates
-- Blade components over `@include`; `@pushOnce` for per-component scripts
-- View Composers for shared view data
-- `@aware` for deeply nested component props
-
-### 19. Conventions & Style → `rules/style.md`
-
-- Follow Laravel naming conventions for all entities
-- Prefer Laravel helpers (`Str`, `Arr`, `Number`, `Uri`, `Str::of()`, `$request->string()`) over raw PHP functions
-- No JS/CSS in Blade, no HTML in PHP classes
-- Code should be readable; comments only for config files
+Check sibling files, related controllers, models, or tests for established patterns. If one exists, follow it. Don't introduce a second way. These rules are defaults for when no pattern exists yet, not overrides.
 
 ## How to Apply
 
-Always use a sub-agent to read rule files and explore this skill's content.
+1. Check the changed files, nearby code, project configuration, and relevant tests for established patterns. Deviate only for a correctness or security defect, and call the deviation out.
+2. Map every affected concern to the rule index below. Read each mapped rule file before editing. Skip unrelated rule files.
+3. Make the smallest coherent change. Keep the application's architecture and naming instead of introducing a second pattern for the same job.
+4. Verify version-sensitive Laravel APIs for the installed version with `search-docs`, or inspect the installed framework when it is unavailable.
+5. Run the narrowest relevant tests first, then the project's formatting and static-analysis checks when the change warrants them.
+6. Re-read the diff against every mapped rule before finishing.
 
-1. Identify the file type and select relevant sections (e.g., migration → §16, controller → §1, §3, §5, §6, §10)
-2. Check sibling files for existing patterns — follow those first per Consistency First
-3. Verify API syntax with `search-docs` for the installed Laravel version
+## Rule Index
+
+Cross-cutting changes often need more than one rule file.
+
+| Concern | Read |
+| --- | --- |
+| Query count, eager loading, indexes, large datasets | [`rules/db-performance.md`](rules/db-performance.md) |
+| Subqueries, aggregates, complex ordering and query plans | [`rules/advanced-queries.md`](rules/advanced-queries.md) |
+| Models, relationships, scopes, casts | [`rules/eloquent.md`](rules/eloquent.md) |
+| Authentication, authorization, input safety, secrets, uploads | [`rules/security.md`](rules/security.md) |
+| Form Requests and validation rules | [`rules/validation.md`](rules/validation.md) |
+| Controllers, route binding, resources, middleware | [`rules/routing.md`](rules/routing.md) |
+| Schema changes, columns, foreign keys, indexes | [`rules/migrations.md`](rules/migrations.md) |
+| Jobs, retries, uniqueness, batches, Horizon | [`rules/queue-jobs.md`](rules/queue-jobs.md) |
+| Cache lifetime, invalidation, locks, memoization | [`rules/caching.md`](rules/caching.md) |
+| Outbound requests, retries, timeouts, fakes | [`rules/http-client.md`](rules/http-client.md) |
+| Exceptions, reporting, rendering, log context | [`rules/error-handling.md`](rules/error-handling.md) |
+| Events and notifications | [`rules/events-notifications.md`](rules/events-notifications.md) |
+| Mailables and mail assertions | [`rules/mail.md`](rules/mail.md) |
+| Scheduled tasks and overlap protection | [`rules/scheduling.md`](rules/scheduling.md) |
+| Collections, lazy iteration, bulk operations | [`rules/collections.md`](rules/collections.md) |
+| Blade components, attributes, composers | [`rules/blade-views.md`](rules/blade-views.md) |
+| Environment values and application configuration | [`rules/config.md`](rules/config.md) |
+| Pest/PHPUnit patterns, factories, fakes | [`rules/testing.md`](rules/testing.md) |
+| Naming, helpers, file boundaries, PHP style | [`rules/style.md`](rules/style.md) |
+| Actions, services, dependencies, application structure | [`rules/architecture.md`](rules/architecture.md) |
+
+## Decision Rules
+
+- Prefer framework features and existing application abstractions over new helpers or dependencies.
+- Avoid speculative abstractions. Extract code when it creates a clear domain boundary, removes meaningful duplication, or makes behavior independently testable.
+- Keep database access out of Blade views and prevent hidden N+1 queries across controllers, resources, jobs, and serialization.

--- a/.claude/skills/laravel-best-practices/rules/style.md
+++ b/.claude/skills/laravel-best-practices/rules/style.md
@@ -44,7 +44,7 @@ Strings — use `Str` and fluent `Str::of()` over raw PHP:
 // Incorrect
 $slug = strtolower(str_replace(' ', '-', $title));
 $short = substr($text, 0, 100) . '...';
-$class = substr(strrchr('App\Models\User', '\'), 1);
+$class = substr(strrchr('App\Models\User', '\\'), 1);
 
 // Correct
 $slug = Str::slug($title);

--- a/composer.lock
+++ b/composer.lock
@@ -972,22 +972,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.13.2",
+            "version": "7.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd"
+                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/bcd989ad36c92d42a3715379af91f2defee5b8dd",
-                "reference": "bcd989ad36c92d42a3715379af91f2defee5b8dd",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
+                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5",
-                "guzzlehttp/psr7": "^2.12.3",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.12.5",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
@@ -1080,7 +1080,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.13.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.14.1"
             },
             "funding": [
                 {
@@ -1096,20 +1096,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-05T19:00:11+00:00"
+            "time": "2026-07-13T01:32:54+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
-                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
@@ -1164,7 +1164,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -1180,20 +1180,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:23:43+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.3",
+            "version": "2.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
+                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
-                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9365d578a9fd1552ad6ca9c3cb530708526feb09",
+                "reference": "9365d578a9fd1552ad6ca9c3cb530708526feb09",
                 "shasum": ""
             },
             "require": {
@@ -1283,7 +1283,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.5"
             },
             "funding": [
                 {
@@ -1299,20 +1299,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-23T15:21:08+00:00"
+            "time": "2026-07-13T01:27:20+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.8",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "9c19128923b05a5d7355e5d2318d7808b7e33bbd"
+                "reference": "d7580af6d3f8384325d9cd3e99b21c3ed1848176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/9c19128923b05a5d7355e5d2318d7808b7e33bbd",
-                "reference": "9c19128923b05a5d7355e5d2318d7808b7e33bbd",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/d7580af6d3f8384325d9cd3e99b21c3ed1848176",
+                "reference": "d7580af6d3f8384325d9cd3e99b21c3ed1848176",
                 "shasum": ""
             },
             "require": {
@@ -1369,7 +1369,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.8"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.9"
             },
             "funding": [
                 {
@@ -1385,7 +1385,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-23T13:02:23+00:00"
+            "time": "2026-07-08T16:19:22+00:00"
         },
         {
             "name": "inertiajs/inertia-laravel",
@@ -2324,16 +2324,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/1902f60f984235023acbe03db6ad614a37b3c3e7",
+                "reference": "1902f60f984235023acbe03db6ad614a37b3c3e7",
                 "shasum": ""
             },
             "require": {
@@ -2355,8 +2355,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -2427,7 +2427,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-07-12T15:29:16+00:00"
         },
         {
             "name": "league/config",
@@ -2645,16 +2645,16 @@
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.16.0",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9"
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9",
-                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/f5f47eff7c48ed1003069a2ca67f316fb4021c76",
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76",
                 "shasum": ""
             },
             "require": {
@@ -2664,7 +2664,7 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "phpstan/phpstan": "^0.12.68",
-                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0 || ^11.0 || ^12.0"
             },
             "type": "library",
             "autoload": {
@@ -2685,7 +2685,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.16.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.17.0"
             },
             "funding": [
                 {
@@ -2697,7 +2697,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-21T08:32:55+00:00"
+            "time": "2026-07-09T11:49:27+00:00"
         },
         {
             "name": "league/uri",
@@ -3066,16 +3066,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.13.0",
+            "version": "3.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "40f6618f052df16b545f626fbf9a878e6497d16a"
+                "reference": "2937ad3d1d2c506fd2bc97d571438a95641f44e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/40f6618f052df16b545f626fbf9a878e6497d16a",
-                "reference": "40f6618f052df16b545f626fbf9a878e6497d16a",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/2937ad3d1d2c506fd2bc97d571438a95641f44e2",
+                "reference": "2937ad3d1d2c506fd2bc97d571438a95641f44e2",
                 "shasum": ""
             },
             "require": {
@@ -3167,7 +3167,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-18T13:49:15+00:00"
+            "time": "2026-07-09T18:23:49+00:00"
         },
         {
             "name": "nette/schema",
@@ -3872,16 +3872,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
@@ -3913,9 +3913,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2026-01-25T14:56:51+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -10199,16 +10199,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.5",
+            "version": "v1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "92f121dde31cd1d89d5d0f9eba64ac40271b236e"
+                "reference": "10941bf38de5c585aa2407b2ec4265d806d4eef2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/92f121dde31cd1d89d5d0f9eba64ac40271b236e",
-                "reference": "92f121dde31cd1d89d5d0f9eba64ac40271b236e",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/10941bf38de5c585aa2407b2ec4265d806d4eef2",
+                "reference": "10941bf38de5c585aa2407b2ec4265d806d4eef2",
                 "shasum": ""
             },
             "require": {
@@ -10254,7 +10254,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.5"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.6"
             },
             "funding": [
                 {
@@ -10262,7 +10262,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-27T14:17:20+00:00"
+            "time": "2026-06-27T16:15:40+00:00"
         },
         {
             "name": "amphp/process",
@@ -11597,16 +11597,16 @@
         },
         {
             "name": "laravel/boost",
-            "version": "v2.4.11",
+            "version": "v2.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/boost.git",
-                "reference": "c98fc9d151de97a1864b51fc7c710fc03023ba17"
+                "reference": "d43bdf901fee8d216145cb062c9847c892844908"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/boost/zipball/c98fc9d151de97a1864b51fc7c710fc03023ba17",
-                "reference": "c98fc9d151de97a1864b51fc7c710fc03023ba17",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/d43bdf901fee8d216145cb062c9847c892844908",
+                "reference": "d43bdf901fee8d216145cb062c9847c892844908",
                 "shasum": ""
             },
             "require": {
@@ -11659,7 +11659,7 @@
                 "issues": "https://github.com/laravel/boost/issues",
                 "source": "https://github.com/laravel/boost"
             },
-            "time": "2026-06-26T08:21:49+00:00"
+            "time": "2026-07-08T09:53:34+00:00"
         },
         {
             "name": "laravel/mcp",
@@ -13582,16 +13582,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.5.5",
+            "version": "2.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "9718a72e7f1aacacbdcb6eeed07a47147bce802e"
+                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/9718a72e7f1aacacbdcb6eeed07a47147bce802e",
-                "reference": "9718a72e7f1aacacbdcb6eeed07a47147bce802e",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ba22f8c087848278fed6b4910d4cf1108096d8d3",
+                "reference": "ba22f8c087848278fed6b4910d4cf1108096d8d3",
                 "shasum": ""
             },
             "require": {
@@ -13630,7 +13630,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.5.5"
+                "source": "https://github.com/rectorphp/rector/tree/2.5.7"
             },
             "funding": [
                 {
@@ -13638,7 +13638,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-09T09:48:44+00:00"
+            "time": "2026-07-13T15:24:18+00:00"
         },
         {
             "name": "revolt/event-loop",

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,18 +117,12 @@
                 "url": "https://opencollective.com/babel"
             }
         },
-        "node_modules/@babel/core/node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+        "node_modules/@babel/core/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
-            "license": "MIT",
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
+            "license": "MIT"
         },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
@@ -718,21 +712,6 @@
                 "stylis": "4.2.0"
             }
         },
-        "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "license": "MIT"
-        },
-        "node_modules/@emotion/babel-plugin/node_modules/source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@emotion/cache": {
             "version": "11.14.0",
             "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
@@ -873,9 +852,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -923,9 +902,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -935,7 +914,7 @@
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.1",
+                "js-yaml": "^4.3.0",
                 "minimatch": "^3.1.5",
                 "strip-json-comments": "^3.1.1"
             },
@@ -954,14 +933,27 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -978,9 +970,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-            "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+            "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1015,28 +1007,28 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+            "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.11"
+                "@floating-ui/utils": "^0.2.12"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.7.6",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-            "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+            "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/core": "^1.7.5",
-                "@floating-ui/utils": "^0.2.11"
+                "@floating-ui/core": "^1.8.0",
+                "@floating-ui/utils": "^0.2.12"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+            "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
             "license": "MIT"
         },
         "node_modules/@floating-ui/vue": {
@@ -1282,9 +1274,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/@laravel/echo-vue": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/@laravel/echo-vue/-/echo-vue-2.3.7.tgz",
-            "integrity": "sha512-52lOuge5JdGKjGs1bgzrgbubh6mGATTB2kpQsf4TVXXQez0xF3joPcSoyFv9YAqcn8wxwxUdm2dStTsqfL0r2A==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@laravel/echo-vue/-/echo-vue-2.4.0.tgz",
+            "integrity": "sha512-6QSz2cD4powFqll+5L0x+HRAi9pULlxg40NeF4hDCM29awtGw2ubHZ+8U6ydWk9QpzXAtP3pnwA7zKEeSj2dLw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1506,9 +1498,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-            "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
@@ -1525,9 +1517,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1541,9 +1533,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-            "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
@@ -1557,9 +1549,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
@@ -1573,9 +1565,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
@@ -1589,9 +1581,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
@@ -1605,11 +1597,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1621,11 +1616,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1637,11 +1635,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1653,11 +1654,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1669,11 +1673,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1685,11 +1692,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1701,9 +1711,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -1717,9 +1727,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
@@ -1766,9 +1776,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
@@ -1782,9 +1792,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
@@ -1809,6 +1819,9 @@
             "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2006,6 +2019,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2023,6 +2039,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2038,6 +2057,9 @@
             "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -2056,6 +2078,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2144,9 +2169,9 @@
             }
         },
         "node_modules/@tanstack/virtual-core": {
-            "version": "3.17.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
-            "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+            "version": "3.17.4",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+            "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -2154,12 +2179,12 @@
             }
         },
         "node_modules/@tanstack/vue-virtual": {
-            "version": "3.13.31",
-            "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.31.tgz",
-            "integrity": "sha512-wZMEoSf852jQqaf3Ika1J7PiBae6341LNy/2CxmIyn0XKDQXMuK41wVX+xp6G0yx8jyR95Ef+Tdr13DK7mbJtQ==",
+            "version": "3.13.32",
+            "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.32.tgz",
+            "integrity": "sha512-E8OCutx7QnwZdvpJijz0Q2PHsYDWBWjnGr3TvgWiqxTU35jB1kVhtkd93scRV7tTFuId2tg3x2iFiw+IE4evjQ==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/virtual-core": "3.17.3"
+                "@tanstack/virtual-core": "3.17.4"
             },
             "funding": {
                 "type": "github",
@@ -2552,9 +2577,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "22.20.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
-            "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -2660,17 +2685,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
-            "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+            "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.63.0",
-                "@typescript-eslint/type-utils": "8.63.0",
-                "@typescript-eslint/utils": "8.63.0",
-                "@typescript-eslint/visitor-keys": "8.63.0",
+                "@typescript-eslint/scope-manager": "8.64.0",
+                "@typescript-eslint/type-utils": "8.64.0",
+                "@typescript-eslint/utils": "8.64.0",
+                "@typescript-eslint/visitor-keys": "8.64.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -2683,15 +2708,15 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.63.0",
+                "@typescript-eslint/parser": "^8.64.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2699,16 +2724,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
-            "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+            "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.63.0",
-                "@typescript-eslint/types": "8.63.0",
-                "@typescript-eslint/typescript-estree": "8.63.0",
-                "@typescript-eslint/visitor-keys": "8.63.0",
+                "@typescript-eslint/scope-manager": "8.64.0",
+                "@typescript-eslint/types": "8.64.0",
+                "@typescript-eslint/typescript-estree": "8.64.0",
+                "@typescript-eslint/visitor-keys": "8.64.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2724,14 +2749,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
-            "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+            "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.63.0",
-                "@typescript-eslint/types": "^8.63.0",
+                "@typescript-eslint/tsconfig-utils": "^8.64.0",
+                "@typescript-eslint/types": "^8.64.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -2746,14 +2771,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
-            "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+            "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.63.0",
-                "@typescript-eslint/visitor-keys": "8.63.0"
+                "@typescript-eslint/types": "8.64.0",
+                "@typescript-eslint/visitor-keys": "8.64.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2764,9 +2789,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
-            "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+            "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2781,15 +2806,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
-            "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+            "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.63.0",
-                "@typescript-eslint/typescript-estree": "8.63.0",
-                "@typescript-eslint/utils": "8.63.0",
+                "@typescript-eslint/types": "8.64.0",
+                "@typescript-eslint/typescript-estree": "8.64.0",
+                "@typescript-eslint/utils": "8.64.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -2806,9 +2831,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
-            "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+            "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2820,16 +2845,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
-            "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+            "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.63.0",
-                "@typescript-eslint/tsconfig-utils": "8.63.0",
-                "@typescript-eslint/types": "8.63.0",
-                "@typescript-eslint/visitor-keys": "8.63.0",
+                "@typescript-eslint/project-service": "8.64.0",
+                "@typescript-eslint/tsconfig-utils": "8.64.0",
+                "@typescript-eslint/types": "8.64.0",
+                "@typescript-eslint/visitor-keys": "8.64.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2848,16 +2873,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
-            "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+            "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.63.0",
-                "@typescript-eslint/types": "8.63.0",
-                "@typescript-eslint/typescript-estree": "8.63.0"
+                "@typescript-eslint/scope-manager": "8.64.0",
+                "@typescript-eslint/types": "8.64.0",
+                "@typescript-eslint/typescript-estree": "8.64.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2872,13 +2897,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
-            "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+            "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/types": "8.64.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -3135,6 +3160,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3149,6 +3177,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3163,6 +3194,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3177,6 +3211,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3191,6 +3228,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3205,6 +3245,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3219,6 +3262,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3233,6 +3279,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3247,6 +3296,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3261,6 +3313,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3482,6 +3537,13 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
+        "node_modules/@vitest/utils/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@volar/language-core": {
             "version": "2.4.15",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
@@ -3634,9 +3696,9 @@
             "license": "MIT"
         },
         "node_modules/@vue/language-core/node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4160,27 +4222,6 @@
                 "npm": ">=6"
             }
         },
-        "node_modules/babel-plugin-macros/node_modules/resolve": {
-            "version": "1.22.12",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "is-core-module": "^2.16.1",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -4192,9 +4233,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.42",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+            "version": "2.10.43",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -4243,6 +4284,23 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/body-parser/node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -4277,9 +4335,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
-            "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+            "version": "4.28.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
             "dev": true,
             "funding": [
                 {
@@ -4298,9 +4356,9 @@
             "license": "MIT",
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.42",
-                "caniuse-lite": "^1.0.30001800",
-                "electron-to-chromium": "^1.5.387",
-                "node-releases": "^2.0.50",
+                "caniuse-lite": "^1.0.30001803",
+                "electron-to-chromium": "^1.5.389",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -4425,9 +4483,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001803",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
-            "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+            "version": "1.0.30001805",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+            "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
             "dev": true,
             "funding": [
                 {
@@ -4549,6 +4607,21 @@
                 "node": ">=4"
             }
         },
+        "node_modules/cli-progress/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/cli-spinners": {
             "version": "3.4.0",
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
@@ -4575,6 +4648,21 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/clsx": {
@@ -4614,13 +4702,12 @@
             "license": "MIT"
         },
         "node_modules/commander": {
-            "version": "14.0.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-            "dev": true,
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
             "license": "MIT",
             "engines": {
-                "node": ">=20"
+                "node": ">= 10"
             }
         },
         "node_modules/concat-map": {
@@ -4631,15 +4718,15 @@
             "license": "MIT"
         },
         "node_modules/concurrently": {
-            "version": "9.2.3",
-            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
-            "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
+            "version": "9.2.4",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+            "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chalk": "4.1.2",
                 "rxjs": "7.8.2",
-                "shell-quote": "1.8.4",
+                "shell-quote": "1.9.0",
                 "supports-color": "8.1.1",
                 "tree-kill": "1.2.2",
                 "yargs": "17.7.2"
@@ -4784,10 +4871,9 @@
             }
         },
         "node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true,
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "license": "MIT"
         },
         "node_modules/cookie": {
@@ -4908,6 +4994,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "devOptional": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/csscolorparser": {
@@ -5111,27 +5207,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/d3-dsv/node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/d3-dsv/node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/d3-ease": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -5207,15 +5282,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/d3-geo-projection/node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 10"
             }
         },
         "node_modules/d3-hierarchy": {
@@ -6052,9 +6118,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true,
             "license": "MIT"
         },
@@ -6161,9 +6227,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.4",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-            "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+            "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6172,8 +6238,8 @@
                 "@eslint/config-array": "^0.21.2",
                 "@eslint/config-helpers": "^0.4.2",
                 "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.5",
-                "@eslint/js": "9.39.4",
+                "@eslint/eslintrc": "^3.3.6",
+                "@eslint/js": "9.39.5",
                 "@eslint/plugin-kit": "^0.4.1",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
@@ -6283,6 +6349,30 @@
                 "ms": "^2.1.1"
             }
         },
+        "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+            "version": "2.0.0-next.7",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+            "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.2",
+                "node-exports-info": "^1.6.0",
+                "object-keys": "^1.1.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/eslint-import-resolver-typescript": {
             "version": "4.4.5",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
@@ -6388,9 +6478,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6518,6 +6608,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/eslint-plugin-vue/node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/eslint-plugin-vue/node_modules/vue-eslint-parser": {
             "version": "9.4.3",
             "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
@@ -6599,9 +6702,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7112,9 +7215,10 @@
             "license": "ISC"
         },
         "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -7422,11 +7526,12 @@
             }
         },
         "node_modules/globals": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+            "version": "17.7.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+            "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -7591,9 +7696,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.28",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
-            "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+            "version": "4.12.30",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+            "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7632,20 +7737,15 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
-            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
-            "dev": true,
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
             "engines": {
                 "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/idb": {
@@ -8490,16 +8590,16 @@
             "license": "MIT"
         },
         "node_modules/json5": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.0"
-            },
             "bin": {
                 "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/jsonfile": {
@@ -8551,9 +8651,9 @@
             }
         },
         "node_modules/laravel-echo": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-2.3.7.tgz",
-            "integrity": "sha512-6NoPtOk16PuaykVgcV1MV5665VPtrbyvacBD6AJ8NJdRjTwrOwKrgOYHgq4bz5E1zUbbVi2UJfMN7P7D/yceyQ==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/laravel-echo/-/laravel-echo-2.4.0.tgz",
+            "integrity": "sha512-8w0fAGSNt6THfbNyqdKc29bhfeNpJg13CGx2fcLgoX0/f0mTJm/AIkYTTakmcr9pc42ZB68cSoE00j4/xNaFGQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8590,9 +8690,9 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.1.0.tgz",
-            "integrity": "sha512-Fzocl+X4eQ9jOi0RwdphYRGkUbPJ3ky1pTAST5Ot18cS2gw6d2vldK2eCrlKDVjtibCjCx5qptYDlA0373n7qg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.1.3.tgz",
+            "integrity": "sha512-cI5Anw4QHY+UzvZczFaj+j8NhwT2FtyEN8aqS/hOdt6DpEFBsn6x3GENxALem3cc+TsGvd9MacneimEvShvKMA==",
             "license": "MIT",
             "dependencies": {
                 "picocolors": "^1.0.0",
@@ -8606,7 +8706,7 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "fontaine": "^0.5.0",
+                "fontaine": "^0.8.0",
                 "vite": "^8.0.0"
             },
             "peerDependenciesMeta": {
@@ -8771,6 +8871,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -8790,6 +8893,9 @@
             "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -8811,6 +8917,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -8830,6 +8939,9 @@
             "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -8989,19 +9101,6 @@
             },
             "engines": {
                 "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/make-asynchronous/node_modules/type-fest": {
-            "version": "4.41.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -9222,9 +9321,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -9320,9 +9419,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.50",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-            "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9647,19 +9746,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ora/node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
         "node_modules/ora/node_modules/chalk": {
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -9671,39 +9757,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/ora/node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-east-asian-width": "^1.5.0",
-                "strip-ansi": "^7.1.2"
-            },
-            "engines": {
-                "node": ">=20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ora/node_modules/strip-ansi": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.2.2"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/own-keys": {
@@ -10110,21 +10163,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/playwright/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/possible-typed-array-names": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10136,9 +10174,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -10268,9 +10306,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.9.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-            "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+            "version": "3.9.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+            "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -10512,6 +10550,23 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/raw-body/node_modules/iconv-lite": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/rc9": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
@@ -10562,6 +10617,16 @@
             },
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/recast-x/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -10705,16 +10770,13 @@
             }
         },
         "node_modules/resolve": {
-            "version": "2.0.0-next.7",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-            "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
-            "dev": true,
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "is-core-module": "^2.16.2",
-                "node-exports-info": "^1.6.0",
-                "object-keys": "^1.1.1",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -10820,12 +10882,12 @@
             "license": "Unlicense"
         },
         "node_modules/rolldown": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-            "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.138.0",
+                "@oxc-project/types": "=0.139.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -10835,21 +10897,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.4",
-                "@rolldown/binding-darwin-arm64": "1.1.4",
-                "@rolldown/binding-darwin-x64": "1.1.4",
-                "@rolldown/binding-freebsd-x64": "1.1.4",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-                "@rolldown/binding-linux-arm64-musl": "1.1.4",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-musl": "1.1.4",
-                "@rolldown/binding-openharmony-arm64": "1.1.4",
-                "@rolldown/binding-wasm32-wasi": "1.1.4",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-                "@rolldown/binding-win32-x64-msvc": "1.1.4"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
         "node_modules/router": {
@@ -11153,6 +11215,16 @@
                 "shadcn-vue": "dist/index.js"
             }
         },
+        "node_modules/shadcn-vue/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/shadcn-vue/node_modules/postcss-selector-parser": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
@@ -11191,9 +11263,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+            "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11325,10 +11397,9 @@
             "license": "MIT"
         },
         "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "devOptional": true,
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -11417,18 +11488,49 @@
             }
         },
         "node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
+                "get-east-asian-width": "^1.5.0",
+                "strip-ansi": "^7.1.2"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/string-width/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/string.prototype.trim": {
@@ -11610,9 +11712,9 @@
             "license": "MIT"
         },
         "node_modules/stylus/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -11721,9 +11823,9 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.31.14",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.14.tgz",
-            "integrity": "sha512-nefRpMCsAI4m71/6JHH//KPaP/d5nTuRVxEtQ7N7SlBrX18DAcC+5Z1JKZYeN9Iw49qMx95BTo/gBMk3Y2H6+g==",
+            "version": "5.31.17",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.17.tgz",
+            "integrity": "sha512-TvFA9iwDWlMjqZVlKIJ0Cy+Zgm9ttlMx0SMRwJDMNKyhlEKWBMb3+WRwDi/3dvHdWbexpos4Osp4U49p5WjB5g==",
             "dev": true,
             "license": "MIT",
             "os": [
@@ -11787,6 +11889,21 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/table/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/tailwind-merge": {
             "version": "3.6.0",
@@ -12011,6 +12128,19 @@
                 "strip-bom": "^3.0.0"
             }
         },
+        "node_modules/tsconfig-paths/node_modules/json5": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+            "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.0"
+            },
+            "bin": {
+                "json5": "lib/cli.js"
+            }
+        },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -12047,13 +12177,13 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
-                "node": ">=10"
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -12185,16 +12315,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.63.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
-            "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
+            "version": "8.64.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
+            "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.63.0",
-                "@typescript-eslint/parser": "8.63.0",
-                "@typescript-eslint/typescript-estree": "8.63.0",
-                "@typescript-eslint/utils": "8.63.0"
+                "@typescript-eslint/eslint-plugin": "8.64.0",
+                "@typescript-eslint/parser": "8.64.0",
+                "@typescript-eslint/typescript-estree": "8.64.0",
+                "@typescript-eslint/utils": "8.64.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12378,15 +12508,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-            "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+            "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
+                "picomatch": "^4.0.5",
                 "postcss": "^8.5.16",
-                "rolldown": "~1.1.3",
+                "rolldown": "~1.1.4",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -12474,6 +12604,20 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vite/node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/vitest": {
@@ -12685,6 +12829,16 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/vue-metamorph/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/vue-sonner": {
@@ -12909,6 +13063,21 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -12986,6 +13155,21 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/yocto-queue": {


### PR DESCRIPTION
Routine in-range dependency refresh (lockfiles only; caret ranges unchanged, no majors).

## What changed
- **Composer** (11 packages, patch/minor): guzzlehttp/guzzle 7.13.2→7.14.1, guzzlehttp/psr7 2.12.3→2.12.5, laravel/boost 2.4.11→2.4.12, league/commonmark 2.8.2→2.8.3, league/mime-type-detection 1.16.0→1.17.0, nesbot/carbon 3.13.0→3.13.1, phpstan/phpdoc-parser 2.3.2→2.3.3, rector/rector 2.5.5→2.5.7, plus guzzle promises/uri-template and amphp/pipeline.
- **npm** (notable direct): vite 8.1.3→8.1.4, laravel-echo & @laravel/echo-vue 2.3.7→2.4.0, laravel-vite-plugin 3.1.0→3.1.3, typescript-eslint family 8.63.0→8.64.0, eslint 9.39.4→9.39.5, prettier 3.9.4→3.9.5, rolldown 1.1.4→1.1.5, @tanstack/vue-virtual, @floating-ui/dom 1.7.6→1.8.0, plus transitive bumps.
- The laravel/boost bump regenerated its bundled `laravel-best-practices` skill guidelines (via the `boost:update` post-update hook); those files are folded into the composer commit as a direct product of that bump.

## Testing
- Backend gate green: `composer test` (Pint + PHPStan + Rector dry-run + coverage **100.0%**).
- Frontend gate green: `lint:check` (0 errors), `format:check`, `types:check` (vue-tsc), `build`, and `vitest` (483 tests).
- Security: `composer audit` and `npm audit` both report **0 advisories**.

No majors, no breakage, no issues filed.