### PR TITLE
feat: add LDAP/AD authentication and directory sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,10 +71,36 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # SSO_OIDC_SCOPES="openid profile email"
 # The team new SSO users join as a Member. Leave blank to use the sole team when
 # the instance has exactly one; otherwise the account gets its own workspace.
+# (Applies to both OIDC and LDAP just-in-time provisioning.)
 # SSO_DEFAULT_TEAM_ID=
-# Set to true to route ALL access through the directory: Fortify registration
-# and password login are disabled, leaving SSO as the only way in. Leave false
-# (the default) to keep a break-glass password account for IdP outages.
+
+# Single sign-on (LDAP / Active Directory). Authenticate users against an on-prem
+# directory through the app login form (bind auth). On a successful bind the entry
+# is matched to an app user by its mail attribute, keyed by its stable objectGUID,
+# and just-in-time provisioned into the default team as a Member; the mapped name
+# is synced on every login. Leave LDAP_HOST/LDAP_BASE_DN blank to disable.
+# LDAP_HOST=ldap.example.com
+# LDAP_PORT=389
+# LDAP_BASE_DN="dc=example,dc=com"
+# Service (bind) account used to search the directory before binding as the user.
+# LDAP_USERNAME="cn=readonly,dc=example,dc=com"
+# LDAP_PASSWORD=
+# Encrypted transport: LDAP_TLS uses LDAPS (usually port 636); LDAP_STARTTLS
+# upgrades a plain connection. Leave both false for an unencrypted connection.
+# LDAP_TLS=false
+# LDAP_STARTTLS=false
+# Attribute mappings. `username` is matched against the login form value (default
+# the mail attribute, so users sign in with their email; set e.g. samaccountname
+# to sign in with a directory username). mail → app email, name → display name,
+# guid → stable identity (objectguid for AD, entryuuid for OpenLDAP).
+# LDAP_ATTR_USERNAME=mail
+# LDAP_ATTR_MAIL=mail
+# LDAP_ATTR_NAME=cn
+# LDAP_ATTR_GUID=objectguid
+
+# Set to true to route ALL access through SSO (OIDC or LDAP): Fortify registration
+# and the local-password login are disabled, leaving the directory as the only way
+# in. Leave false (the default) to keep a break-glass password account for outages.
 # AUTH_SSO_ONLY=false
 
 LOG_CHANNEL=stack

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -64,10 +64,37 @@ GRAVATAR_ENABLED=true
 # SSO_OIDC_DISCOVERY_URL=
 # SSO_OIDC_SCOPES="openid profile email"
 # Team new SSO users join as a Member; blank uses the sole team when there is one.
+# (Applies to both OIDC and LDAP just-in-time provisioning.)
 # SSO_DEFAULT_TEAM_ID=
-# Set true to route ALL access through the directory (disables Fortify
-# registration and password login). Keep false to preserve a break-glass
-# password account for IdP outages.
+
+# --- Single sign-on (LDAP / Active Directory) --------------------------------
+# Authenticate users against an on-prem directory through the app login form
+# (bind auth). On a successful bind the entry is matched to an app user by its
+# mail attribute, keyed by its stable objectGUID, and just-in-time provisioned
+# into the default team as a Member; the mapped name syncs on every login. Leave
+# LDAP_HOST / LDAP_BASE_DN blank to keep LDAP off.
+# LDAP_HOST=ldap.example.com
+# LDAP_PORT=389
+# LDAP_BASE_DN="dc=example,dc=com"
+# Service (bind) account used to search the directory before binding as the user.
+# LDAP_USERNAME="cn=readonly,dc=example,dc=com"
+# LDAP_PASSWORD=
+# Encrypted transport: LDAP_TLS uses LDAPS (usually port 636); LDAP_STARTTLS
+# upgrades a plain connection. Both false = unencrypted (only on a trusted network).
+# LDAP_TLS=false
+# LDAP_STARTTLS=false
+# Attribute mappings: `username` is matched against the login form value (default
+# mail, so users sign in with email; set e.g. samaccountname for a directory
+# username). mail → app email, name → display name, guid → stable identity
+# (objectguid for AD, entryuuid for OpenLDAP).
+# LDAP_ATTR_USERNAME=mail
+# LDAP_ATTR_MAIL=mail
+# LDAP_ATTR_NAME=cn
+# LDAP_ATTR_GUID=objectguid
+
+# Set true to route ALL access through SSO (OIDC or LDAP): disables Fortify
+# registration and the local-password login. Keep false to preserve a break-glass
+# password account for outages.
 # AUTH_SSO_ONLY=false
 
 # --- Database (pgsql service) ------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,10 @@ COPY composer.json composer.lock ./
 
 # --no-scripts: the post-autoload-dump `artisan package:discover` boots the full
 # app, which is deferred to the runtime entrypoint (config:cache) instead.
-# --ignore-platform-req=ext-gd/ext-imagick: this dependency stage only resolves
-# and downloads packages; the image extensions are installed in the runtime stage
-# (which does the actual image processing), so the platform check is skipped here.
+# --ignore-platform-req=ext-gd/ext-imagick/ext-ldap: this dependency stage only
+# resolves and downloads packages; those extensions are installed in the runtime
+# stage (image processing, LDAP directory auth), so the platform check is skipped
+# here.
 RUN composer install \
         --no-dev \
         --no-scripts \
@@ -40,7 +41,8 @@ RUN composer install \
         --no-interaction \
         --no-progress \
         --ignore-platform-req=ext-gd \
-        --ignore-platform-req=ext-imagick
+        --ignore-platform-req=ext-imagick \
+        --ignore-platform-req=ext-ldap
 
 # Add the source and build an authoritative, optimized autoloader.
 COPY . .
@@ -83,6 +85,8 @@ FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS runtime
 # gd/imagick: image processing for attachments (Intervention Image, installed via
 # Composer) — EXIF-stripping and thumbnail generation. Imagick is the default
 # driver (ATTACHMENT_IMAGE_DRIVER); GD is the fallback.
+# ldap: directory bind authentication (LdapRecord); required by the package even
+# when LDAP is not configured, since the extension is a hard dependency.
 RUN install-php-extensions \
         pdo_pgsql \
         redis \
@@ -93,6 +97,7 @@ RUN install-php-extensions \
         opcache \
         gd \
         imagick \
+        ldap \
     && apk add --no-cache curl
 
 # Production PHP/OPcache tuning.

