### PR TITLE
fix: trust the reverse proxy's X-Forwarded-Proto so URLs use https behind TLS

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -26,6 +26,22 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        // Behind a TLS-terminating reverse proxy the container receives plain
+        // HTTP, so trust the proxy's X-Forwarded-* headers — otherwise
+        // $request->isSecure() is false and every absolute URL Laravel generates
+        // (route(), redirect()->route(), Fortify redirects, mail links) comes out
+        // http:// on an https:// page and the browser blocks it as mixed content.
+        // '*' trusts the calling proxy, which is safe for this stack: the app
+        // publishes to loopback / the compose network and is only reachable
+        // through the proxy that sets these headers.
+        $middleware->trustProxies(
+            at: '*',
+            headers: Request::HEADER_X_FORWARDED_FOR
+                | Request::HEADER_X_FORWARDED_HOST
+                | Request::HEADER_X_FORWARDED_PORT
+                | Request::HEADER_X_FORWARDED_PROTO,
+        );
+
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 
         $middleware->web(append: [

--- a/docs/src/content/docs/docs/self-hosting/reverse-proxy.md
+++ b/docs/src/content/docs/docs/self-hosting/reverse-proxy.md
@@ -16,10 +16,12 @@ If your proxy runs **inside** the compose network instead (e.g. a Caddy containe
 on the same network), target the service names `app:8080` / `reverb:8080` and you
 don't need any host publishing at all.
 
-> **HTTPS URLs:** the app must trust your proxy's `X-Forwarded-Proto` header, or it
-> generates `http://` links on an `https://` page and the browser blocks them as
-> mixed content (login/registration break). Make sure your proxy forwards the
-> standard `X-Forwarded-*` headers.
+> **HTTPS URLs:** the app trusts your proxy's `X-Forwarded-*` headers out of the
+> box, so it generates `https://` links from a `X-Forwarded-Proto: https` request.
+> You only need your proxy to **forward those headers** — Caddy and Traefik do
+> automatically; the nginx example below sets `X-Forwarded-Proto`. Without them the
+> app would emit `http://` links on an `https://` page and the browser blocks them
+> as mixed content (login/registration break).
 
 The single hard requirement beyond normal HTTPS termination is that your proxy
 **forwards WebSocket upgrade requests** to Reverb. Without it, the app loads but

--- a/tests/Feature/TrustsReverseProxyTest.php
+++ b/tests/Feature/TrustsReverseProxyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+test('honors the proxy X-Forwarded-Proto so absolute URLs are https', function (): void {
+    // A guest hitting an auth-guarded route is redirected to an absolute login
+    // URL, so the redirect scheme reflects how the app perceives the request.
+    // Without trusting the proxy this comes out http:// on an https:// page and
+    // the browser blocks it as mixed content.
+    $response = $this->get('/t/example-team', ['X-Forwarded-Proto' => 'https']);
+
+    $response->assertRedirect();
+    expect($response->headers->get('Location'))->toStartWith('https://');
+});
+
+test('generates http URLs when the request is not a forwarded https one', function (): void {
+    $response = $this->get('/t/example-team');
+
+    $response->assertRedirect();
+    expect($response->headers->get('Location'))->toStartWith('http://');
+});


### PR DESCRIPTION
## Problem

Deploying v1.5.0 behind a TLS-terminating reverse proxy, `/register` (loaded over HTTPS) throws:

```
Mixed Content: The page at 'https://…/register' was loaded over HTTPS, but requested an
insecure XMLHttpRequest endpoint 'http://…/t/emmanuel-pauls-team'. This request has been blocked…
HttpNetworkError: Network error
```

The proxy terminates HTTPS and forwards **plain HTTP** to the FrankenPHP container, so Laravel sees the request as `http` and generates absolute `http://` URLs (redirects, Fortify redirects, Wayfinder/Inertia targets, mail links). The browser blocks them as mixed content and registration/login break.

## Root cause

`bootstrap/app.php` never called `trustProxies`, so Laravel ignored the proxy's `X-Forwarded-Proto` header — even though [`reverse-proxy.md`](docs/src/content/docs/docs/self-hosting/reverse-proxy.md) already tells operators to forward it and the nginx example sets it. The docs described a behavior the code didn't implement.

## Fix

Trust the proxy's `X-Forwarded-*` headers in `bootstrap/app.php`:

```php
$middleware->trustProxies(
    at: '*',
    headers: Request::HEADER_X_FORWARDED_FOR
        | Request::HEADER_X_FORWARDED_HOST
        | Request::HEADER_X_FORWARDED_PORT
        | Request::HEADER_X_FORWARDED_PROTO,
);
```

`at: '*'` (trust the calling proxy) is safe for this stack: the app publishes to loopback / the compose network and is only reachable through the proxy that sets these headers. This fixes every absolute URL at the source — `isSecure()`, `route()`, redirects, and mail links.

## Tests

New `tests/Feature/TrustsReverseProxyTest.php`:
- with `X-Forwarded-Proto: https`, a guest redirect to the absolute login URL is `https://`
- without it, the URL stays `http://`

## Docs

Updated the reverse-proxy HTTPS note to state the app trusts `X-Forwarded-*` out of the box; operators only need to forward the headers.

Full backend gate green (Pint, PHPStan, Rector, Pest 100% coverage); docs site builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for deployments behind reverse proxies, including correct HTTPS URL and redirect generation.

* **Documentation**
  * Updated reverse-proxy setup guidance to explain forwarded header requirements.

* **Tests**
  * Added coverage verifying HTTPS redirects when proxy headers are present and HTTP redirects when they are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->