### PR TITLE
feat: app:version artisan command reporting the running instance version

### DIFF
--- a/app/Console/Commands/AppVersionCommand.php
+++ b/app/Console/Commands/AppVersionCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+/**
+ * Print the version this instance is running, and nothing else.
+ *
+ * The version lives in the committed VERSION file and is read (and stripped of
+ * its release-please annotation) by config/app.php, so this command reports
+ * that resolved value rather than re-implementing the parsing elsewhere.
+ * Output is bare and newline-terminated so docker/upgrade.sh can capture it
+ * with $(...) and compare it against the version it just deployed: a 200 from
+ * /up proves liveness, not identity.
+ */
+#[Signature('app:version')]
+#[Description('Print the version this instance is running')]
+class AppVersionCommand extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->line((string) config('app.version'));
+
+        return self::SUCCESS;
+    }
+}

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -129,7 +129,8 @@ echo "The Desk ${running} is running."
 ```
 
 If it still reports the version you upgraded from, the old container is most
-likely still up. Re-run `docker compose up -d` and check `docker compose ps`.
+likely still up. Check `docker compose ps`, then re-run the `up -d` step for
+your install path above (`--build` included, if you build from source).
 
 ## Your data persists
 

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -110,6 +110,27 @@ COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
 Migrations run automatically on start — the `app` container's entrypoint runs
 `php artisan migrate --force`.
 
+## Confirm the running version
+
+A healthy stack proves the containers are alive, not that they are running the
+version you just checked out: the old container answers just as happily as the
+new one. Ask the instance directly:
+
+```bash
+docker compose exec -T app php artisan app:version
+```
+
+It prints the bare version and nothing else, newline-terminated, so you can
+compare it against the tag you checked out or capture it in a script:
+
+```bash
+running=$(docker compose exec -T app php artisan app:version)
+echo "The Desk ${running} is running."
+```
+
+If it still reports the version you upgraded from, the old container is most
+likely still up. Re-run `docker compose up -d` and check `docker compose ps`.
+
 ## Your data persists
 
 Data survives `down`/`up` in named volumes:

--- a/tests/Feature/Console/AppVersionCommandTest.php
+++ b/tests/Feature/Console/AppVersionCommandTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+
+it('prints the running version and nothing else', function (): void {
+    config()->set('app.version', '9.9.9');
+
+    $exitCode = Artisan::call('app:version');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toBe("9.9.9\n");
+});
+
+it('prints the version from the VERSION file, stripped of its release-please annotation', function (): void {
+    Artisan::call('app:version');
+
+    expect(trim(Artisan::output()))
+        ->toBe(trim((string) preg_replace('/#.*/', '', (string) file_get_contents(base_path('VERSION')))))
+        ->toMatch('/^\d+\.\d+\.\d+$/');
+});


### PR DESCRIPTION
Part of #470. Implements #474.

## What

Adds `php artisan app:version`, which prints the version the instance is running and nothing else:

```
$ docker compose exec -T app php artisan app:version
1.5.2
```

## Why

`docker/upgrade.sh` (#475) needs to answer one question after restarting the stack: is the version I just deployed the version now running? A `200` from `/up` proves liveness, not identity, since the old container answers just as happily as the new one.

The version already lives in the `VERSION` file and is read (and stripped of its `# x-release-please-version` annotation) by `config/app.php`. This command reports that resolved value, so the parsing stays in the one place that already does it rather than being re-implemented in shell or via a `tinker --execute` one-liner.

Per #470 and #474, the version stays off `/up`: that route is Laravel's stock **unauthenticated** health check, while the version is authenticated-only by design (`HandleInertiaRequests.php:107`). An artisan command needs `docker compose exec`, which already implies host-level Docker access, so it discloses nothing the caller could not read from the `VERSION` file directly.

## How tested

- Two Pest feature tests in `tests/Feature/Console/AppVersionCommandTest.php`: the output is exactly `9.9.9\n` for a stubbed config (proving no banner, no label, newline-terminated, `$(...)`-safe) and exits zero; and it tracks the real `VERSION` file with its annotation stripped.
- Full gate green: `./vendor/bin/sail composer test` reports Pint passed, PHPStan 0 errors, Rector clean, 1277 tests, `Total: 100.0 %`.
- Verified the real invocation is byte-exact `1.5.2\n` via `od -c`: no banner, no ANSI colour codes.

## Docs

`self-hosting/upgrading.md` gains a "Confirm the running version" section covering both upgrade paths.

Note: that file is registered under release-please's `extra-files`, so the examples deliberately carry **no hardcoded version literal**. An un-annotated `1.5.2` in a sample-output block would drift on the next release (the #345 failure mode), and annotating an output line would render the marker as a fake comment in the output.

`cd docs && npm run build` is green.

## Review

Local CodeRabbit (`--base 470-feat-...`) returned two findings:

- **Applied (major, docs):** the version check followed both upgrade paths, so a bare `up -d` was wrong for build-from-source operators. CodeRabbit suggested `up -d --build`, but that is wrong for the image-pull default; the text now points at whichever step the reader used.
- **Skipped (minor):** wrap the `#[Description]` attribute in `__()`. This is impossible: attribute arguments must be constant expressions, so `#[Description(__('...'))]` is a PHP fatal error ("Constant expression contains invalid operations"), verified directly. It also fights convention: all four sibling commands use plain strings, and the i18n rule covers user-visible app copy, not CLI metadata.

The confirming re-review was rate-limited on the free OSS tier (the fix was docs-only); leaving that to the CodeRabbit app review.