### PR TITLE
docs: banner marking docs as in-development vs latest release

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,7 +1,31 @@
-import { defineCollection } from 'astro:content';
+import { readFileSync } from 'node:fs';
+import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
+const repo = 'https://github.com/emmpaul/the-desk';
+
+// The site deploys from `master` (Cloudflare Pages) on every push, so it always
+// describes trunk — but the released Docker image self-hosters run only ships
+// when release-please cuts a `v*` tag. That leaves a window where the docs
+// describe a feature no released image contains yet. `.release-please-manifest.json`
+// is release-please's canonical record of the latest *released* version, so we
+// read it at build time and default every page's banner to name it: operators
+// can tell the docs track the in-development version and cross-check the
+// changelog for what has actually shipped. It updates itself on every release —
+// no manual upkeep. A page may still override `banner` in its own frontmatter.
+const releasedVersion = JSON.parse(
+	readFileSync(new URL('../../.release-please-manifest.json', import.meta.url), 'utf8'),
+)['.'];
+const releaseBannerContent = `📖 These docs track the <strong>in-development</strong> version. The latest released version is <a href="${repo}/releases/tag/v${releasedVersion}"><strong>v${releasedVersion}</strong></a>. Newly documented features may not be in the image you run yet; see the <a href="${repo}/blob/master/CHANGELOG.md">changelog</a> for what has shipped.`;
+
 export const collections = {
-	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+	docs: defineCollection({
+		loader: docsLoader(),
+		schema: docsSchema({
+			extend: z.object({
+				banner: z.object({ content: z.string() }).default({ content: releaseBannerContent }),
+			}),
+		}),
+	}),
 };

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -6,6 +6,21 @@ description: Tag-based upgrades with automatic migrations and version-scoped sea
 Upgrades follow the same tag-based flow you used to install, whether you build
 from source or run the published image.
 
+## These docs track the in-development version
+
+This site is published from `master` on every change, so it always describes the
+latest development version of The Desk. The Docker image you run, however, only
+changes when a release is tagged: the versioned and `latest` images are published
+by the release automation on each `v*` tag, while `master` only moves the rolling
+`edge` tag.
+
+That means a feature can be documented here before it appears in any released
+image. The site-wide banner names the **latest released version**; anything
+documented but not yet in that release is coming in a future one. Check the
+[CHANGELOG](https://github.com/emmpaul/the-desk/blob/master/CHANGELOG.md) to
+confirm which release a given feature shipped in, and pin your `APP_IMAGE` (or
+checkout tag) to a released version rather than `edge` for a stable deployment.
+
 ## Back up first
 
 :::caution


### PR DESCRIPTION
Closes #362.

## Problem

The docs site (`docs/`, Cloudflare Pages) deploys from `master` on every push, but the released Docker image self-hosters run only ships when release-please cuts a `v*` tag (`master` pushes just move the rolling `edge` tag). So when a `feat` lands and its docs update ships in the same PR, the docs describe a feature no released image contains yet, silently misleading operators until the next release.

## Change

Global version banner (the direction chosen for this issue):

- `docs/src/content.config.ts` — read the latest released version from `.release-please-manifest.json` (release-please's canonical record) at build time and default every Starlight page's `banner` to name it, linking the release tag and CHANGELOG. Auto-updates on every release, no per-feature upkeep. (Banner is a schema default in Starlight 0.41.3, not a global config key.)
- `docs/src/content/docs/docs/self-hosting/upgrading.md` — new "These docs track the in-development version" section documenting how docs deploy relative to releases.

## Acceptance criteria

- A self-hoster can tell whether a documented feature is in the latest released image (banner names the released version + links the changelog).
- Docs/image drift is surfaced rather than silent.
- The approach is documented on the Upgrading page.

## Testing

- `cd docs && npm run build` passes; banner renders on all 14 docs pages with `v1.3.0`; the marketing splash `/` correctly has no banner.
- Local CodeRabbit review (`coderabbit review --agent --base master`): 0 findings.

Docs-only change, excluded from the app quality gates per `CLAUDE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documentation banner showing the in-development version, latest release, and changelog link.
* **Documentation**
  * Clarified that documentation may describe upcoming features before release.
  * Added guidance for stable deployments, including pinning application images or using a release tag instead of `edge`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->