### PR TITLE
feat: docker/upgrade.sh one-command upgrade with verification

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -287,6 +287,9 @@ jobs:
       # was built from, so a successful run proves the identity check agrees.
       - name: Run upgrade.sh
         run: |
+          # pipefail: without it the pipeline reports tee's status, so a failing
+          # upgrade.sh would be masked.
+          set -o pipefail
           mkdir -p backups
           ./docker/upgrade.sh backups --no-pull | tee upgrade.log
           grep -q "Upgraded to $(sed -e 's/#.*//' VERSION | tr -d '[:space:]')" upgrade.log
@@ -304,6 +307,8 @@ jobs:
       # successful upgrade.
       - name: Assert a failed upgrade halts, keeps the stack, and hands back a restore command
         run: |
+          version_before=$(docker compose exec -T app php artisan app:version)
+
           if ./docker/upgrade.sh backups --no-pull --target=9.9.9 >failed.log 2>&1; then
             echo "upgrade.sh should have failed on a version mismatch" >&2
             cat failed.log >&2
@@ -327,8 +332,10 @@ jobs:
           gzip -t "$dump"
           gzip -t "$archive"
 
-          # It must have left the stack alone rather than restoring anything.
-          docker compose exec -T app php artisan app:version
+          # It must have left the stack alone rather than restoring anything:
+          # same version running as before the failed attempt.
+          version_after=$(docker compose exec -T app php artisan app:version)
+          test "$version_after" = "$version_before"
 
       - name: Show stack logs on failure
         if: failure()

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -237,3 +237,103 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose down -v
+
+  # Proves docker/upgrade.sh both succeeds and, just as importantly, fails
+  # correctly: the whole point of the script is that a failed upgrade hands the
+  # operator a real backup and a ready-to-paste restore command instead of
+  # rolling back on its own. Shell, so the `--min=100` PHP gate cannot see it
+  # (see #475).
+  upgrade:
+    name: Upgrade script
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build production image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: the-desk:ci
+          cache-from: type=gha
+
+      - name: Prepare a production .env
+        run: |
+          ./docker/gen-secrets.sh
+          {
+            echo "APP_IMAGE=the-desk:ci"
+            echo "APP_URL=http://localhost:8000"
+          } >> .env
+
+      # Start from a running stack, which is what an operator upgrades from.
+      # Not `up -d --wait`: queue/reverb/scheduler inherit FrankenPHP's Caddy
+      # healthcheck and report unhealthy (#477), which would fail --wait.
+      - name: Start the stack
+        run: |
+          docker compose up -d
+          docker compose up -d --wait pgsql app
+
+      # --no-pull because the image under test is local and in no registry.
+      # The target defaults to the VERSION file, which is the version this image
+      # was built from, so a successful run proves the identity check agrees.
+      - name: Run upgrade.sh
+        run: |
+          mkdir -p backups
+          ./docker/upgrade.sh backups --no-pull | tee upgrade.log
+          grep -q "Upgraded to $(sed -e 's/#.*//' VERSION | tr -d '[:space:]')" upgrade.log
+
+      - name: Assert the upgrade took a real backup
+        run: |
+          test -s "$(ls backups/db-backup-*.sql.gz)"
+          test -s "$(ls backups/storage-app-*.tar.gz)"
+          gzip -t backups/db-backup-*.sql.gz
+          gzip -t backups/storage-app-*.tar.gz
+
+      # The failure path is the one that matters. Force a version mismatch: the
+      # stack is healthy and serving, so only the identity check can catch that
+      # it is not running what was asked for. Liveness alone would call this a
+      # successful upgrade.
+      - name: Assert a failed upgrade halts, keeps the stack, and hands back a restore command
+        run: |
+          if ./docker/upgrade.sh backups --no-pull --target=9.9.9 >failed.log 2>&1; then
+            echo "upgrade.sh should have failed on a version mismatch" >&2
+            cat failed.log >&2
+            exit 1
+          fi
+
+          cat failed.log
+
+          # It must say what went wrong, and must not have rolled back by itself.
+          grep -q "running 9.9.9\|not 9.9.9" failed.log
+          grep -q "did NOT roll back" failed.log
+
+          # The restore line must be ready to paste: real paths, both files, and
+          # they must actually exist.
+          restore_line=$(grep -oE '\./docker/restore\.sh \S+ \S+' failed.log | tail -1)
+          test -n "$restore_line"
+          dump=$(echo "$restore_line" | awk '{print $2}')
+          archive=$(echo "$restore_line" | awk '{print $3}')
+          test -f "$dump"
+          test -f "$archive"
+          gzip -t "$dump"
+          gzip -t "$archive"
+
+          # It must have left the stack alone rather than restoring anything.
+          docker compose exec -T app php artisan app:version
+
+      - name: Show stack logs on failure
+        if: failure()
+        run: docker compose logs --tail=100
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/README.md
+++ b/README.md
@@ -220,16 +220,27 @@ Registration is open, so onboarding is self-service:
 
 ### Upgrading
 
