### PR TITLE
test: keep browser-suite sessions alive across the per-test app refresh

### DIFF
--- a/tests/Browser/A11yAuditTest.php
+++ b/tests/Browser/A11yAuditTest.php
@@ -85,6 +85,11 @@ test('the unread jump-to-unread pill has no serious accessibility violations in 
     $page = signInThroughBrowser($alice)
         ->assertSee('Anchor message');
 
+    // Let the initial open settle first: it anchors on the unread divider (pill
+    // hidden, boundary on-screen), and that scroll animation would otherwise
+    // override the programmatic scroll below and leave the divider in view.
+    $page->wait(1);
+
     // The channel opens anchored on the unread divider, which keeps the pill
     // hidden (the boundary is on-screen). Scroll the message-history region to the
     // bottom so the virtualizer drops the divider off the top of its window — the
@@ -97,7 +102,7 @@ test('the unread jump-to-unread pill has no serious accessibility violations in 
     }
     JS);
 
-    $page->wait(0.5)
+    $page->wait(1)
         ->assertPresent('[data-test="jump-to-unread"]')
         ->assertNoAccessibilityIssues();
 

--- a/tests/Browser/Helpers.php
+++ b/tests/Browser/Helpers.php
@@ -12,6 +12,7 @@ use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Illuminate\Foundation\Http\Kernel;
 use Pest\Browser\Api\AwaitableWebpage;
 use Tests\Browser\Support\ForgetGuardsPerRequest;
+use Tests\Browser\Support\PersistentArraySession;
 
 /**
  * Point broadcasting at a real Reverb server for the duration of a browser test.
@@ -56,6 +57,13 @@ function useReverbForBrowserTests(): void
     if ($kernel instanceof Kernel && ! $kernel->hasMiddleware(ForgetGuardsPerRequest::class)) {
         $kernel->prependMiddleware(ForgetGuardsPerRequest::class);
     }
+
+    // TestCase rebuilds the application (and the `array` driver's in-memory session
+    // store) before each test, but the browser keeps firing asynchronous requests
+    // that can land after the rebuild and load an empty session — bouncing the page
+    // to /login mid-test. Pin one handler that survives the refresh so a signed-in
+    // browser stays signed in for the life of its test.
+    PersistentArraySession::attach();
 }
 
 /**

--- a/tests/Browser/Support/PersistentArraySession.php
+++ b/tests/Browser/Support/PersistentArraySession.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Browser\Support;
+
+use Illuminate\Session\ArraySessionHandler;
+
+/**
+ * Pin one `array` session handler that outlives the per-test application refresh.
+ *
+ * The pest browser server (Pest\Browser\Drivers\LaravelHttpServer) serves every
+ * request from a single long-lived process, but Laravel's TestCase rebuilds the
+ * application — and with it the `array` driver's in-memory session store — before
+ * each test. The browser keeps firing asynchronous requests (echo channel auth,
+ * the timeline's mark-as-read, Inertia partial reloads) that can land after the
+ * store was rebuilt. Those requests then load an empty session, resolve as a
+ * guest, and Inertia follows the resulting `302 → /login` by navigating the whole
+ * page to the login screen — failing whichever test is mid-assertion. This is the
+ * flake behind the intermittent "…on the page initially with the url […/login]"
+ * browser-suite failures.
+ *
+ * Reattaching a single handler that survives the refresh keeps every session id
+ * ever issued resolvable no matter which application instance handles the request,
+ * so a signed-in browser stays signed in for the life of its test. Session ids are
+ * regenerated on every login, so carrying prior tests' data forward is inert.
+ *
+ * This is browser-test-only: the helper is called from each browser test's setup
+ * (see tests/Browser/Helpers.php), so it never touches the production stack.
+ */
+final class PersistentArraySession
+{
+    private static ?ArraySessionHandler $handler = null;
+
+    /**
+     * Point the freshly rebuilt session store at the shared, refresh-surviving handler.
+     */
+    public static function attach(): void
+    {
+        self::$handler ??= new ArraySessionHandler((int) config('session.lifetime', 120));
+
+        app('session')->driver()->setHandler(self::$handler);
+    }
+}


### PR DESCRIPTION
## Problem

The `browser` CI job flakes intermittently, failing a random test with:

> Expected element `[…]` to be present in the DOM on the page **initially with the url [http://…/login]** …

It has been taking down unrelated PRs (e.g. #454, #455) even though their changes are nowhere near the failing tests.

## Root cause

The pest browser plugin serves every request from a **single long-lived process** (`Pest\Browser\Drivers\LaravelHttpServer`), but Laravel's `TestCase` rebuilds the application — and with it the `array` session driver's in-memory store — **before each test**.

Meanwhile the browser keeps firing asynchronous requests (echo channel auth, the timeline's mark-as-read, Inertia partial reloads). When one lands just after a rebuild it loads an **empty session**, resolves as a **guest**, and Inertia follows the resulting `302 → /login` by navigating the whole page to the login screen — failing whichever test happens to be mid-assertion. Instrumenting `ForgetGuardsPerRequest` confirmed a just-authenticated session id loading back with its login key gone (`sessUser=none`), across 51 distinct app/handler instances in one run.

The "…url […/login]" in the message is often the page's *initial* visit url, which is why the failures look like they touch different tests each run.

## Fix

- **`PersistentArraySession`** — pin one `array` session handler that survives the per-test app refresh, so any already-issued session id stays resolvable no matter which application instance handles the request. Session ids are regenerated on every login, so carrying prior tests' data forward is inert. Attached from `useReverbForBrowserTests()` (every browser test's `beforeEach`).
- **`A11yAuditTest`** (jump-to-unread) — a separate pre-existing flake: the test scrolled immediately after sign-in, racing the timeline's open-anchor animation so the scroll-to-bottom didn't stick and the pill never appeared. Let the open settle first, mirroring the reliable `TimelineUnreadPillTest` pattern.

## Verification

Full `tests/Browser` suite run locally through Sail (Reverb + Postgres, `--ci`):

- **Before:** failed ~every run on a rotating victim (A11ySearch, jump-to-unread, timeline, …).
- **After:** 4/4 clean runs, 51 passed. The hardened jump-to-unread test: 5/5 in isolation (was ~2/3).

Test-only change (everything under `tests/`) — no product code, coverage/PHPStan/vue-tsc gates unaffected.

## Follow-up for #454 and #455

Both branch off the same `master`; rebase them onto master once this merges and their `browser` job goes green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser test stability by preserving session state during asynchronous requests.
  * Reduced intermittent redirects to the login page during browser testing.
  * Improved accessibility test reliability by allowing unread indicators to fully appear before validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->