### PR TITLE
chore: harden OIDC login (optional id_token validation + issuer-namespaced identities)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,10 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # SSO_OIDC_DISCOVERY_URL=
 # Space-separated OIDC scopes (defaults to "openid profile email").
 # SSO_OIDC_SCOPES="openid profile email"
+# When the provider returns an id_token, verify its signature/claims and require
+# its subject to match UserInfo (defence-in-depth, on by default). Set false only
+# for a non-conformant provider whose id_token cannot be validated.
+# SSO_OIDC_VALIDATE_ID_TOKEN=true
 #
 # Local dev: the compose `sso` profile ships a mock provider (soluto/oidc-server-
 # mock) seeded with users oidc1@the-desk.local … oidc4@the-desk.local (password

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -63,6 +63,9 @@ GRAVATAR_ENABLED=true
 # "openid profile email".
 # SSO_OIDC_DISCOVERY_URL=
 # SSO_OIDC_SCOPES="openid profile email"
+# Verify a returned id_token (signature/claims + subject matches UserInfo);
+# on by default. Set false only for a non-conformant provider.
+# SSO_OIDC_VALIDATE_ID_TOKEN=true
 # Team new SSO users join as a Member; blank uses the sole team when there is one.
 # (Applies to both OIDC and LDAP just-in-time provisioning.)
 # SSO_DEFAULT_TEAM_ID=

--- a/app/Exceptions/Sso/InvalidIdTokenException.php
+++ b/app/Exceptions/Sso/InvalidIdTokenException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Sso;
+
+use RuntimeException;
+
+/**
+ * Thrown when an OIDC id_token fails validation — a mismatched issuer or
+ * audience, or a subject that disagrees with the UserInfo response. Signals a
+ * misbehaving or compromised token exchange, so the sign-in is rejected.
+ */
+class InvalidIdTokenException extends RuntimeException
+{
+    //
+}

--- a/app/Http/Controllers/Auth/Sso/OidcController.php
+++ b/app/Http/Controllers/Auth/Sso/OidcController.php
@@ -49,7 +49,7 @@ class OidcController extends Controller
                 return $this->failed();
             }
 
