### PR TITLE
feat: docker/backup.sh and docker/restore.sh for the production stack

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -185,13 +185,26 @@ jobs:
           tar tzf "$archive" | grep -q smoke-marker.txt
 
       # The guardrail that matters most: restore must not quietly replay a dump
-      # over a populated database.
+      # over a populated database. Refusing is only half the requirement, so
+      # change both markers first and assert they survived: a refusal that had
+      # already dropped the schema would still "refuse", and still be a disaster.
       - name: Assert restore refuses a populated database without --force
         run: |
+          docker compose exec -T pgsql psql -U laravel -d laravel \
+            -c "UPDATE smoke_marker SET note = 'state-before-refusal'"
+          docker compose exec -T app \
+            sh -c 'echo state-before-refusal > /app/storage/app/smoke-marker.txt'
+
           if ./docker/restore.sh backups/db-backup-*.sql.gz backups/storage-app-*.tar.gz </dev/null; then
             echo "restore.sh should have refused a non-empty database" >&2
             exit 1
           fi
+
+          note=$(docker compose exec -T pgsql psql -U laravel -d laravel \
+            -tAc "SELECT note FROM smoke_marker" | tr -d '[:space:]')
+          test "$note" = "state-before-refusal"
+          upload=$(docker compose exec -T app cat /app/storage/app/smoke-marker.txt | tr -d '[:space:]')
+          test "$upload" = "state-before-refusal"
 
       - name: Destroy both durable stores
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,3 +102,125 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Proves docker/backup.sh and docker/restore.sh actually round-trip against the
+  # real production stack: back up, destroy both durable stores, restore, and
+  # assert the data came back. Backing up only proves half of it — a backup you
+  # cannot restore is not a backup.
+  #
+  # This is the ONLY automated verification these two scripts get: they are host
+  # shell, so the app's `--min=100` PHP coverage gate cannot see them (see #473).
+  backup-restore:
+    name: Backup & restore round trip
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # `load` puts the image in the local daemon as the-desk:ci, which the .env
+      # below points APP_IMAGE at, so the stack runs this build rather than
+      # pulling a published release. cache-from reuses the layers the publish job
+      # wrote on the last master build.
+      - name: Build production image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: the-desk:ci
+          cache-from: type=gha
+
+      # gen-secrets.sh writes .env from .env.prod.example, which sets
+      # COMPOSE_FILE. Every `docker compose` below therefore needs no
+      # `-f docker-compose.prod.yml`, exercising the same inheritance the two
+      # scripts rely on.
+      - name: Prepare a production .env
+        run: |
+          ./docker/gen-secrets.sh
+          {
+            echo "APP_IMAGE=the-desk:ci"
+            echo "APP_URL=http://localhost:8000"
+          } >> .env
+
+      - name: Start the stack
+        run: |
+          docker compose up -d
+          # Deliberately not a bare `up -d --wait`: queue, reverb, and scheduler
+          # inherit FrankenPHP's Caddy healthcheck and report unhealthy (#477),
+          # which would fail --wait. Wait on the services whose healthchecks are
+          # meaningful; they are the ones this test touches.
+          docker compose up -d --wait pgsql app
+
+      # A marker in each durable store: the database and the storage-app volume.
+      # Restoring has to bring back both.
+      - name: Seed a marker into both durable stores
+        run: |
+          docker compose exec -T pgsql psql -U laravel -d laravel \
+            -c "CREATE TABLE smoke_marker (note text)" \
+            -c "INSERT INTO smoke_marker VALUES ('round-trip-proof')"
+          docker compose exec -T app \
+            sh -c 'echo uploaded-file-proof > /app/storage/app/smoke-marker.txt'
+
+      - name: Run backup.sh
+        run: |
+          mkdir -p backups
+          ./docker/backup.sh backups
+
+      - name: Assert the backup pair is complete
+        run: |
+          dump=$(ls backups/db-backup-*.sql.gz)
+          archive=$(ls backups/storage-app-*.tar.gz)
+          test -s "$dump"
+          test -s "$archive"
+          gzip -t "$dump"
+          gzip -t "$archive"
+          gunzip -c "$dump" | grep -q round-trip-proof
+          tar tzf "$archive" | grep -q smoke-marker.txt
+
+      # The guardrail that matters most: restore must not quietly replay a dump
+      # over a populated database.
+      - name: Assert restore refuses a populated database without --force
+        run: |
+          if ./docker/restore.sh backups/db-backup-*.sql.gz backups/storage-app-*.tar.gz </dev/null; then
+            echo "restore.sh should have refused a non-empty database" >&2
+            exit 1
+          fi
+
+      - name: Destroy both durable stores
+        run: |
+          docker compose exec -T pgsql psql -U laravel -d laravel \
+            -c "DROP SCHEMA public CASCADE" -c "CREATE SCHEMA public"
+          docker compose exec -T app \
+            sh -c 'find /app/storage/app -mindepth 1 -exec rm -rf {} +'
+          test "$(docker compose exec -T pgsql psql -U laravel -d laravel -tAc \
+            "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'" | tr -d '[:space:]')" = "0"
+
+      - name: Run restore.sh
+        run: ./docker/restore.sh backups/db-backup-*.sql.gz backups/storage-app-*.tar.gz --force
+
+      - name: Assert the stack comes back healthy with both stores restored
+        run: |
+          docker compose up -d
+          docker compose up -d --wait pgsql app
+
+          note=$(docker compose exec -T pgsql psql -U laravel -d laravel \
+            -tAc "SELECT note FROM smoke_marker" | tr -d '[:space:]')
+          test "$note" = "round-trip-proof"
+
+          upload=$(docker compose exec -T app cat /app/storage/app/smoke-marker.txt | tr -d '[:space:]')
+          test "$upload" = "uploaded-file-proof"
+
+      - name: Show stack logs on failure
+        if: failure()
+        run: docker compose logs --tail=100
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/docker/backup.sh
+++ b/docker/backup.sh
@@ -115,9 +115,12 @@ DUMP_FILE="$OUTPUT_DIR/db-backup-$STAMP.sql.gz"
 STORAGE_FILE="$OUTPUT_DIR/storage-app-$STAMP.tar.gz"
 
 # Stage into .partial files next to the final ones (same filesystem, so the