-Upgrades follow the same tag-based flow. Check out the newer release tag and
-restart — `up -d` pulls the image that tag pins:
+Upgrades follow the same tag-based flow. Check out the newer release tag and run
+the upgrade script — it backs up, starts the new release, and verifies the
+instance is actually running it (a healthy stack only proves the containers are
+alive; the old one answers just as happily):
 
 ```bash
 git fetch --tags
 git checkout v1.5.2 # x-release-please-version         (the desired release tag)
-docker compose down
-docker compose up -d
-# pulls the newer pinned image; migrations run automatically via the entrypoint
+./docker/upgrade.sh /srv/backups
 ```
+
+If any step fails it stops, leaves the stack untouched for diagnosis, and prints
+the exact `docker/restore.sh` command for the backup it just took. It never rolls
+back on its own: rolling back means restoring the database, which would destroy
+everything written since that backup, and from the outside a slow boot looks
+identical to a broken one. That call stays yours.
+
+Doing it by hand is still two commands (`docker compose down && docker compose up -d`,
+or `up -d --build` if you build from source); migrations run automatically via the
+entrypoint either way. See the
+[upgrade guide](https://the-desk.emmanuelpaul.com/docs/self-hosting/upgrading/).
 
 Your data persists across `down`/`up` in named volumes (`pgsql-data`,
 `the-desk-meili-<version>`, `redis-data`, `storage-app`).

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -36,7 +36,7 @@
 # `docker compose` resolves the right files for both setups.
 set -eu
 
-BACKUP_DIR="."
+BACKUP_DIR=""
 TARGET=""
 TIMEOUT="300"
 PULL="true"
@@ -67,10 +67,22 @@ for arg in "$@"; do
             exit 1
             ;;
         *)
+            # Take at most one, rather than letting a second path silently win
+            # and send the backup somewhere the operator did not mean.
+            if [ -n "$BACKUP_DIR" ]; then
+                echo "Error: unexpected argument '$arg'; only one backup directory is taken." >&2
+                usage >&2
+                exit 1
+            fi
+
             BACKUP_DIR="$arg"
             ;;
     esac
 done
+
+if [ -z "$BACKUP_DIR" ]; then
+    BACKUP_DIR="."
+fi
 
 if ! echo "$TIMEOUT" | grep -Eq '^[1-9][0-9]*$'; then
     echo "Error: --timeout must be a positive integer, got '$TIMEOUT'." >&2