-            $user = $provisionSsoUser->handle('oidc', (string) $subject, $email, $oidcUser->getName());
+            $user = $provisionSsoUser->handle($this->providerKey(), (string) $subject, $email, $oidcUser->getName());
         } catch (Throwable $e) {
             // Report before the friendly redirect so ops can tell a denied grant
             // from an IdP outage or a provisioning bug — otherwise every failure
@@ -63,6 +63,20 @@ class OidcController extends Controller
         $request->session()->regenerate();
 
         return redirect()->intended(config('fortify.home'));
+    }
+
+    /**
+     * The provider key an OIDC identity is stored under, namespaced by issuer.
+     *
+     * An OIDC `sub` is only unique *within* an issuer, so folding the configured
+     * issuer into the key (`oidc:{issuer}`) keeps two issuers that mint the same
+     * `sub` from ever resolving to the same account. The trailing slash is
+     * normalised away so `https://idp` and `https://idp/` are one issuer, not two.
+     * The issuer is always present here: OIDC is only enabled when it is set.
+     */
+    private function providerKey(): string
+    {
+        return 'oidc:'.rtrim((string) config('services.oidc.issuer'), '/');
     }
 
     /**

--- a/app/Http/Controllers/Auth/Sso/OidcController.php
+++ b/app/Http/Controllers/Auth/Sso/OidcController.php
@@ -72,7 +72,11 @@ class OidcController extends Controller
      * issuer into the key (`oidc:{issuer}`) keeps two issuers that mint the same
      * `sub` from ever resolving to the same account. The trailing slash is
      * normalised away so `https://idp` and `https://idp/` are one issuer, not two.
-     * The issuer is always present here: OIDC is only enabled when it is set.
+     *
+     * The issuer is always present here: this action 404s unless
+     * `config('sso.oidc.enabled')`, which config/sso.php only sets true when
+     * `SSO_OIDC_ISSUER` is filled — so the key can never collapse to a bare
+     * `oidc:` that would reintroduce the cross-issuer collision.
      */
     private function providerKey(): string
     {

--- a/app/Models/SsoIdentity.php
+++ b/app/Models/SsoIdentity.php
@@ -12,9 +12,10 @@ use Illuminate\Support\Carbon;
 
 /**
  * A user's stable identity at an external directory (IdP). The `provider`
- * namespaces the identifier ('oidc', later 'ldap'/'scim') and `provider_id`
- * holds the directory's stable subject (OIDC `sub`, LDAP `objectGUID`, …), so a
- * login survives the user's email changing at the IdP.
+ * namespaces the identifier ('ldap', 'scim', or 'oidc:{issuer}' — the OIDC
+ * issuer is folded in because a `sub` is only unique within its issuer) and
+ * `provider_id` holds the directory's stable subject (OIDC `sub`, LDAP
+ * `objectGUID`, …), so a login survives the user's email changing at the IdP.
  *
  * @property string $id
  * @property string $user_id

--- a/app/Services/Sso/GenericOidcProvider.php
+++ b/app/Services/Sso/GenericOidcProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Services\Sso;
 
+use App\Exceptions\Sso\InvalidIdTokenException;
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;
@@ -14,8 +17,15 @@ use Laravel\Socialite\Two\User;
  * discovery document (`.well-known/openid-configuration`), so a single env
  * configuration works against any conformant OIDC provider (Okta, Microsoft
  * Entra ID, Google Workspace, Auth0, Keycloak, …). Socialite performs the OAuth2
- * authorization-code exchange; user claims are read from the userinfo endpoint,
- * so there is no id_token/JWT verification to hand-roll.
+ * authorization-code exchange; user claims are read from the userinfo endpoint.
+ *
+ * As defence-in-depth, when the token response carries an id_token it is
+ * validated (signature via the provider JWKS, issuer, audience, expiry) and its
+ * subject must match the UserInfo subject before the claims are trusted — see
+ * {@see self::validateIdToken()}. This is optional (config `sso.oidc
+ * .validate_id_token`) because a conformant provider need not return an id_token
+ * at all, in which case UserInfo-over-TLS with a confidential client remains the
+ * trust anchor.
  */
 class GenericOidcProvider extends AbstractProvider implements ProviderInterface
 {
@@ -71,9 +81,8 @@ class GenericOidcProvider extends AbstractProvider implements ProviderInterface
      * Claims come from the UserInfo endpoint, called over TLS with the access
      * token obtained via the authorization-code exchange (a confidential client
      * authenticating with its secret, state-protected by Socialite). This is the
-     * same model Socialite's built-in providers use and keeps us free of
-     * hand-rolled id_token/JWT verification, as the issue requires. Strict
-     * id_token signature + subject validation is a possible future hardening.
+     * same model Socialite's built-in providers use; {@see self::userInstance()}
+     * additionally cross-checks a returned id_token against these claims.
      *
      * @return array<string, mixed>
      */
@@ -103,6 +112,79 @@ class GenericOidcProvider extends AbstractProvider implements ProviderInterface
             'email' => $user['email'] ?? null,
             'avatar' => $user['picture'] ?? null,
         ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Validate the id_token (when present) before the mapped user is built, so a
+     * token whose subject, issuer, or audience disagrees with the exchange — or
+     * whose signature does not verify against the provider JWKS — aborts the
+     * sign-in rather than trusting the UserInfo claims.
+     *
+     * @param  array<string, mixed>  $response
+     * @param  array<string, mixed>  $user
+     */
+    #[\Override]
+    protected function userInstance(array $response, array $user): User
+    {
+        $this->validateIdToken($response, $user);
+
+        return parent::userInstance($response, $user);
+    }
+
+    /**
+     * Cross-check a returned id_token against the exchange and UserInfo claims.
+     *
+     * Skipped entirely when disabled by config or when the provider returns no
+     * id_token (UserInfo-over-TLS then remains the trust anchor). Otherwise the
+     * token's signature is verified against the provider JWKS and its standard
+     * claims (issuer, audience, expiry) are checked, and its `sub` must equal the
+     * UserInfo subject — defeating a misbehaving or compromised UserInfo response
+     * that returns a different account than the one the IdP actually signed for.
+     *
+     * @param  array<string, mixed>  $response
+     * @param  array<string, mixed>  $user
+     */
+    protected function validateIdToken(array $response, array $user): void
+    {
+        if (! config('sso.oidc.validate_id_token', true)) {
+            return;
+        }
+
+        $idToken = $response['id_token'] ?? null;
+
+        if (! is_string($idToken) || $idToken === '') {
+            return;
+        }
+
+        // Verifies the signature against the JWKS and rejects an expired token.
+        $claims = JWT::decode($idToken, JWK::parseKeySet($this->jwks(), 'RS256'));
+
+        $expectedIssuer = $this->discovery()['issuer'] ?? null;
+
+        throw_if(filled($expectedIssuer) && ($claims->iss ?? null) !== $expectedIssuer, InvalidIdTokenException::class, 'The id_token issuer does not match the provider.');
+
+        throw_unless(in_array($this->clientId, (array) ($claims->aud ?? []), true), InvalidIdTokenException::class, 'The id_token audience does not include this client.');
+
+        throw_if(($claims->sub ?? null) !== ($user['sub'] ?? null), InvalidIdTokenException::class, 'The id_token subject does not match the UserInfo subject.');
+    }
+
+    /**
+     * Fetch and cache the provider's JSON Web Key Set for id_token verification.
+     *
+     * Cached for an hour alongside the discovery document; providers publish
+     * signing keys under a stable `jwks_uri` and rotate them infrequently.
+     *
+     * @return array<string, mixed>
+     */
+    protected function jwks(): array
+    {
+        return Cache::remember(
+            'sso.oidc.jwks:'.$this->discoveryUrl,
+            now()->addHour(),
+            fn (): array => json_decode((string) $this->getHttpClient()->get($this->discovery()['jwks_uri'])->getBody(), true),
+        );
     }
 
     /**

--- a/app/Services/Sso/GenericOidcProvider.php
+++ b/app/Services/Sso/GenericOidcProvider.php
@@ -161,9 +161,12 @@ class GenericOidcProvider extends AbstractProvider implements ProviderInterface
         // Verifies the signature against the JWKS and rejects an expired token.
         $claims = JWT::decode($idToken, JWK::parseKeySet($this->jwks(), 'RS256'));
 
+        // Fail closed: OIDC discovery is required to publish `issuer`, so an
+        // absent expected issuer means a malformed/compromised document and the
+        // token's issuer cannot be trusted — reject rather than skip the check.
         $expectedIssuer = $this->discovery()['issuer'] ?? null;
 
-        throw_if(filled($expectedIssuer) && ($claims->iss ?? null) !== $expectedIssuer, InvalidIdTokenException::class, 'The id_token issuer does not match the provider.');
+        throw_unless(filled($expectedIssuer) && ($claims->iss ?? null) === $expectedIssuer, InvalidIdTokenException::class, 'The id_token issuer does not match the provider.');
 
         throw_unless(in_array($this->clientId, (array) ($claims->aud ?? []), true), InvalidIdTokenException::class, 'The id_token audience does not include this client.');
 

--- a/config/sso.php
+++ b/config/sso.php
@@ -63,10 +63,18 @@ return [
     | on the login page (shown only when a provider is configured). The provider
     | credentials themselves live in the `oidc` block of config/services.php.
     |
+    | `validate_id_token` adds defence-in-depth: when the token response carries
+    | an id_token, its signature (via the provider JWKS), issuer, audience, and
+    | expiry are verified and its subject must match the UserInfo subject before
+    | the claims are trusted. On by default; disable only if a non-conformant
+    | provider returns an id_token that cannot be validated (UserInfo-over-TLS
+    | with a confidential client then remains the trust anchor).
+    |
     */
 
     'oidc' => [
         'enabled' => $oidcConfigured,
+        'validate_id_token' => (bool) env('SSO_OIDC_VALIDATE_ID_TOKEN', true),
     ],
 
     /*

--- a/database/migrations/2026_07_14_170929_namespace_oidc_identities_by_issuer.php
+++ b/database/migrations/2026_07_14_170929_namespace_oidc_identities_by_issuer.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Re-key existing OIDC identities under the issuer-namespaced provider.
+     *
+     * OIDC login originally stored identities under a bare `provider = 'oidc'`.
+     * A `sub` is only unique within its issuer, so the key is now `oidc:{issuer}`
+     * (see App\Http\Controllers\Auth\Sso\OidcController::providerKey()). Any rows
+     * written before this change would otherwise stop matching on the next login
+     * and re-provision the account, so they are migrated in place to the current
+     * issuer's namespaced key. The instance-wide, single-issuer model means every
+     * bare `oidc` row belongs to the one configured issuer.
+     *
+     * A no-op when OIDC is unconfigured (no issuer to namespace under, and no such
+     * rows can exist) or when there are none to migrate — e.g. a fresh install.
+     */
+    public function up(): void
+    {
+        $namespaced = $this->namespacedProvider();
+
+        if ($namespaced === null) {
+            return;
+        }
+
+        DB::table('sso_identities')
+            ->where('provider', 'oidc')
+            ->update(['provider' => $namespaced]);
+    }
+
+    /**
+     * Restore the bare `oidc` provider key for this issuer's identities.
+     */
+    public function down(): void
+    {
+        $namespaced = $this->namespacedProvider();
+
+        if ($namespaced === null) {
+            return;
+        }
+
+        DB::table('sso_identities')
+            ->where('provider', $namespaced)
+            ->update(['provider' => 'oidc']);
+    }
+
+    /**
+     * The issuer-namespaced provider key for the configured OIDC issuer, or null
+     * when no issuer is configured. Matches OidcController::providerKey().
+     */
+    private function namespacedProvider(): ?string
+    {
+        $issuer = rtrim((string) config('services.oidc.issuer'), '/');
+
+        if ($issuer === '') {
+            return null;
+        }
+
+        return 'oidc:'.$issuer;
+    }
+};

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -113,6 +113,7 @@ email, otherwise created — into the default team as a **Member**. Leave
 | `SSO_OIDC_REDIRECT_URI`  | `${APP_URL}/auth/oidc/callback`  | Callback URI; must match what you register at the IdP.                     |
 | `SSO_OIDC_DISCOVERY_URL` | *(derived from issuer)*          | Override only if discovery is not at the standard well-known path.         |
 | `SSO_OIDC_SCOPES`        | `openid profile email`           | Space-separated OIDC scopes to request.                                   |
+| `SSO_OIDC_VALIDATE_ID_TOKEN` | `true`                       | When the provider returns an `id_token`, verify its signature (via the provider JWKS), issuer, audience, and expiry, and require its subject to match the UserInfo subject. Defence-in-depth; set `false` only for a non-conformant provider whose `id_token` cannot be validated. |
 | `SSO_DEFAULT_TEAM_ID`    | *(sole team)*                    | Team new SSO users join as a Member. Blank uses the sole team when there is exactly one; otherwise the account gets its own workspace. Shared with LDAP. |
 | `AUTH_SSO_ONLY`          | `false`                          | Route **all** access through SSO (OIDC or LDAP). See [SSO-only mode](/docs/reference/feature-toggles/#sso-only-mode). |
 

--- a/tests/Feature/Auth/Sso/GenericOidcProviderTest.php
+++ b/tests/Feature/Auth/Sso/GenericOidcProviderTest.php
@@ -1,10 +1,37 @@
 <?php
 
+use App\Exceptions\Sso\InvalidIdTokenException;
 use App\Services\Sso\GenericOidcProvider;
+use Firebase\JWT\SignatureInvalidException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Cache;
+
+/**
+ * The token response an IdP returns, carrying the given id_token alongside the
+ * access token used to call UserInfo.
+ */
+function oidcTokenResponse(string $idToken): Response
+{
+    return new Response(200, [], (string) json_encode([
+        'access_token' => 'access-123',
+        'id_token' => $idToken,
+        'expires_in' => 3600,
+    ]));
+}
+
+/**
+ * The UserInfo response for the fixed test subject.
+ */
+function oidcUserInfoResponse(string $sub = 'subject-999'): Response
+{
+    return new Response(200, [], (string) json_encode([
+        'sub' => $sub,
+        'name' => 'Dana Fox',
+        'email' => 'dana@example.com',
+    ]));
+}
 
 /**
  * Build the provider wired to a Guzzle mock handler so the OIDC discovery,
@@ -57,4 +84,118 @@ test('the callback resolves the user from the token and userinfo endpoints', fun
         ->and($user->getEmail())->toBe('dana@example.com')
         ->and($user->getAvatar())->toBe('https://idp.test/dana.png')
         ->and($user->token)->toBe('access-123');
+});
+
+test('a valid id_token whose subject matches userinfo is accepted', function (): void {
+    [$privatePem, $jwks, $kid] = oidcSigningKey();
+    $idToken = oidcIdToken(['sub' => 'subject-999'], $privatePem, $kid);
+
+    $provider = oidcProvider(new MockHandler([
+        oidcDiscoveryResponse(),
+        oidcTokenResponse($idToken),
+        oidcUserInfoResponse('subject-999'),
+        new Response(200, [], (string) json_encode($jwks)),
+    ]));
+
+    request()->merge(['code' => 'auth-code']);
+
+    expect($provider->stateless()->user()->getId())->toBe('subject-999');
+});
+
+test('an id_token whose subject disagrees with userinfo is rejected', function (): void {
+    [$privatePem, $jwks, $kid] = oidcSigningKey();
+    // A well-formed, correctly signed token — but minted for a different subject
+    // than the one UserInfo reports: the exact compromise this guards against.
+    $idToken = oidcIdToken(['sub' => 'attacker-subject'], $privatePem, $kid);
+
+    $provider = oidcProvider(new MockHandler([
+        oidcDiscoveryResponse(),
+        oidcTokenResponse($idToken),
+        oidcUserInfoResponse('subject-999'),
+        new Response(200, [], (string) json_encode($jwks)),
+    ]));
+
+    request()->merge(['code' => 'auth-code']);
+
+    $provider->stateless()->user();
+})->throws(InvalidIdTokenException::class);
+
+test('an id_token from a foreign issuer is rejected', function (): void {
+    [$privatePem, $jwks, $kid] = oidcSigningKey();
+    $idToken = oidcIdToken(['iss' => 'https://evil.test'], $privatePem, $kid);
+
+    $provider = oidcProvider(new MockHandler([
+        oidcDiscoveryResponse(),
+        oidcTokenResponse($idToken),
+        oidcUserInfoResponse(),
+        new Response(200, [], (string) json_encode($jwks)),
+    ]));
+
+    request()->merge(['code' => 'auth-code']);
+
+    $provider->stateless()->user();
+})->throws(InvalidIdTokenException::class);
+
+test('an id_token minted for another audience is rejected', function (): void {
+    [$privatePem, $jwks, $kid] = oidcSigningKey();
+    $idToken = oidcIdToken(['aud' => 'some-other-client'], $privatePem, $kid);
+
+    $provider = oidcProvider(new MockHandler([
+        oidcDiscoveryResponse(),
+        oidcTokenResponse($idToken),
+        oidcUserInfoResponse(),
+        new Response(200, [], (string) json_encode($jwks)),
+    ]));
+
+    request()->merge(['code' => 'auth-code']);
+
+    $provider->stateless()->user();
+})->throws(InvalidIdTokenException::class);
+
+test('an id_token not signed by the provider key is rejected', function (): void {
+    [, $jwks, $kid] = oidcSigningKey();
+    [$attackerPem] = oidcSigningKey();
+    // Signed with a key the provider's JWKS does not vouch for.
+    $idToken = oidcIdToken([], $attackerPem, $kid);
+
+    $provider = oidcProvider(new MockHandler([
+        oidcDiscoveryResponse(),
+        oidcTokenResponse($idToken),
+        oidcUserInfoResponse(),
+        new Response(200, [], (string) json_encode($jwks)),
+    ]));
+
+    request()->merge(['code' => 'auth-code']);
+
+    $provider->stateless()->user();
+})->throws(SignatureInvalidException::class);
+
+test('id_token validation is skipped when the token response omits it', function (): void {
+    $provider = oidcProvider(new MockHandler([
+        oidcDiscoveryResponse(),
+        new Response(200, [], (string) json_encode(['access_token' => 'access-123', 'expires_in' => 3600])),
+        oidcUserInfoResponse('subject-999'),
+    ]));
+
+    request()->merge(['code' => 'auth-code']);
+
+    expect($provider->stateless()->user()->getId())->toBe('subject-999');
+});
+
+test('id_token validation can be turned off, trusting userinfo alone', function (): void {
+    config(['sso.oidc.validate_id_token' => false]);
+
+    [$privatePem] = oidcSigningKey();
+    // A token that would fail validation is ignored entirely when disabled.
+    $idToken = oidcIdToken(['sub' => 'attacker-subject'], $privatePem);
+
+    $provider = oidcProvider(new MockHandler([
+        oidcDiscoveryResponse(),
+        oidcTokenResponse($idToken),
+        oidcUserInfoResponse('subject-999'),
+    ]));
+
+    request()->merge(['code' => 'auth-code']);
+
+    expect($provider->stateless()->user()->getId())->toBe('subject-999');
 });

--- a/tests/Feature/Auth/Sso/GenericOidcProviderTest.php
+++ b/tests/Feature/Auth/Sso/GenericOidcProviderTest.php
@@ -136,6 +136,31 @@ test('an id_token from a foreign issuer is rejected', function (): void {
     $provider->stateless()->user();
 })->throws(InvalidIdTokenException::class);
 
+test('an id_token is rejected when discovery publishes no issuer to verify against', function (): void {
+    [$privatePem, $jwks, $kid] = oidcSigningKey();
+    $idToken = oidcIdToken([], $privatePem, $kid);
+
+    // A discovery document missing the required `issuer` field: the id_token's
+    // issuer cannot be verified, so validation must fail closed rather than skip.
+    $discoveryWithoutIssuer = new Response(200, [], (string) json_encode([
+        'authorization_endpoint' => 'https://idp.test/authorize',
+        'token_endpoint' => 'https://idp.test/token',
+        'userinfo_endpoint' => 'https://idp.test/userinfo',
+        'jwks_uri' => 'https://idp.test/jwks',
+    ]));
+
+    $provider = oidcProvider(new MockHandler([
+        $discoveryWithoutIssuer,
+        oidcTokenResponse($idToken),
+        oidcUserInfoResponse(),
+        new Response(200, [], (string) json_encode($jwks)),
+    ]));
+
+    request()->merge(['code' => 'auth-code']);
+
+    $provider->stateless()->user();
+})->throws(InvalidIdTokenException::class);
+
 test('an id_token minted for another audience is rejected', function (): void {
     [$privatePem, $jwks, $kid] = oidcSigningKey();
     $idToken = oidcIdToken(['aud' => 'some-other-client'], $privatePem, $kid);

--- a/tests/Feature/Auth/Sso/Helpers.php
+++ b/tests/Feature/Auth/Sso/Helpers.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Ldap\DirectoryUser;
+use Firebase\JWT\JWT;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
@@ -16,10 +17,54 @@ use LdapRecord\Testing\ConnectionFake;
 function oidcDiscoveryResponse(): Response
 {
     return new Response(200, [], (string) json_encode([
+        'issuer' => 'https://idp.test',
         'authorization_endpoint' => 'https://idp.test/authorize',
         'token_endpoint' => 'https://idp.test/token',
         'userinfo_endpoint' => 'https://idp.test/userinfo',
+        'jwks_uri' => 'https://idp.test/jwks',
     ]));
+}
+
+/**
+ * A fresh RSA keypair plus the public JWK modulus/exponent, for minting and
+ * verifying id_tokens offline. Returns [privatePem, jwks, kid].
+ *
+ * @return array{0: string, 1: array<string, mixed>, 2: string}
+ */
+function oidcSigningKey(string $kid = 'test-key'): array
+{
+    $resource = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    openssl_pkey_export($resource, $privatePem);
+    $details = openssl_pkey_get_details($resource);
+
+    $base64Url = fn (string $bytes): string => rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
+
+    $jwks = ['keys' => [[
+        'kty' => 'RSA',
+        'alg' => 'RS256',
+        'use' => 'sig',
+        'kid' => $kid,
+        'n' => $base64Url($details['rsa']['n']),
+        'e' => $base64Url($details['rsa']['e']),
+    ]]];
+
+    return [$privatePem, $jwks, $kid];
+}
+
+/**
+ * Sign an OIDC id_token with the given RSA private key.
+ *
+ * @param  array<string, mixed>  $claims
+ */
+function oidcIdToken(array $claims, string $privatePem, string $kid = 'test-key'): string
+{
+    return JWT::encode(array_merge([
+        'iss' => 'https://idp.test',
+        'aud' => 'client-id',
+        'sub' => 'subject-999',
+        'iat' => time(),
+        'exp' => time() + 3600,
+    ], $claims), $privatePem, 'RS256', $kid);
 }
 
 /**

--- a/tests/Feature/Auth/Sso/OidcIssuerNamespaceMigrationTest.php
+++ b/tests/Feature/Auth/Sso/OidcIssuerNamespaceMigrationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\SsoIdentity;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Load the issuer-namespacing data migration as an instance so its up()/down()
+ * can be exercised directly against seeded rows (RefreshDatabase has already run
+ * it once, on an empty table, during setup).
+ */
+function issuerNamespaceMigration(): object
+{
+    return require base_path('database/migrations/2026_07_14_170929_namespace_oidc_identities_by_issuer.php');
+}
+
+test('the migration re-keys legacy bare-oidc identities under the configured issuer', function (): void {
+    config(['services.oidc.issuer' => 'https://idp.test/']);
+    $user = User::factory()->create();
+    DB::table('sso_identities')->insert([
+        'id' => (string) Str::uuid(),
+        'user_id' => $user->id,
+        'provider' => 'oidc',
+        'provider_id' => 'sub-legacy',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    issuerNamespaceMigration()->up();
+
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'oidc:https://idp.test',
+        'provider_id' => 'sub-legacy',
+        'user_id' => $user->id,
+    ]);
+    $this->assertDatabaseMissing('sso_identities', ['provider' => 'oidc']);
+});
+
+test('the migration down() restores the bare-oidc provider key', function (): void {
+    config(['services.oidc.issuer' => 'https://idp.test']);
+    $user = User::factory()->create();
+    SsoIdentity::factory()->for($user)->create([
+        'provider' => 'oidc:https://idp.test',
+        'provider_id' => 'sub-legacy',
+    ]);
+
+    issuerNamespaceMigration()->down();
+
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'oidc',
+        'provider_id' => 'sub-legacy',
+    ]);
+});
+
+test('the migration is a no-op when no OIDC issuer is configured', function (): void {
+    config(['services.oidc.issuer' => null]);
+    $user = User::factory()->create();
+    SsoIdentity::factory()->for($user)->create(['provider' => 'oidc', 'provider_id' => 'sub-legacy']);
+
+    issuerNamespaceMigration()->up();
+
+    $this->assertDatabaseHas('sso_identities', ['provider' => 'oidc', 'provider_id' => 'sub-legacy']);
+});