-# rename is atomic) and only rename once the producing command reported success.
-# A failed run therefore never leaves a truncated file that looks like a good
-# backup. The trap clears the staging files on any exit path.
+# rename is atomic) and publish BOTH only once BOTH producers have reported
+# success. A failed run therefore never leaves a truncated file that looks like a
+# good backup, and never leaves a mismatched pair: publishing the dump as soon as
+# it was written would, on a failed same-day retry, pair today's database with
+# last week's uploads while looking complete. The trap clears the staging files
+# on any exit path.
 DUMP_PARTIAL="$OUTPUT_DIR/.db-backup-$STAMP.sql.gz.partial"
 STORAGE_PARTIAL="$OUTPUT_DIR/.storage-app-$STAMP.tar.gz.partial"
 STATUS_FILE="$(mktemp)"
@@ -179,12 +182,9 @@ echo "Backing up to $OUTPUT_DIR:"
 ) | gzip -c >"$DUMP_PARTIAL"
 
 if [ "$(piped_status)" != "0" ]; then
-    echo "Error: pg_dump failed; no database backup written." >&2
+    echo "Error: pg_dump failed; no backup written." >&2
     exit 1
 fi
-
-mv "$DUMP_PARTIAL" "$DUMP_FILE"
-echo "  wrote $DUMP_FILE"
 
 # ---- Uploaded files ---------------------------------------------------------
 # tar compresses on its own (czf), so this needs no gzip stage; the status file
@@ -196,16 +196,31 @@ echo "  wrote $DUMP_FILE"
 ) >"$STORAGE_PARTIAL"
 
 if [ "$(piped_status)" != "0" ]; then
-    echo "Error: archiving storage/app failed; no storage backup written." >&2
+    echo "Error: archiving storage/app failed; no backup written." >&2
     exit 1
 fi
 
+# ---- Publish ----------------------------------------------------------------
+# Both producers succeeded, so the pair can be published together.
+mv "$DUMP_PARTIAL" "$DUMP_FILE"
+echo "  wrote $DUMP_FILE"
 mv "$STORAGE_PARTIAL" "$STORAGE_FILE"
 echo "  wrote $STORAGE_FILE"
 
 # ---- Retention --------------------------------------------------------------
+# Only complete pairs are counted and pruned: a lone dump or archive left by an
+# older/interrupted run must not consume a --keep slot, or it would evict a good
+# pair while contributing nothing restorable itself.
 if [ -n "$KEEP" ]; then
-    stamps="$(find "$OUTPUT_DIR" -maxdepth 1 -type f -name 'db-backup-*.sql.gz' | sed -e 's|.*/db-backup-||' -e 's|\.sql\.gz$||' | sort)"
+    stamps="$(
+        find "$OUTPUT_DIR" -maxdepth 1 -type f -name 'db-backup-*.sql.gz' |
+            sed -e 's|.*/db-backup-||' -e 's|\.sql\.gz$||' |
+            while IFS= read -r stamp; do
+                if [ -f "$OUTPUT_DIR/storage-app-$stamp.tar.gz" ]; then
+                    echo "$stamp"
+                fi
+            done | sort
+    )"
 
     if [ -n "$stamps" ]; then
         total="$(printf '%s\n' "$stamps" | wc -l | tr -d '[:space:]')"