@@ -177,6 +189,20 @@ if [ -z "$DUMP_FILE" ] || [ -z "$STORAGE_FILE" ] || [ ! -f "$DUMP_FILE" ] || [ !
     exit 1
 fi
 
+# The restore command below is this script's whole promise on the failure path,
+# so it has to survive being pasted. Quote a path only when it contains anything
+# the shell would act on, keeping the usual output clean.
+shell_quote() {
+    case "$1" in
+        *[!A-Za-z0-9_/.@%+-]*)
+            printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+            ;;
+        *)
+            printf '%s' "$1"
+            ;;
+    esac
+}
+
 # Every failure from here on has a backup to offer, so they share this exit.
 fail_with_restore() {
     echo >&2
@@ -191,7 +217,7 @@ fail_with_restore() {
     echo "slow boot looks identical to a broken one from here. That call is yours." >&2
     echo >&2
     echo "Your backup is safe. When you have decided, restore it with:" >&2
-    echo "  ./docker/restore.sh $DUMP_FILE $STORAGE_FILE" >&2
+    echo "  ./docker/restore.sh $(shell_quote "$DUMP_FILE") $(shell_quote "$STORAGE_FILE")" >&2
     echo >&2
     echo "(It will refuse the populated database until you add --force, and say so.)" >&2
     exit 1
@@ -223,18 +249,23 @@ echo "Step 3/3: verifying..."
 # directly), so the host port is not a reliable way to ask. This is the same check
 # the compose healthcheck makes, just polled faster than its 30s interval.
 echo "  waiting for /up (timeout ${TIMEOUT}s)..."
-waited=0
+STARTED="$(date +%s)"
+DEADLINE="$((STARTED + TIMEOUT))"
 
-until docker compose exec -T app curl -fsS -o /dev/null http://localhost:8080/up </dev/null 2>/dev/null; do
-    if [ "$waited" -ge "$TIMEOUT" ]; then
+# The deadline is real elapsed time, not a count of sleeps: every probe spawns a
+# `docker compose exec`, which takes long enough that counting intervals would
+# overshoot --timeout badly on a slow host, exactly where the wait matters most.
+# curl gets its own --max-time so a single wedged probe cannot sail past the
+# deadline either.
+until docker compose exec -T app curl -fsS --max-time 5 -o /dev/null http://localhost:8080/up </dev/null 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$DEADLINE" ]; then
         fail_with_restore "the app did not answer /up within ${TIMEOUT}s. It may still be booting (migrations and search:sync run first), or the migration may have failed: check the logs before deciding. --timeout raises the wait."
     fi
 
     sleep "$POLL_INTERVAL"
-    waited=$((waited + POLL_INTERVAL))
 done
 
-echo "  /up answered after ${waited}s"
+echo "  /up answered after $(($(date +%s) - STARTED))s"
 
 # Liveness is not identity: the OLD container answers /up just as happily as the
 # new one, so a stack that came back on the previous image would look like a

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -1,0 +1,256 @@
+#!/bin/sh
+#
+# Upgrade the production stack in one command: back up, start the new release,
+# and verify the instance is actually running it.
+#
+#   git fetch --tags
+#   git checkout vX.Y.Z
+#   ./docker/upgrade.sh [BACKUP_DIR] [--target=X.Y.Z] [--timeout=SECONDS] [--no-pull]
+#
+# BACKUP_DIR defaults to the current directory and is passed straight to
+# docker/backup.sh, so the backup lands wherever you would have put it anyway.
+#
+# The target version defaults to the VERSION file in this checkout, which is the
+# release the compose file pins. Pass --target only if you override APP_IMAGE to
+# a tag that does not match the checkout.
+#
+# --timeout bounds the health check (default 300s). A cold boot runs migrations
+# and rebuilds the search index (`search:sync`) before /up answers, so it is
+# deliberately generous; raise it on a slow host or a large database.
+#
+# --no-pull skips `docker compose pull` and uses the image already on the host,
+# for air-gapped hosts or when you pulled ahead of the maintenance window.
+# Build-from-source setups never pull: the overlay is detected from COMPOSE_FILE.
+#
+# IT NEVER ROLLS BACK ON ITS OWN. Rolling back is not a git revert here, it is a
+# destructive database restore, and this script cannot tell the two cases apart:
+# a migration that genuinely broke the schema, and an app that is fine but whose
+# /up did not answer inside the timeout (slow first boot, a wedged healthcheck, a
+# proxy hiccup). In the second case an automatic restore is a data-loss event the
+# script itself caused, destroying every message written since the dump, and it
+# would fire at 2am under exactly the conditions where nobody can evaluate it.
+# So on failure it stops, leaves the stack untouched for diagnosis, and prints
+# the exact restore command with the paths filled in. You make that call.
+#
+# No `-f docker-compose.prod.yml` here: .env sets COMPOSE_FILE, so a bare
+# `docker compose` resolves the right files for both setups.
+set -eu
+
+BACKUP_DIR="."
+TARGET=""
+TIMEOUT="300"
+PULL="true"
+POLL_INTERVAL="5"
+
+usage() {
+    echo "Usage: ./docker/upgrade.sh [BACKUP_DIR] [--target=X.Y.Z] [--timeout=SECONDS] [--no-pull]"
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --target=*)
+            TARGET="${arg#--target=}"
+            ;;
+        --timeout=*)
+            TIMEOUT="${arg#--timeout=}"
+            ;;
+        --no-pull)
+            PULL="false"
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "Error: unknown option '$arg'." >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            BACKUP_DIR="$arg"
+            ;;
+    esac
+done
+
+if ! echo "$TIMEOUT" | grep -Eq '^[1-9][0-9]*$'; then
+    echo "Error: --timeout must be a positive integer, got '$TIMEOUT'." >&2
+    exit 1
+fi
+
+if [ ! -f "docker-compose.prod.yml" ]; then
+    echo "Error: run this from the project root (docker-compose.prod.yml not found)." >&2
+    exit 1
+fi
+
+for script in docker/backup.sh docker/restore.sh; do
+    if [ ! -x "$script" ]; then
+        echo "Error: $script is missing or not executable." >&2
+        exit 1
+    fi
+done
+
+# ---- Target version ---------------------------------------------------------
+# The VERSION file carries a release-please annotation (`1.2.3 # x-release-...`),
+# stripped here exactly as config/app.php does, so this matches what the running
+# container reports through `php artisan app:version`.
+if [ -z "$TARGET" ]; then
+    if [ ! -f "VERSION" ]; then
+        echo "Error: no VERSION file here, and no --target given." >&2
+        exit 1
+    fi
+
+    TARGET="$(sed -e 's/#.*//' VERSION | tr -d '[:space:]')"
+fi
+
+if [ -z "$TARGET" ]; then
+    echo "Error: could not determine the target version." >&2
+    exit 1
+fi
+
+# Read a key from .env, falling back to a default. An exported environment
+# variable wins, matching how the other scripts read configuration.
+env_value() {
+    key="$1"
+    default="$2"
+    value=""
+
+    if [ -f ".env" ]; then
+        value="$(sed -n "s/^${key}=//p" .env | tail -n 1 | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/")"
+    fi
+
+    if [ -z "$value" ]; then
+        value="$default"
+    fi
+
+    echo "$value"
+}
+
+# Build-from-source operators list the build overlay in COMPOSE_FILE (that is how
+# the install docs tell them to enable it), so detect the path from there rather
+# than making them remember a flag. They build instead of pulling: their image is
+# not in any registry.
+COMPOSE_FILE_VALUE="${COMPOSE_FILE:-$(env_value COMPOSE_FILE docker-compose.prod.yml)}"
+BUILD_FROM_SOURCE="false"
+
+if echo "$COMPOSE_FILE_VALUE" | grep -q 'docker-compose\.build\.yml'; then
+    BUILD_FROM_SOURCE="true"
+    PULL="false"
+fi
+
+echo "Upgrading to $TARGET."
+if [ "$BUILD_FROM_SOURCE" = "true" ]; then
+    echo "  build-from-source setup detected (COMPOSE_FILE lists the build overlay)"
+fi
+echo
+
+# ---- 1. Back up -------------------------------------------------------------
+# Delegated to backup.sh rather than reimplemented, so there is one definition of
+# what a backup is. Its output is captured to recover the exact paths it wrote,
+# which the failure path needs to hand back to the operator.
+echo "Step 1/3: backing up..."
+BACKUP_LOG="$(mktemp)"
+
+cleanup() {
+    rm -f "$BACKUP_LOG"
+}
+trap cleanup EXIT
+
+if ! ./docker/backup.sh "$BACKUP_DIR" >"$BACKUP_LOG" 2>&1; then
+    cat "$BACKUP_LOG" >&2
+    echo >&2
+    echo "Error: backup failed, so the upgrade stopped before touching the stack." >&2
+    echo "  Nothing has changed. Fix the backup, then run this again." >&2
+    exit 1
+fi
+
+cat "$BACKUP_LOG"
+
+# Parse the paths back out of backup.sh's own report. If its output format ever
+# changes this fails here, before the stack is touched, rather than silently
+# leaving the failure path without a restore command to print.
+DUMP_FILE="$(sed -n 's|^  wrote \(.*db-backup-.*\.sql\.gz\)$|\1|p' "$BACKUP_LOG" | tail -n 1)"
+STORAGE_FILE="$(sed -n 's|^  wrote \(.*storage-app-.*\.tar\.gz\)$|\1|p' "$BACKUP_LOG" | tail -n 1)"
+
+if [ -z "$DUMP_FILE" ] || [ -z "$STORAGE_FILE" ] || [ ! -f "$DUMP_FILE" ] || [ ! -f "$STORAGE_FILE" ]; then
+    echo "Error: the backup reported success but its files could not be identified." >&2
+    echo "  Refusing to upgrade without a known-good backup to point you back at." >&2
+    exit 1
+fi
+
+# Every failure from here on has a backup to offer, so they share this exit.
+fail_with_restore() {
+    echo >&2
+    echo "Error: $1" >&2
+    echo >&2
+    echo "The stack has been left exactly as it is, for diagnosis:" >&2
+    echo "  docker compose ps" >&2
+    echo "  docker compose logs --tail=100 app" >&2
+    echo >&2
+    echo "This did NOT roll back. Rolling back means restoring the database, which" >&2
+    echo "destroys everything written since the backup was taken a moment ago, and a" >&2
+    echo "slow boot looks identical to a broken one from here. That call is yours." >&2
+    echo >&2
+    echo "Your backup is safe. When you have decided, restore it with:" >&2
+    echo "  ./docker/restore.sh $DUMP_FILE $STORAGE_FILE" >&2
+    echo >&2
+    echo "(It will refuse the populated database until you add --force, and say so.)" >&2
+    exit 1
+}
+
+# ---- 2. Start the new release -----------------------------------------------
+echo
+echo "Step 2/3: starting $TARGET..."
+
+if [ "$PULL" = "true" ]; then
+    if ! docker compose pull </dev/null; then
+        fail_with_restore "could not pull the image for $TARGET; nothing was restarted."
+    fi
+fi
+
+# Migrations run automatically on start, via the app service's entrypoint.
+if [ "$BUILD_FROM_SOURCE" = "true" ]; then
+    docker compose up -d --build </dev/null || fail_with_restore "the stack failed to build and start."
+else
+    docker compose up -d </dev/null || fail_with_restore "the stack failed to start."
+fi
+
+# ---- 3. Verify --------------------------------------------------------------
+echo
+echo "Step 3/3: verifying..."
+
+# curl runs inside the container against its own port rather than against a host
+# port: publishing is optional (a proxy inside the compose network reaches app:8080
+# directly), so the host port is not a reliable way to ask. This is the same check
+# the compose healthcheck makes, just polled faster than its 30s interval.
+echo "  waiting for /up (timeout ${TIMEOUT}s)..."
+waited=0
+
+until docker compose exec -T app curl -fsS -o /dev/null http://localhost:8080/up </dev/null 2>/dev/null; do
+    if [ "$waited" -ge "$TIMEOUT" ]; then
+        fail_with_restore "the app did not answer /up within ${TIMEOUT}s. It may still be booting (migrations and search:sync run first), or the migration may have failed: check the logs before deciding. --timeout raises the wait."
+    fi
+
+    sleep "$POLL_INTERVAL"
+    waited=$((waited + POLL_INTERVAL))
+done
+
+echo "  /up answered after ${waited}s"
+
+# Liveness is not identity: the OLD container answers /up just as happily as the
+# new one, so a stack that came back on the previous image would look like a
+# successful upgrade. Ask it what it is actually running.
+RUNNING="$(docker compose exec -T app php artisan app:version </dev/null | tr -d '[:space:]')"
+
+if [ -z "$RUNNING" ]; then
+    fail_with_restore "the app is up but would not report its version, so the upgrade could not be confirmed."
+fi
+
+if [ "$RUNNING" != "$TARGET" ]; then
+    fail_with_restore "the stack is running $RUNNING, not $TARGET. The old container is probably still up, or APP_IMAGE pins a different tag (pass --target if that is deliberate)."
+fi
+
+echo "  running version confirmed: $RUNNING"
+echo
+echo "Upgraded to $RUNNING."
+echo "  backup: $DUMP_FILE"
+echo "          $STORAGE_FILE"

