### PR TITLE
chore: add local LDAP and OIDC dev services to compose stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ APP_FAKER_LOCALE=en_US
 APP_MAINTENANCE_DRIVER=file
 # APP_MAINTENANCE_STORE=database
 
+# Opt-in local dev containers. `sso` starts the mock OIDC provider and OpenLDAP
+# directory (see the SSO sections below) used to exercise the login flows; the
+# default `sail up` leaves them off. Set to a comma-separated list to enable.
+# COMPOSE_PROFILES=sso
+
 PHP_CLI_SERVER_WORKERS=4
 
 BCRYPT_ROUNDS=12
@@ -69,6 +74,16 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # SSO_OIDC_DISCOVERY_URL=
 # Space-separated OIDC scopes (defaults to "openid profile email").
 # SSO_OIDC_SCOPES="openid profile email"
+#
+# Local dev: the compose `sso` profile ships a mock provider (soluto/oidc-server-
+# mock) seeded with users oidc1@the-desk.local … oidc4@the-desk.local (password
+# "password") and a pre-registered client. Bring it up with COMPOSE_PROFILES=sso
+# (or `sail up --profile sso`). It is reached as `oidc:8081` from both the browser
+# and the app container so the issuer stays consistent, so add one line to your
+# host's /etc/hosts once:  127.0.0.1 oidc  — then uncomment:
+# SSO_OIDC_ISSUER=http://oidc:8081
+# SSO_OIDC_CLIENT_ID=the-desk-dev
+# SSO_OIDC_CLIENT_SECRET=the-desk-dev-secret
 # The team new SSO users join as a Member. Leave blank to use the sole team when
 # the instance has exactly one; otherwise the account gets its own workspace.
 # (Applies to both OIDC and LDAP just-in-time provisioning.)
@@ -97,6 +112,17 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # LDAP_ATTR_MAIL=mail
 # LDAP_ATTR_NAME=cn
 # LDAP_ATTR_GUID=objectguid
+#
+# Local dev: the compose `sso` profile ships an OpenLDAP directory (osixia) seeded
+# with users ldap1@the-desk.local … ldap4@the-desk.local (password "password")
+# under dc=the-desk,dc=local. Bring it up with COMPOSE_PROFILES=sso, then use:
+# LDAP_HOST=ldap
+# LDAP_PORT=389
+# LDAP_BASE_DN="dc=the-desk,dc=local"
+# LDAP_USERNAME="cn=admin,dc=the-desk,dc=local"
+# LDAP_PASSWORD=adminpassword
+# OpenLDAP's stable identity is entryUUID, not AD's objectGUID:
+# LDAP_ATTR_GUID=entryuuid
 
 # Set to true to route ALL access through SSO (OIDC or LDAP): Fortify registration
 # and the local-password login are disabled, leaving the directory as the only way

--- a/README.md
+++ b/README.md
@@ -92,6 +92,43 @@ Then, with Sail up (Reverb is part of `sail up -d`) and the frontend built:
 Rebuild the frontend (`npm run build`) after changing any Vue component the
 tests touch, since the in-process server serves the compiled Vite assets.
 