--- a/docker/backup.sh
+++ b/docker/backup.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+#
+# Back up the production stack's durable state to the host.
+#
+#   ./docker/backup.sh [OUTPUT_DIR] [--keep=N]
+#
+# Writes two files into OUTPUT_DIR (default: the current directory):
+#
+#   db-backup-YYYY-MM-DD.sql.gz     gzipped logical dump of the database
+#   storage-app-YYYY-MM-DD.tar.gz   archive of the uploaded files
+#
+# Those two hold everything durable. The Meilisearch index is derived data
+# (rebuilt from Postgres on boot by `php artisan search:sync`) and Redis holds
+# only cache, sessions, and transient jobs, so neither is backed up.
+#
+# --keep=N prunes all but the N most recent backup pairs in OUTPUT_DIR. Without
+# it nothing is pruned. For scheduled backups, drive this from host cron:
+#
+#   0 3 * * * cd /srv/the-desk && ./docker/backup.sh /srv/backups --keep=7
+#
+# pg_dump runs inside the `pgsql` container so its version always matches the
+# server; the app image ships no postgres-client and pg_dump refuses to run
+# against a mismatched server.
+#
+# No `-f docker-compose.prod.yml` here: .env sets COMPOSE_FILE, so a bare
+# `docker compose` resolves the right files for both the published-image and
+# build-from-source setups.
+set -eu
+
+OUTPUT_DIR="."
+KEEP=""
+
+usage() {
+    echo "Usage: ./docker/backup.sh [OUTPUT_DIR] [--keep=N]"
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --keep=*)
+            KEEP="${arg#--keep=}"
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "Error: unknown option '$arg'." >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            OUTPUT_DIR="$arg"
+            ;;
+    esac
+done
+
+if [ -n "$KEEP" ] && ! echo "$KEEP" | grep -Eq '^[1-9][0-9]*$'; then
+    echo "Error: --keep must be a positive integer, got '$KEEP'." >&2
+    exit 1
+fi
+
+if [ ! -f "docker-compose.prod.yml" ]; then
+    echo "Error: run this from the project root (docker-compose.prod.yml not found)." >&2
+    exit 1
+fi
+
+if [ ! -d "$OUTPUT_DIR" ]; then
+    echo "Error: output directory '$OUTPUT_DIR' does not exist." >&2
+    exit 1
+fi
+
+if [ ! -w "$OUTPUT_DIR" ]; then
+    echo "Error: output directory '$OUTPUT_DIR' is not writable." >&2
+    exit 1
+fi
+
+# Read a key from .env, falling back to the same default the compose file uses.
+# An exported environment variable wins, matching the documented one-liners.
+env_value() {
+    key="$1"
+    default="$2"
+    value=""
+
+    if [ -f ".env" ]; then
+        value="$(sed -n "s/^${key}=//p" .env | tail -n 1 | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/")"
+    fi
+
+    if [ -z "$value" ]; then
+        value="$default"
+    fi
+
+    echo "$value"
+}
+
+DB_USERNAME="${DB_USERNAME:-$(env_value DB_USERNAME laravel)}"
+DB_DATABASE="${DB_DATABASE:-$(env_value DB_DATABASE laravel)}"
+
+# Every docker call here reads from /dev/null: `docker compose exec -T` attaches
+# the container's stdin and drains it, which would otherwise silently swallow
+# whatever the caller had on stdin.
+require_running() {
+    service="$1"
+    if [ -z "$(docker compose ps --quiet --status running "$service" 2>/dev/null </dev/null)" ]; then
+        echo "Error: the '$service' service is not running; start the stack first:" >&2
+        echo "  docker compose up -d" >&2
+        exit 1
+    fi
+}
+
+require_running pgsql
+require_running app
+
+STAMP="$(date +%F)"
+DUMP_FILE="$OUTPUT_DIR/db-backup-$STAMP.sql.gz"
+STORAGE_FILE="$OUTPUT_DIR/storage-app-$STAMP.tar.gz"
+
+# Stage into .partial files next to the final ones (same filesystem, so the
+# rename is atomic) and only rename once the producing command reported success.
+# A failed run therefore never leaves a truncated file that looks like a good
+# backup. The trap clears the staging files on any exit path.
+DUMP_PARTIAL="$OUTPUT_DIR/.db-backup-$STAMP.sql.gz.partial"
+STORAGE_PARTIAL="$OUTPUT_DIR/.storage-app-$STAMP.tar.gz.partial"
+STATUS_FILE="$(mktemp)"
+
+cleanup() {
+    rm -f "$DUMP_PARTIAL" "$STORAGE_PARTIAL" "$STATUS_FILE"
+}
+trap cleanup EXIT
+
+# `cmd | gzip > file` reports gzip's exit status, not cmd's, and POSIX sh has no
+# pipefail. Record the producer's status in a file so a failed pg_dump/tar is
+# caught instead of silently yielding a well-formed archive of an error message.
+piped_status() {
+    if [ ! -s "$STATUS_FILE" ]; then
+        echo "1"
+        return
+    fi
+
+    cat "$STATUS_FILE"
+}
+
+# ---- Disk space -------------------------------------------------------------
+# Check before writing anything: a backup that fills the host disk is worse than
+# no backup, since it takes the running instance down with it. Both figures are
+# uncompressed sizes and both files are compressed on the way out, so this is a
+# deliberate over-estimate rather than a tight fit.
+DB_BYTES="$(docker compose exec -T pgsql psql -U "$DB_USERNAME" -d "$DB_DATABASE" -tAc "SELECT pg_database_size('$DB_DATABASE')" </dev/null | tr -d '[:space:]')"
+STORAGE_KB="$(docker compose exec -T app du -sk /app/storage/app </dev/null | awk '{print $1}' | tr -d '[:space:]')"
+
+if ! echo "$DB_BYTES" | grep -Eq '^[0-9]+$' || ! echo "$STORAGE_KB" | grep -Eq '^[0-9]+$'; then
+    echo "Error: could not measure the database and storage sizes." >&2
+    exit 1
+fi
+
+REQUIRED_KB="$(((DB_BYTES / 1024) + STORAGE_KB))"
+AVAILABLE_KB="$(df -Pk "$OUTPUT_DIR" | awk 'NR == 2 {print $4}' | tr -d '[:space:]')"
+
+if ! echo "$AVAILABLE_KB" | grep -Eq '^[0-9]+$'; then
+    echo "Error: could not determine free space in '$OUTPUT_DIR'." >&2
+    exit 1
+fi
+
+if [ "$AVAILABLE_KB" -lt "$REQUIRED_KB" ]; then
+    echo "Error: not enough free space in '$OUTPUT_DIR'." >&2
+    echo "  need about $((REQUIRED_KB / 1024)) MB (uncompressed), $((AVAILABLE_KB / 1024)) MB available." >&2
+    echo "  Free up space or pass a different output directory." >&2
+    exit 1
+fi
+
+echo "Backing up to $OUTPUT_DIR:"
+
+# ---- Database ---------------------------------------------------------------
+# A `( )` subshell, not a `{ }` group: `set +e` must not leak into the rest of
+# the script. Without it `set -e` would abort before the status was recorded.
+(
+    set +e
+    docker compose exec -T pgsql pg_dump -U "$DB_USERNAME" "$DB_DATABASE" </dev/null
+    echo "$?" >"$STATUS_FILE"
+) | gzip -c >"$DUMP_PARTIAL"
+
+if [ "$(piped_status)" != "0" ]; then
+    echo "Error: pg_dump failed; no database backup written." >&2
+    exit 1
+fi
+
+mv "$DUMP_PARTIAL" "$DUMP_FILE"
+echo "  wrote $DUMP_FILE"
+
+# ---- Uploaded files ---------------------------------------------------------
+# tar compresses on its own (czf), so this needs no gzip stage; the status file
+# guards a mid-stream tar failure the same way.
+(
+    set +e
+    docker compose exec -T app tar czf - -C /app/storage/app . </dev/null
+    echo "$?" >"$STATUS_FILE"
+) >"$STORAGE_PARTIAL"
+
+if [ "$(piped_status)" != "0" ]; then
+    echo "Error: archiving storage/app failed; no storage backup written." >&2
+    exit 1
+fi
+
+mv "$STORAGE_PARTIAL" "$STORAGE_FILE"
+echo "  wrote $STORAGE_FILE"
+
+# ---- Retention --------------------------------------------------------------
+if [ -n "$KEEP" ]; then
+    stamps="$(find "$OUTPUT_DIR" -maxdepth 1 -type f -name 'db-backup-*.sql.gz' | sed -e 's|.*/db-backup-||' -e 's|\.sql\.gz$||' | sort)"
+
+    if [ -n "$stamps" ]; then
+        total="$(printf '%s\n' "$stamps" | wc -l | tr -d '[:space:]')"
+
+        if [ "$total" -gt "$KEEP" ]; then
+            printf '%s\n' "$stamps" | head -n "$((total - KEEP))" | while IFS= read -r stamp; do
+                rm -f "$OUTPUT_DIR/db-backup-$stamp.sql.gz" "$OUTPUT_DIR/storage-app-$stamp.tar.gz"
+                echo "  pruned $stamp"
+            done
+        fi
+    fi
+fi
+
+echo
+echo "Done. Store both files off the host. To restore them:"
+echo "  ./docker/restore.sh $DUMP_FILE $STORAGE_FILE"

