### PR TITLE
fix: pin the virtualized timeline to the newest message on initial open of tall lists

### DIFF
--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -39,7 +39,7 @@ import type { MessageBodySegment } from '@/lib/messageBody';
 import { readersForMessage } from '@/lib/readReceipts';
 import { buildTimelineItems, messageAccessibleName } from '@/lib/timeline';
 import type { TimelineGroup, TimelineItem } from '@/lib/timeline';
-import { shouldRenderSkeleton } from '@/lib/virtualTimeline';
+import { bottomGlueSettled, shouldRenderSkeleton } from '@/lib/virtualTimeline';
 import type {
     ChannelReader,
     Mention,
@@ -390,9 +390,19 @@ watch(isScrolling, (scrolling) => {
 // A windowed jump can't know the true bottom up front: `scrollToEnd` aims at the
 // bottom the virtualizer can see now, but each row measured as the animation
 // passes it grows the list, so the target keeps moving. `finalizeJump` follows
-// the animation to the bottom, then briefly glues the view there frame by frame
-// so late measurements settle without a visible bounce.
-const JUMP_GLUE_FRAMES = 12;
+// the animation to the bottom, then glues the view there frame by frame until both
+// the measured height plateaus and the scroll goes quiet, so late measurements
+// settle without a visible bounce.
+//
+// The glue releases on convergence, not a fixed frame count: it holds until the
+// scroll height has been steady for `JUMP_SETTLE_FRAMES` consecutive frames *and*
+// the container has stopped scrolling. A fixed budget let go too early on a slow
+// render — while rows were still measuring, or while the glue's own `scrollTop`
+// writes still counted as scrolling — so unsettled rows flipped in their scrub
+// skeletons and the virtualizer's re-enabled size-change anchoring drifted the
+// view below the fold: the timeline landing short of the newest message on initial
+// open of a long list of tall rows (#500).
+const JUMP_SETTLE_FRAMES = 4;
 const JUMP_MAX_FRAMES = 180;
 let jumpRaf: number | null = null;
 
@@ -404,11 +414,13 @@ let jumpRaf: number | null = null;
  * once it has stopped short — stalled on a skeleton-height estimate rather than
  * the real bottom — snap the residual gap. Gating on the scrolling flag means an
  * explicit `smooth` jump keeps animating instead of being force-converted to an
- * instant snap. Once the bottom is reached, phase two pins `scrollTop` to the
- * end for a handful of frames so a row measured late (taller or shorter than its
- * estimate) can't drift the view up or leave it short: each correction lands
- * before paint, so the settle is invisible rather than a bounce (#347). Bounded
- * by a frame budget so a list that never settles can't spin forever.
+ * instant snap. Once the bottom is reached, phase two pins `scrollTop` to the end
+ * every frame — so a row measured late (taller or shorter than its estimate)
+ * can't drift the view up or leave it short — and releases only once the measured
+ * height has settled (`bottomGlueSettled`) *and* the scroll has quiesced, rather
+ * than after a fixed budget that could expire mid-measurement and strand the view
+ * (#347, #500). Bounded by a frame budget so a list that never settles can't spin
+ * forever.
  */
 function finalizeJump(): void {
     if (jumpRaf !== null) {
@@ -416,7 +428,10 @@ function finalizeJump(): void {
     }
 
     let reachedBottom = false;
-    let glueFrames = 0;
+    let stableFrames = 0;
+    // Sentinel so the first glue frame always registers as a change: the glue
+    // needs at least `JUMP_SETTLE_FRAMES` genuine same-height frames to release.
+    let lastHeight = -1;
     let frames = 0;
 
     const step = (): void => {
@@ -440,11 +455,28 @@ function finalizeJump(): void {
                 scrollToEnd('auto');
             }
         } else {
-            // Glue to the bottom so late row measurements settle invisibly.
+            // Glue to the bottom so late row measurements settle invisibly, and
+            // hold until the height stops moving — the true bottom has arrived.
             el.scrollTop = el.scrollHeight;
-            glueFrames += 1;
 
-            if (glueFrames >= JUMP_GLUE_FRAMES) {
+            const settle = bottomGlueSettled(
+                el.scrollHeight,
+                lastHeight,
+                stableFrames,
+                JUMP_SETTLE_FRAMES,
+            );
+            stableFrames = settle.stableFrames;
+            lastHeight = el.scrollHeight;
+
+            // Release only once the height has settled *and* the scroll has gone
+            // quiet. Letting go while `isScrolling` is still true (the glue's own
+            // `scrollTop` writes keep it set for ~150ms after the last change)
+            // would flip `jumpingToBottom` off mid-scroll, so unsettled rows render
+            // their 56px scrub skeletons — shrinking the content above the viewport
+            // and drifting the view up off the newest message (#347, #500). Waiting
+            // for the scroll to quiesce keeps skeletons suppressed until the view is
+            // safely at rest on the bottom.
+            if (settle.settled && !isScrolling.value) {
                 jumpingToBottom.value = false;
                 jumpRaf = null;
 

--- a/resources/js/lib/virtualTimeline.test.ts
+++ b/resources/js/lib/virtualTimeline.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { buildTimelineItems } from '@/lib/timeline';
 import {
     anchorAfterPrepend,
+    bottomGlueSettled,
     isDividerVisible,
     shouldLoadOlder,
     shouldRenderSkeleton,
@@ -152,6 +153,44 @@ describe('anchorAfterPrepend', () => {
 
     it('leaves scrollTop untouched when nothing was prepended', () => {
         expect(anchorAfterPrepend(1000, 1000, 200)).toBe(200);
+    });
+});
+
+describe('bottomGlueSettled', () => {
+    it('counts a frame as stable when the measured height held steady', () => {
+        // Same height as last frame: one more consecutive stable frame, and not
+        // yet settled while below the required run.
+        expect(bottomGlueSettled(5000, 5000, 1, 3)).toEqual({
+            stableFrames: 2,
+            settled: false,
+        });
+    });
+
+    it('resets the run the moment the height grows (rows still measuring)', () => {
+        // A row measured taller than its estimate, so the true bottom moved down:
+        // the glue must keep following it, not release.
+        expect(bottomGlueSettled(5200, 5000, 2, 3)).toEqual({
+            stableFrames: 0,
+            settled: false,
+        });
+    });
+
+    it('resets the run when the height shrinks below the last frame', () => {
+        // A row measured shorter than its estimate is still a height change, so
+        // measurement is in flight: reset rather than declare victory.
+        expect(bottomGlueSettled(4800, 5000, 2, 3)).toEqual({
+            stableFrames: 0,
+            settled: false,
+        });
+    });
+
+    it('settles once the height has held for the required consecutive frames', () => {
+        // The plateau is reached: the newest message will no longer drift down,
+        // so the glue can release.
+        expect(bottomGlueSettled(5000, 5000, 2, 3)).toEqual({
+            stableFrames: 3,
+            settled: true,
+        });
     });
 });
 

--- a/resources/js/lib/virtualTimeline.ts
+++ b/resources/js/lib/virtualTimeline.ts
@@ -103,6 +103,39 @@ export function anchorAfterPrepend(
 }
 
 /**
+ * Track a jump-to-present's bottom-glue toward release. A windowed jump can't
+ * know the true bottom up front: it sizes from row-height estimates and only
+ * learns a row's real height once it renders, so the newest message's offset
+ * keeps moving down as rows near it measure taller. The glue follows that moving
+ * bottom frame by frame; this decides when it has stopped moving.
+ *
+ * Releasing on a fixed frame budget stranded the view short whenever a row
+ * measured late — after the budget elapsed the glue let go, and the
+ * virtualizer's re-enabled upward size-change anchoring then drifted the newest
+ * message below the fold (#500). Instead, release only once the measured scroll
+ * height has held steady for `requiredStableFrames` consecutive frames: any
+ * change (taller *or* shorter) means measurement is still in flight and resets
+ * the run, so the glue holds until the true bottom truly settles.
+ *
+ * @return the updated consecutive-stable-frame count and whether the run has
+ *         reached the threshold and the glue may release.
+ */
+export function bottomGlueSettled(
+    currentHeight: number,
+    previousHeight: number,
+    priorStableFrames: number,
+    requiredStableFrames: number,
+): { stableFrames: number; settled: boolean } {
+    const stableFrames =
+        currentHeight === previousHeight ? priorStableFrames + 1 : 0;
+
+    return {
+        stableFrames,
+        settled: stableFrames >= requiredStableFrames,
+    };
+}
+
+/**
  * Whether a virtual row should render a height-stable skeleton placeholder
  * instead of its full message content: only while the list is actively being
  * scrubbed and the row has not yet been measured. Deferring the expensive

--- a/tests/Browser/TimelineInitialPinTest.php
+++ b/tests/Browser/TimelineInitialPinTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Message;
+use App\Models\User;
+
+/**
+ * Both the main channel timeline and the thread panel virtualize from row-height
+ * estimates and only measure a row's real height once it renders. On initial open
+ * of a long list of tall rows, the auto-pin to the newest message used to release
+ * its bottom-glue on a fixed frame budget — which could expire while rows near the
+ * bottom were still measuring, so the true bottom moved down and the view was left
+ * a screen or more short of the newest message, with the jump-to-latest pill shown
+ * (#500). These tests assert the newest row is *actually* within the visible
+ * viewport on open (a bounding-rect check — the reported scroll gap is unreliable
+ * mid-measurement) and that no jump pill is offered.
+ */
+
+/**
+ * Seed a channel with enough tall, alternating-author messages that the timeline
+ * virtualizes and stands far taller than the viewport, so the initial pin has many
+ * unmeasured rows to settle over.
+ *
+ * @return array{owner: User, latest: int}
+ */
+function crowdedInitialTimeline(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $authors = [$alice, $bob];
+    $body = str_repeat("lorem ipsum dolor sit amet consectetur\n", 4);
+    $latest = 60;
+
+    // Alternating authors keep every message its own avatar group (more rows), and
+    // the multi-line bodies make a real row dwarf its 84px estimate — the height
+    // gap that used to strand the initial auto-pin short of the newest message.
+    foreach (range(1, $latest) as $i) {
+        Message::factory()->create([
+            'channel_id' => $channel->id,
+            'user_id' => $authors[$i % 2]->id,
+            'body' => "Message {$i}\n{$body}",
+            'created_at' => now()->subMinutes(120 - $i),
+        ]);
+    }
+
+    return ['owner' => $alice, 'latest' => $latest];
+}
+
+/**
+ * Seed a channel whose newest message roots a long thread of tall, alternating
+ * -author replies, so the panel's reply list virtualizes and stands well taller
+ * than the panel viewport.
+ *
+ * @return array{owner: User, replyCount: int}
+ */
+function crowdedInitialThread(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $root = Message::factory()->for($channel)->for($alice)->create([
+        'body' => 'Thread root message',
+        'created_at' => now()->subMinutes(90),
+    ]);
+
+    $authors = [$alice, $bob];
+    $body = str_repeat("lorem ipsum dolor sit amet consectetur\n", 4);
+    $replyCount = 80;
+
+    foreach (range(1, $replyCount) as $i) {
+        Message::factory()->for($channel)->inThread($root)->create([
+            'user_id' => $authors[$i % 2]->id,
+            'body' => "Reply {$i}\n{$body}",
+            'created_at' => now()->subMinutes(60)->addSeconds($i),
+        ]);
+    }
+
+    $root->forceFill([
+        'reply_count' => $replyCount,
+        'last_reply_at' => now(),
+    ])->save();
+
+    return ['owner' => $alice, 'replyCount' => $replyCount];
+}
+
+test('the channel timeline lands on the newest message on initial open', function (): void {
+    ['owner' => $alice, 'latest' => $latest] = crowdedInitialTimeline();
+
+    $page = signInThroughBrowser($alice)->assertSee("Message {$latest}");
+
+    // Let the initial auto-pin and the virtualizer's measurement settle.
+    $page->wait(2);
+
+    // The newest message row is actually within the scroll container's viewport —
+    // a bounding-rect check, since the reported scrollHeight under-reports the true
+    // bottom while rows are still measuring. A short landing would leave the newest
+    // row below the fold (not intersecting the container's rect).
+    $page->assertScript(
+        <<<'JS'
+        (() => {
+            const el = document.querySelector('[data-test=message-history]');
+            const rows = [...el.querySelectorAll('[id^="message-"]')];
+            const last = rows[rows.length - 1];
+            if (!last) return false;
+            const c = el.getBoundingClientRect();
+            const r = last.getBoundingClientRect();
+            const intersectsViewport = r.top < c.bottom && r.bottom > c.top;
+            // Pinned: the newest row sits at the foot of the viewport, not a screen
+            // or more above it.
+            const nearBottom = Math.abs(c.bottom - r.bottom) <= 120;
+            return intersectsViewport && nearBottom;
+        })()
+        JS,
+        true,
+    )
+        // No jump-to-latest pill: the view is pinned to the present, not stranded.
+        ->assertNotPresent('[data-test=jump-to-latest]');
+});
+
+test('the thread panel lands on the newest reply on initial open', function (): void {
+    ['owner' => $alice, 'replyCount' => $replyCount] = crowdedInitialThread();
+
+    $page = signInThroughBrowser($alice)->assertSee('Thread root message');
+
+    // Open the thread from the main-timeline summary and let the reply page land.
+    $page->click('[data-test=thread-summary]')
+        ->assertPresent('[data-test=thread-panel]')
+        ->assertSee("Reply {$replyCount}")
+        ->wait(2);
+
+    // The newest reply row is within the panel's scroll viewport on open.
+    $page->assertScript(
+        <<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-test=thread-panel]');
+            const el = panel.querySelector('[data-index]').closest('.overflow-y-auto');
+            const rows = [...el.querySelectorAll('[id^="message-"]')];
+            const last = rows[rows.length - 1];
+            if (!last) return false;
+            const c = el.getBoundingClientRect();
+            const r = last.getBoundingClientRect();
+            const intersectsViewport = r.top < c.bottom && r.bottom > c.top;
+            const nearBottom = Math.abs(c.bottom - r.bottom) <= 120;
+            return intersectsViewport && nearBottom;
+        })()
+        JS,
+        true,
+    )
+        ->assertNotPresent('[data-test=jump-to-latest-thread]');
+});


### PR DESCRIPTION
Closes #500.

## What

On initial open of a long virtualized timeline of **tall** rows, the main channel timeline and the thread panel landed a screen or more short of the newest message, leaving the reader among older messages with the jump-to-latest pill showing.

## Why

`MessageList.vue`'s `finalizeJump` glued the view to the bottom for a **fixed** `JUMP_GLUE_FRAMES = 12` budget, then released. The issue's guessed root cause ("release once `scrollHeight` stabilizes") is a red herring: during the glue the height is already steady (the view is pinned and the virtualizer's upward size-change anchoring is suppressed). The real driver is that the fixed budget could release while `isScrolling` was still true — the glue's own `el.scrollTop = el.scrollHeight` writes keep tanstack's `isScrolling` flag set for ~150ms after the last change. Releasing mid-scroll flips `jumpingToBottom` off, so unsettled rows render their 56px scrub skeletons (which are only suppressed while `jumpingToBottom`), shrinking the content above the viewport; the re-enabled size-change anchoring then drifts the view up off the newest message.

## How

Release the bottom-glue on convergence instead of a fixed count: hold until the measured height has been steady for `JUMP_SETTLE_FRAMES` consecutive frames **and** the container has stopped scrolling (`!isScrolling`), so skeletons stay suppressed until the view is at rest on the true bottom. The frame-stability decision is extracted into a pure, unit-tested `bottomGlueSettled` helper in `lib/virtualTimeline.ts`. Still bounded by `JUMP_MAX_FRAMES` so a list that never settles can't spin forever.

## Testing

- New `tests/Browser/TimelineInitialPinTest.php`: on initial open of a long, tall channel timeline and thread panel, asserts (via a **bounding-rect** check — the reported `scrollHeight`/gap under-reports mid-measurement) that the newest row is actually within the scroll viewport, with no jump-to-latest pill. Reproduces the bug before the fix; green after (verified 3/3 across repeated runs).
- The #347 jump-to-present regression tests and the #263 thread-virtualization tests stay green.
- `bottomGlueSettled` unit tests in `virtualTimeline.test.ts`.
- Full gate green: Pint + PHPStan + Rector + PHP coverage 100%, and `lint:check` / `format:check` / `types:check` / `build`.

No i18n or docs impact (behavioural fix, no new copy or operator-facing config).