--- a/docs/src/content/docs/docs/faq.md
+++ b/docs/src/content/docs/docs/faq.md
@@ -38,7 +38,7 @@ is rebuilt from Postgres on boot and Redis holds only cache, sessions, and queue
 jobs, so neither needs backing up. `./docker/restore.sh` puts both back.
 
 Add `--keep=N` to prune old backups and drive it from host cron for a schedule.
-See [Backups](/docs/self-hosting/upgrading/#back-up-first) for the details, and
+See [Backups](/docs/self-hosting/upgrading/#backups) for the details, and
 the [Architecture reference](/docs/reference/architecture/) for exactly what runs
 and where state lives.
 

--- a/docs/src/content/docs/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/docs/reference/security-and-compliance.md
@@ -117,7 +117,7 @@ evidence for each of these from **your** environment, not from this project:
 - **Backups.** Take, encrypt, test, and off-site the database and file-volume
   backups. `docker/backup.sh` and `docker/restore.sh` handle the taking and the
   restoring, including a `--keep=N` retention flag and a host-cron example; see
-  [Upgrading](/docs/self-hosting/upgrading/#back-up-first). Encrypting and
+  [Upgrading](/docs/self-hosting/upgrading/#backups). Encrypting and
   off-siting the resulting files remains yours.
 - **Secret management.** `APP_KEY`, `DB_PASSWORD`, `MEILISEARCH_KEY`, the
   `REVERB_*` credentials, and any `SCIM_TOKEN` are full secrets. Generate them

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -1,10 +1,12 @@
 ---
 title: Upgrading
-description: Tag-based upgrades with automatic migrations and version-scoped search reindexing.
+description: One-command upgrades that back up, start the new release, and verify it is running, with automatic migrations and version-scoped search reindexing.
 ---
 
 Upgrades follow the same tag-based flow you used to install, whether you run the
-published image (the default) or build from source.
+published image (the default) or build from source. Check out the release you
+want and run `./docker/upgrade.sh`: it backs up, starts the new release, and
+verifies the instance is actually running it.
 
 ## These docs track the in-development version
 
@@ -21,12 +23,78 @@ documented but not yet in that release is coming in a future one. Check the
 confirm which release a given feature shipped in, and pin your `APP_IMAGE` (or
 checkout tag) to a released version rather than `edge` for a stable deployment.
 
-## Back up first
+## Upgrade
+
+Check out the release you want, then run the upgrade script from the project
+root:
+
+```bash
+git fetch --tags
+git checkout v1.5.2 # x-release-please-version         (the desired release tag)
+./docker/upgrade.sh /srv/backups
+```
+
+It does three things, stopping at the first that fails:
+
+1. **Backs up** by running [`docker/backup.sh`](#backups) for you, into the
+   directory you name (the current one by default).
+2. **Starts the new release.** Migrations run automatically on boot, via the
+   `app` container's entrypoint.
+3. **Verifies the upgrade landed.** It waits for `/up` to answer, then asks the
+   instance what it is actually running and compares that with the release you
+   checked out.
+
+That third step is the one worth understanding. A healthy stack only proves the
+containers are alive: the *old* container answers `/up` just as happily as the
+new one. So the script confirms identity separately, and an upgrade that quietly
+came back on the previous image is reported as a failure rather than a success.
+
+It picks up your setup on its own. Build-from-source installs are detected from
+`COMPOSE_FILE` and get built rather than pulled, so the same command works for
+both paths.
+
+Useful flags:
+
+| Flag | Why |
+| --- | --- |
+| `--target=X.Y.Z` | Expect this version instead of the checked-out one. Only needed if `APP_IMAGE` pins a tag that differs from the checkout. |
+| `--timeout=SECONDS` | How long to wait for `/up` (default 300). A cold boot runs migrations and rebuilds the search index first, so raise it on a slow host or a large database. |
+| `--no-pull` | Use the image already on the host, for air-gapped hosts or when you pulled ahead of the window. |
+
+### If it fails, it stops and hands you the backup
+
+The script **never rolls back on its own**, and that is deliberate.
+
+Rolling back here is not a git revert. It is a destructive database restore, and
+from the outside a slow boot is indistinguishable from a broken one: a first boot
+that runs migrations and `search:sync`, a wedged search healthcheck, or a proxy
+hiccup all look exactly like a failed upgrade for a while, and then recover. A
+script that restored automatically would, in that case, destroy every message
+written since the dump it took minutes earlier. It would be a data-loss event
+caused by the recovery, not the fault, and it would fire at 3am when nobody is
+awake to judge it.
+
+So on failure it exits non-zero, leaves the stack exactly as it is for you to
+inspect, and prints the precise restore command with the backup paths already
+filled in:
+
+```
+Your backup is safe. When you have decided, restore it with:
+  ./docker/restore.sh /srv/backups/db-backup-2026-07-17.sql.gz /srv/backups/storage-app-2026-07-17.tar.gz
+```
+
+You still have the fresh backup and one command to run. What you do not have is a
+script deciding to destroy data on your behalf while you sleep.
+
+## Backups
 
 :::caution
 Migrations run automatically on start and can alter your schema irreversibly. A
-failed or interrupted upgrade can leave the database in a broken state. **Always
-take a backup before upgrading** — especially across a major version.
+failed or interrupted upgrade can leave the database in a broken state.
+`upgrade.sh` takes a backup for you before it starts, so an upgrade through it is
+always covered. **Take one yourself before any other risky change**, and keep
+scheduled backups regardless: the upgrade-time dump is a safety net for that
+upgrade, not a backup policy.
 :::
 
 Two things hold your durable state: the **PostgreSQL database** (all messages,
@@ -112,7 +180,13 @@ with:
 docker compose up -d
 ```
 
-## Default: pull the newer image
+## Doing it by hand
+
+`upgrade.sh` is a wrapper around the steps below. They are worth knowing: this is
+what it runs, and what to fall back to if you would rather drive each step
+yourself.
+
+### Default: pull the newer image
 
 Check out the newer release tag and restart — `up -d` pulls the image that tag
 pins:
@@ -136,7 +210,7 @@ If your `.env` predates that variable, keep passing the flag as before, or add
 `COMPOSE_FILE=docker-compose.prod.yml` to your `.env` to drop it.
 :::
 
-## Build from source
+### Build from source
 
 If you build the image locally with the build overlay, check out the newer tag and
 rebuild:
@@ -160,7 +234,7 @@ COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
 Migrations run automatically on start — the `app` container's entrypoint runs
 `php artisan migrate --force`.
 
-## Confirm the running version
+### Confirm the running version
 
 A healthy stack proves the containers are alive, not that they are running the
 version you just checked out: the old container answers just as happily as the


### PR DESCRIPTION
Part of #470. Implements #475. Lands last: it composes every other child.

## What

```bash
git fetch --tags
git checkout vX.Y.Z
./docker/upgrade.sh /srv/backups
```

It backs up, starts the new release, and verifies the instance is
actually running it. Flags: `--target=X.Y.Z`, `--timeout=SECONDS`
(default 300), `--no-pull`.

## Why

With backup, restore, and version reporting all executable, the upgrade
itself was still a sequence assembled by hand from `upgrading.md`: back
up, checkout, `down`, `up -d`, then squint at logs and hope the
migration landed.

The verify step is the point. A healthy stack only proves the containers
are alive, and the **old** container answers `/up` just as happily as the
new one, so an upgrade that quietly came back on the previous image would
look like a success. It asks the instance what it is running
(`app:version`, #474) and compares.

Build-from-source is detected from `COMPOSE_FILE` (how the install docs
have operators opt in) and built rather than pulled, so one command
covers both paths with no flag to remember.

## It never rolls back on its own

Per #470/#475, and it is the central design decision here. Rolling back
is not a git revert: it is a destructive database restore, and from the
outside a slow boot (migrations plus `search:sync`, a wedged healthcheck,
a proxy hiccup) is indistinguishable from a broken one. Restoring
automatically would destroy every message written since the dump it took
minutes earlier: a data-loss event caused by the recovery rather than the
fault, firing at 3am when nobody can judge it.

So it halts, leaves the stack untouched for diagnosis, and prints the
exact restore command with the paths filled in. The operator makes that
call, with one command, in ten seconds.

## How tested

Shell is invisible to the `--min=100` gate, so `docker.yml` gains an
`upgrade` job covering both the success path and, more importantly, the
failure path: non-zero exit, a well-formed ready-to-paste restore line
whose files exist, and the version unchanged before/after (proving it did
not roll back).

Also verified locally against a real prod stack, doing a genuine upgrade
from the published **1.5.1** image to an image built from this branch:

- Success: backed up, started, `/up` answered, version confirmed 1.5.2,
  exit 0.
- Failure (`--target=9.9.9`): exit 1, all seven services still running,
  and the printed restore line **actually works when pasted** (it refuses
  the populated database and says to add `--force`, exactly as promised;
  with `--force` it restores, exit 0). That round trip is the script's
  whole promise, so I ran it rather than trusting it.
- Backup failure stops before touching the stack; `--timeout` deadline
  fires (20s → 22s elapsed); build-from-source detection; arg validation.

Backend gate green (`Total: 100.0 %`), `cd docs && npm run build` green.

## Docs

`upgrading.md` restructured around the script, with the manual sequence
kept under "Doing it by hand" as the explanation of what it runs. The
halt-and-instruct behaviour is documented explicitly. The backup caution
is reframed now that `upgrade.sh` takes the backup for you (while making
the point that an upgrade-time dump is a safety net, not a backup
policy). `README.md` upgrade section updated.

The `## Back up first` heading became `## Backups`; both inbound links
(`faq.md`, `security-and-compliance.md`) were repointed and every anchor
verified in the built HTML. All version-bearing lines carry
`x-release-please-version` per the `release-version-refs` skill; no
unannotated semver was added.

## Review

Local CodeRabbit (`--base 470-feat-...`) returned 5 findings, all applied
and re-verified locally:

- `--timeout` counted sleep intervals, not elapsed time, so it overshot
  on slow hosts. Now a real `date`-based deadline, plus `curl --max-time`.
- The printed restore line was unquoted, so a backup dir with a space
  produced an unpasteable command. Now shell-quoted only when needed
  (verified with `my backups` as the output dir).
- A second positional silently overwrote the backup dir; now rejected,
  matching `restore.sh`.
- CI: `upgrade.sh | tee` masked a failing exit status behind tee (same
  class as the `pg_dump` pipeline in #473); added `pipefail`.
- CI: the failure assertion now compares the version before/after instead
  of only checking `app:version` answers.

The confirming re-review is clean: 0 findings.

## Note

`docker.yml` only runs on PRs targeting `develop`/`master`, so the new
job does not run on this PR into the foundation. It runs on the epic PR
(#479). The smoke test avoids a bare `up -d --wait` because of #477.