--- a/docker/restore.sh
+++ b/docker/restore.sh
@@ -17,8 +17,9 @@
 # Every check that can refuse runs *before* the stack is stopped, so a run that
 # bails leaves the instance exactly as it found it.
 #
-# The stack is left stopped afterwards so you can check things over; bring it
-# back with `docker compose up -d`.
+# Those services are left stopped afterwards so you can check things over (pgsql
+# stays up: it is what we restore into); bring everything back with
+# `docker compose up -d`.
 #
 # No `-f docker-compose.prod.yml` here: .env sets COMPOSE_FILE, so a bare
 # `docker compose` resolves the right files for both the published-image and
@@ -86,6 +87,15 @@ for file in "$DUMP_FILE" "$STORAGE_FILE"; do
         exit 1
     fi
 done
+
+# `gzip -t` only proves the compressed stream is intact; a valid gzip of garbage
+# passes it. The uploads are extracted after storage/app has been cleared, so
+# check the tar structure now rather than discovering it is unreadable with the
+# existing uploads already gone.
+if ! tar tzf "$STORAGE_FILE" >/dev/null 2>&1; then
+    echo "Error: '$STORAGE_FILE' is not a readable tar archive." >&2
+    exit 1
+fi
 
 # Read a key from .env, falling back to the same default the compose file uses.
 # An exported environment variable wins, matching the documented one-liners.
@@ -192,22 +202,29 @@ if [ -n "$RUNNING" ]; then
 fi
 
 # ---- Database ---------------------------------------------------------------
-# Drop and recreate the public schema so the dump lands in the "freshly created,
-# empty database" it expects. A plain pg_dump carries no DROP statements, so
-# without this every CREATE would collide with the existing schema.
-if [ "$TABLE_COUNT" -gt 0 ]; then
-    echo "Replacing the existing schema in '$DB_DATABASE'..."
-    docker compose exec -T pgsql psql -v ON_ERROR_STOP=1 --quiet -U "$DB_USERNAME" -d "$DB_DATABASE" \
-        -c "DROP SCHEMA public CASCADE" -c "CREATE SCHEMA public" </dev/null >/dev/null
-fi
-
 echo "Restoring the database..."
-# ON_ERROR_STOP makes psql exit non-zero on the first failed statement instead
-# of replaying the rest of the dump over a broken schema and reporting success.
-# psql is last in the pipeline, so `set -e` sees its status; the gzip integrity
-# check above already ruled out a truncated producer.
-gunzip -c "$DUMP_FILE" | docker compose exec -T pgsql \
-    psql -v ON_ERROR_STOP=1 --quiet -U "$DB_USERNAME" -d "$DB_DATABASE" >/dev/null
+# Dropping the schema and replaying the dump go to psql as ONE stream under
+# --single-transaction, so a failure rolls the whole thing back and leaves the
+# database exactly as it was. Doing the DROP as its own statement first would
+# mean a dump that fails to replay leaves the operator with neither their old
+# database nor their backup.
+#
+# The schema is dropped and recreated (rather than restoring over what is there)
+# so the dump lands in the "freshly created, empty database" it expects: a plain
+# pg_dump carries no DROP statements, so every CREATE would otherwise collide.
+#
+# ON_ERROR_STOP is what makes psql abort, and therefore roll back, on the first
+# failed statement instead of replaying the rest over a broken schema and
+# exiting 0. psql is last in the pipeline, so `set -e` sees its status.
+{
+    if [ "$TABLE_COUNT" -gt 0 ]; then
+        echo "DROP SCHEMA public CASCADE;"
+        echo "CREATE SCHEMA public;"
+    fi
+
+    gunzip -c "$DUMP_FILE"
+} | docker compose exec -T pgsql \
+    psql --single-transaction -v ON_ERROR_STOP=1 --quiet -U "$DB_USERNAME" -d "$DB_DATABASE" >/dev/null
 
 # ---- Uploaded files ---------------------------------------------------------
 # `run --rm --no-deps`, not `exec`: the app container is stopped by this point
