### PR TITLE
ci: link the published GHCR image from each GitHub release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,6 +103,58 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # release-please creates the GitHub Release (CHANGELOG body + `v*` tag) BEFORE
+  # the image exists — that tag is exactly what triggers the publish above. So
+  # the link to the published image can only be added here, once `build` has
+  # pushed it. A self-hoster reading the release then gets the exact pull
+  # reference for that version instead of matching the tag by hand under the
+  # repo's Packages sidebar.
+  link-release-image:
+    name: Link GHCR image on the release
+    needs: build
+    runs-on: ubuntu-latest
+    # Only for a published `v*` release tag: that is the only ref that has a
+    # release-please release to annotate. master `edge` pushes and PR build-only
+    # runs are skipped entirely, so this never touches a non-release publish.
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    # `contents: write` is the single scope this needs — to edit the release body
+    # release-please wrote. It reads no packages (the pull reference is derived
+    # from the tag), so it grants none.
+    permissions:
+      contents: write
+
+    steps:
+      # Append the pull reference and package link to the release body without
+      # disturbing the CHANGELOG release-please wrote. A hidden marker makes it
+      # idempotent: a re-run of the publish must not append the block twice.
+      - name: Append the GHCR pull reference to the release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          version="${TAG#v}"
+          package="${REPO#*/}"
+          image="ghcr.io/${REPO}:${version}"
+          package_url="https://github.com/${REPO}/pkgs/container/${package}"
+          marker="<!-- ghcr-image-link -->"
+
+          body="$(gh release view "$TAG" --repo "$REPO" --json body --jq .body)"
+
+          if printf '%s' "$body" | grep -qF "$marker"; then
+            echo "Release $TAG already links its image; nothing to do."
+            exit 0
+          fi
+
+          # shellcheck disable=SC2016  # printf format is intentionally literal; values are the %s args.
+          note="$(printf '\n\n%s\n\n---\n\n### 📦 Docker image\n\nThis release is published to the GitHub Container Registry:\n\n```\n%s\n```\n\nPull it directly or browse the [package page](%s). See the [upgrade guide](https://the-desk.emmanuelpaul.com/docs/self-hosting/upgrading/) for self-hosting steps.\n' "$marker" "$image" "$package_url")"
+
+          gh release edit "$TAG" --repo "$REPO" --notes "${body}${note}"
+          echo "Linked $image on release $TAG."
+
   # Proves docker/backup.sh and docker/restore.sh actually round-trip against the
   # real production stack: back up, destroy both durable stores, restore, and
   # assert the data came back. Backing up only proves half of it — a backup you


### PR DESCRIPTION
Closes #498.

## What

Adds a `link-release-image` job to `docker.yml` that, after the image is published for a `v*` release tag, edits the corresponding GitHub Release to append the exact GHCR pull reference and a link to the package page. Self-hosters reading a release now get `ghcr.io/emmpaul/the-desk:X.Y.Z` and a package link inline, instead of matching the tag by hand under the repo's Packages sidebar.

## Why

release-please creates the Release (CHANGELOG body + tag) *before* the image exists — that tag is what triggers the publish. So nothing on the release page ever pointed at the image it ships. The link can only be added by `docker.yml`, after `Build and push image`, which is the one point where the image is published and the version is known.

## How it meets the acceptance criteria

- **Appends to the existing release** release-please created (matched by tag via `gh release edit`), fetching the current body first and re-writing it with the block appended — the CHANGELOG body is preserved.
- **Idempotent:** a hidden `<!-- ghcr-image-link -->` marker guards against a re-run appending the block twice.
- **No-op for non-`v*` publishes:** the job is gated on `if: startsWith(github.ref, 'refs/tags/v')`, so master `edge` pushes and PR build-only runs skip it entirely and it never fails those builds.
- **Minimal, documented scoping:** a separate job with `permissions: contents: write` only (the single scope needed to edit the release body). The `build` job keeps its `packages: write` / `contents: read` untouched; the new job reads no packages (the pull reference is derived from the tag), consistent with the inline-comment style already in the file.

## Testing

- `actionlint` (via Docker, incl. embedded shellcheck) passes clean on `docker.yml`.
- Shell logic exercised locally: correct version derivation (`v1.7.0` → `1.7.0`), correct package URL, first-run appends, and the idempotency guard skips a re-run without double-appending.
- Verified read-only against the real latest release `v1.7.0`: `gh release view --json body` returns the release-please CHANGELOG body (marker absent → would append), the derived `ghcr.io/emmpaul/the-desk:1.7.0` reference resolves in the registry (`docker manifest inspect`), and the package page returns HTTP 200 — so the link resolves to the correct image version. The write path (`gh release edit`) runs live on the next release.

## i18n / docs

No user-facing app copy and no operator config/env/install/upgrade change, so no i18n catalog or `docs/` update is needed — the change only enriches the auto-generated release page.