### PR TITLE
feat: default COMPOSE_FILE in the prod env template so compose commands need no -f

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -4,11 +4,30 @@
 #   cp .env.prod.example .env
 #   docker run --rm ghcr.io/emmpaul/the-desk:latest php artisan key:generate --show
 #   # paste the value into APP_KEY below, fill in the rest, then:
-#   docker compose -f docker-compose.prod.yml up -d
+#   docker compose up -d
 #
 # Every setting below is documented at:
 # https://the-desk.emmanuelpaul.com/docs/reference/environment-variables/
 # =============================================================================
+
+# --- Docker Compose ----------------------------------------------------------
+# Read by the `docker compose` CLI itself rather than the app. It is why every
+# production command in the docs needs no `-f docker-compose.prod.yml`:
+#
+#   docker compose up -d
+#   docker compose ps
+#   docker compose logs -f app
+#
+# Building the image from source? List both files, separated by a colon, so the
+# build overlay stacks on top and `docker compose up -d --build` stays bare:
+#
+#   COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
+#
+# Caveat: with this set, a bare `docker compose down` in this directory targets
+# the production stack. That is the intent on a production box, but there is no
+# longer an `-f` to remind you what you are pointed at. Passing an explicit `-f`
+# still overrides this for a one-off command.
+COMPOSE_FILE=docker-compose.prod.yml
 
 APP_NAME="The Desk"
 APP_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@
 # Production image for self-hosting (build-from-source at a release tag).
 #
 #   git checkout vX.Y.Z
-#   docker compose -f docker-compose.prod.yml up -d --build
+#   ./docker/gen-secrets.sh
+#   # in .env, extend the COMPOSE_FILE the template ships so the build overlay
+#   # (docker-compose.build.yml) stacks on top and restores a local `build:`:
+#   COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
+#   docker compose up -d --build
 #
 # Development still uses Laravel Sail (compose.yaml); this image is a separate
 # production path and does not replace it. Served with FrankenPHP (Caddy + a

--- a/README.md
+++ b/README.md
@@ -172,8 +172,18 @@ git checkout v1.5.2 # x-release-please-version         (the desired release tag)
 #    changes), so no rebuild is needed when they change.
 
 # 4. Start the stack. This pulls the release-pinned image — no build step.
-docker compose -f docker-compose.prod.yml up -d
+docker compose up -d
 ```
+
+> **Why no `-f docker-compose.prod.yml`?** `.env.prod.example` ships
+> `COMPOSE_FILE=docker-compose.prod.yml`, which the `docker compose` CLI reads
+> from `.env`, so every production subcommand (`up`, `ps`, `logs`, `exec`,
+> `down`) resolves the production stack with no flag. It matters here: this repo
+> also contains `compose.yaml`, the Sail **dev** stack, which a bare
+> `docker compose` would otherwise pick up. The flip side is that a bare
+> `docker compose down` in this directory takes down production, with no `-f` to
+> remind you what you are aimed at. An explicit `-f` still overrides it, so an
+> instance whose `.env` predates this variable keeps working unchanged.
 
 Migrations run automatically on start (the `app` container's entrypoint runs
 `php artisan migrate --force`). The app and Reverb speak plain HTTP and publish to
@@ -216,8 +226,8 @@ restart — `up -d` pulls the image that tag pins:
 ```bash
 git fetch --tags
 git checkout v1.5.2 # x-release-please-version         (the desired release tag)
-docker compose -f docker-compose.prod.yml down
-docker compose -f docker-compose.prod.yml up -d
+docker compose down
+docker compose up -d
 # pulls the newer pinned image; migrations run automatically via the entrypoint
 ```
 
@@ -248,12 +258,23 @@ services (they share one image):
 ```bash
 # Check out the matching release tag first so the build matches the compose file,
 # then run gen-secrets.sh and edit .env exactly as in First install.
