### PR TITLE
fix: render the login page immediately after logout

### DIFF
--- a/app/Http/Responses/LogoutResponse.php
+++ b/app/Http/Responses/LogoutResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
+use Symfony\Component\HttpFoundation\Response;
+
+class LogoutResponse implements LogoutResponseContract
+{
+    /**
+     * Send the client to the login page with a full-page navigation rather than
+     * an Inertia SPA swap.
+     *
+     * Logging out nulls the shared `auth.user` prop, and the authenticated
+     * components still mounted during a client-side swap re-evaluate their
+     * `auth.user`-derived computeds against null and throw, aborting the swap:
+     * the URL changes to the redirect target but the stale authenticated view
+     * stays put until a manual refresh. `Inertia::location()` answers an Inertia
+     * request with a 409 carrying an `X-Inertia-Location` header, so the client
+     * tears the whole app down and renders the login page from a clean slate.
+     *
+     * @param  Request  $request
+     */
+    public function toResponse($request): Response
+    {
+        if ($request->wantsJson()) {
+            return new JsonResponse('', 204);
+        }
+
+        return Inertia::location(route('login'));
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Http\Responses\LoginResponse;
+use App\Http\Responses\LogoutResponse;
 use App\Http\Responses\RegisterResponse;
 use App\Http\Responses\VerifyEmailResponse;
 use App\Models\TeamInvitation;
@@ -18,6 +19,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
 use Laravel\Fortify\Features;
@@ -32,6 +34,7 @@ class FortifyServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(LoginResponseContract::class, LoginResponse::class);
+        $this->app->singleton(LogoutResponseContract::class, LogoutResponse::class);
         $this->app->singleton(RegisterResponseContract::class, RegisterResponse::class);
         $this->app->singleton(VerifyEmailResponseContract::class, VerifyEmailResponse::class);
     }

--- a/tests/Browser/LogoutTest.php
+++ b/tests/Browser/LogoutTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+test('logging out renders the login page immediately without a manual refresh', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice);
+    $page->assertPresent('@message-composer-input');
+
+    // Open the user menu and log out. Logout answers with a full-page navigation
+    // (Inertia::location) to the login screen, so the authenticated shell tears
+    // down and the login form renders in the same flow — no manual refresh, and
+    // the URL and rendered page stay in sync.
+    $page
+        ->click('@sidebar-menu-button')
+        ->click('@logout-button')
+        ->assertPathIs('/login')
+        ->assertPresent('@login-button')
+        ->assertMissing('@message-composer-input');
+});

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -86,7 +86,31 @@ test('users can logout', function (): void {
     $response = $this->actingAs($user)->post(route('logout'));
 
     $this->assertGuest();
-    $response->assertRedirect(route('home'));
+    $response->assertRedirect(route('login'));
+});
+
+test('logout answers an Inertia request with a full-page redirect to login', function (): void {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)
+        ->withHeader('X-Inertia', 'true')
+        ->post(route('logout'));
+
+    $this->assertGuest();
+    // Inertia turns a location redirect into a 409 the client follows as a hard
+    // visit, so the whole app reloads onto the login page from a clean slate.
+    $response->assertStatus(409);
+    $response->assertHeader('X-Inertia-Location', route('login'));
+});
+
+test('logout returns no content for a JSON client', function (): void {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)
+        ->postJson(route('logout'));
+
+    $this->assertGuest();
+    $response->assertNoContent();
 });
 
 test('users are rate limited', function (): void {


### PR DESCRIPTION
## Summary

Clicking **Log out** changed the browser URL but left the previous authenticated screen rendered until a manual refresh.

### Root cause

Logout answered the Inertia SPA visit with a client-side redirect. That redirect nulls the shared `auth.user` prop while the authenticated shell is still mounted, so the many `auth.user`-derived computeds in `MainLayout` and its composables (first to throw: `useNewDirectMessages`, `page.props.auth.user.id`) re-evaluate against `null` and throw. The thrown error aborts Vue's component swap, so the URL updates to the redirect target but the stale authenticated view stays mounted (confirmed via Playwright: `TypeError: Cannot read properties of null (reading 'id')` during the `beforeUnmount`/update).

### Fix

A custom `LogoutResponse` returns `Inertia::location(route('login'))`. Inertia turns this into a `409` carrying `X-Inertia-Location`, so the client performs a full-page navigation to the login screen, tearing the whole app down and rendering login from a clean slate. This sidesteps the entire class of "auth.user is null during teardown" reactivity crashes rather than patching each unguarded read.

## Acceptance criteria

- [x] After clicking Log out, the login page renders immediately (no manual refresh).
- [x] Browser URL and rendered page stay in sync throughout the logout flow.
- [x] A regression test (browser + feature) covers logout landing on the login page.

## Tests

- `tests/Browser/LogoutTest.php` — E2E: sign in, log out, assert the login form renders at `/login` and the composer is gone.
- `tests/Feature/Auth/AuthenticationTest.php` — covers the web redirect to login, the Inertia `409` + `X-Inertia-Location` hard visit, and the JSON `204` branch.

Backend gate green at 100% coverage; CodeRabbit CLI review clean.

Closes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved logout behavior by directing users to the login page immediately after signing out.
  * Added appropriate logout responses for browser navigation, Inertia requests, and JSON clients.

* **Bug Fixes**
  * Fixed logout navigation so the login page loads without requiring a manual refresh.

* **Tests**
  * Added coverage for browser, Inertia, and JSON logout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->