--- a/app/Actions/Sso/ProvisionSsoUser.php
+++ b/app/Actions/Sso/ProvisionSsoUser.php
@@ -28,10 +28,16 @@ class ProvisionSsoUser
      * the subject for next time; (3) else a new account is JIT-provisioned. New
      * accounts have no local password, are treated as email-verified (the IdP
      * verified them), and land in the default team as a Member.
+     *
+     * When $syncName is set, the mapped display name is refreshed from the
+     * directory on every login for an already-existing account (a blank name is
+     * ignored rather than wiping the current one). Directories that push
+     * attributes on each bind — LDAP/AD — opt in; a JIT-created account already
+     * carries the supplied name, so only the returning-user paths need it.
      */
-    public function handle(string $provider, string $providerId, string $email, ?string $name): User
+    public function handle(string $provider, string $providerId, string $email, ?string $name, bool $syncName = false): User
     {
-        return DB::transaction(function () use ($provider, $providerId, $email, $name): User {
+        return DB::transaction(function () use ($provider, $providerId, $email, $name, $syncName): User {
             $email = strtolower($email);
 
             $identity = SsoIdentity::query()
@@ -40,12 +46,17 @@ class ProvisionSsoUser
                 ->first();
 
             if ($identity) {
-                return $identity->user;
+                $user = $identity->user;
+                $this->syncName($user, $name, $syncName);
+
+                return $user;
             }
 
             $user = User::query()->whereRaw('lower(email) = ?', [$email])->first();
 
-            if (! $user) {
+            if ($user) {
+                $this->syncName($user, $name, $syncName);
+            } else {
                 $user = $this->provisionUser($email, $name);
             }
 
@@ -56,6 +67,21 @@ class ProvisionSsoUser
 
             return $user;
         });
+    }
+
+    /**
+     * Refresh an existing user's display name from the directory when opted in.
+     *
+     * A blank directory name is ignored so a sparsely populated entry never wipes
+     * a name the user already has.
+     */
+    private function syncName(User $user, ?string $name, bool $syncName): void
+    {
+        if (! $syncName || $name === null || $name === '') {
+            return;
+        }
+
+        $user->forceFill(['name' => $name])->save();
     }
 
     /**

--- a/app/Http/Middleware/EnsurePasswordLoginEnabled.php
+++ b/app/Http/Middleware/EnsurePasswordLoginEnabled.php
@@ -17,11 +17,22 @@ class EnsurePasswordLoginEnabled
      * still renders the "Sign in with SSO" entry point — so only the credential
      * POST (`login.store`) is short-circuited.
      *
+     * LDAP is the exception: its bind auth runs *through* this same login POST,
+     * so blanket-blocking it would block directory sign-in. When LDAP is enabled
+     * the POST is allowed through and the custom Fortify authenticateUsing
+     * callback enforces the split — directory bind allowed, local password
+     * rejected. So the POST is only short-circuited here for OIDC-only
+     * enforcement, where nothing legitimate posts to it.
+     *
      * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        abort_if(config('sso.enforced') && $request->routeIs('login.store'), 404);
+        $blocked = config('sso.enforced')
+            && ! config('sso.ldap.enabled')
+            && $request->routeIs('login.store');
+
+        abort_if($blocked, 404);
 
         return $next($request);
     }

--- a/app/Ldap/DirectoryUser.php
+++ b/app/Ldap/DirectoryUser.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ldap;
+
+use LdapRecord\Models\Model;
+
+/**
+ * A directory-agnostic LDAP entry used to look up and bind directory users.
+ *
+ * LdapRecord turns `$objectClasses` into an AND query constraint, so it is
+ * restricted to `person` — the single structural class shared by both Active
+ * Directory user entries (top; person; organizationalPerson; user) and OpenLDAP
+ * inetOrgPerson entries — rather than a provider-specific leaf class that would
+ * exclude the other directory's users. It still excludes non-person entries such
+ * as groups that happen to carry a mail attribute. The GUID key (the attribute
+ * holding the stable identity) is configurable so an operator can point it at
+ * `objectguid` (AD) or `entryuuid` (OpenLDAP).
+ */
+class DirectoryUser extends Model
+{
+    /**
+     * The object classes of the LDAP model.
+     *
+     * @var array<int, string>
+     */
+    public static array $objectClasses = ['person'];
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        $this->guidKey = (string) config('sso.ldap.attributes.guid', 'objectguid');
+
+        parent::__construct($attributes);
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -8,8 +8,11 @@ use App\Http\Responses\LoginResponse;
 use App\Http\Responses\RegisterResponse;
 use App\Http\Responses\VerifyEmailResponse;
 use App\Models\TeamInvitation;
+use App\Services\Sso\LdapAuthenticator;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -41,6 +44,7 @@ class FortifyServiceProvider extends ServiceProvider
         $this->configureActions();
         $this->configureViews();
         $this->configureRateLimiting();
+        $this->configureLdapAuthentication();
     }
 
     /**
@@ -50,6 +54,68 @@ class FortifyServiceProvider extends ServiceProvider
     {
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
         Fortify::createUsersUsing(CreateNewUser::class);
+    }
+
+    /**
+     * Route the login form through directory bind authentication when LDAP is
+     * configured.
+     *
+     * The same login POST serves both directory and local-password users, so the
+     * callback tries an LDAP bind first and only falls back to the local password
+     * database when SSO is not enforced. Under enforcement (AUTH_SSO_ONLY with a
+     * provider configured) the directory is the sole credential source, so a
+     * failed bind is a failed login rather than a local-password fallback — this
+     * is how enforcement blocks the local path while still allowing the bind that
+     * shares the same route. When LDAP is not configured the callback is not
+     * registered at all, leaving Fortify's default credential check untouched.
+     */
+    private function configureLdapAuthentication(): void
+    {
+        if (! config('sso.ldap.enabled')) {
+            return;
+        }
+
+        Fortify::authenticateUsing(function (Request $request): ?Authenticatable {
+            $user = app(LdapAuthenticator::class)->attempt(
+                (string) $request->input(Fortify::username()),
+                (string) $request->input('password'),
+            );
+
+            if ($user instanceof Authenticatable) {
+                return $user;
+            }
+
+            if (config('sso.enforced')) {
+                return null;
+            }
+
+            return $this->attemptLocalPassword($request);
+        });
+    }
+
+    /**
+     * Validate the request against the local password database.
+     *
+     * Mirrors Fortify's default credential check (the branch we replace by
+     * registering an authenticateUsing callback) so a break-glass password
+     * account keeps working alongside the directory when SSO is not enforced.
+     */
+    private function attemptLocalPassword(Request $request): ?Authenticatable
+    {
+        $provider = Auth::guard(config('fortify.guard'))->getProvider();
+
+        $credentials = [
+            Fortify::username() => $request->input(Fortify::username()),
+            'password' => $request->input('password'),
+        ];
+
+        $user = $provider->retrieveByCredentials($credentials);
+
+        if ($user && $provider->validateCredentials($user, $credentials)) {
+            return $user;
+        }
+
+        return null;
     }
 
     /**

--- a/app/Services/Sso/LdapAuthenticator.php
+++ b/app/Services/Sso/LdapAuthenticator.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services\Sso;
+
+use App\Actions\Sso\ProvisionSsoUser;
+use App\Ldap\DirectoryUser;
+use App\Models\User;
+use LdapRecord\Container;
+use LdapRecord\LdapRecordException;
+
+/**
+ * Verifies credentials against the configured LDAP/AD directory and resolves
+ * them to an app user. It locates the directory entry by the mapped username
+ * attribute, binds with the submitted password to prove the credentials, then
+ * hands the verified identity (stable GUID, mail, name) to the shared
+ * provisioning layer so directory logins match/JIT exactly like OIDC.
+ */
+class LdapAuthenticator
+{
+    public function __construct(private readonly ProvisionSsoUser $provisionSsoUser) {}
+
+    /**
+     * Bind the given credentials against the directory and resolve the app user.
+     *
+     * Returns null on any clear failure — unknown user, rejected bind,
+     * unreachable directory, or an entry with no mail attribute to match on — so
+     * the caller can fail the login (or fall back to a local password) without
+     * an exception leaking out.
+     */
+    public function attempt(string $identifier, string $password): ?User
+    {
+        if (blank($identifier) || blank($password)) {
+            return null;
+        }
+
+        $connection = config('sso.ldap.connection');
+        $attributes = config('sso.ldap.attributes');
+
+        try {
+            $directoryUser = DirectoryUser::on($connection)
+                ->where($attributes['username'], '=', $identifier)
+                ->first();
+
+            if (! $directoryUser instanceof DirectoryUser) {
+                return null;
+            }
+
+            $bound = Container::getConnection($connection)
+                ->auth()
+                ->attempt((string) $directoryUser->getDn(), $password);
+        } catch (LdapRecordException) {
+            return null;
+        }
+
+        if (! $bound) {
+            return null;
+        }
+
+        $guid = $directoryUser->getConvertedGuid();
+        $mail = $directoryUser->getFirstAttribute($attributes['mail']);
+        $name = $directoryUser->getFirstAttribute($attributes['name']);
+
+        if (blank($guid) || blank($mail)) {
+            return null;
+        }
+
+        return $this->provisionSsoUser->handle('ldap', $guid, $mail, $name, syncName: true);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^8.3",
         "ext-gd": "*",
         "ext-imagick": "*",
+        "directorytree/ldaprecord-laravel": "^4.0",
         "inertiajs/inertia-laravel": "^3.0",
         "intervention/image": "^4.2",
         "laravel/chisel": "^0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "367b577c80276b29dc541dbcfcd115d5",
+    "content-hash": "c891d41a1c9ddc942bff49c3da017c5f",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -443,6 +443,149 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "directorytree/ldaprecord",
+            "version": "v4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DirectoryTree/LdapRecord.git",
+                "reference": "75f25c84f8ffc4b10029be8a310c72fc0d46bf71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DirectoryTree/LdapRecord/zipball/75f25c84f8ffc4b10029be8a310c72fc0d46bf71",
+                "reference": "75f25c84f8ffc4b10029be8a310c72fc0d46bf71",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "ext-ldap": "*",
+                "illuminate/collections": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "nesbot/carbon": "*",
+                "php": ">=8.1",
+                "psr/log": "*",
+                "psr/simple-cache": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.21",
+                "laravel/pint": "^1.6",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^9.0",
+                "spatie/ray": "^1.24"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LdapRecord\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Steve Bauman",
+                    "email": "steven_bauman@outlook.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fully-featured LDAP ORM.",
+            "homepage": "https://www.ldaprecord.com",
+            "keywords": [
+                "active directory",
+                "ad",
+                "adLDAP",
+                "adldap2",
+                "directory",
+                "ldap",
+                "ldaprecord",
+                "orm",
+                "windows"
+            ],
+            "support": {
+                "docs": "https://ldaprecord.com",
+                "email": "steven_bauman@outlook.com",
+                "issues": "https://github.com/DirectoryTree/LdapRecord/issues",
+                "source": "https://github.com/DirectoryTree/LdapRecord"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/stevebauman",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-28T13:39:48+00:00"
+        },
+        {
+            "name": "directorytree/ldaprecord-laravel",
+            "version": "v4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DirectoryTree/LdapRecord-Laravel.git",
+                "reference": "6f02904ba8705c2b0b2fa8a96f33592c77df92a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DirectoryTree/LdapRecord-Laravel/zipball/6f02904ba8705c2b0b2fa8a96f33592c77df92a3",
+                "reference": "6f02904ba8705c2b0b2fa8a96f33592c77df92a3",
+                "shasum": ""
+            },
+            "require": {
+                "directorytree/ldaprecord": "^4.0",
+                "ext-json": "*",
+                "ext-ldap": "*",
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": ">=8.1",
+                "ramsey/uuid": "*"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.9",
+                "laravel/sanctum": "*",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+                "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0",
+                "spatie/ray": "^1.28"
+            },
+            "type": "project",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "LdapRecord\\Laravel\\LdapServiceProvider",
+                        "LdapRecord\\Laravel\\LdapAuthServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LdapRecord\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "LDAP Authentication & Management for Laravel.",
+            "keywords": [
+                "adldap2",
+                "laravel",
+                "ldap",
+                "ldaprecord"
+            ],
+            "support": {
+                "issues": "https://github.com/DirectoryTree/LdapRecord-Laravel/issues",
+                "source": "https://github.com/DirectoryTree/LdapRecord-Laravel/tree/v4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/stevebauman",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-08T17:20:00+00:00"
         },
         {
             "name": "doctrine/deprecations",

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -6,10 +6,12 @@ use Laravel\Fortify\Features;
 
 // SSO-only enforcement only bites when a provider is actually configured (see
 // config/sso.php), so a stray AUTH_SSO_ONLY can never disable both directory and
-// password sign-in and lock everyone out.
-$ssoEnforced = env('AUTH_SSO_ONLY', false)
-    && filled(env('SSO_OIDC_CLIENT_ID'))
-    && filled(env('SSO_OIDC_ISSUER'));
+// password sign-in and lock everyone out. A configured provider is either OIDC
+// (issuer + client id) or an LDAP directory (host + base DN); this mirrors the
+// `sso.enforced` computation so the registration gate below stays in lockstep.
+$oidcConfigured = filled(env('SSO_OIDC_CLIENT_ID')) && filled(env('SSO_OIDC_ISSUER'));
+$ldapConfigured = filled(env('LDAP_HOST')) && filled(env('LDAP_BASE_DN'));
+$ssoEnforced = env('AUTH_SSO_ONLY', false) && ($oidcConfigured || $ldapConfigured);
 
 return [
 

--- a/config/ldap.php
+++ b/config/ldap.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default LDAP Connection Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the LDAP connections below you wish
+    | to use as your default connection for all LDAP operations. Of
+    | course you may add as many connections you'd like below.
+    |
+    */
+
+    'default' => env('LDAP_CONNECTION', 'default'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | LDAP Connections
+    |--------------------------------------------------------------------------
+    |
+    | Below you may configure each LDAP connection your application requires
+    | access to. Be sure to include a valid base DN - otherwise you may
+    | not receive any results when performing LDAP search operations.
+    |
+    */
+
+    'connections' => [
+
+        'default' => [
+            'hosts' => [env('LDAP_HOST', '127.0.0.1')],
+            'username' => env('LDAP_USERNAME', 'cn=user,dc=local,dc=com'),
+            'password' => env('LDAP_PASSWORD', 'secret'),
+            'port' => env('LDAP_PORT', 389),
+            'base_dn' => env('LDAP_BASE_DN', 'dc=local,dc=com'),
+            'timeout' => env('LDAP_TIMEOUT', 5),
+            // Encrypted transport: LDAP_TLS uses LDAPS (ldaps://, typically port
+            // 636); LDAP_STARTTLS upgrades a plain connection with STARTTLS.
+            'use_tls' => env('LDAP_TLS', false),
+            'use_starttls' => env('LDAP_STARTTLS', false),
+            'use_sasl' => env('LDAP_SASL', false),
+            'sasl_options' => [
+                // 'mech' => 'GSSAPI',
+            ],
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | LDAP Logging
+    |--------------------------------------------------------------------------
+    |
+    | When LDAP logging is enabled, all LDAP search and authentication
+    | operations are logged using the default application logging
+    | driver. This can assist in debugging issues and more.
+    |
+    */
+
+    'logging' => [
+        'enabled' => env('LDAP_LOGGING', true),
+        'channel' => env('LOG_CHANNEL', 'stack'),
+        'level' => env('LOG_LEVEL', 'info'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | LDAP Cache
+    |--------------------------------------------------------------------------
+    |
+    | LDAP caching enables the ability of caching search results using the
+    | query builder. This is great for running expensive operations that
+    | may take many seconds to complete, such as a pagination request.
+    |
+    */
+
+    'cache' => [
+        'enabled' => env('LDAP_CACHE', false),
+        'driver' => env('CACHE_DRIVER', 'file'),
+    ],
+
+];

--- a/config/sso.php
+++ b/config/sso.php
@@ -7,6 +7,11 @@ declare(strict_types=1);
 // entry point and — crucially — the SSO-only enforcement below.
 $oidcConfigured = filled(env('SSO_OIDC_CLIENT_ID')) && filled(env('SSO_OIDC_ISSUER'));
 
+// Whether a directory (LDAP/AD) is wired up: a host to reach and a base DN to
+// search under are the minimum. Like OIDC above it gates both the directory
+// login path and SSO-only enforcement.
+$ldapConfigured = filled(env('LDAP_HOST')) && filled(env('LDAP_BASE_DN'));
+
 return [
 
     /*
@@ -14,21 +19,22 @@ return [
     | SSO-only enforcement
     |--------------------------------------------------------------------------
     |
-    | Directory login (OIDC now, LDAP later) sits alongside Fortify's password
-    | login by default, so a break-glass password account survives an IdP
-    | outage. Set AUTH_SSO_ONLY=true to funnel all access through the directory:
-    | Fortify registration and password login are disabled, leaving SSO as the
-    | only way in.
+    | Directory login (OIDC or LDAP/AD) sits alongside Fortify's password login
+    | by default, so a break-glass password account survives an IdP outage. Set
+    | AUTH_SSO_ONLY=true to funnel all access through the directory: Fortify
+    | registration is disabled and the local-password path is blocked, leaving
+    | SSO as the only way in.
     |
     | `enforced` is the *effective* switch used across the app. Enforcement only
-    | takes hold when a provider is actually configured — otherwise AUTH_SSO_ONLY
-    | with no usable SSO would disable every sign-in path and lock everyone out.
+    | takes hold when a provider (OIDC or LDAP) is actually configured —
+    | otherwise AUTH_SSO_ONLY with no usable SSO would disable every sign-in path
+    | and lock everyone out.
     |
     */
 
     'sso_only' => (bool) env('AUTH_SSO_ONLY', false),
 
-    'enforced' => (bool) env('AUTH_SSO_ONLY', false) && $oidcConfigured,
+    'enforced' => (bool) env('AUTH_SSO_ONLY', false) && ($oidcConfigured || $ldapConfigured),
 
     /*
     |--------------------------------------------------------------------------
@@ -56,6 +62,36 @@ return [
 
     'oidc' => [
         'enabled' => $oidcConfigured,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | LDAP / Active Directory
+    |--------------------------------------------------------------------------
+    |
+    | Directory bind authentication. When enabled, the app login form binds the
+    | submitted credentials against the directory (the connection itself lives in
+    | config/ldap.php). On a successful bind the entry is matched to an app user
+    | by its mail attribute, keyed by its stable GUID, and JIT-provisioned into
+    | the default team as a Member — the same identity rules OIDC follows.
+    |
+    | `attributes` maps directory attributes to app fields: `username` is the
+    | attribute matched against the login form value (default the mail attribute,
+    | so users sign in with their email; set it to e.g. `samaccountname` to sign
+    | in with a directory username), `mail` becomes the app email, `name` the
+    | display name synced on every login, and `guid` the stable identity.
+    |
+    */
+
+    'ldap' => [
+        'enabled' => $ldapConfigured,
+        'connection' => env('LDAP_CONNECTION', 'default'),
+        'attributes' => [
+            'username' => env('LDAP_ATTR_USERNAME', 'mail'),
+            'mail' => env('LDAP_ATTR_MAIL', 'mail'),
+            'name' => env('LDAP_ATTR_NAME', 'cn'),
+            'guid' => env('LDAP_ATTR_GUID', 'objectguid'),
+        ],
     ],
 
 ];

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -113,8 +113,40 @@ email, otherwise created — into the default team as a **Member**. Leave
 | `SSO_OIDC_REDIRECT_URI`  | `${APP_URL}/auth/oidc/callback`  | Callback URI; must match what you register at the IdP.                     |
 | `SSO_OIDC_DISCOVERY_URL` | *(derived from issuer)*          | Override only if discovery is not at the standard well-known path.         |
 | `SSO_OIDC_SCOPES`        | `openid profile email`           | Space-separated OIDC scopes to request.                                   |
-| `SSO_DEFAULT_TEAM_ID`    | *(sole team)*                    | Team new SSO users join as a Member. Blank uses the sole team when there is exactly one; otherwise the account gets its own workspace. |
-| `AUTH_SSO_ONLY`          | `false`                          | Route **all** access through the directory. See [SSO-only mode](/docs/reference/feature-toggles/#sso-only-mode). |
+| `SSO_DEFAULT_TEAM_ID`    | *(sole team)*                    | Team new SSO users join as a Member. Blank uses the sole team when there is exactly one; otherwise the account gets its own workspace. Shared with LDAP. |
+| `AUTH_SSO_ONLY`          | `false`                          | Route **all** access through SSO (OIDC or LDAP). See [SSO-only mode](/docs/reference/feature-toggles/#sso-only-mode). |
+
+## Single sign-on (LDAP / Active Directory)
+
+Authenticate members against an on-prem **LDAP / Active Directory** directory.
+Unlike OIDC's browser redirect, users enter their directory credentials in the
+app's own login form and the app **binds** to the directory to verify them. On a
+successful bind the entry is matched to an app user by its **mail** attribute,
+keyed by its stable **objectGUID**, and — like OIDC — **just-in-time provisioned**
+into the default team as a **Member** with a verified email. The mapped display
+name is **synced on every login**. Leave `LDAP_HOST` / `LDAP_BASE_DN` blank to keep
+LDAP off.
+
+Directory login sits alongside the local password form by default, so a
+break-glass password account survives a directory outage. `AUTH_SSO_ONLY=true`
+engages once LDAP is configured too, disabling the local-password path while still
+allowing the directory bind.
+
+| Variable             | Default                       | Notes                                                                                             |
+| -------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------- |
+| `LDAP_HOST`          | *(blank)*                     | Directory host. Blank (with `LDAP_BASE_DN`) keeps LDAP off.                                        |
+| `LDAP_PORT`          | `389`                         | `389` for plain/STARTTLS, `636` for LDAPS.                                                         |
+| `LDAP_BASE_DN`       | *(blank)*                     | Base DN searched for the user, e.g. `dc=example,dc=com`.                                           |
+| `LDAP_USERNAME`      | *(blank)*                     | DN of the service (bind) account used to search before binding as the user.                       |
+| `LDAP_PASSWORD`      | *(blank)*                     | Password for the service account.                                                                 |
+| `LDAP_TLS`           | `false`                       | Use LDAPS (encrypted transport, usually port 636).                                                |
+| `LDAP_STARTTLS`      | `false`                       | Upgrade a plain connection with STARTTLS.                                                          |
+| `LDAP_TIMEOUT`       | `5`                           | Connection timeout in seconds.                                                                     |
+| `LDAP_ATTR_USERNAME` | `mail`                        | Directory attribute matched against the login form value. Set to e.g. `samaccountname` to sign in with a directory username instead of email. |
+| `LDAP_ATTR_MAIL`     | `mail`                        | Directory attribute used as the app email (how users are matched/linked).                         |
+| `LDAP_ATTR_NAME`     | `cn`                          | Directory attribute synced to the app display name on every login.                                |
+| `LDAP_ATTR_GUID`     | `objectguid`                  | Stable identity attribute. `objectguid` for Active Directory, `entryuuid` for OpenLDAP.           |
+| `LDAP_CONNECTION`    | `default`                     | Name of the connection in `config/ldap.php` to use.                                               |
 
 ## Attachments
 

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -50,17 +50,23 @@ registered, so flipping the flag takes effect immediately with no data migration
 
 | Variable        | Default | Effect                                                                 |
 | --------------- | ------- | --------------------------------------------------------------------- |
-| `AUTH_SSO_ONLY` | `false` | Route **all** access through your identity provider.                  |
+| `AUTH_SSO_ONLY` | `false` | Route **all** access through single sign-on.                          |
 
-Single sign-on ([OpenID Connect](/docs/reference/environment-variables/#single-sign-on-openid-connect))
+Single sign-on — [OpenID Connect](/docs/reference/environment-variables/#single-sign-on-openid-connect)
+or [LDAP / Active Directory](/docs/reference/environment-variables/#single-sign-on-ldap--active-directory) —
 sits **alongside** password login by default, so a break-glass password account
-keeps working during an IdP outage. Set `AUTH_SSO_ONLY=true` to funnel everyone
-through the directory instead: Fortify **registration** and **password login** are
-disabled, and the login page shows only the "Sign in with SSO" button.
+keeps working during an outage. Set `AUTH_SSO_ONLY=true` to funnel everyone
+through the directory instead: Fortify **registration** and the **local-password
+login** are disabled. (LDAP bind auth uses the same login form, so it keeps
+working — only the local-password path is blocked.)
+
+`AUTH_SSO_ONLY` only takes effect once a provider (OIDC **or** LDAP) is actually
+configured, so a stray flag can never lock everyone out of an instance with no
+working SSO.
 
 :::caution
-With `AUTH_SSO_ONLY=true` there is no password fallback — if your IdP is
-unreachable, no one can sign in. Only turn it on once SSO is verified working,
+With `AUTH_SSO_ONLY=true` there is no local-password fallback — if your directory
+is unreachable, no one can sign in. Only turn it on once SSO is verified working,
 and keep a way to flip it back (edit `.env` and restart the stack).
 :::
 

--- a/docs/src/content/docs/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/docs/self-hosting/configuration.md
@@ -90,6 +90,42 @@ scopes, and routing **all** access through the directory with `AUTH_SSO_ONLY` �
 see [Environment variables → Single sign-on](/docs/reference/environment-variables/#single-sign-on-openid-connect)
 and [Feature toggles → SSO-only mode](/docs/reference/feature-toggles/#sso-only-mode).
 
+## Single sign-on (LDAP / Active Directory)
+
+To authenticate members against an on-prem LDAP or Active Directory server, point
+the app at your directory and a read-only service (bind) account:
+
+```bash
+LDAP_HOST=ldap.example.com
+LDAP_PORT=389
+LDAP_BASE_DN="dc=example,dc=com"
+LDAP_USERNAME="cn=readonly,dc=example,dc=com"
+LDAP_PASSWORD=your-service-account-password
+# Encrypt the connection in production:
+LDAP_TLS=true          # LDAPS (usually port 636)
+# LDAP_STARTTLS=true   # or upgrade a plain connection instead
+```
+
+Members then sign in with their directory credentials on the normal login form
+(the app **binds** to verify them — no browser redirect). The first login
+just-in-time provisions the account into the default team as a Member, matched to
+an existing user by the directory's **mail** attribute and keyed by its stable
+**objectGUID**; the mapped display name syncs on every login.
+
+By default members sign in with their **email** and the display name comes from
+`cn`. If your directory uses different attributes — for example Active Directory
+where users log in with `sAMAccountName` — remap them:
+
+```bash
+LDAP_ATTR_USERNAME=samaccountname   # what members type on the login form
+LDAP_ATTR_NAME=displayname          # attribute used as the app display name
+LDAP_ATTR_GUID=objectguid           # objectguid (AD) or entryuuid (OpenLDAP)
+```
+
+See [Environment variables → Single sign-on (LDAP)](/docs/reference/environment-variables/#single-sign-on-ldap--active-directory)
+for every attribute mapping, and [Feature toggles → SSO-only mode](/docs/reference/feature-toggles/#sso-only-mode)
+to require directory login.
+
 ## Applying changes
 
 After editing `.env`, restart the stack to pick up the new values:

--- a/tests/Feature/Auth/Sso/Helpers.php
+++ b/tests/Feature/Auth/Sso/Helpers.php
@@ -2,9 +2,12 @@
 
 declare(strict_types=1);
 
+use App\Ldap\DirectoryUser;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use LdapRecord\Laravel\Testing\DirectoryEmulator;
+use LdapRecord\Testing\ConnectionFake;
 
 /**
  * A canned OIDC discovery document pointing at fake IdP endpoints, served to the
@@ -38,4 +41,40 @@ function oidcServicesConfig(MockHandler $mock, array $overrides = []): array
         'scopes' => null,
         'guzzle' => ['handler' => HandlerStack::create($mock)],
     ], $overrides);
+}
+
+/**
+ * The env needed to wire up an LDAP directory: a host to reach and a base DN to
+ * search under. Pass to reloadWithEnv() so config('sso.ldap.enabled') is true and
+ * the Fortify directory-bind callback is registered when the app boots.
+ *
+ * @param  array<string, bool|int|string>  $overrides
+ * @return array<string, bool|int|string>
+ */
+function ldapEnv(array $overrides = []): array
+{
+    return array_merge([
+        'LDAP_HOST' => 'ldap.test',
+        'LDAP_BASE_DN' => 'dc=the-desk,dc=local',
+    ], $overrides);
+}
+
+/**
+ * Stand up LdapRecord's in-memory directory emulator on the default connection,
+ * so tests bind against a fake directory rather than a live server. Returns the
+ * fake connection; call actingAs($entry) on it to let a given entry's bind pass.
+ */
+function fakeDirectory(): ConnectionFake
+{
+    return DirectoryEmulator::setup('default');
+}
+
+/**
+ * Create a directory entry in the emulator.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function directoryUser(array $attributes): DirectoryUser
+{
+    return DirectoryUser::create($attributes);
 }

--- a/tests/Feature/Auth/Sso/LdapLoginTest.php
+++ b/tests/Feature/Auth/Sso/LdapLoginTest.php
@@ -1,0 +1,210 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Ldap\DirectoryUser;
+use App\Models\SsoIdentity;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\Sso\LdapAuthenticator;
+use LdapRecord\Laravel\Testing\DirectoryEmulator;
+
+afterEach(function (): void {
+    DirectoryEmulator::tearDown();
+});
+
+test('a directory user is bound, just-in-time provisioned into the sole team, and logged in', function (): void {
+    $this->reloadWithEnv(ldapEnv());
+    $team = Team::factory()->create();
+
+    $fake = fakeDirectory();
+    $entry = directoryUser(['cn' => 'Ada Byte', 'mail' => 'ada@example.com', 'uid' => 'ada']);
+    $fake->actingAs($entry);
+
+    $response = $this->post('/login', ['email' => 'ada@example.com', 'password' => 'directory-secret']);
+
+    $this->assertAuthenticated();
+    $response->assertRedirect();
+
+    $user = auth()->user();
+    expect($user->email)->toBe('ada@example.com')
+        ->and($user->name)->toBe('Ada Byte')
+        ->and($user->password)->toBeNull()
+        ->and($user->email_verified_at)->not->toBeNull()
+        ->and($user->teamRole($team))->toBe(TeamRole::Member);
+
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'ldap',
+        'user_id' => $user->id,
+    ]);
+});
+
+test('a directory login for an existing email links that account and syncs the display name', function (): void {
+    $this->reloadWithEnv(ldapEnv());
+    $existing = User::factory()->create(['email' => 'ada@example.com', 'name' => 'Old Name']);
+
+    $fake = fakeDirectory();
+    $entry = directoryUser(['cn' => 'Ada Byte', 'mail' => 'ada@example.com', 'uid' => 'ada']);
+    $fake->actingAs($entry);
+
+    $this->post('/login', ['email' => 'ada@example.com', 'password' => 'directory-secret']);
+
+    expect(auth()->id())->toBe($existing->id)
+        ->and($existing->fresh()->name)->toBe('Ada Byte')
+        ->and(User::query()->where('email', 'ada@example.com')->count())->toBe(1);
+
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'ldap',
+        'user_id' => $existing->id,
+    ]);
+});
+
+test('a rejected bind (wrong password) fails the login and leaves the user a guest', function (): void {
+    $this->reloadWithEnv(ldapEnv());
+
+    // The entry exists but is never `actingAs`, so any bind attempt is rejected.
+    fakeDirectory();
+    directoryUser(['cn' => 'Ada Byte', 'mail' => 'ada@example.com', 'uid' => 'ada']);
+
+    $response = $this->post('/login', ['email' => 'ada@example.com', 'password' => 'wrong']);
+
+    $this->assertGuest();
+    $response->assertSessionHasErrors();
+    expect(User::query()->count())->toBe(0);
+});
+
+test('the authenticator refuses blank credentials without ever binding, guarding against anonymous binds', function (): void {
+    // A blank password must be rejected before any bind: LDAP servers can treat
+    // an empty password as an anonymous bind and return success, which would let
+    // a known username in with no password.
+    $authenticator = app(LdapAuthenticator::class);
+
+    expect($authenticator->attempt('', 'secret'))->toBeNull()
+        ->and($authenticator->attempt('ada@example.com', ''))->toBeNull();
+});
+
+test('an unknown directory user fails the login', function (): void {
+    $this->reloadWithEnv(ldapEnv());
+    fakeDirectory();
+
+    $response = $this->post('/login', ['email' => 'nobody@example.com', 'password' => 'secret']);
+
+    $this->assertGuest();
+    $response->assertSessionHasErrors();
+    expect(User::query()->count())->toBe(0);
+});
+
+test('a bound entry with no mail attribute is a clear failure and provisions nobody', function (): void {
+    // Sign in with a directory username (uid) rather than email, so the entry can
+    // be found and bound yet still lack the mail attribute we match the app user on.
+    $this->reloadWithEnv(ldapEnv(['LDAP_ATTR_USERNAME' => 'uid']));
+
+    $fake = fakeDirectory();
+    $entry = directoryUser(['cn' => 'No Mail', 'uid' => 'nomail']);
+    $fake->actingAs($entry);
+
+    $response = $this->post('/login', ['email' => 'nomail', 'password' => 'directory-secret']);
+
+    $this->assertGuest();
+    $response->assertSessionHasErrors();
+    expect(User::query()->count())->toBe(0);
+});
+
+test('an unreachable directory fails gracefully rather than erroring', function (): void {
+    $this->reloadWithEnv(ldapEnv());
+    fakeDirectory();
+
+    // Point the authenticator at a connection that was never registered, so the
+    // lookup throws inside the guard and the login fails cleanly.
+    config(['sso.ldap.connection' => 'unconfigured']);
+
+    $response = $this->post('/login', ['email' => 'ada@example.com', 'password' => 'directory-secret']);
+
+    $this->assertGuest();
+    $response->assertSessionHasErrors();
+});
+
+test('under sso enforcement a local password login is rejected but the login POST is not blocked', function (): void {
+    $this->reloadWithEnv(ldapEnv(['AUTH_SSO_ONLY' => true]));
+    fakeDirectory();
+    $user = User::factory()->create(['password' => Hash::make('password')]);
+
+    $response = $this->post('/login', ['email' => $user->email, 'password' => 'password']);
+
+    // The middleware lets the POST through (not a 404) so LDAP can bind, but the
+    // custom callback refuses to fall back to the local password under enforcement.
+    $this->assertGuest();
+    $response->assertSessionHasErrors();
+    $response->assertStatus(302);
+});
+
+test('under sso enforcement a directory bind still logs in', function (): void {
+    $this->reloadWithEnv(ldapEnv(['AUTH_SSO_ONLY' => true]));
+    Team::factory()->create();
+
+    $fake = fakeDirectory();
+    $entry = directoryUser(['cn' => 'Ada Byte', 'mail' => 'ada@example.com', 'uid' => 'ada']);
+    $fake->actingAs($entry);
+
+    $this->post('/login', ['email' => 'ada@example.com', 'password' => 'directory-secret']);
+
+    $this->assertAuthenticated();
+    expect(auth()->user()->email)->toBe('ada@example.com');
+});
+
+test('when LDAP is enabled but not enforced a local break-glass password still works', function (): void {
+    $this->reloadWithEnv(ldapEnv());
+    fakeDirectory();
+    $user = User::factory()->create(['password' => Hash::make('password')]);
+
+    $this->post('/login', ['email' => $user->email, 'password' => 'password']);
+
+    $this->assertAuthenticated();
+    expect(auth()->id())->toBe($user->id);
+});
+
+test('the configurable GUID attribute keys the identity, e.g. entryuuid for OpenLDAP', function (): void {
+    // Point the identity at OpenLDAP's entryuuid instead of AD's objectguid and
+    // confirm that exact value — not an auto-assigned objectguid — becomes the
+    // stored provider id, proving the mapping is honoured.
+    $this->reloadWithEnv(ldapEnv(['LDAP_ATTR_GUID' => 'entryuuid']));
+    Team::factory()->create();
+
+    $fake = fakeDirectory();
+    $entry = directoryUser([
+        'cn' => 'Ada Byte',
+        'mail' => 'ada@example.com',
+        'uid' => 'ada',
+        'entryuuid' => '11111111-2222-3333-4444-555555555555',
+    ]);
+    $fake->actingAs($entry);
+
+    $this->post('/login', ['email' => 'ada@example.com', 'password' => 'directory-secret']);
+
+    $this->assertAuthenticated();
+
+    $guid = DirectoryUser::query()->where('mail', '=', 'ada@example.com')->first()->getConvertedGuid();
+    expect($guid)->toBe('11111111-2222-3333-4444-555555555555');
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'ldap',
+        'provider_id' => $guid,
+    ]);
+});
+
+test('a returning directory user resolves to the same account without duplicating the identity', function (): void {
+    $this->reloadWithEnv(ldapEnv());
+    Team::factory()->create();
+
+    $fake = fakeDirectory();
+    $entry = directoryUser(['cn' => 'Ada Byte', 'mail' => 'ada@example.com', 'uid' => 'ada']);
+    $fake->actingAs($entry);
+
+    $this->post('/login', ['email' => 'ada@example.com', 'password' => 'directory-secret']);
+    $firstId = auth()->id();
+    auth()->logout();
+
+    $this->post('/login', ['email' => 'ada@example.com', 'password' => 'directory-secret']);
+
+    expect(auth()->id())->toBe($firstId)
+        ->and(User::query()->count())->toBe(1)
+        ->and(SsoIdentity::query()->where('provider', 'ldap')->count())->toBe(1);
+});

--- a/tests/Feature/Auth/Sso/ProvisionSsoUserTest.php
+++ b/tests/Feature/Auth/Sso/ProvisionSsoUserTest.php
@@ -103,3 +103,38 @@ test('a provisioned user with no name falls back to their email', function (): v
 
     expect($user->name)->toBe('jordan@example.com');
 });
+
+test('syncName refreshes the display name of an email-matched user from the directory', function (): void {
+    $existing = User::factory()->create(['email' => 'jordan@example.com', 'name' => 'Old Name']);
+
+    $user = app(ProvisionSsoUser::class)->handle('ldap', 'guid-1', 'jordan@example.com', 'Jordan Rivers', syncName: true);
+
+    expect($user->id)->toBe($existing->id)
+        ->and($existing->fresh()->name)->toBe('Jordan Rivers');
+});
+
+test('syncName refreshes the display name of an identity-matched user on a return login', function (): void {
+    $existing = User::factory()->create(['name' => 'Old Name']);
+    SsoIdentity::factory()->provider('ldap')->for($existing)->create(['provider_id' => 'guid-1']);
+
+    app(ProvisionSsoUser::class)->handle('ldap', 'guid-1', 'someone@example.com', 'Jordan Rivers', syncName: true);
+
+    expect($existing->fresh()->name)->toBe('Jordan Rivers');
+});
+
+test('syncName leaves the name untouched when the directory supplies no name', function (): void {
+    $existing = User::factory()->create(['name' => 'Kept Name']);
+    SsoIdentity::factory()->provider('ldap')->for($existing)->create(['provider_id' => 'guid-1']);
+
+    app(ProvisionSsoUser::class)->handle('ldap', 'guid-1', 'someone@example.com', null, syncName: true);
+
+    expect($existing->fresh()->name)->toBe('Kept Name');
+});
+
+test('without syncName an existing matched user keeps their current name', function (): void {
+    $existing = User::factory()->create(['email' => 'jordan@example.com', 'name' => 'Kept Name']);
+
+    app(ProvisionSsoUser::class)->handle('oidc', 'sub-123', 'jordan@example.com', 'Jordan Rivers');
+
+    expect($existing->fresh()->name)->toBe('Kept Name');
+});

--- a/tests/Feature/Auth/Sso/SsoOnlyFlagTest.php
+++ b/tests/Feature/Auth/Sso/SsoOnlyFlagTest.php
@@ -46,6 +46,29 @@ test('password login still works when sso-only mode is off', function (): void {
     $this->assertAuthenticated();
 });
 
+test('sso-only enforcement also engages when only an LDAP directory is configured', function (): void {
+    $this->reloadWithEnv([
+        'AUTH_SSO_ONLY' => true,
+        'REGISTRATION_ENABLED' => true,
+        'LDAP_HOST' => 'ldap.test',
+        'LDAP_BASE_DN' => 'dc=the-desk,dc=local',
+    ]);
+
+    expect(config('sso.enforced'))->toBeTrue();
+
+    // Registration is closed and the password login POST reaches the directory
+    // bind callback (not a 404) so LDAP sign-in still works.
+    $this->get('/register')->assertNotFound();
+    $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertNotFound();
+
+    $this->assertGuest();
+});
+
 test('sso-only mode has no effect when no provider is configured, so no one is locked out', function (): void {
     // AUTH_SSO_ONLY on but no OIDC provider: enforcement must not engage, or the
     // instance would disable every sign-in path.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Tests;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Env;
 use Laravel\Fortify\Features;
+use Laravel\Fortify\Fortify;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -42,6 +43,12 @@ abstract class TestCase extends BaseTestCase
         }
 
         $this->originalEnv = [];
+
+        // The LDAP directory-bind path registers a custom Fortify auth callback
+        // (FortifyServiceProvider::configureLdapAuthentication). It lives on a
+        // static, so booting a later test without LDAP would otherwise inherit
+        // the previous test's callback; clear it so each test starts clean.
+        Fortify::$authenticateUsingCallback = null;
 
         parent::tearDown();
     }


### PR DESCRIPTION
Closes #120. Part of the SSO epic #118.

**Stacked PR** — base is `feat/sso-oidc-foundation` (the #119 OIDC foundation), not `master`. Only the foundation branch merges to `master`.

## What this adds

Authenticate members against an on-prem **LDAP / Active Directory** directory via **bind auth** through the app's own login form, reusing the #119 shared identity layer (no rebuild):

- On a successful bind, the entry is matched to an app user by its **mail** attribute, keyed by its stable **objectGUID**, and JIT-provisioned into the default team as a **Member** with `email_verified_at` stamped — identical rules to OIDC.
- Existing app users with a matching email are **linked, not duplicated**.
- The mapped display **name syncs on every login**.
- Library: **LdapRecord-Laravel** (`directorytree/ldaprecord-laravel`), approved as a new dependency. Tests use its **directory emulator** (no live server).

## The three nuances #119 left open

1. **Attribute sync** — `ProvisionSsoUser::handle()` gains an opt-in `syncName` step that refreshes an existing user's name from the directory (a blank name never wipes the current one). OIDC behavior is unchanged.
2. **Enforcement predicate** — `sso.enforced` (and its mirror in `config/fortify.php`) now also engages when LDAP is configured (`LDAP_HOST` + `LDAP_BASE_DN`), not just OIDC.
3. **Enforcement conflict** — LDAP bind runs through the same `login.store` POST as local password. Resolved with a custom `Fortify::authenticateUsing` (registered only when LDAP is enabled) that tries the directory bind, then falls back to the local password **unless enforced**. `EnsurePasswordLoginEnabled` now lets the bind POST through when LDAP is enabled (still 404s the OIDC-only case), so enforcement blocks the local-DB path while allowing the directory bind.

## Config & docs

Env-driven connection (host/port/base DN/bind DN+password/TLS/LDAPS) in `config/ldap.php`, attribute mappings (`username`/`mail`/`name`/`guid`) in `config/sso.php`. Documented in `.env(.prod).example`, `environment-variables.md`, `feature-toggles.md`, and `self-hosting/configuration.md`. `ext-ldap` added to the production Dockerfile (build + runtime).

## Review

CodeRabbit CLI run against the base branch; acted on its substantive findings:
- `DirectoryUser` object classes narrowed to `person` only (the AND-matched constraint would otherwise exclude AD `user` entries).
- `ext-ldap` added to the prod image build/runtime (LdapRecord hard-requires it).
- Added a test proving the configurable GUID attribute (`entryuuid` for OpenLDAP) is honored.
- Blank-credential guard covered (guards against LDAP anonymous binds).

## Testing

Feature tests against the LdapRecord emulator: bind→JIT-create, existing-user link, name sync, returning user, bind rejection, unknown user, missing-mail failure, unreachable directory, blank-credential guard, configurable GUID, and the enforcement split (local password blocked / directory bind allowed / break-glass fallback). Full backend gate green: **100% coverage**, Pint/PHPStan/Rector clean.

## Manual verification

Automated tests use the emulator. End-to-end verification against a real directory is tracked by #356 (local LDAP service in `compose.yaml`).

## Out of scope (deferred, per the issue)

Group (`memberOf`) → team/role mapping and scheduled full-directory import.