+
+# Extend COMPOSE_FILE in .env to list both files, separated by a colon:
+#   COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
+docker compose up -d --build
+```
+
+Setting `COMPOSE_FILE` once keeps both files layered for every later command, so
+you never have to remember to repeat the overlay. The explicit form still works
+and overrides it if you would rather not edit `.env`:
+
+```bash
 docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
 ```
 
 Everything else — secrets, `.env`, and the automatic migrations — is identical to
-the pull flow. To go back to the published image, drop the overlay and `up -d`
-again.
+the pull flow. To go back to the published image, drop `:docker-compose.build.yml`
+from `COMPOSE_FILE` and `up -d` again.
 
 > **Reverb settings are runtime, so mind the browser vs. server split.** The
 > container speaks plain `http` on `8080` (`REVERB_PORT` / `REVERB_SCHEME`), but

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,8 +1,12 @@
 # Opt-in overlay that builds the app image from source instead of pulling the
-# published one. Layer it on top of the production stack:
+# published one. Layer it on top of the production stack by listing both files in
+# COMPOSE_FILE (in .env), separated by a colon:
 #
 #   git fetch --tags && git checkout vX.Y.Z
-#   docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
+#   ./docker/gen-secrets.sh
+#   # then in .env, extend the COMPOSE_FILE the template shipped:
+#   COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
+#   docker compose up -d --build
 #
 # It restores a local `build:` for the four app-role services (they share one
 # image) and retags it to a local tag so the build never masquerades as the

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,17 @@
 # Production stack for self-hosting. Pull the prebuilt image and start it:
 #
 #   git fetch --tags && git checkout vX.Y.Z
-#   docker compose -f docker-compose.prod.yml up -d   # pulls the image, no build
+#   ./docker/gen-secrets.sh          # creates .env, which sets COMPOSE_FILE
+#   docker compose up -d             # pulls the image, no build
 #
-# To build the app image from source instead, layer the build overlay on top:
-#   docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
+# The bare `docker compose` above is not a typo: .env.prod.example ships
+# COMPOSE_FILE=docker-compose.prod.yml, so the CLI resolves this file with no
+# `-f`. Without it a bare command would pick up compose.yaml, the Sail dev stack.
+#
+# To build the app image from source instead, layer the build overlay on top by
+# listing both files in COMPOSE_FILE:
+#   COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
+#   docker compose up -d --build
 #
 # Development uses Laravel Sail (compose.yaml) — this file does not replace it.
 #
@@ -34,7 +41,8 @@ x-app: &app
   #
   # To build from source instead, add the build overlay (docker-compose.build.yml)
   # which restores a local build for these services:
-  #   docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
+  #   COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml   # in .env
+  #   docker compose up -d --build
   image: ${APP_IMAGE:-ghcr.io/emmpaul/the-desk:1.5.2} # x-release-please-version
   env_file:
     - .env

--- a/docker/gen-secrets.sh
+++ b/docker/gen-secrets.sh
@@ -58,4 +58,4 @@ set_if_empty "REVERB_APP_SECRET" "$(openssl rand -hex 16)"
 echo
 echo "Done. Review $ENV_FILE and set APP_URL, mail credentials, and the"
 echo "browser-side REVERB_*_PUBLIC values before running:"
-echo "  docker compose -f docker-compose.prod.yml up -d"
+echo "  docker compose up -d"

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -13,6 +13,19 @@ Run `./docker/gen-secrets.sh` to generate the required secrets — it fills
 with fresh random values and never overwrites values you have already set.
 :::
 
+## Docker Compose
+
+One variable in `.env` is read by the **`docker compose` CLI itself** rather than
+by the app:
+
+| Variable       | Default                   | Notes                                                                 |
+| -------------- | ------------------------- | --------------------------------------------------------------------- |
+| `COMPOSE_FILE` | `docker-compose.prod.yml` | Which compose file(s) a bare `docker compose` resolves. Shipped in `.env.prod.example`, which is why no command on this site passes `-f docker-compose.prod.yml`. Building from source? List both files separated by a colon: `docker-compose.prod.yml:docker-compose.build.yml`. |
+
+See [the COMPOSE_FILE variable](/docs/self-hosting/installation/#the-compose_file-variable)
+for the caveat about a bare `docker compose down`, and for what to do if your
+`.env` predates this variable.
+
 ## Required secrets
 
 The stack **refuses to start** without these (no defaults):

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -8,7 +8,7 @@ Several behaviours are switched from `.env`. Like all settings, they are read at
 needed:
 
 ```bash