--- a/tests/Feature/Auth/Sso/OidcLoginTest.php
+++ b/tests/Feature/Auth/Sso/OidcLoginTest.php
@@ -42,7 +42,7 @@ test('the callback route is hidden when oidc is not configured', function (): vo
 });
 
 test('a first-time callback just-in-time provisions and logs in the user', function (): void {
-    config(['sso.oidc.enabled' => true]);
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp.test']);
     $team = Team::factory()->create();
     Socialite::fake('oidc', fakeOidcUser());
 
@@ -56,14 +56,14 @@ test('a first-time callback just-in-time provisions and logs in the user', funct
         ->and($user->teamRole($team))->toBe(TeamRole::Member);
 
     $this->assertDatabaseHas('sso_identities', [
-        'provider' => 'oidc',
+        'provider' => 'oidc:https://idp.test',
         'provider_id' => 'sub-1',
         'user_id' => $user->id,
     ]);
 });
 
 test('a callback for an existing email links that account rather than duplicating it', function (): void {
-    config(['sso.oidc.enabled' => true]);
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp.test']);
     $existing = User::factory()->create(['email' => 'ada@example.com']);
     Socialite::fake('oidc', fakeOidcUser());
 
@@ -73,9 +73,37 @@ test('a callback for an existing email links that account rather than duplicatin
         ->and(User::query()->where('email', 'ada@example.com')->count())->toBe(1);
 
     $this->assertDatabaseHas('sso_identities', [
-        'provider' => 'oidc',
+        'provider' => 'oidc:https://idp.test',
         'provider_id' => 'sub-1',
         'user_id' => $existing->id,
+    ]);
+});
+
+test('identities are namespaced by issuer so the same subject at two issuers never collides', function (): void {
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp-a.test']);
+    Socialite::fake('oidc', fakeOidcUser(email: 'alice@example.com', id: 'shared-sub'));
+    $this->get(route('sso.oidc.callback'));
+    $alice = auth()->user();
+
+    // The trailing slash is normalised away, so it can never mint a second
+    // identity for what is really the same configured issuer.
+    config(['services.oidc.issuer' => 'https://idp-b.test/']);
+    Socialite::fake('oidc', fakeOidcUser(email: 'bob@example.com', id: 'shared-sub'));
+    $this->get(route('sso.oidc.callback'));
+    $bob = auth()->user();
+
+    expect($bob->id)->not->toBe($alice->id)
+        ->and(User::query()->count())->toBe(2);
+
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'oidc:https://idp-a.test',
+        'provider_id' => 'shared-sub',
+        'user_id' => $alice->id,
+    ]);
+    $this->assertDatabaseHas('sso_identities', [
+        'provider' => 'oidc:https://idp-b.test',
+        'provider_id' => 'shared-sub',
+        'user_id' => $bob->id,
     ]);
 });
 


