### PR TITLE
docs: declare UPDATE_CHECK_* in the env templates and trim .env.prod.example prose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,19 @@ GRAVATAR_ENABLED=true
 # GRAVATAR_SIZE=200
 # GRAVATAR_DEFAULT=404
 
+# A daily scheduled command asks the GitHub releases API for the latest stable
+# release and caches the result, so an outdated instance can surface a low-key
+# "update available" indicator. Set UPDATE_CHECK_ENABLED=false to disable it
+# entirely (no outbound requests to api.github.com) on an air-gapped or
+# egress-filtered network.
+UPDATE_CHECK_ENABLED=true
+# The GitHub "owner/repo" the check queries for releases and links to for
+# release notes; point a fork at its own upstream. UPDATE_CHECK_CACHE_TTL_HOURS
+# is how long a successful check is trusted before the next daily refresh (the
+# last known-good result is kept on failure, so it is a soft ceiling).
+# UPDATE_CHECK_REPOSITORY=emmpaul/the-desk
+# UPDATE_CHECK_CACHE_TTL_HOURS=12
+
 # Message file & image attachments. Per-file size cap and per-message count are
 # enforced on upload and send. Raising ATTACHMENT_MAX_SIZE_MB also requires
 # raising the server's PHP upload_max_filesize/post_max_size and any reverse-proxy

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -6,22 +6,17 @@
 #   # paste the value into APP_KEY below, fill in the rest, then:
 #   docker compose -f docker-compose.prod.yml up -d
 #
-# Every setting here is read at RUNTIME — including the browser-facing Reverb
-# values, which the app serves to the frontend at boot. Changing any of them
-# only requires a container restart, never an image rebuild, so the same image
-# works for any host.
-#
-# `up -d` pulls the prebuilt image pinned in docker-compose.prod.yml (no build).
-# Set APP_IMAGE to override the tag, e.g. APP_IMAGE=ghcr.io/emmpaul/the-desk:edge.
+# Every setting below is documented at:
+# https://the-desk.emmanuelpaul.com/docs/reference/environment-variables/
 # =============================================================================
 
 APP_NAME="The Desk"
 APP_ENV=production
-# Generate once with: docker run --rm ghcr.io/emmpaul/the-desk:latest php artisan key:generate --show
+# Required. Generate with: docker run --rm ghcr.io/emmpaul/the-desk:latest php artisan key:generate --show
 APP_KEY=
 APP_DEBUG=false
-# Public URL your reverse proxy serves the app on.
 APP_URL=https://chat.example.com
+# APP_IMAGE=ghcr.io/emmpaul/the-desk:edge
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
@@ -34,93 +29,41 @@ LOG_STACK=single
 LOG_LEVEL=warning
 
 # --- Feature toggles ---------------------------------------------------------
-# Set to false to close public sign-ups on a private/invite-only instance:
-# /register then returns 404 and the "sign up" links disappear. Create your own
-# account first (while this is still true), then flip it and restart the stack.
 REGISTRATION_ENABLED=true
-# Set to true to require new accounts to confirm their email before using the
-# app (needs working SMTP so the verification mail is delivered). Defaults to
-# false: registration logs the user straight in.
 EMAIL_VERIFICATION_ENABLED=false
-# User avatars are derived from each user's Gravatar (keyed on the MD5 of their
-# email, so the raw address is never in the URL); users without one fall back to
-# their initials. Set to false to disable it entirely (no outbound requests to
-# gravatar.com) and always show initials. Endpoint/size/default are tunable via
-# GRAVATAR_URL, GRAVATAR_SIZE, and GRAVATAR_DEFAULT.
 GRAVATAR_ENABLED=true
