### PR TITLE
feat: add a /gif Giphy GIF picker

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -58,6 +58,8 @@ GRAVATAR_ENABLED=true
 UPDATE_CHECK_ENABLED=true
 # UPDATE_CHECK_REPOSITORY=emmpaul/the-desk
 # UPDATE_CHECK_CACHE_TTL_HOURS=12
+GIPHY_API_KEY=
+GIPHY_CONTENT_RATING=g
 
 # --- Single sign-on (OpenID Connect) -----------------------------------------
 # SSO_OIDC_ISSUER=https://your-idp.example.com

--- a/app/Actions/Channels/CreateGiphyAttachment.php
+++ b/app/Actions/Channels/CreateGiphyAttachment.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Channels;
+
+use App\Data\GiphyGifData;
+use App\Enums\AttachmentSource;
+use App\Enums\AttachmentStatus;
+use App\Models\Attachment;
+use App\Models\Channel;
+use App\Models\User;
+
+class CreateGiphyAttachment
+{
+    /**
+     * Register a re-resolved Giphy GIF as a pending remote attachment.
+     *
+     * The row carries no blob — the media is hotlinked from `remote_url` — so it
+     * mirrors the upload path's ownership (uploader + channel, no message yet) but
+     * skips storage entirely. It is claimed by the send that follows via the same
+     * `attachment_ids[]` flow, and swept by the same pending-orphan GC if never
+     * sent. The channel + team are loaded so the caller can build the DTO
+     * (and the `url` accessor) N+1-free.
+     */
+    public function handle(Channel $channel, User $user, GiphyGifData $gif): Attachment
+    {
+        $attachment = Attachment::create([
+            'user_id' => $user->id,
+            'channel_id' => $channel->id,
+            'source' => AttachmentSource::Giphy,
+            'mime_type' => 'image/gif',
+            // A remote attachment has no stored bytes; the column is non-null.
+            'size_bytes' => 0,
+            'width' => $gif->width,
+            'height' => $gif->height,
+            'remote_url' => $gif->url,
+            'description' => $gif->description,
+            'status' => AttachmentStatus::Pending,
+        ]);
+
+        $attachment->setRelation('channel', $channel->loadMissing('team'));
+
+        return $attachment;
+    }
+}

--- a/app/Data/AttachmentData.php
+++ b/app/Data/AttachmentData.php
@@ -2,6 +2,7 @@
 
 namespace App\Data;
 
+use App\Enums\AttachmentSource;
 use App\Models\Attachment;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -11,21 +12,31 @@ class AttachmentData extends Data
 {
     public function __construct(
         public string $id,
-        public string $filename,
+        // The original upload filename, or null for a remote (Giphy) attachment
+        // which has no uploaded file — the client labels it from `description`.
+        public ?string $filename,
         public string $mimeType,
         public int $sizeBytes,
         public ?int $width,
         public ?int $height,
         // Whether the client should render the file inline as an image. False for
-        // SVG (download-only) and every non-image type.
+        // SVG (download-only) and every non-image type. A Giphy GIF is `image/gif`,
+        // so it renders inline through the same path with no special-casing.
         public bool $isImage,
-        // The authorized download URL (never a filesystem URL); images are served
-        // inline, everything else as a download.
+        // The attachment's provenance: an operator-hosted upload or a remote
+        // (hotlinked) Giphy GIF. The client renders both identically.
+        public AttachmentSource $source,
+        // The media URL. For an upload this is the authorized download route
+        // (never a filesystem URL); for a Giphy GIF it is the CDN media URL,
+        // hotlinked directly.
         public string $url,
         // The authorized thumbnail URL for the timeline grid, or null when no
-        // thumbnail was generated (SVG and every non-image type); the client then
-        // falls back to the full-resolution `url`.
+        // thumbnail was generated (SVG, every non-image type, and Giphy GIFs);
+        // the client then falls back to the full-resolution `url`.
         public ?string $thumbUrl,
+        // The image's alt text: the Giphy content description for a GIF, or null
+        // for an upload (which has no provider-supplied description).
+        public ?string $description,
     ) {}
 
     /**
@@ -45,8 +56,10 @@ class AttachmentData extends Data
             width: $attachment->width,
             height: $attachment->height,
             isImage: $attachment->isImage(),
+            source: $attachment->source,
             url: $attachment->url,
             thumbUrl: $attachment->thumb_url,
+            description: $attachment->description,
         );
     }
 }

--- a/app/Data/GiphyGifData.php
+++ b/app/Data/GiphyGifData.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class GiphyGifData extends Data
+{
+    public function __construct(
+        // The opaque Giphy id. The only thing the client sends back to claim a
+        // GIF; the server re-resolves it authoritatively (never trusting a URL).
+        public string $id,
+        // The animated media URL (Giphy `fixed_height` rendition): the URL stored
+        // on the attachment and rendered inline in the timeline.
+        public string $url,
+        // A smaller animated rendition for the picker grid tile, keeping the grid
+        // light while the full media is only fetched once a GIF is picked/sent.
+        public string $previewUrl,
+        // The media pixel dimensions, so the picker grid and (once sent) the
+        // virtualized timeline both reserve stable layout.
+        public int $width,
+        public int $height,
+        // The Giphy content description, used as the rendered `<img alt>`.
+        public ?string $description,
+    ) {}
+}

--- a/app/Data/GiphySearchData.php
+++ b/app/Data/GiphySearchData.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+#[TypeScript]
+class GiphySearchData extends Data
+{
+    /**
+     * @param  array<int, GiphyGifData>  $results
+     */
+    public function __construct(
+        // The GIFs for this page of results.
+        public array $results,
+        // The offset to request for the next page, or null when the results are
+        // exhausted — drives the picker's infinite scroll.
+        public ?int $nextOffset,
+    ) {}
+}

--- a/app/Enums/AttachmentSource.php
+++ b/app/Enums/AttachmentSource.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum AttachmentSource: string
+{
+    /**
+     * The attachment is an operator-hosted blob uploaded by a member. Its bytes
+     * live on the configured disk (`disk`/`path`), are served through the
+     * authorized download route, and are reclaimed on force-delete.
+     */
+    case Upload = 'upload';
+
+    /**
+     * The attachment is a remote GIF resolved from Giphy. It has no blob: `disk`,
+     * `path`, and `original_filename` are null, and its media is hotlinked from
+     * the Giphy CDN via `remote_url` (bypassing the blob-only serve route).
+     */
+    case Giphy = 'giphy';
+}

--- a/app/Http/Controllers/Channels/GiphyController.php
+++ b/app/Http/Controllers/Channels/GiphyController.php
@@ -18,12 +18,6 @@ use Illuminate\Http\JsonResponse;
 class GiphyController extends Controller
 {
     /**
-     * The picker page size. One value for trending and search; the infinite
-     * scroll pages by Giphy's offset cursor.
-     */
-    private const int PAGE_SIZE = 24;
-
-    /**
      * Proxy a Giphy trending/search page for the composer picker.
      *
      * The API key stays server-side; the endpoint is throttled per user and the
@@ -36,7 +30,7 @@ class GiphyController extends Controller
         $page = $giphy->search(
             query: $request->validated('q'),
             offset: (int) $request->validated('offset', 0),
-            limit: self::PAGE_SIZE,
+            limit: (int) config('services.giphy.page_size'),
             lang: $request->user()->locale->value,
         );
 

--- a/app/Http/Controllers/Channels/GiphyController.php
+++ b/app/Http/Controllers/Channels/GiphyController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Channels;
 
 use App\Actions\Channels\CreateGiphyAttachment;
 use App\Data\AttachmentData;
+use App\Data\GiphyGifData;
 use App\Data\GiphySearchData;
 use App\Http\Controllers\Controller;
 use App\Http\Middleware\EnsureGiphyEnabled;
@@ -55,7 +56,7 @@ class GiphyController extends Controller
     {
         $gif = $giphy->resolve($request->validated('id'));
 
-        abort_if($gif === null, 422, __('That GIF is no longer available.'));
+        abort_if(! $gif instanceof GiphyGifData, 422, __('That GIF is no longer available.'));
 
         $attachment = $createGiphyAttachment->handle($channel, $request->user(), $gif);
 

--- a/app/Http/Controllers/Channels/GiphyController.php
+++ b/app/Http/Controllers/Channels/GiphyController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Channels;
+
+use App\Actions\Channels\CreateGiphyAttachment;
+use App\Data\AttachmentData;
+use App\Data\GiphySearchData;
+use App\Http\Controllers\Controller;
+use App\Http\Middleware\EnsureGiphyEnabled;
+use App\Http\Requests\Channels\GifSearchRequest;
+use App\Http\Requests\Channels\StoreGifRequest;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Support\GiphyClient;
+use Illuminate\Http\JsonResponse;
+
+class GiphyController extends Controller
+{
+    /**
+     * The picker page size. One value for trending and search; the infinite
+     * scroll pages by Giphy's offset cursor.
+     */
+    private const int PAGE_SIZE = 24;
+
+    /**
+     * Proxy a Giphy trending/search page for the composer picker.
+     *
+     * The API key stays server-side; the endpoint is throttled per user and the
+     * client's app locale is passed through for localized results. Authorized by
+     * the post-message policy (see {@see GifSearchRequest}) and reachable only
+     * when Giphy is configured (see {@see EnsureGiphyEnabled}).
+     */
+    public function search(GifSearchRequest $request, Team $team, Channel $channel, GiphyClient $giphy): JsonResponse
+    {
+        $page = $giphy->search(
+            query: $request->validated('q'),
+            offset: (int) $request->validated('offset', 0),
+            limit: self::PAGE_SIZE,
+            lang: $request->user()->locale->value,
+        );
+
+        return response()->json(GiphySearchData::from($page));
+    }
+
+    /**
+     * Attach a chosen GIF to a draft as a pending remote attachment.
+     *
+     * The client sends only the opaque Giphy id; the server re-resolves it (the
+     * sole authority on the stored URL) and creates a pending `source=giphy`
+     * attachment owned by the sender and channel. The subsequent send claims it
+     * through the ordinary `attachment_ids[]` flow. An id Giphy no longer knows
+     * is rejected.
+     */
+    public function store(StoreGifRequest $request, Team $team, Channel $channel, GiphyClient $giphy, CreateGiphyAttachment $createGiphyAttachment): JsonResponse
+    {
+        $gif = $giphy->resolve($request->validated('id'));
+
+        abort_if($gif === null, 422, __('That GIF is no longer available.'));
+
+        $attachment = $createGiphyAttachment->handle($channel, $request->user(), $gif);
+
+        return response()->json(AttachmentData::fromAttachment($attachment), 201);
+    }
+}

--- a/app/Http/Middleware/EnsureGiphyEnabled.php
+++ b/app/Http/Middleware/EnsureGiphyEnabled.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Support\GiphyClient;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Gate the Giphy endpoints on the feature being configured. With no API key the
+ * picker is fully hidden client-side; this makes the server match — the search
+ * and attach endpoints 404, so nothing leaks on an unconfigured deployment.
+ */
+class EnsureGiphyEnabled
+{
+    public function __construct(private readonly GiphyClient $giphy) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        abort_unless($this->giphy->isEnabled(), 404);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -102,6 +102,11 @@ class HandleInertiaRequests extends Middleware
                 'maxSizeMb' => (int) config('attachments.max_size_mb'),
                 'maxPerMessage' => (int) config('attachments.max_per_message'),
             ],
+            // Whether the Giphy `/gif` picker is available, derived from the API
+            // key being set. False fully hides the picker client-side (and the
+            // `/gif` command is absent from autocomplete), matching the 404 the
+            // search/attach endpoints return when unconfigured.
+            'gifPickerEnabled' => filled(config('services.giphy.key')),
             // The instance's version standing, so authenticated users see a
             // low-key "update available" indicator when the self-hosted release
             // is behind. `current` is always present; `latest`/`notesUrl` fill in

--- a/app/Http/Requests/Channels/GifSearchRequest.php
+++ b/app/Http/Requests/Channels/GifSearchRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class GifSearchRequest extends FormRequest
+{
+    /**
+     * Searching the picker reuses the post-message policy: if the user could not
+     * post a message to this channel, they cannot search GIFs for one either.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('postMessage', $this->channel());
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // Blank/absent → Giphy trending; otherwise a search term.
+            'q' => ['nullable', 'string', 'max:100'],
+            // Infinite-scroll cursor (Giphy is offset-paginated).
+            'offset' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+
+    /**
+     * Get the channel the picker is scoped to.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+}

--- a/app/Http/Requests/Channels/StoreGifRequest.php
+++ b/app/Http/Requests/Channels/StoreGifRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Channels;
+
+use App\Models\Channel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class StoreGifRequest extends FormRequest
+{
+    /**
+     * Attaching a GIF reuses the post-message policy, exactly like uploading a
+     * file: if the user could not post here, they cannot stage a GIF for a
+     * message either.
+     */
+    public function authorize(): bool
+    {
+        return Gate::allows('postMessage', $this->channel());
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // The opaque Giphy id, the only thing the client sends; the server
+            // re-resolves it authoritatively (never trusting a client URL).
+            'id' => ['required', 'string', 'max:100'],
+        ];
+    }
+
+    /**
+     * Get the channel the GIF is being attached to.
+     */
+    public function channel(): Channel
+    {
+        $channel = $this->route('channel');
+
+        abort_if(! $channel instanceof Channel, 404);
+
+        return $channel;
+    }
+}

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\AttachmentSource;
 use App\Enums\AttachmentStatus;
 use Database\Factories\AttachmentFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -19,13 +20,16 @@ use Illuminate\Support\Facades\Storage;
  * @property string|null $message_id
  * @property string $user_id
  * @property string $channel_id
- * @property string $disk
- * @property string $path
- * @property string $original_filename
+ * @property AttachmentSource $source
+ * @property string|null $disk
+ * @property string|null $path
+ * @property string|null $original_filename
  * @property string $mime_type
  * @property int $size_bytes
  * @property int|null $width
  * @property int|null $height
+ * @property string|null $remote_url
+ * @property string|null $description
  * @property string|null $thumb_path
  * @property AttachmentStatus $status
  * @property Carbon|null $deleted_at
@@ -37,11 +41,22 @@ use Illuminate\Support\Facades\Storage;
  * @property-read User $user
  * @property-read Channel $channel
  */