-docker compose -f docker-compose.prod.yml up -d
+docker compose up -d
 ```
 
 ## Open registration

--- a/docs/src/content/docs/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/docs/self-hosting/configuration.md
@@ -171,5 +171,9 @@ for the full reference.
 After editing `.env`, restart the stack to pick up the new values:
 
 ```bash
-docker compose -f docker-compose.prod.yml up -d
+docker compose up -d
 ```
+
+The bare `docker compose` needs no `-f docker-compose.prod.yml` because `.env`
+sets `COMPOSE_FILE`. See
+[the COMPOSE_FILE variable](/docs/self-hosting/installation/#the-compose_file-variable).

--- a/docs/src/content/docs/docs/self-hosting/first-user.md
+++ b/docs/src/content/docs/docs/self-hosting/first-user.md
@@ -18,7 +18,7 @@ separate admin bootstrap step.
 :::tip
 If you enabled email verification and the email never arrives, your SMTP
 configuration is almost certainly the cause. Check the `queue` container logs
-(`docker compose -f docker-compose.prod.yml logs queue`) — mail is sent through
+(`docker compose logs queue`) — mail is sent through
 the queue worker.
 :::
 

--- a/docs/src/content/docs/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/docs/self-hosting/installation.md
@@ -41,13 +41,44 @@ git fetch --tags && git checkout v1.5.2 # x-release-please-version   (the desire
 ./docker/gen-secrets.sh
 
 # 3. Start the stack. up -d pulls the release-pinned image (no build step).
-docker compose -f docker-compose.prod.yml up -d
+docker compose up -d
 ```
 
 The checked-out tag pins the image, so no `APP_IMAGE` is needed. To run a
 different tag (e.g. `edge`), set `APP_IMAGE=ghcr.io/emmpaul/the-desk:<tag>` in
 `.env`. Upgrades just check out a newer tag and restart — see
 [Upgrading](/docs/self-hosting/upgrading/).
+
+## The COMPOSE_FILE variable
+
+Every production command on this site is a bare `docker compose`, with no
+`-f docker-compose.prod.yml`. That works because `.env.prod.example` ships:
+
+```
+COMPOSE_FILE=docker-compose.prod.yml
+```
+
+`COMPOSE_FILE` is read by the `docker compose` CLI itself, not by the app, and
+`gen-secrets.sh` writes `.env` from that template before you run any compose
+command. So the flag is redundant from the very first `up -d`, for every
+subcommand: `ps`, `logs`, `exec`, `pull`, `down`.
+
+This matters for more than typing. This repository also contains `compose.yaml`,
+the Laravel Sail **development** stack. Without `COMPOSE_FILE`, a bare
+`docker compose` in this directory would resolve that dev file instead of the
+production one.
+
+:::caution
+The flip side: with `COMPOSE_FILE` set, a bare `docker compose down` in this
+directory takes down the **production stack**. On a production box that is the
+intent, but there is no longer an `-f` to remind you what you are pointed at.
+Passing an explicit `-f` still overrides `COMPOSE_FILE` for a one-off command.
+:::
+
+Upgrading an instance installed before this variable existed? Your `.env`
+predates the template change, so nothing breaks: keep passing
+`-f docker-compose.prod.yml` exactly as before, or add the `COMPOSE_FILE` line to
+your `.env` to drop the flag.
 
 ## Build from source
 
