### PR TITLE
fix: add team-admin evidence group to the settings sidebar

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -117,6 +117,16 @@ class HandleInertiaRequests extends Middleware
             'canInviteToCurrentTeam' => fn () => $user?->currentTeam
                 ? $user->toTeamPermissions($user->currentTeam)->canCreateInvitation
                 : false,
+            // The settings sidebar surfaces a team-admin "evidence" group (Audit
+            // log, Security log, Exports) gated by the same permissions as the
+            // Team-settings cards, so an admin can jump straight to those surfaces
+            // from any settings page. Both default to false off a team / for guests.
+            'canViewCurrentTeamAudit' => fn (): bool => $user?->currentTeam
+                ? $user->toTeamPermissions($user->currentTeam)->canViewAudit
+                : false,
+            'canViewCurrentTeamSecurityLog' => fn (): bool => $user?->currentTeam
+                ? $user->toTeamPermissions($user->currentTeam)->canViewSecurityLog
+                : false,
             'invitableRoles' => TeamRole::assignable(),
             'channels' => fn (): array => $this->channelsForSidebar($request, $user),
             // The current team's members feed the DM entry points (the sidebar

--- a/resources/js/components/SettingsNav.vue
+++ b/resources/js/components/SettingsNav.vue
@@ -4,10 +4,13 @@ import type { LucideIcon } from '@lucide/vue';
 import {
     ArrowLeft,
     Database,
+    Download,
     Info,
     Languages,
     Palette,
+    ScrollText,
     Shield,
+    ShieldCheck,
     User,
     Users,
 } from '@lucide/vue';
@@ -30,6 +33,9 @@ import { edit as editLocale } from '@/routes/locale';
 import { edit as editProfile } from '@/routes/profile';
 import { edit as editSecurity } from '@/routes/security';
 import { index as teams } from '@/routes/teams';
+import { index as teamAudit } from '@/routes/teams/audit';
+import { index as teamAuditExports } from '@/routes/teams/audit-exports';
+import { index as teamSecurityLog } from '@/routes/teams/security-log';
 import type { NavItem } from '@/types';
 
 const page = usePage();
@@ -82,6 +88,52 @@ const navItems = computed<SettingsNavItem[]>(() => [
     },
 ]);
 
+// The team-admin "evidence" surfaces (Audit log, Security log, Exports) live
+// under the current team and are gated per-item by the same permissions as the
+// Team-settings cards. Members without either permission see none of them, so
+// the whole group collapses. Exports needs either permission, mirroring the card.
+const teamAdminNavItems = computed<SettingsNavItem[]>(() => {
+    const team = page.props.currentTeam;
+
+    if (!team) {
+        return [];
+    }
+
+    const items: SettingsNavItem[] = [];
+
+    if (page.props.canViewCurrentTeamAudit) {
+        items.push({
+            title: t('Audit log'),
+            href: teamAudit(team.slug),
+            icon: ScrollText,
+            slug: 'audit-log',
+        });
+    }
+
+    if (page.props.canViewCurrentTeamSecurityLog) {
+        items.push({
+            title: t('Security log'),
+            href: teamSecurityLog(team.slug),
+            icon: ShieldCheck,
+            slug: 'security-log',
+        });
+    }
+
+    if (
+        page.props.canViewCurrentTeamAudit ||
+        page.props.canViewCurrentTeamSecurityLog
+    ) {
+        items.push({
+            title: t('Exports'),
+            href: teamAuditExports(team.slug),
+            icon: Download,
+            slug: 'exports',
+        });
+    }
+
+    return items;
+});
+
 const { isCurrentOrParentUrl } = useCurrentUrl();
 </script>
 
@@ -112,6 +164,46 @@ const { isCurrentOrParentUrl } = useCurrentUrl();
                 <SidebarMenu>
                     <SidebarMenuItem
                         v-for="item in navItems"
