### PR TITLE
fix: ship faker as a production dependency so demo:seed runs under --no-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "ext-imagick": "*",
         "arietimmerman/laravel-scim-server": "^1.5",
         "directorytree/ldaprecord-laravel": "^4.0",
+        "fakerphp/faker": "^1.24",
         "geoip2/geoip2": "^3.3",
         "inertiajs/inertia-laravel": "^3.0",
         "intervention/image": "^4.2",
@@ -33,7 +34,6 @@
     },
     "require-dev": {
         "driftingly/rector-laravel": "^2.5",
-        "fakerphp/faker": "^1.24",
         "larastan/larastan": "^3.9",
         "laravel/boost": "^2.2",
         "laravel/pail": "^1.2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "281512cc79398348a5565d2010a68a78",
+    "content-hash": "957ffc5c40ec508ac714ea5647cff52a",
     "packages": [
         {
             "name": "arietimmerman/laravel-scim-server",
@@ -1112,6 +1112,69 @@
                 "source": "https://github.com/igorw/evenement/tree/v3.0.2"
             },
             "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -12004,69 +12067,6 @@
                 "source": "https://github.com/driftingly/rector-laravel/tree/2.5.0"
             },
             "time": "2026-06-02T16:22:14+00:00"
-        },
-        {
-            "name": "fakerphp/faker",
-            "version": "v1.24.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
-                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ^8.0",
-                "psr/container": "^1.0 || ^2.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
-            },
-            "conflict": {
-                "fzaninotto/faker": "*"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
-                "doctrine/persistence": "^1.3 || ^2.0",
-                "ext-intl": "*",
-                "phpunit/phpunit": "^9.5.26",
-                "symfony/phpunit-bridge": "^5.4.16"
-            },
-            "suggest": {
-                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
-                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
-                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
-                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
-                "ext-mbstring": "Required for multibyte Unicode string functionality."
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "support": {
-                "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
-            },
-            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",

--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -420,6 +420,7 @@ class WorkspaceSeeder extends Seeder
     private function backfillChannelHistory(Channel $channel, array $authorIds, int $weeks, int $weekdayVolume): void
     {
         $weekdayVolume = max(1, $weekdayVolume);
+        $now = now();
         $rows = [];
 
         for ($day = $weeks * 7; $day >= 1; $day--) {
@@ -433,6 +434,17 @@ class WorkspaceSeeder extends Seeder
 
             for ($index = 0; $index < $count; $index++) {
                 $createdAt = $date->copy()->addHours($index);
+
+                // A day's messages spread forward from 09:00, one hour each, so the
+                // most recent day's tail can cross midnight into the future when the
+                // seeder runs in the small hours. A future `created_at` mints a
+                // UUIDv7 that outranks every real message and breaks the `id DESC`
+                // timeline (the residual #447/#448 flake). Stop the day once a row
+                // would land at or after "now" — later indexes only push further
+                // ahead.
+                if ($createdAt->greaterThanOrEqualTo($now)) {
+                    break;
+                }
 
                 $rows[] = [
                     // Derive a UUIDv7 from this row's back-dated `created_at` so the

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,6 +40,13 @@ x-app: &app
     - .env
   restart: unless-stopped
   volumes:
+    # `env_file` injects the variables into the container's environment, but also
+    # bind-mount the file itself so the physical `.env` is on disk inside the app.
+    # Artisan commands run against the container (e.g. `demo:seed`, maintenance)
+    # then resolve configuration exactly like a standard on-disk install, even
+    # when the boot-time config cache has been cleared. Read-only: the operator
+    # owns and edits the file on the host.
+    - ./.env:/app/.env:ro
     - storage-app:/app/storage/app
   depends_on:
     pgsql:

--- a/docs/src/content/docs/docs/reference/architecture.md
+++ b/docs/src/content/docs/docs/reference/architecture.md
@@ -4,8 +4,11 @@ description: What runs in the production stack and why — the web app, Reverb, 
 ---
 
 The production stack (`docker-compose.prod.yml`) is a set of containers, all
-driven by the same `.env`. The app image is served with
-[FrankenPHP](https://frankenphp.dev/). By default the four app-role services
+driven by the same `.env`. Its values are injected into every app-role container,
+and the file itself is also bind-mounted read-only at `/app/.env`, so artisan
+commands run against a container (maintenance, seeding the public demo) resolve
+configuration exactly like a standard on-disk install. The app image is served
+with [FrankenPHP](https://frankenphp.dev/). By default the four app-role services
 (`app`, `reverb`, `queue`, `scheduler`) share one **prebuilt image** pulled from
 the registry; the optional `docker-compose.build.yml` overlay replaces that pull
 with a local build from source (see

--- a/tests/Feature/WorkspaceSeederBackfillTest.php
+++ b/tests/Feature/WorkspaceSeederBackfillTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Models\Message;
+use Illuminate\Support\Carbon;
+
+/**
+ * Regression guard for the residual #447/#448 timeline flake. The busiest
+ * channel's analytics backfill spreads each day's messages forward from 09:00,
+ * one hour per message, so the most recent day's tail spills past midnight into
+ * "now" whenever the seeder runs in the small hours. A back-dated message that
+ * lands in the future mints a UUIDv7 whose embedded timestamp outranks every real
+ * message, so `id DESC` (the timeline) surfaces a seed row on top and a freshly
+ * sent message no longer sorts newest.
+ *
+ * Freeze a post-midnight instant plus the fixed faker seed that drove the
+ * overshoot (a busy final day whose tail reached 01:00), then assert the backfill
+ * never dates a message ahead of the clock.
+ */
+test('backfilled channel history never dates a message in the future when seeded after midnight', function (): void {
+    Carbon::setTestNow('2026-07-17 00:30:00');
+    fake()->seed(4);
+
+    $this->seed();
+
+    expect(Message::where('created_at', '>', now())->exists())->toBeFalse();
+});

--- a/tests/Unit/ProductionDependenciesTest.php
+++ b/tests/Unit/ProductionDependenciesTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The production image installs with `composer install --no-dev`, so anything the
+ * demo seeder leans on must live in `require`, not `require-dev`. Faker backs
+ * `DemoSeeder` (`fake()` and every model factory), and `demo:seed` is a
+ * production command (a public demo host reseeds on a schedule) — so faker has to
+ * ship in production builds. See issue #464.
+ */
+test('faker ships as a production dependency so demo:seed runs under --no-dev', function (): void {
+    $composer = json_decode((string) file_get_contents(dirname(__DIR__, 2).'/composer.json'), true, flags: JSON_THROW_ON_ERROR);
+
+    expect($composer['require'])->toHaveKey('fakerphp/faker')
+        ->and($composer['require-dev'] ?? [])->not->toHaveKey('fakerphp/faker');
+});


### PR DESCRIPTION
Closes #464.

Three fixes that surfaced while getting the public demo (`demo:seed`) to run on a production deployment.

## 1. Faker as a production dependency (#464)
`demo:seed` crashed in a prod image with `Call to undefined function Database\Seeders\fake()`. The prod image builds with `composer install --no-dev` (`Dockerfile:36`), but `DemoSeeder` calls `fake()` and builds everything through model factories (all using `$this->faker`), and `demo:seed` is a **production** command (not env-gated — a public demo host reseeds on a schedule). Moved `fakerphp/faker` from `require-dev` to `require` (lock relocated, version unchanged at `v1.24.1`).

## 2. Backfill no longer dates messages in the future
`WorkspaceSeeder::backfillChannelHistory` spreads each day's messages forward from 09:00, one hour per message. The most recent day's tail could cross midnight into the *future* when the seeder runs in the small hours, minting a UUIDv7 whose timestamp outranked every real message so `id DESC` (the timeline) surfaced a seed row on top. This is the residual of the #447/#448 timeline-ordering flake. Now the loop stops a day once a row would land at or after "now".

## 3. Bind-mount `.env` into the production app containers
`docker-compose.prod.yml` only passed config via `env_file` (variables injected into the environment). Also bind-mount the file itself read-only at `/app/.env` so artisan commands run against a container (`demo:seed`, maintenance) resolve configuration like a standard on-disk install, even when the boot-time config cache has been cleared.

## Testing
- `tests/Unit/ProductionDependenciesTest.php` — guards faker staying in `require` (not `require-dev`).
- `tests/Feature/WorkspaceSeederBackfillTest.php` — freezes a post-midnight instant + a fixed faker seed that drove the overshoot and asserts no message is dated in the future. Red before the fix, green after.
- Verified `demo:seed` runs end-to-end to "Demo workspace seeded."
- Full backend gate green at `Total: 100.0 %` (Pint, PHPStan, Rector, coverage). Docs site builds.

## Docs
- Updated `reference/architecture.md` to note the read-only `.env` bind mount.

No frontend files changed.