### PR TITLE
docs: use HTTPS clone URL in README and install docs so SSH keys aren't required

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ install, reverse proxy & TLS, upgrades) live at
 Local development uses [Laravel Sail](https://laravel.com/docs/sail):
 
 ```bash
-git clone git@github.com:emmpaul/the-desk.git
+git clone https://github.com/emmpaul/the-desk.git
 cd the-desk
 cp .env.example .env
 composer install
@@ -154,7 +154,7 @@ one-line overlay restores a local build — see
 
 ```bash
 # 1. Clone and check out the latest release tag.
-git clone git@github.com:emmpaul/the-desk.git
+git clone https://github.com/emmpaul/the-desk.git
 cd the-desk
 git fetch --tags
 git checkout v1.5.2 # x-release-please-version         (the desired release tag)

--- a/docs/src/content/docs/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/docs/self-hosting/installation.md
@@ -33,7 +33,7 @@ the same image works for any operator's host.
 
 ```bash
 # 1. Grab the compose file, env template, and secret generator from a release tag.
-git clone git@github.com:emmpaul/the-desk.git
+git clone https://github.com/emmpaul/the-desk.git
 cd the-desk
 git fetch --tags && git checkout v1.5.2 # x-release-please-version   (the desired release tag)
 
@@ -57,7 +57,7 @@ top, which restores a local build for the app services (they share one image):
 
 ```bash
 # 1. Clone and check out the latest release tag.
-git clone git@github.com:emmpaul/the-desk.git
+git clone https://github.com/emmpaul/the-desk.git
 cd the-desk
 git fetch --tags
 git checkout v1.5.2 # x-release-please-version         (the desired release tag)

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -366,7 +366,7 @@ const jsonLd = {
 						<span class="terminal-host">you@yourserver</span>
 					</div>
 					<div class="terminal-body">
-						<div><span class="prompt">$</span> git clone github.com/emmpaul/the-desk &amp;&amp; cd the-desk</div>
+						<div><span class="prompt">$</span> git clone https://github.com/emmpaul/the-desk.git &amp;&amp; cd the-desk</div>
 						<div><span class="prompt">$</span> ./docker/gen-secrets.sh <span class="prompt"># fills APP_KEY, DB, Reverb keys</span></div>
 						<div><span class="prompt">$</span> docker compose -f docker-compose.prod.yml up -d</div>
 						<div class="dim">Pulling ghcr.io/emmpaul/the-desk:{releaseTag}… done</div>


### PR DESCRIPTION
Closes #467.

## What

Every copy-pasteable `git clone` command in the operator-facing docs now uses the HTTPS URL instead of the SSH one:

- `README.md` — Development setup, First install
- `docs/src/content/docs/docs/self-hosting/installation.md` — pull flow, build-from-source flow

Also fixed the illustrative terminal on the docs landing page (`docs/src/pages/index.astro`), which showed `git clone github.com/emmpaul/the-desk` — schemeless, so it wouldn't actually work if copied.

## Why

`git@github.com:emmpaul/the-desk.git` requires an SSH key registered on the operator's GitHub account. A self-hoster following the install docs verbatim typically has no SSH keys set up, so the very first step failed with `Permission denied (publickey)`. The repo is public, so HTTPS clones need no authentication at all.

## Scope note

`CONTRIBUTING.md:21` still uses the SSH URL. That is intentional and left alone: contributors push, so they need SSH (or another credential) configured regardless. The issue scoped this to the self-hosting path.

## Testing

Docs-only change — no PHP or app JavaScript is touched, so the backend/frontend gate has no surface here. Verified the docs site still builds cleanly:

```
cd docs && npm run build   # 16 pages built, Complete!
```

Local CodeRabbit pass against `master`: clean, 0 findings.

No i18n impact (no user-facing app copy changed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository cloning instructions to use HTTPS URLs.
  * Applied the updated commands across local setup, self-hosting installation, and the landing page.
  * No other setup steps or commands were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->