### PR TITLE
refactor: migrate remaining raw buttons onto the Button primitive

### DIFF
--- a/resources/js/components/AddDirectMessagePeopleModal.vue
+++ b/resources/js/components/AddDirectMessagePeopleModal.vue
@@ -162,8 +162,9 @@ function submit(): void {
                         >{{ getInitials(person.name) }}</span
                     >
                     {{ person.name }}
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke tiny chip-dismiss control -->
-                    <button
+                    <Button
+                        variant="unstyled"
+                        size="none"
                         type="button"
                         :data-test="`add-people-remove-${person.id}`"
                         :aria-label="$t('Remove :name', { name: person.name })"
@@ -171,7 +172,7 @@ function submit(): void {
                         @click="removePerson(person.id)"
                     >
                         <X class="size-3.5" />
-                    </button>
+                    </Button>
                 </span>
                 <div class="flex min-w-[8rem] flex-1 items-center gap-1.5 px-1">
                     <Search

--- a/resources/js/components/AppearanceTabs.vue
+++ b/resources/js/components/AppearanceTabs.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Check } from '@lucide/vue';
+import { Button } from '@/components/ui/button';
 import { useAppearance } from '@/composables/useAppearance';
 import { useTranslations } from '@/composables/useTranslations';
 
@@ -20,14 +21,15 @@ const options = [
       fixed (not the active-theme tokens) — a light swatch always reads light.
     -->
     <div class="grid max-w-2xl grid-cols-3 gap-3">
-        <!-- eslint-disable-next-line local/no-raw-button -- bespoke segmented theme toggle (aria-pressed options) -->
-        <button
+        <Button
             v-for="{ value, label } in options"
             :key="value"
+            variant="unstyled"
+            size="none"
             type="button"
             :aria-pressed="appearance === value"
             @click="updateAppearance(value)"
-            class="flex flex-col gap-2 rounded-[13px] text-left focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            class="flex flex-col gap-2 rounded-[13px] text-left"
         >
             <div
                 class="overflow-hidden rounded-xl border-2 transition-colors"
@@ -108,6 +110,6 @@ const options = [
                 <span v-else class="size-3.5" aria-hidden="true" />
                 {{ label }}
             </span>
-        </button>
+        </Button>
     </div>
 </template>

--- a/resources/js/components/ChannelEmptyState.vue
+++ b/resources/js/components/ChannelEmptyState.vue
@@ -4,6 +4,7 @@ import { Send, UserPlus } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
+import { Button } from '@/components/ui/button';
 import { useOnboardingTour } from '@/composables/useOnboardingTour';
 import { useTranslations } from '@/composables/useTranslations';
 import { groupDmMastheadName } from '@/lib/groupDm';
@@ -94,8 +95,9 @@ const conversationName = computed(() =>
 
             <div class="mt-7 flex w-full flex-col gap-2.5">
                 <CreateChannelModal :team-slug="props.teamSlug">
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke welcome action card -->
-                    <button
+                    <Button
+                        variant="unstyled"
+                        size="none"
                         type="button"
                         data-test="welcome-create-channel"
                         class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
@@ -117,12 +119,13 @@ const conversationName = computed(() =>
                             class="inline-flex h-9 items-center rounded-full bg-primary px-4 text-[13px] font-semibold text-primary-foreground"
                             >{{ $t('Create') }}</span
                         >
-                    </button>
+                    </Button>
                 </CreateChannelModal>
 
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke welcome action card -->
-                <button
+                <Button
                     v-if="canInviteToCurrentTeam"
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     data-test="welcome-invite"
                     class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
@@ -146,10 +149,11 @@ const conversationName = computed(() =>
                         class="inline-flex h-9 items-center rounded-full border border-input bg-background px-4 text-[13px] font-semibold text-foreground"
                         >{{ $t('Invite') }}</span
                     >
-                </button>
+                </Button>
 
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke welcome action card -->
-                <button
+                <Button
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     data-test="welcome-post-message"
                     class="flex items-center gap-3.5 rounded-[13px] border border-border bg-card px-4 py-3.5 text-left shadow-sm transition-colors hover:bg-accent/40"
@@ -173,20 +177,21 @@ const conversationName = computed(() =>
                         class="inline-flex h-9 items-center rounded-full border border-input bg-background px-4 text-[13px] font-semibold text-foreground"
                         >{{ $t('Compose') }}</span
                     >
-                </button>
+                </Button>
             </div>
 
             <p class="mt-5 text-[12.5px] text-muted-foreground">
                 {{ $t('Prefer to explore on your own?') }}
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline text-link control -->
-                <button
+                <Button
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     data-test="welcome-take-tour"
                     class="font-semibold text-brass-fill-foreground hover:underline"
                     @click="openOnboardingTour"
                 >
                     {{ $t('Take the 30-second tour') }}
-                </button>
+                </Button>
             </p>
         </div>
 

--- a/resources/js/components/ForwardMessageDialog.vue
+++ b/resources/js/components/ForwardMessageDialog.vue
@@ -160,19 +160,15 @@ function submit(): void {
                                 v-for="channel in rankedChannels"
                                 :key="channel.id"
                             >
-                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke selectable recipient row (aria-pressed) -->
-                                <button
+                                <Button
+                                    variant="unstyled"
+                                    size="none"
                                     type="button"
                                     data-test="forward-channel-option"
                                     :aria-pressed="
                                         isSelected('channel', channel.id)
                                     "
-                                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted"
-                                    :class="
-                                        isSelected('channel', channel.id)
-                                            ? 'bg-muted font-medium'
-                                            : ''
-                                    "
+                                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted aria-pressed:bg-muted aria-pressed:font-medium"
                                     @click="selectChannel(channel)"
                                 >
                                     <Hash class="size-4 shrink-0 opacity-60" />
@@ -183,7 +179,7 @@ function submit(): void {
                                         v-if="isSelected('channel', channel.id)"
                                         class="ml-auto size-4 shrink-0 text-primary"
                                     />
-                                </button>
+                                </Button>
                             </li>
                         </ul>
                     </div>
@@ -196,19 +192,15 @@ function submit(): void {
                         </p>
                         <ul class="space-y-0.5">
                             <li v-for="person in rankedPeople" :key="person.id">
-                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke selectable recipient row (aria-pressed) -->
-                                <button
+                                <Button
+                                    variant="unstyled"
+                                    size="none"
                                     type="button"
                                     data-test="forward-person-option"
                                     :aria-pressed="
                                         isSelected('user', person.id)
                                     "
-                                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted"
-                                    :class="
-                                        isSelected('user', person.id)
-                                            ? 'bg-muted font-medium'
-                                            : ''
-                                    "
+                                    class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted aria-pressed:bg-muted aria-pressed:font-medium"
                                     @click="
                                         selectPerson({
                                             id: person.id,
@@ -230,7 +222,7 @@ function submit(): void {
                                         v-if="isSelected('user', person.id)"
                                         class="ml-auto size-4 shrink-0 text-primary"
                                     />
-                                </button>
+                                </Button>
                             </li>
                         </ul>
                     </div>

--- a/resources/js/components/MessageAttachments.vue
+++ b/resources/js/components/MessageAttachments.vue
@@ -2,6 +2,7 @@
 import { Download, FileText } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import MessageLightbox from '@/components/MessageLightbox.vue';
+import { Button } from '@/components/ui/button';
 import { useTranslations } from '@/composables/useTranslations';
 import {
     fileTypeLabel,
@@ -71,14 +72,15 @@ function isSvg(attachment: AttachmentData): boolean {
                 loading="lazy"
                 class="size-full object-cover"
             />
-            <!-- eslint-disable-next-line local/no-raw-button -- bespoke full-bleed image overlay, not a variant button -->
-            <button
+            <Button
+                variant="unstyled"
+                size="none"
                 type="button"
                 data-test="attachment-image"
                 :aria-label="t('Open :name', { name: images[0].filename })"
-                class="absolute inset-0 z-10 cursor-zoom-in focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                class="absolute inset-0 z-10 cursor-zoom-in"
                 @click="openLightbox(0)"
-            ></button>
+            />
             <a
                 :href="images[0].url"
                 :download="images[0].filename"
@@ -104,16 +106,17 @@ function isSvg(attachment: AttachmentData): boolean {
             }"
             data-test="attachment-grid"
         >
-            <!-- eslint-disable-next-line local/no-raw-button -- bespoke image grid tile, not a variant button -->
-            <button
+            <Button
                 v-for="tile in tiles"
                 :key="tile.attachment.id"
+                variant="unstyled"
+                size="none"
                 type="button"
                 data-test="attachment-image"
                 :aria-label="
                     t('Open :name', { name: tile.attachment.filename })
                 "
-                class="group relative aspect-square cursor-zoom-in overflow-hidden rounded-xl border border-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                class="group relative aspect-square cursor-zoom-in overflow-hidden rounded-xl border border-border"
                 @click="openLightbox(tile.index)"
             >
                 <img
@@ -128,7 +131,7 @@ function isSvg(attachment: AttachmentData): boolean {
                     class="absolute inset-0 flex items-center justify-center bg-[rgba(18,16,12,0.6)] text-2xl font-semibold text-[#f3efe4]"
                     >+{{ tile.overflow }}</span
                 >
-            </button>
+            </Button>
         </div>
 
         <!-- Non-image files (SVG included): a download card each. -->

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -816,8 +816,9 @@ function onKeydown(event: KeyboardEvent): void {
                         :is-deleted="props.replyTarget.isDeleted"
                     />
                 </span>
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke composer chip dismiss -->
-                <button
+                <Button
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     data-test="reply-preview-dismiss"
                     :aria-label="$t('Cancel reply')"
@@ -825,7 +826,7 @@ function onKeydown(event: KeyboardEvent): void {
                     @click="emit('cancelReply')"
                 >
                     <X class="size-3.5" />
-                </button>
+                </Button>
             </div>
 
             <!-- Edit-mode banner: brass-tinted so the composer unmistakably
@@ -845,8 +846,9 @@ function onKeydown(event: KeyboardEvent): void {
                 <span class="shrink-0 text-[11.5px] text-muted-foreground">
                     {{ $t('Enter to save · Esc to cancel') }}
                 </span>
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke composer chip dismiss -->
-                <button
+                <Button
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     data-test="composer-editing-dismiss"
                     :aria-label="$t('Cancel edit')"
@@ -854,7 +856,7 @@ function onKeydown(event: KeyboardEvent): void {
                     @click="exitEditMode"
                 >
                     <X class="size-3.5" />
-                </button>
+                </Button>
             </div>
 
             <!-- Floating pill: input on the left, ghost tool icons and the ink
@@ -901,19 +903,21 @@ function onKeydown(event: KeyboardEvent): void {
                                 </span>
                                 <span class="text-[11px] text-destructive">
                                     {{ $t('Upload failed') }} ·
-                                    <!-- eslint-disable-next-line local/no-raw-button -- inline text retry action -->
-                                    <button
+                                    <Button
+                                        variant="unstyled"
+                                        size="none"
                                         type="button"
                                         data-test="composer-attachment-retry"
                                         class="underline hover:no-underline"
                                         @click="uploads.retry(item.localId)"
                                     >
                                         {{ $t('Retry') }}
-                                    </button>
+                                    </Button>
                                 </span>
                             </span>
-                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke tray chip dismiss -->
-                            <button
+                            <Button
+                                variant="unstyled"
+                                size="none"
                                 type="button"
                                 data-test="composer-attachment-remove"
                                 :aria-label="$t('Remove attachment')"
@@ -921,7 +925,7 @@ function onKeydown(event: KeyboardEvent): void {
                                 @click="uploads.remove(item.localId)"
                             >
                                 <X class="size-3" />
-                            </button>
+                            </Button>
                         </div>
 
                         <!-- Image preview thumbnail (never SVG). -->
@@ -950,8 +954,9 @@ function onKeydown(event: KeyboardEvent): void {
                                     :style="{ width: `${item.progress}%` }"
                                 ></div>
                             </div>
-                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke tray chip dismiss -->
-                            <button
+                            <Button
+                                variant="unstyled"
+                                size="none"
                                 type="button"
                                 data-test="composer-attachment-remove"
                                 :aria-label="$t('Remove attachment')"
@@ -959,7 +964,7 @@ function onKeydown(event: KeyboardEvent): void {
                                 @click="uploads.remove(item.localId)"
                             >
                                 <X class="size-2.75" />
-                            </button>
+                            </Button>
                         </div>
 
                         <!-- Non-image file chip (uploading or done). -->
@@ -1000,8 +1005,9 @@ function onKeydown(event: KeyboardEvent): void {
                                     ></div>
                                 </div>
                             </span>
-                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke tray chip dismiss -->
-                            <button
+                            <Button
+                                variant="unstyled"
+                                size="none"
                                 type="button"
                                 data-test="composer-attachment-remove"
                                 :aria-label="$t('Remove attachment')"
@@ -1009,7 +1015,7 @@ function onKeydown(event: KeyboardEvent): void {
                                 @click="uploads.remove(item.localId)"
                             >
                                 <X class="size-3" />
-                            </button>
+                            </Button>
                         </div>
                     </template>
                 </div>

--- a/resources/js/components/MessageLightbox.vue
+++ b/resources/js/components/MessageLightbox.vue
@@ -10,6 +10,7 @@ import {
     DialogTitle,
 } from 'reka-ui';
 import { computed, ref, watch } from 'vue';
+import { Button } from '@/components/ui/button';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatFileSize } from '@/lib/attachments';
 import { formatTimeOfDay } from '@/lib/datetime';
@@ -134,8 +135,9 @@ function onKeydown(event: KeyboardEvent): void {
                 </div>
 
                 <template v-if="images.length > 1">
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke lightbox nav control on a dark backdrop -->
-                    <button
+                    <Button
+                        variant="unstyled"
+                        size="none"
                         type="button"
                         data-test="lightbox-prev"
                         :aria-label="t('Previous image')"
@@ -143,9 +145,10 @@ function onKeydown(event: KeyboardEvent): void {
                         @click="step(-1)"
                     >
                         <ChevronLeft class="size-4" />
-                    </button>
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke lightbox nav control on a dark backdrop -->
-                    <button
+                    </Button>
+                    <Button
+                        variant="unstyled"
+                        size="none"
                         type="button"
                         data-test="lightbox-next"
                         :aria-label="t('Next image')"
@@ -153,7 +156,7 @@ function onKeydown(event: KeyboardEvent): void {
                         @click="step(1)"
                     >
                         <ChevronRight class="size-4" />
-                    </button>
+                    </Button>
                     <span
                         class="absolute bottom-3 left-1/2 -translate-x-1/2 text-[11.5px] text-[#8b8370] tabular-nums"
                     >

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -853,13 +853,14 @@ function confirmDelete(): void {
                                     }}</span>
                                 </div>
 
-                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke quoted-reply preview control -->
-                                <button
+                                <Button
                                     v-if="
                                         message.replyTo &&
                                         !message.isDeleted &&
                                         editingId !== message.id
                                     "
+                                    variant="unstyled"
+                                    size="none"
                                     type="button"
                                     data-test="message-quote"
                                     :aria-label="
@@ -881,7 +882,7 @@ function confirmDelete(): void {
                                         :body="message.replyTo.body"
                                         :is-deleted="message.replyTo.isDeleted"
                                     />
-                                </button>
+                                </Button>
 
                                 <p
                                     v-if="message.isDeleted"
@@ -1099,8 +1100,9 @@ function confirmDelete(): void {
                                     v-if="showThreadSummary(message)"
                                     class="mt-1.5 flex flex-wrap items-center gap-2"
                                 >
-                                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke thread-summary card -->
-                                    <button
+                                    <Button
+                                        variant="unstyled"
+                                        size="none"
                                         type="button"
                                         data-test="thread-summary"
                                         :aria-label="
@@ -1185,7 +1187,7 @@ function confirmDelete(): void {
                                             class="text-[12px] text-muted-foreground"
                                             >→</span
                                         >
-                                    </button>
+                                    </Button>
                                     <span
                                         v-if="message.threadLastReplyAt"
                                         class="text-[11.5px] text-muted-foreground"

--- a/resources/js/components/MessageReactions.vue
+++ b/resources/js/components/MessageReactions.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { SmilePlus } from '@lucide/vue';
 import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
+import { Button } from '@/components/ui/button';
 import {
     HoverCard,
     HoverCardContent,
@@ -76,8 +77,9 @@ function toggle(emoji: string): void {
             :close-delay="100"
         >
             <HoverCardTrigger as-child>
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke reaction pill (toggle) -->
-                <button
+                <Button
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     data-test="reaction-pill"
                     :data-emoji="reaction.emoji"
@@ -85,12 +87,7 @@ function toggle(emoji: string): void {
                     :disabled="!props.canReact"
                     :aria-label="`${reaction.emoji} ${roster(reaction)}`"
                     :aria-pressed="reacted(reaction)"
-                    class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[12px] leading-none transition-colors"
-                    :class="
-                        reacted(reaction)
-                            ? 'border-brass-border bg-brass-fill text-brass-fill-foreground'
-                            : 'border-border bg-muted/40 text-muted-foreground hover:bg-muted'
-                    "
+                    class="inline-flex items-center gap-1 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[12px] leading-none text-muted-foreground hover:bg-muted aria-pressed:border-brass-border aria-pressed:bg-brass-fill aria-pressed:text-brass-fill-foreground"
                     @click="toggle(reaction.emoji)"
                 >
                     <img
@@ -103,7 +100,7 @@ function toggle(emoji: string): void {
                     <span class="font-medium tabular-nums">{{
                         reaction.count
                     }}</span>
-                </button>
+                </Button>
             </HoverCardTrigger>
             <HoverCardContent
                 data-test="reaction-reactors"
@@ -136,15 +133,16 @@ function toggle(emoji: string): void {
             v-if="props.canReact"
             @select="(emoji) => emit('toggle', emoji)"
         >
-            <!-- eslint-disable-next-line local/no-raw-button -- bespoke add-reaction pill -->
-            <button
+            <Button
+                variant="unstyled"
+                size="none"
                 type="button"
                 data-test="add-reaction"
                 :aria-label="$t('Add reaction')"
                 class="inline-flex items-center rounded-full border border-border bg-muted/40 p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
             >
                 <SmilePlus class="size-3.5" />
-            </button>
+            </Button>
         </EmojiPickerPopover>
     </div>
 </template>

--- a/resources/js/components/MessageReminderPopover.vue
+++ b/resources/js/components/MessageReminderPopover.vue
@@ -7,6 +7,7 @@ import {
     PopoverTrigger,
 } from 'reka-ui';
 import { computed, ref } from 'vue';
+import { Button } from '@/components/ui/button';
 import {
     Tooltip,
     TooltipContent,
@@ -91,14 +92,15 @@ function chooseCustom(): void {
                     {{ $t('Remind me about this') }}
                 </div>
                 <div class="flex flex-col">
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke reminder menu item -->
-                    <button
+                    <Button
                         v-for="preset in presets"
                         :key="preset.key"
+                        variant="ghost"
+                        size="none"
                         type="button"
                         data-test="reminder-preset"
                         :data-preset="preset.key"
-                        class="flex h-9 items-center justify-between gap-2 rounded-lg px-3 text-[13.5px] font-medium text-foreground transition-colors hover:bg-accent"
+                        class="flex h-9 items-center justify-between gap-2 rounded-lg px-3 text-[13.5px] font-medium text-foreground"
                         @click="choose(preset.remindAt)"
                     >
                         <span>{{ $t(preset.label) }}</span>
@@ -107,18 +109,19 @@ function chooseCustom(): void {
                             class="text-[12px] font-normal text-muted-foreground"
                             >{{ preset.detail }}</span
                         >
-                    </button>
+                    </Button>
                     <div class="mx-2 my-1.5 h-px bg-border"></div>
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke reminder menu item -->
-                    <button
+                    <Button
+                        variant="ghost"
+                        size="none"
                         type="button"
                         data-test="reminder-custom"
-                        class="flex h-9 items-center gap-2 rounded-lg px-3 text-[13.5px] font-medium text-brass-fill-foreground transition-colors hover:bg-accent"
+                        class="flex h-9 items-center gap-2 rounded-lg px-3 text-[13.5px] font-medium text-brass-fill-foreground"
                         @click="chooseCustom"
                     >
                         <CalendarClock class="size-3.5" />
                         {{ $t('Custom date & time…') }}
-                    </button>
+                    </Button>
                 </div>
             </PopoverContent>
         </PopoverPortal>

--- a/resources/js/components/OnboardingTour.vue
+++ b/resources/js/components/OnboardingTour.vue
@@ -178,15 +178,16 @@ onBeforeUnmount(() => {
                     />
                 </div>
 
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke control on the branded tour surface -->
-                <button
+                <Button
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     data-test="onboarding-skip"
                     class="text-[12.5px] font-medium text-primary-foreground/60 hover:text-primary-foreground"
                     @click="skip"
                 >
                     {{ $t('Skip tour') }}
-                </button>
+                </Button>
 
                 <Button
                     size="sm"

--- a/resources/js/components/PasswordInput.vue
+++ b/resources/js/components/PasswordInput.vue
@@ -2,6 +2,7 @@
 import { Eye, EyeOff } from '@lucide/vue';
 import { ref, useTemplateRef } from 'vue';
 import type { HTMLAttributes } from 'vue';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
@@ -28,15 +29,12 @@ defineExpose({
             :class="cn('pr-10', props.class)"
             v-bind="$attrs"
         />
-        <!-- eslint-disable-next-line local/no-raw-button -- bespoke show/hide toggle nested inside the input -->
-        <button
+        <Button
+            variant="unstyled"
+            size="none"
             type="button"
             @click="showPassword = !showPassword"
-            :class="
-                cn(
-                    'absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 text-muted-foreground hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:outline-none',
-                )
-            "
+            class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-3 text-muted-foreground hover:text-foreground"
             :aria-label="
                 showPassword ? $t('Hide password') : $t('Show password')
             "
@@ -44,6 +42,6 @@ defineExpose({
         >
             <EyeOff v-if="showPassword" class="size-4" />
             <Eye v-else class="size-4" />
-        </button>
+        </Button>
     </div>
 </template>

--- a/resources/js/components/PinsPanel.vue
+++ b/resources/js/components/PinsPanel.vue
@@ -2,6 +2,7 @@
 import { Pin, X } from '@lucide/vue';
 import { onBeforeUnmount, onMounted } from 'vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
 import { formatDateTime } from '@/lib/datetime';
 import { messageBodyPreview } from '@/lib/messageBody';
@@ -122,8 +123,9 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                     :key="message.id"
                     class="group/pin relative"
                 >
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke pinned-message list row -->
-                    <button
+                    <Button
+                        variant="unstyled"
+                        size="none"
                         type="button"
                         data-test="pins-panel-row"
                         class="flex w-full flex-col gap-1.5 rounded-[10px] px-2.5 pt-2.5 pb-3 text-left hover:bg-muted"
@@ -196,13 +198,14 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                                 >
                             </span>
                         </span>
-                    </button>
+                    </Button>
 
                     <!-- Unpin: a floating pill revealed on row hover. Any member
                          may unpin (shared toggle); hidden read-only otherwise. -->
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke floating unpin pill -->
-                    <button
+                    <Button
                         v-if="props.canPin"
+                        variant="unstyled"
+                        size="none"
                         type="button"
                         data-test="pins-panel-unpin"
                         class="absolute -top-1 right-3 hidden items-center gap-1.5 rounded-lg border border-border bg-popover px-2.5 py-1 text-[11.5px] font-semibold text-muted-foreground shadow-md group-hover/pin:inline-flex hover:text-foreground"
@@ -210,7 +213,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                     >
                         <X class="size-3" />
                         {{ $t('Unpin') }}
-                    </button>
+                    </Button>
                 </div>
             </div>
         </div>

--- a/resources/js/components/ReminderNudge.vue
+++ b/resources/js/components/ReminderNudge.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { AlarmClock, X } from '@lucide/vue';
 import { computed } from 'vue';
+import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
 import { messageBodyPreview } from '@/lib/messageBody';
 import type { MessageReminder } from '@/types';
@@ -42,8 +43,9 @@ const channelLabel = computed(() =>
             >
                 {{ $t('Reminder · due now') }}
             </span>
-            <!-- eslint-disable-next-line local/no-raw-button -- bespoke dismiss on the branded nudge -->
-            <button
+            <Button
+                variant="unstyled"
+                size="none"
                 type="button"
                 data-test="reminder-nudge-close"
                 :aria-label="$t('Dismiss reminder')"
@@ -51,7 +53,7 @@ const channelLabel = computed(() =>
                 @click="emit('dismiss', reminder)"
             >
                 <X class="size-3.5" />
-            </button>
+            </Button>
         </div>
 
         <div
@@ -90,33 +92,36 @@ const channelLabel = computed(() =>
         </div>
 
         <div class="flex items-center gap-2.5">
-            <!-- eslint-disable-next-line local/no-raw-button -- bespoke pill on the branded nudge -->
-            <button
+            <Button
+                variant="unstyled"
+                size="none"
                 type="button"
                 data-test="reminder-nudge-open"
                 class="inline-flex h-8 items-center rounded-full bg-brass px-4 text-[12.5px] font-semibold text-brass-foreground transition-opacity hover:opacity-90"
                 @click="emit('open', reminder)"
             >
                 {{ $t('Open message') }}
-            </button>
-            <!-- eslint-disable-next-line local/no-raw-button -- bespoke pill on the branded nudge -->
-            <button
+            </Button>
+            <Button
+                variant="unstyled"
+                size="none"
                 type="button"
                 data-test="reminder-nudge-snooze"
                 class="inline-flex h-8 items-center rounded-full border border-primary-foreground/25 px-3.5 text-[12.5px] font-medium text-primary-foreground/80 transition-colors hover:bg-primary-foreground/10"
                 @click="emit('snooze', reminder)"
             >
                 {{ $t('Snooze 20 min') }}
-            </button>
-            <!-- eslint-disable-next-line local/no-raw-button -- bespoke text action on the branded nudge -->
-            <button
+            </Button>
+            <Button
+                variant="unstyled"
+                size="none"
                 type="button"
                 data-test="reminder-nudge-done"
                 class="ml-auto text-[12.5px] font-medium text-primary-foreground/60 transition-colors hover:text-primary-foreground"
                 @click="emit('dismiss', reminder)"
             >
                 {{ $t('Done') }}
-            </button>
+            </Button>
         </div>
     </div>
 </template>

--- a/resources/js/components/RemindersDialog.vue
+++ b/resources/js/components/RemindersDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { AlarmClock, Clock, X } from '@lucide/vue';
 import { computed } from 'vue';
+import { Button } from '@/components/ui/button';
 import {
     Dialog,
     DialogContent,
@@ -90,16 +91,17 @@ function openReminder(reminder: MessageReminder): void {
                             })
                         }}
                     </span>
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline text action -->
-                    <button
+                    <Button
                         v-if="reminders.length > 0"
+                        variant="unstyled"
+                        size="none"
                         type="button"
                         data-test="reminders-clear-all"
                         class="ml-auto font-sans text-[12.5px] font-medium text-muted-foreground transition-colors hover:text-destructive"
                         @click="emit('clearAll')"
                     >
                         {{ $t('Clear all') }}
-                    </button>
+                    </Button>
                 </div>
                 <DialogDescription>
                     {{
@@ -143,8 +145,9 @@ function openReminder(reminder: MessageReminder): void {
                             :data-reminder="reminder.id"
                             class="flex items-center gap-3 rounded-xl border border-border bg-card p-3"
                         >
-                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke reminder list row -->
-                            <button
+                            <Button
+                                variant="unstyled"
+                                size="none"
                                 type="button"
                                 data-test="reminder-open"
                                 class="flex min-w-0 flex-1 items-center gap-3 text-left"
@@ -188,7 +191,7 @@ function openReminder(reminder: MessageReminder): void {
                                         >{{ excerpt(reminder) }}</span
                                     >
                                 </div>
-                            </button>
+                            </Button>
                             <span
                                 class="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-brass-fill px-2.5 py-1 text-[11.5px] font-semibold text-brass-fill-foreground"
                                 data-test="reminder-when"
@@ -196,8 +199,9 @@ function openReminder(reminder: MessageReminder): void {
                                 <Clock class="size-3" />
                                 {{ whenLabel(reminder.remindAt) }}
                             </span>
-                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke row icon action -->
-                            <button
+                            <Button
+                                variant="unstyled"
+                                size="none"
                                 type="button"
                                 data-test="reminder-clear"
                                 :aria-label="$t('Clear reminder')"
@@ -205,7 +209,7 @@ function openReminder(reminder: MessageReminder): void {
                                 @click="emit('clear', reminder.id)"
                             >
                                 <X class="size-4" />
-                            </button>
+                            </Button>
                         </div>
                     </section>
                 </template>

--- a/resources/js/components/ScheduleMessageDialog.vue
+++ b/resources/js/components/ScheduleMessageDialog.vue
@@ -185,20 +185,16 @@ function confirm(): void {
             </DialogHeader>
 
             <div class="grid grid-cols-2 gap-2" data-test="schedule-presets">
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke schedule-preset item -->
-                <button
+                <Button
                     v-for="preset in presets"
                     :key="preset.key"
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     data-test="schedule-preset"
                     :data-preset="preset.key"
                     :aria-pressed="preset.key === activePresetKey"
-                    class="flex items-center justify-between gap-2 rounded-md border px-3 py-1.5 text-left text-[13px] transition-colors"
-                    :class="
-                        preset.key === activePresetKey
-                            ? 'border-primary bg-primary/5 font-medium text-foreground'
-                            : 'border-input hover:bg-muted'
-                    "
+                    class="flex items-center justify-between gap-2 rounded-md border border-input px-3 py-1.5 text-left text-[13px] hover:bg-muted aria-pressed:border-primary aria-pressed:bg-primary/5 aria-pressed:font-medium aria-pressed:text-foreground"
                     @click="choosePreset(preset)"
                 >
                     <span class="truncate">{{ $t(preset.label) }}</span>
@@ -206,7 +202,7 @@ function confirm(): void {
                         v-if="preset.key === activePresetKey"
                         class="size-4 shrink-0 text-primary"
                     />
-                </button>
+                </Button>
             </div>
 
             <div class="rounded-lg border border-border">

--- a/resources/js/components/ScheduledMessagesDialog.vue
+++ b/resources/js/components/ScheduledMessagesDialog.vue
@@ -135,16 +135,17 @@ function bodyPreview(body: string): string {
                         <div
                             class="mt-2 flex items-center justify-between gap-2"
                         >
-                            <!-- eslint-disable-next-line local/no-raw-button -- bespoke reschedule pill -->
-                            <button
+                            <Button
+                                variant="ghost"
+                                size="none"
                                 type="button"
                                 data-test="scheduled-reschedule"
-                                class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[13px] text-muted-foreground hover:bg-muted hover:text-foreground"
+                                class="gap-1.5 px-2 py-1 text-[13px] text-muted-foreground"
                                 @click="rescheduling = true"
                             >
                                 <CalendarClock class="size-3.5" />
                                 {{ whenLabel(editSendAt) }}
-                            </button>
+                            </Button>
                             <div class="flex items-center gap-1.5">
                                 <Button
                                     variant="secondary"
@@ -189,26 +190,28 @@ function bodyPreview(body: string): string {
                                 {{ whenLabel(scheduled.sendAt) }}
                             </span>
                             <div class="flex items-center gap-1">
-                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke row icon action -->
-                                <button
+                                <Button
+                                    variant="ghost"
+                                    size="icon-sm"
                                     type="button"
                                     :aria-label="$t('Edit scheduled message')"
                                     data-test="scheduled-edit"
-                                    class="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                                    class="text-muted-foreground"
                                     @click="startEdit(scheduled)"
                                 >
                                     <Pencil class="size-4" />
-                                </button>
-                                <!-- eslint-disable-next-line local/no-raw-button -- bespoke row icon action -->
-                                <button
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="icon-sm"
                                     type="button"
                                     :aria-label="$t('Cancel scheduled message')"
                                     data-test="scheduled-cancel"
-                                    class="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive"
+                                    class="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
                                     @click="cancelSend(scheduled)"
                                 >
                                     <Trash2 class="size-4" />
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </template>

--- a/resources/js/components/ui/button/Button.test.ts
+++ b/resources/js/components/ui/button/Button.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { createSSRApp, h } from "vue"
 import { renderToString } from "vue/server-renderer"
-import { Button } from "."
+import { Button, buttonVariants } from "."
 
 /**
  * Renders `<Button>` to an HTML string in the node test environment (no DOM
@@ -38,5 +38,45 @@ describe("Button loading prop", () => {
     expect(html).not.toContain("animate-spin")
     expect(html).not.toMatch(/disabled(?!:)/)
     expect(html).not.toContain("aria-busy")
+  })
+})
+
+describe("Button variants and sizes", () => {
+  it("drives the segmented selected state off aria-pressed, not a class ternary", async () => {
+    const html = await renderButton({
+      variant: "segmented",
+      "aria-pressed": true,
+    })
+
+    // The selected treatment ships as `aria-pressed:` utilities, so the CSS
+    // (not the call-site) reacts to the bound `aria-pressed` attribute.
+    expect(html).toContain("aria-pressed:bg-card")
+    expect(html).toContain("aria-pressed:text-foreground")
+    expect(html).toContain('aria-pressed="true"')
+    // Unselected resting state.
+    expect(html).toContain("text-muted-foreground")
+  })
+
+  it("gives the pill size rounded-full geometry", () => {
+    expect(buttonVariants({ size: "pill" })).toContain("rounded-full")
+  })
+
+  it("carries the destructive token on the link-destructive variant", () => {
+    const classes = buttonVariants({ variant: "linkDestructive" })
+
+    expect(classes).toContain("text-destructive")
+    expect(classes).toContain("hover:underline")
+    // Not the default primary link colour.
+    expect(classes).not.toContain("text-primary")
+  })
+
+  it("drops the button silhouette for the unstyled escape hatch but keeps the focus ring", () => {
+    const classes = buttonVariants({ variant: "unstyled", size: "none" })
+
+    // Owns no inline layout — the card/row container supplies its own.
+    expect(classes).not.toContain("inline-flex")
+    expect(classes).not.toContain("h-9")
+    // Still inherits the shared focus ring.
+    expect(classes).toContain("focus-visible:ring-ring/50")
   })
 })

--- a/resources/js/components/ui/button/index.ts
+++ b/resources/js/components/ui/button/index.ts
@@ -3,36 +3,58 @@ import { cva } from "class-variance-authority"
 
 export { default as Button } from "./Button.vue"
 
-export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        "default": "h-9 px-4 py-2 has-[>svg]:px-3",
-        "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        "lg": "h-10 rounded-md px-6 has-[>svg]:px-4",
-        "icon": "size-9",
-        "icon-sm": "size-8",
-        "icon-lg": "size-10",
-      },
+// Universal interaction/a11y utilities every button-like control shares —
+// transition, focus ring, disabled handling, and svg sizing. Kept in the cva
+// base so even the `unstyled` escape hatch (card/row containers) inherits the
+// focus ring.
+const interaction =
+  "transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+
+// The default button silhouette — inline, centered, medium text. Prepended to
+// every styled variant so `unstyled` can drop it while still inheriting the
+// focus ring above. `cn` runs tailwind-merge, so a later variant/size class
+// (e.g. `rounded-full` on `pill`) cleanly overrides the matching token here.
+const shape =
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium shrink-0"
+
+export const buttonVariants = cva(interaction, {
+  variants: {
+    variant: {
+      default: `${shape} bg-primary text-primary-foreground hover:bg-primary/90`,
+      destructive: `${shape} bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60`,
+      outline: `${shape} border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50`,
+      secondary: `${shape} bg-secondary text-secondary-foreground hover:bg-secondary/80`,
+      ghost: `${shape} hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50`,
+      link: `${shape} text-primary underline-offset-4 hover:underline`,
+      // Same underline treatment as `link` but carrying the destructive token,
+      // for inline "Remove"/"Clear all"/"Discard" actions that read as text.
+      linkDestructive: `${shape} text-destructive underline-offset-4 hover:underline`,
+      // Radio-like toggle in a segmented control. The selected option is driven
+      // by `aria-pressed`, so call-sites bind `:aria-pressed` and drop their
+      // hand-rolled `selected ? … : …` class ternary.
+      segmented: `${shape} rounded-full text-muted-foreground hover:text-foreground aria-pressed:bg-card aria-pressed:text-foreground aria-pressed:shadow-sm`,
+      // No silhouette at all — only the shared focus ring. For full-width card
+      // and list-row controls that own their layout, so the container can be a
+      // real button without inheriting inline padding/height. Pair with
+      // `size="none"`.
+      unstyled: "",
     },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
+    size: {
+      "default": "h-9 px-4 py-2 has-[>svg]:px-3",
+      "sm": "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+      "lg": "h-10 rounded-md px-6 has-[>svg]:px-4",
+      "icon": "size-9",
+      "icon-sm": "size-8",
+      "icon-lg": "size-10",
+      // Rounded-full geometry for chips/pills; height stays overridable via class.
+      "pill": "h-7.5 rounded-full gap-1.5 px-3.5 text-xs",
+      // Opts out of sizing entirely — pairs with `variant="unstyled"`.
+      "none": "",
     },
   },
-)
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+})
 export type ButtonVariants = VariantProps<typeof buttonVariants>

--- a/resources/js/components/ui/button/index.ts
+++ b/resources/js/components/ui/button/index.ts
@@ -8,7 +8,7 @@ export { default as Button } from "./Button.vue"
 // base so even the `unstyled` escape hatch (card/row containers) inherits the
 // focus ring.
 const interaction =
-  "transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+  "transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
 
 // The default button silhouette — inline, centered, medium text. Prepended to
 // every styled variant so `unstyled` can drop it while still inheriting the

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1040,7 +1040,7 @@ function archive(): void {
                         leave-from-class="translate-y-0 opacity-100"
                         leave-to-class="-translate-y-1 opacity-0"
                     >
-                        <!-- eslint-disable-next-line local/no-raw-button -- bespoke jump-to-unread pill -->
+                        <!-- eslint-disable-next-line local/no-raw-button -- jump pill: stays raw with the deferred jump-to-latest pills (#316); the primitive does not compose as a <Transition> child here -->
                         <button
                             v-if="showJumpToUnread"
                             type="button"
@@ -1219,15 +1219,16 @@ function archive(): void {
                                       )
                             }}
                         </span>
-                        <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline text action -->
-                        <button
+                        <Button
+                            variant="unstyled"
+                            size="none"
                             type="button"
                             data-test="discard-queue"
                             class="ml-auto shrink-0 font-semibold text-rose-600 hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300"
                             @click="discardQueue"
                         >
                             {{ $t('Discard queue') }}
-                        </button>
+                        </Button>
                     </div>
 
                     <TypingIndicator
@@ -1235,9 +1236,10 @@ function archive(): void {
                         class="mx-5 shrink-0"
                     />
 
-                    <!-- eslint-disable-next-line local/no-raw-button -- bespoke scheduled-messages pill -->
-                    <button
+                    <Button
                         v-if="props.scheduledMessages.length > 0"
+                        variant="unstyled"
+                        size="none"
                         type="button"
                         data-test="scheduled-trigger"
                         class="mx-5 mb-1 inline-flex w-fit items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-[12px] font-medium text-muted-foreground hover:bg-muted/70 hover:text-foreground"
@@ -1250,7 +1252,7 @@ function archive(): void {
                                 ? $t('scheduled message')
                                 : $t('scheduled messages')
                         }}
-                    </button>
+                    </Button>
 
                     <MessageComposer
                         ref="channelComposer"

--- a/resources/js/pages/settings/Appearance.vue
+++ b/resources/js/pages/settings/Appearance.vue
@@ -5,6 +5,7 @@ import { ref, watch } from 'vue';
 import AppearanceTabs from '@/components/AppearanceTabs.vue';
 import SettingsPane from '@/components/SettingsPane.vue';
 import SettingsPaneSection from '@/components/SettingsPaneSection.vue';
+import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { useChimes } from '@/composables/useChimes';
 import { useReadReceipts } from '@/composables/useReadReceipts';
@@ -71,34 +72,31 @@ const { shareReadReceipts, updateShareReadReceipts } = useReadReceipts();
             "
         >
             <div class="flex flex-wrap items-center gap-2">
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke segmented chime-sound option (aria-pressed) -->
-                <button
+                <Button
                     v-for="option in chimeSounds"
                     :key="option.value"
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     :aria-pressed="selected === option.value"
                     @click="choose(option.value)"
-                    class="inline-flex h-7.5 items-center rounded-full border px-3.5 text-[12.5px] transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-                    :class="
-                        selected === option.value
-                            ? 'border-brass bg-brass-fill font-semibold text-foreground'
-                            : 'border-border bg-card font-medium text-muted-foreground hover:text-foreground'
-                    "
+                    class="inline-flex h-7.5 items-center rounded-full border border-border bg-card px-3.5 text-[12.5px] font-medium text-muted-foreground hover:text-foreground aria-pressed:border-brass aria-pressed:bg-brass-fill aria-pressed:font-semibold aria-pressed:text-foreground"
                 >
                     {{ option.label }}
-                </button>
+                </Button>
 
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline preview control -->
-                <button
+                <Button
+                    variant="unstyled"
+                    size="none"
                     type="button"
                     :disabled="selected === 'off'"
                     data-test="preview-chime"
                     @click="preview(selected)"
-                    class="ml-1 inline-flex h-7.5 items-center gap-1.5 rounded-full border border-border bg-card px-3.5 text-xs font-semibold text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+                    class="ml-1 inline-flex h-7.5 items-center gap-1.5 rounded-full border border-border bg-card px-3.5 text-xs font-semibold text-muted-foreground hover:text-foreground"
                 >
                     <Play class="size-3 fill-current" />
                     {{ $t('Preview') }}
-                </button>
+                </Button>
             </div>
         </SettingsPaneSection>
 

--- a/resources/js/pages/teams/Analytics.vue
+++ b/resources/js/pages/teams/Analytics.vue
@@ -12,6 +12,7 @@ import {
 import { computed, onMounted, ref } from 'vue';
 import Heading from '@/components/Heading.vue';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
 import type { ChartConfig } from '@/components/ui/chart';
 import {
     ChartContainer,
@@ -307,23 +308,19 @@ function channelColor(indexInList: number): string {
                 :aria-label="$t('Time range')"
                 data-test="analytics-range"
             >
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke segmented range option -->
-                <button
+                <Button
                     v-for="option in rangeOptions"
                     :key="option.value"
+                    variant="segmented"
+                    size="none"
                     type="button"
-                    class="inline-flex h-7 items-center rounded-full px-3.5 text-[12.5px] font-medium transition-colors"
-                    :class="
-                        option.value === range
-                            ? 'bg-card text-foreground shadow-sm'
-                            : 'text-muted-foreground hover:text-foreground'
-                    "
+                    class="h-7 px-3.5 text-[12.5px] font-medium"
                     :aria-pressed="option.value === range"
                     :data-test="`analytics-range-${option.value}`"
                     @click="selectRange(option.value)"
                 >
                     {{ option.label }}
-                </button>
+                </Button>
             </div>
         </div>
 

--- a/resources/js/pages/teams/Emojis.vue
+++ b/resources/js/pages/teams/Emojis.vue
@@ -256,12 +256,13 @@ function addedAt(iso: string): string {
                 <span class="w-28 shrink-0 text-xs text-muted-foreground">{{
                     addedAt(emoji.createdAt)
                 }}</span>
-                <!-- eslint-disable-next-line local/no-raw-button -- bespoke inline remove text-link -->
-                <button
+                <Button
                     v-if="canRemove(emoji)"
+                    variant="linkDestructive"
+                    size="none"
                     type="button"
                     :data-test="`emoji-remove-${emoji.name}`"
-                    class="shrink-0 text-xs font-semibold text-destructive hover:underline"
+                    class="shrink-0 text-xs font-semibold"
                     @click="pendingRemoval = emoji"
                 >
                     {{
@@ -269,7 +270,7 @@ function addedAt(iso: string): string {
                             ? $t('Delete')
                             : $t('Revoke')
                     }}
-                </button>
+                </Button>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
Closes #323. Final child of the frontend-deepening epic #313 (follow-up to #316/#324).

## What

Extends the `components/ui/button` primitive with the states the bespoke controls actually needed, then migrates the remaining raw `<button>` elements onto `<Button>` and drops their per-occurrence `eslint-disable local/no-raw-button` opt-outs.

### Primitive additions (each with a paired test in `Button.test.ts`)
- **`segmented` variant** — radio-like toggle whose selected treatment is driven by `aria-pressed` (`aria-pressed:bg-card …`), so call-sites drop their hand-rolled `selected ? … : …` class ternary.
- **`pill` size** — `rounded-full` chip geometry.
- **`linkDestructive` variant** — the `link` underline treatment carrying the destructive token, for inline "Delete"/"Revoke"/"Clear all" text actions.
- **`unstyled` variant + `none` size** — an escape hatch that keeps only the shared focus ring, for full-width card/list-row controls that own their own layout (welcome cards, pinned-message rows, reminder rows, recipient rows, thread-summary/quoted-reply).

The cva base was refactored so the button silhouette lives on each styled variant (not the base), letting `unstyled` opt out while every existing variant keeps an identical class set (tailwind-merge dedupes the relocated tokens).

### Migration
~45 raw `<button>`s across 21 components moved onto `<Button>`. Every `data-test`, `aria-label`, and `aria-pressed`/`data-*` hook is preserved; the primitive's focus ring replaces the various hand-rolled ones (the intended a11y consolidation). Row/dismiss icon buttons follow the established `variant="ghost" size="icon-sm"` idiom from #316.

## Remaining opt-outs (5, all documented exceptions per the issue's AC)
- **Jump-pill family** — the two deferred jump-to-latest pills (`ScrollableMessageList`) and the jump-to-unread pill (`channels/Show`). These stay raw: they live inside a `<Transition>`, and the primitive does not compose as a `<Transition>` child here (verified — wrapping the jump-to-unread pill in `<Button>` broke the `A11yAuditTest` render). Keeping them raw keeps the whole jump-pill family consistent.
- **Emoji-grid cells** (`EmojiPickerPopover`) and the **full-screen backdrop click-catcher** (`PinsPanel`) — the genuinely-structural exceptions the issue explicitly allows.

## Verification
- `lint:check` (0 errors), `types:check`, `format:check` (changed files), `build`, and `vitest` (608 passing, incl. 4 new Button tests) all green.
- Pest browser suite green (`tests/Browser` 32/32; a11y audits, composer attachments, timeline).
- CodeRabbit CLI review: **no findings**.

## Note
While verifying, found a pre-existing `format:check` drift on `auth/Login.vue` (Sail prettier vs green CI) — filed as #409, not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized interactive controls across messaging, reminders, scheduling, onboarding, settings, and workspace screens.
  * Improved consistency for selected, segmented, link, and unstyled button states.
  * Preserved existing actions, accessibility labels, and keyboard focus behavior.

* **Tests**
  * Added coverage for button variants, sizes, selected states, destructive links, and focus styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->