### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/resources/js/theme/designTokens.test.ts
+++ b/resources/js/theme/designTokens.test.ts
@@ -11,9 +11,13 @@ const viteConfig = readFileSync(`${repoRoot}/vite.config.ts`, 'utf8');
  * Guards the "The Desk" foundation contract: components consume these tokens, so a
  * regression in a value silently reskins the whole app.
  */
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function tokenValue(selector: string, property: string): string | null {
     const block = appCss.match(
-        new RegExp(`${selector.replace('.', '\\.')}\\s*\\{([\\s\\S]*?)\\}`),
+        new RegExp(`${escapeRegExp(selector)}\\s*\\{([\\s\\S]*?)\\}`),
     );
 
     if (block === null) {
@@ -21,7 +25,7 @@ function tokenValue(selector: string, property: string): string | null {
     }
 
     const declaration = block[1].match(
-        new RegExp(`${property.replace(/[-]/g, '\\$&')}:\\s*([^;]+);`),
+        new RegExp(`${escapeRegExp(property)}:\\s*([^;]+);`),
     );
 
     return declaration === null ? null : declaration[1].trim();


### PR DESCRIPTION
Potential fix for [https://github.com/emmpaul/the-desk/security/code-scanning/1](https://github.com/emmpaul/the-desk/security/code-scanning/1)

Use complete regex-escaping for any string interpolated into `new RegExp(...)`.  
The best fix here is to add a small helper that escapes **all** regex metacharacters (including backslash), then use it for both `selector` and `property` instead of partial ad-hoc replacements.

In `resources/js/theme/designTokens.test.ts`:
- Add a helper function near `tokenValue`:
  - `escapeRegExp(value: string): string`
  - implementation: `value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`
- Update line building the selector regex to use `escapeRegExp(selector)`.
- Update line building the declaration regex to use `escapeRegExp(property)`.

This preserves existing behavior while making regex construction correct for all inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
