### PR TITLE
fix: lead message hover no longer duplicates the group timestamp

### DIFF
--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -668,11 +668,22 @@ function confirmDelete(): void {
                                  gutter on hover, and hidden from AT since the
                                  row's accessible name already carries the time.
                                  The `<time datetime>` keeps the row machine-
-                                 readable regardless of the hover styling. -->
+                                 readable regardless of the hover styling.
+                                 Only non-lead rows (index > 0) reveal it on
+                                 hover — the lead row already shows the group
+                                 time above, so revealing this here would stack a
+                                 duplicate on top of it. The lead's <time> stays
+                                 present but never fades in, so its machine-
+                                 readable value is unchanged. -->
                                 <time
                                     :datetime="message.createdAt"
                                     aria-hidden="true"
-                                    class="pointer-events-none absolute top-1.5 -left-13 font-mono text-[9.5px] text-muted-foreground opacity-0 transition-opacity group-hover/message:opacity-100"
+                                    class="pointer-events-none absolute top-1.5 -left-10.75 -translate-x-1/2 font-mono text-[9.5px] text-muted-foreground opacity-0 transition-opacity"
+                                    :class="
+                                        index > 0
+                                            ? 'group-hover/message:opacity-100'
+                                            : ''
+                                    "
                                     >{{ formatTime(message.createdAt) }}</time
                                 >
 

--- a/tests/Browser/TimelineTimestampHoverTest.php
+++ b/tests/Browser/TimelineTimestampHoverTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Message;
+use App\Models\User;
+
+/**
+ * Two of Bob's messages a minute apart collapse into a single author group, so
+ * the timeline shows one always-visible lead time under the avatar plus a
+ * per-message time revealed on hover in the same gutter.
+ *
+ * @return array{owner: User, lead: Message, follow: Message}
+ */
+function timelineAuthorGroup(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $lead = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $bob->id,
+        'body' => 'Kickoff at nine',
+        'created_at' => now()->subMinutes(2),
+    ]);
+
+    // Same author, well within the grouping window, so it folds under the lead
+    // rather than starting a fresh group with its own avatar and lead time.
+    $follow = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $bob->id,
+        'body' => 'Bring the deck',
+        'created_at' => now()->subMinute(),
+    ]);
+
+    return ['owner' => $alice, 'lead' => $lead, 'follow' => $follow];
+}
+
+test('hovering a later message reveals its timestamp but hovering the lead does not duplicate the group time', function (): void {
+    ['owner' => $alice, 'lead' => $lead, 'follow' => $follow] = timelineAuthorGroup();
+
+    signInThroughBrowser($alice)
+        ->assertSee('Kickoff at nine')
+        ->assertSee('Bring the deck')
+        // A non-lead row carries its own gutter <time>, hidden at rest and faded
+        // in on hover. The 0.4s wait clears the 150ms opacity transition.
+        ->hover("#message-{$follow->id}")
+        ->wait(0.4)
+        ->assertScript(
+            "getComputedStyle(document.querySelector('#message-{$follow->id} > time')).opacity",
+            '1',
+        )
+        // The lead row already shows the group time under the avatar, so hovering
+        // it must not fade in a second, overlapping timestamp: its <time> stays
+        // fully transparent even while the row is hovered.
+        ->hover("#message-{$lead->id}")
+        ->wait(0.4)
+        ->assertScript(
+            "getComputedStyle(document.querySelector('#message-{$lead->id} > time')).opacity",
+            '0',
+        );
+});
+
+test('every message row keeps a machine-readable time regardless of the hover treatment', function (): void {
+    ['owner' => $alice, 'lead' => $lead, 'follow' => $follow] = timelineAuthorGroup();
+
+    // The lead row no longer reveals its hover time, but it must still carry the
+    // <time datetime> element so the row stays machine-readable like the rest.
+    signInThroughBrowser($alice)
+        ->assertSee('Kickoff at nine')
+        ->assertPresent("#message-{$lead->id} > time[datetime]")
+        ->assertPresent("#message-{$follow->id} > time[datetime]");
+});


### PR DESCRIPTION
## What

The channel timeline renders two timestamps in the avatar gutter: an always-visible **lead** time under the avatar for the author group, and a per-message time revealed on hover in the same slot. On the **first (lead)** row these coincide, so hovering stacked a second, overlapping timestamp on top of the lead time (e.g. "2:33 PM" over "2:33 PM").

## Fix

- Only **non-lead** rows (`index > 0`) now fade their per-message hover time in. The lead's `<time datetime>` stays in the DOM (so every row remains machine-readable) but never reveals on hover, since the lead time is already shown above.
- The hover time is now **centered on the gutter** (`-left-10.75 -translate-x-1/2`) so it lines up with the lead time in a single column regardless of the time string's width, instead of drifting a few pixels to the right.

## Tests

`tests/Browser/TimelineTimestampHoverTest.php`:
- Hovering a later message reveals its timestamp (opacity → 1); hovering the lead keeps its `<time>` transparent (opacity stays 0), so no duplicate appears.
- Every row keeps a `<time datetime>` element regardless of the hover treatment.

Verified red→green (fails without the fix). Full gate green (Pint, PHPStan, Rector, 100% coverage; frontend lint/format/types/build).

Closes #339