### PR TITLE
ci: add security policy, CodeQL, and dependency-review scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,13 @@
+name: "CodeQL config"
+
+# The docs site (docs/) is a separate Astro/Starlight install with its own
+# node_modules and is excluded from every app quality gate; keep it out of the
+# CodeQL scan too so it neither breaks setup nor adds noise. Generated and
+# vendored code carry no first-party risk we can act on.
+paths-ignore:
+  - docs
+  - "**/node_modules"
+  - "**/vendor"
+  - "resources/js/generated"
+  - bootstrap/ssr
+  - public/build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+name: "CodeQL"
+
+# CodeQL static analysis for the JavaScript/TypeScript codebase (Inertia + Vue
+# frontend). PHP is not a CodeQL-supported language, so the backend relies on
+# PHPStan/Larastan, Rector, and Dependabot for its static-analysis and
+# dependency-vulnerability coverage instead.
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    branches:
+      - develop
+      - master
+  schedule:
+    # Weekly full scan (Mondays 07:00 UTC) so newly disclosed patterns are caught
+    # in code that has not changed since the last push.
+    - cron: "0 7 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload results to the code-scanning (Security) tab.
+      security-events: write
+      # Needed by CodeQL to read the workflow run on private repos; harmless here.
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,35 @@
+name: "Dependency review"
+
+# Blocks pull requests that introduce dependencies with a known advisory,
+# comparing the base and head of the PR against the GitHub Advisory Database.
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Allows the action to post its summary comment on the PR when it fails.
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ read **[CONTRIBUTING.md](CONTRIBUTING.md)** for the development setup, the quali
 gates (100% test coverage, Pint/PHPStan/Rector, and the frontend checks), the
 Conventional Commits convention, and the PR workflow.
 