@@ -222,5 +239,10 @@ docker compose run --rm --no-deps -T --entrypoint sh app \
     <"$STORAGE_FILE"
 
 echo
-echo "Restore complete. The stack is stopped; start it with:"
+echo "Restore complete."
+if [ -n "$RUNNING" ]; then
+    # pgsql is deliberately still up: it is what we restored into.
+    echo "Still stopped so you can check things over first: $RUNNING"
+fi
+echo "Bring the stack back with:"
 echo "  docker compose up -d"

--- a/docker/restore.sh
+++ b/docker/restore.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+#
+# Restore the production stack's durable state from a backup pair.
+#
+#   ./docker/restore.sh db-backup-YYYY-MM-DD.sql.gz storage-app-YYYY-MM-DD.tar.gz [--force]
+#
+# Restore is destructive in a way backup is not, so this script:
+#
+#   - refuses a non-empty database unless --force is passed, because psql
+#     replaying a plain dump over existing tables produces a half-merged mess
+#     rather than the backup you asked for;
+#   - prints exactly what it will overwrite and asks for confirmation, which
+#     --force also skips for non-interactive use (cron, CI);
+#   - stops app, reverb, queue, and scheduler before touching anything, so
+#     nothing writes to the database or the uploads mid-restore.
+#
+# Every check that can refuse runs *before* the stack is stopped, so a run that
+# bails leaves the instance exactly as it found it.
+#
+# The stack is left stopped afterwards so you can check things over; bring it
+# back with `docker compose up -d`.
+#
+# No `-f docker-compose.prod.yml` here: .env sets COMPOSE_FILE, so a bare
+# `docker compose` resolves the right files for both the published-image and
+# build-from-source setups.
+set -eu
+
+DUMP_FILE=""
+STORAGE_FILE=""
+FORCE="false"
+
+usage() {
+    echo "Usage: ./docker/restore.sh DUMP_FILE STORAGE_FILE [--force]"
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --force)
+            FORCE="true"
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "Error: unknown option '$arg'." >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            if [ -z "$DUMP_FILE" ]; then
+                DUMP_FILE="$arg"
+            elif [ -z "$STORAGE_FILE" ]; then
+                STORAGE_FILE="$arg"
+            else
+                echo "Error: unexpected argument '$arg'." >&2
+                usage >&2
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$DUMP_FILE" ] || [ -z "$STORAGE_FILE" ]; then
+    echo "Error: both a database dump and a storage archive are required." >&2
+    usage >&2
+    exit 1
+fi
+
+if [ ! -f "docker-compose.prod.yml" ]; then
+    echo "Error: run this from the project root (docker-compose.prod.yml not found)." >&2
+    exit 1
+fi
+
+# Verify both archives before anything is stopped or overwritten. Restoring half
+# of a truncated pair is worse than refusing the whole run: a valid gzip prefix
+# can replay into psql cleanly and look like it worked.
+for file in "$DUMP_FILE" "$STORAGE_FILE"; do
+    if [ ! -r "$file" ]; then
+        echo "Error: '$file' does not exist or is not readable." >&2
+        exit 1
+    fi
+
+    if ! gzip -t "$file" 2>/dev/null; then
+        echo "Error: '$file' is not a readable gzip archive (truncated or corrupt?)." >&2
+        exit 1
+    fi
+done
+
+# Read a key from .env, falling back to the same default the compose file uses.
+# An exported environment variable wins, matching the documented one-liners.
+env_value() {
+    key="$1"
+    default="$2"
+    value=""
+
+    if [ -f ".env" ]; then
+        value="$(sed -n "s/^${key}=//p" .env | tail -n 1 | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/")"
+    fi
+
+    if [ -z "$value" ]; then
+        value="$default"
+    fi
+
+    echo "$value"
+}
+
+DB_USERNAME="${DB_USERNAME:-$(env_value DB_USERNAME laravel)}"
+DB_DATABASE="${DB_DATABASE:-$(env_value DB_DATABASE laravel)}"
+
+# pgsql is the one service that must be up: it is what we restore into, and the
+# emptiness check below has to query it. Starting it changes no data.
+#
+# Every docker call from here to the confirmation prompt reads from /dev/null:
+# `docker compose exec -T` attaches the container's stdin and drains it, which
+# would otherwise eat the operator's answer before `read` sees it (and makes
+# `echo yes | ./docker/restore.sh ...` fail).
+echo "Ensuring the database is up..."
+docker compose up -d --wait pgsql </dev/null
+
+# ---- Guard a populated database ---------------------------------------------
+TABLE_COUNT="$(docker compose exec -T pgsql psql -U "$DB_USERNAME" -d "$DB_DATABASE" -tAc \
+    "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'" </dev/null | tr -d '[:space:]')"
+
+if ! echo "$TABLE_COUNT" | grep -Eq '^[0-9]+$'; then
+    echo "Error: could not inspect database '$DB_DATABASE'." >&2
+    exit 1
+fi
+
+if [ "$TABLE_COUNT" -gt 0 ] && [ "$FORCE" != "true" ]; then
+    echo "Error: database '$DB_DATABASE' is not empty ($TABLE_COUNT tables)." >&2
+    echo "  Restoring a dump over existing tables produces a half-merged database," >&2
+    echo "  so this needs an explicit --force, which replaces the schema outright:" >&2
+    echo "  ./docker/restore.sh $DUMP_FILE $STORAGE_FILE --force" >&2
+    exit 1
+fi
+
+# ---- Which writers are up ---------------------------------------------------
+# Everything that could write mid-restore. pgsql stays up by design. reverb is
+# included because it shares the app image and boots the framework, even though
+# it is not itself a writer of note.
+WRITERS="app reverb queue scheduler"
+
+running_writers() {
+    for service in $WRITERS; do
+        if [ -n "$(docker compose ps --quiet --status running "$service" 2>/dev/null </dev/null)" ]; then
+            echo "$service"
+        fi
+    done
+}
+
+RUNNING="$(running_writers | tr '\n' ' ' | sed -e 's/ *$//')"
+
+# ---- Plan and confirm -------------------------------------------------------
+echo
+echo "About to restore into this instance, overwriting:"
+if [ "$TABLE_COUNT" -gt 0 ]; then
+    echo "  database '$DB_DATABASE' ($TABLE_COUNT existing tables, schema will be replaced)"
+else
+    echo "  database '$DB_DATABASE' (currently empty)"
+fi
+echo "    <- $DUMP_FILE"
+echo "  all uploaded files in storage/app"
+echo "    <- $STORAGE_FILE"
+
+if [ -n "$RUNNING" ]; then
+    echo "  stopping first, so nothing writes mid-restore: $RUNNING"
+fi
+echo
+
+if [ "$FORCE" != "true" ]; then
+    printf 'This cannot be undone. Type "yes" to continue: '
+    if ! read -r reply; then
+        echo >&2
+        echo "Error: no input available to confirm; pass --force for non-interactive use." >&2
+        exit 1
+    fi
+
+    if [ "$reply" != "yes" ]; then
+        echo "Aborted; nothing was changed."
+        exit 1
+    fi
+    echo
+fi
+
+# ---- Stop the writers -------------------------------------------------------
+if [ -n "$RUNNING" ]; then
+    echo "Stopping $RUNNING..."
+    # Unquoted on purpose: the service names are a word list, not one argument.
+    # shellcheck disable=SC2086
+    docker compose stop $RUNNING </dev/null
+fi
+
+# ---- Database ---------------------------------------------------------------
+# Drop and recreate the public schema so the dump lands in the "freshly created,
+# empty database" it expects. A plain pg_dump carries no DROP statements, so
+# without this every CREATE would collide with the existing schema.
+if [ "$TABLE_COUNT" -gt 0 ]; then
+    echo "Replacing the existing schema in '$DB_DATABASE'..."
+    docker compose exec -T pgsql psql -v ON_ERROR_STOP=1 --quiet -U "$DB_USERNAME" -d "$DB_DATABASE" \
+        -c "DROP SCHEMA public CASCADE" -c "CREATE SCHEMA public" </dev/null >/dev/null
+fi
+
+echo "Restoring the database..."
+# ON_ERROR_STOP makes psql exit non-zero on the first failed statement instead
+# of replaying the rest of the dump over a broken schema and reporting success.
+# psql is last in the pipeline, so `set -e` sees its status; the gzip integrity
+# check above already ruled out a truncated producer.
+gunzip -c "$DUMP_FILE" | docker compose exec -T pgsql \
+    psql -v ON_ERROR_STOP=1 --quiet -U "$DB_USERNAME" -d "$DB_DATABASE" >/dev/null
+
+# ---- Uploaded files ---------------------------------------------------------
+# `run --rm --no-deps`, not `exec`: the app container is stopped by this point
+# and exec needs a running one. This starts a throwaway container with the same
+# storage-app volume mounted. The entrypoint is overridden because its job is to
+# migrate and cache config, none of which should happen mid-restore. The volume
+# is cleared first so the result is the backup, not the backup merged over
+# whatever was already there.
+echo "Restoring uploaded files..."
+docker compose run --rm --no-deps -T --entrypoint sh app \
+    -c 'set -e; find /app/storage/app -mindepth 1 -exec rm -rf {} +; exec tar xzf - -C /app/storage/app' \
+    <"$STORAGE_FILE"
+
+echo
+echo "Restore complete. The stack is stopped; start it with:"
+echo "  docker compose up -d"

