### PR TITLE
fix: sync Meilisearch index settings on deploy

### DIFF
--- a/app/Console/Commands/SearchIndexSyncCommand.php
+++ b/app/Console/Commands/SearchIndexSyncCommand.php
@@ -44,11 +44,28 @@ class SearchIndexSyncCommand extends Command
             return self::SUCCESS;
         }
 
+        $this->syncIndexSettings();
+
         foreach (self::SEARCHABLE_MODELS as $model) {
             $this->syncModel($meilisearch, $model);
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Apply the configured index settings (filterable/sortable attributes)
+     * declared in config/scout.php to Meilisearch.
+     *
+     * Importing documents auto-creates the index with empty filterable
+     * attributes, so this must run unconditionally — independent of whether the
+     * index already holds documents — or the channel-ACL search scope
+     * (`channel_id IN [...]`) fails on any fresh or rotated Meilisearch volume.
+     * The underlying update is idempotent.
+     */
+    private function syncIndexSettings(): void
+    {
+        $this->call('scout:sync-index-settings');
     }
 
     /**

--- a/tests/Feature/Console/SearchIndexSyncCommandTest.php
+++ b/tests/Feature/Console/SearchIndexSyncCommandTest.php
@@ -17,6 +17,7 @@ function fakeMeilisearchDocumentCount(int $documents): void
 {
     $index = Mockery::mock(Indexes::class);
     $index->shouldReceive('stats')->andReturn(['numberOfDocuments' => $documents]);
+    $index->shouldReceive('updateSettings')->andReturn([]);
 
     test()->mock(Client::class, function ($mock) use ($index): void {
         $mock->shouldReceive('index')->with('messages')->andReturn($index);
@@ -55,6 +56,7 @@ it('imports when the meilisearch index does not exist yet', function (): void {
         new Response(404, [], (string) json_encode(['code' => 'index_not_found'])),
         ['code' => 'index_not_found'],
     ));
+    $index->shouldReceive('updateSettings')->andReturn([]);
     $this->mock(Client::class, fn ($mock) => $mock->shouldReceive('index')->andReturn($index));
 
     Message::withoutSyncingToSearch(fn () => Message::factory()->count(2)->create());
@@ -82,6 +84,36 @@ it('skips import when there are no records to index', function (): void {
     fakeMeilisearchDocumentCount(0);
 
     $this->artisan('search:sync')->assertSuccessful();
+
+    Queue::assertNotPushed(MakeSearchable::class);
+});
+
+it('syncs the configured index settings even when the index is already populated', function (): void {
+    config()->set('scout.driver', 'meilisearch');
+    Queue::fake();
+
+    $captured = null;
+    $index = Mockery::mock(Indexes::class);
+    $index->shouldReceive('stats')->andReturn(['numberOfDocuments' => 5]);
+    $index->shouldReceive('updateSettings')
+        ->once()
+        ->andReturnUsing(function (array $settings) use (&$captured): array {
+            $captured = $settings;
+
+            return [];
+        });
+
+    $this->mock(Client::class, fn ($mock) => $mock->shouldReceive('index')->with('messages')->andReturn($index));
+
+    $this->artisan('search:sync')->assertSuccessful();
+
+    // Settings are synced unconditionally — not gated on an empty index — so a
+    // rotated Meilisearch volume gets the filterable/sortable attributes that
+    // the channel-ACL search scope (`channel_id IN [...]`) depends on.
+    expect($captured)->toMatchArray([
+        'filterableAttributes' => ['channel_id', 'user_id', 'created_at'],
+        'sortableAttributes' => ['created_at'],
+    ]);
 
     Queue::assertNotPushed(MakeSearchable::class);
 });


### PR DESCRIPTION
Closes #506.

## What

`search:sync` (run on boot by `docker/entrypoint.sh` when `AUTORUN_MIGRATIONS=true`) imported search documents but never applied the `filterableAttributes` / `sortableAttributes` declared in `config/scout.php`. When the import auto-created the `messages` index on a fresh or rotated Meilisearch volume, the index came up with **empty** filterable attributes, so the channel-ACL search scope (`channel_id IN [...]`) threw `Attribute \`channel_id\` is not filterable` and search was completely broken until an operator ran an undocumented manual command.

## How

`SearchIndexSyncCommand::handle()` now calls `scout:sync-index-settings` **unconditionally** (once the driver is Meilisearch), before the empty-index import loop. This applies the configured settings idempotently and independent of whether the index already holds documents — so a populated index still gets its settings synced. Keeps the search bootstrap in one place, covered by the command's tests.

## Testing

- New test asserts `search:sync` applies `filterableAttributes = [channel_id, user_id, created_at]` and `sortableAttributes = [created_at]` even when the index is already populated (idempotent, not gated on empty).
- Existing empty-index / missing-index / populated / no-records tests updated for the new settings-sync call.
- Full backend gate green: Pint, PHPStan (0), Rector (clean dry-run), 1299 tests, 100% coverage.

## i18n / docs

No user-facing copy and no operator-facing surface change (no new env/config/steps — the fix removes the previously-required manual `scout:sync-index-settings` workaround), so no i18n or docs updates needed.