### PR TITLE
chore: seed compliance surfaces (security events, exports, SSO identities) in WorkspaceSeeder

### DIFF
--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -10,12 +10,17 @@ use App\Actions\Channels\SyncMentions;
 use App\Actions\Teams\CreateTeam;
 use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
+use App\Enums\SecurityEventType;
 use App\Enums\TeamRole;
+use App\Models\AuditExport;
 use App\Models\Channel;
 use App\Models\CustomEmoji;
+use App\Models\DataExport;
 use App\Models\Message;
 use App\Models\MessagePin;
 use App\Models\MessageReaction;
+use App\Models\SecurityEvent;
+use App\Models\SsoIdentity;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
@@ -206,6 +211,10 @@ class WorkspaceSeeder extends Seeder
         $this->seedDirectMessages($acme, $demo, $admin, $member1, $member2);
         $this->seedInvitations($acme, $demo);
         $this->seedAuditLog($acme, $demo, $admin, $member1, $announcements, $archived, $secret);
+        $this->seedSecurityEvents($demo);
+        $this->seedAuditExports($acme, $demo);
+        $this->seedDataExports($demo);
+        $this->seedSsoIdentities($demo);
         $this->seedAnalyticsHistory($acme, $members, [$general, $announcements, $random]);
 
         return $acme;
@@ -289,6 +298,74 @@ class WorkspaceSeeder extends Seeder
         $this->auditRecorder->record($team, $owner, AuditAction::ChannelArchived, $archived, [
             'channel_name' => $archived->name,
         ]);