+## Security
+
+Found a vulnerability? Please report it privately through GitHub's
+[private vulnerability reporting](https://github.com/emmpaul/the-desk/security/advisories/new)
+rather than opening a public issue. See **[SECURITY.md](SECURITY.md)** for the
+full policy, supported versions, and response timeline. The codebase is scanned
+continuously with CodeQL, dependency review, and Dependabot; findings surface in
+the [Security tab](https://github.com/emmpaul/the-desk/security).
+
 ## License
 
 The Desk is open source under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Security Policy
+
+The Desk is a self-hosted application, so most deployments run entirely under
+your own control. We still take security seriously and want reporting a problem
+to be straightforward and safe.
+
+## Supported versions
+
+The Desk ships from `master` with automated releases, so security fixes land in
+the next tagged release rather than being backported. Always run the most recent
+release to stay covered.
+
+| Version        | Supported |
+| -------------- | --------- |
+| Latest release | Yes       |
+| Older releases | No        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue, discussion, or pull request for a security
+vulnerability. Public disclosure before a fix is available puts every operator at
+risk.
+
+Report vulnerabilities privately through GitHub's **private vulnerability
+reporting**:
+
+1. Open the repository's [**Security** tab](https://github.com/emmpaul/the-desk/security).
+2. Click **Report a vulnerability**, or use the direct link:
+   [github.com/emmpaul/the-desk/security/advisories/new](https://github.com/emmpaul/the-desk/security/advisories/new).
+3. Describe the issue with enough detail to reproduce it: affected version, a
+   proof of concept or steps, and the impact you observed.
+
+Reports stay private between you and the maintainers until a fix is released.
+
+## What to expect
+
+We aim to respond to a report on the following timeline (best effort for a
+volunteer-maintained project):
+
+| Stage                          | Target             |
+| ------------------------------ | ------------------ |
+| Acknowledge your report        | Within 3 days      |
+| Initial assessment and triage  | Within 7 days      |
+| Fix and coordinated disclosure | Depends on severity and complexity |
+
+We follow **coordinated disclosure**: we will work with you on a fix, agree on a
+disclosure date, and credit you in the published advisory unless you prefer to
+stay anonymous. Please give us a reasonable window to ship a fix before disclosing
+publicly.
+
+## Scope
+
+In scope:
+
+- The application code in this repository (Laravel backend, Inertia + Vue
+  frontend, and the Reverb WebSocket server).
+- The production deployment assets in this repository (`docker-compose.prod.yml`,
+  the container image build, and the default configuration).
+
+Out of scope:
+
+- Vulnerabilities in third-party dependencies that already have a public advisory
+  and an available upgrade. Bump the dependency (Dependabot handles most of these
+  automatically) or open a regular issue instead.
+- Findings that require a misconfigured, out-of-date, or otherwise non-default
+  deployment (for example, running with `APP_DEBUG=true` in production, or exposing
+  internal services without a reverse proxy). See the
+  [self-hosting docs](https://the-desk.emmanuelpaul.com/docs/self-hosting/installation/)
+  for the recommended setup.
+- Social engineering, physical attacks, and denial-of-service testing against any
+  hosted instance you do not own.
+
+## Automated scanning
+
+This repository runs continuous security scanning so many classes of issue are
+caught before they ship:
+
+- **CodeQL** static analysis on every push and pull request, plus a weekly scan.
+- **Dependency review** on pull requests, which blocks known-vulnerable
+  dependencies from being introduced.
+- **Dependabot** security updates and secret scanning with push protection.
+
+Findings surface in the repository's **Security** tab.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
 						{ label: 'Architecture', slug: 'docs/reference/architecture' },
 						{ label: 'Feature toggles', slug: 'docs/reference/feature-toggles' },
 						{ label: 'Environment variables', slug: 'docs/reference/environment-variables' },
+						{ label: 'Security & compliance', slug: 'docs/reference/security' },
 					],
 				},
 			],

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -1,0 +1,50 @@
+---
+title: Security & compliance
+description: How to report a vulnerability in The Desk, and the automated security scanning that runs on every change.
+---
+
+The Desk is self-hosted, so you own the deployment and its data. This page covers
+how to report a security problem responsibly and what automated checks guard the
+codebase.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a security problem. Report it privately
+through GitHub's **private vulnerability reporting** instead:
+
+1. Open the [**Security** tab](https://github.com/emmpaul/the-desk/security) on the
+   repository.
+2. Click **Report a vulnerability**, or go straight to
+   [the advisory form](https://github.com/emmpaul/the-desk/security/advisories/new).
+3. Include the affected version, steps to reproduce, and the impact you observed.
+
+The report stays private between you and the maintainers until a fix is released.
+The full policy, including the response timeline, coordinated-disclosure
+expectations, and scope, lives in
+[SECURITY.md](https://github.com/emmpaul/the-desk/blob/master/SECURITY.md).
+
+## Automated scanning
+
+Every change to the repository runs through continuous security scanning, and all
+findings surface in the repository's **Security** tab:
+
+| Check                 | When it runs                              | What it does                                                              |
+| --------------------- | ----------------------------------------- | ------------------------------------------------------------------------- |
+| **CodeQL**            | Every push and pull request, plus weekly  | Static analysis of the JavaScript/TypeScript frontend for security bugs.  |
+| **Dependency review** | Every pull request                        | Blocks introducing a dependency that has a known advisory.                |
+| **Dependabot**        | Weekly, and on new advisories             | Opens PRs to update vulnerable or outdated dependencies.                  |
+| **Secret scanning**   | Continuous, with push protection          | Detects committed credentials and blocks pushes that contain them.        |
+
+:::note
+CodeQL does not support PHP, so the Laravel backend is covered by PHPStan
+(Larastan), Rector, and Dependabot rather than CodeQL. See the project's quality
+gates in the repository for details.
+:::
+
+## Hardening your deployment
+
+Most security outcomes for a self-hosted instance depend on how you run it. Follow
+the [installation](/docs/self-hosting/installation/) and
+[reverse proxy & TLS](/docs/self-hosting/reverse-proxy/) guides, keep
+`APP_DEBUG=false` in production, and stay on the
+[latest release](/docs/self-hosting/upgrading/) so you receive security fixes.


### PR DESCRIPTION
Part of the compliance-readiness epic (#417). Bundles two security-posture issues into one PR.

## #425 - SECURITY.md and vulnerability-disclosure policy
- Adds a root `SECURITY.md`: supported versions, private reporting via GitHub **private vulnerability reporting**, response/triage timeline, coordinated-disclosure expectations, and scope.
- Enabled GitHub **private vulnerability reporting** on the repo.
- Adds a **Security & compliance** docs page (+ sidebar entry) and links the policy from the README.
- No em dashes in the new copy (project preference).

## #426 - CodeQL and dependency scanning
- Adds a **CodeQL** workflow (JavaScript/TypeScript, `build-mode: none`) on push + PR to develop/master, plus a weekly schedule. A CodeQL config excludes the `docs/` Astro site and generated/vendored code so it neither breaks nor adds noise.
- Adds a **dependency-review** workflow blocking PRs that introduce a dependency with a known advisory (`fail-on-severity: high`).
- PHP is not a CodeQL-supported language, so the backend stays covered by PHPStan/Larastan, Rector, and Dependabot (noted in both the workflow and docs).
- Findings surface in the repository **Security** tab.

## Notes
- No app code touched (only `.github/`, `docs/`, `README.md`, `SECURITY.md`), so the app quality gates are unaffected. Docs site builds cleanly (`npm run build`).
- Non-bumping change per the repo's Conventional-Commit rules (`ci:`/`docs:` do not appear in the changelog or bump the version).

Closes #425
Closes #426