+### Local SSO providers (OIDC & LDAP)
+
+Two opt-in dev containers let you exercise the single sign-on flows against real
+providers locally, without registering an app at an external IdP. They sit
+behind the `sso` compose profile, so a plain `sail up` never starts them. Enable
+them by setting `COMPOSE_PROFILES=sso` in your `.env` (or `sail up --profile
+sso`), then uncomment the matching dev values in `.env.example`:
+
+- **OIDC** — a mock provider ([soluto/oidc-server-mock](https://github.com/Soluto/oidc-server-mock))
+  seeded with `oidc1@the-desk.local` … `oidc4@the-desk.local` (password
+  `password`) and a pre-registered `the-desk-dev` client. It's reached as
+  `oidc:8081` from both the browser and the app container so the derived issuer
+  stays consistent, so add one line to your host's `/etc/hosts` once:
+
+  ```
+  127.0.0.1 oidc
+  ```
+
+  Then set `SSO_OIDC_ISSUER=http://oidc:8081`, `SSO_OIDC_CLIENT_ID=the-desk-dev`,
+  `SSO_OIDC_CLIENT_SECRET=the-desk-dev-secret` and use "Sign in with SSO".
+
+- **LDAP** — an OpenLDAP directory ([osixia/openldap](https://github.com/osixia/docker-openldap))
+  seeded with `ldap1@the-desk.local` … `ldap4@the-desk.local` (password
+  `password`) under `dc=the-desk,dc=local`. Uncomment the dev block in
+  `.env.example`:
+
+  ```
+  LDAP_HOST=ldap
+  LDAP_PORT=389
+  LDAP_BASE_DN="dc=the-desk,dc=local"
+  LDAP_USERNAME="cn=admin,dc=the-desk,dc=local"
+  LDAP_PASSWORD=adminpassword
+  LDAP_ATTR_GUID=entryuuid   # OpenLDAP's stable id, not AD's objectGUID
+  ```
+
+  Then sign in through the normal login form with a seeded email.
+
 ## Self-Hosting with Docker
 
 The production stack is orchestrated with `docker-compose.prod.yml`. The app is

--- a/compose.yaml
+++ b/compose.yaml
@@ -143,6 +143,116 @@ services:
             - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
         networks:
             - sail
+    # Opt-in identity providers for exercising the SSO flows locally (#356/#357).
+    # Guarded by the `sso` compose profile so a default `sail up` never starts
+    # them: enable with COMPOSE_PROFILES=sso in .env, or `sail up --profile sso`.
+    ldap:
+        image: 'osixia/openldap:1.5.0'
+        profiles:
+            - sso
+        command:
+            - '--copy-service'
+        environment:
+            LDAP_ORGANISATION: 'The Desk'
+            LDAP_DOMAIN: 'the-desk.local'
+            LDAP_ADMIN_PASSWORD: '${LDAP_ADMIN_PASSWORD:-adminpassword}'
+        ports:
+            - '${FORWARD_LDAP_PORT:-389}:389'
+        volumes:
+            - 'sail-ldap:/var/lib/ldap'
+            - 'sail-ldap-config:/etc/ldap/slapd.d'
+            - './docker/ldap/bootstrap.ldif:/container/service/slapd/assets/config/bootstrap/ldif/custom/50-the-desk.ldif'
+        networks:
+            - sail
+    # Mock OpenID Connect provider (soluto/oidc-server-mock): config-driven, no
+    # DB, serves a real discovery document. Reached as `oidc:8081` from BOTH the
+    # browser and the app container so the derived issuer stays consistent — add
+    # `127.0.0.1 oidc` to your host's /etc/hosts once (see .env.example). If you
+    # change FORWARD_OIDC_PORT, keep SSO_OIDC_ISSUER and /etc/hosts in step.
+    oidc:
+        image: 'ghcr.io/soluto/oidc-server-mock:0.8.6'
+        # Pinned + amd64: the `latest` tag fails to boot on arm64 (assembly load
+        # error) and floats the underlying IdentityServer build; this tag is a
+        # known-good .NET image that runs under emulation on Apple Silicon.
+        platform: 'linux/amd64'
+        profiles:
+            - sso
+        environment:
+            ASPNETCORE_ENVIRONMENT: 'Development'
+            ASPNETCORE_URLS: 'http://+:8081'
+            SERVER_OPTIONS_INLINE: |
+                {
+                    "AccessTokenJwtType": "JWT",
+                    "Discovery": { "ShowKeySet": true },
+                    "Authentication": {
+                        "CookieSameSiteMode": "Lax",
+                        "CheckSessionCookieSameSiteMode": "Lax"
+                    }
+                }
+            LOGIN_OPTIONS_INLINE: |
+                { "AllowRememberLogin": false }
+            CLIENTS_CONFIGURATION_INLINE: |
+                [
+                    {
+                        "ClientId": "the-desk-dev",
+                        "ClientSecrets": ["the-desk-dev-secret"],
+                        "Description": "The Desk local dev",
+                        "AllowedGrantTypes": ["authorization_code"],
+                        "RequirePkce": false,
+                        "RequireClientSecret": true,
+                        "AllowedScopes": ["openid", "profile", "email"],
+                        "RedirectUris": ["http://localhost/auth/oidc/callback"],
+                        "IdentityTokenLifetime": 3600,
+                        "AccessTokenLifetime": 3600
+                    }
+                ]
+            USERS_CONFIGURATION_INLINE: |
+                [
+                    {
+                        "SubjectId": "oidc1",
+                        "Username": "oidc1@the-desk.local",
+                        "Password": "password",
+                        "Claims": [
+                            { "Type": "name", "Value": "OIDC User One", "ValueType": "string" },
+                            { "Type": "email", "Value": "oidc1@the-desk.local", "ValueType": "string" },
+                            { "Type": "email_verified", "Value": "true", "ValueType": "boolean" }
+                        ]
+                    },
+                    {
+                        "SubjectId": "oidc2",
+                        "Username": "oidc2@the-desk.local",
+                        "Password": "password",
+                        "Claims": [
+                            { "Type": "name", "Value": "OIDC User Two", "ValueType": "string" },
+                            { "Type": "email", "Value": "oidc2@the-desk.local", "ValueType": "string" },
+                            { "Type": "email_verified", "Value": "true", "ValueType": "boolean" }
+                        ]
+                    },
+                    {
+                        "SubjectId": "oidc3",
+                        "Username": "oidc3@the-desk.local",
+                        "Password": "password",
+                        "Claims": [
+                            { "Type": "name", "Value": "OIDC User Three", "ValueType": "string" },
+                            { "Type": "email", "Value": "oidc3@the-desk.local", "ValueType": "string" },
+                            { "Type": "email_verified", "Value": "true", "ValueType": "boolean" }
+                        ]
+                    },
+                    {
+                        "SubjectId": "oidc4",
+                        "Username": "oidc4@the-desk.local",
+                        "Password": "password",
+                        "Claims": [
+                            { "Type": "name", "Value": "OIDC User Four", "ValueType": "string" },
+                            { "Type": "email", "Value": "oidc4@the-desk.local", "ValueType": "string" },
+                            { "Type": "email_verified", "Value": "true", "ValueType": "boolean" }
+                        ]
+                    }
+                ]
+        ports:
+            - '${FORWARD_OIDC_PORT:-8081}:8081'
+        networks:
+            - sail
 networks:
     sail:
         driver: bridge
@@ -152,4 +262,8 @@ volumes:
     sail-redis:
         driver: local
     sail-meilisearch:
+        driver: local
+    sail-ldap:
+        driver: local
+    sail-ldap-config:
         driver: local

--- a/docker/ldap/bootstrap.ldif
+++ b/docker/ldap/bootstrap.ldif
@@ -1,0 +1,45 @@
+# Dev-only directory seed for the local `ldap` service (compose.yaml).
+#
+# osixia/openldap auto-creates the base DN (dc=the-desk,dc=local) and the admin
+# account (cn=admin,dc=the-desk,dc=local) from LDAP_DOMAIN/LDAP_ADMIN_PASSWORD.
+# This file adds an organisational unit and four test users so the LDAP/AD bind
+# + JIT-provisioning flow (#120) can be exercised locally. Each user signs in
+# with their email (the default `username` attribute is `mail`) and the password
+# `password`. Their stable identity is the operational `entryUUID` attribute
+# OpenLDAP assigns automatically, so set LDAP_ATTR_GUID=entryuuid locally.
+
+dn: ou=people,dc=the-desk,dc=local
+objectClass: organizationalUnit
+ou: people
+
+dn: uid=ldap1,ou=people,dc=the-desk,dc=local
+objectClass: inetOrgPerson
+cn: LDAP User One
+sn: One
+uid: ldap1
+mail: ldap1@the-desk.local
+userPassword: password
+
+dn: uid=ldap2,ou=people,dc=the-desk,dc=local
+objectClass: inetOrgPerson
+cn: LDAP User Two
+sn: Two
+uid: ldap2
+mail: ldap2@the-desk.local
+userPassword: password
+
+dn: uid=ldap3,ou=people,dc=the-desk,dc=local
+objectClass: inetOrgPerson
+cn: LDAP User Three
+sn: Three
+uid: ldap3
+mail: ldap3@the-desk.local
+userPassword: password
+
+dn: uid=ldap4,ou=people,dc=the-desk,dc=local
+objectClass: inetOrgPerson
+cn: LDAP User Four
+sn: Four
+uid: ldap4
+mail: ldap4@the-desk.local
+userPassword: password


### PR DESCRIPTION
## Summary

Adds two **opt-in** local dev providers so the SSO login flows can be exercised end-to-end without an external IdP. Both sit behind the `sso` compose profile, so a default `sail up` never starts them (enable with `COMPOSE_PROFILES=sso` or `sail up --profile sso`).

- **`ldap`** — `osixia/openldap`, seeded via a bootstrap LDIF with `ldap1@the-desk.local` … `ldap4@the-desk.local` (password `password`) under `dc=the-desk,dc=local`. Real slapd, so `entryUUID`/base-DN semantics match a production directory.
- **`oidc`** — `soluto/oidc-server-mock` (pinned `0.8.6`, `linux/amd64`), config-driven, seeded with `oidc1…oidc4@the-desk.local` and a pre-registered `the-desk-dev` client whose redirect is `http://localhost/auth/oidc/callback`.

Matching commented values are surfaced in `.env.example`; a "Local SSO providers" note is added to the README's Development section. Dev-tooling only — nothing is added to `docker-compose.prod.yml`.

## Why these images

The issues suggested `bitnami/openldap` and either mock, but **Bitnami's free catalog was frozen to `bitnamilegacy/*` on 2025-08-28** (no updates; current tags now need a paid subscription), so it's a poor default for contributors. `osixia/openldap` is the de-facto real-slapd migration target. For OIDC, `oidc-server-mock` is the lightest config-driven mock that seeds password users + a login UI and serves a real discovery document; `latest` fails to boot on arm64, hence the pinned `0.8.6` + `platform: linux/amd64`.

### OIDC networking
The provider is reached as `oidc:8081` from **both** the browser and the app container so the request-derived issuer stays consistent (verified: discovery `issuer` tracks the request host). This needs one one-time host entry — documented in `.env.example` and the README:

```
127.0.0.1 oidc
```

## Verification

Booted both containers in an isolated compose project and exercised the real paths:
- LDAP: all four users present with `mail` + `entryUUID`; **bind as `ldap1` with the correct password succeeds and fails (Invalid credentials) with a wrong one** — the exact path #120's bind auth uses.
- OIDC: `.well-known/openid-configuration` returns 200 with `openid profile email` scopes and issuer tracking the request host.

Ran CodeRabbit CLI before opening — its one minor finding (incomplete LDAP settings in the README) is addressed.

No application code changed, so the PHP/TS/coverage gates are unaffected.

Closes #356
Closes #357