+    }
+
+    /**
+     * Populate the demo user's security-activity log with a representative spread
+     * of event types, so the per-user (and admin-visible) security-event surface
+     * has data on load — including a `newDevice()` login so the "new device" flag
+     * renders.
+     *
+     * Passkey coverage is limited to the `PasskeyRegistered` event for now; a
+     * dedicated passkey model/factory is not yet on `master`, so seeding actual
+     * `passkeys` rows is deferred (see #419).
+     */
+    private function seedSecurityEvents(User $demo): void
+    {
+        $types = [
+            SecurityEventType::LoggedIn,
+            SecurityEventType::PasswordChanged,
+            SecurityEventType::TwoFactorEnabled,
+            SecurityEventType::TwoFactorConfirmed,
+            SecurityEventType::PasskeyRegistered,
+        ];
+
+        foreach ($types as $type) {
+            SecurityEvent::factory()->for($demo)->ofType($type)->create();
+        }
+
+        // A login from an unfamiliar device, so the "new device" flag surfaces.
+        SecurityEvent::factory()->for($demo)->newDevice()->create();
+    }
+
+    /**
+     * Seed audit-log export jobs for the demo user's owned team, covering both
+     * the audit and security (`security()`) variants in each terminal state —
+     * a ready-to-download row, an expired one, and a failed one — so the export
+     * history table shows every download/expiry/failure state. One ready export
+     * is emitted as JSON to exercise the `json()` state alongside the CSV rows.
+     */
+    private function seedAuditExports(Team $team, User $demo): void
+    {
+        AuditExport::factory()->for($team)->for($demo, 'requester')->ready()->create();
+        AuditExport::factory()->for($team)->for($demo, 'requester')->expired()->create();
+        AuditExport::factory()->for($team)->for($demo, 'requester')->failed()->create();
+
+        AuditExport::factory()->for($team)->for($demo, 'requester')->security()->json()->ready()->create();
+        AuditExport::factory()->for($team)->for($demo, 'requester')->security()->expired()->create();
+        AuditExport::factory()->for($team)->for($demo, 'requester')->security()->failed()->create();
+    }
+
+    /**
+     * Seed the demo user's self-service data exports: a `ready()` archive (its
+     * download button is live) plus an `expired()` one whose window has closed,
+     * so both the downloadable and expired rows render.
+     */
+    private function seedDataExports(User $demo): void
+    {
+        DataExport::factory()->for($demo)->ready()->create();
+        DataExport::factory()->for($demo)->expired()->create();
+    }
+
+    /**
+     * Link a couple of external directory identities to the demo user across
+     * providers (OIDC and LDAP), so the "connected accounts" surface is
+     * populated and exercises the `provider()` state.
+     */
+    private function seedSsoIdentities(User $demo): void
+    {
+        SsoIdentity::factory()->for($demo)->provider('oidc')->create();
+        SsoIdentity::factory()->for($demo)->provider('ldap')->create();
     }
 
     /**

--- a/tests/Feature/DatabaseSeederTest.php
+++ b/tests/Feature/DatabaseSeederTest.php
@@ -1,11 +1,18 @@
 <?php
 
+use App\Enums\AuditExportLogType;
+use App\Enums\AuditExportStatus;
 use App\Enums\ChannelType;
 use App\Enums\ChannelVisibility;
 use App\Enums\MessageType;
+use App\Enums\SecurityEventType;
 use App\Enums\TeamRole;
+use App\Models\AuditExport;
 use App\Models\Channel;
+use App\Models\DataExport;
 use App\Models\Message;
+use App\Models\SecurityEvent;
+use App\Models\SsoIdentity;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
@@ -167,6 +174,46 @@ test('it seeds direct messages covering the self, empty and excluded shapes', fu
     // A DM the demo is excluded from (between two other members).
     $excluded = $directChannels->first(fn (Channel $channel) => $channel->members()->whereKey($this->demo->id)->doesntExist());
     expect($excluded)->not->toBeNull();
+});
+
+test('it seeds a spread of security events for the demo user, including a new-device login', function (): void {
+    $events = $this->demo->securityEvents()->get();
+    $types = $events->pluck('type');
+
+    expect($events->count())->toBeGreaterThanOrEqual(5)
+        ->and($types)->toContain(SecurityEventType::LoggedIn)
+        ->and($types)->toContain(SecurityEventType::PasswordChanged)
+        ->and($types)->toContain(SecurityEventType::PasskeyRegistered)
+        ->and($events->contains(fn (SecurityEvent $event): bool => $event->type === SecurityEventType::LoggedIn
+            && $event->is_new_device))->toBeTrue();
+});
+
+test('it seeds audit exports for both log types across every terminal state', function (): void {
+    $acme = Team::where('name', 'Acme Corp')->firstOrFail();
+    $exports = AuditExport::where('team_id', $acme->id)->get();
+
+    foreach ([AuditExportLogType::Audit, AuditExportLogType::Security] as $logType) {
+        $forType = $exports->where('log_type', $logType);
+
+        expect($forType->contains(fn (AuditExport $export): bool => $export->isReady() && ! $export->isExpired()))->toBeTrue()
+            ->and($forType->contains(fn (AuditExport $export): bool => $export->isReady() && $export->isExpired()))->toBeTrue()
+            ->and($forType->contains(fn (AuditExport $export): bool => $export->status === AuditExportStatus::Failed))->toBeTrue();
+    }
+});
+
+test('it seeds ready and expired data exports for the demo user', function (): void {
+    $exports = $this->demo->dataExports()->get();
+
+    expect($exports->contains(fn (DataExport $export): bool => $export->isReady() && ! $export->isExpired()))->toBeTrue()
+        ->and($exports->contains(fn (DataExport $export): bool => $export->isExpired()))->toBeTrue();
+});
+
+test('it links sso identities to the demo user across providers', function (): void {
+    $identities = $this->demo->ssoIdentities()->get();
+
+    expect($identities->count())->toBeGreaterThanOrEqual(2)
+        ->and($identities->pluck('provider')->unique()->count())->toBeGreaterThan(1)
+        ->and(SsoIdentity::where('user_id', $this->demo->id)->exists())->toBeTrue();
 });
 
 test('it seeds pending, accepted and expired invitations across roles on an admin team', function (): void {


### PR DESCRIPTION
Closes #439. Part of #417.

## What
Extends `WorkspaceSeeder` so every compliance/security surface from epic #417 has data after a fresh `migrate:fresh --seed` — no manual generation to demo the features. Four new `seed*` helpers, all driven through the existing factories and their states:

- **`seedSecurityEvents`** — a spread of event types for the demo user (`LoggedIn`, `PasswordChanged`, `TwoFactorEnabled`, `TwoFactorConfirmed`, `PasskeyRegistered`) plus a `newDevice()` login so the "new device" flag surfaces.
- **`seedAuditExports`** — the audit and security (`security()`) variants in each terminal state: ready-to-download, expired, and failed (one ready row emitted as `json()` to exercise that state).
- **`seedDataExports`** — a `ready()` archive (download button live) plus an `expired()` one for the demo user.
- **`seedSsoIdentities`** — OIDC and LDAP identities linked to the demo user so "connected accounts" is populated.

## Why
Purely a dev-experience change (no user-facing behavior), so it ships as `chore:` — it won't appear in the changelog or bump the version.

## Notes
- **Passkeys (#419):** no passkey model/factory is on `master` yet, so actual `passkeys` rows are deferred; the `PasskeyRegistered` security event is seeded and the deferral is documented in `seedSecurityEvents`'s PHPDoc referencing #419.
- New helpers follow the existing `seed*` private-method + PHPDoc convention (mirroring `seedAuditLog` / `seedDirectMessages`) and use factory states, not raw inserts.

## Testing
- Added four assertions to `DatabaseSeederTest` covering the security-event spread + new-device login, audit exports across both log types and every terminal state, ready/expired data exports, and multi-provider SSO identities (TDD red → green).
- `./vendor/bin/sail composer test` green: Pint, PHPStan (0 errors), Rector (clean dry-run), 1198 tests, **100% coverage**.
- i18n / docs: no user-facing copy or operator-facing config touched.

Local CodeRabbit pass surfaced one minor finding (tighten the new-device assertion to a single `LoggedIn` event) — applied; a follow-up pass hit the free-tier rate limit, so leaning on the app review.