### PR TITLE
fix: keep the "New messages" pill dismissed after it has been seen

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,13 +52,7 @@ jobs:
         run: composer refactor:check
 
       - name: Format Frontend
-        run: npm run format
+        run: npm run format:check
 
       - name: Lint Frontend
         run: npm run lint
-
-      # - name: Commit Changes
-      #   uses: stefanzweifel/git-auto-commit-action@v7
-      #   with:
-      #     commit_message: fix code style
-      #     commit_options: '--no-verify'

--- a/resources/js/lib/virtualTimeline.test.ts
+++ b/resources/js/lib/virtualTimeline.test.ts
@@ -111,16 +111,23 @@ describe('isDividerVisible', () => {
 describe('shouldShowUnreadJump', () => {
     it('shows the jump pill only while the divider sits above the window', () => {
         // Divider at 2, window starts at 4 -> scrolled past it, offer the jump.
-        expect(shouldShowUnreadJump(2, 4, 8)).toBe(true);
+        expect(shouldShowUnreadJump(2, 4, 8, false)).toBe(true);
     });
 
     it('hides the pill once the divider is within or below the window', () => {
-        expect(shouldShowUnreadJump(4, 4, 8)).toBe(false);
-        expect(shouldShowUnreadJump(9, 4, 8)).toBe(false);
+        expect(shouldShowUnreadJump(4, 4, 8, false)).toBe(false);
+        expect(shouldShowUnreadJump(9, 4, 8, false)).toBe(false);
     });
 
     it('hides the pill when there is no unread divider', () => {
-        expect(shouldShowUnreadJump(-1, 0, 8)).toBe(false);
+        expect(shouldShowUnreadJump(-1, 0, 8, false)).toBe(false);
+    });
+
+    it('stays hidden once the divider has been seen, even scrolled away', () => {
+        // Same geometry as the "shows" case (divider above the window), but the
+        // reader has already reached the boundary this visit — the pill must not
+        // reappear when they scroll (or jump) away from it.
+        expect(shouldShowUnreadJump(2, 4, 8, true)).toBe(false);
     });
 });
 

--- a/resources/js/lib/virtualTimeline.ts
+++ b/resources/js/lib/virtualTimeline.ts
@@ -54,13 +54,20 @@ export function isDividerVisible(
  * existing unread divider sits strictly above the rendered window, i.e. the
  * reader has scrolled (or opened) past it and it's off-screen upward. Once the
  * divider scrolls into or below the window the pill is redundant and hides.
+ *
+ * `dividerSeen` is a per-visit latch: once the reader has reached the unread
+ * boundary (scrolled it into view) or jumped back to the present, the pill is
+ * dismissed for the rest of the channel visit and must not reappear when they
+ * later scroll away from the (frozen) divider.
  */
 export function shouldShowUnreadJump(
     dividerIndex: number,
     startIndex: number,
     endIndex: number,
+    dividerSeen: boolean,
 ): boolean {
     return (
+        !dividerSeen &&
         dividerIndex >= 0 &&
         !isDividerVisible(dividerIndex, startIndex, endIndex) &&
         dividerIndex < startIndex

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -46,10 +46,7 @@ defineProps<{
         <!-- Single sign-on entry point, shown only when an OIDC provider is
         configured. A full-page navigation (native anchor) hands off to the IdP;
         an Inertia visit would break the OAuth redirect. -->
-        <div
-            v-if="$page.props.sso.oidcEnabled"
-            class="flex flex-col gap-6"
-        >
+        <div v-if="$page.props.sso.oidcEnabled" class="flex flex-col gap-6">
             <Button
                 as-child
                 variant="outline"

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -64,6 +64,7 @@ import { groupDmMastheadName } from '@/lib/groupDm';
 import { createOutbox } from '@/lib/outbox';
 import { buildTimelineItems } from '@/lib/timeline';
 import {
+    isDividerVisible,
     shouldShowUnreadJump,
     timelineItemIndexForMessage,
     unreadDividerIndex,
@@ -396,22 +397,64 @@ const { unreadDividerId } = useUnreadDivider({
 // The unread boundary's render-item index, or -1 when there's none.
 const unreadIndex = computed(() => unreadDividerIndex(timelineItems.value));
 
+// Per-visit latch: once the reader reaches the unread boundary (it scrolls into
+// the window) or jumps back to the present, the "New messages" pill is dismissed
+// for the rest of this channel visit. Without it the pill reappears whenever the
+// (frozen) divider sits above the window again — e.g. right after Jump to present
+// (#411). Both flags are refrozen alongside the divider on every channel switch.
+const unreadDividerSeen = ref(false);
+
+// Whether the boundary has ever sat above the window this visit. The reader
+// "reaches" the divider only when it scrolls back into view *after* having been
+// above — the transition the seen latch keys off. This guards against the initial
+// pre-`scrollToBottom` render (rows start at the top, so the divider is briefly
+// on screen before the open pins to the newest message) latching it prematurely.
+const unreadDividerWasAbove = ref(false);
+
+watch(
+    () => props.channel.id,
+    () => {
+        unreadDividerSeen.value = false;
+        unreadDividerWasAbove.value = false;
+    },
+);
+
+// Track the boundary's position relative to the window and latch it as seen the
+// moment it scrolls back into view after having been above — the reader clicking
+// the pill or scrolling up to the divider.
+watch([timelineRange, unreadIndex], ([range, index]) => {
+    if (!range || index < 0) {
+        return;
+    }
+
+    if (index < range.startIndex) {
+        unreadDividerWasAbove.value = true;
+    } else if (
+        unreadDividerWasAbove.value &&
+        isDividerVisible(index, range.startIndex, range.endIndex)
+    ) {
+        unreadDividerSeen.value = true;
+    }
+});
+
 // Show the floating "New messages" pill while the unread boundary sits above the
-// virtualizer's window. Windowing drops the off-screen divider from the DOM, so
-// this replaces the old IntersectionObserver with pure range math. Before the
-// first range lands the view is pinned to the bottom, so an existing boundary is
+// virtualizer's window and the reader hasn't reached it yet. Windowing drops the
+// off-screen divider from the DOM, so this replaces the old IntersectionObserver
+// with pure range math plus the per-visit seen latch. Before the first range
+// lands the view is pinned to the bottom, so an existing, unseen boundary is
 // necessarily above it.
 const showJumpToUnread = computed(() => {
     const range = timelineRange.value;
 
     if (!range) {
-        return unreadIndex.value >= 0;
+        return unreadIndex.value >= 0 && !unreadDividerSeen.value;
     }
 
     return shouldShowUnreadJump(
         unreadIndex.value,
         range.startIndex,
         range.endIndex,
+        unreadDividerSeen.value,
     );
 });
 
@@ -421,6 +464,14 @@ function scrollToUnread(): void {
     if (unreadIndex.value >= 0) {
         messageListRef.value?.scrollToIndex(unreadIndex.value, 'start');
     }
+}
+
+// Return to the newest message. Jumping to present counts as reaching the unread
+// boundary, so latch it — the reader is done with the "New messages" pill for
+// this visit even if the frozen divider now sits above the window again (#411).
+function jumpToPresent(): void {
+    unreadDividerSeen.value = true;
+    scrollToBottom(true);
 }
 
 // The day the topmost visible row falls in, driving the floating sticky date
@@ -1087,7 +1138,7 @@ function archive(): void {
                         :pinned-to-bottom="pinnedToBottom"
                         :new-message-count="newMessageCount"
                         @scroll="onScroll"
-                        @jump="scrollToBottom(true)"
+                        @jump="jumpToPresent"
                     >
                         <Transition
                             enter-active-class="transition duration-150 ease-out"

--- a/tests/Browser/TimelineUnreadPillTest.php
+++ b/tests/Browser/TimelineUnreadPillTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Message;
+use App\Models\User;
+
+/**
+ * Seed a channel with an unread boundary partway up a virtualized timeline: 30
+ * tall, alternating-author messages, with the owner's read pointer frozen at an
+ * early message so a long tail of peer messages is unread. The alternating
+ * authors keep every message its own avatar group (so a peer message always sits
+ * in the unread tail to anchor the "New messages" divider), and the long bodies
+ * make the list stand taller than the viewport so it virtualizes and the divider
+ * scrolls off-screen above the window.
+ *
+ * @return array{owner: User}
+ */
+function unreadCrowdedTimeline(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $authors = [$alice, $bob];
+    $body = str_repeat("lorem ipsum dolor sit amet\n", 3);
+
+    /** @var array<int, string> $messageIds */
+    $messageIds = [];
+
+    foreach (range(1, 30) as $i) {
+        $message = Message::factory()->create([
+            'channel_id' => $channel->id,
+            'user_id' => $authors[$i % 2]->id,
+            'body' => "Message {$i}\n{$body}",
+            'created_at' => now()->subMinutes(60 - $i),
+        ]);
+
+        $messageIds[$i] = $message->id;
+    }
+
+    // Freeze Alice's read pointer near the top so messages 6..30 are unread and
+    // the "New messages" divider sits well above the bottom-pinned window at open.
+    $channel->members()->updateExistingPivot($alice->id, [
+        'last_read_message_id' => $messageIds[5],
+    ]);
+
+    return ['owner' => $alice];
+}
+
+test('the New messages pill does not reappear after jumping to present', function (): void {
+    ['owner' => $alice] = unreadCrowdedTimeline();
+
+    $page = signInThroughBrowser($alice)->assertSee('Message 30');
+
+    // Let the initial open settle (it lands on the newest message, leaving the
+    // frozen unread divider above the window) before driving the pills.
+    $page->wait(1)
+        // On open the rose "New messages" pill shows: the unread boundary is above
+        // the bottom-pinned window.
+        ->assertPresent('[data-test=jump-to-unread]')
+        // Click it — the timeline scrolls the divider into view, so the pill hides
+        // and the boundary is latched as seen for this visit.
+        ->click('[data-test=jump-to-unread]')
+        ->wait(1)
+        ->assertNotPresent('[data-test=jump-to-unread]')
+        // Return to the present. The frozen divider now sits above the window
+        // again, but the reader has already seen it, so the pill must stay
+        // dismissed rather than reappearing (#411).
+        ->assertPresent('[data-test=jump-to-latest]')
+        ->click('[data-test=jump-to-latest]')
+        ->wait(2)
+        ->assertNotPresent('[data-test=jump-to-unread]');
+});


### PR DESCRIPTION
Implements two issues in one PR.

## `fix:` "New messages" pill lingers after Jump to present (#411)

The top-center rose **"New messages"** jump-to-unread pill derived its visibility purely from *"is the frozen unread divider above the rendered window"*, with no *already-seen* latch. So after the reader scrolled through the unread messages and hit **Jump to present**, the frozen divider sat above the window again and the pill reappeared — even though those messages had been seen.

**Fix:** a per-visit *seen* latch in `channels/Show.vue`, plumbed through the pure `shouldShowUnreadJump(...)` helper:
- The divider is latched **seen** once it scrolls back into view *after* having been above the window (the reader clicking the pill or scrolling up to it), or once the reader jumps to present.
- A `wasAbove` guard stops the initial pre-`scrollToBottom` render (rows start at the top, so the divider is briefly on screen at open) from latching it prematurely — the pill still shows on open.
- Both flags refreeze alongside the divider on every channel switch.

Covered by a `shouldShowUnreadJump` latch unit test and a Pest browser test (`TimelineUnreadPillTest`) that opens a channel with unread history, clicks the pill, jumps to present, and asserts the pill stays dismissed.

## `ci:` enforce the frontend format:check gate (#409)

`auth/Login.vue` failed local Sail's `format:check` while the `linter` workflow stayed green. Root cause was **not** a prettier version drift (the lockfile already pins `prettier@3.9.5` + `prettier-plugin-tailwindcss@0.8.0` identically for both) — it was that `lint.yml` ran the **auto-fixing write variant** `npm run format`, which always exits 0 and discarded its rewrites in the ephemeral runner (the auto-commit step was commented out). So CI never enforced the `format:check` gate that CLAUDE.md documents as required.

**Fix:** switch the Format step to `format:check` so CI enforces exactly what the local gate does, and reconcile `auth/Login.vue` to the config (collapse the SSO gate `<div>` onto one line).

The eslint step keeps running `npm run lint`: enforcing `lint:check` needs the quality job to first generate the gitignored Wayfinder `@/actions`/`@/routes` files, otherwise `import/order` mis-groups the unresolved imports and 74 CI-only errors surface. Deferred to #414.

Closes #411
Closes #409