### PR TITLE
chore: stamp released version into docs via release-please extra-files

### DIFF
--- a/.agents/skills/release-version-refs/SKILL.md
+++ b/.agents/skills/release-version-refs/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: release-version-refs
+description: Keep hardcoded release-version strings (git checkout vX.Y.Z, ghcr.io/emmpaul/the-desk:X.Y.Z image pins, "as of vX.Y.Z" prose) from drifting. release-please only stamps the new version into lines carrying an x-release-please annotation in a file registered under extra-files. Use whenever a change adds or edits a quick-start / install / upgrade step, an image-pin example, an .env example, or any operator-facing sentence that names a released version — before opening the PR.
+---
+
+Stop hardcoded version strings from silently going stale.
+
+## Why this exists
+
+When release-please cuts a release it bumps `.release-please-manifest.json` and `CHANGELOG.md`, and it stamps the new version into **operator-facing docs** — but **only** into lines that carry an `x-release-please-*` annotation **and** live in a file registered under `extra-files` in `release-please-config.json`. Anything else is invisible to it and drifts the moment a release ships. That is exactly how the README once told operators to `git checkout v1.0.0` while the manifest was already at `1.2.0` (issue #345).
+
+So the rule is mechanical: **a new hardcoded release-version string that is not annotated, or whose file is not registered, will drift.** This is a release-hygiene skill, sibling to `open-pr` — run through it before the PR goes up.
+
+## The rule
+
+Any new **display** of a released version — `git checkout vX.Y.Z`, an `APP_IMAGE=ghcr.io/emmpaul/the-desk:X.Y.Z` pin, a `.env` example, prose like "as of vX.Y.Z" — must:
+
+1. **Carry an annotation** on its line so release-please rewrites the version, and
+2. **Live in a file registered** under `extra-files` in `release-please-config.json`.
+
+Scope is version **display** strings only. **Do not** annotate dependency ranges, lockfile versions, GitHub Action SHA-pin `# vX.Y.Z` comments, or `CHANGELOG.md` — release-please owns the changelog and the manifest, and dep versions are not releases of this app.
+
+## How the annotations work
+
+release-please's **generic** updater scans each registered file line by line. On any line containing one of these markers it replaces the **first** semver on that line with the newly released version:
+
+- `x-release-please-version` → full `X.Y.Z`
+- `x-release-please-major` → the major only
+- `x-release-please-minor` → `X.Y`
+
+The marker just has to appear somewhere on the line; surrounding text is ignored, and only the numeric semver is rewritten (a `v` prefix or `**` bold markers stay put). Pick the form that matches the file's comment syntax:
+
+- **Shell / YAML / `.env` (a `#` comment line):** put the marker in the trailing comment.
+  ```bash
+  git checkout v1.2.0 # x-release-please-version         (the desired release tag)
+  echo 'APP_IMAGE=ghcr.io/emmpaul/the-desk:1.2.0' >> .env # x-release-please-version
+  ```
+- **Markdown prose (no code comment):** append an HTML comment, which renders invisibly.
+  ```markdown
+  As of **v1.2.0**, The Desk does not yet ship attachments. <!-- x-release-please-version -->
+  ```
+
+Because only the **first** semver on the line is replaced, keep exactly one version per annotated line. For a multi-version block, use the block form instead:
+
+```
+<!-- x-release-please-start-version -->
+... one or more version strings ...
+<!-- x-release-please-end -->
+```
+
+## Registering the file
+
+Every annotated file must appear under `extra-files` in `release-please-config.json`. Use the explicit generic form so the annotation scanner runs regardless of file extension (a bare string path picks an updater by extension and can skip your annotations in `.yml`/`.json` files):
+
+```json
+"extra-files": [
+  { "type": "generic", "path": "README.md" }
+]
+```
+
+If you add a version reference to a brand-new file, add that file here too.
+
+## Before opening the PR — grep the diff
+
+Catch any un-annotated version string you (or a sibling edit) introduced:
+
+```bash
+# Version displays added in this branch that are NOT annotated:
+git diff master... -- . ':(exclude)CHANGELOG.md' \
+  | grep -E '^\+' \
+  | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+|the-desk:[0-9]+\.[0-9]+' \
+  | grep -v 'x-release-please'
+```
+
+Every hit is either something to annotate + register, or a false positive to consciously skip (an Action SHA-pin comment, a dependency version, changelog text). Then confirm every annotated file is registered:
+
+```bash
+grep -rlE 'x-release-please' --include='*.md' --include='*.yml' --include='*.env*' . \
+  | grep -v node_modules
+# → each of these paths must appear under extra-files in release-please-config.json
+```
+
+## Verify
+
+- **Config is valid JSON:** `python3 -m json.tool release-please-config.json > /dev/null`.
+- **Dry-run the release PR** to see the stamped lines (needs a token/network; skip if unavailable): `npx release-please release-pr --dry-run --repo-url emmpaul/the-desk --config-file release-please-config.json --manifest-file .release-please-manifest.json`. Or just inspect the next release PR release-please opens — it should rewrite every annotated line with no manual edits.
+- **Docs still build** if you touched `docs/`: `cd docs && npm run build`.
+
+## See also
+
+- `open-pr` — the other release-hygiene skill; the PR **title** is the Conventional Commit release-please reads on a squash merge.
+- `CLAUDE.md` → "Commits & PR titles" and "Self-Hosting Documentation" — never hand-edit `CHANGELOG.md` / `VERSION` / `.release-please-manifest.json`; keep operator docs in sync in the same PR.

--- a/.claude/skills/release-version-refs
+++ b/.claude/skills/release-version-refs
@@ -1,0 +1,1 @@
+../../.agents/skills/release-version-refs

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ There are two supported ways to get the app image, both driven by the same
 git clone git@github.com:emmpaul/the-desk.git
 cd the-desk
 git fetch --tags
-git checkout v1.0.0                                   # the desired release tag
+git checkout v1.2.0 # x-release-please-version         (the desired release tag)
 
 # 2. Generate .env with all required secrets filled in.
 #    Creates .env from the template and fills APP_KEY, DB_PASSWORD,
@@ -178,7 +178,7 @@ rebuild:
 
 ```bash
 git fetch --tags
-git checkout v1.4.0                                   # the desired release tag
+git checkout v1.2.0 # x-release-please-version         (the desired release tag)
 docker compose -f docker-compose.prod.yml down
 docker compose -f docker-compose.prod.yml up -d --build
 # migrations run automatically via the entrypoint
@@ -211,13 +211,13 @@ it at your `.env` and go:
 # 1. Grab the compose file, env template, and secret generator from a release tag.
 git clone git@github.com:emmpaul/the-desk.git
 cd the-desk
-git fetch --tags && git checkout v1.0.0                # the desired release tag
+git fetch --tags && git checkout v1.2.0 # x-release-please-version   (the desired release tag)
 
 # 2. Generate .env secrets, then edit APP_URL, mail, and REVERB_*_PUBLIC (see below).
 ./docker/gen-secrets.sh
 
 # 3. Run the published image instead of building. Pin the version to the tag.
-echo 'APP_IMAGE=ghcr.io/emmpaul/the-desk:1.0.0' >> .env
+echo 'APP_IMAGE=ghcr.io/emmpaul/the-desk:1.2.0' >> .env # x-release-please-version
 docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 ```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,10 +16,11 @@
 
 x-app: &app
   # Defaults to the local build tag (build-from-source). Set APP_IMAGE to the
-  # published image — e.g. APP_IMAGE=ghcr.io/emmpaul/the-desk:1.0.0 — to run the
-  # prebuilt turnkey image instead: `docker compose -f docker-compose.prod.yml pull`
-  # then `up -d`, no build step. Browser Reverb settings are read at runtime, so
-  # one published image works for any host.
+  # published image to run the prebuilt turnkey image instead:
+  # `docker compose -f docker-compose.prod.yml pull` then `up -d`, no build step.
+  # Browser Reverb settings are read at runtime, so one published image works for
+  # any host. Example pin:
+  #   APP_IMAGE=ghcr.io/emmpaul/the-desk:1.2.0 # x-release-please-version
   image: ${APP_IMAGE:-the-desk:latest}
   build:
     context: .

--- a/docs/src/content/docs/docs/comparison.md
+++ b/docs/src/content/docs/docs/comparison.md
@@ -43,10 +43,9 @@ established self-hosted alternatives. The Desk is the newcomer optimizing for
 
 ## When The Desk is *not* the right fit (yet)
 
-Being honest saves you a wasted afternoon. As of **v1.0.0**, The Desk does **not**
+Being honest saves you a wasted afternoon. As of **v1.2.0**, The Desk does **not** <!-- x-release-please-version -->
 have:
 
-- **File & image attachments** — in active development, not shipped yet.
 - **Voice or video calls** — not planned for the near term.
 - **SSO / OIDC / LDAP / SCIM** — on the roadmap, not available today. If your org
   *requires* directory-managed logins now, Mattermost or Rocket.Chat are the

--- a/docs/src/content/docs/docs/faq.md
+++ b/docs/src/content/docs/docs/faq.md
@@ -52,14 +52,14 @@ there's no dedicated iOS/Android app or mobile push notifications today.
 
 ## Does it support file attachments, voice, or video?
 
-**File & image attachments** are in active development but not shipped as of
-v1.0.0. **Voice and video calls** are not on the near-term roadmap. If you need
-those now, see the [comparison page](/docs/comparison/).
+**File & image attachments** are supported. **Voice and video calls** are not on
+the near-term roadmap; if you need those now, see the
+[comparison page](/docs/comparison/).
 
 ## Does it support SSO, OIDC, or LDAP?
 
 Not today — single sign-on and directory-managed users are on the roadmap but not
-available in v1.0.0. If your organization requires them now, a larger platform is
+available in v1.2.0. If your organization requires them now, a larger platform is <!-- x-release-please-version -->
 the safer choice for the moment. See the [comparison](/docs/comparison/).
 
 ## How do upgrades work?

--- a/docs/src/content/docs/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/docs/self-hosting/installation.md
@@ -34,13 +34,13 @@ build time — the same image works for any operator's host with no rebuild.
 # 1. Grab the compose file, env template, and secret generator from a release tag.
 git clone git@github.com:emmpaul/the-desk.git
 cd the-desk
-git fetch --tags && git checkout v1.0.0                # the desired release tag
+git fetch --tags && git checkout v1.2.0 # x-release-please-version   (the desired release tag)
 
 # 2. Generate .env secrets, then edit APP_URL, mail, and REVERB_*_PUBLIC.
 ./docker/gen-secrets.sh
 
 # 3. Run the published image instead of building. Pin the version to the tag.
-echo 'APP_IMAGE=ghcr.io/emmpaul/the-desk:1.0.0' >> .env
+echo 'APP_IMAGE=ghcr.io/emmpaul/the-desk:1.2.0' >> .env # x-release-please-version
 docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 ```
@@ -56,7 +56,7 @@ step. Upgrades are just `APP_IMAGE=…:X.Y.Z`, then `pull` + `up -d` again — s
 git clone git@github.com:emmpaul/the-desk.git
 cd the-desk
 git fetch --tags
-git checkout v1.0.0                                   # the desired release tag
+git checkout v1.2.0 # x-release-please-version         (the desired release tag)
 
 # 2. Generate .env with all required secrets filled in.
 #    Creates .env from the template and fills APP_KEY, DB_PASSWORD,

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -53,7 +53,7 @@ Check out the newer release tag and rebuild:
 
 ```bash
 git fetch --tags
-git checkout v1.4.0                                   # the desired release tag
+git checkout v1.2.0 # x-release-please-version         (the desired release tag)
 docker compose -f docker-compose.prod.yml down
 docker compose -f docker-compose.prod.yml up -d --build
 # migrations run automatically via the entrypoint
@@ -64,7 +64,7 @@ docker compose -f docker-compose.prod.yml up -d --build
 Point `APP_IMAGE` at the new tag, then pull and restart:
 
 ```bash
-sed -i 's|^APP_IMAGE=.*|APP_IMAGE=ghcr.io/emmpaul/the-desk:1.4.0|' .env
+sed -i 's|^APP_IMAGE=.*|APP_IMAGE=ghcr.io/emmpaul/the-desk:1.2.0|' .env # x-release-please-version
 docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
 ```

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,14 @@
         { "type": "perf", "section": "Performance" },
         { "type": "refactor", "section": "Code Refactoring" },
         { "type": "deps", "section": "Dependencies" }
+      ],
+      "extra-files": [
+        { "type": "generic", "path": "README.md" },
+        { "type": "generic", "path": "docker-compose.prod.yml" },
+        { "type": "generic", "path": "docs/src/content/docs/docs/comparison.md" },
+        { "type": "generic", "path": "docs/src/content/docs/docs/faq.md" },
+        { "type": "generic", "path": "docs/src/content/docs/docs/self-hosting/installation.md" },
+        { "type": "generic", "path": "docs/src/content/docs/docs/self-hosting/upgrading.md" }
       ]
     }
   }


