### PR TITLE
fix: derive seeded message ids from created_at so the timeline never flakes

### DIFF
--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -554,9 +554,17 @@ class WorkspaceSeeder extends Seeder
 
         for ($index = 0; $index < $count; $index++) {
             $author = $authors[$index % count($authors)];
+            $createdAt = now()->subMinutes($count - $index);
 
             $messages[] = Message::factory()->for($channel)->for($author)->create([
-                'created_at' => now()->subMinutes($count - $index),
+                // Derive the UUIDv7 id from this row's back-dated `created_at` (as the
+                // real send path and `backfillChannelHistory()` do) rather than taking
+                // the trait's wall-clock default. Otherwise a message stamped "now"
+                // could rank ahead of a later `created_at` when the seed run straddles a
+                // time boundary, making `id DESC` disagree with `created_at DESC` — the
+                // intermittent timeline-ordering flake behind #447 and #448.
+                'id' => (string) Str::uuid7($createdAt),
+                'created_at' => $createdAt,
             ]);
         }
 

--- a/tests/Feature/DatabaseSeederTest.php
+++ b/tests/Feature/DatabaseSeederTest.php
@@ -17,6 +17,7 @@ use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use Database\Seeders\WorkspaceSeeder;
+use Ramsey\Uuid\Uuid;
 
 beforeEach(function (): void {
     $this->seed();
@@ -114,6 +115,26 @@ test('backfilled messages carry time-ordered ids so a newly sent message sorts n
     $sent = Message::factory()->for($busiest)->for($this->demo)->create();
 
     expect($busiest->messages()->orderByDesc('id')->value('id'))->toBe($sent->id);
+});
+
+test('every seeded message derives its UUIDv7 id from its own created_at, never wall-clock seed time', function (): void {
+    // Root cause of the #447/#448 flake: a back-dated message that takes a
+    // wall-clock UUIDv7 id (stamped at seed time) instead of one derived from its
+    // `created_at` ranks by "now", so `id DESC` can disagree with `created_at DESC`
+    // whenever the seed run straddles a time boundary. Assert the invariant the
+    // timeline depends on — each id's embedded timestamp matches its own row's
+    // `created_at` (to the second) — across the busiest channel's whole history.
+    $busiest = Channel::withCount('messages')->orderByDesc('messages_count')->firstOrFail();
+
+    $busiest->messages()->get(['id', 'created_at'])->each(function (Message $message): void {
+        $uuid = Uuid::fromString($message->id);
+
+        // The id must be a UUIDv7 for its embedded timestamp to be meaningful — a
+        // random v4 would carry no `created_at` and break the time-ordered timeline.
+        expect($uuid->getVersion())->toBe(7);
+
+        expect(abs($uuid->getDateTime()->getTimestamp() - $message->created_at->getTimestamp()))->toBeLessThanOrEqual(1);
+    });
 });
 
 test('it seeds edited, soft-deleted and mention-bearing messages', function (): void {


### PR DESCRIPTION
Closes #447. Closes #448.

## Problem

`DatabaseSeederTest`'s timeline-ordering assertions (`id DESC` should equal `created_at DESC` for the busiest channel) flake intermittently in CI. Both issues are the **same root cause**: `WorkspaceSeeder::seedMessages()` back-dates each message's `created_at` (`now()->subMinutes(...)`) but lets the id fall through to the `HasUuids` default, which is `Str::uuid7()` at **real wall-clock time**. The recent messages' ids therefore encode the seed-run instant, not their `created_at`. When a seed run straddles a time boundary and two ids collide within a millisecond, the random tail can order them against the `created_at` spread, so `id DESC` disagrees with `created_at DESC` and the strict `toBe` fails (~1 failure per full run).

`backfillChannelHistory()` already derives its ids from `created_at`; `seedMessages()` was the one path that didn't.

## Fix

Derive the id from `created_at` in `seedMessages()` (`Str::uuid7($createdAt)`), matching `backfillChannelHistory()` and the real send path. `id DESC` and `created_at DESC` can no longer disagree, regardless of when the seed run lands.

## Testing

Added a deterministic test asserting every message in the busiest channel carries a **UUIDv7** id whose embedded timestamp matches its own `created_at` (to the second) — the invariant the timeline depends on. It fails reliably against the old seeder (id timestamp hundreds of seconds off `created_at`) and passes with the fix, so the flake is now caught deterministically rather than by chance.

- `./vendor/bin/sail composer test` — green, `Total: 100.0 %` (Pint + PHPStan + Rector + coverage).
- No i18n or docs impact (test/seeder only, no user-facing copy or operator settings).

## Notes

- Local CodeRabbit flagged narrowing the parsed id to `UuidV7` before `getDateTime()`. Its verbatim suggestion (`toBeInstanceOf(UuidV7::class)`) would fail — ramsey 4.x `Uuid::fromString()` returns a `LazyUuidFromString`, not a concrete `UuidV7` — so I honored the intent with the working `getVersion()` API instead. A follow-up re-review hit the free-tier rate limit; the app's PR review will cover it.