### PR TITLE
feat: add SCIM 2.0 directory provisioning and deprovisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,6 +103,14 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # in. Leave false (the default) to keep a break-glass password account for outages.
 # AUTH_SSO_ONLY=false
 
+# Directory provisioning (SCIM 2.0). Let your IdP (Okta, Entra ID, …) push user
+# create/update/deactivate events to ${APP_URL}/scim/v2, so a directory removal
+# automatically tombstones the account here (access revoked, history kept) — a
+# later active:true reactivates it. The IdP authenticates with SCIM_TOKEN; leave
+# it blank to keep the endpoint off entirely. Use a long random secret.
+# SCIM_TOKEN=
+# SCIM_BASE_PATH=/scim
+
 LOG_CHANNEL=stack
 LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -97,6 +97,16 @@ GRAVATAR_ENABLED=true
 # password account for outages.
 # AUTH_SSO_ONLY=false
 
+# --- Directory provisioning (SCIM 2.0) ---------------------------------------
+# Let your IdP (Okta, Entra ID, OneLogin, …) push user create/update/deactivate
+# events to ${APP_URL}/scim/v2, so a directory removal automatically tombstones
+# the account here (access revoked and sessions ended, history kept) — a later
+# active:true reactivates it. The IdP authenticates with the bearer SCIM_TOKEN;
+# leave it blank to keep the endpoint off entirely. Use a long random secret and
+# only expose SCIM over HTTPS.
+# SCIM_TOKEN=
+# SCIM_BASE_PATH=/scim
+
 # --- Database (pgsql service) ------------------------------------------------
 DB_CONNECTION=pgsql
 DB_HOST=pgsql

--- a/app/Actions/Sso/SetSsoUserActivation.php
+++ b/app/Actions/Sso/SetSsoUserActivation.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Sso;
+
+use App\Models\User;
+use App\Support\SessionRegistry;
+
+/**
+ * Toggles a directory user's activation, the app side of SCIM deprovisioning.
+ *
+ * Deactivation tombstones the account (sets `deactivated_at`) rather than
+ * deleting it, so authored history is retained, and revokes every active session
+ * so access is cut immediately. Reactivation reverses the flag on a subsequent
+ * `active: true`. Enforcement of the revoked state on future requests lives in
+ * App\Http\Middleware\EnsureUserIsActive.
+ */
+class SetSsoUserActivation
+{
+    public function __construct(private readonly SessionRegistry $sessions) {}
+
+    /**
+     * Deactivate the account and terminate its sessions.
+     *
+     * A no-op timestamp refresh is avoided when the account is already
+     * deactivated, so the original deactivation moment is preserved.
+     */
+    public function deactivate(User $user): void
+    {
+        if ($user->isDeactivated()) {
+            return;
+        }
+
+        $user->forceFill(['deactivated_at' => now()])->save();
+
+        $this->sessions->flush((string) $user->getKey());
+    }
+
+    /**
+     * Reactivate a previously deactivated account.
+     */
+    public function reactivate(User $user): void
+    {
+        if (! $user->isDeactivated()) {
+            return;
+        }
+
+        $user->forceFill(['deactivated_at' => null])->save();
+    }
+}

--- a/app/Http/Controllers/Scim/ScimUserController.php
+++ b/app/Http/Controllers/Scim/ScimUserController.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Scim;
+
+use App\Actions\Sso\ProvisionSsoUser;
+use App\Actions\Sso\SetSsoUserActivation;
+use App\Models\User;
+use App\Support\SessionRegistry;
+use ArieTimmerman\Laravel\SCIMServer\Events\Create;
+use ArieTimmerman\Laravel\SCIMServer\Exceptions\SCIMException;
+use ArieTimmerman\Laravel\SCIMServer\Http\Controllers\ResourceController;
+use ArieTimmerman\Laravel\SCIMServer\PolicyDecisionPoint;
+use ArieTimmerman\Laravel\SCIMServer\ResourceType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * The SCIM `/Users` endpoint, wired to this app's identity model.
+ *
+ * Read, list-with-filter, and the SCIM attribute mapping are inherited from the
+ * package's ResourceController; the write paths are overridden so every mutation
+ * flows through the shared directory layer:
+ *
+ * - Create matches or just-in-time provisions through App\Actions\Sso\
+ *   ProvisionSsoUser (email match or create, default team as Member, stable
+ *   provider id), exactly like OIDC and LDAP.
+ * - Deactivate (DELETE, or `active: false` via PUT/PATCH) tombstones the account
+ *   and revokes its sessions rather than hard-deleting, so history is retained.
+ * - Reactivate (`active: true`) reverses it.
+ *
+ * The controller is bound over the package's ResourceController in
+ * App\Providers\SsoServiceProvider so the package routes resolve to it.
+ */
+class ScimUserController extends ResourceController
+{
+    public function __construct(
+        private readonly ProvisionSsoUser $provisionSsoUser,
+        private readonly SetSsoUserActivation $activation,
+        private readonly SessionRegistry $sessions,
+    ) {}
+
+    /**
+     * Provision (or link) the app user for a SCIM create.
+     *
+     * The IdP's `userName` is treated as the user's email — the identity the
+     * shared layer matches on — and `externalId` (falling back to the email) as
+     * the stable provider id stored on the SCIM identity. The `active` flag is
+     * applied after provisioning so a create can immediately (de)activate.
+     *
+     * @param  bool  $isMe
+     */
+    #[\Override]
+    public function createObject(Request $request, PolicyDecisionPoint $pdp, ResourceType $resourceType, $isMe = false): Model
+    {
+        $email = $this->email($request);
+
+        if ($email === '') {
+            throw (new SCIMException('The userName attribute is required.'))->setCode(400)->setScimType('invalidValue');
+        }
+
+        $externalId = trim((string) $request->input('externalId'));
+        $name = $request->input('name.formatted');
+
+        $user = $this->provisionSsoUser->handle(
+            'scim',
+            $externalId !== '' ? $externalId : $email,
+            $email,
+            is_string($name) ? $name : null,
+            syncName: true,
+        );
+
+        $this->applyActiveFlag($user, $request->input('active'));
+
+        event(new Create($user, $resourceType, $isMe, $request->input()));
+
+        return $user;
+    }
+
+    /**
+     * Replace a user (PUT), revoking sessions if the write deactivated them.
+     *
+     * @param  bool  $isMe
+     */
+    #[\Override]
+    public function replace(Request $request, PolicyDecisionPoint $pdp, ResourceType $resourceType, Model $resourceObject, $isMe = false): Response
+    {
+        $wasDeactivated = $this->isDeactivated($resourceObject);
+
+        $response = parent::replace($request, $pdp, $resourceType, $resourceObject, $isMe);
+
+        $this->revokeSessionsIfNewlyDeactivated($resourceObject, $wasDeactivated);
+
+        return $response;
+    }
+
+    /**
+     * Patch a user, revoking sessions if the write deactivated them.
+     *
+     * @param  bool  $isMe
+     */
+    #[\Override]
+    public function update(Request $request, PolicyDecisionPoint $pdp, ResourceType $resourceType, Model $resourceObject, $isMe = false): Response
+    {
+        $wasDeactivated = $this->isDeactivated($resourceObject);
+
+        $response = parent::update($request, $pdp, $resourceType, $resourceObject, $isMe);
+
+        $this->revokeSessionsIfNewlyDeactivated($resourceObject, $wasDeactivated);
+
+        return $response;
+    }
+
+    /**
+     * Deactivate on DELETE — tombstone and revoke access instead of removing.
+     */
+    #[\Override]
+    public function delete(Request $request, PolicyDecisionPoint $pdp, ResourceType $resourceType, Model $resourceObject): Response
+    {
+        $this->deactivate($resourceObject);
+
+        return response(null, 204);
+    }
+
+    /**
+     * Resolve the email the SCIM create keys on: `userName`, else the first email.
+     */
+    private function email(Request $request): string
+    {
+        $userName = trim((string) $request->input('userName'));
+
+        if ($userName !== '') {
+            return $userName;
+        }
+
+        return trim((string) $request->input('emails.0.value'));
+    }
+
+    /**
+     * Apply an incoming `active` flag (default active) to a provisioned user.
+     */
+    private function applyActiveFlag(User $user, mixed $active): void
+    {
+        if ($active === false) {
+            $this->deactivate($user);
+
+            return;
+        }
+
+        $this->activation->reactivate($user);
+    }
+
+    /**
+     * Deactivate a user through the shared action (tombstone + session flush).
+     */
+    private function deactivate(Model $user): void
+    {
+        if ($user instanceof User) {
+            $this->activation->deactivate($user);
+        }
+    }
+
+    /**
+     * Whether the resolved resource is a deactivated app user.
+     */
+    private function isDeactivated(Model $user): bool
+    {
+        return $user instanceof User && $user->isDeactivated();
+    }
+
+    /**
+     * Revoke sessions when a PUT/PATCH flipped an active account to deactivated.
+     *
+     * The `active` mapping has already stamped `deactivated_at` and saved by the
+     * time this runs, so only the session revocation remains — and only on the
+     * active-to-deactivated edge, never on a reactivation or a no-op write.
+     */
+    private function revokeSessionsIfNewlyDeactivated(Model $user, bool $wasDeactivated): void
+    {
+        if (! $wasDeactivated && $this->isDeactivated($user)) {
+            $this->sessions->flush((string) $user->getKey());
+        }
+    }
+}

