### PR TITLE
fix: move toast notifications to top-center so they don't obstruct the composer

### DIFF
--- a/resources/js/components/ui/sonner/Sonner.vue
+++ b/resources/js/components/ui/sonner/Sonner.vue
@@ -6,7 +6,12 @@ import { cn } from "@/lib/utils"
 
 import 'vue-sonner/style.css';
 
-const props = defineProps<ToasterProps>()
+// Default toasts to top-center so they never cover the bottom-anchored message
+// composer (send button, attachment/emoji actions, scheduled-message chip). Any
+// usage can still override `position` explicitly.
+const props = withDefaults(defineProps<ToasterProps>(), {
+  position: "top-center",
+})
 </script>
 
 <template>

--- a/tests/Browser/ToastPositionTest.php
+++ b/tests/Browser/ToastPositionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+// Toasts must render at top-center so they never cover the bottom-anchored
+// message composer (send button, attachment/emoji actions, scheduled-message
+// chip). vue-sonner exposes the resolved placement on the toaster region via
+// `data-y-position` / `data-x-position`.
+
+test('toasts render at top-center in the authenticated shell', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->assertAttribute('[data-sonner-toaster]', 'data-y-position', 'top')
+        ->assertAttribute('[data-sonner-toaster]', 'data-x-position', 'center');
+});
+
+test('toasts render at top-center on auth pages', function (): void {
+    visit('/login')
+        ->assertAttribute('[data-sonner-toaster]', 'data-y-position', 'top')
+        ->assertAttribute('[data-sonner-toaster]', 'data-x-position', 'center');
+});


### PR DESCRIPTION
## Summary

Toasts previously rendered in vue-sonner's default **bottom-right** position, where they overlapped the bottom-anchored message composer (send button, attachment/emoji actions, scheduled-message chip) and could block the user from acting. They now render at **top-center**, clear of those controls.

## Changes

- Default `position` to `top-center` in the shared `Sonner.vue` wrapper via `withDefaults`, so the placement is applied consistently in one place for both `MainLayout` and `AuthLayout` (any usage can still override `position` explicitly).
- Add `tests/Browser/ToastPositionTest.php` asserting the toaster region resolves to `top-center` (`data-y-position="top"`, `data-x-position="center"`) in the authenticated shell and on auth pages.

## Notes

- Top-center placement uses vue-sonner's default offset and sits above the transient "New messages" pill / update-available indicator without a persistent collision (toasts are ephemeral).
- CodeRabbit CLI review: no findings.

Closes #430