### PR DESCRIPTION
Closes #345.

## What

release-please already bumps `.release-please-manifest.json` and `CHANGELOG.md` on release, but it never touched the hardcoded version strings scattered through operator-facing docs, so they drifted (the README told operators to `git checkout v1.0.0` while the manifest was already at `1.2.0`, plus a stray `v1.4.0`).

This wires those strings into release-please's `extra-files` so the release PR stamps them automatically, fixes the current drift, and adds a skill so new version references don't reintroduce the gap.

### Version stamping (`extra-files` + `x-release-please-version` annotations)
- Registered every file holding a release-version display under `extra-files` in `release-please-config.json`, using the explicit `{ "type": "generic", "path": … }` form so the annotation scanner runs regardless of extension.
- Annotated each version-display line: trailing `# x-release-please-version` in shell/YAML/`.env` blocks, invisible `<!-- x-release-please-version -->` in Markdown prose.
- Files: `README.md`, `docker-compose.prod.yml`, `docs/.../comparison.md`, `docs/.../faq.md`, `docs/.../self-hosting/installation.md`, `docs/.../self-hosting/upgrading.md`.

### Drift fix
- README/installation/upgrading `v1.0.0` and `v1.4.0` pins and the `the-desk:1.0.0`/`1.4.0` image pins now read the current `1.2.0`; comparison/faq "as of vX.Y.Z" prose likewise.
- Also removed the "File & image attachments — not shipped yet" note from the comparison page and updated the FAQ, since attachments have shipped.

### New skill
- `release-version-refs` (under `.agents/skills/`, symlinked into `.claude/skills/` like `open-pr`): explains the mechanism, gives the rule (new version displays must be annotated **and** their file registered), shows how to grep the diff and verify. Cross-references `open-pr`.

## Testing
- Ran release-please's real `Generic` updater against the working-tree files: it rewrites exactly the 12 annotated version-display lines across all 6 registered files and nothing else.
- `release-please-config.json` validated as JSON.
- Docs site builds (`cd docs && npm run build`).
- No PHP/JS/Vue changed; the change touches only docs, root config/yaml, and the skill — outside the app quality gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting, installation, upgrade, and README instructions to use release **v1.2.0**.
  * Updated published image examples to use the **1.2.0** container image.
  * Clarified how to run the prebuilt production image with Docker Compose.
  * Updated the FAQ to confirm that file and image attachments are supported.
  * Revised feature availability details, including current limitations around SSO, OIDC, LDAP, and voice/video calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->