### PR TITLE
fix(docker): stop queue, reverb and scheduler reporting unhealthy in the prod stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,5 +135,14 @@ USER www
 
 EXPOSE 8080
 
+# The FrankenPHP base image ships a HEALTHCHECK that curls Caddy's admin API on
+# port 2019. This one image runs four different ways in the production stack
+# (web server, reverb, queue:work, schedule:work), and only the web role serves
+# Caddy — so that inherited probe would report the other three permanently
+# unhealthy. Drop it and let docker-compose.prod.yml declare a real healthcheck
+# per service where one is meaningful (the HTTP-serving `app` and `reverb`); the
+# non-HTTP `queue`/`scheduler` workers intentionally run with no healthcheck.
+HEALTHCHECK NONE
+
 ENTRYPOINT ["docker/entrypoint.sh"]
 CMD ["frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,19 +81,31 @@ services:
       retries: 5
       start_period: 60s
 
-  # WebSocket server for broadcasting.
+  # WebSocket server for broadcasting. Reverb serves a health endpoint at
+  # GET /up on the same 8080 port, so it gets a real probe (unlike queue and
+  # scheduler, which have no HTTP surface).
   reverb:
     <<: *app
     command: ['php', 'artisan', 'reverb:start', '--host=0.0.0.0', '--port=8080']
     ports:
       - '${APP_BIND:-127.0.0.1}:${REVERB_PORT:-8080}:8080'
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:8080/up']
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
-  # Queue worker (queue connection is `redis`).
+  # Queue worker (queue connection is `redis`). No HTTP surface, so no
+  # healthcheck: the image sets HEALTHCHECK NONE and this service leaves it that
+  # way, reporting a plain `Up` rather than a decorative or perpetually failing
+  # probe. `restart: unless-stopped` (from the *app anchor) keeps it running.
   queue:
     <<: *app
     command: ['php', 'artisan', 'queue:work', '--tries=3']
 
   # Scheduler (delivers due scheduled messages, prunes expired invitations).
+  # Also no HTTP surface — same no-healthcheck rationale as `queue` above.
   scheduler:
     <<: *app
     command: ['php', 'artisan', 'schedule:work']

--- a/docs/src/content/docs/docs/reference/architecture.md
+++ b/docs/src/content/docs/docs/reference/architecture.md
@@ -34,17 +34,19 @@ Every app process (`app`, `reverb`, `queue`, `scheduler`) waits for `pgsql`,
 The app image itself declares no health check, so `docker compose ps` reports
 each app-role service by what it actually serves:
 
-| Service     | Health in `docker compose ps` | Probe                          |
-| ----------- | ----------------------------- | ------------------------------ |
-| `app`       | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080)    |
-| `reverb`    | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080)    |
-| `queue`     | `Up` (no health column)       | none — no HTTP surface         |
-| `scheduler` | `Up` (no health column)       | none — no HTTP surface         |
+| Service     | Health in `docker compose ps` | Probe                       |
+| ----------- | ----------------------------- | --------------------------- |
+| `app`       | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080) |
+| `reverb`    | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080) |
+| `queue`     | `Up` (no health column)       | none (no HTTP surface)      |
+| `scheduler` | `Up` (no health column)       | none (no HTTP surface)      |
 
 `queue` and `scheduler` run background workers (`queue:work` / `schedule:work`)
 with nothing to curl, so they carry no health check by design and show a plain
-`Up` — that is the expected, healthy state, not a fault. `app` and `reverb` both
-answer `GET /up`, so a genuine outage flips them to `unhealthy`.
+`Up`. That confirms the container is running, not that jobs are being processed;
+check the worker logs (`docker compose logs queue`, `docker compose logs
+scheduler`) to confirm throughput. `app` and `reverb` both answer `GET /up`, so
+a genuine outage flips them to `unhealthy`.
 
 ## Data flow
 

--- a/docs/src/content/docs/docs/reference/architecture.md
+++ b/docs/src/content/docs/docs/reference/architecture.md
@@ -29,6 +29,23 @@ with a local build from source (see
 Every app process (`app`, `reverb`, `queue`, `scheduler`) waits for `pgsql`,
 `redis`, and `meilisearch` to report healthy before it starts.
 
+## Health checks
+
+The app image itself declares no health check, so `docker compose ps` reports
+each app-role service by what it actually serves:
+
+| Service     | Health in `docker compose ps` | Probe                          |
+| ----------- | ----------------------------- | ------------------------------ |
+| `app`       | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080)    |
+| `reverb`    | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080)    |
+| `queue`     | `Up` (no health column)       | none — no HTTP surface         |
+| `scheduler` | `Up` (no health column)       | none — no HTTP surface         |
+
+`queue` and `scheduler` run background workers (`queue:work` / `schedule:work`)
+with nothing to curl, so they carry no health check by design and show a plain
+`Up` — that is the expected, healthy state, not a fault. `app` and `reverb` both
+answer `GET /up`, so a genuine outage flips them to `unhealthy`.
+
 ## Data flow
 
 - **HTTP** requests hit `app` (FrankenPHP) behind your reverse proxy.


### PR DESCRIPTION
Closes #477.

## What

Three of the seven prod containers (`queue`, `reverb`, `scheduler`) came up
`unhealthy` and stayed that way on a fresh self-host deploy, even though the
processes themselves were fine.

## Why

`Dockerfile` declared no `HEALTHCHECK`, so the image silently inherited the
FrankenPHP base image's probe (`curl -f http://localhost:2019/metrics`), which
targets Caddy's admin API. Only the `app` role serves Caddy; `queue`,
`scheduler` and `reverb` override the command to run workers with no port-2019
listener, so the inherited probe could never pass.

## How

- **`Dockerfile`**: declare `HEALTHCHECK NONE` in the runtime stage so the image
  no longer inherits a probe that doesn't match how the container is run.
- **`docker-compose.prod.yml`**: give `reverb` a real probe (`curl -fsS
  http://localhost:8080/up`, the endpoint Reverb serves), matching `app`'s
  shape. `queue` and `scheduler` have no HTTP surface, so they run with no
  health check and report a plain `Up`.
- **docs**: add a "Health checks" section to `reference/architecture.md`
  documenting the resulting per-service status.

## Testing

Docker/compose/docs change only (no PHP/Vue), so the coverage gate does not
apply. Verified:

- Base image probe confirmed (`curl ... :2019/metrics`); `HEALTHCHECK NONE`
  built and inspected reduces it to `["NONE"]` (disabled).
- `docker compose config` resolves `app` and `reverb` with the `/up` probe and
  `queue`/`scheduler` with none.
- Reverb `/up` end-to-end: serving returns `HTTP 200` (probe passes → healthy);
  after killing the process the port refuses connections (probe fails →
  unhealthy), satisfying the acceptance criterion.
- Docs site rebuilds cleanly.
- Local CodeRabbit pass: clean (one nit applied, clarifying that a plain `Up`
  means the container is running, not that jobs are being processed).

Unblocks #475 (`docker/upgrade.sh`), which would otherwise hang waiting on the
falsely-unhealthy containers.