--- a/docs/src/content/docs/docs/faq.md
+++ b/docs/src/content/docs/docs/faq.md
@@ -32,10 +32,14 @@ does.
 
 ## How do I back it up?
 
-Everything lives in **PostgreSQL** and a few **Docker volumes** (uploads and the
-Meilisearch index). Back up the Postgres database and those volumes on your normal
-schedule and you can restore the whole instance. The
-[Architecture reference](/docs/reference/architecture/) lists exactly what runs
+Run `./docker/backup.sh`. It dumps the **PostgreSQL** database and archives the
+**uploads** volume, which together are everything durable: the Meilisearch index
+is rebuilt from Postgres on boot and Redis holds only cache, sessions, and queued
+jobs, so neither needs backing up. `./docker/restore.sh` puts both back.
+
+Add `--keep=N` to prune old backups and drive it from host cron for a schedule.
+See [Backups](/docs/self-hosting/upgrading/#back-up-first) for the details, and
+the [Architecture reference](/docs/reference/architecture/) for exactly what runs
 and where state lives.
 
 ## Can people sign up themselves, or is it invite-only?

--- a/docs/src/content/docs/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/docs/reference/security-and-compliance.md
@@ -43,7 +43,7 @@ criterion in the context of your whole system.
 | **Account deletion and erasure** | Deleting an account removes the user record and reassigns their authored messages to a shared "Deleted User" tombstone, so conversations stay coherent while personal attribution is removed. The user's personal teams are deleted. | (Privacy) P4 | A.8.10, A.5.34 |
 | **Retention windows** | Uploaded-but-unsent attachments are swept after `ATTACHMENT_PENDING_TTL_HOURS` (default 24). Data-export archives and audit-evidence export files are downloadable for a fixed 7-day window, after which a scheduled task deletes both the file and its record. Long-term retention of the audit and activity logs themselves is an operator decision (see the note below). | (Privacy) P4 | A.8.10, A.5.34 |
 | **Encryption and transport posture** | The application encrypts session data and any encrypted attributes with `APP_KEY` (AES-256). Containers speak plain HTTP by design; TLS termination is delegated to your reverse proxy (see operator responsibilities). | CC6.1, CC6.7 | A.8.24, A.5.14 |
-| **Backups** | Durable state is one PostgreSQL database plus the uploaded-files volume; the search index and Redis are derived or transient. Logical dump and restore commands are documented, but taking, testing, and storing backups is an operator responsibility. | A1.2 | A.8.13 |
+| **Backups** | Durable state is one PostgreSQL database plus the uploaded-files volume; the search index and Redis are derived or transient. `docker/backup.sh` and `docker/restore.sh` ship with the stack and cover the dump, restore, and retention (`--keep=N`), but scheduling, testing, encrypting, and off-siting backups is an operator responsibility. | A1.2 | A.8.13 |
 
 ### Notes an auditor should read
 
@@ -115,7 +115,10 @@ evidence for each of these from **your** environment, not from this project:
   database and the uploaded-files volume. This is provided by your host or storage
   layer, not the app.
 - **Backups.** Take, encrypt, test, and off-site the database and file-volume
-  backups. Commands are in [Upgrading](/docs/self-hosting/upgrading/#back-up-first).
+  backups. `docker/backup.sh` and `docker/restore.sh` handle the taking and the
+  restoring, including a `--keep=N` retention flag and a host-cron example; see
+  [Upgrading](/docs/self-hosting/upgrading/#back-up-first). Encrypting and
+  off-siting the resulting files remains yours.
 - **Secret management.** `APP_KEY`, `DB_PASSWORD`, `MEILISEARCH_KEY`, the
   `REVERB_*` credentials, and any `SCIM_TOKEN` are full secrets. Generate them
   with `./docker/gen-secrets.sh`, store them in a secret manager rather than a

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -35,31 +35,76 @@ Meilisearch index is derived data — it is rebuilt from Postgres on boot, so it
 needs no backup — and Redis holds only cache, sessions, and transient queued
 jobs.
 
-Take a logical database dump (portable across Postgres versions) and an archive
-of the uploaded files:
+Take both with one command, from the project root:
 
 ```bash
-# Database — logical dump, gzipped
-docker compose exec -T pgsql \
-  pg_dump -U "${DB_USERNAME:-laravel}" "${DB_DATABASE:-laravel}" \
-  | gzip > db-backup-$(date +%F).sql.gz
-
-# Uploaded files — stream a tar out of the running app container
-docker compose exec -T app \
-  tar czf - -C /app/storage/app . > storage-app-$(date +%F).tar.gz
+./docker/backup.sh
 ```
 
-Store both files off the host. To restore into a **freshly created, empty**
-database and a running stack:
+It writes a gzipped logical database dump (portable across Postgres versions) and
+an archive of the uploaded files into the current directory, named with the date:
+
+```
+db-backup-YYYY-MM-DD.sql.gz
+storage-app-YYYY-MM-DD.tar.gz
+```
+
+Pass a directory to write them somewhere else, and `--keep=N` to prune all but
+the N most recent backup pairs in it:
 
 ```bash
-# Database
-gunzip -c db-backup-YYYY-MM-DD.sql.gz | docker compose exec -T pgsql \
-  psql -U "${DB_USERNAME:-laravel}" "${DB_DATABASE:-laravel}"
+./docker/backup.sh /srv/backups --keep=7
+```
 
-# Uploaded files
-docker compose exec -T app \
-  tar xzf - -C /app/storage/app < storage-app-YYYY-MM-DD.tar.gz
+The script checks there is enough free space before it starts and refuses rather
+than filling the host disk, and it never leaves a truncated file behind that
+could be mistaken for a good backup. `pg_dump` runs inside the `pgsql` container,
+so its version always matches the server.
+
+Store both files off the host. They are an ordinary gzipped `pg_dump` and an
+ordinary gzipped tar of `storage/app`, so any backup tooling you already run can
+consume them.
+
+### Scheduled backups
+
+Run the script from **host cron**:
+
+```cron
+0 3 * * * cd /srv/the-desk && ./docker/backup.sh /srv/backups --keep=7
+```
+
+The app's own `scheduler` container cannot do this. It runs inside Docker and
+would need the Docker socket mounted to drive `docker compose`, which is
+root-equivalent access to the host: too much to trade for a cron line.
+
+### Restoring
+
+```bash
+./docker/restore.sh db-backup-YYYY-MM-DD.sql.gz storage-app-YYYY-MM-DD.tar.gz
+```
+
+Restore is destructive in a way backup is not, so the script:
+
+- **stops `app`, `reverb`, `queue`, and `scheduler` first**, so nothing writes to
+  the database or the uploads mid-restore;
+- **refuses a non-empty database** unless `--force` is passed, because `psql`
+  replaying a dump over existing tables produces a half-merged database rather
+  than the backup you asked for;
+- **prints exactly what it will overwrite** and asks you to confirm.
+
+Every check that can refuse runs before anything is stopped or overwritten, so a
+run that bails leaves the instance as it found it.
+
+Pass `--force` to skip the confirmation for non-interactive use (cron, CI). On a
+populated database `--force` also replaces the existing schema outright, which is
+what makes the restore land in the freshly created, empty database a dump
+expects.
+
+The stack is left stopped afterwards so you can check things over. Start it again
+with:
+
+```bash
+docker compose up -d
 ```
 
 ## Default: pull the newer image

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -41,8 +41,11 @@ Take both with one command, from the project root:
 ./docker/backup.sh
 ```
 
-It writes a gzipped logical database dump (portable across Postgres versions) and
-an archive of the uploaded files into the current directory, named with the date:
+It writes a gzipped logical database dump (SQL statements rather than a physical
+copy of the data files, which is what makes it portable across Postgres versions
+in the ordinary case, though restoring into a very different major version or a
+host missing an extension can still need work) and an archive of the uploaded
+files into the current directory, named with the date:
 
 ```
 db-backup-YYYY-MM-DD.sql.gz
@@ -93,7 +96,9 @@ Restore is destructive in a way backup is not, so the script:
 - **prints exactly what it will overwrite** and asks you to confirm.
 
 Every check that can refuse runs before anything is stopped or overwritten, so a
-run that bails leaves the instance as it found it.
+run that bails leaves the instance as it found it. The database restore itself
+runs in a single transaction: if it fails part way, it rolls back and leaves the
+database as it was, rather than dropped and half-restored.
 
 Pass `--force` to skip the confirmation for non-interactive use (cron, CI). On a
 populated database `--force` also replaces the existing schema outright, which is


### PR DESCRIPTION
Part of #470. Implements #473.

## What

Two operator-facing scripts next to `docker/gen-secrets.sh`, in the same style (POSIX `sh`, `set -eu`, run from the project root):

```bash
./docker/backup.sh                          # -> db-backup-YYYY-MM-DD.sql.gz + storage-app-YYYY-MM-DD.tar.gz
./docker/backup.sh /srv/backups --keep=7    # output dir + retention, for host cron
./docker/restore.sh <dump> <archive>        # confirms first; --force for non-interactive
```

## Why

`upgrading.md` documented the procedure correctly, as four one-liners the operator copy-pastes. The procedure was right; it just was not executable. The restore half especially is something an operator reads for the first time while their instance is down, which is the worst possible moment to be parsing a `gunzip | psql` pipeline out of a docs page.

Per #470/#473 these are host shell rather than an artisan command: the runtime image ships no `postgres-client`, and adding one would permanently couple the app image's `pg_dump` to the `postgres:18-alpine` major (`pg_dump` refuses outright on a server mismatch), which this repo bumps independently. Running `pg_dump` inside the `pgsql` container makes the version match free.

Neither script hardcodes `-f docker-compose.prod.yml`; both inherit `COMPOSE_FILE` (#472), so build-from-source operators work unchanged.

## Design notes

- **backup.sh** checks free space before writing (a backup that fills the host disk takes the instance down with it), stages both files through `.partial` names and publishes them only once **both** producers succeed, and prunes complete pairs only.
- **restore.sh** front-loads every check that can refuse, so a run that bails leaves the instance exactly as it found it. It verifies both archives, refuses a non-empty database without `--force`, prints what it will overwrite, and asks to confirm. Only then does it stop the writers.
- The database restore is **one `--single-transaction` stream** (schema drop + replay), so a failure rolls back rather than leaving the operator with neither their old database nor their backup.
- Storage restores via `compose run --rm --no-deps`, not `exec`: the app container is stopped by then and `exec` needs a running one.
- Every docker call that must not consume stdin reads from `/dev/null`. `docker compose exec -T` attaches and drains stdin, which otherwise ate the operator's confirmation before `read` saw it (`echo yes | ./docker/restore.sh ...` failed).

## How tested

Shell is invisible to the `--min=100` gate, so `docker.yml` gains a `backup-restore` job that proves the **round trip** against the real stack, not just the backup half: seed a marker into both durable stores, back up, assert the pair is complete, assert restore refuses a populated database *without destroying it*, destroy both stores, restore, and assert the data came back.

I also ran the whole thing locally against a real prod stack (published image, isolated compose project). Verified:

- Round trip: 32 tables and both markers destroyed, then restored (`round-trip-proof`, `uploaded-file-proof`).
- Restore genuinely **replaces** data: a mutated marker came back as the backed-up value.
- **Rollback:** a dump that fails part way exits non-zero and leaves all 32 tables and data intact.
- Refusals are non-destructive: non-empty DB, corrupt archive, missing file, declined confirmation. All exit non-zero with every service still running.
- `--keep=2` prunes the oldest pairs and leaves an orphan dump alone.
- Disk-space guard fires and leaves no partial behind; stack-down, bad `--keep`, unknown option, missing output dir all error clearly.

Backend gate green (`Total: 100.0 %`), `cd docs && npm run build` green.

## Docs

`upgrading.md` replaces the copy-paste blocks with the script invocations plus the host-cron example (the `scheduler` container cannot do this: it is inside Docker and would need the Docker socket, which is root-equivalent host access). `faq.md` and `security-and-compliance.md` updated to match. The `#back-up-first` anchor that other pages link to is preserved, verified in the built HTML.

## Notes

- **CI trigger:** `docker.yml` only runs on PRs targeting `develop`/`master`, so the new job does not run on this PR into the foundation branch. It runs on the epic PR (#479), which targets `master`. Local verification above stands in meanwhile.
- The smoke test deliberately avoids a bare `docker compose up -d --wait`: `queue`, `reverb`, and `scheduler` inherit FrankenPHP's Caddy healthcheck and report unhealthy, which would fail `--wait`. That is the pre-existing #477, found again while testing this; not fixed here.

Local CodeRabbit (`--base 470-feat-...`): clean, 0 findings. Its earlier pass caught the mismatched-pair, non-atomic-restore, and gzip-vs-tar defects fixed in e122bfc.