--- a/app/Http/Middleware/EnsureScimBearerToken.php
+++ b/app/Http/Middleware/EnsureScimBearerToken.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Authenticates the identity provider against the SCIM API with an instance-wide
+ * bearer token.
+ *
+ * SCIM is a machine-to-machine REST API, not a login form, so it carries none of
+ * Fortify's session/guard machinery: the IdP presents `Authorization: Bearer
+ * <token>` and this middleware compares it (in constant time) to the configured
+ * secret, rejecting anything that does not match with a SCIM-shaped 401. The
+ * routes are only mounted when a token is configured (see SsoServiceProvider), so
+ * a missing secret means the endpoint does not exist rather than being open.
+ */
+class EnsureScimBearerToken
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $configured = (string) config('sso.scim.token');
+        $presented = (string) $request->bearerToken();
+
+        if ($presented === '' || ! hash_equals($configured, $presented)) {
+            return $this->unauthorized();
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Build a SCIM-conformant 401 error response.
+     */
+    private function unauthorized(): JsonResponse
+    {
+        return new JsonResponse([
+            'schemas' => ['urn:ietf:params:scim:api:messages:2.0:Error'],
+            'detail' => 'Unauthorized',
+            'status' => '401',
+        ], 401, [
+            'Content-Type' => 'application/scim+json',
+            'WWW-Authenticate' => 'Bearer',
+        ]);
+    }
+}

--- a/app/Http/Middleware/EnsureUserIsActive.php
+++ b/app/Http/Middleware/EnsureUserIsActive.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Enforces directory deprovisioning on every authenticated web request.
+ *
+ * Deactivating an account (SCIM push) revokes its sessions immediately, but that
+ * alone would not stop the user simply signing in again through OIDC/LDAP. This
+ * middleware fail-closes that gap: a deactivated user is logged out and bounced
+ * to the login screen on any request, so a tombstoned account stays locked out
+ * regardless of how it authenticated — until a subsequent `active: true` clears
+ * the flag (see App\Actions\Sso\SetSsoUserActivation).
+ */
+class EnsureUserIsActive
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user instanceof User && $user->isDeactivated()) {
+            Auth::guard()->logout();
+
+            if ($request->hasSession()) {
+                $request->session()->invalidate();
+                $request->session()->regenerateToken();
+            }
+
+            return redirect()->guest(route('login'))->with(
+                'status',
+                __('Your account has been deactivated. Please contact your administrator.'),
+            );
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,6 +47,7 @@ use Illuminate\Support\Str;
  * @property bool $share_read_receipts
  * @property Carbon|null $onboarding_completed_at
  * @property bool $is_tombstone
+ * @property Carbon|null $deactivated_at
  * @property array<int, string>|null $collapsed_channel_sections
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -134,6 +135,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
             'share_read_receipts' => 'boolean',
             'onboarding_completed_at' => 'datetime',
             'is_tombstone' => 'boolean',
+            'deactivated_at' => 'datetime',
             'collapsed_channel_sections' => 'array',
         ];
     }
@@ -250,5 +252,17 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
     public function ssoIdentities(): HasMany
     {
         return $this->hasMany(SsoIdentity::class);
+    }
+
+    /**
+     * Whether the account has been deactivated (directory-pushed deprovisioning).
+     *
+     * A deactivated account is tombstoned rather than deleted: its history stays
+     * intact but access is revoked (see App\Http\Middleware\EnsureUserIsActive and
+     * App\Actions\Sso\SetSsoUserActivation). Reactivation clears `deactivated_at`.
+     */
+    public function isDeactivated(): bool
+    {
+        return $this->deactivated_at !== null;
     }
 }

--- a/app/Providers/SsoServiceProvider.php
+++ b/app/Providers/SsoServiceProvider.php
@@ -2,7 +2,13 @@
 
 namespace App\Providers;
 
+use App\Http\Controllers\Scim\ScimUserController;
+use App\Http\Middleware\EnsureScimBearerToken;
+use App\Scim\ScimConfig;
 use App\Services\Sso\GenericOidcProvider;
+use ArieTimmerman\Laravel\SCIMServer\Http\Controllers\ResourceController;
+use ArieTimmerman\Laravel\SCIMServer\RouteProvider;
+use ArieTimmerman\Laravel\SCIMServer\SCIMConfig as PackageScimConfig;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Socialite\Facades\Socialite;
 
@@ -14,7 +20,11 @@ class SsoServiceProvider extends ServiceProvider
     #[\Override]
     public function register(): void
     {
-        //
+        // Point the SCIM server at this app's resource map (Users only) and its
+        // identity-aware controller, so the package's routes resolve to logic
+        // that flows through the shared provisioning layer.
+        $this->app->bind(PackageScimConfig::class, ScimConfig::class);
+        $this->app->bind(ResourceController::class, ScimUserController::class);
     }
 
     /**
@@ -23,6 +33,7 @@ class SsoServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerOidcDriver();
+        $this->registerScimRoutes();
     }
 
     /**
@@ -54,5 +65,32 @@ class SsoServiceProvider extends ServiceProvider
 
             return $provider;
         });
+    }
+
+    /**
+     * Mount the SCIM 2.0 routes when provisioning is configured.
+     *
+     * The routes are deliberately not auto-published by the package (see
+     * config/scim.php): they exist only when a bearer token is set, and every
+     * one — the /Users surface and the discovery endpoints — is wrapped in the
+     * token guard, so an unauthenticated provisioning API is never exposed. The
+     * base path is operator-configurable via SCIM_BASE_PATH.
+     *
+     * When routes are cached (`route:cache`, as production does) the cached table
+     * already contains these routes, so re-registering here would duplicate them;
+     * the guard skips that. Toggling SCIM then requires rebuilding the route cache,
+     * like any route change.
+     */
+    private function registerScimRoutes(): void
+    {
+        if ($this->app->routesAreCached() || ! config('sso.scim.enabled')) {
+            return;
+        }
+
+        RouteProvider::routes([
+            'path' => config('sso.scim.path'),
+            'middleware' => [EnsureScimBearerToken::class],
+            'public_middleware' => [EnsureScimBearerToken::class],
+        ]);
     }
 }

--- a/app/Scim/Attributes/ScimActiveAttribute.php
+++ b/app/Scim/Attributes/ScimActiveAttribute.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim\Attributes;
+
+use ArieTimmerman\Laravel\SCIMServer\Attribute\Eloquent;
+use ArieTimmerman\Laravel\SCIMServer\Parser\Path;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Maps the SCIM boolean `active` attribute onto the app's `deactivated_at`
+ * timestamp so directory (de)activation flows through one column.
+ *
+ * Reading reports `active: true` while `deactivated_at` is null; writing a false
+ * stamps the deactivation moment (preserving an existing one so repeated pushes
+ * are idempotent) and a true clears it. Filtering (`active eq true|false`) is
+ * translated to a null / not-null check on the column. The session revocation
+ * that must accompany a deactivation is applied by App\Http\Controllers\Scim\
+ * ScimUserController, which owns the request lifecycle.
+ */
+class ScimActiveAttribute extends Eloquent
+{
+    public function __construct()
+    {
+        parent::__construct('active', 'deactivated_at');
+    }
+
+    /**
+     * Report the account's active state (the inverse of being deactivated).
+     *
+     * @param  Model  $object
+     * @param  array<int, string>  $attributes
+     */
+    #[\Override]
+    protected function doRead(&$object, $attributes = []): bool
+    {
+        return $object->getAttribute('deactivated_at') === null;
+    }
+
+    /**
+     * Apply an `active` value supplied via PUT (full replace).
+     *
+     * @param  mixed  $value
+     * @param  mixed  $path
+     */
+    #[\Override]
+    public function replace($value, Model &$object, $path = null): void
+    {
+        $this->applyActive($value, $object);
+    }
+
+    /**
+     * Apply an `active` value supplied via a PATCH operation.
+     *
+     * @param  string  $operation
+     * @param  mixed  $value
+     */
+    #[\Override]
+    public function patch($operation, $value, Model &$object, ?Path $path = null): void
+    {
+        $this->applyActive($value, $object);
+    }
+
+    /**
+     * Translate an `active` filter comparison to the backing timestamp column.
+     *
+     * @param  Builder<Model>  $query
+     * @param  mixed  $parentAttribute
+     */
+    #[\Override]
+    public function applyComparison(Builder &$query, Path $path, $parentAttribute = null): void
+    {
+        if (filter_var($path->node->compareValue, FILTER_VALIDATE_BOOLEAN)) {
+            $query->whereNull('deactivated_at');
+
+            return;
+        }
+
+        $query->whereNotNull('deactivated_at');
+    }
+
+    /**
+     * Stamp or clear `deactivated_at` from a SCIM boolean.
+     */
+    private function applyActive(mixed $value, Model $object): void
+    {
+        $object->setAttribute('deactivated_at', filter_var($value, FILTER_VALIDATE_BOOLEAN)
+            ? null
+            : ($object->getAttribute('deactivated_at') ?? now()));
+
+        $this->dirty = true;
+    }
+}

--- a/app/Scim/Attributes/ScimIdAttribute.php
+++ b/app/Scim/Attributes/ScimIdAttribute.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim\Attributes;
+
+use ArieTimmerman\Laravel\SCIMServer\Attribute\Constant;
+use ArieTimmerman\Laravel\SCIMServer\Parser\Path;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Exposes the app user's primary key as the immutable SCIM resource `id`.
+ *
+ * The id is server-owned: it is echoed as a string and a PUT that omits it must
+ * not wipe it, so removal is a deliberate no-op (a full replace runs the parent
+ * "remove attributes not present in the payload" pass over every root attribute).
+ */
+class ScimIdAttribute extends Constant
+{
+    public function __construct()
+    {
+        parent::__construct('id', null);
+    }
+
+    /**
+     * Read the resource id as a string.
+     *
+     * @param  Model  $object
+     * @param  array<int, string>  $attributes
+     */
+    #[\Override]
+    protected function doRead(&$object, $attributes = []): string
+    {
+        return (string) $object->getKey();
+    }
+
+    /**
+     * Ignore attempts to remove the server-owned id.
+     *
+     * @param  mixed  $value
+     */
+    #[\Override]
+    public function remove($value, Model &$object, ?Path $path = null): void
+    {
+        // The id is immutable; a full-replace's "unset what's absent" pass must
+        // leave it untouched.
+    }
+}

--- a/app/Scim/Attributes/ScimSchemasAttribute.php
+++ b/app/Scim/Attributes/ScimSchemasAttribute.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim\Attributes;
+
+use ArieTimmerman\Laravel\SCIMServer\Attribute\Constant;
+use ArieTimmerman\Laravel\SCIMServer\SCIM\Schema;
+
+/**
+ * The constant `schemas` list for the User resource.
+ *
+ * The vendor Constant rejects any write whose value differs from the constant,
+ * which would 403 a PUT whose `schemas` array is merely reordered or carries an
+ * (unmapped) extension urn. Since the value is server-defined anyway, the replace
+ * is accepted as a no-op so a full replace never fails on this housekeeping field.
+ */
+class ScimSchemasAttribute extends Constant
+{
+    public function __construct()
+    {
+        parent::__construct('schemas', [Schema::SCHEMA_USER]);
+    }
+
+    /**
+     * Accept (and ignore) the incoming schemas on a full replace.
+     *
+     * @param  mixed  $value
+     * @param  mixed  $object
+     * @param  mixed  $path
+     */
+    #[\Override]
+    public function replace($value, &$object, $path = null): void
+    {
+        $this->dirty = true;
+    }
+}

--- a/app/Scim/ScimConfig.php
+++ b/app/Scim/ScimConfig.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Scim;
+
+use App\Models\User;
+use App\Scim\Attributes\ScimActiveAttribute;
+use App\Scim\Attributes\ScimIdAttribute;
+use App\Scim\Attributes\ScimSchemasAttribute;
+use ArieTimmerman\Laravel\SCIMServer\Attribute\Complex;
+use ArieTimmerman\Laravel\SCIMServer\Attribute\Eloquent;
+use ArieTimmerman\Laravel\SCIMServer\Attribute\Meta;
+use ArieTimmerman\Laravel\SCIMServer\Attribute\Schema as AttributeSchema;
+use ArieTimmerman\Laravel\SCIMServer\SCIM\Schema;
+use ArieTimmerman\Laravel\SCIMServer\SCIMConfig as BaseScimConfig;
+
+/**
+ * The SCIM resource map for this app: a single, trimmed `Users` resource.
+ *
+ * Groups are intentionally out of scope (issue #121), so only the User resource
+ * is exposed — a request to any other resource type resolves to nothing and 404s.
+ * The map is deliberately small: `userName` is the user's email (the identifier
+ * the IdP reconciles and filters on), `name.formatted` the display name, and
+ * `active` the deactivation state (see App\Scim\Attributes\ScimActiveAttribute).
+ * Creation and the activation side effects are handled by ScimUserController so
+ * every SCIM user flows through the shared App\Actions\Sso\ProvisionSsoUser layer.
+ */
+class ScimConfig extends BaseScimConfig
+{
+    /**
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function getUserConfig(): array
+    {
+        return [
+            'class' => User::class,
+            'singular' => 'User',
+            'withRelations' => [],
+            'description' => 'User Account',
+
+            'map' => (new Complex)->withSubAttributes(
+                new ScimSchemasAttribute,
+                new ScimIdAttribute,
+                new Meta('Users'),
+                (new AttributeSchema(Schema::SCHEMA_USER, true))->withSubAttributes(
+                    (new Eloquent('userName', 'email'))->ensure('required'),
+                    (new Complex('name'))->withSubAttributes(
+                        new Eloquent('formatted', 'name'),
+                    ),
+                    new ScimActiveAttribute,
+                ),
+            ),
+        ];
+    }
+
+    /**
+     * Expose only the User resource; Groups are out of scope for this app.
+     *
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    public function getConfig(): array
+    {
+        return [
+            'Users' => $this->getUserConfig(),
+        ];
+    }
+}

--- a/app/Support/SessionRegistry.php
+++ b/app/Support/SessionRegistry.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use App\Http\Middleware\TrackActiveSession;
 use Illuminate\Contracts\Cache\Repository as Cache;
 
 /**
@@ -99,6 +100,24 @@ class SessionRegistry
 
         if ($removed > 0) {
             $this->save($userId, $sessions);
+        }
+
+        return $removed;
+    }
+
+    /**
+     * Revoke every session for the user, returning the number removed.
+     *
+     * Used when an account is deactivated (directory deprovisioning): dropping
+     * the whole index logs the user out of every device on their next request
+     * via {@see TrackActiveSession}.
+     */
+    public function flush(string $userId): int
+    {
+        $removed = count($this->load($userId));
+
+        if ($removed > 0) {
+            $this->cache->forget($this->key($userId));
         }
 
         return $removed;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Middleware\EnsurePasswordLoginEnabled;
+use App\Http\Middleware\EnsureUserIsActive;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\SetLocale;
@@ -34,6 +35,7 @@ return Application::configure(basePath: dirname(__DIR__))
             AddLinkHeadersForPreloadedAssets::class,
             SetTeamUrlDefaults::class,
             TrackActiveSession::class,
+            EnsureUserIsActive::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^8.3",
         "ext-gd": "*",
         "ext-imagick": "*",
+        "arietimmerman/laravel-scim-server": "^1.5",
         "directorytree/ldaprecord-laravel": "^4.0",
         "inertiajs/inertia-laravel": "^3.0",
         "intervention/image": "^4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,69 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c891d41a1c9ddc942bff49c3da017c5f",
+    "content-hash": "5508162af344f5f7fe80a1672fcce374",
     "packages": [
+        {
+            "name": "arietimmerman/laravel-scim-server",
+            "version": "v1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/limosa-io/laravel-scim-server.git",
+                "reference": "f4182bc138e51f73dd892d68b328dc09635cf3ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/limosa-io/laravel-scim-server/zipball/f4182bc138e51f73dd892d68b328dc09635cf3ac",
+                "reference": "f4182bc138e51f73dd892d68b328dc09635cf3ac",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.66",
+                "laravel/legacy-factories": "^1.4.2",
+                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "SCIMServerHelper": "ArieTimmerman\\Laravel\\SCIMServer\\Helper"
+                    },
+                    "providers": [
+                        "ArieTimmerman\\Laravel\\SCIMServer\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ArieTimmerman\\Laravel\\SCIMServer\\": "src/"
+                },
+                "classmap": [
+                    "database/migrations"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Arie Timmerman",
+                    "email": "arietimmerman@gmail.com"
+                }
+            ],
+            "description": "Laravel Package for creating a SCIM server",
+            "support": {
+                "issues": "https://github.com/limosa-io/laravel-scim-server/issues",
+                "source": "https://github.com/limosa-io/laravel-scim-server/tree/v1.5.1"
+            },
+            "time": "2026-04-23T05:29:48+00:00"
+        },
         {
             "name": "bacon/bacon-qr-code",
             "version": "v3.1.1",

--- a/config/scim.php
+++ b/config/scim.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+// Configuration for arietimmerman/laravel-scim-server. The SCIM routes are NOT
+// auto-published here: App\Providers\SsoServiceProvider mounts them only when
+// SCIM is enabled (config('sso.scim.enabled')) and wraps them in the bearer-token
+// guard, so the base path, middleware, and on/off switch all live in config/sso.php.
+return [
+    'publish_routes' => false,
+
+    // Hoist the core User attributes (userName, name, active, …) to the top of
+    // the resource instead of nesting them under the schema urn, which is what
+    // standard SCIM clients (Okta, Entra ID, …) expect.
+    'omit_main_schema_in_return' => true,
+    'omit_null_values' => env('SCIM_OMIT_NULL_VALUES', true),
+
+    'path' => env('SCIM_BASE_PATH', '/scim'),
+    'domain' => env('SCIM_DOMAIN'),
+    'middleware' => env('SCIM_MIDDLEWARE', []),
+    'public_middleware' => env('SCIM_PUBLIC_MIDDLEWARE', []),
+
+    'pagination' => [
+        'defaultPageSize' => 10,
+        'maxPageSize' => 100,
+        'cursorPaginationEnabled' => true,
+    ],
+
+    'authenticationSchemes' => [
+        'oauthbearertoken',
+    ],
+];

--- a/config/sso.php
+++ b/config/sso.php
@@ -12,6 +12,11 @@ $oidcConfigured = filled(env('SSO_OIDC_CLIENT_ID')) && filled(env('SSO_OIDC_ISSU
 // login path and SSO-only enforcement.
 $ldapConfigured = filled(env('LDAP_HOST')) && filled(env('LDAP_BASE_DN'));
 
+// Whether SCIM provisioning is wired up: the endpoint only functions with a
+// bearer token to authenticate the identity provider, so its presence is what
+// mounts (and guards) the SCIM routes.
+$scimConfigured = filled(env('SCIM_TOKEN'));
+
 return [
 
     /*
@@ -92,6 +97,31 @@ return [
             'name' => env('LDAP_ATTR_NAME', 'cn'),
             'guid' => env('LDAP_ATTR_GUID', 'objectguid'),
         ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | SCIM 2.0 provisioning
+    |--------------------------------------------------------------------------
+    |
+    | A bearer-token REST API the corporate IdP (Okta, Entra ID, OneLogin, …)
+    | pushes user create / update / deactivate events to, so directory removals
+    | become automatic account deactivation here. Unlike OIDC/LDAP it is not a
+    | login path: the IdP authenticates with `SCIM_TOKEN` and every request is
+    | rejected without it (App\Http\Middleware\EnsureScimBearerToken).
+    |
+    | `enabled` mounts the endpoints only when a token is set — an unauthenticated
+    | provisioning API is never exposed by accident. `path` is the route *prefix*
+    | (default `/scim`); the package mounts the versioned resources beneath it, so
+    | with the default the IdP's base URL is `${APP_URL}/scim/v2` and users live at
+    | `/scim/v2/Users`.
+    |
+    */
+
+    'scim' => [
+        'enabled' => $scimConfigured,
+        'token' => env('SCIM_TOKEN'),
+        'path' => env('SCIM_BASE_PATH', '/scim'),
     ],
 
 ];

--- a/database/migrations/2026_07_14_133103_add_deactivated_at_to_users_table.php
+++ b/database/migrations/2026_07_14_133103_add_deactivated_at_to_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            // When a directory (SCIM) pushes a deactivation the account is
+            // tombstoned here rather than hard-deleted, so history is retained
+            // while access is revoked. Null means active; a timestamp records
+            // when the account was deactivated, and reactivation clears it. This
+            // is deliberately distinct from `is_tombstone`, which flags the
+            // single shared "Deleted User" placeholder (see User::tombstone()).
+            $table->timestamp('deactivated_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('deactivated_at');
+        });
+    }
+};

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -148,6 +148,32 @@ allowing the directory bind.
 | `LDAP_ATTR_GUID`     | `objectguid`                  | Stable identity attribute. `objectguid` for Active Directory, `entryuuid` for OpenLDAP.           |
 | `LDAP_CONNECTION`    | `default`                     | Name of the connection in `config/ldap.php` to use.                                               |
 
+## Directory provisioning (SCIM 2.0)
+
+Let your identity provider (Okta, Entra ID, OneLogin, …) **push** user lifecycle
+changes over **SCIM 2.0**, so removing someone from the directory automatically
+deactivates their account here. This is separate from the login paths above: it
+is a bearer-token REST API the IdP calls, not a form users sign in through.
+
+Point your IdP at `${APP_URL}/scim/v2` and authenticate it with `SCIM_TOKEN`.
+**Creates** match or just-in-time provision the user through the same rules as
+OIDC/LDAP (email match or create, default team as **Member**). **Deactivations**
+(`active: false` or `DELETE`) **tombstone** the account — access is revoked and
+every session ends, but history is kept, not hard-deleted — and a later
+`active: true` **reactivates** it. Leave `SCIM_TOKEN` blank to keep the endpoint
+off (it is not mounted at all without a token).
+
+| Variable         | Default  | Notes                                                                                          |
+| ---------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `SCIM_TOKEN`     | *(blank)* | Bearer token the IdP presents on every SCIM request. Blank keeps the endpoint off. Use a long random secret. |
+| `SCIM_BASE_PATH` | `/scim`  | Route **prefix** the SCIM API mounts under; the versioned resources sit beneath it. With the default, the IdP base URL is `${APP_URL}/scim/v2` and users live at `/scim/v2/Users`. |
+
+:::caution
+`SCIM_TOKEN` is a full provisioning credential — anyone holding it can create and
+deactivate accounts. Keep it secret, serve SCIM over HTTPS only, and rotate it if
+it leaks.
+:::
+
 ## Attachments
 
 Files and images members attach to messages.

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -70,6 +70,27 @@ is unreachable, no one can sign in. Only turn it on once SSO is verified working
 and keep a way to flip it back (edit `.env` and restart the stack).
 :::
 
+## Directory provisioning (SCIM 2.0)
+
+| Variable     | Default   | Effect                                                        |
+| ------------ | --------- | ------------------------------------------------------------- |
+| `SCIM_TOKEN` | *(blank)* | Mounts a bearer-token SCIM 2.0 endpoint for the IdP to push to. |
+
+Setting `SCIM_TOKEN` turns on the **SCIM 2.0** provisioning endpoint at
+`${APP_URL}/scim/v2`, letting your identity provider (Okta, Entra ID, …) create,
+update, and **deactivate** accounts automatically as directory membership changes.
+A deactivation **tombstones** the account — access is revoked and sessions end,
+but history is retained — and it can be reversed by a later `active: true`. Leave
+`SCIM_TOKEN` blank and the endpoint is not mounted at all.
+
+See [Environment variables → Directory provisioning (SCIM 2.0)](/docs/reference/environment-variables/#directory-provisioning-scim-20)
+for the full setup.
+
+:::caution
+The token is a full provisioning credential — treat it like a password, serve
+SCIM over HTTPS only, and rotate it if it leaks.
+:::
+
 ## Gravatar avatars
 
 User avatars are derived from [Gravatar](https://gravatar.com) using the MD5 hash

--- a/docs/src/content/docs/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/docs/self-hosting/configuration.md
@@ -126,6 +126,45 @@ See [Environment variables → Single sign-on (LDAP)](/docs/reference/environmen
 for every attribute mapping, and [Feature toggles → SSO-only mode](/docs/reference/feature-toggles/#sso-only-mode)
 to require directory login.
 
+## Directory provisioning (SCIM 2.0)
+
+The sign-on options above provision an account the first time someone logs in. To
+also have accounts **deactivated automatically** when someone is removed from the
+directory, enable the **SCIM 2.0** endpoint and let your identity provider push
+lifecycle changes to it. Set a bearer token:
+
+```bash
+SCIM_TOKEN=a-long-random-secret   # blank keeps the endpoint off
+# SCIM_BASE_PATH=/scim            # change the base path if you need to
+```
+
+Then, in your IdP's provisioning settings, point it at:
+
+```
+SCIM base URL:  https://your-desk.example.com/scim/v2
+Auth:           HTTP header — Authorization: Bearer a-long-random-secret
+```
+
+The IdP then keeps accounts in sync automatically:
+
+- **Create** matches an existing account by email or provisions a new one into the
+  default team as a Member — the same rules as OIDC/LDAP.
+- **Deactivate** (`active: false`, or a `DELETE`) **tombstones** the account: its
+  sessions end immediately and it can no longer sign in, but its messages and
+  history are kept rather than hard-deleted.
+- **Reactivate** (`active: true`) restores access.
+
+Members are matched on `userName`, which should be their email.
+
+:::caution
+The token is a full provisioning credential — anyone with it can create and
+deactivate accounts. Keep it secret, only expose SCIM over HTTPS, and rotate it if
+it leaks. Leaving `SCIM_TOKEN` blank means the endpoint does not exist at all.
+:::
+
+See [Environment variables → Directory provisioning (SCIM 2.0)](/docs/reference/environment-variables/#directory-provisioning-scim-20)
+for the full reference.
+
 ## Applying changes
 
 After editing `.env`, restart the stack to pick up the new values:

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -694,6 +694,7 @@
   "You're offline. 1 message is queued and will send automatically.": "Vous êtes hors ligne. 1 message est en file d’attente et sera envoyé automatiquement.",
   "You're offline. :count messages are queued and will send automatically.": "Vous êtes hors ligne. :count messages sont en file d’attente et seront envoyés automatiquement.",
   "You've been invited to join :teamName": "Vous avez été invité à rejoindre :teamName",
+  "Your account has been deactivated. Please contact your administrator.": "Votre compte a été désactivé. Veuillez contacter votre administrateur.",
   "Your data export is ready": "Votre export de données est prêt",
   "Your edit failed to save. Please try again.": "Votre modification n’a pas pu être enregistrée. Veuillez réessayer.",
   "Your email address is unverified.": "Votre adresse e-mail n’est pas vérifiée.",

--- a/tests/Feature/Auth/Sso/EnsureUserIsActiveTest.php
+++ b/tests/Feature/Auth/Sso/EnsureUserIsActiveTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\User;
+
+test('a deactivated user is logged out and bounced to login', function (): void {
+    $user = User::factory()->create(['deactivated_at' => now()]);
+
+    $response = $this->actingAs($user)->get(route('profile.edit'));
+
+    $response->assertRedirect(route('login'));
+    $this->assertGuest();
+});
+
+test('an active user reaches authenticated pages normally', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->get(route('profile.edit'))->assertOk();
+});

--- a/tests/Feature/Auth/Sso/SetSsoUserActivationTest.php
+++ b/tests/Feature/Auth/Sso/SetSsoUserActivationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Actions\Sso\SetSsoUserActivation;
+use App\Models\User;
+use App\Support\SessionRegistry;
+
+function activation(): SetSsoUserActivation
+{
+    return app(SetSsoUserActivation::class);
+}
+
+test('deactivating stamps deactivated_at and revokes every session', function (): void {
+    $user = User::factory()->create();
+    app(SessionRegistry::class)->record($user->id, 'session-a', '203.0.113.1', 'Chrome', now()->timestamp);
+
+    activation()->deactivate($user);
+
+    expect($user->fresh()->isDeactivated())->toBeTrue()
+        ->and(app(SessionRegistry::class)->all($user->id))->toBe([]);
+});
+
+test('deactivating an already-deactivated account keeps the original timestamp', function (): void {
+    $deactivatedAt = now()->subDay();
+    $user = User::factory()->create(['deactivated_at' => $deactivatedAt]);
+
+    activation()->deactivate($user);
+
+    expect($user->fresh()->deactivated_at->timestamp)->toBe($deactivatedAt->timestamp);
+});
+
+test('reactivating clears deactivated_at', function (): void {
+    $user = User::factory()->create(['deactivated_at' => now()]);
+
+    activation()->reactivate($user);
+
+    expect($user->fresh()->isDeactivated())->toBeFalse();
+});
+
+test('reactivating an active account is a no-op', function (): void {
+    $user = User::factory()->create();
+
+    activation()->reactivate($user);
+
+    expect($user->fresh()->isDeactivated())->toBeFalse();
+});

--- a/tests/Feature/Scim/Helpers.php
+++ b/tests/Feature/Scim/Helpers.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The bearer token every SCIM test authenticates with once provisioning is
+ * enabled via enableScim().
+ */
+const SCIM_TEST_TOKEN = 'scim-secret-token';
+
+/**
+ * The core User schema urn every create/replace payload carries.
+ */
+const SCIM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User';
+
+/**
+ * The PatchOp schema urn every PATCH payload carries.
+ */
+const SCIM_PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp';
+
+/**
+ * A SCIM User create/replace body with sensible defaults, merged with overrides.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function scimUserPayload(array $overrides = []): array
+{
+    return array_merge([
+        'schemas' => [SCIM_USER_SCHEMA],
+        'userName' => 'ada@example.com',
+        'name' => ['formatted' => 'Ada Byte'],
+        'active' => true,
+    ], $overrides);
+}
+
+/**
+ * A SCIM PatchOp body wrapping the given operations.
+ *
+ * @param  array<int, array<string, mixed>>  $operations
+ * @return array<string, mixed>
+ */
+function scimPatch(array $operations): array
+{
+    return [
+        'schemas' => [SCIM_PATCH_SCHEMA],
+        'Operations' => $operations,
+    ];
+}

--- a/tests/Feature/Scim/ScimUsersTest.php
+++ b/tests/Feature/Scim/ScimUsersTest.php
@@ -1,0 +1,253 @@
+<?php
+
+use App\Enums\TeamRole;
+use App\Http\Controllers\Scim\ScimUserController;
+use App\Models\Team;
+use App\Models\User;
+use App\Scim\ScimConfig;
+use App\Support\SessionRegistry;
+use ArieTimmerman\Laravel\SCIMServer\Http\Controllers\ResourceController;
+use ArieTimmerman\Laravel\SCIMServer\SCIMConfig as PackageScimConfig;
+
+/**
+ * Reboot the app with SCIM provisioning enabled, so the routes are mounted and
+ * the bearer guard has a token to check against.
+ */
+function enableScim(): void
+{
+    test()->reloadWithEnv(['SCIM_TOKEN' => SCIM_TEST_TOKEN]);
+}
+
+beforeEach(function (): void {
+    enableScim();
+});
+
+// --- Provider wiring & endpoint gating -------------------------------------
+
+test('the SCIM server resolves to this app\'s controller and resource map', function (): void {
+    expect(app(ResourceController::class))->toBeInstanceOf(ScimUserController::class)
+        ->and(app(PackageScimConfig::class))->toBeInstanceOf(ScimConfig::class);
+});
+
+test('only the Users resource is exposed; Groups are out of scope', function (): void {
+    expect(array_keys(app(ScimConfig::class)->getConfig()))->toBe(['Users']);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->postJson('/scim/v2/Groups', ['schemas' => ['urn:ietf:params:scim:schemas:core:2.0:Group']])
+        ->assertNotFound();
+});
+
+test('the SCIM endpoints do not exist when no token is configured', function (): void {
+    test()->reloadWithEnv(['SCIM_TOKEN' => '']);
+
+    $this->postJson('/scim/v2/Users', scimUserPayload())->assertNotFound();
+});
+
+// --- Bearer-token auth ------------------------------------------------------
+
+test('a request without a bearer token is rejected with a SCIM error', function (): void {
+    $response = $this->postJson('/scim/v2/Users', scimUserPayload())
+        ->assertUnauthorized()
+        ->assertJsonPath('schemas.0', 'urn:ietf:params:scim:api:messages:2.0:Error')
+        ->assertJsonPath('status', '401');
+
+    expect($response->headers->get('Content-Type'))->toContain('application/scim+json')
+        ->and($response->headers->get('WWW-Authenticate'))->toBe('Bearer');
+});
+
+test('a request with the wrong bearer token is rejected', function (): void {
+    $this->withToken('nope')
+        ->postJson('/scim/v2/Users', scimUserPayload())
+        ->assertUnauthorized();
+});
+
+test('the discovery endpoints are also guarded by the bearer token', function (): void {
+    $this->getJson('/scim/v2/ServiceProviderConfig')->assertUnauthorized();
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->getJson('/scim/v2/ServiceProviderConfig')
+        ->assertOk();
+});
+
+// --- Create (JIT / matching) -----------------------------------------------
+
+test('a create just-in-time provisions the user into the default team as a member', function (): void {
+    $team = Team::factory()->create();
+
+    $response = $this->withToken(SCIM_TEST_TOKEN)->postJson('/scim/v2/Users', scimUserPayload([
+        'externalId' => 'okta-123',
+    ]));
+
+    $response->assertCreated()
+        ->assertJsonPath('userName', 'ada@example.com')
+        ->assertJsonPath('name.formatted', 'Ada Byte')
+        ->assertJsonPath('active', true);
+
+    $user = User::query()->whereRaw('lower(email) = ?', ['ada@example.com'])->firstOrFail();
+
+    expect($user->teamRole($team))->toBe(TeamRole::Member)
+        ->and($user->hasVerifiedEmail())->toBeTrue();
+
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'scim',
+        'provider_id' => 'okta-123',
+        'user_id' => $user->id,
+    ]);
+});
+
+test('a create for an existing email links that account instead of duplicating it', function (): void {
+    $existing = User::factory()->create(['email' => 'ada@example.com']);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->postJson('/scim/v2/Users', scimUserPayload(['externalId' => 'okta-123']))
+        ->assertCreated();
+
+    expect(User::query()->where('email', 'ada@example.com')->count())->toBe(1);
+
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'scim',
+        'provider_id' => 'okta-123',
+        'user_id' => $existing->id,
+    ]);
+});
+
+test('a create falls back to the first email when no userName is sent', function (): void {
+    $this->withToken(SCIM_TEST_TOKEN)->postJson('/scim/v2/Users', [
+        'schemas' => [SCIM_USER_SCHEMA],
+        'emails' => [['value' => 'grace@example.com', 'primary' => true]],
+        'name' => ['formatted' => 'Grace Hopper'],
+    ])->assertCreated()->assertJsonPath('userName', 'grace@example.com');
+
+    $this->assertDatabaseHas('users', ['email' => 'grace@example.com']);
+});
+
+test('a create without any identifier is rejected', function (): void {
+    $this->withToken(SCIM_TEST_TOKEN)->postJson('/scim/v2/Users', [
+        'schemas' => [SCIM_USER_SCHEMA],
+        'name' => ['formatted' => 'Nobody'],
+    ])->assertStatus(400);
+});
+
+test('a create can provision an already-deactivated user', function (): void {
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->postJson('/scim/v2/Users', scimUserPayload(['active' => false, 'externalId' => 'okta-9']))
+        ->assertCreated()
+        ->assertJsonPath('active', false);
+
+    $user = User::query()->whereRaw('lower(email) = ?', ['ada@example.com'])->firstOrFail();
+
+    expect($user->isDeactivated())->toBeTrue();
+});
+
+// --- Read & list-with-filter ------------------------------------------------
+
+test('a user can be read back by id', function (): void {
+    $user = User::factory()->create(['email' => 'ada@example.com', 'name' => 'Ada Byte']);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->getJson("/scim/v2/Users/{$user->id}")
+        ->assertOk()
+        ->assertJsonPath('id', $user->id)
+        ->assertJsonPath('userName', 'ada@example.com')
+        ->assertJsonPath('active', true);
+});
+
+test('users can be looked up by a userName filter', function (): void {
+    User::factory()->create(['email' => 'ada@example.com']);
+    User::factory()->create(['email' => 'grace@example.com']);
+
+    $response = $this->withToken(SCIM_TEST_TOKEN)
+        ->getJson('/scim/v2/Users?filter='.urlencode('userName eq "ada@example.com"'))
+        ->assertOk()
+        ->assertJsonPath('totalResults', 1);
+
+    expect($response->json('Resources.0.userName'))->toBe('ada@example.com');
+});
+
+test('users can be filtered by active state', function (): void {
+    User::factory()->create(['email' => 'active@example.com']);
+    User::factory()->create(['email' => 'gone@example.com', 'deactivated_at' => now()]);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->getJson('/scim/v2/Users?filter='.urlencode('active eq true'))
+        ->assertOk()
+        ->assertJsonPath('totalResults', 1)
+        ->assertJsonPath('Resources.0.userName', 'active@example.com');
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->getJson('/scim/v2/Users?filter='.urlencode('active eq false'))
+        ->assertOk()
+        ->assertJsonPath('totalResults', 1)
+        ->assertJsonPath('Resources.0.userName', 'gone@example.com');
+});
+
+// --- Attribute update -------------------------------------------------------
+
+test('a patch syncs the display name', function (): void {
+    $user = User::factory()->create(['email' => 'ada@example.com', 'name' => 'Ada Byte']);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->patchJson("/scim/v2/Users/{$user->id}", scimPatch([
+            ['op' => 'replace', 'path' => 'name.formatted', 'value' => 'Ada Lovelace'],
+        ]))
+        ->assertOk()
+        ->assertJsonPath('name.formatted', 'Ada Lovelace');
+
+    expect($user->fresh()->name)->toBe('Ada Lovelace');
+});
+
+test('a put replaces mapped profile fields', function (): void {
+    $user = User::factory()->create(['email' => 'ada@example.com', 'name' => 'Ada Byte']);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->putJson("/scim/v2/Users/{$user->id}", scimUserPayload([
+            'userName' => 'ada@example.com',
+            'name' => ['formatted' => 'Ada Renamed'],
+        ]))
+        ->assertOk()
+        ->assertJsonPath('name.formatted', 'Ada Renamed');
+
+    expect($user->fresh()->name)->toBe('Ada Renamed');
+});
+
+// --- Deactivate / reactivate ------------------------------------------------
+
+test('a delete tombstones the user and revokes their sessions instead of hard-deleting', function (): void {
+    $user = User::factory()->create(['email' => 'ada@example.com']);
+    app(SessionRegistry::class)->record($user->id, 'session-a', '203.0.113.1', 'Chrome', now()->timestamp);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->deleteJson("/scim/v2/Users/{$user->id}")
+        ->assertNoContent();
+
+    expect($user->fresh()->isDeactivated())->toBeTrue()
+        ->and(app(SessionRegistry::class)->all($user->id))->toBe([]);
+});
+
+test('a patch with active false deactivates and revokes sessions', function (): void {
+    $user = User::factory()->create(['email' => 'ada@example.com']);
+    app(SessionRegistry::class)->record($user->id, 'session-a', '203.0.113.1', 'Chrome', now()->timestamp);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->patchJson("/scim/v2/Users/{$user->id}", scimPatch([
+            ['op' => 'replace', 'path' => 'active', 'value' => false],
+        ]))
+        ->assertOk()
+        ->assertJsonPath('active', false);
+
+    expect($user->fresh()->isDeactivated())->toBeTrue()
+        ->and(app(SessionRegistry::class)->all($user->id))->toBe([]);
+});
+
+test('a patch with active true reactivates a deactivated user', function (): void {
+    $user = User::factory()->create(['email' => 'ada@example.com', 'deactivated_at' => now()]);
+
+    $this->withToken(SCIM_TEST_TOKEN)
+        ->patchJson("/scim/v2/Users/{$user->id}", scimPatch([
+            ['op' => 'replace', 'path' => 'active', 'value' => true],
+        ]))
+        ->assertOk()
+        ->assertJsonPath('active', true);
+
+    expect($user->fresh()->isDeactivated())->toBeFalse();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -72,3 +72,4 @@ function something(): void
 
 require_once __DIR__.'/Browser/Helpers.php';
 require_once __DIR__.'/Feature/Auth/Sso/Helpers.php';
+require_once __DIR__.'/Feature/Scim/Helpers.php';

--- a/tests/Unit/SessionRegistryTest.php
+++ b/tests/Unit/SessionRegistryTest.php
@@ -25,3 +25,19 @@ test('forgetting the last session clears the index', function (): void {
 test('forgetting an absent session is a no-op', function (): void {
     expect(registry()->forget('user-1', 'never-seen'))->toBeFalse();
 });
+
+test('flushing revokes every session and clears the index', function (): void {
+    $registry = registry();
+    $registry->record('user-1', 'session-a', '203.0.113.1', 'Chrome', now()->timestamp);
+    $registry->record('user-1', 'session-b', '203.0.113.2', 'Firefox', now()->timestamp);
+
+    expect($registry->flush('user-1'))->toBe(2);
+
+    expect($registry->all('user-1'))->toBe([])
+        ->and($registry->has('user-1', 'session-a'))->toBeFalse()
+        ->and($registry->has('user-1', 'session-b'))->toBeFalse();
+});
+
+test('flushing a user with no sessions removes nothing', function (): void {
+    expect(registry()->flush('user-1'))->toBe(0);
+});


### PR DESCRIPTION
Closes #121. Final sub-issue of the SSO epic #118, stacked on #120 (base = `feat/sso-ldap-directory`).

## What

Adds a **SCIM 2.0** provisioning endpoint so a corporate IdP (Okta, Entra ID, OneLogin, …) can **push** user create / update / **deactivate** events, turning "removed from the directory" into automatic account deactivation. Users-only (Groups are out of scope per the issue).

Built on `arietimmerman/laravel-scim-server` (maintained, Laravel 13 compatible) rather than hand-rolling RFC 7643/7644. Every write is funnelled through the shared `App\Actions\Sso\ProvisionSsoUser` layer, so SCIM matches/JITs identically to OIDC and LDAP.

## Behavior

- **Bearer-token auth** (`SCIM_TOKEN`, env-configured). The routes are mounted *only* when a token is set — a missing secret means the endpoint doesn't exist, not that it's open. Both the `/Users` surface and the discovery endpoints are guarded.
- **Create** → match-by-email or JIT provision into the default team as `Member`, storing the IdP's `externalId` as the stable SCIM identity (`provider = 'scim'`).
- **Update** (PUT/PATCH) → syncs mapped profile fields (`userName` → email, `name.formatted` → display name).
- **Deactivate** (`active: false` / `DELETE`) → **tombstones** the account via a dedicated `users.deactivated_at` column (see below), revokes every session, and blocks re-login — history is retained, not hard-deleted.
- **Reactivate** (`active: true`) → reverses it.
- List with `filter` (`userName eq …`, `active eq …`).

## Two design decisions (confirmed up front)

1. **Dedicated `deactivated_at` column, not `is_tombstone`.** The issue suggested reusing `users.is_tombstone`, but that flag is a *singleton* for the shared "Deleted User" placeholder (`User::tombstone()` does `firstOrCreate(['is_tombstone' => true])`) — overloading it would make that lookup return a real deactivated user. A dedicated nullable timestamp keeps the two concepts separate.
2. **Used the package** (per the issue's explicit directive), after confirming it resolves against Laravel 13 / PHP 8.5 and is actively maintained.

Access revocation is enforced by a new `EnsureUserIsActive` web middleware (logs out + bounces any deactivated user), on top of proactive session flushing.

## Tests & docs

- Feature tests for token auth (accept/reject + SCIM error headers), create → provisioned, existing-email link, deactivate → tombstoned + sessions revoked, reactivate, attribute update, and filter lookup. **100% coverage gate green**; Pint / PHPStan / Rector clean.
- Operator docs updated in all four places: `environment-variables.md`, `feature-toggles.md`, `self-hosting/configuration.md`, and `.env(.prod).example`.
- CodeRabbit CLI review run against the base: **no findings**.