+                        :key="toUrl(item.href)"
+                    >
+                        <SidebarMenuButton
+                            as-child
+                            :is-active="isCurrentOrParentUrl(item.href)"
+                            class="h-7.5 gap-2 rounded-[9px] px-2.5 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground data-[active=true]:bg-sidebar-primary data-[active=true]:font-medium data-[active=true]:text-sidebar-primary-foreground data-[active=true]:hover:bg-sidebar-primary data-[active=true]:hover:text-sidebar-primary-foreground"
+                        >
+                            <Link
+                                :href="item.href"
+                                :data-test="`settings-nav-${item.slug}`"
+                                :aria-current="
+                                    isCurrentOrParentUrl(item.href)
+                                        ? 'page'
+                                        : undefined
+                                "
+                            >
+                                <component :is="item.icon" class="size-3.25" />
+                                <span>{{ item.title }}</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
+            </SidebarGroupContent>
+        </SidebarGroup>
+
+        <!--
+            Team-admin evidence group: only rendered when the viewer can reach at
+            least one of Audit log / Security log / Exports for the current team.
+            The team name heads the group, mirroring the #421 design's team subnav.
+        -->
+        <SidebarGroup v-if="teamAdminNavItems.length > 0" class="pt-0">
+            <div
+                class="flex h-7 items-center px-2 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground uppercase"
+            >
+                {{ page.props.currentTeam?.name }}
+            </div>
+            <SidebarGroupContent>
+                <SidebarMenu>
+                    <SidebarMenuItem
+                        v-for="item in teamAdminNavItems"
                         :key="toUrl(item.href)"
                     >
                         <SidebarMenuButton

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -31,6 +31,8 @@ declare module '@inertiajs/core' {
             currentTeam: Team | null;
             teams: Team[];
             canInviteToCurrentTeam: boolean;
+            canViewCurrentTeamAudit: boolean;
+            canViewCurrentTeamSecurityLog: boolean;
             invitableRoles: RoleOption[];
             channels?: Channel[];
             teamMembers?: PersonRef[];

--- a/tests/Browser/SettingsNavTest.php
+++ b/tests/Browser/SettingsNavTest.php
@@ -2,29 +2,23 @@
 
 declare(strict_types=1);
 
-use App\Models\User;
-use Pest\Browser\Api\Webpage;
-
 /**
  * Open Settings from the workspace user menu (a client-side Inertia visit, so the
  * browser session survives), gating each step before asserting on the sidebar.
+ * Inlined per test — the fluent chain's runtime type is not worth pinning behind
+ * a helper (matching the settings navigation in A11yShellTest).
  */
-function visitSettings(User $user): Webpage
-{
-    return signInThroughBrowser($user)
+test('an admin reaches the team-evidence group from the settings sidebar', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
         ->click('@sidebar-menu-button')
         ->assertPresent('@settings-menu-item')
         // Let the dropdown settle past its open/pointer-grace window, otherwise
         // the item click can be swallowed and never navigate.
         ->wait(0.5)
         ->click('@settings-menu-item')
-        ->assertPathContains('/settings');
-}
-
-test('an admin reaches the team-evidence group from the settings sidebar', function (): void {
-    ['owner' => $alice] = browserTeamWithChannel();
-
-    visitSettings($alice)
+        ->assertPathContains('/settings')
         ->assertPresent('[data-test="settings-nav-audit-log"]')
         ->assertPresent('[data-test="settings-nav-security-log"]')
         ->assertPresent('[data-test="settings-nav-exports"]');
@@ -33,7 +27,12 @@ test('an admin reaches the team-evidence group from the settings sidebar', funct
 test('a plain member never sees the team-evidence group', function (): void {
     ['member' => $bob] = browserTeamWithChannel();
 
-    visitSettings($bob)
+    signInThroughBrowser($bob)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@settings-menu-item')
+        ->wait(0.5)
+        ->click('@settings-menu-item')
+        ->assertPathContains('/settings')
         // The personal Settings items still render for everyone...
         ->assertPresent('[data-test="settings-nav-profile"]')
         // ...but none of the admin-only evidence surfaces do.

--- a/tests/Browser/SettingsNavTest.php
+++ b/tests/Browser/SettingsNavTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Pest\Browser\Api\Webpage;
+
+/**
+ * Open Settings from the workspace user menu (a client-side Inertia visit, so the
+ * browser session survives), gating each step before asserting on the sidebar.
+ */
+function visitSettings(User $user): Webpage
+{
+    return signInThroughBrowser($user)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@settings-menu-item')
+        // Let the dropdown settle past its open/pointer-grace window, otherwise
+        // the item click can be swallowed and never navigate.
+        ->wait(0.5)
+        ->click('@settings-menu-item')
+        ->assertPathContains('/settings');
+}
+
+test('an admin reaches the team-evidence group from the settings sidebar', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    visitSettings($alice)
+        ->assertPresent('[data-test="settings-nav-audit-log"]')
+        ->assertPresent('[data-test="settings-nav-security-log"]')
+        ->assertPresent('[data-test="settings-nav-exports"]');
+});
+
+test('a plain member never sees the team-evidence group', function (): void {
+    ['member' => $bob] = browserTeamWithChannel();
+
+    visitSettings($bob)
+        // The personal Settings items still render for everyone...
+        ->assertPresent('[data-test="settings-nav-profile"]')
+        // ...but none of the admin-only evidence surfaces do.
+        ->assertMissing('[data-test="settings-nav-audit-log"]')
+        ->assertMissing('[data-test="settings-nav-security-log"]')
+        ->assertMissing('[data-test="settings-nav-exports"]');
+});

--- a/tests/Feature/Settings/SettingsNavTest.php
+++ b/tests/Feature/Settings/SettingsNavTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * The settings sidebar surfaces a team-admin "evidence" group (Audit log,
+ * Security log, Exports). Its visibility rides on two shared Inertia props,
+ * gated by the same permissions as the Team-settings cards. These tests pin
+ * that gating so an admin can reach the surfaces while a plain member cannot.
+ */
+test('an admin sees the team-evidence permissions on every settings page', function (): void {
+    $owner = User::factory()->create();
+    app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)
+        ->get(route('profile.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('canViewCurrentTeamAudit', true)
+            ->where('canViewCurrentTeamSecurityLog', true)
+        );
+});
+
+test('a plain member sees no team-evidence permissions', function (): void {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $member = User::factory()->create();
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+    $member->switchTeam($team);
+
+    $this->actingAs($member)
+        ->get(route('profile.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('canViewCurrentTeamAudit', false)
+            ->where('canViewCurrentTeamSecurityLog', false)
+        );
+});
+
+test('a personal team exposes no team-evidence permissions', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('profile.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('canViewCurrentTeamAudit', false)
+            ->where('canViewCurrentTeamSecurityLog', false)
+        );
+});


### PR DESCRIPTION
Closes #440.

## What

The audit/security **Exports** UI (shipped in #438) was reachable only by drilling into Team settings and clicking a card. This adds a gated **team-admin evidence group** to the settings sidebar (`SettingsNav.vue`) — **Audit log**, **Security log**, and **Exports** — so an admin can jump straight there from any settings page, matching the #421 design's team subnav (team name heads the group).

## Why the group (not Exports-only)

The #421 design (`Audit Export.dc.html`) draws all three surfaces in the team subnav, noting Exports "lives as a fourth item in the team subnav next to the two log views it exports." A sidebar shortcut to *export* the logs but not to *view* them would be odd, so the group is the faithful choice (the issue explicitly allowed it).

## How

- **Backend:** two new shared Inertia props in `HandleInertiaRequests`, mirroring the existing `canInviteToCurrentTeam` pattern — `canViewCurrentTeamAudit` / `canViewCurrentTeamSecurityLog`, computed from `toTeamPermissions($user->currentTeam)`. Both default to `false` off a team / for guests.
- **Frontend:** `SettingsNav.vue` renders a second, team-name-headed `SidebarGroup`. Each item is gated per-permission (Audit log → `canViewCurrentTeamAudit`; Security log → `canViewCurrentTeamSecurityLog`; Exports → either, matching the card). The whole group collapses for members without either permission. Reuses the existing `SidebarMenuButton` styling, icons (`ScrollText` / `ShieldCheck` / `Download`) and Wayfinder routes; active-state highlighting via the existing `isCurrentOrParentUrl` + `aria-current`.

## i18n

All labels reuse existing keys already present in `lang/fr.json` (`Audit log`, `Security log`, `Exports`) via `t()`; `data-test` slugs (`settings-nav-audit-log` / `-security-log` / `-exports`) stay untranslated. No new keys needed.

## Testing

- **Feature** (`tests/Feature/Settings/SettingsNavTest.php`): the two shared props are `true` for an admin/owner, `false` for a plain member, `false` on a personal team.
- **Browser** (`tests/Browser/SettingsNavTest.php`): the evidence group is present for an admin and absent for a plain member; verified active-state highlighting on the Exports route (`aria-current="page"`) during development.
- Full gate green: Pint / PHPStan / Rector clean, **1197 tests pass at 100% coverage**; frontend `lint:check` / `format:check` / `types:check` / `build` all pass.

No operator-facing config/toggle change, so no docs update required.

_Local CodeRabbit pass was rate-limited (free tier); relying on the PR review._