-# A daily scheduled command asks the GitHub releases API for the latest stable
-# release and caches the result, so an outdated instance can surface a low-key
-# "update available" indicator. Set to false to disable it entirely (no outbound
-# requests to api.github.com) on an air-gapped or egress-filtered network.
+# GRAVATAR_URL="https://www.gravatar.com/avatar"
+# GRAVATAR_SIZE=200
+# GRAVATAR_DEFAULT=404
 UPDATE_CHECK_ENABLED=true
-# The GitHub "owner/repo" the check queries for releases and links to for release
-# notes; point a fork at its own upstream. UPDATE_CHECK_CACHE_TTL_HOURS is how
-# long a successful check is trusted before the next daily refresh (the last
-# known-good result is kept on failure, so it is a soft ceiling).
 # UPDATE_CHECK_REPOSITORY=emmpaul/the-desk
 # UPDATE_CHECK_CACHE_TTL_HOURS=12
 
 # --- Single sign-on (OpenID Connect) -----------------------------------------
-# Point these at your identity provider (Okta, Microsoft Entra ID, Google
-# Workspace, Auth0, Keycloak, …) to add a "Sign in with SSO" button. The app
-# reads {issuer}/.well-known/openid-configuration to discover the provider's
-# endpoints, so only the issuer, client id, and secret are required. First SSO
-# login just-in-time provisions the account (matched to an existing user by
-# verified email) into the default team as a Member. Leave the client id / issuer
-# blank to keep SSO off.
 # SSO_OIDC_ISSUER=https://your-idp.example.com
 # SSO_OIDC_CLIENT_ID=
 # SSO_OIDC_CLIENT_SECRET=
-# Callback URI registered at the IdP (defaults to APP_URL + /auth/oidc/callback).
 # SSO_OIDC_REDIRECT_URI="${APP_URL}/auth/oidc/callback"
-# Override only if discovery is not at the standard path; scopes default to
-# "openid profile email".
 # SSO_OIDC_DISCOVERY_URL=
 # SSO_OIDC_SCOPES="openid profile email"
-# Verify a returned id_token (signature/claims + subject matches UserInfo);
-# on by default. Set false only for a non-conformant provider.
 # SSO_OIDC_VALIDATE_ID_TOKEN=true
-# Team new SSO users join as a Member; blank uses the sole team when there is one.
-# (Applies to both OIDC and LDAP just-in-time provisioning.)
 # SSO_DEFAULT_TEAM_ID=
 
 # --- Single sign-on (LDAP / Active Directory) --------------------------------
-# Authenticate users against an on-prem directory through the app login form
-# (bind auth). On a successful bind the entry is matched to an app user by its
-# mail attribute, keyed by its stable objectGUID, and just-in-time provisioned
-# into the default team as a Member; the mapped name syncs on every login. Leave
-# LDAP_HOST / LDAP_BASE_DN blank to keep LDAP off.
 # LDAP_HOST=ldap.example.com
 # LDAP_PORT=389
 # LDAP_BASE_DN="dc=example,dc=com"
-# Service (bind) account used to search the directory before binding as the user.
 # LDAP_USERNAME="cn=readonly,dc=example,dc=com"
 # LDAP_PASSWORD=
-# Encrypted transport: LDAP_TLS uses LDAPS (usually port 636); LDAP_STARTTLS
-# upgrades a plain connection. Both false = unencrypted (only on a trusted network).
 # LDAP_TLS=false
 # LDAP_STARTTLS=false
-# Attribute mappings: `username` is matched against the login form value (default
-# mail, so users sign in with email; set e.g. samaccountname for a directory
-# username). mail → app email, name → display name, guid → stable identity
-# (objectguid for AD, entryuuid for OpenLDAP).
 # LDAP_ATTR_USERNAME=mail
 # LDAP_ATTR_MAIL=mail
 # LDAP_ATTR_NAME=cn
 # LDAP_ATTR_GUID=objectguid
-
-# Set true to route ALL access through SSO (OIDC or LDAP): disables Fortify
-# registration and the local-password login. Keep false to preserve a break-glass
-# password account for outages.
 # AUTH_SSO_ONLY=false
 
 # --- Directory provisioning (SCIM 2.0) ---------------------------------------