@@ -66,9 +97,25 @@ git checkout v1.5.2 # x-release-please-version         (the desired release tag)
 #    REVERB_*_PUBLIC (see Configuration) — identical to the pull flow above.
 ./docker/gen-secrets.sh
 
-# 3. Build the image and start the stack.
+# 3. Extend COMPOSE_FILE in .env so the build overlay stacks on the prod stack.
+#    Both files, separated by a colon:
+#      COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
+
+# 4. Build the image and start the stack.
+docker compose up -d --build
+```
+
+Setting `COMPOSE_FILE` once means every later command (`up`, `down`, `logs`,
+`exec`) keeps both files layered, so you never have to remember to repeat the
+overlay. If you would rather not edit `.env`, the explicit form still works and
+overrides it:
+
+```bash
 docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
 ```
+
+To go back to the published image, drop `:docker-compose.build.yml` from
+`COMPOSE_FILE` and run `docker compose up -d` again.
 
 ## What happens on start
 

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -40,12 +40,12 @@ of the uploaded files:
 
 ```bash
 # Database — logical dump, gzipped
-docker compose -f docker-compose.prod.yml exec -T pgsql \
+docker compose exec -T pgsql \
   pg_dump -U "${DB_USERNAME:-laravel}" "${DB_DATABASE:-laravel}" \
   | gzip > db-backup-$(date +%F).sql.gz
 
 # Uploaded files — stream a tar out of the running app container
-docker compose -f docker-compose.prod.yml exec -T app \
+docker compose exec -T app \
   tar czf - -C /app/storage/app . > storage-app-$(date +%F).tar.gz
 ```
 
@@ -54,11 +54,11 @@ database and a running stack:
 
 ```bash
 # Database
-gunzip -c db-backup-YYYY-MM-DD.sql.gz | docker compose -f docker-compose.prod.yml exec -T pgsql \
+gunzip -c db-backup-YYYY-MM-DD.sql.gz | docker compose exec -T pgsql \
   psql -U "${DB_USERNAME:-laravel}" "${DB_DATABASE:-laravel}"
 
 # Uploaded files
-docker compose -f docker-compose.prod.yml exec -T app \
+docker compose exec -T app \
   tar xzf - -C /app/storage/app < storage-app-YYYY-MM-DD.tar.gz
 ```
 
@@ -70,13 +70,21 @@ pins:
 ```bash
 git fetch --tags
 git checkout v1.5.2 # x-release-please-version         (the desired release tag)
-docker compose -f docker-compose.prod.yml down
-docker compose -f docker-compose.prod.yml up -d
+docker compose down
+docker compose up -d
 # pulls the newer pinned image; migrations run automatically via the entrypoint
 ```
 
 If you override `APP_IMAGE` in `.env`, point it at the new tag first (e.g.
 `APP_IMAGE=ghcr.io/emmpaul/the-desk:<tag>`) before restarting.
+
+:::note
+These commands need no `-f docker-compose.prod.yml` because `.env` sets
+`COMPOSE_FILE`. See
+[the COMPOSE_FILE variable](/docs/self-hosting/installation/#the-compose_file-variable).
+If your `.env` predates that variable, keep passing the flag as before, or add
+`COMPOSE_FILE=docker-compose.prod.yml` to your `.env` to drop it.
+:::
 
 ## Build from source
 
@@ -86,9 +94,17 @@ rebuild:
 ```bash
 git fetch --tags
 git checkout v1.5.2 # x-release-please-version         (the desired release tag)
-docker compose -f docker-compose.prod.yml down
-docker compose -f docker-compose.prod.yml -f docker-compose.build.yml up -d --build
+docker compose down
+docker compose up -d --build
 # migrations run automatically via the entrypoint