### PR DESCRIPTION
## Summary

Two defence-in-depth hardening improvements to the OIDC login foundation (#119), deferred there as out of scope. Both are hardening for the single-issuer, instance-wide model #119 targets, not correctness bugs.

### 1. Optional `id_token` validation
When the token response carries an `id_token`, `GenericOidcProvider` now:
- verifies its **signature** against the provider JWKS (`firebase/php-jwt`, already vendored via `laravel/socialite`),
- checks **issuer / audience / expiry** (failing **closed** if discovery publishes no `issuer` to verify against), and
- requires its **`sub` to match the UserInfo subject** — rejecting a misbehaving or compromised UserInfo response that returns a different account than the IdP actually signed for.

Skipped when no `id_token` is returned (UserInfo-over-TLS with a confidential client remains the trust anchor). Toggle via `SSO_OIDC_VALIDATE_ID_TOKEN` (on by default). Failures redirect gracefully back to login, as before.

### 2. Issuer-namespaced identities
An OIDC `sub` is only unique **within an issuer**, so identities are now keyed as `oidc:{issuer}` (trailing slash normalised). Switching the configured issuer — or any future multi-issuer support — can no longer link the wrong account when two issuers mint colliding `sub` values. A data migration re-keys any pre-existing bare `oidc` rows under the configured issuer so logins keep resolving to existing accounts.

## Tests
- `id_token` validation: accept (matching `sub`), reject on `sub` / issuer / audience mismatch, reject on bad signature, reject when discovery omits `issuer`, skip when absent, and honour the disable toggle.
- Issuer namespacing: same `sub` at two different issuers stays separate; trailing-slash normalisation.
- Migration: re-keys legacy rows, `down()` restores, no-op when unconfigured.
- Full gate green: Pint, PHPStan, Rector, `--min=100` coverage. Docs build green. Reviewed with the CodeRabbit CLI.

## Operator-facing
- New `SSO_OIDC_VALIDATE_ID_TOKEN` env var documented in `environment-variables.md` and both `.env` examples.

Closes #358.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional OpenID Connect `id_token` validation, enabled by default.
  - Verifies token signatures, issuer, audience, expiry, and subject consistency with UserInfo.
  - Namespaces OIDC identities by issuer to prevent account collisions across providers.

- **Bug Fixes**
  - Improved rejection of invalid or non-conformant identity tokens.

- **Documentation**
  - Documented the new `SSO_OIDC_VALIDATE_ID_TOKEN` setting and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->