-# Let your IdP (Okta, Entra ID, OneLogin, …) push user create/update/deactivate
-# events to ${APP_URL}/scim/v2, so a directory removal automatically tombstones
-# the account here (access revoked and sessions ended, history kept) — a later
-# active:true reactivates it. The IdP authenticates with the bearer SCIM_TOKEN;
-# leave it blank to keep the endpoint off entirely. Use a long random secret and
-# only expose SCIM over HTTPS.
 # SCIM_TOKEN=
 # SCIM_BASE_PATH=/scim
 
@@ -130,7 +73,7 @@ DB_HOST=pgsql
 DB_PORT=5432
 DB_DATABASE=laravel
 DB_USERNAME=laravel
-# Required — used by both the app and the Postgres container.
+# Required. Used by both the app and the Postgres container.
 DB_PASSWORD=
 
 # --- Cache / session / queue (redis service) ---------------------------------
@@ -145,7 +88,6 @@ FILESYSTEM_DISK=local
 QUEUE_CONNECTION=redis
 CACHE_STORE=redis
 
-# Redis connection for the drivers above (the redis service on the compose network).
 REDIS_CLIENT=phpredis
 REDIS_HOST=redis
 REDIS_PASSWORD=null
@@ -164,41 +106,22 @@ MAIL_FROM_NAME="${APP_NAME}"
 # --- Search (meilisearch service) --------------------------------------------
 SCOUT_DRIVER=meilisearch
 MEILISEARCH_HOST=http://meilisearch:7700
-# Required — master key for the Meilisearch container. Use a long random string.
+# Required. Long random string, shared with the Meilisearch container.
 MEILISEARCH_KEY=
 MEILISEARCH_NO_ANALYTICS=true
 
 # --- Broadcasting (reverb service) -------------------------------------------
-# Required — generate with: docker run --rm ghcr.io/emmpaul/the-desk:latest php artisan reverb:secret
+# Required. Generate with: docker run --rm ghcr.io/emmpaul/the-desk:latest php artisan reverb:secret
 REVERB_APP_ID=
 REVERB_APP_KEY=
 REVERB_APP_SECRET=
-# Server-side host/port/scheme the app broadcasts to: the reverb container on the
-# compose network (plain http on 8080, behind your TLS proxy).
 REVERB_HOST=reverb
 REVERB_PORT=8080
 REVERB_SCHEME=http
-
-# Browser-side values, served to the SPA at RUNTIME (no rebuild). The browser
-# uses REVERB_APP_KEY above; host/port/scheme default to the APP_URL host +
-# REVERB_PORT + REVERB_SCHEME. Since your TLS proxy terminates https/wss on 443
-# while the container speaks http on 8080, override the port and scheme so the
-# browser connects over wss:
 REVERB_PORT_PUBLIC=443
 REVERB_SCHEME_PUBLIC=https
-# Set only for a dedicated WebSocket subdomain (otherwise the APP_URL host is used):
 # REVERB_HOST_PUBLIC=ws.example.com
 
 # --- Container port mapping (host side) --------------------------------------
-# The app and reverb containers speak PLAIN HTTP, so their host ports publish to
-# loopback on non-privileged ports by default: the unencrypted origin is never
-# exposed to the public internet, and nothing squats on 80/443. A host-based proxy
-# targets 127.0.0.1:${APP_PORT} / 127.0.0.1:${REVERB_PORT}; a proxy running inside
-# the compose network reaches app:8080 / reverb:8080 directly and ignores these.
-#
-# Bind address for both published ports. Set to 0.0.0.0 only to deliberately
-# expose the raw HTTP app off-box (not recommended — put a TLS proxy in front).
 # APP_BIND=127.0.0.1
-# Host port the app is published on (proxy sits in front of this). Defaults to 8000.
 # APP_PORT=8000