+```
+
+This assumes your `.env` lists both files, as the
+[build-from-source install](/docs/self-hosting/installation/#build-from-source)
+sets up:
+
+```
+COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
 ```
 
 Migrations run automatically on start — the `app` container's entrypoint runs

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -368,7 +368,7 @@ const jsonLd = {
 					<div class="terminal-body">
 						<div><span class="prompt">$</span> git clone https://github.com/emmpaul/the-desk.git &amp;&amp; cd the-desk</div>
 						<div><span class="prompt">$</span> ./docker/gen-secrets.sh <span class="prompt"># fills APP_KEY, DB, Reverb keys</span></div>
-						<div><span class="prompt">$</span> docker compose -f docker-compose.prod.yml up -d</div>
+						<div><span class="prompt">$</span> docker compose up -d</div>
 						<div class="dim">Pulling ghcr.io/emmpaul/the-desk:{releaseTag}… done</div>
 						<div class="dim">Running migrations… done</div>
 						<div><span class="ok">✓</span> The Desk is live at <span class="ok">https://desk.your-domain.com</span></div>


### PR DESCRIPTION
Part of #470. Implements #472.

## What

`.env.prod.example` now ships `COMPOSE_FILE=docker-compose.prod.yml`. Docker Compose reads that variable from the project's `.env`, so every production subcommand resolves the prod stack with no `-f`:

```bash
docker compose up -d      # was: docker compose -f docker-compose.prod.yml up -d
docker compose logs -f app
docker compose exec -T pgsql psql -U laravel
```

`gen-secrets.sh` creates `.env` from the template before any compose command runs, so the variable is in place from the very first `up -d`.

## Why

`-f docker-compose.prod.yml` is ceremony on a box that only runs the production stack, and it was repeated in every operator-facing doc. It also removes a real footgun: this repo ships `compose.yaml` (the Sail **dev** stack) next to the prod file, so a bare `docker compose` in a production checkout previously resolved the **dev** stack. `COMPOSE_FILE` points it at the right one.

This is not a new mechanism here: `.env.example` already uses `# COMPOSE_PROFILES=sso`, the same class of Compose variable read from `.env`.

This lands first in #470 because it decides how `backup.sh`, `restore.sh`, and `upgrade.sh` invoke Compose. Those scripts inherit `COMPOSE_FILE` rather than hardcoding `-f docker-compose.prod.yml`, which would silently break build-from-source operators.

## No change for existing operators

An explicit `-f` still overrides `COMPOSE_FILE` (verified). Instances whose `.env` predates this template change keep using `-f` exactly as today; the docs say so.

## Build from source

Those operators need both files, so they list them colon-separated and the overlay stacks on every command, not just the one they remember to flag:

```
COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
```

The explicit two-file `-f` form is documented as the alternative.

## How tested

No app code changed, so this is invisible to the `--min=100` gate; the full gate is green regardless (`Total: 100.0 %`). The behaviour claims were verified directly against Docker Compose v5.1.2 in a scratch project:

- Without `COMPOSE_FILE`, a bare `docker compose` resolves the dev `compose.yaml` decoy; with it, it resolves the prod file.
- Variable interpolation from the same `.env` keeps working.
- The colon-separated two-file form yields a config containing both `build:` and `image:`.
- An explicit `-f` overrides `COMPOSE_FILE` in both directions.

## Docs

Updated in this PR per `CLAUDE.md`: `installation.md` (new "The COMPOSE_FILE variable" section covering the mechanism, the dev-stack footgun, the bare-`down` caveat, and pre-existing installs), `upgrading.md`, `configuration.md`, `first-user.md`, `feature-toggles.md`, `reference/environment-variables.md` (new Docker Compose entry), the docs landing page, plus `README.md` and the `docker-compose.prod.yml` / `docker-compose.build.yml` / `Dockerfile` headers.

`cd docs && npm run build` is green, and every internal anchor added was verified to resolve against the built HTML.

While rewriting the `Dockerfile` header's build-from-source example, corrected a latent inaccuracy: it showed `-f docker-compose.prod.yml up -d --build`, which builds nothing because the prod file has no `build:` key. It now shows the two-file `COMPOSE_FILE` form.

## Note

The local CodeRabbit pass hit the free-tier rate limit, so this PR leans on the CodeRabbit app review.