-#[Fillable(['message_id', 'user_id', 'channel_id', 'disk', 'path', 'original_filename', 'mime_type', 'size_bytes', 'width', 'height', 'thumb_path', 'status'])]
+#[Fillable(['message_id', 'user_id', 'channel_id', 'source', 'disk', 'path', 'original_filename', 'mime_type', 'size_bytes', 'width', 'height', 'remote_url', 'description', 'thumb_path', 'status'])]
 class Attachment extends Model
 {
     /** @use HasFactory<AttachmentFactory> */
     use HasFactory, HasUuids, SoftDeletes;
+
+    /**
+     * Default an attachment to an operator-hosted upload, so a row created
+     * without an explicit `source` (the upload path) has it populated in memory
+     * — not just via the database column default after a reload.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'source' => AttachmentSource::Upload->value,
+    ];
 
     /**
      * Mime types that are image-shaped but must never be rendered inline. SVG is
@@ -63,6 +78,11 @@ class Attachment extends Model
     protected static function booted(): void
     {
         static::forceDeleted(function (Attachment $attachment): void {
+            // A remote attachment (Giphy) has no blob on disk — nothing to reclaim.
+            if ($attachment->path === null) {
+                return;
+            }
+
             try {
                 $disk = Storage::disk($attachment->disk);
                 $disk->delete($attachment->path);
@@ -133,15 +153,20 @@ class Attachment extends Model
      * team are expected to be eager-loaded (via the message payload's relation
      * set) so building this per attachment stays N+1-free.
      *
+     * A remote attachment (Giphy) has no blob to serve, so its media is the
+     * CDN URL hotlinked directly — the blob-only serve route does not apply.
+     *
      * @return Attribute<string, never>
      */
     protected function url(): Attribute
     {
-        return Attribute::get(fn (): string => route('channels.attachments.download', [
-            'team' => $this->channel->team->slug,
-            'channel' => $this->channel->slug,
-            'attachment' => $this->id,
-        ]));
+        return Attribute::get(fn (): string => $this->source === AttachmentSource::Giphy
+            ? (string) $this->remote_url
+            : route('channels.attachments.download', [
+                'team' => $this->channel->team->slug,
+                'channel' => $this->channel->slug,
+                'attachment' => $this->id,
+            ]));
     }
 
     /**
@@ -169,6 +194,7 @@ class Attachment extends Model
             'size_bytes' => 'int',
             'width' => 'int',
             'height' => 'int',
+            'source' => AttachmentSource::class,
             'status' => AttachmentStatus::class,
         ];
     }

--- a/app/Providers/SlashCommandServiceProvider.php
+++ b/app/Providers/SlashCommandServiceProvider.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\SlashCommands\Commands\GifCommand;
 use App\SlashCommands\Commands\ShrugCommand;
 use App\SlashCommands\Commands\TableflipCommand;
 use App\SlashCommands\Commands\UnflipCommand;
 use App\SlashCommands\SlashCommand;
 use App\SlashCommands\SlashCommandRegistry;
+use App\Support\GiphyClient;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -42,6 +44,13 @@ class SlashCommandServiceProvider extends ServiceProvider
 
         foreach (self::COMMANDS as $command) {
             $registry->register($this->app->make($command));
+        }
+
+        // The GIF picker command only exists when Giphy is configured, so `/gif`
+        // is absent from autocomplete (and posts as literal text) on a deployment
+        // with no key — honouring the fully-hidden-when-unconfigured contract.
+        if ($this->app->make(GiphyClient::class)->isEnabled()) {
+            $registry->register($this->app->make(GifCommand::class));
         }
     }
 }

--- a/app/SlashCommands/Commands/GifCommand.php
+++ b/app/SlashCommands/Commands/GifCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\SlashCommands\Commands;
+
+use App\SlashCommands\BaseSlashCommand;
+use App\SlashCommands\SlashCommandContext;
+use App\SlashCommands\SlashCommandResult;
+
+/**
+ * `/gif [search]` — open the Giphy picker to send a GIF.
+ *
+ * Registered only when Giphy is configured, so it appears in the composer's `/`
+ * autocomplete. The interaction is client-side: selecting `/gif` opens the
+ * picker, and the chosen GIF is sent as a remote attachment through the ordinary
+ * attachment flow — never as text through the command endpoint. This handler is
+ * therefore a fallback for a client that submits `/gif` as raw text (e.g. with
+ * JavaScript disabled): it returns a hint rather than posting a literal `/gif`.
+ */
+class GifCommand extends BaseSlashCommand
+{
+    public function name(): string
+    {
+        return 'gif';
+    }
+
+    public function description(): string
+    {
+        return __('Search Giphy for a GIF to send');
+    }
+
+    public function argumentHint(): ?string
+    {
+        return __('[search]');
+    }
+
+    public function handle(SlashCommandContext $ctx): SlashCommandResult
+    {
+        return SlashCommandResult::error(__('Pick a GIF from the picker to send one.'));
+    }
+}

--- a/app/Support/GiphyClient.php
+++ b/app/Support/GiphyClient.php
@@ -19,22 +19,9 @@ use Illuminate\Support\Facades\Http;
  */
 class GiphyClient
 {
-    private const string BASE_URL = 'https://api.giphy.com/v1/gifs';
-
     /**
-     * Total time budget for a single request, in seconds.
-     */
-    private const int TIMEOUT_SECONDS = 5;
-
-    /**
-     * How long a resolved search/trending page stays cached. Short, because
-     * trending and search results are meant to feel live; long enough to absorb
-     * a burst of identical requests (a member scrolling) off the shared key.
-     */
-    private const int CACHE_TTL_SECONDS = 300; // 5 minutes
-
-    /**
-     * Giphy's own per-request page-size ceiling.
+     * Giphy's own per-request page-size ceiling (an API constraint, not an
+     * operator knob).
      */
     private const int MAX_LIMIT = 50;
 
@@ -62,7 +49,7 @@ class GiphyClient
         /** @var array{results: array<int, array<string, mixed>>, nextOffset: int|null} $payload */
         $payload = Cache::remember(
             $cacheKey,
-            now()->addSeconds(self::CACHE_TTL_SECONDS),
+            now()->addSeconds((int) config('services.giphy.cache_ttl')),
             fn (): array => $this->fetchPage($query, $offset, $limit, $lang),
         );
 
@@ -81,7 +68,7 @@ class GiphyClient
     public function resolve(string $id): ?GiphyGifData
     {
         try {
-            $response = Http::timeout(self::TIMEOUT_SECONDS)->get(self::BASE_URL.'/'.$id, [
+            $response = Http::timeout($this->timeout())->get($this->baseUrl().'/'.$id, [
                 'api_key' => (string) config('services.giphy.key'),
             ]);
         } catch (ConnectionException) {
@@ -114,7 +101,7 @@ class GiphyClient
      */
     private function fetchPage(string $query, int $offset, int $limit, string $lang): array
     {
-        $endpoint = $query === '' ? self::BASE_URL.'/trending' : self::BASE_URL.'/search';
+        $endpoint = $query === '' ? $this->baseUrl().'/trending' : $this->baseUrl().'/search';
 
         $params = array_filter([
             'api_key' => (string) config('services.giphy.key'),
@@ -127,7 +114,7 @@ class GiphyClient
         ], fn (mixed $value): bool => $value !== null);
 
         try {
-            $response = Http::timeout(self::TIMEOUT_SECONDS)->get($endpoint, $params);
+            $response = Http::timeout($this->timeout())->get($endpoint, $params);
         } catch (ConnectionException) {
             // DNS/connect/timeout failure degrades to an empty page, so a Giphy
             // outage never 500s the picker.
@@ -217,6 +204,22 @@ class GiphyClient
         }
 
         return null;
+    }
+
+    /**
+     * The Giphy v2 API base URL, from config.
+     */
+    private function baseUrl(): string
+    {
+        return (string) config('services.giphy.base_url');
+    }
+
+    /**
+     * The per-request time budget in seconds, from config.
+     */
+    private function timeout(): int
+    {
+        return (int) config('services.giphy.timeout');
     }
 
     /**

--- a/app/Support/GiphyClient.php
+++ b/app/Support/GiphyClient.php
@@ -6,6 +6,7 @@ namespace App\Support;
 
 use App\Data\GiphyGifData;
 use App\Data\GiphySearchData;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -79,9 +80,15 @@ class GiphyClient
      */
     public function resolve(string $id): ?GiphyGifData
     {
-        $response = Http::timeout(self::TIMEOUT_SECONDS)->get(self::BASE_URL.'/'.$id, [
-            'api_key' => (string) config('services.giphy.key'),
-        ]);
+        try {
+            $response = Http::timeout(self::TIMEOUT_SECONDS)->get(self::BASE_URL.'/'.$id, [
+                'api_key' => (string) config('services.giphy.key'),
+            ]);
+        } catch (ConnectionException) {
+            // DNS/connect/timeout failure — degrade like an unknown id rather
+            // than 500 the attach request.
+            return null;
+        }
 
         if (! $response->successful()) {
             return null;
@@ -119,7 +126,13 @@ class GiphyClient
             'lang' => $query === '' ? null : $lang,
         ], fn (mixed $value): bool => $value !== null);
 
-        $response = Http::timeout(self::TIMEOUT_SECONDS)->get($endpoint, $params);
+        try {
+            $response = Http::timeout(self::TIMEOUT_SECONDS)->get($endpoint, $params);
+        } catch (ConnectionException) {
+            // DNS/connect/timeout failure degrades to an empty page, so a Giphy
+            // outage never 500s the picker.
+            return ['results' => [], 'nextOffset' => null];
+        }
 
         if (! $response->successful()) {
             return ['results' => [], 'nextOffset' => null];

--- a/app/Support/GiphyClient.php
+++ b/app/Support/GiphyClient.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Data\GiphyGifData;
+use App\Data\GiphySearchData;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * A thin server-side proxy for the Giphy v2 API. The operator's API key never
+ * leaves the server, results are short-TTL cached (respecting Giphy's caching
+ * terms and protecting the shared key), and every response is normalized to the
+ * small {@see GiphyGifData} shape the picker needs — the client never sees a raw
+ * Giphy payload and never chooses which rendition is stored.
+ */
+class GiphyClient
+{
+    private const string BASE_URL = 'https://api.giphy.com/v1/gifs';
+
+    /**
+     * Total time budget for a single request, in seconds.
+     */
+    private const int TIMEOUT_SECONDS = 5;
+
+    /**
+     * How long a resolved search/trending page stays cached. Short, because
+     * trending and search results are meant to feel live; long enough to absorb
+     * a burst of identical requests (a member scrolling) off the shared key.
+     */
+    private const int CACHE_TTL_SECONDS = 300; // 5 minutes
+
+    /**
+     * Giphy's own per-request page-size ceiling.
+     */
+    private const int MAX_LIMIT = 50;
+
+    /**
+     * Whether the feature is configured. With no key the picker is fully hidden
+     * and its endpoints 404, so nothing here is ever reached unconfigured.
+     */
+    public function isEnabled(): bool
+    {
+        return filled(config('services.giphy.key'));
+    }
+
+    /**
+     * Fetch a page of GIFs: Giphy trending when the query is blank, else a search.
+     * Results are cached per (query, offset, limit, lang, rating).
+     */
+    public function search(?string $query, int $offset = 0, int $limit = 24, string $lang = 'en'): GiphySearchData
+    {
+        $query = trim((string) $query);
+        $limit = max(1, min($limit, self::MAX_LIMIT));
+        $offset = max(0, $offset);
+
+        $cacheKey = 'giphy:'.sha1(implode('|', [$query, $offset, $limit, $lang, $this->rating()]));
+
+        /** @var array{results: array<int, array<string, mixed>>, nextOffset: int|null} $payload */
+        $payload = Cache::remember(
+            $cacheKey,
+            now()->addSeconds(self::CACHE_TTL_SECONDS),
+            fn (): array => $this->fetchPage($query, $offset, $limit, $lang),
+        );
+
+        return new GiphySearchData(
+            results: array_map(GiphyGifData::from(...), $payload['results']),
+            nextOffset: $payload['nextOffset'],
+        );
+    }
+
+    /**
+     * Re-resolve an opaque Giphy id to its authoritative media, or null when the
+     * id is unknown/invalid. This is the sole authority on the stored URL: the
+     * client sends only an id, never a URL, so a member cannot inject an arbitrary
+     * host into another member's DOM.
+     */
+    public function resolve(string $id): ?GiphyGifData
+    {
+        $response = Http::timeout(self::TIMEOUT_SECONDS)->get(self::BASE_URL.'/'.$id, [
+            'api_key' => (string) config('services.giphy.key'),
+        ]);
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        $gif = $response->json('data');
+
+        if (! is_array($gif) || $gif === []) {
+            return null;
+        }
+
+        $normalized = $this->normalize($gif);
+
+        return $normalized === null ? null : GiphyGifData::from($normalized);
+    }
+
+    /**
+     * Perform a single search/trending request and normalize it into a cacheable
+     * array payload. A failed request degrades to an empty page rather than
+     * throwing, so a Giphy outage never 500s the picker.
+     *
+     * @return array{results: array<int, array<string, mixed>>, nextOffset: int|null}
+     */
+    private function fetchPage(string $query, int $offset, int $limit, string $lang): array
+    {
+        $endpoint = $query === '' ? self::BASE_URL.'/trending' : self::BASE_URL.'/search';
+
+        $params = array_filter([
+            'api_key' => (string) config('services.giphy.key'),
+            'q' => $query === '' ? null : $query,
+            'limit' => $limit,
+            'offset' => $offset,
+            'rating' => $this->rating(),
+            // Trending is not query-scoped, so a language hint is meaningless there.
+            'lang' => $query === '' ? null : $lang,
+        ], fn (mixed $value): bool => $value !== null);
+
+        $response = Http::timeout(self::TIMEOUT_SECONDS)->get($endpoint, $params);
+
+        if (! $response->successful()) {
+            return ['results' => [], 'nextOffset' => null];
+        }
+
+        $results = [];
+
+        foreach ((array) $response->json('data', []) as $gif) {
+            $normalized = is_array($gif) ? $this->normalize($gif) : null;
+
+            if ($normalized !== null) {
+                $results[] = $normalized;
+            }
+        }
+
+        return ['results' => $results, 'nextOffset' => $this->nextOffset($response->json('pagination', []), $offset, $limit, count($results))];
+    }
+
+    /**
+     * Work out the offset for the next page from Giphy's pagination block. When
+     * `total_count` is known we page until it is exhausted; trending omits it, so
+     * a full page is taken to imply there is more.
+     *
+     * @param  array<string, mixed>  $pagination
+     */
+    private function nextOffset(array $pagination, int $offset, int $limit, int $resultCount): ?int
+    {
+        $count = (int) ($pagination['count'] ?? $resultCount);
+        $totalCount = (int) ($pagination['total_count'] ?? 0);
+        $currentOffset = (int) ($pagination['offset'] ?? $offset);
+        $next = $currentOffset + $count;
+
+        $hasMore = $count > 0 && ($totalCount > 0 ? $next < $totalCount : $count >= $limit);
+
+        return $hasMore ? $next : null;
+    }
+
+    /**
+     * Reduce a raw Giphy GIF object to the fields the picker and attachment need,
+     * or null when it lacks a usable animated rendition or id.
+     *
+     * @param  array<string, mixed>  $gif
+     * @return array{id: string, url: string, previewUrl: string, width: int, height: int, description: string|null}|null
+     */
+    private function normalize(array $gif): ?array
+    {
+        $id = (string) ($gif['id'] ?? '');
+        $images = (array) ($gif['images'] ?? []);
+        $media = $images['fixed_height'] ?? null;
+
+        if ($id === '' || ! is_array($media) || empty($media['url'])) {
+            return null;
+        }
+
+        $preview = $images['fixed_height_small'] ?? $images['preview_gif'] ?? $media;
+        $preview = is_array($preview) ? $preview : $media;
+
+        return [
+            'id' => $id,
+            'url' => (string) $media['url'],
+            'previewUrl' => (string) ($preview['url'] ?? $media['url']),
+            'width' => (int) ($media['width'] ?? 0),
+            'height' => (int) ($media['height'] ?? 0),
+            'description' => $this->description($gif),
+        ];
+    }
+
+    /**
+     * Pick the best alt text for a GIF: Giphy's `alt_text` if present, else its
+     * `title`, else null.
+     *
+     * @param  array<string, mixed>  $gif
+     */
+    private function description(array $gif): ?string
+    {
+        foreach (['alt_text', 'title'] as $key) {
+            $value = trim((string) ($gif[$key] ?? ''));
+
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The strictest content rating Giphy may return, from config; defaults to the
+     * workplace-safe `g` if an operator blanks it.
+     */
+    private function rating(): string
+    {
+        $rating = (string) config('services.giphy.rating');
+
+        return $rating === '' ? 'g' : $rating;
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -45,6 +45,18 @@ return [
     'giphy' => [
         'key' => env('GIPHY_API_KEY'),
         'rating' => env('GIPHY_CONTENT_RATING', 'g'),
+        // The Giphy v2 API base. Not an operator knob (kept out of .env); here so
+        // it is overridable in tests and never hardcoded in the client.
+        'base_url' => 'https://api.giphy.com/v1/gifs',
+        // Per-request time budget (seconds) for the outbound Giphy call.
+        'timeout' => 5,
+        // How long a resolved search/trending page is cached — short, so results
+        // feel live, but long enough to absorb a burst of identical requests
+        // (a member scrolling) off the shared key.
+        'cache_ttl' => 300,
+        // Picker page size for trending and search; infinite scroll pages by
+        // Giphy's offset cursor.
+        'page_size' => 24,
     ],
 
     // Generic OpenID Connect provider (Okta, Microsoft Entra ID, Google

--- a/config/services.php
+++ b/config/services.php
@@ -37,6 +37,16 @@ return [
         ],
     ],
 
+    // Giphy powers the composer's `/gif` picker. The feature is fully hidden and
+    // its endpoints 404 unless `GIPHY_API_KEY` is set (an operator-supplied key
+    // from developers.giphy.com), so a default deployment ships it off. `rating`
+    // is the strictest content rating Giphy may return — `g` (workplace-safe)
+    // by default; loosen to `pg`, `pg-13`, or `r` for a casual community.
+    'giphy' => [
+        'key' => env('GIPHY_API_KEY'),
+        'rating' => env('GIPHY_CONTENT_RATING', 'g'),
+    ],
+
     // Generic OpenID Connect provider (Okta, Microsoft Entra ID, Google
     // Workspace, Auth0, Keycloak, …). Socialite resolves the driver named
     // "oidc" from this block; App\Providers\SsoServiceProvider reads the issuer's

--- a/database/factories/AttachmentFactory.php
+++ b/database/factories/AttachmentFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\AttachmentSource;
 use App\Enums\AttachmentStatus;
 use App\Models\Attachment;
 use App\Models\Channel;
@@ -26,6 +27,7 @@ class AttachmentFactory extends Factory
             'message_id' => null,
             'user_id' => User::factory(),
             'channel_id' => Channel::factory(),
+            'source' => AttachmentSource::Upload,
             'disk' => config('attachments.disk'),
             'path' => 'attachments/'.fake()->uuid().'/'.fake()->uuid().'.png',
             'original_filename' => fake()->word().'.png',
@@ -35,6 +37,27 @@ class AttachmentFactory extends Factory
             'height' => 600,
             'status' => AttachmentStatus::Pending,
         ];
+    }
+
+    /**
+     * Indicate the attachment is a remote Giphy GIF: no blob (disk/path/filename
+     * are null), hotlinked from the CDN via `remote_url`, with a content
+     * description used as the rendered `alt` text.
+     */
+    public function giphy(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'source' => AttachmentSource::Giphy,
+            'disk' => null,
+            'path' => null,
+            'original_filename' => null,
+            'mime_type' => 'image/gif',
+            'size_bytes' => fake()->numberBetween(50_000, 2_000_000),
+            'width' => 480,
+            'height' => 270,
+            'remote_url' => 'https://media.giphy.com/media/'.fake()->uuid().'/giphy.gif',
+            'description' => fake()->words(3, true),
+        ]);
     }
 
     /**

--- a/database/migrations/2026_07_18_005725_add_remote_source_to_attachments_table.php
+++ b/database/migrations/2026_07_18_005725_add_remote_source_to_attachments_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Enums\AttachmentSource;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Add the remote-attachment variant to the attachments table. A remote
+     * attachment (currently a Giphy GIF) carries no blob: its media is hotlinked
+     * from a CDN via `remote_url`, so `disk`/`path`/`original_filename` become
+     * nullable. `source` discriminates the two variants; `description` holds the
+     * remote content description, surfaced as the rendered image's `alt` text.
+     */
+    public function up(): void
+    {
+        Schema::table('attachments', function (Blueprint $table): void {
+            $table->string('source')->default(AttachmentSource::Upload->value)->after('channel_id');
+            // The resolved remote CDN media URL, used directly as the `<img src>`;
+            // null for an uploaded blob (which serves through the download route).
+            $table->string('remote_url')->nullable()->after('height');
+            // The remote content description, used as the rendered `<img alt>`;
+            // null for uploads (which have no provider-supplied description).
+            $table->string('description')->nullable()->after('remote_url');
+
+            // A remote attachment has no blob, so the blob columns are nullable.
+            $table->string('disk')->nullable()->change();
+            $table->string('path')->nullable()->change();
+            $table->string('original_filename')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('attachments', function (Blueprint $table): void {
+            $table->dropColumn(['source', 'remote_url', 'description']);
+            // Note: the blob columns are left nullable on rollback. Reverting them
+            // to NOT NULL would fail if any remote row exists, and the create
+            // migration's down() drops the whole table anyway.
+        });
+    }
+};

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -231,7 +231,8 @@ before the app ever sees them. See [Reverse proxy](/docs/self-hosting/reverse-pr
 
 The composer's `/gif` picker searches [Giphy](https://developers.giphy.com/) and sends the chosen
 GIF into any channel or DM. It is **off** until you supply an API key, so a default deployment ships
-without it — the `/gif` command, the picker, and the search/attach endpoints are all absent.
+without it — the `/gif` command and picker are hidden, and the search/attach routes (though still
+registered) return **404**.
 
 | Variable               | Default   | Notes                                                                                     |
 | ---------------------- | --------- | ----------------------------------------------------------------------------------------- |

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -227,6 +227,27 @@ If these are lower than `ATTACHMENT_MAX_SIZE_MB`, large uploads are rejected by 
 before the app ever sees them. See [Reverse proxy](/docs/self-hosting/reverse-proxy/).
 :::
 
+## GIFs (Giphy)
+
+The composer's `/gif` picker searches [Giphy](https://developers.giphy.com/) and sends the chosen
+GIF into any channel or DM. It is **off** until you supply an API key, so a default deployment ships
+without it — the `/gif` command, the picker, and the search/attach endpoints are all absent.
+
+| Variable               | Default   | Notes                                                                                     |
+| ---------------------- | --------- | ----------------------------------------------------------------------------------------- |
+| `GIPHY_API_KEY`        | *(blank)* | A Giphy API key (free from developers.giphy.com). Blank hides the feature entirely.       |
+| `GIPHY_CONTENT_RATING` | `g`       | Strictest rating Giphy may return: `g`, `pg`, `pg-13`, or `r`. `g` is workplace-safe.     |
+
+See [Feature toggles → GIF picker](/docs/reference/feature-toggles/#gif-picker-giphy) for how the
+feature behaves once enabled.
+
+:::note[GIFs are hotlinked from Giphy's CDN]
+A sent GIF is stored as a **reference** to Giphy's CDN URL — the bytes are never downloaded to your
+server. Viewers' browsers therefore load the GIF directly from Giphy's CDN, which means Giphy can see
+those requests (IP address, timing). This is a minor privacy consideration; self-hosting the GIF bytes
+is not currently supported.
+:::
+
 ## Session geolocation
 
 The **Security** settings page can show an approximate location (city, country)

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -219,3 +219,30 @@ own upstream.
 The check only reads public release metadata. It sends no information about your
 instance to GitHub.
 :::
+
+## GIF picker (Giphy)
+
+| Variable        | Default   | Effect                                                        |
+| --------------- | --------- | ------------------------------------------------------------ |
+| `GIPHY_API_KEY` | *(blank)* | Enables the composer's `/gif` [Giphy](https://developers.giphy.com/) picker. |
+
+The `/gif` picker is **off** by default. Setting `GIPHY_API_KEY` (a free key from
+developers.giphy.com) turns it on: typing `/gif` in the composer opens a picker
+that searches Giphy — trending on an empty query, debounced search as you type,
+infinite scroll — and the chosen GIF is sent as a normal message attachment.
+
+Leave the key blank and the feature is **fully hidden**: the `/gif` command is
+absent from autocomplete, the picker never appears, and the search/attach
+endpoints return **404**. The key is read server-side and never exposed to the
+browser.
+
+`GIPHY_CONTENT_RATING` (default `g`) caps the strictest rating Giphy may
+return — `g`, `pg`, `pg-13`, or `r`. `g` keeps results workplace-safe; loosen it
+for a casual community. See
+[Environment variables → GIFs (Giphy)](/docs/reference/environment-variables/#gifs-giphy).
+
+:::note
+A sent GIF is **hotlinked** from Giphy's CDN, not stored on your server, so
+viewers' browsers fetch it directly from Giphy. See the privacy note under
+[Environment variables → GIFs (Giphy)](/docs/reference/environment-variables/#gifs-giphy).
+:::

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -920,5 +920,17 @@
   "in thread · 1 reply": "dans un fil · 1 réponse",
   "in thread · :count replies": "dans un fil · :count réponses",
   "Search scope": "Portée de la recherche",
-  "All workspaces": "Tous les espaces"
+  "All workspaces": "Tous les espaces",
+  "GIF picker": "Sélecteur de GIF",
+  "GIF results": "Résultats de GIF",
+  "GIFs could not be loaded. Try again.": "Impossible de charger les GIF. Réessayez.",
+  "No GIFs found.": "Aucun GIF trouvé.",
+  "Loading more…": "Chargement…",
+  "Powered by GIPHY": "Propulsé par GIPHY",
+  "Search GIFs": "Rechercher des GIF",
+  "That GIF could not be added. Try another one.": "Ce GIF n'a pas pu être ajouté. Essayez-en un autre.",
+  "Search Giphy for a GIF to send": "Rechercher un GIF à envoyer sur Giphy",
+  "[search]": "[recherche]",
+  "Pick a GIF from the picker to send one.": "Choisissez un GIF dans le sélecteur pour en envoyer un.",
+  "That GIF is no longer available.": "Ce GIF n'est plus disponible."
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -57,5 +57,6 @@
         <env name="SSO_OIDC_ISSUER" value=""/>
         <env name="SSO_DEFAULT_TEAM_ID" value=""/>
         <env name="SCIM_TOKEN" value=""/>
+        <env name="GIPHY_API_KEY" value=""/>
     </php>
 </phpunit>

--- a/resources/js/components/GifPickerPanel.test.ts
+++ b/resources/js/components/GifPickerPanel.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import GifPickerPanel from './GifPickerPanel.vue';
+
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+vi.mock('@/components/ui/button', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        Button: defineComponent({
+            name: 'ButtonStub',
+            inheritAttrs: false,
+            setup:
+                (_props, { attrs, slots }) =>
+                () =>
+                    h('button', attrs, slots.default?.()),
+        }),
+    };
+});
+
+function gif(id: string): App.Data.GiphyGifData {
+    return {
+        id,
+        url: `https://media.giphy.com/${id}/200.gif`,
+        previewUrl: `https://media.giphy.com/${id}/100.gif`,
+        width: 2,
+        height: 1,
+        description: `gif ${id}`,
+    };
+}
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+function mountPanel(options: {
+    searchGifs?: (
+        url: string,
+        signal?: AbortSignal,
+    ) => Promise<App.Data.GiphySearchData>;
+    attachGif?: (url: string, id: string) => Promise<unknown>;
+    initialQuery?: string;
+}) {
+    const selected: unknown[] = [];
+    const closed: number[] = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(GifPickerPanel as Component, {
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                    initialQuery: options.initialQuery ?? '',
+                    debounceMs: 0,
+                    searchGifs: options.searchGifs,
+                    attachGif: options.attachGif,
+                    onSelect: (attachment: unknown) =>
+                        selected.push(attachment),
+                    onClose: () => closed.push(1),
+                }),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(container);
+    active.push({ app, container });
+
+    return { container, selected, closed };
+}
+
+function optionEls(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+        container.querySelectorAll<HTMLElement>('[data-test="gif-option"]'),
+    );
+}
+
+/**
+ * Settle the panel. Two macrotasks: the first lets the query watcher schedule
+ * its (0ms) debounce timer, the second lets that timer fire; then the
+ * search/attach promise chain's microtasks resolve.
+ */
+async function flush(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+    await Promise.resolve();
+    await Promise.resolve();
+    await nextTick();
+}
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+    vi.clearAllMocks();
+});
+
+describe('GifPickerPanel', () => {
+    it('loads trending on open and renders the grid', async () => {
+        const searchGifs = vi.fn().mockResolvedValue({
+            results: [gif('a'), gif('b')],
+            nextOffset: null,
+        });
+
+        const { container } = mountPanel({ searchGifs });
+        await flush();
+
+        expect(optionEls(container)).toHaveLength(2);
+        expect(
+            container.querySelector('[data-test="gif-powered-by"]'),
+        ).not.toBeNull();
+        // A blank query means trending: no `q` in the requested URL.
+        expect(searchGifs.mock.calls[0][0]).not.toContain('q=');
+    });
+
+    it('debounced-searches with the typed query', async () => {
+        const searchGifs = vi
+            .fn()
+            .mockResolvedValue({ results: [gif('a')], nextOffset: null });
+
+        const { container } = mountPanel({ searchGifs });
+        await flush();
+
+        const input = container.querySelector<HTMLInputElement>(
+            '[data-test="gif-search-input"]',
+        )!;
+        input.value = 'cats';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await flush();
+
+        expect(searchGifs.mock.calls.at(-1)?.[0]).toContain('q=cats');
+    });
+
+    it('attaches a picked GIF and emits it', async () => {
+        const attachment = { id: 'att-1', source: 'giphy' };
+        const attachGif = vi.fn().mockResolvedValue(attachment);
+
+        const { container, selected } = mountPanel({
+            searchGifs: vi
+                .fn()
+                .mockResolvedValue({ results: [gif('a')], nextOffset: null }),
+            attachGif,
+        });
+        await flush();
+
+        optionEls(container)[0].click();
+        await flush();
+
+        expect(attachGif).toHaveBeenCalledWith(expect.any(String), 'a');
+        expect(selected).toEqual([attachment]);
+    });
+
+    it('shows an empty state when there are no results', async () => {
+        const { container } = mountPanel({
+            searchGifs: vi
+                .fn()
+                .mockResolvedValue({ results: [], nextOffset: null }),
+        });
+        await flush();
+
+        expect(
+            container.querySelector('[data-test="gif-empty"]'),
+        ).not.toBeNull();
+    });
+
+    it('shows an error state when the search fails', async () => {
+        const { container } = mountPanel({
+            searchGifs: vi.fn().mockRejectedValue(new Error('boom')),
+        });
+        await flush();
+
+        expect(
+            container.querySelector('[data-test="gif-error"]'),
+        ).not.toBeNull();
+    });
+
+    it('closes on Escape', async () => {
+        const { container, closed } = mountPanel({
+            searchGifs: vi
+                .fn()
+                .mockResolvedValue({ results: [gif('a')], nextOffset: null }),
+        });
+        await flush();
+
+        container
+            .querySelector('[data-test="gif-picker"]')!
+            .dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+            );
+        await nextTick();
+
+        expect(closed).toEqual([1]);
+    });
+
+    it('appends the next page on scroll to the end', async () => {
+        const searchGifs = vi
+            .fn()
+            .mockResolvedValueOnce({ results: [gif('a')], nextOffset: 1 })
+            .mockResolvedValueOnce({ results: [gif('b')], nextOffset: null });
+
+        const { container } = mountPanel({ searchGifs });
+        await flush();
+        expect(optionEls(container)).toHaveLength(1);
+
+        container
+            .querySelector('[role="listbox"]')!
+            .dispatchEvent(new Event('scroll'));
+        await flush();
+
+        expect(optionEls(container)).toHaveLength(2);
+        expect(searchGifs.mock.calls[1][0]).toContain('offset=1');
+    });
+});

--- a/resources/js/components/GifPickerPanel.vue
+++ b/resources/js/components/GifPickerPanel.vue
@@ -78,6 +78,10 @@ function searchUrl(offset: number): string {
 
 let controller: AbortController | null = null;
 
+// False once the panel has unmounted, so an in-flight attach that resolves after
+// the user closed the picker doesn't stage a GIF they cancelled.
+let alive = true;
+
 /**
  * Load a page of results, replacing them (a new/changed query) or appending
  * (infinite scroll). A superseded in-flight request is aborted so its late
@@ -177,6 +181,13 @@ async function pick(gif: App.Data.GiphyGifData): Promise<void> {
             }),
             gif.id,
         );
+
+        // The user may have closed the picker while the attach was in flight;
+        // don't stage a GIF they cancelled.
+        if (!alive) {
+            return;
+        }
+
         emit('select', attachment);
     } catch {
         toast.error(t('That GIF could not be added. Try another one.'));
@@ -241,6 +252,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+    alive = false;
     controller?.abort();
 
     if (debounceTimer) {

--- a/resources/js/components/GifPickerPanel.vue
+++ b/resources/js/components/GifPickerPanel.vue
@@ -1,0 +1,359 @@
+<script setup lang="ts">
+import { X } from '@lucide/vue';
+import {
+    computed,
+    nextTick,
+    onBeforeUnmount,
+    onMounted,
+    ref,
+    watch,
+} from 'vue';
+import { toast } from 'vue-sonner';
+import {
+    search as searchRoute,
+    store as storeRoute,
+} from '@/actions/App/Http/Controllers/Channels/GiphyController';
+import { Button } from '@/components/ui/button';
+import { useTranslations } from '@/composables/useTranslations';
+import { attachGiphyGif, fetchGiphyPage } from '@/lib/giphy';
+import type { AttachmentData } from '@/types/attachments';
+
+const props = withDefaults(
+    defineProps<{
+        // The channel the picker searches and attaches within.
+        teamSlug: string;
+        channelSlug: string;
+        // The search term to seed from (`/gif cats` → "cats"); blank → trending.
+        initialQuery?: string;
+        // Debounce for search-as-you-type; 0 in tests for determinism.
+        debounceMs?: number;
+        // Transport, injected in tests so the panel unit-tests without a network.
+        searchGifs?: (
+            url: string,
+            signal?: AbortSignal,
+        ) => Promise<App.Data.GiphySearchData>;
+        attachGif?: (url: string, id: string) => Promise<AttachmentData>;
+    }>(),
+    {
+        initialQuery: '',
+        debounceMs: 300,
+        searchGifs: fetchGiphyPage,
+        attachGif: attachGiphyGif,
+    },
+);
+
+const emit = defineEmits<{
+    // A GIF was picked and attached; carries the stored remote attachment.
+    select: [attachment: AttachmentData];
+    // The picker should close (Escape, the close button, or a backdrop click).
+    close: [];
+}>();
+
+const { t } = useTranslations();
+
+const query = ref(props.initialQuery);
+const results = ref<App.Data.GiphyGifData[]>([]);
+const nextOffset = ref<number | null>(null);
+const loading = ref(false);
+const loadingMore = ref(false);
+const errored = ref(false);
+const attaching = ref(false);
+// The keyboard-active option, or -1 when focus is in the search field.
+const activeIndex = ref(-1);
+
+const searchInput = ref<HTMLInputElement | null>(null);
+const grid = ref<HTMLElement | null>(null);
+
+const isEmpty = computed(
+    () => !loading.value && !errored.value && results.value.length === 0,
+);
+
+/** The search endpoint for a given page offset (blank query → trending). */
+function searchUrl(offset: number): string {
+    return searchRoute.url(
+        { team: props.teamSlug, channel: props.channelSlug },
+        { query: { q: query.value.trim() || undefined, offset } },
+    );
+}
+
+let controller: AbortController | null = null;
+
+/**
+ * Load a page of results, replacing them (a new/changed query) or appending
+ * (infinite scroll). A superseded in-flight request is aborted so its late
+ * response can't clobber the current one.
+ */
+async function loadPage(offset: number, append: boolean): Promise<void> {
+    controller?.abort();
+    const request = new AbortController();
+    controller = request;
+
+    if (append) {
+        loadingMore.value = true;
+    } else {
+        loading.value = true;
+        errored.value = false;
+    }
+
+    try {
+        const page = await props.searchGifs(searchUrl(offset), request.signal);
+
+        if (request.signal.aborted) {
+            return;
+        }
+
+        results.value = append
+            ? [...results.value, ...page.results]
+            : page.results;
+        nextOffset.value = page.nextOffset;
+    } catch {
+        if (request.signal.aborted) {
+            return;
+        }
+
+        if (!append) {
+            results.value = [];
+        }
+
+        errored.value = true;
+        nextOffset.value = null;
+    } finally {
+        if (!request.signal.aborted) {
+            loading.value = false;
+            loadingMore.value = false;
+        }
+    }
+}
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+watch(query, () => {
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+    }
+
+    debounceTimer = setTimeout(() => {
+        activeIndex.value = -1;
+        void loadPage(0, false);
+    }, props.debounceMs);
+});
+
+/** Fetch the next page when the grid is scrolled near its end. */
+function onScroll(): void {
+    const el = grid.value;
+
+    if (
+        !el ||
+        loadingMore.value ||
+        loading.value ||
+        nextOffset.value === null
+    ) {
+        return;
+    }
+
+    if (el.scrollTop + el.clientHeight >= el.scrollHeight - 240) {
+        void loadPage(nextOffset.value, true);
+    }
+}
+
+/** Attach the chosen GIF, then hand it back to the composer. */
+async function pick(gif: App.Data.GiphyGifData): Promise<void> {
+    if (attaching.value) {
+        return;
+    }
+
+    attaching.value = true;
+
+    try {
+        const attachment = await props.attachGif(
+            storeRoute.url({
+                team: props.teamSlug,
+                channel: props.channelSlug,
+            }),
+            gif.id,
+        );
+        emit('select', attachment);
+    } catch {
+        toast.error(t('That GIF could not be added. Try another one.'));
+    } finally {
+        attaching.value = false;
+    }
+}
+
+/** Move the active option, clamping into the results range. */
+function moveActive(delta: number): void {
+    const count = results.value.length;
+
+    if (count === 0) {
+        return;
+    }
+
+    const next = Math.min(Math.max(activeIndex.value + delta, 0), count - 1);
+    activeIndex.value = next;
+
+    nextTick(() => {
+        grid.value
+            ?.querySelector<HTMLElement>(`[data-gif-index="${next}"]`)
+            ?.scrollIntoView({ block: 'nearest' });
+    });
+}
+
+function onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+        event.preventDefault();
+        emit('close');
+
+        return;
+    }
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+        event.preventDefault();
+        moveActive(activeIndex.value < 0 ? 0 : 1);
+
+        return;
+    }
+
+    if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+        event.preventDefault();
+        moveActive(-1);
+
+        return;
+    }
+
+    if (event.key === 'Enter' && activeIndex.value >= 0) {
+        const gif = results.value[activeIndex.value];
+
+        if (gif) {
+            event.preventDefault();
+            void pick(gif);
+        }
+    }
+}
+
+onMounted(() => {
+    void loadPage(0, false);
+    nextTick(() => searchInput.value?.focus());
+});
+
+onBeforeUnmount(() => {
+    controller?.abort();
+
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+    }
+});
+</script>
+
+<template>
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- the picker is a dialog; the key handler routes Escape/arrow navigation for the listbox it contains -->
+    <div
+        role="dialog"
+        :aria-label="$t('GIF picker')"
+        data-test="gif-picker"
+        class="absolute bottom-full left-0 z-20 mb-2 flex w-80 flex-col overflow-hidden rounded-2xl border bg-popover shadow-[0_10px_28px_rgba(29,26,21,0.14)]"
+        @keydown="onKeydown"
+    >
+        <div class="flex items-center gap-2 border-b border-border p-2">
+            <input
+                ref="searchInput"
+                v-model="query"
+                type="search"
+                data-test="gif-search-input"
+                :aria-label="$t('Search GIFs')"
+                :placeholder="$t('Search GIFs')"
+                class="h-8 flex-1 rounded-full bg-muted px-3 text-sm outline-none focus:ring-2 focus:ring-brass"
+            />
+            <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                class="size-8 shrink-0"
+                :aria-label="$t('Close')"
+                @click="emit('close')"
+            >
+                <X class="size-4" />
+            </Button>
+        </div>
+
+        <div
+            ref="grid"
+            role="listbox"
+            :aria-label="$t('GIF results')"
+            class="max-h-72 overflow-y-auto p-2"
+            @scroll="onScroll"
+        >
+            <div
+                v-if="loading"
+                data-test="gif-loading"
+                class="grid grid-cols-2 gap-2"
+                aria-hidden="true"
+            >
+                <div
+                    v-for="n in 6"
+                    :key="n"
+                    class="h-24 animate-pulse rounded-lg bg-muted"
+                />
+            </div>
+
+            <p
+                v-else-if="errored"
+                data-test="gif-error"
+                class="px-2 py-8 text-center text-sm text-muted-foreground"
+            >
+                {{ $t('GIFs could not be loaded. Try again.') }}
+            </p>
+
+            <p
+                v-else-if="isEmpty"
+                data-test="gif-empty"
+                class="px-2 py-8 text-center text-sm text-muted-foreground"
+            >
+                {{ $t('No GIFs found.') }}
+            </p>
+
+            <div v-else class="grid grid-cols-2 gap-2">
+                <!-- eslint-disable-next-line local/no-raw-button -- bespoke GIF-grid cell -->
+                <button
+                    v-for="(gif, index) in results"
+                    :key="gif.id"
+                    type="button"
+                    role="option"
+                    tabindex="-1"
+                    data-test="gif-option"
+                    :data-gif-index="index"
+                    :aria-selected="index === activeIndex"
+                    :aria-label="gif.description ?? $t('GIF')"
+                    :disabled="attaching"
+                    class="overflow-hidden rounded-lg border border-transparent bg-muted focus-visible:outline-none aria-selected:border-brass"
+                    @click="pick(gif)"
+                    @focus="activeIndex = index"
+                    @mouseenter="activeIndex = index"
+                >
+                    <img
+                        :src="gif.previewUrl"
+                        :alt="gif.description ?? ''"
+                        :width="gif.width"
+                        :height="gif.height"
+                        loading="lazy"
+                        class="h-24 w-full object-cover"
+                    />
+                </button>
+
+                <div
+                    v-if="loadingMore"
+                    data-test="gif-loading-more"
+                    class="col-span-2 py-3 text-center text-xs text-muted-foreground"
+                >
+                    {{ $t('Loading more…') }}
+                </div>
+            </div>
+        </div>
+
+        <div
+            data-test="gif-powered-by"
+            class="border-t border-border px-3 py-1.5 text-[10.5px] font-semibold tracking-[0.08em] text-muted-foreground uppercase"
+        >
+            {{ $t('Powered by GIPHY') }}
+        </div>
+    </div>
+</template>

--- a/resources/js/components/GifPickerPanel.vue
+++ b/resources/js/components/GifPickerPanel.vue
@@ -111,10 +111,15 @@ async function loadPage(offset: number, append: boolean): Promise<void> {
             return;
         }
 
-        if (!append) {
-            results.value = [];
+        // An infinite-scroll (append) failure keeps the loaded grid and simply
+        // stops paging; only an initial-load failure shows the full error state.
+        if (append) {
+            nextOffset.value = null;
+
+            return;
         }
 
+        results.value = [];
         errored.value = true;
         nextOffset.value = null;
     } finally {
@@ -259,6 +264,13 @@ onBeforeUnmount(() => {
                 v-model="query"
                 type="search"
                 data-test="gif-search-input"
+                role="combobox"
+                aria-controls="gif-listbox"
+                aria-autocomplete="list"
+                :aria-expanded="results.length > 0"
+                :aria-activedescendant="
+                    activeIndex >= 0 ? `gif-option-${activeIndex}` : undefined
+                "
                 :aria-label="$t('Search GIFs')"
                 :placeholder="$t('Search GIFs')"
                 class="h-8 flex-1 rounded-full bg-muted px-3 text-sm outline-none focus:ring-2 focus:ring-brass"
@@ -276,6 +288,7 @@ onBeforeUnmount(() => {
         </div>
 
         <div
+            id="gif-listbox"
             ref="grid"
             role="listbox"
             :aria-label="$t('GIF results')"
@@ -315,6 +328,7 @@ onBeforeUnmount(() => {
                 <!-- eslint-disable-next-line local/no-raw-button -- bespoke GIF-grid cell -->
                 <button
                     v-for="(gif, index) in results"
+                    :id="`gif-option-${index}`"
                     :key="gif.id"
                     type="button"
                     role="option"

--- a/resources/js/components/MessageAttachments.test.ts
+++ b/resources/js/components/MessageAttachments.test.ts
@@ -13,8 +13,10 @@ function image(overrides: Partial<AttachmentData> = {}): AttachmentData {
         width: 800,
         height: 600,
         isImage: true,
+        source: 'upload',
         url: 'https://desk.test/orig.png',
         thumbUrl: 'https://desk.test/thumb.png',
+        description: null,
         ...overrides,
     };
 }

--- a/resources/js/components/MessageAttachments.vue
+++ b/resources/js/components/MessageAttachments.vue
@@ -105,6 +105,8 @@ function isSvg(attachment: AttachmentData): boolean {
             <a
                 :href="images[0].url"
                 :download="images[0].filename"
+                :target="images[0].filename ? undefined : '_blank'"
+                :rel="images[0].filename ? undefined : 'noopener noreferrer'"
                 :aria-label="
                     t('Download :name', { name: imageLabel(images[0]) })
                 "
@@ -162,6 +164,8 @@ function isSvg(attachment: AttachmentData): boolean {
             :key="file.id"
             :href="file.url"
             :download="file.filename ?? undefined"
+            :target="file.filename ? undefined : '_blank'"
+            :rel="file.filename ? undefined : 'noopener noreferrer'"
             data-test="attachment-file"
             :aria-label="t('Download :name', { name: file.filename ?? '' })"
             class="flex w-95 max-w-full items-center gap-3 rounded-xl border border-border bg-muted/40 px-3 py-2.5 transition-colors hover:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"

--- a/resources/js/components/MessageAttachments.vue
+++ b/resources/js/components/MessageAttachments.vue
@@ -50,6 +50,27 @@ function previewSrc(attachment: AttachmentData): string {
     return attachment.thumbUrl ?? attachment.url;
 }
 
+/**
+ * A human label for an image: its upload filename, else its remote description
+ * (a Giphy GIF has no filename), else a generic "GIF" fallback. Used for the
+ * open/download affordance names and the hover caption.
+ */
+function imageLabel(attachment: AttachmentData): string {
+    return attachment.filename ?? attachment.description ?? t('GIF');
+}
+
+/**
+ * The hover caption for an image: its label, and its size when it has one. A
+ * remote GIF is hotlinked (no stored bytes), so its size is omitted.
+ */
+function imageCaption(attachment: AttachmentData): string {
+    const label = imageLabel(attachment);
+
+    return attachment.sizeBytes > 0
+        ? `${label} · ${formatFileSize(attachment.sizeBytes)}`
+        : label;
+}
+
 function isSvg(attachment: AttachmentData): boolean {
     return attachment.mimeType.toLowerCase() === 'image/svg+xml';
 }
@@ -68,7 +89,7 @@ function isSvg(attachment: AttachmentData): boolean {
         >
             <img
                 :src="previewSrc(images[0])"
-                alt=""
+                :alt="images[0].description ?? ''"
                 loading="lazy"
                 class="size-full object-cover"
             />
@@ -77,14 +98,16 @@ function isSvg(attachment: AttachmentData): boolean {
                 size="none"
                 type="button"
                 data-test="attachment-image"
-                :aria-label="t('Open :name', { name: images[0].filename })"
+                :aria-label="t('Open :name', { name: imageLabel(images[0]) })"
                 class="absolute inset-0 z-10 cursor-zoom-in"
                 @click="openLightbox(0)"
             />
             <a
                 :href="images[0].url"
                 :download="images[0].filename"
-                :aria-label="t('Download :name', { name: images[0].filename })"
+                :aria-label="
+                    t('Download :name', { name: imageLabel(images[0]) })
+                "
                 class="absolute top-2.5 right-2.5 z-20 flex size-7.5 items-center justify-center rounded-[9px] bg-[rgba(29,26,21,0.72)] text-[#f3efe4] opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-[#f3efe4] focus-visible:outline-none"
             >
                 <Download class="size-3.5" />
@@ -92,8 +115,7 @@ function isSvg(attachment: AttachmentData): boolean {
             <span
                 class="pointer-events-none absolute bottom-2.5 left-2.5 z-20 inline-flex h-6 max-w-[calc(100%-1.25rem)] items-center truncate rounded-md bg-[rgba(29,26,21,0.72)] px-2.5 text-[11px] font-medium text-[#f3efe4] opacity-0 transition-opacity group-hover:opacity-100"
             >
-                {{ images[0].filename }} ·
-                {{ formatFileSize(images[0].sizeBytes) }}
+                {{ imageCaption(images[0]) }}
             </span>
         </div>
 
@@ -114,14 +136,14 @@ function isSvg(attachment: AttachmentData): boolean {
                 type="button"
                 data-test="attachment-image"
                 :aria-label="
-                    t('Open :name', { name: tile.attachment.filename })
+                    t('Open :name', { name: imageLabel(tile.attachment) })
                 "
                 class="group relative aspect-square cursor-zoom-in overflow-hidden rounded-xl border border-border"
                 @click="openLightbox(tile.index)"
             >
                 <img
                     :src="previewSrc(tile.attachment)"
-                    alt=""
+                    :alt="tile.attachment.description ?? ''"
                     loading="lazy"
                     class="size-full object-cover"
                 />
@@ -139,9 +161,9 @@ function isSvg(attachment: AttachmentData): boolean {
             v-for="file in files"
             :key="file.id"
             :href="file.url"
-            :download="file.filename"
+            :download="file.filename ?? undefined"
             data-test="attachment-file"
-            :aria-label="t('Download :name', { name: file.filename })"
+            :aria-label="t('Download :name', { name: file.filename ?? '' })"
             class="flex w-95 max-w-full items-center gap-3 rounded-xl border border-border bg-muted/40 px-3 py-2.5 transition-colors hover:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
             <span
@@ -156,7 +178,7 @@ function isSvg(attachment: AttachmentData): boolean {
                     {{ file.filename }}
                 </span>
                 <span class="text-[11.5px] text-muted-foreground">
-                    {{ fileTypeLabel(file.filename, file.mimeType) }} ·
+                    {{ fileTypeLabel(file.filename ?? '', file.mimeType) }} ·
                     {{ formatFileSize(file.sizeBytes)
                     }}<template v-if="isSvg(file)">
                         · {{ t('download only') }}</template

--- a/resources/js/components/MessageComposer.gif.test.ts
+++ b/resources/js/components/MessageComposer.gif.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import type { CommandCallbacks } from '@/composables/useMessageActions';
+import MessageComposer from './MessageComposer.vue';
+
+/**
+ * Covers the composer's `/gif` interception: typing or selecting `/gif` opens the
+ * Giphy picker (rather than posting a message or a text command), and a picked
+ * GIF is staged in the attachment tray. The picker itself is stubbed — its own
+ * behaviour is covered in GifPickerPanel.test.ts.
+ */
+
+vi.mock('@/actions/App/Http/Controllers/Channels/AttachmentController', () => ({
+    store: () => ({ url: '/t/acme/c/general/attachments' }),
+}));
+
+vi.mock('@/components/GifPickerPanel.vue', async () => {
+    const { defineComponent, h } = await import('vue');
+    const remoteGif = {
+        id: 'gif-1',
+        filename: null,
+        mimeType: 'image/gif',
+        sizeBytes: 0,
+        width: 2,
+        height: 1,
+        isImage: true,
+        source: 'giphy',
+        url: 'https://media.giphy.com/gif-1/200.gif',
+        thumbUrl: null,
+        description: 'a happy cat',
+    };
+
+    return {
+        default: defineComponent({
+            name: 'GifPickerPanelStub',
+            emits: ['select', 'close'],
+            setup:
+                (_props, { emit }) =>
+                () =>
+                    h('div', { 'data-test': 'gif-picker' }, [
+                        h(
+                            'button',
+                            {
+                                'data-test': 'stub-pick',
+                                onClick: () => emit('select', remoteGif),
+                            },
+                            'pick',
+                        ),
+                    ]),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/button', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        Button: defineComponent({
+            name: 'ButtonStub',
+            inheritAttrs: false,
+            setup:
+                (_props, { attrs, slots }) =>
+                () =>
+                    h('button', attrs, slots.default?.()),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { defineComponent, h } = await import('vue');
+    const slot = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        Tooltip: slot('TooltipStub'),
+        TooltipContent: slot('TooltipContentStub'),
+        TooltipProvider: slot('TooltipProviderStub'),
+        TooltipTrigger: slot('TooltipTriggerStub'),
+    };
+});
+
+const MANIFEST: App.Data.SlashCommandData[] = [
+    {
+        name: 'gif',
+        description: 'Search Giphy for a GIF to send',
+        argumentHint: '[search]',
+    },
+    {
+        name: 'shrug',
+        description: 'Append a shrug to your message',
+        argumentHint: '[message]',
+    },
+];
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+function mountComposer() {
+    const sent: string[] = [];
+    const commands: Array<{ body: string; callbacks: CommandCallbacks }> = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(MessageComposer as Component, {
+                    channelName: 'general',
+                    members: [],
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                    slashCommands: MANIFEST,
+                    gifPickerEnabled: true,
+                    onSend: (body: string) => sent.push(body),
+                    onCommand: (body: string, callbacks: CommandCallbacks) =>
+                        commands.push({ body, callbacks }),
+                }),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(container);
+    active.push({ app, container });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+        '[data-test="message-composer-input"]',
+    )!;
+
+    return { container, sent, commands, textarea };
+}
+
+function type(textarea: HTMLTextAreaElement, value: string): Promise<void> {
+    textarea.value = value;
+    textarea.setSelectionRange(value.length, value.length);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+    return nextTick();
+}
+
+function press(textarea: HTMLTextAreaElement, key: string): Promise<void> {
+    textarea.dispatchEvent(
+        new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }),
+    );
+
+    return nextTick();
+}
+
+/** Wait for the async-loaded picker stub (a dynamic import) to resolve. */
+async function settle(): Promise<void> {
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+}
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+});
+
+describe('MessageComposer /gif picker', () => {
+    it('opens the picker on submitting /gif instead of posting', async () => {
+        const { container, textarea, sent, commands } = mountComposer();
+
+        await type(textarea, '/gif cats');
+        await press(textarea, 'Enter');
+        await settle();
+
+        expect(
+            container.querySelector('[data-test="gif-picker"]'),
+        ).not.toBeNull();
+        expect(sent).toEqual([]);
+        expect(commands).toEqual([]);
+        // The `/gif` text is cleared from the composer once the picker opens.
+        expect(textarea.value).toBe('');
+    });
+
+    it('opens the picker when /gif is chosen from the slash menu', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, '/gif');
+        // The gif command is the sole, active suggestion; Enter selects it.
+        await press(textarea, 'Enter');
+        await settle();
+
+        expect(
+            container.querySelector('[data-test="gif-picker"]'),
+        ).not.toBeNull();
+    });
+
+    it('stages a picked GIF in the attachment tray', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, '/gif');
+        await press(textarea, 'Enter');
+        await settle();
+
+        container
+            .querySelector<HTMLButtonElement>('[data-test="stub-pick"]')!
+            .click();
+        await nextTick();
+
+        expect(
+            container.querySelector('[data-test="composer-attachment"]'),
+        ).not.toBeNull();
+        // The picker closes once a GIF is picked.
+        expect(container.querySelector('[data-test="gif-picker"]')).toBeNull();
+    });
+});

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -415,10 +415,15 @@ const GIF_COMMAND_NAME = 'gif';
 const gifPickerOpen = ref(false);
 const gifPickerQuery = ref('');
 
-// The picker is usable only when configured and when the composer knows its
-// channel (a picked GIF is staged as an attachment on that channel).
+// The picker is usable only when configured, when the composer knows its
+// channel (a picked GIF is staged as an attachment on that channel), and while
+// composing a new message — not editing an existing one (an inline edit saves
+// text only and cannot carry an attachment).
 const gifPickerAvailable = computed(
-    () => Boolean(props.gifPickerEnabled) && attachmentsEnabled.value,
+    () =>
+        Boolean(props.gifPickerEnabled) &&
+        attachmentsEnabled.value &&
+        !editingMessage.value,
 );
 
 /**
@@ -449,10 +454,14 @@ function closeGifPicker(): void {
     nextTick(() => textarea.value?.focus());
 }
 
-/** A picked GIF joins the tray as a remote attachment; the picker then closes. */
+/**
+ * A picked GIF joins the tray as a remote attachment; the picker closes only if
+ * it was accepted, so a full tray keeps the picker open with its toast shown.
+ */
 function onGifSelected(attachment: AttachmentData): void {
-    uploads.addRemote(attachment);
-    closeGifPicker();
+    if (uploads.addRemote(attachment)) {
+        closeGifPicker();
+    }
 }
 
 function selectSlashCommand(command: App.Data.SlashCommandData): void {

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -14,6 +14,7 @@ import {
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { store as storeAttachment } from '@/actions/App/Http/Controllers/Channels/AttachmentController';
 import ComposerSendButton from '@/components/ComposerSendButton.vue';
+import GifPickerPanel from '@/components/GifPickerPanel.vue';
 import MessageQuote from '@/components/MessageQuote.vue';
 import ScheduleMessageDialog from '@/components/ScheduleMessageDialog.vue';
 import { Button } from '@/components/ui/button';
@@ -38,6 +39,7 @@ import {
 import { isInteractiveComposerTarget } from '@/lib/composerFocus';
 import { toggleInlineMark } from '@/lib/composerFormat';
 import type { Mention, Message } from '@/types';
+import type { AttachmentData } from '@/types/attachments';
 
 const props = defineProps<{
     channelName: string;
@@ -76,6 +78,9 @@ const props = defineProps<{
     // commands apply (the main channel composer); absent/empty elsewhere (e.g.
     // the thread composer), which disables all slash handling.
     slashCommands?: App.Data.SlashCommandData[];
+    // Whether the Giphy `/gif` picker is available (an API key is configured).
+    // When false, `/gif` is neither in the manifest nor intercepted here.
+    gifPickerEnabled?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -402,7 +407,61 @@ function slashMoveActive(delta: number): void {
     slashActiveIndex.value = (slashActiveIndex.value + delta + count) % count;
 }
 
+// The one picker-backed command: `/gif` opens the Giphy picker instead of
+// completing to text and posting through the command endpoint.
+const GIF_COMMAND_NAME = 'gif';
+
+// The GIF picker's open state and the search term it opens on (from `/gif cats`).
+const gifPickerOpen = ref(false);
+const gifPickerQuery = ref('');
+
+// The picker is usable only when configured and when the composer knows its
+// channel (a picked GIF is staged as an attachment on that channel).
+const gifPickerAvailable = computed(
+    () => Boolean(props.gifPickerEnabled) && attachmentsEnabled.value,
+);
+
+/**
+ * The search term if `text` is the `/gif` command (`/gif` or `/gif <query>`) and
+ * the picker is available, else null. Used to divert `/gif` away from the text
+ * command path and into the picker.
+ */
+function gifCommandQuery(text: string): string | null {
+    if (!gifPickerAvailable.value) {
+        return null;
+    }
+
+    const match = text.match(/^\/gif(?:\s+(.*))?$/i);
+
+    return match ? (match[1]?.trim() ?? '') : null;
+}
+
+/** Open the GIF picker on the given search term, clearing the `/gif` text. */
+function openGifPicker(query: string): void {
+    slashMenuOpen.value = false;
+    gifPickerQuery.value = query;
+    gifPickerOpen.value = true;
+    body.value = '';
+}
+
+function closeGifPicker(): void {
+    gifPickerOpen.value = false;
+    nextTick(() => textarea.value?.focus());
+}
+
+/** A picked GIF joins the tray as a remote attachment; the picker then closes. */
+function onGifSelected(attachment: AttachmentData): void {
+    uploads.addRemote(attachment);
+    closeGifPicker();
+}
+
 function selectSlashCommand(command: App.Data.SlashCommandData): void {
+    if (command.name === GIF_COMMAND_NAME && gifPickerAvailable.value) {
+        openGifPicker('');
+
+        return;
+    }
+
     body.value = `/${command.name} `;
     slashMenuOpen.value = false;
 
@@ -694,6 +753,16 @@ function submit(): void {
     // non-optimistic send. Only when the tray is empty — a command carries no
     // attachments, so a command-looking body with staged files posts as text.
     if (uploads.attachmentIds.value.length === 0 && looksLikeCommand(trimmed)) {
+        // `/gif [query]` opens the picker rather than posting text; the chosen
+        // GIF is then sent as an attachment through the ordinary path.
+        const gifQuery = gifCommandQuery(trimmed);
+
+        if (gifQuery !== null) {
+            openGifPicker(gifQuery);
+
+            return;
+        }
+
         submitCommand(trimmed);
 
         return;
@@ -1051,6 +1120,18 @@ function onKeydown(event: KeyboardEvent): void {
                     </span>
                 </li>
             </ul>
+
+            <!-- The Giphy picker, opened by `/gif`. Sits in the same anchored
+                 position as the autocomplete menus; picking a GIF stages it in
+                 the attachment tray below. -->
+            <GifPickerPanel
+                v-if="gifPickerOpen && gifPickerAvailable"
+                :team-slug="props.teamSlug ?? ''"
+                :channel-slug="props.channelSlug ?? ''"
+                :initial-query="gifPickerQuery"
+                @select="onGifSelected"
+                @close="closeGifPicker"
+            />
 
             <div
                 v-if="props.replyTarget"

--- a/resources/js/components/MessageLightbox.vue
+++ b/resources/js/components/MessageLightbox.vue
@@ -130,6 +130,12 @@ function onKeydown(event: KeyboardEvent): void {
                     <a
                         :href="activeImage.url"
                         :download="activeImage.filename ?? undefined"
+                        :target="activeImage.filename ? undefined : '_blank'"
+                        :rel="
+                            activeImage.filename
+                                ? undefined
+                                : 'noopener noreferrer'
+                        "
                         :aria-label="t('Download :name', { name: activeLabel })"
                         class="flex size-8 items-center justify-center rounded-[9px] bg-[rgba(243,239,228,0.12)] text-[#ece7da] transition-colors hover:bg-[rgba(243,239,228,0.22)] focus-visible:ring-2 focus-visible:ring-[#ece7da] focus-visible:outline-none"
                     >

--- a/resources/js/components/MessageLightbox.vue
+++ b/resources/js/components/MessageLightbox.vue
@@ -47,6 +47,14 @@ watch(
 
 const activeImage = computed<AttachmentData>(() => props.images[current.value]);
 
+// A human name for the active image: its upload filename, else its remote
+// description (a Giphy GIF has no filename), else a generic fallback. Feeds the
+// dialog title, download name, and alt.
+const activeLabel = computed(
+    () =>
+        activeImage.value.filename ?? activeImage.value.description ?? t('GIF'),
+);
+
 const meta = computed(() => {
     const parts = [
         props.authorName,
@@ -57,7 +65,10 @@ const meta = computed(() => {
         parts.push(`${activeImage.value.width}×${activeImage.value.height}`);
     }
 
-    parts.push(formatFileSize(activeImage.value.sizeBytes));
+    // A remote GIF carries no byte size (it is hotlinked, not stored).
+    if (activeImage.value.sizeBytes > 0) {
+        parts.push(formatFileSize(activeImage.value.sizeBytes));
+    }
 
     return parts.join(' · ');
 });
@@ -98,7 +109,7 @@ function onKeydown(event: KeyboardEvent): void {
             >
                 <img
                     :src="activeImage.url"
-                    :alt="activeImage.filename"
+                    :alt="activeImage.description ?? ''"
                     class="max-h-[85vh] max-w-[85vw] rounded-lg object-contain shadow-2xl"
                 />
 
@@ -106,7 +117,7 @@ function onKeydown(event: KeyboardEvent): void {
                     <DialogTitle
                         class="truncate text-[13px] font-semibold text-[#ece7da]"
                     >
-                        {{ activeImage.filename }}
+                        {{ activeLabel }}
                     </DialogTitle>
                     <DialogDescription
                         class="text-[11.5px] text-[#8b8370] tabular-nums"
@@ -118,10 +129,8 @@ function onKeydown(event: KeyboardEvent): void {
                 <div class="absolute top-3 right-4 flex gap-2">
                     <a
                         :href="activeImage.url"
-                        :download="activeImage.filename"
-                        :aria-label="
-                            t('Download :name', { name: activeImage.filename })
-                        "
+                        :download="activeImage.filename ?? undefined"
+                        :aria-label="t('Download :name', { name: activeLabel })"
                         class="flex size-8 items-center justify-center rounded-[9px] bg-[rgba(243,239,228,0.12)] text-[#ece7da] transition-colors hover:bg-[rgba(243,239,228,0.22)] focus-visible:ring-2 focus-visible:ring-[#ece7da] focus-visible:outline-none"
                     >
                         <Download class="size-3.5" />

--- a/resources/js/composables/useAttachmentUploads.test.ts
+++ b/resources/js/composables/useAttachmentUploads.test.ts
@@ -123,6 +123,69 @@ describe('useAttachmentUploads', () => {
         expect(calls[0].url).toBe('/t/acme/c/design/attachments');
     });
 
+    it('stages a picked GIF as a ready remote row carrying its claimable id', () => {
+        uploads.addRemote({
+            id: 'gif-1',
+            filename: null,
+            mimeType: 'image/gif',
+            sizeBytes: 0,
+            width: 2,
+            height: 1,
+            isImage: true,
+            source: 'giphy',
+            url: 'https://media.giphy.com/gif-1/200.gif',
+            thumbUrl: null,
+            description: 'a happy cat',
+        });
+
+        expect(uploads.items.value).toHaveLength(1);
+        const row = uploads.items.value[0];
+        expect(row.status).toBe('done');
+        expect(row.isImage).toBe(true);
+        // A remote GIF previews straight from its CDN url (no local blob).
+        expect(row.previewUrl).toBe('https://media.giphy.com/gif-1/200.gif');
+        expect(row.name).toBe('a happy cat');
+        expect(uploads.isUploading.value).toBe(false);
+        expect(uploads.attachmentIds.value).toEqual(['gif-1']);
+        // No upload is fired for an already-created remote attachment.
+        expect(calls).toHaveLength(0);
+    });
+
+    it('honours the per-message cap for picked GIFs', () => {
+        for (let i = 0; i < 3; i++) {
+            uploads.addRemote({
+                id: `gif-${i}`,
+                filename: null,
+                mimeType: 'image/gif',
+                sizeBytes: 0,
+                width: 2,
+                height: 1,
+                isImage: true,
+                source: 'giphy',
+                url: `https://media.giphy.com/gif-${i}/200.gif`,
+                thumbUrl: null,
+                description: null,
+            });
+        }
+
+        uploads.addRemote({
+            id: 'gif-over',
+            filename: null,
+            mimeType: 'image/gif',
+            sizeBytes: 0,
+            width: 2,
+            height: 1,
+            isImage: true,
+            source: 'giphy',
+            url: 'https://media.giphy.com/over/200.gif',
+            thumbUrl: null,
+            description: null,
+        });
+
+        expect(uploads.items.value).toHaveLength(3);
+        expect(toastError).toHaveBeenCalledOnce();
+    });
+
     it('previews an image row via an object URL but not a plain file', () => {
         uploads.addFiles([
             fakeFile('pic.png', 'image/png'),

--- a/resources/js/composables/useAttachmentUploads.ts
+++ b/resources/js/composables/useAttachmentUploads.ts
@@ -76,6 +76,13 @@ export interface AttachmentUploads {
     attachmentIds: ComputedRef<string[]>;
     /** Stage and begin uploading the given files, validating size and count. */
     addFiles: (files: Iterable<File>) => void;
+    /**
+     * Stage an already-created remote attachment (a picked Giphy GIF): it is
+     * "done" the moment it lands — the server created the pending row — so it
+     * joins the tray with its claimable id, contributing to `attachmentIds`.
+     * Honours the per-message count cap.
+     */
+    addRemote: (attachment: AttachmentData) => void;
     /** Remove a row, cancelling its upload and releasing any preview. */
     remove: (localId: string) => void;
     /** Re-upload a previously failed row. */
@@ -269,6 +276,32 @@ export function useAttachmentUploads(
         }
     }
 
+    function addRemote(attachment: AttachmentData): void {
+        // A remote attachment carries no File and no local blob preview: it is
+        // hotlinked, so the tray previews it (and later renders it) straight from
+        // the CDN url. It has no upload to run — it arrives already `done`.
+        if (items.value.length >= options.maxPerMessage()) {
+            toast.error(
+                t('You can attach up to :max files per message.', {
+                    max: options.maxPerMessage(),
+                }),
+            );
+
+            return;
+        }
+
+        items.value.push({
+            localId: generateUuid(),
+            name: attachment.description ?? t('GIF'),
+            sizeBytes: attachment.sizeBytes,
+            isImage: attachment.isImage,
+            previewUrl: attachment.thumbUrl ?? attachment.url,
+            status: 'done',
+            progress: 100,
+            attachment,
+        });
+    }
+
     function remove(localId: string): void {
         const source = sources.get(localId);
         source?.abort();
@@ -376,6 +409,7 @@ export function useAttachmentUploads(
         hasFailed,
         attachmentIds,
         addFiles,
+        addRemote,
         remove,
         retry,
         detach,

--- a/resources/js/composables/useAttachmentUploads.ts
+++ b/resources/js/composables/useAttachmentUploads.ts
@@ -80,9 +80,10 @@ export interface AttachmentUploads {
      * Stage an already-created remote attachment (a picked Giphy GIF): it is
      * "done" the moment it lands — the server created the pending row — so it
      * joins the tray with its claimable id, contributing to `attachmentIds`.
-     * Honours the per-message count cap.
+     * Honours the per-message count cap; returns whether it was accepted (false
+     * when the tray is already full).
      */
-    addRemote: (attachment: AttachmentData) => void;
+    addRemote: (attachment: AttachmentData) => boolean;
     /** Remove a row, cancelling its upload and releasing any preview. */
     remove: (localId: string) => void;
     /** Re-upload a previously failed row. */
@@ -276,7 +277,7 @@ export function useAttachmentUploads(
         }
     }
 
-    function addRemote(attachment: AttachmentData): void {
+    function addRemote(attachment: AttachmentData): boolean {
         // A remote attachment carries no File and no local blob preview: it is
         // hotlinked, so the tray previews it (and later renders it) straight from
         // the CDN url. It has no upload to run — it arrives already `done`.
@@ -287,7 +288,7 @@ export function useAttachmentUploads(
                 }),
             );
 
-            return;
+            return false;
         }
 
         items.value.push({
@@ -300,6 +301,8 @@ export function useAttachmentUploads(
             progress: 100,
             attachment,
         });
+
+        return true;
     }
 
     function remove(localId: string): void {
@@ -388,8 +391,10 @@ export function useAttachmentUploads(
     }
 
     function clear(): void {
-        for (const localId of [...sources.keys()]) {
-            remove(localId);
+        // Iterate the live rows, not `sources`: a remote (Giphy) row created by
+        // addRemote has no `sources` entry, so keying off rows removes it too.
+        for (const item of [...items.value]) {
+            remove(item.localId);
         }
     }
 

--- a/resources/js/lib/attachmentLayout.test.ts
+++ b/resources/js/lib/attachmentLayout.test.ts
@@ -17,8 +17,10 @@ function attachment(overrides: Partial<AttachmentData> = {}): AttachmentData {
         width: null,
         height: null,
         isImage: false,
+        source: 'upload',
         url: 'https://example.test/a1/download',
         thumbUrl: null,
+        description: null,
         ...overrides,
     };
 }

--- a/resources/js/lib/giphy.test.ts
+++ b/resources/js/lib/giphy.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { attachGiphyGif, fetchGiphyPage } from '@/lib/giphy';
+
+describe('fetchGiphyPage', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('returns the parsed page for a successful response', async () => {
+        const page = {
+            results: [
+                {
+                    id: 'a',
+                    url: 'u',
+                    previewUrl: 'p',
+                    width: 1,
+                    height: 1,
+                    description: null,
+                },
+            ],
+            nextOffset: 24,
+        };
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve(page),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(fetchGiphyPage('/gifs?q=cats')).resolves.toEqual(page);
+        expect(fetchMock).toHaveBeenCalledWith('/gifs?q=cats', {
+            headers: { Accept: 'application/json' },
+            signal: undefined,
+        });
+    });
+
+    it('throws when the response is not ok', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+
+        await expect(fetchGiphyPage('/gifs')).rejects.toThrow(
+            'giphy-search-failed',
+        );
+    });
+});
+
+describe('attachGiphyGif', () => {
+    beforeEach(() => {
+        vi.stubGlobal('document', { cookie: 'XSRF-TOKEN=tok%20en' });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('posts the id with the CSRF header and returns the attachment', async () => {
+        const attachment = { id: 'att-1', source: 'giphy' };
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve(attachment),
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(attachGiphyGif('/gifs', 'giphy-id')).resolves.toEqual(
+            attachment,
+        );
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe('/gifs');
+        expect(init.method).toBe('POST');
+        expect(init.body).toBe(JSON.stringify({ id: 'giphy-id' }));
+        expect(init.headers['X-XSRF-TOKEN']).toBe('tok en');
+        expect(init.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('throws when the attach response is not ok', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+
+        await expect(attachGiphyGif('/gifs', 'x')).rejects.toThrow(
+            'giphy-attach-failed',
+        );
+    });
+});

--- a/resources/js/lib/giphy.ts
+++ b/resources/js/lib/giphy.ts
@@ -1,0 +1,58 @@
+import { parseXsrfToken } from '@/lib/uploadAttachment';
+import type { AttachmentData } from '@/types/attachments';
+
+/**
+ * Fetch a page of GIFs (trending or search) from the server-side Giphy proxy.
+ * The endpoint returns the normalized {@see App.Data.GiphySearchData} shape — the
+ * client never touches the Giphy API or key directly. An `AbortSignal` lets a
+ * superseded search (the user kept typing) be cancelled.
+ */
+export async function fetchGiphyPage(
+    url: string,
+    signal?: AbortSignal,
+): Promise<App.Data.GiphySearchData> {
+    const response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+        signal,
+    });
+
+    if (!response.ok) {
+        throw new Error('giphy-search-failed');
+    }
+
+    return (await response.json()) as App.Data.GiphySearchData;
+}
+
+/**
+ * Attach a chosen GIF by its opaque Giphy id: the server re-resolves the id (the
+ * sole authority on the stored URL) and creates a pending remote attachment,
+ * returning its DTO. Sends the CSRF header the stateful `web` guard expects.
+ */
+export async function attachGiphyGif(
+    url: string,
+    id: string,
+): Promise<AttachmentData> {
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    const token = parseXsrfToken(document.cookie);
+
+    if (token) {
+        headers['X-XSRF-TOKEN'] = token;
+    }
+
+    const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ id }),
+    });
+
+    if (!response.ok) {
+        throw new Error('giphy-attach-failed');
+    }
+
+    return (await response.json()) as AttachmentData;
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1320,6 +1320,7 @@ function archive(): void {
                         allow-schedule
                         :timezone="timezone"
                         :slash-commands="page.props.slashCommands"
+                        :gif-picker-enabled="page.props.gifPickerEnabled"
                         @send="
                             (
                                 body,

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -27,6 +27,7 @@ declare module '@inertiajs/core' {
             emailVerificationEnabled: boolean;
             sso: { oidcEnabled: boolean; passwordLoginEnabled: boolean };
             attachments: { maxSizeMb: number; maxPerMessage: number };
+            gifPickerEnabled: boolean;
             sidebarOpen: boolean;
             currentTeam: Team | null;
             teams: Team[];

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Channels\ChannelStarController;
 use App\Http\Controllers\Channels\DirectMessageController;
 use App\Http\Controllers\Channels\DirectMessagePeopleController;
 use App\Http\Controllers\Channels\ForwardMessageController;
+use App\Http\Controllers\Channels\GiphyController;
 use App\Http\Controllers\Channels\HideDirectMessageController;
 use App\Http\Controllers\Channels\MessageController;
 use App\Http\Controllers\Channels\MessageReminderController;
@@ -25,6 +26,7 @@ use App\Http\Controllers\LocaleCatalogController;
 use App\Http\Controllers\OnboardingController;
 use App\Http\Controllers\SidebarSectionController;
 use App\Http\Controllers\Teams\TeamInvitationController;
+use App\Http\Middleware\EnsureGiphyEnabled;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Support\Facades\Route;
 
@@ -111,6 +113,17 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/attachments', [AttachmentController::class, 'store'])
         ->scopeBindings()
         ->name('channels.attachments.store');
+    // The Giphy picker: a throttled, key-gated search proxy and an attach
+    // endpoint that re-resolves the chosen id into a pending remote attachment.
+    // EnsureGiphyEnabled 404s both when no API key is configured.
+    Route::get('t/{team}/c/{channel}/gifs', [GiphyController::class, 'search'])
+        ->middleware([EnsureGiphyEnabled::class, 'throttle:30,1'])
+        ->scopeBindings()
+        ->name('channels.gifs.search');
+    Route::post('t/{team}/c/{channel}/gifs', [GiphyController::class, 'store'])
+        ->middleware([EnsureGiphyEnabled::class, 'throttle:30,1'])
+        ->scopeBindings()
+        ->name('channels.gifs.store');
     Route::get('t/{team}/c/{channel}/attachments/{attachment}/download', [AttachmentController::class, 'download'])
         ->scopeBindings()
         ->name('channels.attachments.download');

--- a/tests/Feature/AttachmentLimitsSharingTest.php
+++ b/tests/Feature/AttachmentLimitsSharingTest.php
@@ -34,7 +34,7 @@ test('the gif picker is flagged enabled only when a Giphy key is configured', fu
     $this->get(route('home'))
         ->assertInertia(fn (Assert $page): Assert => $page->where('gifPickerEnabled', true));
 
-    config()->set('services.giphy.key', null);
+    config()->set('services.giphy.key');
 
     $this->get(route('home'))
         ->assertInertia(fn (Assert $page): Assert => $page->where('gifPickerEnabled', false));

--- a/tests/Feature/AttachmentLimitsSharingTest.php
+++ b/tests/Feature/AttachmentLimitsSharingTest.php
@@ -27,3 +27,15 @@ test('the shared attachment limits track the operator-configured values', functi
             ->where('attachments.maxPerMessage', 3)
         );
 });
+
+test('the gif picker is flagged enabled only when a Giphy key is configured', function (): void {
+    config()->set('services.giphy.key', 'test-key');
+
+    $this->get(route('home'))
+        ->assertInertia(fn (Assert $page): Assert => $page->where('gifPickerEnabled', true));
+
+    config()->set('services.giphy.key', null);
+
+    $this->get(route('home'))
+        ->assertInertia(fn (Assert $page): Assert => $page->where('gifPickerEnabled', false));
+});

--- a/tests/Feature/Channels/GiphyPickerTest.php
+++ b/tests/Feature/Channels/GiphyPickerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\AttachmentSource;
+use App\Enums\AttachmentStatus;
+use App\Models\Attachment;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+/**
+ * Create a team with its owner in #general and Giphy configured.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function giphyTeam(): array
+{
+    config()->set('services.giphy.key', 'test-key');
+    config()->set('services.giphy.rating', 'g');
+
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * A Giphy GIF object with a usable `fixed_height` rendition.
+ *
+ * @return array<string, mixed>
+ */
+function fakeGiphyGif(string $id, string $description = 'a cat'): array
+{
+    return [
+        'id' => $id,
+        'alt_text' => $description,
+        'images' => [
+            'fixed_height' => ['url' => "https://media.giphy.com/{$id}/200.gif", 'width' => '360', 'height' => '200'],
+            'fixed_height_small' => ['url' => "https://media.giphy.com/{$id}/100.gif", 'width' => '180', 'height' => '100'],
+        ],
+    ];
+}
+
+test('a channel member can search Giphy, scoped to their locale', function (): void {
+    [$owner, $team, $general] = giphyTeam();
+    $owner->update(['locale' => 'fr']);
+
+    Http::fake(['api.giphy.com/v1/gifs/search*' => Http::response([
+        'data' => [fakeGiphyGif('abc', 'a happy cat')],
+        'pagination' => ['total_count' => 100, 'count' => 1, 'offset' => 0],
+    ])]);
+
+    $response = $this->actingAs($owner)
+        ->getJson(route('channels.gifs.search', ['team' => $team->slug, 'channel' => $general->slug, 'q' => 'cats']));
+
+    $response->assertOk()
+        ->assertJsonPath('results.0.id', 'abc')
+        ->assertJsonPath('results.0.url', 'https://media.giphy.com/abc/200.gif')
+        ->assertJsonPath('results.0.description', 'a happy cat')
+        ->assertJsonPath('nextOffset', 1);
+
+    Http::assertSent(fn ($request): bool => $request['q'] === 'cats' && $request['lang'] === 'fr');
+});
+
+test('a blank query returns Giphy trending', function (): void {
+    [$owner, $team, $general] = giphyTeam();
+
+    Http::fake(['api.giphy.com/v1/gifs/trending*' => Http::response([
+        'data' => [fakeGiphyGif('trend')],
+        'pagination' => ['total_count' => 100, 'count' => 1, 'offset' => 0],
+    ])]);
+
+    $this->actingAs($owner)
+        ->getJson(route('channels.gifs.search', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertOk()
+        ->assertJsonPath('results.0.id', 'trend');
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/trending'));
+});
+
+test('search 404s when Giphy is not configured', function (): void {
+    [$owner, $team, $general] = giphyTeam();
+    config()->set('services.giphy.key', null);
+
+    $this->actingAs($owner)
+        ->getJson(route('channels.gifs.search', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertNotFound();
+});
+
+test('a non-member cannot search a channel they cannot post to', function (): void {
+    [, $team, $general] = giphyTeam();
+    $outsider = User::factory()->create();
+
+    $this->actingAs($outsider)
+        ->getJson(route('channels.gifs.search', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertForbidden();
+});
+
+test('picking a GIF re-resolves its id and stores a pending remote attachment', function (): void {
+    [$owner, $team, $general] = giphyTeam();
+
+    Http::fake(['api.giphy.com/v1/gifs/abc*' => Http::response(['data' => fakeGiphyGif('abc', 'a dog waving')])]);
+
+    $response = $this->actingAs($owner)
+        ->postJson(route('channels.gifs.store', ['team' => $team->slug, 'channel' => $general->slug]), ['id' => 'abc']);
+
+    $response->assertCreated()
+        ->assertJsonPath('source', 'giphy')
+        ->assertJsonPath('url', 'https://media.giphy.com/abc/200.gif')
+        ->assertJsonPath('description', 'a dog waving')
+        ->assertJsonPath('isImage', true)
+        ->assertJsonPath('mimeType', 'image/gif');
+
+    $attachment = Attachment::sole();
+    expect($attachment->source)->toBe(AttachmentSource::Giphy)
+        ->and($attachment->status)->toBe(AttachmentStatus::Pending)
+        ->and($attachment->user_id)->toBe($owner->id)
+        ->and($attachment->channel_id)->toBe($general->id)
+        ->and($attachment->message_id)->toBeNull()
+        ->and($attachment->disk)->toBeNull()
+        ->and($attachment->path)->toBeNull()
+        ->and($attachment->remote_url)->toBe('https://media.giphy.com/abc/200.gif')
+        ->and($attachment->width)->toBe(360)
+        ->and($attachment->height)->toBe(200);
+});
+
+test('picking a GIF Giphy no longer knows is rejected', function (): void {
+    [$owner, $team, $general] = giphyTeam();
+
+    Http::fake(['api.giphy.com/*' => Http::response(['meta' => ['status' => 404]], 404)]);
+
+    $this->actingAs($owner)
+        ->postJson(route('channels.gifs.store', ['team' => $team->slug, 'channel' => $general->slug]), ['id' => 'gone'])
+        ->assertStatus(422);
+
+    expect(Attachment::count())->toBe(0);
+});
+
+test('attaching a GIF 404s when Giphy is not configured', function (): void {
+    [$owner, $team, $general] = giphyTeam();
+    config()->set('services.giphy.key', null);
+
+    $this->actingAs($owner)
+        ->postJson(route('channels.gifs.store', ['team' => $team->slug, 'channel' => $general->slug]), ['id' => 'abc'])
+        ->assertNotFound();
+});
+
+test('a sent GIF is claimed by its message through the ordinary attachment flow', function (): void {
+    [$owner, $team, $general] = giphyTeam();
+
+    $gif = Attachment::factory()->giphy()->create([
+        'user_id' => $owner->id,
+        'channel_id' => $general->id,
+    ]);
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'check this out',
+            'client_uuid' => (string) Str::uuid(),
+            'attachment_ids' => [$gif->id],
+        ])
+        ->assertRedirect();
+
+    $gif->refresh();
+    expect($gif->status)->toBe(AttachmentStatus::Attached)
+        ->and($gif->message_id)->not->toBeNull();
+});

--- a/tests/Feature/Channels/GiphyPickerTest.php
+++ b/tests/Feature/Channels/GiphyPickerTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Actions\Channels\CreateGiphyAttachment;
 use App\Actions\Teams\CreateTeam;
+use App\Data\GiphyGifData;
 use App\Enums\AttachmentSource;
 use App\Enums\AttachmentStatus;
 use App\Models\Attachment;
@@ -146,6 +148,37 @@ test('attaching a GIF 404s when Giphy is not configured', function (): void {
     $this->actingAs($owner)
         ->postJson(route('channels.gifs.store', ['team' => $team->slug, 'channel' => $general->slug]), ['id' => 'abc'])
         ->assertNotFound();
+});
+
+test('CreateGiphyAttachment stores a pending remote row with its channel and team loaded', function (): void {
+    [$owner, , $general] = giphyTeam();
+
+    $gif = new GiphyGifData(
+        id: 'abc',
+        url: 'https://media.giphy.com/abc/200.gif',
+        previewUrl: 'https://media.giphy.com/abc/100.gif',
+        width: 360,
+        height: 200,
+        description: 'a dog waving',
+    );
+
+    $attachment = app(CreateGiphyAttachment::class)->handle($general, $owner, $gif);
+
+    expect($attachment->source)->toBe(AttachmentSource::Giphy)
+        ->and($attachment->status)->toBe(AttachmentStatus::Pending)
+        ->and($attachment->user_id)->toBe($owner->id)
+        ->and($attachment->channel_id)->toBe($general->id)
+        ->and($attachment->message_id)->toBeNull()
+        ->and($attachment->disk)->toBeNull()
+        ->and($attachment->path)->toBeNull()
+        ->and($attachment->remote_url)->toBe('https://media.giphy.com/abc/200.gif')
+        ->and($attachment->description)->toBe('a dog waving')
+        ->and($attachment->width)->toBe(360)
+        ->and($attachment->height)->toBe(200)
+        // The channel is returned with its team loaded, so the DTO's url accessor
+        // resolves N+1-free.
+        ->and($attachment->relationLoaded('channel'))->toBeTrue()
+        ->and($attachment->channel->relationLoaded('team'))->toBeTrue();
 });
 
 test('a sent GIF is claimed by its message through the ordinary attachment flow', function (): void {

--- a/tests/Feature/Channels/GiphyPickerTest.php
+++ b/tests/Feature/Channels/GiphyPickerTest.php
@@ -78,12 +78,12 @@ test('a blank query returns Giphy trending', function (): void {
         ->assertOk()
         ->assertJsonPath('results.0.id', 'trend');
 
-    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/trending'));
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), '/trending'));
 });
 
 test('search 404s when Giphy is not configured', function (): void {
     [$owner, $team, $general] = giphyTeam();
-    config()->set('services.giphy.key', null);
+    config()->set('services.giphy.key');
 
     $this->actingAs($owner)
         ->getJson(route('channels.gifs.search', ['team' => $team->slug, 'channel' => $general->slug]))
@@ -141,7 +141,7 @@ test('picking a GIF Giphy no longer knows is rejected', function (): void {
 
 test('attaching a GIF 404s when Giphy is not configured', function (): void {
     [$owner, $team, $general] = giphyTeam();
-    config()->set('services.giphy.key', null);
+    config()->set('services.giphy.key');
 
     $this->actingAs($owner)
         ->postJson(route('channels.gifs.store', ['team' => $team->slug, 'channel' => $general->slug]), ['id' => 'abc'])

--- a/tests/Feature/Channels/RemoteAttachmentDataTest.php
+++ b/tests/Feature/Channels/RemoteAttachmentDataTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Data\AttachmentData;
+use App\Enums\AttachmentSource;
+use App\Models\Attachment;
+
+it('serves the remote CDN url for a giphy attachment, bypassing the blob route', function (): void {
+    $attachment = Attachment::factory()->giphy()->create([
+        'remote_url' => 'https://media.giphy.com/media/abc123/giphy.gif',
+    ]);
+
+    expect($attachment->source)->toBe(AttachmentSource::Giphy)
+        ->and($attachment->url)->toBe('https://media.giphy.com/media/abc123/giphy.gif')
+        ->and($attachment->thumb_url)->toBeNull();
+});
+
+it('exposes source, remote url and description through AttachmentData for a giphy row', function (): void {
+    $attachment = Attachment::factory()->giphy()->create([
+        'remote_url' => 'https://media.giphy.com/media/abc123/giphy.gif',
+        'description' => 'a cat waving',
+        'width' => 480,
+        'height' => 270,
+    ]);
+
+    $data = AttachmentData::fromAttachment($attachment);
+
+    expect($data->source)->toBe(AttachmentSource::Giphy)
+        ->and($data->url)->toBe('https://media.giphy.com/media/abc123/giphy.gif')
+        ->and($data->thumbUrl)->toBeNull()
+        ->and($data->description)->toBe('a cat waving')
+        ->and($data->filename)->toBeNull()
+        ->and($data->mimeType)->toBe('image/gif')
+        ->and($data->isImage)->toBeTrue()
+        ->and($data->width)->toBe(480)
+        ->and($data->height)->toBe(270);
+});
+
+it('still serves an uploaded attachment through the authorized download route', function (): void {
+    $attachment = Attachment::factory()->create();
+    $attachment->load('channel.team');
+
+    expect($attachment->source)->toBe(AttachmentSource::Upload)
+        ->and($attachment->url)->toContain('/attachments/'.$attachment->id.'/download');
+
+    $data = AttachmentData::fromAttachment($attachment);
+
+    expect($data->source)->toBe(AttachmentSource::Upload)
+        ->and($data->description)->toBeNull();
+});

--- a/tests/Feature/Console/PurgeExpiredAttachmentsTest.php
+++ b/tests/Feature/Console/PurgeExpiredAttachmentsTest.php
@@ -33,6 +33,17 @@ test('a pending attachment older than the ttl is purged, row and blob', function
     Storage::disk('local')->assertMissing($stale->path);
 });
 
+test('a stale pending Giphy attachment is purged without touching storage', function (): void {
+    Storage::fake('local');
+    config()->set('attachments.pending_ttl_hours', 24);
+    $stale = Attachment::factory()->giphy()->create(['created_at' => now()->subHours(48)]);
+
+    $purged = app(PurgeExpiredAttachments::class)->handle();
+
+    expect($purged)->toBe(1);
+    $this->assertDatabaseMissing('attachments', ['id' => $stale->id]);
+});
+
 test('a pending attachment within the ttl survives', function (): void {
     Storage::fake('local');
     config()->set('attachments.pending_ttl_hours', 24);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -24,6 +24,10 @@ pest()->extend(TestCase::class)
 // they need the application booted (but no database).
 pest()->extend(TestCase::class)->in('Unit/SlashCommands');
 
+// The Giphy client unit test drives config/Http/Cache facades, so it needs the
+// application booted (but no database).
+pest()->extend(TestCase::class)->in('Unit/Support/GiphyClientTest.php');
+
 /*
 |--------------------------------------------------------------------------
 | Browser (E2E) Test Case

--- a/tests/Unit/SlashCommands/GifCommandTest.php
+++ b/tests/Unit/SlashCommands/GifCommandTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use App\Providers\SlashCommandServiceProvider;
+use App\SlashCommands\Commands\GifCommand;
+use App\SlashCommands\SlashCommandContext;
+use App\SlashCommands\SlashCommandRegistry;
+
+function gifContext(string $args = 'cats'): SlashCommandContext
+{
+    return new SlashCommandContext(
+        user: new User,
+        team: new Team,
+        channel: new Channel,
+        threadRootId: null,
+        args: $args,
+        clientUuid: 'uuid',
+    );
+}
+
+test('the /gif command advertises itself for autocomplete', function (): void {
+    $command = new GifCommand;
+
+    expect($command->name())->toBe('gif')
+        ->and($command->description())->toBe('Search Giphy for a GIF to send')
+        ->and($command->argumentHint())->toBe('[search]');
+});
+
+test('submitting /gif as raw text points the user to the picker', function (): void {
+    $result = (new GifCommand)->handle(gifContext());
+
+    expect($result->isError())->toBeTrue()
+        ->and($result->text)->toBe('Pick a GIF from the picker to send one.');
+});
+
+test('the /gif command is registered only when Giphy is configured', function (): void {
+    config()->set('services.giphy.key', 'test-key');
+    $enabled = new SlashCommandRegistry;
+    app()->instance(SlashCommandRegistry::class, $enabled);
+    (new SlashCommandServiceProvider(app()))->boot();
+
+    expect($enabled->has('gif'))->toBeTrue();
+
+    config()->set('services.giphy.key', null);
+    $disabled = new SlashCommandRegistry;
+    app()->instance(SlashCommandRegistry::class, $disabled);
+    (new SlashCommandServiceProvider(app()))->boot();
+
+    expect($disabled->has('gif'))->toBeFalse()
+        // The built-in text commands are always present regardless.
+        ->and($disabled->has('shrug'))->toBeTrue();
+});

--- a/tests/Unit/SlashCommands/GifCommandTest.php
+++ b/tests/Unit/SlashCommands/GifCommandTest.php
@@ -43,7 +43,7 @@ test('the /gif command is registered only when Giphy is configured', function ()
 
     expect($enabled->has('gif'))->toBeTrue();
 
-    config()->set('services.giphy.key', null);
+    config()->set('services.giphy.key');
     $disabled = new SlashCommandRegistry;
     app()->instance(SlashCommandRegistry::class, $disabled);
     (new SlashCommandServiceProvider(app()))->boot();

--- a/tests/Unit/Support/GiphyClientTest.php
+++ b/tests/Unit/Support/GiphyClientTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Support\GiphyClient;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -134,6 +135,21 @@ it('degrades to an empty page when Giphy errors', function (): void {
 
     expect($page->results)->toBe([])
         ->and($page->nextOffset)->toBeNull();
+});
+
+it('degrades to an empty page on a connection failure', function (): void {
+    Http::fake(fn () => throw new ConnectionException('timeout'));
+
+    $page = app(GiphyClient::class)->search('cats');
+
+    expect($page->results)->toBe([])
+        ->and($page->nextOffset)->toBeNull();
+});
+
+it('returns null when resolving hits a connection failure', function (): void {
+    Http::fake(fn () => throw new ConnectionException('timeout'));
+
+    expect(app(GiphyClient::class)->resolve('abc'))->toBeNull();
 });
 
 it('re-resolves an opaque id to authoritative media', function (): void {

--- a/tests/Unit/Support/GiphyClientTest.php
+++ b/tests/Unit/Support/GiphyClientTest.php
@@ -30,7 +30,7 @@ function giphyGif(string $id, string $description = 'a cat'): array
 it('reports enabled only when a key is configured', function (): void {
     expect(app(GiphyClient::class)->isEnabled())->toBeTrue();
 
-    config()->set('services.giphy.key', null);
+    config()->set('services.giphy.key');
 
     expect(app(GiphyClient::class)->isEnabled())->toBeFalse();
 });
@@ -54,7 +54,7 @@ it('fetches trending when the query is blank and normalizes the renditions', fun
         ->and($gif->height)->toBe(200)
         ->and($gif->description)->toBe('a happy cat');
 
-    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/trending')
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), '/trending')
         && $request['api_key'] === 'test-key'
         && $request['rating'] === 'g');
 });
@@ -69,7 +69,7 @@ it('searches Giphy with the query and language when a query is given', function 
 
     app(GiphyClient::class)->search('cats', offset: 0, limit: 24, lang: 'fr');
 
-    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/search')
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), '/search')
         && $request['q'] === 'cats'
         && $request['lang'] === 'fr');
 });
@@ -109,6 +109,22 @@ it('skips GIFs without a usable animated rendition', function (): void {
 
     expect($page->results)->toHaveCount(1)
         ->and($page->results[0]->id)->toBe('good');
+});
+
+it('leaves the description null when a GIF has no alt text or title', function (): void {
+    Http::fake([
+        'api.giphy.com/*' => Http::response([
+            'data' => [[
+                'id' => 'plain',
+                'images' => ['fixed_height' => ['url' => 'https://media.giphy.com/plain/200.gif', 'width' => '100', 'height' => '100']],
+            ]],
+            'pagination' => ['total_count' => 1, 'count' => 1, 'offset' => 0],
+        ]),
+    ]);
+
+    $page = app(GiphyClient::class)->search('cats');
+
+    expect($page->results[0]->description)->toBeNull();
 });
 
 it('degrades to an empty page when Giphy errors', function (): void {

--- a/tests/Unit/Support/GiphyClientTest.php
+++ b/tests/Unit/Support/GiphyClientTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Support\GiphyClient;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    config()->set('services.giphy.key', 'test-key');
+    config()->set('services.giphy.rating', 'g');
+    Cache::flush();
+});
+
+/**
+ * Build a Giphy GIF object with a usable `fixed_height` rendition.
+ *
+ * @return array<string, mixed>
+ */
+function giphyGif(string $id, string $description = 'a cat'): array
+{
+    return [
+        'id' => $id,
+        'alt_text' => $description,
+        'images' => [
+            'fixed_height' => ['url' => "https://media.giphy.com/{$id}/200.gif", 'width' => '360', 'height' => '200'],
+            'fixed_height_small' => ['url' => "https://media.giphy.com/{$id}/100.gif", 'width' => '180', 'height' => '100'],
+        ],
+    ];
+}
+
+it('reports enabled only when a key is configured', function (): void {
+    expect(app(GiphyClient::class)->isEnabled())->toBeTrue();
+
+    config()->set('services.giphy.key', null);
+
+    expect(app(GiphyClient::class)->isEnabled())->toBeFalse();
+});
+
+it('fetches trending when the query is blank and normalizes the renditions', function (): void {
+    Http::fake([
+        'api.giphy.com/v1/gifs/trending*' => Http::response([
+            'data' => [giphyGif('abc', 'a happy cat')],
+            'pagination' => ['total_count' => 100, 'count' => 1, 'offset' => 0],
+        ]),
+    ]);
+
+    $page = app(GiphyClient::class)->search(null);
+
+    expect($page->results)->toHaveCount(1);
+    $gif = $page->results[0];
+    expect($gif->id)->toBe('abc')
+        ->and($gif->url)->toBe('https://media.giphy.com/abc/200.gif')
+        ->and($gif->previewUrl)->toBe('https://media.giphy.com/abc/100.gif')
+        ->and($gif->width)->toBe(360)
+        ->and($gif->height)->toBe(200)
+        ->and($gif->description)->toBe('a happy cat');
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/trending')
+        && $request['api_key'] === 'test-key'
+        && $request['rating'] === 'g');
+});
+
+it('searches Giphy with the query and language when a query is given', function (): void {
+    Http::fake([
+        'api.giphy.com/v1/gifs/search*' => Http::response([
+            'data' => [giphyGif('xyz')],
+            'pagination' => ['total_count' => 100, 'count' => 1, 'offset' => 0],
+        ]),
+    ]);
+
+    app(GiphyClient::class)->search('cats', offset: 0, limit: 24, lang: 'fr');
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/search')
+        && $request['q'] === 'cats'
+        && $request['lang'] === 'fr');
+});
+
+it('computes the next offset from pagination and stops when exhausted', function (): void {
+    Http::fakeSequence('api.giphy.com/v1/gifs/search*')
+        ->push(['data' => [giphyGif('a'), giphyGif('b')], 'pagination' => ['total_count' => 3, 'count' => 2, 'offset' => 0]])
+        ->push(['data' => [giphyGif('c')], 'pagination' => ['total_count' => 3, 'count' => 1, 'offset' => 2]]);
+
+    expect(app(GiphyClient::class)->search('cats', offset: 0)->nextOffset)->toBe(2);
+    expect(app(GiphyClient::class)->search('cats', offset: 2)->nextOffset)->toBeNull();
+});
+
+it('caches identical pages so the shared key is only hit once', function (): void {
+    Http::fake([
+        'api.giphy.com/*' => Http::response(['data' => [giphyGif('a')], 'pagination' => ['total_count' => 1, 'count' => 1, 'offset' => 0]]),
+    ]);
+
+    app(GiphyClient::class)->search('cats');
+    app(GiphyClient::class)->search('cats');
+
+    Http::assertSentCount(1);
+});
+
+it('skips GIFs without a usable animated rendition', function (): void {
+    Http::fake([
+        'api.giphy.com/*' => Http::response([
+            'data' => [
+                ['id' => 'no-images', 'images' => []],
+                giphyGif('good'),
+            ],
+            'pagination' => ['total_count' => 2, 'count' => 2, 'offset' => 0],
+        ]),
+    ]);
+
+    $page = app(GiphyClient::class)->search('cats');
+
+    expect($page->results)->toHaveCount(1)
+        ->and($page->results[0]->id)->toBe('good');
+});
+
+it('degrades to an empty page when Giphy errors', function (): void {
+    Http::fake(['api.giphy.com/*' => Http::response(null, 500)]);
+
+    $page = app(GiphyClient::class)->search('cats');
+
+    expect($page->results)->toBe([])
+        ->and($page->nextOffset)->toBeNull();
+});
+
+it('re-resolves an opaque id to authoritative media', function (): void {
+    Http::fake([
+        'api.giphy.com/v1/gifs/abc*' => Http::response(['data' => giphyGif('abc', 'a dog')]),
+    ]);
+
+    $gif = app(GiphyClient::class)->resolve('abc');
+
+    expect($gif)->not->toBeNull()
+        ->and($gif->id)->toBe('abc')
+        ->and($gif->url)->toBe('https://media.giphy.com/abc/200.gif')
+        ->and($gif->description)->toBe('a dog');
+});
+
+it('returns null when resolving an unknown id', function (): void {
+    Http::fake(['api.giphy.com/*' => Http::response(['meta' => ['status' => 404]], 404)]);
+
+    expect(app(GiphyClient::class)->resolve('nope'))->toBeNull();
+});
+
+it('returns null when resolving an id whose data is empty', function (): void {
+    Http::fake(['api.giphy.com/*' => Http::response(['data' => []])]);
+
+    expect(app(GiphyClient::class)->resolve('empty'))->toBeNull();
+});


### PR DESCRIPTION
Closes #280.

Adds a **`/gif` command** that searches **Giphy** and sends a GIF into any channel or DM. A sent GIF is a **remote-sourced attachment** riding the #276/#277 attachments foundation — it reuses the pending→claim send flow, inline image rendering, broadcast, and pending-GC, adding only what is GIF-specific.

> **Provider note:** the issue specified Tenor, but the Tenor API was decommissioned (Jan 2026), so this ships on **Giphy** instead. All the settled design decisions (remote attachment model, key-gated + feature-toggled, server-authoritative id re-resolution, throttled + short-TTL-cached proxy, locale-aware, "Powered by GIPHY" attribution) carry over unchanged; only provider specifics differ (env var names, `offset` pagination, `rating` scheme).

## What
- **Data model:** `attachments` gains `source` (`upload`|`giphy` enum), `remote_url`, `description`; `disk`/`path`/`original_filename` are now nullable. `AttachmentData` carries `source` + `description` and serves `remote_url` for Giphy rows (bypassing the blob-only serve route). Claim, pending-GC, and inline `<img>` rendering needed ~zero change (`image/gif` already renders inline; stored `width`/`height` keep the virtualizer stable).
- **Endpoints:** a throttled, short-TTL-cached Giphy **search proxy** (trending on empty query, locale-aware) and an **attach** endpoint that accepts only the opaque Giphy id, **re-resolves** it server-side (sole authority on the stored URL), and creates a `pending` `source=giphy` attachment. Both are authorized by the post-message policy and **404 when no key is set**.
- **Framework fit:** `#280` predated the #281 slash-command framework. `/gif` is **registered in that framework only when Giphy is configured** (so it appears in `/` autocomplete, key-gated), but the composer **intercepts** it to open a Giphy picker; the pick posts as a remote attachment via the existing `attachment_ids[]` flow. The framework's result/dispatcher are untouched.
- **Picker UX:** `GifPickerPanel` (blueprinted on the emoji picker) — debounced search, trending on empty, infinite scroll via Giphy's `offset`, keyboard nav with `aria-activedescendant`, "Powered by GIPHY" attribution. A picked GIF drops into the composer's pre-send tray (with remove) and Send claims it.
- **Config:** `GIPHY_API_KEY` (blank ⇒ feature fully hidden) and `GIPHY_CONTENT_RATING` (default `g`). An enabled boolean is shared to the frontend.

## Testing
- `sail composer test` green at **100% coverage** (Pint · PHPStan · Rector · Pest).
- `lint:check` / `format:check` / `types:check` / `build` and the full `test:js` suite (681 tests) green.
- Local CodeRabbit pass: applied the valid findings (connection-failure degradation, `addRemote` acceptance, `/gif` disabled while editing, picker `aria-activedescendant`, append-failure keeps the grid, `clear()` covers remote rows, direct action test); the re-review hit the free-tier rate limit, so this leans on the app PR review for the final pass.

## i18n & docs
- All picker/validation/command copy through `$t` / `__()`, with French added to `lang/fr.json`.
- Starlight docs updated: `GIPHY_API_KEY` + `GIPHY_CONTENT_RATING` in `reference/environment-variables.md` and `reference/feature-toggles.md`, including the CDN-hotlink privacy note. `.env.prod.example` updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GIPHY-powered GIF picker with trending results, search, infinite scrolling, keyboard navigation, and GIF attachments.
  * GIFs can be selected from the composer using the `/gif` command or picker.
  * Remote GIFs display with accessible labels, descriptions, previews, and lightbox support.
* **Documentation**
  * Documented GIPHY configuration, content ratings, feature availability, and remote CDN storage.
* **Bug Fixes**
  * Improved attachment handling for remote GIFs without filenames or stored file sizes.
* **Tests**
  * Added coverage for GIF searching, selection, attachments, accessibility states, and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->