-# REVERB_PORT above doubles as the host port the reverb service is published on.

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -48,6 +48,17 @@ EMAIL_VERIFICATION_ENABLED=false
 # gravatar.com) and always show initials. Endpoint/size/default are tunable via
 # GRAVATAR_URL, GRAVATAR_SIZE, and GRAVATAR_DEFAULT.
 GRAVATAR_ENABLED=true
+# A daily scheduled command asks the GitHub releases API for the latest stable
+# release and caches the result, so an outdated instance can surface a low-key
+# "update available" indicator. Set to false to disable it entirely (no outbound
+# requests to api.github.com) on an air-gapped or egress-filtered network.
+UPDATE_CHECK_ENABLED=true
+# The GitHub "owner/repo" the check queries for releases and links to for release
+# notes; point a fork at its own upstream. UPDATE_CHECK_CACHE_TTL_HOURS is how
+# long a successful check is trusted before the next daily refresh (the last
+# known-good result is kept on failure, so it is a soft ceiling).
+# UPDATE_CHECK_REPOSITORY=emmpaul/the-desk
+# UPDATE_CHECK_CACHE_TTL_HOURS=12
 
 # --- Single sign-on (OpenID Connect) -----------------------------------------
 # Point these at your identity provider (Okta, Microsoft Entra ID, Google

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -16,7 +16,6 @@ APP_ENV=production
 APP_KEY=
 APP_DEBUG=false
 APP_URL=https://chat.example.com
-# APP_IMAGE=ghcr.io/emmpaul/the-desk:edge
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en


### PR DESCRIPTION
Closes #469.

## What

- `.env.example`: declares `UPDATE_CHECK_ENABLED=true` after the Gravatar entries, with `UPDATE_CHECK_REPOSITORY` and `UPDATE_CHECK_CACHE_TTL_HOURS` as commented tunables. Defaults match `config/updates.php` exactly.
- `.env.prod.example`: same three vars declared, plus a trim of the whole file from explanatory prose down to values under section headers, with a single docs pointer in the header.

## Why

The update check is default-on and makes an outbound request to `api.github.com` on a daily schedule, but was the only setting of that class an operator could not discover while filling in their `.env`. It is now declared where they read.

The prose trim is a deviation from the issue's acceptance criteria, which asked for the new block to match the verbose `REGISTRATION_ENABLED` / `GRAVATAR_ENABLED` style in `.env.prod.example`. That style is what got trimmed instead: the template is a form to fill in, not the documentation, and the docs site already covers every setting. The file drops from 205 to 124 lines. `.env.example` (dev) keeps its explanatory style.

The only comments left in the prod template are actions rather than documentation: the two `key:generate` / `reverb:secret` generate commands, and `Required.` markers on the empty secrets.

## Testing

- Key set in `.env.prod.example` verified to be a strict superset of the original, so the trim drops nothing. `GRAVATAR_URL` / `GRAVATAR_SIZE` / `GRAVATAR_DEFAULT` were promoted from prose-only mentions to commented keys. `APP_IMAGE` is documented on the env-vars page the header links to and is not declared here.
- `docker/gen-secrets.sh` matches `^KEY=$`; all six keys it fills (`APP_KEY`, `DB_PASSWORD`, `MEILISEARCH_KEY`, `REVERB_APP_ID`, `REVERB_APP_KEY`, `REVERB_APP_SECRET`) are still present and empty.
- All three `UPDATE_CHECK_*` vars are covered on `feature-toggles.md`, which the linked env-vars page points to, so the header link is not a dead end.
- `./vendor/bin/sail composer test` green at 100% coverage. Local CodeRabbit pass clean.

## i18n / docs

No doc-site change: `environment-variables.md` and `feature-toggles.md` already cover these correctly. No user-facing copy, so no `lang/fr.json` change. No behaviour change, no version bump.
