### PR TITLE
fix: default the prod compose stack to the prebuilt image so up -d never builds

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -10,6 +10,9 @@
 # values, which the app serves to the frontend at boot. Changing any of them
 # only requires a container restart, never an image rebuild, so the same image
 # works for any host.
+#
+# `up -d` pulls the prebuilt image pinned in docker-compose.prod.yml (no build).
+# Set APP_IMAGE to override the tag, e.g. APP_IMAGE=ghcr.io/emmpaul/the-desk:edge.
 # =============================================================================
 
 APP_NAME="The Desk"

--- a/README.md
+++ b/README.md
@@ -135,15 +135,12 @@ The production stack is orchestrated with `docker-compose.prod.yml`. The app is
 served with [FrankenPHP](https://frankenphp.dev/); Postgres, Meilisearch, Reverb,
 a queue worker, and the scheduler all run as containers.
 
-There are two supported ways to get the app image, both driven by the same
-`.env`:
-
-- **Pull the prebuilt image** from the GitHub Container Registry
-  (`ghcr.io/emmpaul/the-desk`) — no build step. Every setting, including the
-  browser-facing Reverb values, is read at **runtime**, so one published image
-  works for any host. See [Using the published image](#using-the-published-image).
-- **Build from source** at a release tag — clone the repo, check out a tag, and
-  `--build`. See [First install](#first-install).
+By default the stack **pulls a prebuilt image** from the GitHub Container Registry
+(`ghcr.io/emmpaul/the-desk`), so `up -d` runs it with no build step. Every setting,
+including the browser-facing Reverb values, is read at **runtime**, so one
+published image works for any host. If you would rather **build from source**, a
+one-line overlay restores a local build — see
+[Building from source](#building-from-source).
 
 ### Prerequisites
 
@@ -174,8 +171,8 @@ git checkout v1.5.0 # x-release-please-version         (the desired release tag)
 #    REVERB_SCHEME_PUBLIC=https. These are read at runtime (a restart applies
 #    changes), so no rebuild is needed when they change.
 
-# 4. Build the images and start the stack.
-docker compose -f docker-compose.prod.yml up -d --build
+# 4. Start the stack. This pulls the release-pinned image — no build step.
+docker compose -f docker-compose.prod.yml up -d
 ```
 
 Migrations run automatically on start (the `app` container's entrypoint runs
@@ -214,14 +211,14 @@ Registration is open, so onboarding is self-service:
 ### Upgrading
 
 Upgrades follow the same tag-based flow. Check out the newer release tag and
-rebuild:
+restart — `up -d` pulls the image that tag pins:
 
 ```bash
 git fetch --tags
 git checkout v1.5.0 # x-release-please-version         (the desired release tag)
 docker compose -f docker-compose.prod.yml down
-docker compose -f docker-compose.prod.yml up -d --build
-# migrations run automatically via the entrypoint
+docker compose -f docker-compose.prod.yml up -d
+# pulls the newer pinned image; migrations run automatically via the entrypoint
 ```
 
 Your data persists across `down`/`up` in named volumes (`pgsql-data`,
@@ -238,32 +235,25 @@ Your data persists across `down`/`up` in named volumes (`pgsql-data`,
 > corresponding [GitHub Release notes](https://github.com/emmpaul/the-desk/releases)
 > for required manual steps.
 
-### Using the published image
+### Building from source
 
 Each release publishes a prebuilt image to the GitHub Container Registry at
 `ghcr.io/emmpaul/the-desk` (tags `X.Y.Z`, `X.Y`, and `latest`; `edge` tracks the
-tip of `master`). Because the app name and the browser-facing Reverb settings are
-served to the frontend at **runtime** — not baked into the JavaScript bundle at
-build time — the same image works for any operator's host with no rebuild. Point
-it at your `.env` and go:
+tip of `master`), and the [First install](#first-install) steps above pull it. If
+you would rather build the image yourself — to audit or patch the source, or to
+run in an air-gapped environment — layer the build overlay
+(`docker-compose.build.yml`) on top. It restores a local build for the app
+services (they share one image):
 
 ```bash
-# 1. Grab the compose file, env template, and secret generator from a release tag.
-git clone git@github.com:emmpaul/the-desk.git
-cd the-desk
-git fetch --tags && git checkout v1.5.0 # x-release-please-version   (the desired release tag)
-
-# 2. Generate .env secrets, then edit APP_URL, mail, and REVERB_*_PUBLIC (see below).
-./docker/gen-secrets.sh
-
-# 3. Run the published image instead of building. Pin the version to the tag.
-echo 'APP_IMAGE=ghcr.io/emmpaul/the-desk:1.5.0' >> .env # x-release-please-version
-docker compose -f docker-compose.prod.yml pull
-docker compose -f docker-compose.prod.yml up -d
+# Check out the matching release tag first so the build matches the compose file,
+# then run gen-secrets.sh and edit .env exactly as in First install.
+docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
 ```
 
-`docker compose pull` fetches the prebuilt image; `up -d` runs it without a build
-step. Upgrades are just `APP_IMAGE=…:X.Y.Z`, then `pull` + `up -d` again.
+Everything else — secrets, `.env`, and the automatic migrations — is identical to
+the pull flow. To go back to the published image, drop the overlay and `up -d`
+again.
 
 > **Reverb settings are runtime, so mind the browser vs. server split.** The
 > container speaks plain `http` on `8080` (`REVERB_PORT` / `REVERB_SCHEME`), but

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,25 @@
+# Opt-in overlay that builds the app image from source instead of pulling the
+# published one. Layer it on top of the production stack:
+#
+#   git fetch --tags && git checkout vX.Y.Z
+#   docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
+#
+# It restores a local `build:` for the four app-role services (they share one
+# image) and retags it to a local tag so the build never masquerades as the
+# registry image. Everything else (Postgres, Meilisearch, Redis, ports, volumes)
+# comes from docker-compose.prod.yml unchanged.
+
+x-build: &build
+  build:
+    context: .
+  image: the-desk:latest
+
+services:
+  app:
+    <<: *build
+  reverb:
+    <<: *build
+  queue:
+    <<: *build
+  scheduler:
+    <<: *build

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,10 @@
-# Production stack for self-hosting. Build-from-source at a release tag:
+# Production stack for self-hosting. Pull the prebuilt image and start it:
 #
 #   git fetch --tags && git checkout vX.Y.Z
-#   docker compose -f docker-compose.prod.yml up -d --build
+#   docker compose -f docker-compose.prod.yml up -d   # pulls the image, no build
+#
+# To build the app image from source instead, layer the build overlay on top:
+#   docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
 #
 # Development uses Laravel Sail (compose.yaml) — this file does not replace it.
 #
@@ -23,15 +26,16 @@
 # it being healthy before it starts.
 
 x-app: &app
-  # Defaults to the local build tag (build-from-source). Set APP_IMAGE to the
-  # published image to run the prebuilt turnkey image instead:
-  # `docker compose -f docker-compose.prod.yml pull` then `up -d`, no build step.
-  # Browser Reverb settings are read at runtime, so one published image works for
-  # any host. Example pin:
-  #   APP_IMAGE=ghcr.io/emmpaul/the-desk:1.5.0 # x-release-please-version
-  image: ${APP_IMAGE:-the-desk:latest}
-  build:
-    context: .
+  # Runs the prebuilt turnkey image from the GitHub Container Registry — `up -d`
+  # pulls it, no build step. The default pins the image to this release, so a
+  # checkout of vX.Y.Z runs exactly that version; set APP_IMAGE to run a different
+  # tag (e.g. `edge`, or an older release). Browser Reverb settings are read at
+  # runtime, so one published image works for any host.
+  #
+  # To build from source instead, add the build overlay (docker-compose.build.yml)
+  # which restores a local build for these services:
+  #   docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
+  image: ${APP_IMAGE:-ghcr.io/emmpaul/the-desk:1.5.0} # x-release-please-version
   env_file:
     - .env
   restart: unless-stopped

--- a/docs/src/content/docs/docs/reference/architecture.md
+++ b/docs/src/content/docs/docs/reference/architecture.md
@@ -5,7 +5,11 @@ description: What runs in the production stack and why — the web app, Reverb, 
 
 The production stack (`docker-compose.prod.yml`) is a set of containers, all
 driven by the same `.env`. The app image is served with
-[FrankenPHP](https://frankenphp.dev/).
+[FrankenPHP](https://frankenphp.dev/). By default the four app-role services
+(`app`, `reverb`, `queue`, `scheduler`) share one **prebuilt image** pulled from
+the registry; the optional `docker-compose.build.yml` overlay replaces that pull
+with a local build from source (see
+[Installation](/docs/self-hosting/installation/#build-from-source)).
 
 ## Services
 

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -31,7 +31,7 @@ The stack **refuses to start** without these (no defaults):
 | `APP_NAME` | `The Desk`     | Shown in the UI and emails. Served at runtime.    |
 | `APP_PORT` | `8000`         | Host port the web app is published on (bound to `APP_BIND`). |
 | `APP_BIND` | `127.0.0.1`    | Address the published app/reverb ports bind to. `0.0.0.0` exposes the raw HTTP origin off-box. |
-| `APP_IMAGE`| `the-desk:latest` | Set to `ghcr.io/emmpaul/the-desk:X.Y.Z` to run the published image instead of building. |
+| `APP_IMAGE`| *(pinned release image)* | Overrides the app image. Defaults to the release-pinned `ghcr.io/emmpaul/the-desk:X.Y.Z`, which `up -d` pulls with no build. Set it to run a different tag (e.g. `edge`) or an older release. |
 
 ## Database
 

--- a/docs/src/content/docs/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/docs/self-hosting/installation.md
@@ -7,28 +7,29 @@ The production stack is orchestrated with `docker-compose.prod.yml`. The app is
 served with [FrankenPHP](https://frankenphp.dev/); Postgres, Meilisearch, Redis,
 Reverb, a queue worker, and the scheduler all run as containers.
 
-There are **two supported ways** to get the app image, both driven by the same
-`.env`:
+The stack **pulls a prebuilt image** by default, and can optionally **build from
+source** — both driven by the same `.env`:
 
-- **[Pull the prebuilt image](#option-a-pull-the-published-image)** from the
-  GitHub Container Registry (`ghcr.io/emmpaul/the-desk`) — no build step. Every
-  setting, including the browser-facing Reverb values, is read at **runtime**, so
-  one published image works for any host.
-- **[Build from source](#option-b-build-from-source)** at a release tag — clone
-  the repo, check out a tag, and `--build`.
+- **[Pull the published image](#pull-the-published-image)** from the GitHub
+  Container Registry (`ghcr.io/emmpaul/the-desk`) — the default, no build step.
+  Every setting, including the browser-facing Reverb values, is read at
+  **runtime**, so one published image works for any host.
+- **[Build from source](#build-from-source)** at a release tag — layer a build
+  overlay to compile the image locally.
 
 :::note
 Make sure you meet the [requirements](/docs/self-hosting/requirements/) first — Docker
 24+, a domain, a TLS reverse proxy, and working SMTP.
 :::
 
-## Option A — Pull the published image
+## Pull the published image
 
-Each release publishes a prebuilt image to the GitHub Container Registry at
-`ghcr.io/emmpaul/the-desk` (tags `X.Y.Z`, `X.Y`, and `latest`; `edge` tracks the
-tip of `master`). Because the app name and the browser-facing Reverb settings are
-served to the frontend at **runtime** — not baked into the JavaScript bundle at
-build time — the same image works for any operator's host with no rebuild.
+`docker-compose.prod.yml` pins the app image to this release's published tag on
+the GitHub Container Registry (`ghcr.io/emmpaul/the-desk`; tags `X.Y.Z`, `X.Y`,
+and `latest`, with `edge` tracking the tip of `master`), so `up -d` pulls and runs
+it with **no build step**. Because the app name and browser-facing Reverb settings
+are served to the frontend at **runtime** — not baked into the JavaScript bundle —
+the same image works for any operator's host.
 
 ```bash
 # 1. Grab the compose file, env template, and secret generator from a release tag.
@@ -39,17 +40,20 @@ git fetch --tags && git checkout v1.5.0 # x-release-please-version   (the desire
 # 2. Generate .env secrets, then edit APP_URL, mail, and REVERB_*_PUBLIC.
 ./docker/gen-secrets.sh
 
-# 3. Run the published image instead of building. Pin the version to the tag.
-echo 'APP_IMAGE=ghcr.io/emmpaul/the-desk:1.5.0' >> .env # x-release-please-version
-docker compose -f docker-compose.prod.yml pull
+# 3. Start the stack. up -d pulls the release-pinned image (no build step).
 docker compose -f docker-compose.prod.yml up -d
 ```
 
-`docker compose pull` fetches the prebuilt image; `up -d` runs it without a build
-step. Upgrades are just `APP_IMAGE=…:X.Y.Z`, then `pull` + `up -d` again — see
+The checked-out tag pins the image, so no `APP_IMAGE` is needed. To run a
+different tag (e.g. `edge`), set `APP_IMAGE=ghcr.io/emmpaul/the-desk:<tag>` in
+`.env`. Upgrades just check out a newer tag and restart — see
 [Upgrading](/docs/self-hosting/upgrading/).
 
-## Option B — Build from source
+## Build from source
+
+To build the image yourself — to audit or patch the source, or run in an
+air-gapped environment — layer the build overlay (`docker-compose.build.yml`) on
+top, which restores a local build for the app services (they share one image):
 
 ```bash
 # 1. Clone and check out the latest release tag.
@@ -58,17 +62,12 @@ cd the-desk
 git fetch --tags
 git checkout v1.5.0 # x-release-please-version         (the desired release tag)
 
-# 2. Generate .env with all required secrets filled in.
-#    Creates .env from the template and fills APP_KEY, DB_PASSWORD,
-#    MEILISEARCH_KEY, and the REVERB_* keys with fresh random values.
-#    Safe to re-run — it never overwrites values you have already set.
+# 2. Generate .env with all required secrets, then edit APP_URL, mail, and
+#    REVERB_*_PUBLIC (see Configuration) — identical to the pull flow above.
 ./docker/gen-secrets.sh
 
-# 3. Edit .env and set the non-secret settings the script can't guess
-#    (APP_URL, SMTP mail credentials, REVERB_*_PUBLIC). See Configuration.
-
-# 4. Build the images and start the stack.
-docker compose -f docker-compose.prod.yml up -d --build
+# 3. Build the image and start the stack.
+docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
 ```
 
 ## What happens on start

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -3,8 +3,8 @@ title: Upgrading
 description: Tag-based upgrades with automatic migrations and version-scoped search reindexing.
 ---
 
-Upgrades follow the same tag-based flow you used to install, whether you build
-from source or run the published image.
+Upgrades follow the same tag-based flow you used to install, whether you run the
+published image (the default) or build from source.
 
 ## These docs track the in-development version
 
@@ -62,26 +62,33 @@ docker compose -f docker-compose.prod.yml exec -T app \
   tar xzf - -C /app/storage/app < storage-app-YYYY-MM-DD.tar.gz
 ```
 
-## Build-from-source
+## Default: pull the newer image
 
-Check out the newer release tag and rebuild:
+Check out the newer release tag and restart — `up -d` pulls the image that tag
+pins:
 
 ```bash
 git fetch --tags
 git checkout v1.5.0 # x-release-please-version         (the desired release tag)
 docker compose -f docker-compose.prod.yml down
-docker compose -f docker-compose.prod.yml up -d --build
-# migrations run automatically via the entrypoint
+docker compose -f docker-compose.prod.yml up -d
+# pulls the newer pinned image; migrations run automatically via the entrypoint
 ```
 
-## Published image
+If you override `APP_IMAGE` in `.env`, point it at the new tag first (e.g.
+`APP_IMAGE=ghcr.io/emmpaul/the-desk:<tag>`) before restarting.
 
-Point `APP_IMAGE` at the new tag, then pull and restart:
+## Build from source
+
+If you build the image locally with the build overlay, check out the newer tag and
+rebuild:
 
 ```bash
-sed -i 's|^APP_IMAGE=.*|APP_IMAGE=ghcr.io/emmpaul/the-desk:1.5.0|' .env # x-release-please-version
-docker compose -f docker-compose.prod.yml pull
-docker compose -f docker-compose.prod.yml up -d
+git fetch --tags
+git checkout v1.5.0 # x-release-please-version         (the desired release tag)
+docker compose -f docker-compose.prod.yml down
+docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
+# migrations run automatically via the entrypoint
 ```
 
 Migrations run automatically on start — the `app` container's entrypoint runs


### PR DESCRIPTION
## Problem

Following the docs to deploy in prod, `docker compose -f docker-compose.prod.yml up -d` **builds the app from source** (Composer + a full `npm ci && npm run build` Vite build) instead of just pulling the published image and starting the stack.

## Root cause

The shared `x-app` anchor declared **both** `image: ${APP_IMAGE:-the-desk:latest}` **and** `build: context: .`. The default tag `the-desk:latest` exists in no registry, and because a `build:` section is present, Compose builds from source rather than pulling. The published `ghcr.io/emmpaul/the-desk` image is already fully turnkey (assets + vendor baked in), so the local build was pure friction — avoidable only by manually setting `APP_IMAGE` and running `pull` first.

## Fix

- **`docker-compose.prod.yml`**: drop `build:` from the anchor and default the image to the release-pinned `ghcr.io/emmpaul/the-desk:X.Y.Z` (stamped by release-please). A checkout of a release tag now runs exactly that version, and `up -d` pulls it with **no build step**.
- **New `docker-compose.build.yml`**: opt-in overlay that restores a local build for the four app services (they share one image) and retags to `the-desk:latest`. Build-from-source becomes:
  ```
  docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
  ```
- **Docs**: README + `installation.md` / `upgrading.md` / `architecture.md` restructured so pulling is the default and building is an advanced option; `environment-variables.md` + `.env.prod.example` note `APP_IMAGE` as an optional tag override.

## Verification

- `docker compose -f docker-compose.prod.yml config` → all four app services resolve to `ghcr.io/emmpaul/the-desk:1.5.0`, **zero `build:` keys**.
- `... -f docker-compose.build.yml config` → `build.context` restored, app services retagged to `the-desk:latest`; infra images untouched.
- `cd docs && npm run build` passes.

No app/PHP code changes.