### PR TITLE
refactor: promote JS/TS inline comments to JSDoc/TSDoc and trim redundant ones

### DIFF
--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -86,6 +86,7 @@ Follow every rule in `CLAUDE.md` as you go — they are not optional:
 - **i18n:** no hardcoded user-facing copy. Frontend through `$t` / `useTranslations`; backend through `__()`. Add every new key's French translation to `lang/fr.json`.
 - **Laravel the Laravel way:** `php artisan make:*` for new files, constructor property promotion, explicit return types and type hints, `Data` classes for DTOs, named routes.
 - **Frontend:** Vue + Inertia v3 conventions; prefer generated `App.Data.*` / `App.Enums.*` types over hand-rolled ones; regenerate them with `./vendor/bin/sail artisan typescript:transform` after touching a `Data` class or enum; use Wayfinder route functions, not hardcoded URLs.
+- **Comments:** don't emit narrating inline `//` comments in JS/TS that merely restate the code — the names and the code carry the *what*. When a comment documents a *declaration* (prop, emit, type member, function, exported symbol), write it as a JSDoc/TSDoc `/** … */` block above that declaration, not a loose `//`. Reserve bare `//` for a non-obvious *why*, intent, edge case, or ordering constraint *inside* a body. (Same rule as the PHP "prefer PHPDoc over inline comments" convention — see `CLAUDE.md` → *Code Comments (JS/TS)*.)
 - **Run all Node/npm tooling through Sail** (`./vendor/bin/sail npm run …`), never bare `npm`.
 - **Docs:** if the change is operator-facing (a new `.env`/config setting, feature toggle, install/upgrade/stack change), update `docs/` in the same change.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,13 @@ Vue components must have a single root element.
 - `vue-tsc` (`npm run types:check`) doesn't use those native bindings, so it can run on the host, but prefer Sail for consistency.
 - The frontend quality gate is `./vendor/bin/sail npm run lint:check`, `format:check`, `types:check`, and `build` — all four must pass before pushing. Use `sail npm run lint` / `format` (the write variants) to auto-fix violations.
 
+## Code Comments (JS/TS) — no redundant inline `//`
+
+- **The PHP rule (`Prefer PHPDoc blocks over inline comments…`) has a JS/TS counterpart: don't litter function bodies with narrating inline `//` comments.** A comment that restates what the code already says (`// loop over messages` above a `for`, `// increment counter`, `// return the result`) is noise — it hides the signal, and it rots when the code changes and the comment doesn't. Delete it; let the names and the code speak.
+- **Promote, don't inline-document.** A comment that documents a *declaration* — a prop, an emit, an interface/type member, a function, or an exported symbol — belongs in a JSDoc/TSDoc `/** … */` block directly above that declaration (editors and Volar surface it on hover), not a loose `//` line. When you keep such a comment, convert it to a `/** … */` block. Reserve bare `//` for explaining a statement or branch *inside* a body.
+- **Keep the comments that earn their place:** ones that explain a non-obvious *why*, an intent, an edge case, an ordering constraint, or a workaround the code alone can't convey. When in doubt about a *why*-comment, keep it — the target is the redundant *what*, not genuine explanation.
+- **Leave existing doc-comments alone.** JSDoc/TSDoc blocks (`/** … */`) are documentation, not inline noise — keep them, the same way PHPDoc blocks are kept on the PHP side.
+
 ## Generated TypeScript Types
 
 - **Prefer the generated `App.Data.*` / `App.Enums.*` ambient types over hand-duplicating a DTO or enum in `@/types`.** They are produced from the PHP `Data` classes and enums by `spatie/laravel-typescript-transformer` (configured in `app/Providers/TypeScriptTransformerServiceProvider.php`), so the frontend stays in lockstep with the backend shape. Example: `type CustomEmoji = App.Data.CustomEmojiData`.

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -10,9 +10,11 @@ import { initializeFlashToast } from '@/lib/flashToast';
 import { setMessages, translate } from '@/lib/i18n';
 import type { Messages } from '@/lib/i18n';
 
-// Seeded from the server-shared props at boot (see `withApp`), so both Echo and
-// the document title use the operator's runtime settings rather than values
-// baked into the bundle at build time.
+/**
+ * Seeded from the server-shared props at boot (see `withApp`), so both Echo and
+ * the document title use the operator's runtime settings rather than values
+ * baked into the bundle at build time.
+ */
 let appName = 'Laravel';
 
 // createInertiaApp returns a bootstrap Promise we intentionally don't await.
@@ -65,8 +67,6 @@ void createInertiaApp({
     },
 });
 
-// This will set light / dark mode on page load...
 initializeTheme();
 
-// This will listen for flash toast data from the server...
 initializeFlashToast();

--- a/resources/js/components/ChannelEmptyState.vue
+++ b/resources/js/components/ChannelEmptyState.vue
@@ -12,7 +12,7 @@ import type { Channel } from '@/types';
 
 const props = defineProps<{
     channel: Channel;
-    // Whether the open DM is the viewer's own space, tuning the empty-state copy.
+    /** Whether the open DM is the viewer's own space, tuning the empty-state copy. */
     isSelfDm: boolean;
     teamName: string;
     teamSlug: string;
@@ -26,18 +26,22 @@ const page = usePage();
 
 const { t } = useTranslations();
 
-// The brand-new-workspace welcome replaces the plain "no messages" empty state on
-// a fresh #general for a user who has not yet completed onboarding — the reachable
-// "first channel, first message" moment. Any other empty channel/DM keeps the
-// plain copy.
+/**
+ * The brand-new-workspace welcome replaces the plain "no messages" empty state on
+ * a fresh #general for a user who has not yet completed onboarding — the reachable
+ * "first channel, first message" moment. Any other empty channel/DM keeps the
+ * plain copy.
+ */
 const showWelcome = computed(
     () =>
         props.channel.slug === 'general' &&
         page.props.auth.user.onboarding_completed_at == null,
 );
 
-// The welcome's "Invite your teammates" action reuses the member-invite modal,
-// gated on the same permission and roles the workspace already shares.
+/**
+ * The welcome's "Invite your teammates" action reuses the member-invite modal,
+ * gated on the same permission and roles the workspace already shares.
+ */
 const inviteOpen = ref(false);
 const canInviteToCurrentTeam = computed(
     () => page.props.canInviteToCurrentTeam ?? false,
@@ -47,9 +51,11 @@ const currentTeamForInvite = computed(() => page.props.currentTeam);
 
 const { open: openOnboardingTour } = useOnboardingTour();
 
-// The viewer-relative conversation name for the DM empty state: a group joins
-// its participants ("Jonas, Ana & Tomas"), a 1:1 uses the pre-resolved name. A
-// group whose other members have all left falls back to a generic label.
+/**
+ * The viewer-relative conversation name for the DM empty state: a group joins
+ * its participants ("Jonas, Ana & Tomas"), a 1:1 uses the pre-resolved name. A
+ * group whose other members have all left falls back to a generic label.
+ */
 const conversationName = computed(() =>
     props.channel.isGroupDirect
         ? groupDmMastheadName(props.channel.dmParticipants ?? []) ||

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -47,33 +47,45 @@ import type {
 const props = defineProps<{
     channel: Channel;
     teamSlug: string;
-    // The team roster the page already carries for the composer, reused for the
-    // overlapping member facepile.
+    /**
+     * The team roster the page already carries for the composer, reused for the
+     * overlapping member facepile.
+     */
     members: Mention[];
-    // Ids of team members currently online, driving the DM presence dot.
+    /** Ids of team members currently online, driving the DM presence dot. */
     onlineIds: Set<string>;
-    // The viewer-relative title (self-DM reads "You"); the page also feeds it to
-    // `<Head>`, so it is resolved once there and passed down.
+    /**
+     * The viewer-relative title (self-DM reads "You"); the page also feeds it to
+     * `<Head>`, so it is resolved once there and passed down.
+     */
     title: string;
     canManagePreferences: boolean;
     canArchive: boolean;
-    // Whether the viewer may leave the channel — a member of a standard channel
-    // that isn't #general, or of a group DM. Drives the "Leave" menu item.
+    /**
+     * Whether the viewer may leave the channel — a member of a standard channel
+     * that isn't #general, or of a group DM. Drives the "Leave" menu item.
+     */
     canLeave: boolean;
-    // Whether the viewer may add people to this DM (a member of any DM). Drives
-    // the masthead's "Add people" button.
+    /**
+     * Whether the viewer may add people to this DM (a member of any DM). Drives
+     * the masthead's "Add people" button.
+     */
     canAddPeople: boolean;
     notificationLevels: NotificationLevelOption[];
     starred: boolean;
     muted: boolean;
-    // The channel's pinned-message count, driving the pins button's badge. Kept
-    // live from the `MessagePinned` broadcast by the page.
+    /**
+     * The channel's pinned-message count, driving the pins button's badge. Kept
+     * live from the `MessagePinned` broadcast by the page.
+     */
     pinCount: number;
     notificationLevel: NotificationLevel;
-    // A compact header cue for a non-default notification state, or null.
+    /** A compact header cue for a non-default notification state, or null. */
     notificationStatus: NotificationIndicator | null;
-    // The realtime connection cue: a reconnecting pill, a transient back-online
-    // confirmation, or null when the socket is steadily connected.
+    /**
+     * The realtime connection cue: a reconnecting pill, a transient back-online
+     * confirmation, or null when the socket is steadily connected.
+     */
     connectionPill?: ConnectionPill;
 }>();
 
@@ -87,39 +99,45 @@ const emit = defineEmits<{
     openPins: [];
 }>();
 
-// How many member avatars the masthead shows before collapsing the rest into a
-// single "+N" overflow chip.
+/**
+ * How many member avatars the masthead shows before collapsing the rest into a
+ * single "+N" overflow chip.
+ */
 const MAX_MASTHEAD_AVATARS = 3;
 
-// The overlapping member avatars for the masthead's right side.
+/** The overlapping member avatars for the masthead's right side. */
 const mastheadAvatars = computed(() =>
     memberAvatarStack(props.members, MAX_MASTHEAD_AVATARS),
 );
 
 const page = usePage();
 
-// The other participant of a 1:1 DM, whose avatar the masthead shows.
+/** The other participant of a 1:1 DM, whose avatar the masthead shows. */
 const dmParticipant = computed(() => props.channel.dmParticipants?.[0] ?? null);
 
-// The avatar image for the 1:1 masthead: the other participant's, or — in a
-// self-DM, which has no other participant — the viewer's own. Null (so the
-// initials fallback shows) when that person has no avatar.
+/**
+ * The avatar image for the 1:1 masthead: the other participant's, or — in a
+ * self-DM, which has no other participant — the viewer's own. Null (so the
+ * initials fallback shows) when that person has no avatar.
+ */
 const dmAvatar = computed(() =>
     dmParticipant.value
         ? (dmParticipant.value.avatar ?? null)
         : (page.props.auth.user.avatar ?? null),
 );
 
-// A 1:1 DM renders viewer-relative: the other participant's presence dot follows
-// the team roster. A DM is a fixed set, so the "who's in the channel" facepile is
-// meaningless and hidden.
+/**
+ * A 1:1 DM renders viewer-relative: the other participant's presence dot follows
+ * the team roster. A DM is a fixed set, so the "who's in the channel" facepile is
+ * meaningless and hidden.
+ */
 const dmParticipantOnline = computed(
     () =>
         props.channel.dmUserId != null &&
         props.onlineIds.has(props.channel.dmUserId),
 );
 
-// The group's participant count, including the viewer, for the subtitle.
+/** The group's participant count, including the viewer, for the subtitle. */
 const groupParticipantCount = computed(
     () => (props.channel.dmParticipants?.length ?? 0) + 1,
 );

--- a/resources/js/components/ComposerSendButton.vue
+++ b/resources/js/components/ComposerSendButton.vue
@@ -13,23 +13,27 @@ import {
 import { formatPresetPreview, schedulePresets } from '@/lib/scheduleTime';
 
 const props = defineProps<{
-    // Whether the composer has something to send right now (text or a ready
-    // attachment). Gates the primary Send and the "Send now" menu item.
+    /**
+     * Whether the composer has something to send right now (text or a ready
+     * attachment). Gates the primary Send and the "Send now" menu item.
+     */
     canSubmit: boolean;
-    // Whether the composer body carries text to schedule. Scheduling never
-    // includes attachments, so it gates on text alone — matching the old
-    // schedule button's "empty composer has nothing to schedule" guard.
+    /**
+     * Whether the composer body carries text to schedule. Scheduling never
+     * includes attachments, so it gates on text alone — matching the old
+     * schedule button's "empty composer has nothing to schedule" guard.
+     */
     canSchedule: boolean;
-    // The viewer's stored IANA zone; drives the quick presets' resolved times.
+    /** The viewer's stored IANA zone; drives the quick presets' resolved times. */
     timezone: string | null;
 }>();
 
 const emit = defineEmits<{
-    // Deliver the composer body now.
+    /** Deliver the composer body now. */
     send: [];
-    // Schedule the body for the given UTC instant (a quick preset was chosen).
+    /** Schedule the body for the given UTC instant (a quick preset was chosen). */
     scheduleAt: [sendAt: string];
-    // Open the full schedule dialog to pick a custom time.
+    /** Open the full schedule dialog to pick a custom time. */
     customTime: [];
 }>();
 
@@ -58,8 +62,10 @@ type QuickPreset = {
     preview: string;
 };
 
-// Resolved on open so the times stay current with the wall clock each time the
-// menu is shown, rather than frozen at mount.
+/**
+ * Resolved on open so the times stay current with the wall clock each time the
+ * menu is shown, rather than frozen at mount.
+ */
 const quickPresets = ref<QuickPreset[]>([]);
 
 function buildPresets(): void {

--- a/resources/js/components/DirectMessageListItem.test.ts
+++ b/resources/js/components/DirectMessageListItem.test.ts
@@ -3,10 +3,12 @@ import { createSSRApp, h } from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import type { Channel } from '@/types/channels';
 
-// Inertia + Wayfinder + UI stubs so the row's own markup (unread badge, close
-// button) can be rendered in isolation without the full app/router context.
-// `stub(tag)` builds a passthrough component; hoisted so the vi.mock factories
-// (which run before the module body) can reach it.
+/**
+ * Inertia + Wayfinder + UI stubs so the row's own markup (unread badge, close
+ * button) can be rendered in isolation without the full app/router context.
+ * `stub(tag)` builds a passthrough component; hoisted so the vi.mock factories
+ * (which run before the module body) can reach it.
+ */
 const { stub } = await vi.hoisted(async () => {
     const { defineComponent, h: hyper } = await import('vue');
 

--- a/resources/js/components/EmojiPickerPopover.vue
+++ b/resources/js/components/EmojiPickerPopover.vue
@@ -18,11 +18,13 @@ import { useTranslations } from '@/composables/useTranslations';
 import type { CustomEmojiEntry } from '@/lib/customEmoji';
 
 defineProps<{
-    // Optional label shown in a tooltip above the trigger on hover and keyboard
-    // focus. When set, the trigger is composed as Tooltip → PopoverTrigger so the
-    // one button anchors both the popover (on click) and the tooltip (on
-    // hover/focus); this requires a TooltipProvider ancestor. Consumers that
-    // don't want a tooltip omit it and get the bare trigger.
+    /**
+     * Optional label shown in a tooltip above the trigger on hover and keyboard
+     * focus. When set, the trigger is composed as Tooltip → PopoverTrigger so the
+     * one button anchors both the popover (on click) and the tooltip (on
+     * hover/focus); this requires a TooltipProvider ancestor. Consumers that
+     * don't want a tooltip omit it and get the bare trigger.
+     */
     tooltip?: string;
 }>();
 

--- a/resources/js/components/ForwardMessageDialog.vue
+++ b/resources/js/components/ForwardMessageDialog.vue
@@ -20,13 +20,15 @@ import type { ForwardTarget } from '@/types/forward';
 import type { PersonRef } from '@/types/people';
 
 const props = defineProps<{
-    // The message being forwarded, driving the preview; null when the dialog is
-    // closed (nothing is being forwarded).
+    /**
+     * The message being forwarded, driving the preview; null when the dialog is
+     * closed (nothing is being forwarded).
+     */
     message: Message | null;
     channels: Channel[];
-    // Team members, offered as DM targets (opened-or-created on forward).
+    /** Team members, offered as DM targets (opened-or-created on forward). */
     people: PersonRef[];
-    // The viewer's own id, so their entry can read "You" and open a self-DM.
+    /** The viewer's own id, so their entry can read "You" and open a self-DM. */
     currentUserId: string;
 }>();
 
@@ -42,8 +44,10 @@ const query = ref('');
 const note = ref('');
 const selected = ref<ForwardTarget | null>(null);
 
-// Only standard channels are ranked here; DMs are reached through the People
-// section (which opens-or-creates the DM), so they never double up as channels.
+/**
+ * Only standard channels are ranked here; DMs are reached through the People
+ * section (which opens-or-creates the DM), so they never double up as channels.
+ */
 const rankedChannels = computed(() =>
     rankChannels(
         props.channels.filter((channel) => !channel.isDirect),
@@ -59,7 +63,7 @@ const hasResults = computed(
     () => rankedChannels.value.length > 0 || rankedPeople.value.length > 0,
 );
 
-// A one-line snippet of the message being forwarded, empty for a deleted source.
+/** A one-line snippet of the message being forwarded, empty for a deleted source. */
 const preview = computed(() =>
     props.message && !props.message.isDeleted
         ? messageBodyPreview(props.message.body)

--- a/resources/js/components/GifPickerPanel.vue
+++ b/resources/js/components/GifPickerPanel.vue
@@ -20,14 +20,14 @@ import type { AttachmentData } from '@/types/attachments';
 
 const props = withDefaults(
     defineProps<{
-        // The channel the picker searches and attaches within.
+        /** The channel the picker searches and attaches within. */
         teamSlug: string;
         channelSlug: string;
-        // The search term to seed from (`/gif cats` → "cats"); blank → trending.
+        /** The search term to seed from (`/gif cats` → "cats"); blank → trending. */
         initialQuery?: string;
-        // Debounce for search-as-you-type; 0 in tests for determinism.
+        /** Debounce for search-as-you-type; 0 in tests for determinism. */
         debounceMs?: number;
-        // Transport, injected in tests so the panel unit-tests without a network.
+        /** Transport, injected in tests so the panel unit-tests without a network. */
         searchGifs?: (
             url: string,
             signal?: AbortSignal,
@@ -43,9 +43,9 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-    // A GIF was picked and attached; carries the stored remote attachment.
+    /** A GIF was picked and attached; carries the stored remote attachment. */
     select: [attachment: AttachmentData];
-    // The picker should close (Escape, the close button, or a backdrop click).
+    /** The picker should close (Escape, the close button, or a backdrop click). */
     close: [];
 }>();
 
@@ -58,7 +58,7 @@ const loading = ref(false);
 const loadingMore = ref(false);
 const errored = ref(false);
 const attaching = ref(false);
-// The keyboard-active option, or -1 when focus is in the search field.
+/** The keyboard-active option, or -1 when focus is in the search field. */
 const activeIndex = ref(-1);
 
 const searchInput = ref<HTMLInputElement | null>(null);
@@ -78,8 +78,10 @@ function searchUrl(offset: number): string {
 
 let controller: AbortController | null = null;
 
-// False once the panel has unmounted, so an in-flight attach that resolves after
-// the user closed the picker doesn't stage a GIF they cancelled.
+/**
+ * False once the panel has unmounted, so an in-flight attach that resolves after
+ * the user closed the picker doesn't stage a GIF they cancelled.
+ */
 let alive = true;
 
 /**

--- a/resources/js/components/JoinChannelBar.vue
+++ b/resources/js/components/JoinChannelBar.vue
@@ -8,8 +8,10 @@ const props = defineProps<{
     teamSlug: string;
     channelName: string;
     channelSlug: string;
-    // The channel's current member count, shown so a non-member sees how many
-    // teammates are already in the channel before joining.
+    /**
+     * The channel's current member count, shown so a non-member sees how many
+     * teammates are already in the channel before joining.
+     */
     memberCount: number;
 }>();
 </script>

--- a/resources/js/components/MessageActions.vue
+++ b/resources/js/components/MessageActions.vue
@@ -36,17 +36,17 @@ import type { Message } from '@/types';
 const props = defineProps<{
     message: Message;
     currentUserId: string;
-    // Whether the viewer may add/remove reactions (member of a live channel).
+    /** Whether the viewer may add/remove reactions (member of a live channel). */
     canReact?: boolean;
-    // Whether the viewer may pin/unpin messages (member of a non-archived channel).
+    /** Whether the viewer may pin/unpin messages (member of a non-archived channel). */
     canPin?: boolean;
-    // Whether the viewer may moderate others' messages (delete them).
+    /** Whether the viewer may moderate others' messages (delete them). */
     canModerate?: boolean;
-    // Rendered inside a thread panel: suppresses the reply/thread affordances.
+    /** Rendered inside a thread panel: suppresses the reply/thread affordances. */
     inThread?: boolean;
-    // Whether this row is an optimistic send with no stable server id yet.
+    /** Whether this row is an optimistic send with no stable server id yet. */
     pending?: boolean;
-    // The viewer's stored zone, feeding the reminder popover's wall-clock presets.
+    /** The viewer's stored zone, feeding the reminder popover's wall-clock presets. */
     viewerTimezone: string | null;
 }>();
 
@@ -85,7 +85,7 @@ const showForward = computed(() =>
     canForwardMessage(props.message, context.value),
 );
 const showPin = computed(() => canPinMessage(props.message, context.value));
-// The button toggles: a pinned message offers Unpin, an unpinned one offers Pin.
+/** The button toggles: a pinned message offers Unpin, an unpinned one offers Pin. */
 const isPinned = computed(() => props.message.pin !== null);
 const showRemind = computed(() =>
     canRemindAboutMessage(props.message, context.value),
@@ -98,8 +98,10 @@ const showBar = computed(() =>
     hasAnyMessageAction(props.message, context.value),
 );
 
-// The hairline divider only earns its place when it sits between two clusters:
-// the react/reply group and the forward/edit/delete group.
+/**
+ * The hairline divider only earns its place when it sits between two clusters:
+ * the react/reply group and the forward/edit/delete group.
+ */
 const showDivider = computed(
     () =>
         (showReact.value || showStartThread.value || showReply.value) &&
@@ -110,15 +112,17 @@ const showDivider = computed(
             showDelete.value),
 );
 
-// The bar's icon buttons ride the `<Button variant="ghost" size="icon-sm">`
-// primitive; these classes only tune what the primitive doesn't own: a muted
-// resting glyph (`ghost` rests transparent), and — for the two popover triggers
-// (react / remind) — an accent-filled "open" state so it reads as active while
-// its menu is attached.
+/**
+ * The bar's icon buttons ride the `<Button variant="ghost" size="icon-sm">`
+ * primitive; these classes only tune what the primitive doesn't own: a muted
+ * resting glyph (`ghost` rests transparent), and — for the two popover triggers
+ * (react / remind) — an accent-filled "open" state so it reads as active while
+ * its menu is attached.
+ */
 const iconButtonClass = 'text-muted-foreground';
 const openStateClass = 'bg-accent text-accent-foreground';
 
-// Delete recolors to the destructive token on hover instead of neutral.
+/** Delete recolors to the destructive token on hover instead of neutral. */
 const deleteButtonClass =
     'text-muted-foreground hover:bg-destructive/10 hover:text-destructive';
 </script>

--- a/resources/js/components/MessageAttachments.vue
+++ b/resources/js/components/MessageAttachments.vue
@@ -18,8 +18,10 @@ const props = defineProps<{
     attachments: AttachmentData[];
     authorName: string;
     createdAt: string;
-    // The viewer's configured timezone, so the lightbox's timestamp matches the
-    // timeline. Undefined falls back to the browser's local zone.
+    /**
+     * The viewer's configured timezone, so the lightbox's timestamp matches the
+     * timeline. Undefined falls back to the browser's local zone.
+     */
     viewerTimeZone?: string;
 }>();
 

--- a/resources/js/components/MessageComposer.attachmentRestore.test.ts
+++ b/resources/js/components/MessageComposer.attachmentRestore.test.ts
@@ -25,7 +25,7 @@ import MessageComposer from './MessageComposer.vue';
  * instead so the real staging → detach → restore flow runs.
  */
 
-// Control the upload transport so a staged file settles to `done` on demand.
+/** Control the upload transport so a staged file settles to `done` on demand. */
 const uploads = vi.hoisted(
     () => [] as Array<{ resolve: (value: unknown) => void }>,
 );
@@ -113,9 +113,11 @@ vi.mock('@/components/MessageQuote', async () => {
 
 let active: Array<{ app: App; container: HTMLElement }> = [];
 
-// An image staged in the tray gets a preview object URL, which `dispose()`
-// revokes and `restore()` keeps alive — the observable difference between an
-// accepted and a rejected send. jsdom ships neither, so stand them up here.
+/**
+ * An image staged in the tray gets a preview object URL, which `dispose()`
+ * revokes and `restore()` keeps alive — the observable difference between an
+ * accepted and a rejected send. jsdom ships neither, so stand them up here.
+ */
 const PREVIEW_URL = 'blob:preview-1';
 const revokeObjectUrl = vi.fn();
 

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -48,38 +48,54 @@ const props = defineProps<{
     placeholder?: string;
     allowSendToChannel?: boolean;
     autofocus?: boolean;
-    // Text to seed the composer with on mount, e.g. a persisted draft. Restored
-    // verbatim (mention tokens included) so it round-trips faithfully.
+    /**
+     * Text to seed the composer with on mount, e.g. a persisted draft. Restored
+     * verbatim (mention tokens included) so it round-trips faithfully.
+     */
     initialBody?: string;
-    // Whether to offer the "schedule for later" affordance (main channel
-    // composer only). The viewer's zone drives the picker's presets.
+    /**
+     * Whether to offer the "schedule for later" affordance (main channel
+     * composer only). The viewer's zone drives the picker's presets.
+     */
     allowSchedule?: boolean;
     timezone?: string | null;
-    // The messages of the surface this composer posts to (main timeline or the
-    // open thread), oldest first. ArrowUp on an empty composer loads the
-    // viewer's most recent editable one from here into an inline edit mode.
+    /**
+     * The messages of the surface this composer posts to (main timeline or the
+     * open thread), oldest first. ArrowUp on an empty composer loads the
+     * viewer's most recent editable one from here into an inline edit mode.
+     */
     messages?: Message[];
-    // The viewer's id, resolving which of `messages` they may edit.
+    /** The viewer's id, resolving which of `messages` they may edit. */
     currentUserId?: string;
-    // Client uuids of the viewer's in-flight optimistic sends; those rows have
-    // no stable id yet and are skipped when resolving the edit target.
+    /**
+     * Client uuids of the viewer's in-flight optimistic sends; those rows have
+     * no stable id yet and are skipped when resolving the edit target.
+     */
     pendingUuids?: string[];
-    // The team and channel slugs the composer posts to. Both are required to
-    // enable attachments: files pre-upload to this channel's endpoint, so
-    // without them the "Add attachment" button stays disabled (e.g. the thread
-    // composer, which does not carry a channel slug).
+    /**
+     * The team and channel slugs the composer posts to. Both are required to
+     * enable attachments: files pre-upload to this channel's endpoint, so
+     * without them the "Add attachment" button stays disabled (e.g. the thread
+     * composer, which does not carry a channel slug).
+     */
     teamSlug?: string;
     channelSlug?: string;
-    // The per-file and per-message attachment caps, pre-checked client-side for
-    // instant feedback (the server re-enforces both).
+    /**
+     * The per-file and per-message attachment caps, pre-checked client-side for
+     * instant feedback (the server re-enforces both).
+     */
     maxAttachmentSizeMb?: number;
     maxAttachmentsPerMessage?: number;
-    // The server's slash-command autocomplete manifest. Passed only where slash
-    // commands apply (the main channel composer); absent/empty elsewhere (e.g.
-    // the thread composer), which disables all slash handling.
+    /**
+     * The server's slash-command autocomplete manifest. Passed only where slash
+     * commands apply (the main channel composer); absent/empty elsewhere (e.g.
+     * the thread composer), which disables all slash handling.
+     */
     slashCommands?: App.Data.SlashCommandData[];
-    // Whether the Giphy `/gif` picker is available (an API key is configured).
-    // When false, `/gif` is neither in the manifest nor intercepted here.
+    /**
+     * Whether the Giphy `/gif` picker is available (an API key is configured).
+     * When false, `/gif` is neither in the manifest nor intercepted here.
+     */
     gifPickerEnabled?: boolean;
 }>();
 
@@ -89,26 +105,36 @@ const emit = defineEmits<{
         mentions: Mention[],
         sendToChannel: boolean,
         attachmentIds: string[],
-        // Outcome hooks: the tray is emptied optimistically on send, so a failed
-        // online send restores the staged attachments (and body) through these.
+        /**
+         * Outcome hooks: the tray is emptied optimistically on send, so a failed
+         * online send restores the staged attachments (and body) through these.
+         */
         callbacks: SendCallbacks,
     ];
-    // A slash command was typed and sent. The raw body goes to the server, which
-    // parses it authoritatively; the callbacks clear the composer on success and
-    // keep the text on error (the send is non-optimistic).
+    /**
+     * A slash command was typed and sent. The raw body goes to the server, which
+     * parses it authoritatively; the callbacks clear the composer on success and
+     * keep the text on error (the send is non-optimistic).
+     */
     command: [body: string, callbacks: CommandCallbacks];
     typing: [];
     cancelReply: [];
-    // The composer body changed (typed, restored-then-edited, or cleared on
-    // send). The parent decides whether to persist it as a draft.
+    /**
+     * The composer body changed (typed, restored-then-edited, or cleared on
+     * send). The parent decides whether to persist it as a draft.
+     */
     draftChange: [body: string];
-    // The composer text should be delivered later, at the chosen UTC instant.
+    /** The composer text should be delivered later, at the chosen UTC instant. */
     schedule: [body: string, mentions: Mention[], sendAt: string];
-    // Save an inline composer edit through the same PATCH path the message
-    // list's inline editor uses.
+    /**
+     * Save an inline composer edit through the same PATCH path the message
+     * list's inline editor uses.
+     */
     edit: [message: Message, body: string];
-    // The composer entered (message id) or left (null) edit mode, so the
-    // parent can highlight the target row in the timeline.
+    /**
+     * The composer entered (message id) or left (null) edit mode, so the
+     * parent can highlight the target row in the timeline.
+     */
     editingChange: [messageId: string | null];
 }>();
 
@@ -118,15 +144,19 @@ const { t } = useTranslations();
 const body = ref(props.initialBody ?? '');
 const textarea = ref<HTMLTextAreaElement | null>(null);
 
-// The message the composer is editing in place, or null in normal compose mode.
-// Set by the ArrowUp "edit last message" shortcut; while non-null the body is
-// scoped to that message, not a new-message draft.
+/**
+ * The message the composer is editing in place, or null in normal compose mode.
+ * Set by the ArrowUp "edit last message" shortcut; while non-null the body is
+ * scoped to that message, not a new-message draft.
+ */
 const editingMessage = ref<Message | null>(null);
 
-// When true, the next body change is a programmatic clear-on-send (or the wipe
-// that leaves edit mode), not a user edit, so it must not emit a draft change:
-// sending already clears the draft server-side, and re-emitting would fire a
-// redundant save.
+/**
+ * When true, the next body change is a programmatic clear-on-send (or the wipe
+ * that leaves edit mode), not a user edit, so it must not emit a draft change:
+ * sending already clears the draft server-side, and re-emitting would fire a
+ * redundant save.
+ */
 let clearingAfterSend = false;
 
 // Surface every body change so the parent can persist (or clear) the draft.
@@ -148,19 +178,23 @@ watch(body, (value) => {
     emit('draftChange', value);
 });
 
-// In a thread composer, whether the reply is also surfaced in the main timeline.
+/** In a thread composer, whether the reply is also surfaced in the main timeline. */
 const sendToChannel = ref(false);
 
-// Attachments are enabled only when the composer knows its channel: files
-// pre-upload to that channel's endpoint. The thread composer omits the slug, so
-// its "Add attachment" button stays disabled (thread attachments are a separate
-// epic child).
+/**
+ * Attachments are enabled only when the composer knows its channel: files
+ * pre-upload to that channel's endpoint. The thread composer omits the slug, so
+ * its "Add attachment" button stays disabled (thread attachments are a separate
+ * epic child).
+ */
 const attachmentsEnabled = computed(
     () => Boolean(props.teamSlug) && Boolean(props.channelSlug),
 );
 
-// The pre-send attachment tray: files upload immediately on pick/paste/drop,
-// each row tracking its own progress; the send later claims the finished ids.
+/**
+ * The pre-send attachment tray: files upload immediately on pick/paste/drop,
+ * each row tracking its own progress; the send later claims the finished ids.
+ */
 const uploads = useAttachmentUploads({
     endpoint: () =>
         storeAttachment({
@@ -176,9 +210,11 @@ const showTray = computed(
     () => attachmentsEnabled.value && trayItems.value.length > 0,
 );
 
-// A send is allowed once nothing is mid-upload or failed and there is something
-// to send (body text or at least one finished attachment). Body is optional
-// when the tray carries a ready attachment.
+/**
+ * A send is allowed once nothing is mid-upload or failed and there is something
+ * to send (body text or at least one finished attachment). Body is optional
+ * when the tray carries a ready attachment.
+ */
 const canSubmit = computed(() => {
     if (uploads.isUploading.value || uploads.hasFailed.value) {
         return false;
@@ -187,7 +223,7 @@ const canSubmit = computed(() => {
     return body.value.trim() !== '' || uploads.attachmentIds.value.length > 0;
 });
 
-// The hidden native file input the "Add attachment" button proxies to.
+/** The hidden native file input the "Add attachment" button proxies to. */
 const fileInput = ref<HTMLInputElement | null>(null);
 
 function openFilePicker(): void {
@@ -205,8 +241,10 @@ function onFilesPicked(event: Event): void {
     input.value = '';
 }
 
-// Pasting image data (a screenshot) or files into the composer stages them in
-// the tray instead of dropping raw bytes into the text.
+/**
+ * Pasting image data (a screenshot) or files into the composer stages them in
+ * the tray instead of dropping raw bytes into the text.
+ */
 function onPaste(event: ClipboardEvent): void {
     if (!attachmentsEnabled.value) {
         return;
@@ -220,8 +258,10 @@ function onPaste(event: ClipboardEvent): void {
     }
 }
 
-// Stage externally-provided files (the channel pane's drag-and-drop overlay
-// forwards its drop here). Exposed below.
+/**
+ * Stage externally-provided files (the channel pane's drag-and-drop overlay
+ * forwards its drop here). Exposed below.
+ */
 function addFiles(files: FileList | File[]): void {
     if (attachmentsEnabled.value) {
         uploads.addFiles(files);
@@ -258,13 +298,17 @@ watch(
     },
 );
 
-// Well-formed mention token: `@[Display Name](user-id)`. The parser on the
-// server resolves the id; here it lets us collect the mentions being sent and
-// recognise a completed token so it never re-triggers the autocomplete.
+/**
+ * Well-formed mention token: `@[Display Name](user-id)`. The parser on the
+ * server resolves the id; here it lets us collect the mentions being sent and
+ * recognise a completed token so it never re-triggers the autocomplete.
+ */
 const MENTION_TOKEN = /@\[[^\]]+\]\(([0-9a-fA-F-]{36})\)/g;
 
-// A fresh `@query` at the caret: an `@` at the start or after whitespace,
-// followed by run of non-space characters that isn't already a token.
+/**
+ * A fresh `@query` at the caret: an `@` at the start or after whitespace,
+ * followed by run of non-space characters that isn't already a token.
+ */
 const MENTION_QUERY = /(?:^|\s)@([^\s@[\]()]*)$/;
 
 const MAX_SUGGESTIONS = 8;
@@ -354,10 +398,12 @@ function selectActive(): void {
     }
 }
 
-// A slash command occupies the whole body up to the caret: a leading `/`
-// followed by word characters and nothing else. The menu therefore triggers
-// only at composer position 0 and closes the instant a space is typed (which
-// breaks the match), matching the server's `^/(name)(\s|$)` interception rule.
+/**
+ * A slash command occupies the whole body up to the caret: a leading `/`
+ * followed by word characters and nothing else. The menu therefore triggers
+ * only at composer position 0 and closes the instant a space is typed (which
+ * breaks the match), matching the server's `^/(name)(\s|$)` interception rule.
+ */
 const SLASH_QUERY = /^\/(\w*)$/;
 
 const slashSuggestions = ref<App.Data.SlashCommandData[]>([]);
@@ -368,8 +414,10 @@ const showSlashMenu = computed(
     () => slashMenuOpen.value && slashSuggestions.value.length > 0,
 );
 
-// True while a command send awaits the server. Unlike a normal (optimistic)
-// send, a command keeps its text and blocks re-submits until the outcome lands.
+/**
+ * True while a command send awaits the server. Unlike a normal (optimistic)
+ * send, a command keeps its text and blocks re-submits until the outcome lands.
+ */
 const commandPending = ref(false);
 
 function refreshSlashSuggestions(): void {
@@ -407,18 +455,22 @@ function slashMoveActive(delta: number): void {
     slashActiveIndex.value = (slashActiveIndex.value + delta + count) % count;
 }
 
-// The one picker-backed command: `/gif` opens the Giphy picker instead of
-// completing to text and posting through the command endpoint.
+/**
+ * The one picker-backed command: `/gif` opens the Giphy picker instead of
+ * completing to text and posting through the command endpoint.
+ */
 const GIF_COMMAND_NAME = 'gif';
 
-// The GIF picker's open state and the search term it opens on (from `/gif cats`).
+/** The GIF picker's open state and the search term it opens on (from `/gif cats`). */
 const gifPickerOpen = ref(false);
 const gifPickerQuery = ref('');
 
-// The picker is usable only when configured, when the composer knows its
-// channel (a picked GIF is staged as an attachment on that channel), and while
-// composing a new message — not editing an existing one (an inline edit saves
-// text only and cannot carry an attachment).
+/**
+ * The picker is usable only when configured, when the composer knows its
+ * channel (a picked GIF is staged as an attachment on that channel), and while
+ * composing a new message — not editing an existing one (an inline edit saves
+ * text only and cannot carry an attachment).
+ */
 const gifPickerAvailable = computed(
     () =>
         Boolean(props.gifPickerEnabled) &&
@@ -546,8 +598,10 @@ function resize(): void {
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
 }
 
-// The platform's primary modifier, for the format tooltips' shortcut hints.
-// Falls back to Ctrl off-Mac (and during SSR, where `navigator` is absent).
+/**
+ * The platform's primary modifier, for the format tooltips' shortcut hints.
+ * Falls back to Ctrl off-Mac (and during SSR, where `navigator` is absent).
+ */
 const isMac =
     typeof navigator !== 'undefined' &&
     /Mac|iPhone|iPad/.test(navigator.platform);
@@ -675,19 +729,23 @@ function insertMention(member: Mention): void {
     });
 }
 
-// Focus the input field, e.g. from the brand-new-workspace welcome's "Post your
-// first message" action.
+/**
+ * Focus the input field, e.g. from the brand-new-workspace welcome's "Post your
+ * first message" action.
+ */
 function focus(): void {
     nextTick(() => textarea.value?.focus());
 }
 
-// The whole card reads as "the message box", so a click anywhere in its chrome —
-// the padding, the whitespace around the single line of text — should activate
-// the input. Clicks that land on a control (send/attachment/schedule buttons) or
-// on the textarea itself carry their own behaviour and are left untouched; only
-// clicks on the non-interactive chrome fall through here to focus the field with
-// the caret at the end. `mousedown` is preventable before focus shifts, so the
-// redirect happens without a flicker of the card losing then regaining focus.
+/**
+ * The whole card reads as "the message box", so a click anywhere in its chrome —
+ * the padding, the whitespace around the single line of text — should activate
+ * the input. Clicks that land on a control (send/attachment/schedule buttons) or
+ * on the textarea itself carry their own behaviour and are left untouched; only
+ * clicks on the non-interactive chrome fall through here to focus the field with
+ * the caret at the end. `mousedown` is preventable before focus shifts, so the
+ * redirect happens without a flicker of the card losing then regaining focus.
+ */
 function focusFromCard(event: MouseEvent): void {
     const el = textarea.value;
 
@@ -710,8 +768,10 @@ function focusFromCard(event: MouseEvent): void {
 
 defineExpose({ insertMention, focus, addFiles });
 
-// Clear the composer after the text has been handed off (an immediate send or a
-// scheduled one), flagging the wipe so it doesn't re-persist as a draft.
+/**
+ * Clear the composer after the text has been handed off (an immediate send or a
+ * scheduled one), flagging the wipe so it doesn't re-persist as a draft.
+ */
 function clearAfterHandoff(): void {
     clearingAfterSend = true;
     body.value = '';
@@ -899,12 +959,16 @@ function saveEdit(): void {
     exitEditMode();
 }
 
-// Whether the schedule picker is open. Opening requires some text — an empty
-// composer has nothing to schedule.
+/**
+ * Whether the schedule picker is open. Opening requires some text — an empty
+ * composer has nothing to schedule.
+ */
 const scheduling = ref(false);
 
-// Scheduling never carries attachments, so the "Send later" affordances gate on
-// body text alone, matching the old schedule button's guard.
+/**
+ * Scheduling never carries attachments, so the "Send later" affordances gate on
+ * body text alone, matching the old schedule button's guard.
+ */
 const canSchedule = computed(() => body.value.trim() !== '');
 
 function openSchedule(): void {

--- a/resources/js/components/MessageForward.vue
+++ b/resources/js/components/MessageForward.vue
@@ -7,7 +7,7 @@ import type { Mention } from '@/types';
 
 const props = defineProps<{
     authorName: string;
-    // Null when the source is a direct message, which has no channel name.
+    /** Null when the source is a direct message, which has no channel name. */
     channelName: string | null;
     body: string;
     isDeleted: boolean;
@@ -16,8 +16,10 @@ const props = defineProps<{
 
 const { map: customEmojis } = useCustomEmojis();
 
-// The forwarded body, rendered with its own mentions; empty for a deleted
-// source, whose body is never sent to the client.
+/**
+ * The forwarded body, rendered with its own mentions; empty for a deleted
+ * source, whose body is never sent to the client.
+ */
 const rendered = computed(() =>
     props.isDeleted
         ? ''

--- a/resources/js/components/MessageLightbox.vue
+++ b/resources/js/components/MessageLightbox.vue
@@ -22,7 +22,7 @@ const props = defineProps<{
     startIndex: number;
     authorName: string;
     createdAt: string;
-    // The viewer's configured timezone, matching the timeline's formatting.
+    /** The viewer's configured timezone, matching the timeline's formatting. */
     viewerTimeZone?: string;
 }>();
 
@@ -32,8 +32,10 @@ const emit = defineEmits<{
 
 const { t } = useTranslations();
 
-// The image currently on screen. Seeded from the tile that was clicked and
-// stepped through the message's images with the arrows; wraps at either end.
+/**
+ * The image currently on screen. Seeded from the tile that was clicked and
+ * stepped through the message's images with the arrows; wraps at either end.
+ */
 const current = ref(props.startIndex);
 
 watch(
@@ -47,9 +49,11 @@ watch(
 
 const activeImage = computed<AttachmentData>(() => props.images[current.value]);
 
-// A human name for the active image: its upload filename, else its remote
-// description (a Giphy GIF has no filename), else a generic fallback. Feeds the
-// dialog title, download name, and alt.
+/**
+ * A human name for the active image: its upload filename, else its remote
+ * description (a Giphy GIF has no filename), else a generic fallback. Feeds the
+ * dialog title, download name, and alt.
+ */
 const activeLabel = computed(
     () =>
         activeImage.value.filename ?? activeImage.value.description ?? t('GIF'),

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -50,50 +50,74 @@ import type {
 
 const props = defineProps<{
     messages: Message[];
-    // The team the messages belong to, so author hover cards can resolve the
-    // right member profile.
+    /**
+     * The team the messages belong to, so author hover cards can resolve the
+     * right member profile.
+     */
     teamSlug: string;
     pendingUuids?: string[];
-    // Client uuids of the viewer's own sends held in the offline outbox; each
-    // renders a "Queued — will send on reconnect" marker until it flushes.
+    /**
+     * Client uuids of the viewer's own sends held in the offline outbox; each
+     * renders a "Queued — will send on reconnect" marker until it flushes.
+     */
     queuedUuids?: string[];
     currentUserId: string;
-    // Whether the timeline belongs to a direct message, so a "member left" notice
-    // reads "left the conversation" rather than "left the channel".
+    /**
+     * Whether the timeline belongs to a direct message, so a "member left" notice
+     * reads "left the conversation" rather than "left the channel".
+     */
     isDirect?: boolean;
     canModerate?: boolean;
-    // Whether the viewer may add/remove reactions (member of a non-archived
-    // channel); existing reaction pills still render read-only when false.
+    /**
+     * Whether the viewer may add/remove reactions (member of a non-archived
+     * channel); existing reaction pills still render read-only when false.
+     */
     canReact?: boolean;
-    // Whether the viewer may pin/unpin messages (member of a non-archived
-    // channel); the "Pinned by" indicator still renders read-only when false.
+    /**
+     * Whether the viewer may pin/unpin messages (member of a non-archived
+     * channel); the "Pinned by" indicator still renders read-only when false.
+     */
     canPin?: boolean;
     onlineIds?: Set<string>;
     highlightMessageId?: string | null;
-    // The message the "New messages" divider sits above — the first unread on
-    // channel open — or null when there's no unread boundary to mark.
+    /**
+     * The message the "New messages" divider sits above — the first unread on
+     * channel open — or null when there's no unread boundary to mark.
+     */
     unreadDividerId?: string | null;
-    // Rendered inside a thread panel: hides the per-message thread affordances
-    // (you're already in the thread), so the panel only shows the conversation.
+    /**
+     * Rendered inside a thread panel: hides the per-message thread affordances
+     * (you're already in the thread), so the panel only shows the conversation.
+     */
     inThread?: boolean;
-    // The root of the currently-open thread, highlighted in the main timeline.
+    /** The root of the currently-open thread, highlighted in the main timeline. */
     activeThreadRootId?: string | null;
-    // The message currently being edited from the composer, brass-highlighted so
-    // the edit target is unmistakable while the composer holds its text.
+    /**
+     * The message currently being edited from the composer, brass-highlighted so
+     * the edit target is unmistakable while the composer holds its text.
+     */
     editingMessageId?: string | null;
-    // Read positions of channel members who share read receipts, driving the
-    // "Seen by" affordance under the newest message. Omitted inside a thread.
+    /**
+     * Read positions of channel members who share read receipts, driving the
+     * "Seen by" affordance under the newest message. Omitted inside a thread.
+     */
     readers?: ChannelReader[];
-    // Opt into windowed (virtualized) rendering. The main channel timeline sets
-    // this so only on-screen rows mount; the thread panel leaves it off and
-    // renders the full list.
+    /**
+     * Opt into windowed (virtualized) rendering. The main channel timeline sets
+     * this so only on-screen rows mount; the thread panel leaves it off and
+     * renders the full list.
+     */
     virtualize?: boolean;
-    // The parent-owned scroll container the virtualizer drives. Required when
-    // `virtualize` is set; the virtualizer reads its scroll offset and height.
+    /**
+     * The parent-owned scroll container the virtualizer drives. Required when
+     * `virtualize` is set; the virtualizer reads its scroll offset and height.
+     */
     scrollElement?: HTMLElement | null;
-    // Whether older history remains to fetch, and whether a fetch is already in
-    // flight — read by the virtualizer to gate its top-load trigger. Supplied by
-    // the parent, which owns Inertia's `<InfiniteScroll>` merge engine.
+    /**
+     * Whether older history remains to fetch, and whether a fetch is already in
+     * flight — read by the virtualizer to gate its top-load trigger. Supplied by
+     * the parent, which owns Inertia's `<InfiniteScroll>` merge engine.
+     */
     hasOlder?: () => boolean;
     isLoadingOlder?: () => boolean;
 }>();
@@ -111,19 +135,21 @@ const emit = defineEmits<{
     openThread: [messageId: string];
     jump: [messageId: string];
     mention: [member: { id: string; name: string }];
-    // The reader has scrolled near the top of the loaded history: fetch older.
+    /** The reader has scrolled near the top of the loaded history: fetch older. */
     loadOlder: [];
-    // The virtualizer's visible render-item window changed, so the parent can
-    // recompute position-dependent affordances (the unread-jump pill).
+    /**
+     * The virtualizer's visible render-item window changed, so the parent can
+     * recompute position-dependent affordances (the unread-jump pill).
+     */
     rangeChange: [range: { startIndex: number; endIndex: number }];
 }>();
 
-// The viewer's stored zone, feeding the reminder popover's wall-clock presets.
+/** The viewer's stored zone, feeding the reminder popover's wall-clock presets. */
 const viewerTimezone = computed<string | null>(
     () => page.props.auth.user.timezone ?? null,
 );
 
-// How many participant avatars to preview on a root's "N replies" affordance.
+/** How many participant avatars to preview on a root's "N replies" affordance. */
 const MAX_THREAD_AVATARS = 3;
 
 function threadAvatars(message: Message): Mention[] {
@@ -143,12 +169,16 @@ function isThreadRoot(item: TimelineGroup): boolean {
     return props.inThread === true && item.messages[0]?.threadRootId === null;
 }
 
-// How many reader avatars to preview on the "Seen by" row before collapsing the
-// rest into a "+N" overflow chip.
+/**
+ * How many reader avatars to preview on the "Seen by" row before collapsing the
+ * rest into a "+N" overflow chip.
+ */
 const MAX_SEEN_AVATARS = 3;
 
-// The members who have read up to the newest message, driving the "Seen by" row.
-// Empty inside a thread panel and on an empty timeline.
+/**
+ * The members who have read up to the newest message, driving the "Seen by" row.
+ * Empty inside a thread panel and on an empty timeline.
+ */
 const seenByReaders = computed<MessageAuthor[]>(() => {
     if (props.inThread || props.messages.length === 0) {
         return [];
@@ -171,8 +201,10 @@ const extraSeenBy = computed(() =>
     Math.max(0, seenByReaders.value.length - MAX_SEEN_AVATARS),
 );
 
-// A full, human-readable roster ("Seen by Alice, Bob and 3 others") used as the
-// row's accessible label and hover title, so the compact avatars still name who.
+/**
+ * A full, human-readable roster ("Seen by Alice, Bob and 3 others") used as the
+ * row's accessible label and hover title, so the compact avatars still name who.
+ */
 const seenByLabel = computed(() => {
     const names = seenByReaders.value.map((reader) => reader.name);
 
@@ -210,7 +242,7 @@ const { map: customEmojis } = useCustomEmojis();
 
 const page = usePage();
 
-// Render timestamps in the viewer's stored zone, falling back to the browser's.
+/** Render timestamps in the viewer's stored zone, falling back to the browser's. */
 const viewerTimeZone = computed(
     () => page.props.auth.user.timezone ?? undefined,
 );
@@ -268,22 +300,26 @@ function systemNoticeText(message: Message): string {
         : t(':name joined the channel', { name });
 }
 
-// The grouped, divider-interleaved render list. The grouping and boundary logic
-// lives in a pure, unit-tested helper; the day label is formatted here so it
-// stays relative to the viewer's "today".
+/**
+ * The grouped, divider-interleaved render list. The grouping and boundary logic
+ * lives in a pure, unit-tested helper; the day label is formatted here so it
+ * stays relative to the viewer's "today".
+ */
 const renderItems = computed(() =>
     buildTimelineItems(props.messages, props.unreadDividerId ?? null),
 );
 
-// Windowed rendering. Only the main channel timeline opts in (`virtualize`); the
-// thread panel leaves the virtualizer idle (count 0) and renders every row. The
-// virtualizer drives the parent's scroll container, keeping its real
-// `scrollHeight`/`scrollTop` so the shared pin-to-bottom math is untouched.
-// Windowing is client-only: the virtualizer needs a live scroll element and
-// measured heights, neither of which exist during SSR. Rendering the full list
-// on the server (and through first hydration) keeps server and client markup
-// identical, then we switch to the window once mounted — a post-hydration
-// re-render, not a mismatch.
+/**
+ * Windowed rendering. Only the main channel timeline opts in (`virtualize`); the
+ * thread panel leaves the virtualizer idle (count 0) and renders every row. The
+ * virtualizer drives the parent's scroll container, keeping its real
+ * `scrollHeight`/`scrollTop` so the shared pin-to-bottom math is untouched.
+ * Windowing is client-only: the virtualizer needs a live scroll element and
+ * measured heights, neither of which exist during SSR. Rendering the full list
+ * on the server (and through first hydration) keeps server and client markup
+ * identical, then we switch to the window once mounted — a post-hydration
+ * re-render, not a mismatch.
+ */
 const isMounted = ref(false);
 
 onMounted(() => {
@@ -294,14 +330,16 @@ const virtualizeActive = computed(
     () => props.virtualize === true && isMounted.value,
 );
 
-// True while a deliberate jump-to-present is in flight. The scrub skeletons swap
-// full message content for a fixed 56px placeholder, so measuring them mid-jump
-// feeds the virtualizer short heights; when rows then swap to their taller real
-// content the list grows and the animation is left stranded above the newest
-// message — the "it stops when the skeleton loads" symptom (#347). While this is
-// set, skeletons are suppressed so every row entering the window measures its
-// real height, and the virtualizer's upward size-change anchoring is disabled so
-// a row measured above the viewport can't drift us up as we settle on the bottom.
+/**
+ * True while a deliberate jump-to-present is in flight. The scrub skeletons swap
+ * full message content for a fixed 56px placeholder, so measuring them mid-jump
+ * feeds the virtualizer short heights; when rows then swap to their taller real
+ * content the list grows and the animation is left stranded above the newest
+ * message — the "it stops when the skeleton loads" symptom (#347). While this is
+ * set, skeletons are suppressed so every row entering the window measures its
+ * real height, and the virtualizer's upward size-change anchoring is disabled so
+ * a row measured above the viewport can't drift us up as we settle on the bottom.
+ */
 const jumpingToBottom = ref(false);
 
 const {
@@ -332,9 +370,11 @@ type RenderRow = {
     offsetTop: number | null;
 };
 
-// The rows to render: the full list when the thread panel renders it flat, or
-// just the virtualizer's window (each carrying its absolute offset) for the main
-// timeline.
+/**
+ * The rows to render: the full list when the thread panel renders it flat, or
+ * just the virtualizer's window (each carrying its absolute offset) for the main
+ * timeline.
+ */
 const renderRows = computed<RenderRow[]>(() => {
     if (!virtualizeActive.value) {
         return renderItems.value.map((item, index) => ({
@@ -351,9 +391,11 @@ const renderRows = computed<RenderRow[]>(() => {
     }));
 });
 
-// Render items whose height the virtualizer has already settled. A row is
-// recorded once scrolling stops, so a fast scrub shows height-stable skeletons
-// for rows it hasn't paused on, and they materialize the instant it settles.
+/**
+ * Render items whose height the virtualizer has already settled. A row is
+ * recorded once scrolling stops, so a fast scrub shows height-stable skeletons
+ * for rows it hasn't paused on, and they materialize the instant it settles.
+ */
 const settledKeys = ref<Set<string>>(new Set());
 
 /**
@@ -387,21 +429,23 @@ watch(isScrolling, (scrolling) => {
     }
 });
 
-// A windowed jump can't know the true bottom up front: `scrollToEnd` aims at the
-// bottom the virtualizer can see now, but each row measured as the animation
-// passes it grows the list, so the target keeps moving. `finalizeJump` follows
-// the animation to the bottom, then glues the view there frame by frame until both
-// the measured height plateaus and the scroll goes quiet, so late measurements
-// settle without a visible bounce.
-//
-// The glue releases on convergence, not a fixed frame count: it holds until the
-// scroll height has been steady for `JUMP_SETTLE_FRAMES` consecutive frames *and*
-// the container has stopped scrolling. A fixed budget let go too early on a slow
-// render — while rows were still measuring, or while the glue's own `scrollTop`
-// writes still counted as scrolling — so unsettled rows flipped in their scrub
-// skeletons and the virtualizer's re-enabled size-change anchoring drifted the
-// view below the fold: the timeline landing short of the newest message on initial
-// open of a long list of tall rows (#500).
+/**
+ * A windowed jump can't know the true bottom up front: `scrollToEnd` aims at the
+ * bottom the virtualizer can see now, but each row measured as the animation
+ * passes it grows the list, so the target keeps moving. `finalizeJump` follows
+ * the animation to the bottom, then glues the view there frame by frame until both
+ * the measured height plateaus and the scroll goes quiet, so late measurements
+ * settle without a visible bounce.
+ *
+ * The glue releases on convergence, not a fixed frame count: it holds until the
+ * scroll height has been steady for `JUMP_SETTLE_FRAMES` consecutive frames *and*
+ * the container has stopped scrolling. A fixed budget let go too early on a slow
+ * render — while rows were still measuring, or while the glue's own `scrollTop`
+ * writes still counted as scrolling — so unsettled rows flipped in their scrub
+ * skeletons and the virtualizer's re-enabled size-change anchoring drifted the
+ * view below the fold: the timeline landing short of the newest message on initial
+ * open of a long list of tall rows (#500).
+ */
 const JUMP_SETTLE_FRAMES = 4;
 const JUMP_MAX_FRAMES = 180;
 let jumpRaf: number | null = null;
@@ -569,10 +613,12 @@ function isQueued(message: Message): boolean {
     return queued.value.has(message.clientUuid);
 }
 
-// The viewer context each per-message guard resolves against. The hover-action
-// bar (extracted to MessageActions) owns the toolbar guards; the two rules below
-// stay here because they drive non-toolbar UI — the reaction pills and the
-// thread summary — and share the same context.
+/**
+ * The viewer context each per-message guard resolves against. The hover-action
+ * bar (extracted to MessageActions) owns the toolbar guards; the two rules below
+ * stay here because they drive non-toolbar UI — the reaction pills and the
+ * thread summary — and share the same context.
+ */
 function actionContext(message: Message): MessageActionContext {
     return {
         currentUserId: props.currentUserId,
@@ -584,25 +630,31 @@ function actionContext(message: Message): MessageActionContext {
     };
 }
 
-// The viewer may react to any live, confirmed message when they're a member of
-// the (non-archived) channel; drives whether the reaction pills accept toggles.
+/**
+ * The viewer may react to any live, confirmed message when they're a member of
+ * the (non-archived) channel; drives whether the reaction pills accept toggles.
+ */
 function canReactTo(message: Message): boolean {
     return canReactToMessage(message, actionContext(message));
 }
 
-// The "N replies" affordance shows on any root that has replies, even a deleted
-// one — the thread outlives its root as a tombstone.
+/**
+ * The "N replies" affordance shows on any root that has replies, even a deleted
+ * one — the thread outlives its root as a tombstone.
+ */
 function showThreadSummary(message: Message): boolean {
     return showsThreadSummary(message, actionContext(message));
 }
 
-// The message currently being edited inline, and its working draft.
+/** The message currently being edited inline, and its working draft. */
 const editingId = ref<string | null>(null);
 const editDraft = ref('');
 const editField = ref<HTMLTextAreaElement | null>(null);
 
-// A plain template ref inside v-for collects into an array; a function ref keeps
-// the single visible editor element (only one row edits at a time).
+/**
+ * A plain template ref inside v-for collects into an array; a function ref keeps
+ * the single visible editor element (only one row edits at a time).
+ */
 function setEditField(el: unknown): void {
     editField.value = (el as HTMLTextAreaElement | null) ?? null;
 }
@@ -629,7 +681,7 @@ function saveEdit(message: Message): void {
     cancelEdit();
 }
 
-// The message queued for deletion; a non-null value drives the confirm dialog.
+/** The message queued for deletion; a non-null value drives the confirm dialog. */
 const pendingDelete = ref<Message | null>(null);
 
 function requestDelete(message: Message): void {

--- a/resources/js/components/MessageReactions.vue
+++ b/resources/js/components/MessageReactions.vue
@@ -15,8 +15,10 @@ import type { Reaction } from '@/types';
 const props = defineProps<{
     reactions: Reaction[];
     currentUserId: string;
-    // Whether the viewer may add/remove reactions (channel member, non-archived);
-    // when false the existing pills still render read-only.
+    /**
+     * Whether the viewer may add/remove reactions (channel member, non-archived);
+     * when false the existing pills still render read-only.
+     */
     canReact: boolean;
 }>();
 

--- a/resources/js/components/MessageReminderPopover.vue
+++ b/resources/js/components/MessageReminderPopover.vue
@@ -16,20 +16,24 @@ import {
 import { reminderPresets } from '@/lib/reminderTime';
 
 const props = defineProps<{
-    // The viewer's stored IANA zone; falls back to the runtime zone when null so
-    // the wall-clock presets ("Tomorrow 9am") resolve in a real zone.
+    /**
+     * The viewer's stored IANA zone; falls back to the runtime zone when null so
+     * the wall-clock presets ("Tomorrow 9am") resolve in a real zone.
+     */
     timezone: string | null;
-    // Optional label shown in a tooltip above the trigger on hover and keyboard
-    // focus. When set, the trigger is composed as Tooltip → PopoverTrigger so the
-    // one button anchors both the popover (on click) and the tooltip (on
-    // hover/focus); this requires a TooltipProvider ancestor.
+    /**
+     * Optional label shown in a tooltip above the trigger on hover and keyboard
+     * focus. When set, the trigger is composed as Tooltip → PopoverTrigger so the
+     * one button anchors both the popover (on click) and the tooltip (on
+     * hover/focus); this requires a TooltipProvider ancestor.
+     */
     tooltip?: string;
 }>();
 
 const emit = defineEmits<{
-    // A preset was chosen: the resolved UTC instant to remind at.
+    /** A preset was chosen: the resolved UTC instant to remind at. */
     set: [remindAt: string];
-    // The viewer wants to pick an exact date & time instead.
+    /** The viewer wants to pick an exact date & time instead. */
     custom: [];
 }>();
 
@@ -39,8 +43,10 @@ const effectiveZone = computed(
     () => props.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
 );
 
-// Recomputed each time the popover opens so "In 20 minutes" is always measured
-// from now, never from when the row first rendered.
+/**
+ * Recomputed each time the popover opens so "In 20 minutes" is always measured
+ * from now, never from when the row first rendered.
+ */
 const presets = ref(reminderPresets(effectiveZone.value));
 
 function onOpenChange(next: boolean): void {

--- a/resources/js/components/OnboardingTour.vue
+++ b/resources/js/components/OnboardingTour.vue
@@ -7,14 +7,16 @@ import { useOnboardingTour } from '@/composables/useOnboardingTour';
 const { isOpen, stepIndex, steps, currentStep, isLastStep, next, skip } =
     useOnboardingTour();
 
-// Padding around the spotlighted element, and how far the coachmark sits from it.
+/** Padding around the spotlighted element, and how far the coachmark sits from it. */
 const SPOTLIGHT_PADDING = 8;
 const BUBBLE_GAP = 16;
 const BUBBLE_WIDTH = 340;
 
-// The active step's anchor rect in viewport coordinates, or null when the anchor
-// is not on the page (e.g. it lives inside the collapsed mobile sidebar sheet),
-// in which case the coachmark falls back to the screen centre.
+/**
+ * The active step's anchor rect in viewport coordinates, or null when the anchor
+ * is not on the page (e.g. it lives inside the collapsed mobile sidebar sheet),
+ * in which case the coachmark falls back to the screen centre.
+ */
 const targetRect = ref<DOMRect | null>(null);
 
 function measure(): void {
@@ -33,8 +35,10 @@ function measure(): void {
     targetRect.value = element?.getBoundingClientRect() ?? null;
 }
 
-// The spotlight ring: a transparent box over the anchor whose huge box-shadow
-// dims the rest of the screen, cutting a lit hole around the highlighted action.
+/**
+ * The spotlight ring: a transparent box over the anchor whose huge box-shadow
+ * dims the rest of the screen, cutting a lit hole around the highlighted action.
+ */
 const spotlightStyle = computed(() => {
     const rect = targetRect.value;
 
@@ -50,9 +54,11 @@ const spotlightStyle = computed(() => {
     };
 });
 
-// Position the coachmark next to the anchor — above it when it sits in the lower
-// half of the viewport, otherwise below — clamped to stay on screen. Falls back
-// to the centre when there is no anchor.
+/**
+ * Position the coachmark next to the anchor — above it when it sits in the lower
+ * half of the viewport, otherwise below — clamped to stay on screen. Falls back
+ * to the centre when there is no anchor.
+ */
 const bubbleStyle = computed(() => {
     const rect = targetRect.value;
 

--- a/resources/js/components/PinsPanel.vue
+++ b/resources/js/components/PinsPanel.vue
@@ -9,15 +9,17 @@ import { messageBodyPreview } from '@/lib/messageBody';
 import type { Message } from '@/types';
 
 const props = defineProps<{
-    // The channel's pinned messages, most-recently-pinned first.
+    /** The channel's pinned messages, most-recently-pinned first. */
     pins: Message[];
-    // The channel's pin count, shown as "N of :max" in the header.
+    /** The channel's pin count, shown as "N of :max" in the header. */
     pinCount: number;
-    // Whether the viewer may unpin (member of a non-archived channel). The
-    // per-row Unpin affordance is hidden when false — a non-member or an archived
-    // channel still lists and jumps to pins, read-only.
+    /**
+     * Whether the viewer may unpin (member of a non-archived channel). The
+     * per-row Unpin affordance is hidden when false — a non-member or an archived
+     * channel still lists and jumps to pins, read-only.
+     */
     canPin: boolean;
-    // The viewer's stored zone, so pinned-at and authored-at read in their clock.
+    /** The viewer's stored zone, so pinned-at and authored-at read in their clock. */
     viewerTimezone: string | null;
 }>();
 
@@ -27,18 +29,20 @@ const emit = defineEmits<{
     unpin: [message: Message];
 }>();
 
-// The hard cap, mirroring PinMessageRequest::MAX_PINS, shown as "N of 100".
+/** The hard cap, mirroring PinMessageRequest::MAX_PINS, shown as "N of 100". */
 const MAX_PINS = 100;
 
 const { getInitials } = useInitials();
 
-// A pinned row always carries its pin (it came from the pins query), but the
-// type is nullable; this narrows it for the template without a non-null bang.
+/**
+ * A pinned row always carries its pin (it came from the pins query), but the
+ * type is nullable; this narrows it for the template without a non-null bang.
+ */
 function pinnedByName(message: Message): string {
     return message.pin?.pinnedBy.name ?? '';
 }
 
-// Dismiss the popover on Escape, matching the outside-click backdrop.
+/** Dismiss the popover on Escape, matching the outside-click backdrop. */
 function onKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape') {
         emit('close');

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -39,22 +39,26 @@ const props = defineProps<{
 const open = defineModel<boolean>('open', { default: false });
 
 const emit = defineEmits<{
-    // The viewer picked the "Reminders" action; the layout owns the dialog.
+    /** The viewer picked the "Reminders" action; the layout owns the dialog. */
     openReminders: [];
 }>();
 
-// Our own query drives the fuzzy channel ranking. The Command's internal filter
-// state is deliberately left untouched (empty) so it never hides a subsequence
-// match that `rankChannels` chose to surface — the ranked list is the single
-// source of truth for what shows and in what order.
+/**
+ * Our own query drives the fuzzy channel ranking. The Command's internal filter
+ * state is deliberately left untouched (empty) so it never hides a subsequence
+ * match that `rankChannels` chose to surface — the ranked list is the single
+ * source of truth for what shows and in what order.
+ */
 const query = ref('');
 
 const trimmedQuery = computed(() => query.value.trim().replace(/^#+/, ''));
 
-// Parse the raw input into the shared filter model so `from:` / `in:` /
-// `before:` / `after:` tokens drive the same structured search the page uses —
-// the palette just has no visible chip bar. The residual text is the query the
-// results highlight and the channel/people groups keep ranking on.
+/**
+ * Parse the raw input into the shared filter model so `from:` / `in:` /
+ * `before:` / `after:` tokens drive the same structured search the page uses —
+ * the palette just has no visible chip bar. The residual text is the query the
+ * results highlight and the channel/people groups keep ranking on.
+ */
 const parsedFilters = computed(() =>
     parseSearchQuery(query.value, {
         members: props.members,
@@ -76,9 +80,11 @@ const peopleResults = computed(() =>
     rankPeople(props.members, query.value, props.currentUserId),
 );
 
-// Live message search: a debounced JSON call to the suggest endpoint, with the
-// in-flight request cancelled whenever the query changes so late responses
-// never overwrite newer ones.
+/**
+ * Live message search: a debounced JSON call to the suggest endpoint, with the
+ * in-flight request cancelled whenever the query changes so late responses
+ * never overwrite newer ones.
+ */
 const {
     results: messageResults,
     isSearching: isSearchingMessages,

--- a/resources/js/components/ReminderNudge.vue
+++ b/resources/js/components/ReminderNudge.vue
@@ -11,20 +11,20 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-    // Jump to the reminded message and acknowledge the nudge.
+    /** Jump to the reminded message and acknowledge the nudge. */
     open: [reminder: MessageReminder];
-    // Push the reminder out by 20 minutes.
+    /** Push the reminder out by 20 minutes. */
     snooze: [reminder: MessageReminder];
-    // Acknowledge and clear the nudge without jumping.
+    /** Acknowledge and clear the nudge without jumping. */
     dismiss: [reminder: MessageReminder];
 }>();
 
 const { getInitials } = useInitials();
 
-// A one-line preview of the reminded message, or a stub when it was deleted.
+/** A one-line preview of the reminded message, or a stub when it was deleted. */
 const excerpt = computed(() => messageBodyPreview(props.reminder.body));
 
-// "#design" for a channel, blank for a direct message (no channel name).
+/** "#design" for a channel, blank for a direct message (no channel name). */
 const channelLabel = computed(() =>
     props.reminder.channelName ? `#${props.reminder.channelName}` : null,
 );

--- a/resources/js/components/RemindersDialog.vue
+++ b/resources/js/components/RemindersDialog.vue
@@ -21,11 +21,11 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-    // Jump to the reminded message (and close the dialog).
+    /** Jump to the reminded message (and close the dialog). */
     open: [reminder: MessageReminder];
-    // Clear a single pending reminder.
+    /** Clear a single pending reminder. */
     clear: [id: string];
-    // Clear every pending reminder shown.
+    /** Clear every pending reminder shown. */
     clearAll: [];
 }>();
 
@@ -37,8 +37,10 @@ const effectiveZone = computed(
     () => props.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
 );
 
-// The pending reminders arrive sorted soonest-first; split them so due-today
-// reminders sit above the rest, matching the design's "Today / Later" sections.
+/**
+ * The pending reminders arrive sorted soonest-first; split them so due-today
+ * reminders sit above the rest, matching the design's "Today / Later" sections.
+ */
 const todayReminders = computed(() =>
     props.reminders.filter((reminder) =>
         isReminderToday(reminder.remindAt, effectiveZone.value),

--- a/resources/js/components/ScheduleMessageDialog.vue
+++ b/resources/js/components/ScheduleMessageDialog.vue
@@ -33,10 +33,12 @@ import type { SchedulePreset } from '@/lib/scheduleTime';
 
 const props = withDefaults(
     defineProps<{
-        // The viewer's stored IANA zone; falls back to the runtime zone when null
-        // so presets and the picker are always resolved in a real zone.
+        /**
+         * The viewer's stored IANA zone; falls back to the runtime zone when null
+         * so presets and the picker are always resolved in a real zone.
+         */
         timezone: string | null;
-        // When editing an existing scheduled message, the instant to open on.
+        /** When editing an existing scheduled message, the instant to open on. */
         initialSendAt?: string | null;
         title?: string;
         confirmLabel?: string;

--- a/resources/js/components/ScheduledCountChip.vue
+++ b/resources/js/components/ScheduledCountChip.vue
@@ -3,14 +3,16 @@ import { Clock } from '@lucide/vue';
 import { Button } from '@/components/ui/button';
 
 defineProps<{
-    // Number of pending scheduled messages for the channel (always > 0 at the
-    // call site — the chip is only rendered when there are some to view).
+    /**
+     * Number of pending scheduled messages for the channel (always > 0 at the
+     * call site — the chip is only rendered when there are some to view).
+     */
     count: number;
     channelName: string;
 }>();
 
 const emit = defineEmits<{
-    // Open the scheduled-messages list dialog.
+    /** Open the scheduled-messages list dialog. */
     view: [];
 }>();
 </script>

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -11,13 +11,17 @@ import { useScrollPin } from '@/composables/useScrollPin';
 import type { Mention, Message } from '@/types';
 
 const props = defineProps<{
-    // The open thread's root id, used to key the reply scroll so switching
-    // threads mounts a fresh, bottom-anchored list.
+    /**
+     * The open thread's root id, used to key the reply scroll so switching
+     * threads mounts a fresh, bottom-anchored list.
+     */
     rootId: string;
     teamSlug: string;
     channelName: string;
-    // The root followed by its replies (oldest first), merged and deduped by the
-    // parent's thread stream; empty while the thread is still loading.
+    /**
+     * The root followed by its replies (oldest first), merged and deduped by the
+     * parent's thread stream; empty while the thread is still loading.
+     */
     messages: Message[];
     pendingUuids?: string[];
     members: Mention[];
@@ -45,29 +49,37 @@ const emit = defineEmits<{
     jump: [messageId: string];
 }>();
 
-// The root is the thread's only top-level message; everything else is a reply.
+/** The root is the thread's only top-level message; everything else is a reply. */
 const root = computed(() =>
     props.messages.find((message) => message.threadRootId === null),
 );
 const hasRoot = computed(() => root.value !== undefined);
-// The header shows the thread's total reply count (denormalized on the root),
-// not just the replies currently paged into view.
+/**
+ * The header shows the thread's total reply count (denormalized on the root),
+ * not just the replies currently paged into view.
+ */
 const replyCount = computed(() => root.value?.threadReplyCount ?? 0);
 const showSkeleton = computed(() => props.loading || !hasRoot.value);
 
-// Shared scroll/pin bookkeeping, identical to the main timeline's: the
-// pinned-to-newest flag, the "N new replies" count while scrolled up, and the
-// smooth jump back to the bottom.
+/**
+ * Shared scroll/pin bookkeeping, identical to the main timeline's: the
+ * pinned-to-newest flag, the "N new replies" count while scrolled up, and the
+ * smooth jump back to the bottom.
+ */
 const scrollContainer = ref<HTMLElement | null>(null);
-// `ScrollableMessageList` owns the scroll element; this points our ref at it so
-// `useScrollPin` binds to the very same node.
+/**
+ * `ScrollableMessageList` owns the scroll element; this points our ref at it so
+ * `useScrollPin` binds to the very same node.
+ */
 const setScrollContainer = (el: HTMLElement | null): void => {
     scrollContainer.value = el;
 };
-// The windowed `MessageList` exposes `scrollToLatest`, so the jump-to-newest
-// lands on the real bottom: a native `scrollTo(scrollHeight)` settles short on
-// the virtualizer's estimated spacer (#347). Inertia's manual `<InfiniteScroll>`
-// exposes the older-page fetch. Both are read through template refs.
+/**
+ * The windowed `MessageList` exposes `scrollToLatest`, so the jump-to-newest
+ * lands on the real bottom: a native `scrollTo(scrollHeight)` settles short on
+ * the virtualizer's estimated spacer (#347). Inertia's manual `<InfiniteScroll>`
+ * exposes the older-page fetch. Both are read through template refs.
+ */
 const messageListRef = ref<{
     scrollToIndex: (
         index: number,
@@ -81,19 +93,25 @@ const infiniteScrollRef = ref<{
     hasNext: () => boolean;
 } | null>(null);
 
-// True while an older reply page is being fetched, gating the virtualizer's
-// top-load trigger so a burst of range updates during a fast scroll can't stack
-// duplicate requests. Cleared once the merged list grows (older replies landed).
+/**
+ * True while an older reply page is being fetched, gating the virtualizer's
+ * top-load trigger so a burst of range updates during a fast scroll can't stack
+ * duplicate requests. Cleared once the merged list grows (older replies landed).
+ */
 const loadingOlder = ref(false);
 
-// In reverse mode the server returns replies newest-first, so "load older" maps
-// to the paginator's *next* page.
+/**
+ * In reverse mode the server returns replies newest-first, so "load older" maps
+ * to the paginator's *next* page.
+ */
 const hasOlder = (): boolean => infiniteScrollRef.value?.hasNext() ?? false;
 
 const isLoadingOlder = (): boolean => loadingOlder.value;
 
-// Fetch the next older reply page through Inertia's merge engine; the virtualizer
-// decides *when* (the reader nears the top of loaded history) via `@load-older`.
+/**
+ * Fetch the next older reply page through Inertia's merge engine; the virtualizer
+ * decides *when* (the reader nears the top of loaded history) via `@load-older`.
+ */
 function loadOlderReplies(): void {
     if (loadingOlder.value || !hasOlder()) {
         return;
@@ -127,21 +145,27 @@ const {
         messageListRef.value?.scrollToLatest(smooth ? 'smooth' : 'auto'),
 });
 
-// The thread reply composer, so a hover card on a thread message can drop a
-// mention into it rather than the main channel composer.
+/**
+ * The thread reply composer, so a hover card on a thread message can drop a
+ * mention into it rather than the main channel composer.
+ */
 const threadComposer = ref<InstanceType<typeof MessageComposer> | null>(null);
 
 function mentionInThread(member: { id: string; name: string }): void {
     threadComposer.value?.insertMention(member);
 }
 
-// The reply the thread composer is editing in place (via the ↑ shortcut), or
-// null. Highlights the target row in the thread while editing.
+/**
+ * The reply the thread composer is editing in place (via the ↑ shortcut), or
+ * null. Highlights the target row in the thread while editing.
+ */
 const editingMessageId = ref<string | null>(null);
 
-// The id of the newest reply currently shown, so a reply appended at the bottom
-// (which should follow the reader or raise the count) can be told apart from
-// older replies paging in at the top, which must leave the viewport anchored.
+/**
+ * The id of the newest reply currently shown, so a reply appended at the bottom
+ * (which should follow the reader or raise the count) can be told apart from
+ * older replies paging in at the top, which must leave the viewport anchored.
+ */
 const newestMessageId = ref<string | null>(null);
 
 // Keep the panel pinned to the newest reply as the conversation grows: the

--- a/resources/js/components/settings/AvatarUpload.vue
+++ b/resources/js/components/settings/AvatarUpload.vue
@@ -7,13 +7,13 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
 
-//
-// The Settings → Profile photo block. Uploads commit on selection (no Save
-// button): the server strips metadata, downscales, and stores the image, then
-// redirects back with the fresh avatar. "Remove photo" reverts to the
-// Gravatar → initials fallback. The circle center-crops via object-cover, so no
-// client-side cropper is needed.
-//
+/**
+ * The Settings → Profile photo block. Uploads commit on selection (no Save
+ * button): the server strips metadata, downscales, and stores the image, then
+ * redirects back with the fresh avatar. "Remove photo" reverts to the
+ * Gravatar → initials fallback. The circle center-crops via object-cover, so no
+ * client-side cropper is needed.
+ */
 const props = defineProps<{
     avatar: string | null;
     name: string;

--- a/resources/js/components/ui/button/Button.vue
+++ b/resources/js/components/ui/button/Button.vue
@@ -11,9 +11,11 @@ interface Props extends PrimitiveProps {
   variant?: ButtonVariants["variant"]
   size?: ButtonVariants["size"]
   class?: HTMLAttributes["class"]
-  // Renders a leading spinner and disables the control while a request is in
-  // flight, so every submit button gets consistent pending feedback without
-  // each caller re-wiring `<Spinner v-if="processing" />` by hand.
+  /**
+   * Renders a leading spinner and disables the control while a request is in
+   * flight, so every submit button gets consistent pending feedback without
+   * each caller re-wiring `<Spinner v-if="processing" />` by hand.
+   */
   loading?: boolean
 }
 

--- a/resources/js/components/ui/button/index.ts
+++ b/resources/js/components/ui/button/index.ts
@@ -3,17 +3,21 @@ import { cva } from "class-variance-authority"
 
 export { default as Button } from "./Button.vue"
 
-// Universal interaction/a11y utilities every button-like control shares —
-// transition, focus ring, disabled handling, and svg sizing. Kept in the cva
-// base so even the `unstyled` escape hatch (card/row containers) inherits the
-// focus ring.
+/**
+ * Universal interaction/a11y utilities every button-like control shares —
+ * transition, focus ring, disabled handling, and svg sizing. Kept in the cva
+ * base so even the `unstyled` escape hatch (card/row containers) inherits the
+ * focus ring.
+ */
 const interaction =
   "transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
 
-// The default button silhouette — inline, centered, medium text. Prepended to
-// every styled variant so `unstyled` can drop it while still inheriting the
-// focus ring above. `cn` runs tailwind-merge, so a later variant/size class
-// (e.g. `rounded-full` on `pill`) cleanly overrides the matching token here.
+/**
+ * The default button silhouette — inline, centered, medium text. Prepended to
+ * every styled variant so `unstyled` can drop it while still inheriting the
+ * focus ring above. `cn` runs tailwind-merge, so a later variant/size class
+ * (e.g. `rounded-full` on `pill`) cleanly overrides the matching token here.
+ */
 const shape =
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium shrink-0"
 

--- a/resources/js/components/ui/chart/utils.ts
+++ b/resources/js/components/ui/chart/utils.ts
@@ -3,10 +3,9 @@ import { isClient } from "@vueuse/core"
 import { useId } from "reka-ui"
 import { h, render } from "vue"
 
-// Simple cache using a Map to store serialized object keys
 const cache = new Map<string, string>()
 
-// Convert object to a consistent string key
+/** Convert object to a consistent string key */
 function serializeKey(key: Record<string, any>): string {
   return JSON.stringify(key, Object.keys(key).sort())
 }

--- a/resources/js/components/ui/command/Command.vue
+++ b/resources/js/components/ui/command/Command.vue
@@ -41,11 +41,9 @@ function filterItems() {
     return
   }
 
-  // Reset the groups
   filterState.filtered.groups = new Set()
   let itemCount = 0
 
-  // Check which items should be included
   for (const [id, value] of allItems.value) {
     const score = contains(value, filterState.search)
     filterState.filtered.items.set(id, score ? 1 : 0)
@@ -53,7 +51,6 @@ function filterItems() {
       itemCount++
   }
 
-  // Check which groups have at least 1 item shown
   for (const [groupId, group] of allGroups.value) {
     for (const itemId of group) {
       if (filterState.filtered.items.get(itemId)! > 0) {

--- a/resources/js/components/ui/command/CommandItem.vue
+++ b/resources/js/components/ui/command/CommandItem.vue
@@ -30,7 +30,6 @@ const isRender = computed(() => {
       return true
     }
 
-    // Check with filter
     return filteredCurrentItem > 0
   }
 })

--- a/resources/js/components/ui/sidebar/SidebarProvider.vue
+++ b/resources/js/components/ui/sidebar/SidebarProvider.vue
@@ -38,7 +38,6 @@ function setOpenMobile(value: boolean) {
   openMobile.value = value
 }
 
-// Helper to toggle the sidebar.
 function toggleSidebar() {
   return isMobile.value ? setOpenMobile(!openMobile.value) : setOpen(!open.value)
 }
@@ -50,8 +49,10 @@ useEventListener("keydown", (event: KeyboardEvent) => {
   }
 })
 
-// We add a state so that we can do data-state="expanded" or "collapsed".
-// This makes it easier to style the sidebar with Tailwind classes.
+/**
+ * We add a state so that we can do data-state="expanded" or "collapsed".
+ * This makes it easier to style the sidebar with Tailwind classes.
+ */
 const state = computed(() => open.value ? "expanded" : "collapsed")
 
 provideSidebarContext({

--- a/resources/js/composables/useAppearance.ts
+++ b/resources/js/composables/useAppearance.ts
@@ -75,11 +75,9 @@ export function initializeTheme(): void {
         return;
     }
 
-    // Initialize theme from saved preference or default to system...
     const savedAppearance = getStoredAppearance();
     updateTheme(savedAppearance || 'system');
 
-    // Set up system theme change listener...
     mediaQuery()?.addEventListener('change', handleSystemThemeChange);
 }
 

--- a/resources/js/composables/useChannelRealtime.ts
+++ b/resources/js/composables/useChannelRealtime.ts
@@ -69,17 +69,21 @@ function channelName(id: string): string {
  * this composable stays a thin bridge between Echo and the streams.
  */
 export function useChannelRealtime(options: ChannelRealtimeOptions): void {
-    // An edit or deletion may touch either timeline (or both, for a
-    // sent-to-channel reply); patch both streams, since a patch is ignored where
-    // the message isn't rendered.
+    /**
+     * An edit or deletion may touch either timeline (or both, for a
+     * sent-to-channel reply); patch both streams, since a patch is ignored where
+     * the message isn't rendered.
+     */
     function applyPatch(message: Message): void {
         options.mainStream.applyPatch(message);
         options.threadStream.applyPatch(message);
     }
 
-    // Route a broadcast message to the timeline it belongs to, following the main
-    // timeline down when the reader is near the bottom and reconciling the open
-    // thread's read state — all decided by `placeIncomingMessage`.
+    /**
+     * Route a broadcast message to the timeline it belongs to, following the main
+     * timeline down when the reader is near the bottom and reconciling the open
+     * thread's read state — all decided by `placeIncomingMessage`.
+     */
     function routeIncoming(message: Message): void {
         const root = options
             .displayMessages()
@@ -206,9 +210,11 @@ export function useChannelRealtime(options: ChannelRealtimeOptions): void {
         },
     });
 
-    // Drive the fleet as a single-channel subscription: `null` active id keeps the
-    // handoff dormant, so each reconcile leaves the previous channel and
-    // subscribes the current one.
+    /**
+     * Drive the fleet as a single-channel subscription: `null` active id keeps the
+     * handoff dormant, so each reconcile leaves the previous channel and
+     * subscribes the current one.
+     */
     function moveSubscription(): void {
         fleet.reconcile([options.channelId()], null);
     }

--- a/resources/js/composables/useConnectionState.test.ts
+++ b/resources/js/composables/useConnectionState.test.ts
@@ -14,11 +14,13 @@ import {
 } from '@/composables/useConnectionState';
 import type { ConnectionState } from '@/composables/useConnectionState';
 
-// A no-op custom renderer lets us mount a real component instance under Node
-// (no DOM), which is what fires the composable's `onMounted` — the hook that
-// ungates the pill so first paint matches SSR. An effectScope alone never
-// mounts, so the pill would stay blank and the reconnecting/back-online
-// assertions below could never be exercised.
+/**
+ * A no-op custom renderer lets us mount a real component instance under Node
+ * (no DOM), which is what fires the composable's `onMounted` — the hook that
+ * ungates the pill so first paint matches SSR. An effectScope alone never
+ * mounts, so the pill would stay blank and the reconnecting/back-online
+ * assertions below could never be exercised.
+ */
 const { createApp } = createRenderer<object, object>({
     insert: () => {},
     remove: () => {},

--- a/resources/js/composables/useMessageSearch.test.ts
+++ b/resources/js/composables/useMessageSearch.test.ts
@@ -17,7 +17,7 @@ function jsonResponse(results: MessageSearchResult[], ok = true): Response {
 const ids = (results: MessageSearchResult[]): string[] =>
     results.map((result) => result.message.id);
 
-// Drain the microtask queue so an already-resolved fetch chain settles.
+/** Drain the microtask queue so an already-resolved fetch chain settles. */
 const flush = async (): Promise<void> => {
     await vi.advanceTimersByTimeAsync(0);
 };

--- a/resources/js/composables/useOnboardingTour.ts
+++ b/resources/js/composables/useOnboardingTour.ts
@@ -48,9 +48,11 @@ export function shouldAutoStartTour(
     return !user.onboarding_completed_at;
 }
 
-// Shared open-state for the tour overlay. It is mounted once in the workspace
-// layout, but can be started on first login and replayed from the user menu
-// without prop-drilling through the component tree.
+/**
+ * Shared open-state for the tour overlay. It is mounted once in the workspace
+ * layout, but can be started on first login and replayed from the user menu
+ * without prop-drilling through the component tree.
+ */
 const isOpen = ref(false);
 const stepIndex = ref(0);
 
@@ -63,9 +65,11 @@ export function useOnboardingTour() {
         stepIndex.value = 0;
     }
 
-    // Persist completion so the tour and the brand-new-workspace welcome stay
-    // dismissed across reloads and devices. Idempotent server-side, so replaying
-    // and finishing again is harmless.
+    /**
+     * Persist completion so the tour and the brand-new-workspace welcome stay
+     * dismissed across reloads and devices. Idempotent server-side, so replaying
+     * and finishing again is harmless.
+     */
     function persistCompletion(): void {
         router.patch(
             completeOnboarding().url,

--- a/resources/js/composables/useTeamPresence.ts
+++ b/resources/js/composables/useTeamPresence.ts
@@ -3,8 +3,10 @@ import { echo } from '@laravel/echo-vue';
 import { onBeforeUnmount, onMounted, ref, toValue, watch } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
-// How long to coalesce a burst of profile updates before reloading, so many
-// teammates changing avatars at once trigger a single authoritative refetch.
+/**
+ * How long to coalesce a burst of profile updates before reloading, so many
+ * teammates changing avatars at once trigger a single authoritative refetch.
+ */
 const PROFILE_RELOAD_DEBOUNCE_MS = 400;
 
 /**

--- a/resources/js/composables/useTimelineVirtualizer.ts
+++ b/resources/js/composables/useTimelineVirtualizer.ts
@@ -41,10 +41,12 @@ export function useTimelineVirtualizer(options: {
     hasOlder: () => boolean;
     isLoadingOlder: () => boolean;
     loadOlder: () => void;
-    // True while the consumer is deliberately pinning the view to the newest
-    // message (a jump-to-present). Upward size-change anchoring is suppressed
-    // during it so a row measured above the viewport can't drift the view up
-    // while we settle on the bottom.
+    /**
+     * True while the consumer is deliberately pinning the view to the newest
+     * message (a jump-to-present). Upward size-change anchoring is suppressed
+     * during it so a row measured above the viewport can't drift the view up
+     * while we settle on the bottom.
+     */
     isPinning?: () => boolean;
 }) {
     const virtualizer = useVirtualizer(

--- a/resources/js/composables/useUnreadDivider.ts
+++ b/resources/js/composables/useUnreadDivider.ts
@@ -52,7 +52,7 @@ export function useUnreadDivider(options: UnreadDividerOptions): UnreadDivider {
         () => unreadDividerId.value !== null && !unreadDividerInView.value,
     );
 
-    // Watch the divider element so the pill hides once it scrolls into view.
+    /** Watch the divider element so the pill hides once it scrolls into view. */
     function observeDivider(): void {
         observer?.disconnect();
         observer = null;

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -107,9 +107,11 @@ const page = usePage();
 
 const { t } = useTranslations();
 
-// The same workspace shell wraps the settings/teams section, but its sidebar
-// swaps the channel list for the settings navigation so there is a single
-// sidebar rather than a nested one.
+/**
+ * The same workspace shell wraps the settings/teams section, but its sidebar
+ * swaps the channel list for the settings navigation so there is a single
+ * sidebar rather than a nested one.
+ */
 const isSettingsSection = computed(() => {
     const component = page.component;
 
@@ -134,13 +136,13 @@ const currentTeam = computed(() => page.props.currentTeam);
 const teams = computed(() => page.props.teams ?? []);
 const channels = computed(() => page.props.channels ?? []);
 const currentUserId = computed(() => String(page.props.auth.user.id));
-// The current team's members, feeding the DM entry points (people picker + ⌘K).
+/** The current team's members, feeding the DM entry points (people picker + ⌘K). */
 const teamMembers = computed(() => page.props.teamMembers ?? []);
 
-// Online roster for the current team, driving the presence dot on each DM row.
+/** Online roster for the current team, driving the presence dot on each DM row. */
 const { onlineIds } = useTeamPresence(() => currentTeam.value?.id);
 
-// The "New message" people picker opened from the "Direct messages" header.
+/** The "New message" people picker opened from the "Direct messages" header. */
 const newDmOpen = ref(false);
 const activeChannelSlug = computed(
     () => (page.props.channel as { slug?: string } | undefined)?.slug ?? null,
@@ -148,8 +150,10 @@ const activeChannelSlug = computed(
 const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
 const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
 
-// The dock header's "invite people" mini-button reuses the member-invite modal;
-// the permission and assignable roles ride along on the shared workspace props.
+/**
+ * The dock header's "invite people" mini-button reuses the member-invite modal;
+ * the permission and assignable roles ride along on the shared workspace props.
+ */
 const canInviteToCurrentTeam = computed(
     () => page.props.canInviteToCurrentTeam ?? false,
 );
@@ -158,20 +162,26 @@ const invitableRoles = computed<RoleOption[]>(
 );
 const inviteOpen = ref(false);
 
-// The user's custom sidebar sections for the current team, kept in their
-// persisted order.
+/**
+ * The user's custom sidebar sections for the current team, kept in their
+ * persisted order.
+ */
 const customSections = computed<ChannelSection[]>(
     () => page.props.channelSections ?? [],
 );
 
-// Local, drag-mutable copies of each sidebar group. vuedraggable writes to these
-// arrays as the user drags; they are re-seeded from the shared props whenever the
-// server recomputes them (a star toggle, a live badge update, or a persisted
-// reorder round-tripping), so the layout follows the user across devices.
+/**
+ * Local, drag-mutable copies of each sidebar group. vuedraggable writes to these
+ * arrays as the user drags; they are re-seeded from the shared props whenever the
+ * server recomputes them (a star toggle, a live badge update, or a persisted
+ * reorder round-tripping), so the layout follows the user across devices.
+ */
 const starredList = ref<Channel[]>([]);
 const defaultList = ref<Channel[]>([]);
-// Direct messages, ordered by recent activity (the partitioner sorts them). Not
-// drag-mutable — DMs never file into sections — so this is a plain projection.
+/**
+ * Direct messages, ordered by recent activity (the partitioner sorts them). Not
+ * drag-mutable — DMs never file into sections — so this is a plain projection.
+ */
 const directList = ref<Channel[]>([]);
 const customGroups = ref<{ section: ChannelSection; channels: Channel[] }[]>(
     [],
@@ -339,7 +349,7 @@ function blurInput(event: Event): void {
     }
 }
 
-// Creating a new section from the inline form under the "Channels" header.
+/** Creating a new section from the inline form under the "Channels" header. */
 const sectionFormOpen = ref(false);
 const newSectionName = ref('');
 
@@ -380,9 +390,11 @@ function createSection(): void {
     );
 }
 
-// Inline renaming of an existing section. The input renders inside the sections
-// v-for, so its DOM node is resolved by its section-scoped `data-test` once
-// mounted (see focusSidebarInput).
+/**
+ * Inline renaming of an existing section. The input renders inside the sections
+ * v-for, so its DOM node is resolved by its section-scoped `data-test` once
+ * mounted (see focusSidebarInput).
+ */
 const renamingSectionId = ref<string | null>(null);
 const renameValue = ref('');
 
@@ -478,10 +490,12 @@ function toggleCustomSection(group: {
     );
 }
 
-// Which sidebar sections the user has collapsed, seeded from the shared prop and
-// kept in sync when the server recomputes it (e.g. after a reload on another
-// device). A local ref lets the header toggle feel instant before the persisted
-// state round-trips.
+/**
+ * Which sidebar sections the user has collapsed, seeded from the shared prop and
+ * kept in sync when the server recomputes it (e.g. after a reload on another
+ * device). A local ref lets the header toggle feel instant before the persisted
+ * state round-trips.
+ */
 const collapsedSections = ref<string[]>([
     ...(page.props.collapsedChannelSections ?? []),
 ]);
@@ -532,8 +546,10 @@ const quickSwitcherOpen = ref(false);
 const { isOpen: shortcutsOpen, toggle: toggleShortcuts } =
     useKeyboardShortcutsModal();
 
-// The viewer's still-pending reminders in this team, feeding the "Reminders"
-// list and its sidebar count; the due-and-unacknowledged ones drive the nudges.
+/**
+ * The viewer's still-pending reminders in this team, feeding the "Reminders"
+ * list and its sidebar count; the due-and-unacknowledged ones drive the nudges.
+ */
 const reminders = computed<MessageReminder[]>(() => page.props.reminders ?? []);
 const firedReminders = computed<MessageReminder[]>(
     () => page.props.firedReminders ?? [],
@@ -550,8 +566,10 @@ const reminderReloadOptions = {
     only: ['reminders', 'firedReminders'] as string[],
 };
 
-// Jump to the reminded message, then clear its now-acknowledged nudge. The
-// clear runs first so the fresh page load no longer carries the fired reminder.
+/**
+ * Jump to the reminded message, then clear its now-acknowledged nudge. The
+ * clear runs first so the fresh page load no longer carries the fired reminder.
+ */
 function openReminder(reminder: MessageReminder): void {
     const target = show(
         { team: reminder.teamSlug, channel: reminder.channelSlug },
@@ -567,7 +585,7 @@ function openReminder(reminder: MessageReminder): void {
     );
 }
 
-// Push a fired reminder out by 20 minutes, re-arming it back to pending.
+/** Push a fired reminder out by 20 minutes, re-arming it back to pending. */
 function snoozeReminder(reminder: MessageReminder): void {
     router.post(
         storeReminder({ team: reminder.teamSlug }).url,
@@ -587,7 +605,7 @@ function snoozeReminder(reminder: MessageReminder): void {
     );
 }
 
-// Clear a single reminder — an acknowledged nudge, or a pending row from the list.
+/** Clear a single reminder — an acknowledged nudge, or a pending row from the list. */
 function clearReminder(
     reminder: Pick<MessageReminder, 'id' | 'teamSlug'>,
 ): void {
@@ -597,7 +615,7 @@ function clearReminder(
     );
 }
 
-// Clear every pending reminder in the current team at once.
+/** Clear every pending reminder in the current team at once. */
 function clearAllReminders(): void {
     if (!currentTeam.value) {
         return;
@@ -609,8 +627,10 @@ function clearAllReminders(): void {
     );
 }
 
-// The dialog rows only carry the reminder id; resolve the team from the shared
-// prop (all listed reminders belong to the current team).
+/**
+ * The dialog rows only carry the reminder id; resolve the team from the shared
+ * prop (all listed reminders belong to the current team).
+ */
 function clearReminderById(id: string): void {
     const reminder = reminders.value.find((entry) => entry.id === id);
 
@@ -649,8 +669,10 @@ useKeyboardShortcuts({
 
 const { timezone, syncDetectedTimezone } = useTimezone();
 
-// Which edge the dock sits on, read from the shared user prop so the redirect
-// after a change re-binds :side live (no reload).
+/**
+ * Which edge the dock sits on, read from the shared user prop so the redirect
+ * after a change re-binds :side live (no reload).
+ */
 const { sidebarPosition } = useSidebarPosition();
 
 onMounted(() => {

--- a/resources/js/lib/attachmentLayout.ts
+++ b/resources/js/lib/attachmentLayout.ts
@@ -68,9 +68,9 @@ export function imageGridColumns(count: number): number {
 
 export type ImageGridTile = {
     attachment: AttachmentData;
-    // Index within the message's image list, so the lightbox opens at this tile.
+    /** Index within the message's image list, so the lightbox opens at this tile. */
     index: number;
-    // The count of images hidden behind this tile ("+N"), or 0 when none.
+    /** The count of images hidden behind this tile ("+N"), or 0 when none. */
     overflow: number;
 };
 

--- a/resources/js/lib/composerEdit.ts
+++ b/resources/js/lib/composerEdit.ts
@@ -7,23 +7,25 @@ import type { Message } from '@/types';
  * unit-testable, independent of the live `KeyboardEvent` and Vue refs.
  */
 export type ComposerEditTriggerState = {
-    // The pressed key (`event.key`).
+    /** The pressed key (`event.key`). */
     key: string;
-    // Modifier flags; any held modifier disqualifies the trigger so it never
-    // clashes with `⌥↑` channel navigation.
+    /**
+     * Modifier flags; any held modifier disqualifies the trigger so it never
+     * clashes with `⌥↑` channel navigation.
+     */
     altKey: boolean;
     ctrlKey: boolean;
     metaKey: boolean;
     shiftKey: boolean;
-    // Whether the mention autocomplete menu is open (ArrowUp navigates it then).
+    /** Whether the mention autocomplete menu is open (ArrowUp navigates it then). */
     menuOpen: boolean;
-    // Whether the composer is already in edit mode (no re-entry).
+    /** Whether the composer is already in edit mode (no re-entry). */
     editing: boolean;
-    // Whether a reply is being composed (the composer answers that instead).
+    /** Whether a reply is being composed (the composer answers that instead). */
     hasReplyTarget: boolean;
-    // Whether the composer body is empty (trimmed).
+    /** Whether the composer body is empty (trimmed). */
     isEmpty: boolean;
-    // Whether the caret sits at the very start of the field.
+    /** Whether the caret sits at the very start of the field. */
     caretAtStart: boolean;
 };
 

--- a/resources/js/lib/datetime.test.ts
+++ b/resources/js/lib/datetime.test.ts
@@ -7,8 +7,10 @@ import {
 } from './datetime';
 import { formatNumber } from './numbers';
 
-// A fixed instant: 2026-07-10 15:30 UTC. July is DST in the US, so New York
-// (UTC-4) reads 11:30 and Tokyo (UTC+9) reads the next day at 00:30.
+/**
+ * A fixed instant: 2026-07-10 15:30 UTC. July is DST in the US, so New York
+ * (UTC-4) reads 11:30 and Tokyo (UTC+9) reads the next day at 00:30.
+ */
 const INSTANT = '2026-07-10T15:30:00Z';
 
 describe('formatTimeOfDay', () => {

--- a/resources/js/lib/messageActions.ts
+++ b/resources/js/lib/messageActions.ts
@@ -20,16 +20,18 @@ export function isSystemMessage(message: Pick<Message, 'type'>): boolean {
  */
 export type MessageActionContext = {
     currentUserId: string;
-    // Whether the viewer may add/remove reactions (member of a live channel).
+    /** Whether the viewer may add/remove reactions (member of a live channel). */
     canReact: boolean;
-    // Whether the viewer may pin/unpin messages (member of a non-archived
-    // channel). Pinning is a shared toggle — any member may unpin any pin.
+    /**
+     * Whether the viewer may pin/unpin messages (member of a non-archived
+     * channel). Pinning is a shared toggle — any member may unpin any pin.
+     */
     canPin: boolean;
-    // Whether the viewer may moderate others' messages (delete them).
+    /** Whether the viewer may moderate others' messages (delete them). */
     canModerate: boolean;
-    // Rendered inside a thread panel: suppresses the reply/thread affordances.
+    /** Rendered inside a thread panel: suppresses the reply/thread affordances. */
     inThread: boolean;
-    // Whether this row is an optimistic send with no stable server id yet.
+    /** Whether this row is an optimistic send with no stable server id yet. */
     pending: boolean;
 };
 

--- a/resources/js/lib/messageBody.ts
+++ b/resources/js/lib/messageBody.ts
@@ -16,16 +16,20 @@ function escapeHtml(text: string): string {
     return text.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
 }
 
-// The composer stores each resolved mention as a `@[Display Name](user-id)`
-// token. None of its literal characters are altered by HTML escaping, so the
-// token survives escapeHtml intact and can be matched afterwards.
+/**
+ * The composer stores each resolved mention as a `@[Display Name](user-id)`
+ * token. None of its literal characters are altered by HTML escaping, so the
+ * token survives escapeHtml intact and can be matched afterwards.
+ */
 const MENTION_PATTERN = /@\[([^\]]+)\]\(([0-9a-fA-F-]{36})\)/g;
 
-// http/https URLs, consuming everything up to whitespace. Any escaped `<`
-// becomes `&lt;` before this runs, so it can never re-open a tag.
+/**
+ * http/https URLs, consuming everything up to whitespace. Any escaped `<`
+ * becomes `&lt;` before this runs, so it can never re-open a tag.
+ */
 const URL_PATTERN = /\bhttps?:\/\/[^\s]+/gi;
 
-// Punctuation that commonly trails a URL in prose and shouldn't be linked.
+/** Punctuation that commonly trails a URL in prose and shouldn't be linked. */
 const TRAILING_PUNCTUATION = /[.,!?;:'")\]]+$/;
 
 /**
@@ -70,11 +74,13 @@ function wrapMarks(inner: string, marks: InlineMark[]): string {
     return html;
 }
 
-// The fixed allowlist DOMPurify sanitizes emitted HTML against — the formatting
-// scaffold plus the mention/emoji/link markup this module builds. This is the
-// XSS trust boundary: every HTML string we hand to a `v-html`/rendered surface
-// passes through {@see sanitize} first, so an attacker-authored tag or
-// `javascript:` URL that somehow reached the output could never survive it.
+/**
+ * The fixed allowlist DOMPurify sanitizes emitted HTML against — the formatting
+ * scaffold plus the mention/emoji/link markup this module builds. This is the
+ * XSS trust boundary: every HTML string we hand to a `v-html`/rendered surface
+ * passes through {@see sanitize} first, so an attacker-authored tag or
+ * `javascript:` URL that somehow reached the output could never survive it.
+ */
 const SANITIZE_CONFIG = {
     ALLOWED_TAGS: ['strong', 'em', 'del', 'code', 'br', 'span', 'a', 'img'],
     ALLOWED_ATTR: ['class', 'href', 'target', 'rel', 'src', 'alt', 'title'],
@@ -111,8 +117,10 @@ export type MessageBodySegment =
     | { kind: 'mention'; id: string; name: string; marks?: InlineMark[] }
     | { kind: 'emoji'; name: string; url: string; marks?: InlineMark[] };
 
-// The highlighted-pill styling for a resolved mention, shared by the interactive
-// segment renderer and the flat-HTML {@see renderMessageBody}.
+/**
+ * The highlighted-pill styling for a resolved mention, shared by the interactive
+ * segment renderer and the flat-HTML {@see renderMessageBody}.
+ */
 const MENTION_PILL_CLASS =
     'rounded px-1 py-0.5 font-medium text-blue-700 bg-blue-500/10 dark:text-blue-300 dark:bg-blue-400/15';
 
@@ -120,7 +128,7 @@ function mentionPillHtml(name: string): string {
     return `<span class="${MENTION_PILL_CLASS}">@${escapeHtml(name)}</span>`;
 }
 
-// Escape a run of text for HTML and preserve its newlines as `<br>`.
+/** Escape a run of text for HTML and preserve its newlines as `<br>`. */
 function escapeInline(text: string): string {
     return escapeHtml(text).replace(/\n/g, '<br>');
 }
@@ -154,7 +162,7 @@ function tokenizeTextRun(
         return marks.length > 0 ? { ...segment, marks: [...marks] } : segment;
     };
 
-    // Emoji shortcodes inside a run that already has no URL or mention.
+    /** Emoji shortcodes inside a run that already has no URL or mention. */
     const pushEmojiRun = (value: string): void => {
         if (value === '') {
             return;
@@ -181,9 +189,11 @@ function tokenizeTextRun(
         pushHtml(value.slice(lastIndex));
     };
 
-    // Mentions within a run that has no URL. Only ids present in `resolved`
-    // become interactive; any other well-formed token falls back to plain
-    // `@Name` text so a spoofed token can never masquerade as a real mention.
+    /**
+     * Mentions within a run that has no URL. Only ids present in `resolved`
+     * become interactive; any other well-formed token falls back to plain
+     * `@Name` text so a spoofed token can never masquerade as a real mention.
+     */
     const pushInline = (chunk: string): void => {
         const pattern = new RegExp(MENTION_PATTERN.source, 'g');
         let lastIndex = 0;
@@ -325,9 +335,11 @@ function linkHtml(href: string): string {
     return `<a href="${safe}" target="_blank" rel="noopener noreferrer nofollow" class="text-primary underline underline-offset-2 hover:no-underline">${safe}</a>`;
 }
 
-// The shared inline-image markup for a resolved custom emoji. The url comes from
-// the trusted server-shared map and the name is regex-constrained kebab-case, so
-// both are safe to interpolate; the alt is still escaped defensively.
+/**
+ * The shared inline-image markup for a resolved custom emoji. The url comes from
+ * the trusted server-shared map and the name is regex-constrained kebab-case, so
+ * both are safe to interpolate; the alt is still escaped defensively.
+ */
 const EMOJI_IMG_CLASS =
     'custom-emoji inline-block h-[1.35em] w-[1.35em] align-text-bottom';
 

--- a/resources/js/lib/reminderTime.test.ts
+++ b/resources/js/lib/reminderTime.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { isReminderToday, reminderPresets } from '@/lib/reminderTime';
 
-// A fixed reference instant: Tuesday 14 Jul 2026, 15:30 UTC.
+/** A fixed reference instant: Tuesday 14 Jul 2026, 15:30 UTC. */
 const NOW = new Date('2026-07-14T15:30:00.000Z');
 
 describe('reminderPresets', () => {

--- a/resources/js/lib/scheduleTime.test.ts
+++ b/resources/js/lib/scheduleTime.test.ts
@@ -10,7 +10,7 @@ import {
     zonedWallTime,
 } from '@/lib/scheduleTime';
 
-// A fixed reference instant: Tuesday 14 Jul 2026, 15:30 UTC.
+/** A fixed reference instant: Tuesday 14 Jul 2026, 15:30 UTC. */
 const NOW = new Date('2026-07-14T15:30:00.000Z');
 
 describe('zonedWallTime', () => {

--- a/resources/js/lib/scheduleTime.ts
+++ b/resources/js/lib/scheduleTime.ts
@@ -13,9 +13,11 @@ import { i18n, translate } from './i18n';
 /** Wall-clock components, as read off a clock on the wall in some zone. */
 export type WallTime = {
     year: number;
-    month: number; // 1-12
+    /** 1-12 */
+    month: number;
     day: number;
-    hour: number; // 0-23
+    /** 0-23 */
+    hour: number;
     minute: number;
 };
 

--- a/resources/js/lib/timeline.test.ts
+++ b/resources/js/lib/timeline.test.ts
@@ -18,8 +18,10 @@ function message(
     } as unknown as Message;
 }
 
-// Noon timestamps keep day boundaries unambiguous regardless of the runner's
-// timezone; a calendar day never flips around midday.
+/**
+ * Noon timestamps keep day boundaries unambiguous regardless of the runner's
+ * timezone; a calendar day never flips around midday.
+ */
 const DAY_1_NOON = '2026-07-10T12:00:00.000Z';
 
 function minutesLater(iso: string, minutes: number): string {

--- a/resources/js/lib/timeline.ts
+++ b/resources/js/lib/timeline.ts
@@ -3,8 +3,10 @@ import { translate } from '@/lib/i18n';
 import { isSystemMessage } from '@/lib/messageActions';
 import type { Message, MessageAuthor } from '@/types';
 
-// Consecutive messages from the same author within this window collapse under a
-// single avatar + header line in the timeline.
+/**
+ * Consecutive messages from the same author within this window collapse under a
+ * single avatar + header line in the timeline.
+ */
 export const GROUPING_WINDOW_MS = 5 * 60 * 1000;
 
 /**

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -69,17 +69,21 @@ const props = defineProps<{
 const { t } = useTranslations();
 const page = usePage();
 
-// The current team's channels and members feed the facet pickers and the token
-// parser; both are shared props, so the search route already carries them. The
-// teams list decides whether the workspace-scope control shows.
+/**
+ * The current team's channels and members feed the facet pickers and the token
+ * parser; both are shared props, so the search route already carries them. The
+ * teams list decides whether the workspace-scope control shows.
+ */
 const channels = computed(() => page.props.channels ?? []);
 const members = computed(() => page.props.teamMembers ?? []);
 const teams = computed(() => page.props.teams ?? []);
 const showScopeControl = computed(() => teams.value.length > 1);
 
-// The URL is the state: the input, facets, and scope seed from the server-echoed
-// query and filters, and every change writes them back so a shared link
-// reproduces the filtered view.
+/**
+ * The URL is the state: the input, facets, and scope seed from the server-echoed
+ * query and filters, and every change writes them back so a shared link
+ * reproduces the filtered view.
+ */
 const term = ref(props.query);
 const authorId = ref<string | null>(props.filters.from);
 const channelId = ref<string | null>(props.filters.in);
@@ -87,9 +91,11 @@ const after = ref<string | null>(props.filters.after);
 const before = ref<string | null>(props.filters.before);
 const scope = ref(props.filters.scope);
 
-// In cross-team mode the channel facet lists the union across all the user's
-// teams; otherwise just the current team's channels. Either way, every known
-// channel resolves a chip label, so a shared link's channel id renders its name.
+/**
+ * In cross-team mode the channel facet lists the union across all the user's
+ * teams; otherwise just the current team's channels. Either way, every known
+ * channel resolves a chip label, so a shared link's channel id renders its name.
+ */
 const channelOptions = computed<
     Array<{
         id: string;
@@ -150,9 +156,11 @@ function currentFilters(): SearchFilters {
     };
 }
 
-// A single scoped reload that refreshes only the results and the echoed
-// query/filters, preserving the input's focus and the scroll position. The
-// default `team` scope stays out of the URL; only `all` is serialized.
+/**
+ * A single scoped reload that refreshes only the results and the echoed
+ * query/filters, preserving the input's focus and the scroll position. The
+ * default `team` scope stays out of the URL; only `all` is serialized.
+ */
 function reload(): void {
     router.get(
         search(props.team.slug).url,
@@ -184,7 +192,7 @@ function setScope(next: string): void {
     reload();
 }
 
-// Debounce keystrokes; a facet change (chip/picker) reloads immediately.
+/** Debounce keystrokes; a facet change (chip/picker) reloads immediately. */
 const debouncedTerm = useDebouncedPost((raw: string) => commitTerm(raw), {
     delay: 300,
 });
@@ -200,8 +208,10 @@ watch(term, (value) => {
     debouncedTerm.schedule(value);
 });
 
-// Recognized `from:` / `in:` / `before:` / `after:` tokens promote to facet
-// chips and are stripped from the visible input; unknown tokens stay literal.
+/**
+ * Recognized `from:` / `in:` / `before:` / `after:` tokens promote to facet
+ * chips and are stripped from the visible input; unknown tokens stay literal.
+ */
 function commitTerm(raw: string): void {
     const parsed = parseSearchQuery(raw, lookup.value);
 
@@ -272,7 +282,7 @@ function searchAllChannels(): void {
     reload();
 }
 
-// Facet-picker filter inputs.
+/** Facet-picker filter inputs. */
 const channelFilter = ref('');
 const authorFilter = ref('');
 
@@ -332,7 +342,7 @@ const datePresets = computed(() => {
 
 const showCustomRange = ref(after.value !== null || before.value !== null);
 
-// The applied chip labels.
+/** The applied chip labels. */
 const authorName = computed(
     () =>
         (authorId.value && memberById.value.get(authorId.value)?.name) || null,
@@ -366,7 +376,7 @@ const hasFilters = computed(
         before.value !== null,
 );
 
-// The zero-result summary names the active filters back to the user.
+/** The zero-result summary names the active filters back to the user. */
 const activeFilterSummary = computed(() => {
     const parts: string[] = [];
 
@@ -393,9 +403,11 @@ function formatTimestamp(iso: string): string {
     return formatDateTime(iso, page.props.auth.user.timezone ?? undefined);
 }
 
-// Each result links into its own team's channel — for a same-team result that is
-// the current team; for a cross-team ("All workspaces") result it targets the
-// message's own workspace, which resolves because ACL guarantees membership.
+/**
+ * Each result links into its own team's channel — for a same-team result that is
+ * the current team; for a cross-team ("All workspaces") result it targets the
+ * message's own workspace, which resolves because ACL guarantees membership.
+ */
 function jumpHref(result: MessageSearchResult): string {
     return show(
         { team: result.teamSlug, channel: result.channelSlug },

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -90,39 +90,57 @@ const props = defineProps<{
     members: Mention[];
     canArchive: boolean;
     canManagePreferences: boolean;
-    // Whether the viewer may leave the channel (a member of a standard channel
-    // that isn't #general); drives the "Leave channel" menu item and modal.
+    /**
+     * Whether the viewer may leave the channel (a member of a standard channel
+     * that isn't #general); drives the "Leave channel" menu item and modal.
+     */
     canLeave: boolean;
-    // Whether the viewer may react (member of a non-archived channel); read-only
-    // reaction pills still render for a non-member browsing a public channel.
+    /**
+     * Whether the viewer may react (member of a non-archived channel); read-only
+     * reaction pills still render for a non-member browsing a public channel.
+     */
     canReact: boolean;
-    // Whether the viewer already belongs to the channel. A non-member viewing a
-    // public channel by URL sees a "Join channel" bar in place of the composer.
+    /**
+     * Whether the viewer already belongs to the channel. A non-member viewing a
+     * public channel by URL sees a "Join channel" bar in place of the composer.
+     */
     isMember: boolean;
-    // The channel's member count, surfaced in the join bar for a non-member.
+    /** The channel's member count, surfaced in the join bar for a non-member. */
     memberCount: number;
-    // The channel's pinned-message count, driving the masthead badge on first
-    // load; kept live from the MessagePinned broadcast thereafter.
+    /**
+     * The channel's pinned-message count, driving the masthead badge on first
+     * load; kept live from the MessagePinned broadcast thereafter.
+     */
     pinCount: number;
-    // The channel's pinned messages, most-recently-pinned first, feeding the pins
-    // popover. Refreshed via a partial reload when the panel opens or a pin
-    // changes; each row is a full Message (its `pin` carries the attribution).
+    /**
+     * The channel's pinned messages, most-recently-pinned first, feeding the pins
+     * popover. Refreshed via a partial reload when the panel opens or a pin
+     * changes; each row is a full Message (its `pin` carries the attribution).
+     */
     pins: Message[];
     notificationLevels: NotificationLevelOption[];
     jumpToMessageId?: string | null;
-    // The viewer's read pointer at load time, used to place the "New messages"
-    // divider; null when the channel has never been read.
+    /**
+     * The viewer's read pointer at load time, used to place the "New messages"
+     * divider; null when the channel has never been read.
+     */
     lastReadMessageId?: string | null;
-    // Read positions of the channel's other members who share read receipts,
-    // seeding the "Seen by" affordance; later advances arrive via MessageRead.
+    /**
+     * Read positions of the channel's other members who share read receipts,
+     * seeding the "Seen by" affordance; later advances arrive via MessageRead.
+     */
     channelReaders: ChannelReader[];
-    // The open thread's root, loaded on demand keyed by `?thread=`.
+    /** The open thread's root, loaded on demand keyed by `?thread=`. */
     thread?: Thread | null;
-    // The open thread's replies, a reverse-infinite-scroll page that grows as
-    // older replies load. Empty when no thread is open.
+    /**
+     * The open thread's replies, a reverse-infinite-scroll page that grows as
+     * older replies load. Empty when no thread is open.
+     */
     threadReplies: MessagePage;
-    // The viewer's own pending scheduled messages for this channel, soonest
-    // first, feeding the composer's "Scheduled" affordance.
+    /**
+     * The viewer's own pending scheduled messages for this channel, soonest
+     * first, feeding the composer's "Scheduled" affordance.
+     */
     scheduledMessages: ScheduledMessage[];
 }>();
 
@@ -135,21 +153,27 @@ const currentUser = computed(() => ({
     name: page.props.auth.user.name,
 }));
 
-// Peers currently composing on this channel, driven by `typing` client
-// whispers over the same private channel as the message events.
+/**
+ * Peers currently composing on this channel, driven by `typing` client
+ * whispers over the same private channel as the message events.
+ */
 const typing = useTypingIndicator((user: TypingUser) => {
     echo().private(channelName(props.channel.id)).whisper('typing', user);
 });
 
 const typingNames = typing.typingNames;
 
-// Live roster of team members currently online, driving the presence dots on
-// message avatars. Follows the team across channel switches.
+/**
+ * Live roster of team members currently online, driving the presence dots on
+ * message avatars. Follows the team across channel switches.
+ */
 const { onlineIds } = useTeamPresence(() => props.team.id);
 
-// Read positions of the channel's other members who share read receipts, keyed
-// by user id. Seeded from the server prop and kept current from the MessageRead
-// broadcast, driving the "Seen by" affordance under the newest message.
+/**
+ * Read positions of the channel's other members who share read receipts, keyed
+ * by user id. Seeded from the server prop and kept current from the MessageRead
+ * broadcast, driving the "Seen by" affordance under the newest message.
+ */
 const readers = ref(new Map<string, ChannelReader>());
 
 function seedReaders(): void {
@@ -164,15 +188,17 @@ function onTyping(): void {
     typing.signalTyping(currentUser.value);
 }
 
-// You can't @mention yourself; drop the current user from the composer list.
+/** You can't @mention yourself; drop the current user from the composer list. */
 const mentionableMembers = computed(() =>
     props.members.filter((member) => member.id !== currentUser.value.id),
 );
 
-// A direct message renders viewer-relative: no "#", the other participant's
-// name (the viewer's own self-DM reads "You"), or a group's participant-joined
-// name. Drives the `<Head>` title, the masthead, and the empty state's
-// viewer-relative copy; the masthead owns the DM avatar and facepile itself.
+/**
+ * A direct message renders viewer-relative: no "#", the other participant's
+ * name (the viewer's own self-DM reads "You"), or a group's participant-joined
+ * name. Drives the `<Head>` title, the masthead, and the empty state's
+ * viewer-relative copy; the masthead owns the DM avatar and facepile itself.
+ */
 const isSelfDm = computed(
     () =>
         props.channel.isDirect &&
@@ -189,35 +215,43 @@ const mastheadTitle = computed(() => {
     return isSelfDm.value ? t('You') : props.channel.name;
 });
 
-// The viewer may add people to any DM they belong to; grows a 1:1 into a group
-// or a group further. Drives the masthead's "Add people" button and its modal.
+/**
+ * The viewer may add people to any DM they belong to; grows a 1:1 into a group
+ * or a group further. Drives the masthead's "Add people" button and its modal.
+ */
 const canAddPeople = computed(() => props.channel.isDirect && props.isMember);
 const addingPeople = ref(false);
 
-// A DM's composer addresses the conversation by its participant name rather than
-// a "#channel", so its placeholder overrides the composer's channel default.
+/**
+ * A DM's composer addresses the conversation by its participant name rather than
+ * a "#channel", so its placeholder overrides the composer's channel default.
+ */
 const composerPlaceholder = computed(() =>
     props.channel.isDirect
         ? t('Message :name', { name: mastheadTitle.value })
         : undefined,
 );
 
-// A team Admin+ may delete anyone's message in the channel (moderation).
+/** A team Admin+ may delete anyone's message in the channel (moderation). */
 const canModerate = computed(() =>
     ['admin', 'owner'].includes(page.props.currentTeam?.role ?? ''),
 );
 
 const scrollContainer = ref<HTMLElement | null>(null);
-// `ScrollableMessageList` owns the scroll element; this points our ref at it so
-// `useScrollPin`, `useUnreadDivider`, and the virtualized `MessageList` all bind
-// to the very same node.
+/**
+ * `ScrollableMessageList` owns the scroll element; this points our ref at it so
+ * `useScrollPin`, `useUnreadDivider`, and the virtualized `MessageList` all bind
+ * to the very same node.
+ */
 const setScrollContainer = (el: HTMLElement | null): void => {
     scrollContainer.value = el;
 };
 
-// The windowed timeline exposes `scrollToIndex` so off-screen jump targets can be
-// brought into view; Inertia's `<InfiniteScroll>` (driven manually) exposes the
-// older-page fetch. Both are read through template refs.
+/**
+ * The windowed timeline exposes `scrollToIndex` so off-screen jump targets can be
+ * brought into view; Inertia's `<InfiniteScroll>` (driven manually) exposes the
+ * older-page fetch. Both are read through template refs.
+ */
 const messageListRef = ref<{
     scrollToIndex: (
         index: number,
@@ -231,19 +265,25 @@ const infiniteScrollRef = ref<{
     hasNext: () => boolean;
 } | null>(null);
 
-// The virtualizer's visible render-item window, surfaced by `MessageList` so the
-// unread-jump pill can be derived without a DOM `IntersectionObserver`.
+/**
+ * The virtualizer's visible render-item window, surfaced by `MessageList` so the
+ * unread-jump pill can be derived without a DOM `IntersectionObserver`.
+ */
 const timelineRange = ref<{ startIndex: number; endIndex: number } | null>(
     null,
 );
 
-// True while an older page is being fetched, gating the virtualizer's top-load
-// trigger so a burst of range updates can't stack duplicate requests. Cleared
-// once the merged page grows (older rows have landed).
+/**
+ * True while an older page is being fetched, gating the virtualizer's top-load
+ * trigger so a burst of range updates can't stack duplicate requests. Cleared
+ * once the merged page grows (older rows have landed).
+ */
 const loadingOlder = ref(false);
 
-// In reverse mode, older history is the paginator's *next* page (the server
-// returns messages newest-first), so "load older" maps to fetchNext/hasNext.
+/**
+ * In reverse mode, older history is the paginator's *next* page (the server
+ * returns messages newest-first), so "load older" maps to fetchNext/hasNext.
+ */
 const hasOlder = (): boolean => infiniteScrollRef.value?.hasNext() ?? false;
 
 const isLoadingOlder = (): boolean => loadingOlder.value;
@@ -269,9 +309,11 @@ watch(
     },
 );
 
-// Shared scroll/pin bookkeeping: the pinned-to-newest flag, the "N new messages"
-// count while scrolled up, and the smooth jump back to the bottom. The thread
-// panel runs its own instance of the same composable.
+/**
+ * Shared scroll/pin bookkeeping: the pinned-to-newest flag, the "N new messages"
+ * count while scrolled up, and the smooth jump back to the bottom. The thread
+ * panel runs its own instance of the same composable.
+ */
 const {
     pinnedToBottom,
     newMessageCount,
@@ -288,49 +330,61 @@ const {
         messageListRef.value?.scrollToLatest(smooth ? 'smooth' : 'auto'),
 });
 
-// `Inertia::scroll` delivers messages newest-first; reverse for display.
+/** `Inertia::scroll` delivers messages newest-first; reverse for display. */
 const serverMessages = computed<Message[]>(() =>
     [...(props.messages?.data ?? [])].reverse(),
 );
 
-// The main channel timeline: optimistic sends + live echoes + edit/delete
-// patches, all merged over the server page and deduped by client uuid.
+/**
+ * The main channel timeline: optimistic sends + live echoes + edit/delete
+ * patches, all merged over the server page and deduped by client uuid.
+ */
 const mainStream = useMessageStream(serverMessages);
 const displayMessages = mainStream.displayMessages;
 
-// Announce genuine inbound messages to screen readers via a polite live region;
-// the virtualized timeline itself can't be a `role="log"` (rows unmount).
+/**
+ * Announce genuine inbound messages to screen readers via a polite live region;
+ * the virtualized timeline itself can't be a `role="log"` (rows unmount).
+ */
 const { announcement } = useMessageAnnouncer({
     messages: () => displayMessages.value,
     currentUserId: () => currentUser.value.id,
 });
 
-// A failed optimistic send rolls its row back silently; this polite live region
-// announces the failure so a screen-reader user hears it, mirroring the toast.
+/**
+ * A failed optimistic send rolls its row back silently; this polite live region
+ * announces the failure so a screen-reader user hears it, mirroring the toast.
+ */
 const { announcement: sendFailureAnnouncement, announce: announceSendFailure } =
     useSendFailureAnnouncer();
 const pendingUuids = mainStream.pendingUuids;
 
 const hasMessages = computed(() => displayMessages.value.length > 0);
 
-// The same grouped render list the virtualized `MessageList` builds, recomputed
-// here so index-based affordances (jump-to-message, the unread boundary) can map
-// a message or divider to the render-item index the virtualizer scrolls to. Pure
-// and cheap; `unreadDividerId` is resolved lazily by the composable below.
+/**
+ * The same grouped render list the virtualized `MessageList` builds, recomputed
+ * here so index-based affordances (jump-to-message, the unread boundary) can map
+ * a message or divider to the render-item index the virtualizer scrolls to. Pure
+ * and cheap; `unreadDividerId` is resolved lazily by the composable below.
+ */
 const timelineItems = computed(() =>
     buildTimelineItems(displayMessages.value, unreadDividerId.value ?? null),
 );
 
-// Focus the channel composer — from the empty-state welcome's "Post your first
-// message" card, or a profile hover card dropping in a mention.
+/**
+ * Focus the channel composer — from the empty-state welcome's "Post your first
+ * message" card, or a profile hover card dropping in a mention.
+ */
 function focusComposer(): void {
     channelComposer.value?.focus();
 }
 
-// The thread panel's whole open → load → reset → mark-read lifecycle, with its own
-// merge stream over the root plus paginated replies. It resets itself on a channel
-// switch, so this page no longer juggles two stream lifecycles inline;
-// `sendThreadReply` stays in `useMessageActions`, sharing this panel's stream.
+/**
+ * The thread panel's whole open → load → reset → mark-read lifecycle, with its own
+ * merge stream over the root plus paginated replies. It resets itself on a channel
+ * switch, so this page no longer juggles two stream lifecycles inline;
+ * `sendThreadReply` stays in `useMessageActions`, sharing this panel's stream.
+ */
 const {
     activeThreadRootId,
     threadLoading,
@@ -350,9 +404,11 @@ const {
     threadReplies: () => props.threadReplies,
 });
 
-// The message to briefly highlight after a search jump. The server windows the
-// initial page so the target is loaded; we scroll it into view and clear the
-// highlight after a short beat.
+/**
+ * The message to briefly highlight after a search jump. The server windows the
+ * initial page so the target is loaded; we scroll it into view and clear the
+ * highlight after a short beat.
+ */
 const highlightedMessageId = ref<string | null>(null);
 let highlightTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -383,10 +439,12 @@ function jumpToMessage(id: string): void {
     });
 }
 
-// The "New messages" divider's lifecycle — freeze its position at open, refreeze
-// on each channel switch, and hide the jump pill once it scrolls into view —
-// lives in this composable. It reads the server page (not the live-merged list)
-// so the boundary is immune to the order per-channel state resets on a switch.
+/**
+ * The "New messages" divider's lifecycle — freeze its position at open, refreeze
+ * on each channel switch, and hide the jump pill once it scrolls into view —
+ * lives in this composable. It reads the server page (not the live-merged list)
+ * so the boundary is immune to the order per-channel state resets on a switch.
+ */
 const { unreadDividerId } = useUnreadDivider({
     channelId: () => props.channel.id,
     scrollContainer,
@@ -395,21 +453,25 @@ const { unreadDividerId } = useUnreadDivider({
     currentUserId: () => currentUser.value.id,
 });
 
-// The unread boundary's render-item index, or -1 when there's none.
+/** The unread boundary's render-item index, or -1 when there's none. */
 const unreadIndex = computed(() => unreadDividerIndex(timelineItems.value));
 
-// Per-visit latch: once the reader reaches the unread boundary (it scrolls into
-// the window) or jumps back to the present, the "New messages" pill is dismissed
-// for the rest of this channel visit. Without it the pill reappears whenever the
-// (frozen) divider sits above the window again — e.g. right after Jump to present
-// (#411). Both flags are refrozen alongside the divider on every channel switch.
+/**
+ * Per-visit latch: once the reader reaches the unread boundary (it scrolls into
+ * the window) or jumps back to the present, the "New messages" pill is dismissed
+ * for the rest of this channel visit. Without it the pill reappears whenever the
+ * (frozen) divider sits above the window again — e.g. right after Jump to present
+ * (#411). Both flags are refrozen alongside the divider on every channel switch.
+ */
 const unreadDividerSeen = ref(false);
 
-// Whether the boundary has ever sat above the window this visit. The reader
-// "reaches" the divider only when it scrolls back into view *after* having been
-// above — the transition the seen latch keys off. This guards against the initial
-// pre-`scrollToBottom` render (rows start at the top, so the divider is briefly
-// on screen before the open pins to the newest message) latching it prematurely.
+/**
+ * Whether the boundary has ever sat above the window this visit. The reader
+ * "reaches" the divider only when it scrolls back into view *after* having been
+ * above — the transition the seen latch keys off. This guards against the initial
+ * pre-`scrollToBottom` render (rows start at the top, so the divider is briefly
+ * on screen before the open pins to the newest message) latching it prematurely.
+ */
 const unreadDividerWasAbove = ref(false);
 
 watch(
@@ -438,12 +500,14 @@ watch([timelineRange, unreadIndex], ([range, index]) => {
     }
 });
 
-// Show the floating "New messages" pill while the unread boundary sits above the
-// virtualizer's window and the reader hasn't reached it yet. Windowing drops the
-// off-screen divider from the DOM, so this replaces the old IntersectionObserver
-// with pure range math plus the per-visit seen latch. Before the first range
-// lands the view is pinned to the bottom, so an existing, unseen boundary is
-// necessarily above it.
+/**
+ * Show the floating "New messages" pill while the unread boundary sits above the
+ * virtualizer's window and the reader hasn't reached it yet. Windowing drops the
+ * off-screen divider from the DOM, so this replaces the old IntersectionObserver
+ * with pure range math plus the per-visit seen latch. Before the first range
+ * lands the view is pinned to the bottom, so an existing, unseen boundary is
+ * necessarily above it.
+ */
 const showJumpToUnread = computed(() => {
     const range = timelineRange.value;
 
@@ -459,26 +523,32 @@ const showJumpToUnread = computed(() => {
     );
 });
 
-// Scroll the unread boundary to the top of the viewport via the virtualizer,
-// bringing it on screen even when it wasn't rendered.
+/**
+ * Scroll the unread boundary to the top of the viewport via the virtualizer,
+ * bringing it on screen even when it wasn't rendered.
+ */
 function scrollToUnread(): void {
     if (unreadIndex.value >= 0) {
         messageListRef.value?.scrollToIndex(unreadIndex.value, 'start');
     }
 }
 
-// Return to the newest message. Jumping to present counts as reaching the unread
-// boundary, so latch it — the reader is done with the "New messages" pill for
-// this visit even if the frozen divider now sits above the window again (#411).
+/**
+ * Return to the newest message. Jumping to present counts as reaching the unread
+ * boundary, so latch it — the reader is done with the "New messages" pill for
+ * this visit even if the frozen divider now sits above the window again (#411).
+ */
 function jumpToPresent(): void {
     unreadDividerSeen.value = true;
     scrollToBottom(true);
 }
 
-// The day the topmost visible row falls in, driving the floating sticky date
-// chip while the reader is scrolled up into history (design 1a). Reads the first
-// dated render item at or after the window's top — a group's lead timestamp or a
-// day divider's own ISO.
+/**
+ * The day the topmost visible row falls in, driving the floating sticky date
+ * chip while the reader is scrolled up into history (design 1a). Reads the first
+ * dated render item at or after the window's top — a group's lead timestamp or a
+ * day divider's own ISO.
+ */
 const stickyDayLabel = computed<string | null>(() => {
     const range = timelineRange.value;
     const items = timelineItems.value;
@@ -513,10 +583,12 @@ function channelName(id: string): string {
     return `channel.${id}`;
 }
 
-// Advance the read pointer for the open channel so its sidebar badge clears.
-// Debounced and gated on tab focus: a channel is only "read" while the user is
-// actually looking at it, and a burst of arriving messages collapses to one
-// request. The redirect refreshes just the shared `channels` prop.
+/**
+ * Advance the read pointer for the open channel so its sidebar badge clears.
+ * Debounced and gated on tab focus: a channel is only "read" while the user is
+ * actually looking at it, and a burst of arriving messages collapses to one
+ * request. The redirect refreshes just the shared `channels` prop.
+ */
 const readPost = useDebouncedPost(
     () => {
         router.post(
@@ -535,10 +607,12 @@ function markRead(): void {
     readPost.schedule();
 }
 
-// The member's own star/mute/notification-level preferences for this channel:
-// seeded from the server, reseeded on every channel switch, saved optimistically
-// and rolled back on error. `threadUnreadSuppressed` mirrors the server's dot
-// suppression and feeds the realtime router below.
+/**
+ * The member's own star/mute/notification-level preferences for this channel:
+ * seeded from the server, reseeded on every channel switch, saved optimistically
+ * and rolled back on error. `threadUnreadSuppressed` mirrors the server's dot
+ * suppression and feeds the realtime router below.
+ */
 const {
     notificationLevel,
     muted,
@@ -555,11 +629,13 @@ const {
     channelSlug: () => props.channel.slug,
 });
 
-// The channel-level pin count driving the masthead badge, and the pins popover
-// state. The count is seeded from the server, resynced on partial reloads and
-// channel switches (the prop watch below), and patched live by the MessagePinned
-// broadcast; the pins list itself rides the `pins` prop, refreshed whenever the
-// panel opens or a pin changes.
+/**
+ * The channel-level pin count driving the masthead badge, and the pins popover
+ * state. The count is seeded from the server, resynced on partial reloads and
+ * channel switches (the prop watch below), and patched live by the MessagePinned
+ * broadcast; the pins list itself rides the `pins` prop, refreshed whenever the
+ * panel opens or a pin changes.
+ */
 const pinCount = ref(props.pinCount);
 watch(
     () => props.pinCount,
@@ -570,15 +646,17 @@ watch(
 
 const pinsPanelOpen = ref(false);
 
-// Open the pins popover, pulling the freshest pins first — another member may
-// have pinned or unpinned since this page loaded, and the count badge and list
-// should agree with the server on open.
+/**
+ * Open the pins popover, pulling the freshest pins first — another member may
+ * have pinned or unpinned since this page loaded, and the count badge and list
+ * should agree with the server on open.
+ */
 function openPinsPanel(): void {
     pinsPanelOpen.value = true;
     router.reload({ only: ['pins', 'pinCount'] });
 }
 
-// Jump to a pinned message from the panel, closing the popover on the way.
+/** Jump to a pinned message from the panel, closing the popover on the way. */
 function jumpToPin(id: string): void {
     pinsPanelOpen.value = false;
     jumpToMessage(id);
@@ -668,11 +746,13 @@ onBeforeUnmount(() => {
     }
 });
 
-// The message the composer is currently quoting, or null for a normal send.
+/** The message the composer is currently quoting, or null for a normal send. */
 const replyTarget = ref<Message | null>(null);
 
-// The id of the message the main composer is editing in place (via the ↑
-// shortcut), or null. Highlights the target row in the timeline while editing.
+/**
+ * The id of the message the main composer is editing in place (via the ↑
+ * shortcut), or null. Highlights the target row in the timeline while editing.
+ */
 const composerEditingId = ref<string | null>(null);
 
 function startReply(message: Message): void {
@@ -683,18 +763,22 @@ function cancelReply(): void {
     replyTarget.value = null;
 }
 
-// The channel composer, so a profile hover card in the main timeline can drop a
-// mention straight into it.
+/**
+ * The channel composer, so a profile hover card in the main timeline can drop a
+ * mention straight into it.
+ */
 const channelComposer = ref<InstanceType<typeof MessageComposer> | null>(null);
 
 function mentionInChannel(member: { id: string; name: string }): void {
     channelComposer.value?.insertMention(member);
 }
 
-// Whole-pane drag-and-drop: dropping files anywhere over the channel content
-// stages them in the composer tray. A depth counter tracks nested
-// dragenter/dragleave so the brass overlay doesn't flicker as the pointer
-// crosses child elements. Only meaningful where the composer itself is shown.
+/**
+ * Whole-pane drag-and-drop: dropping files anywhere over the channel content
+ * stages them in the composer tray. A depth counter tracks nested
+ * dragenter/dragleave so the brass overlay doesn't flicker as the pointer
+ * crosses child elements. Only meaningful where the composer itself is shown.
+ */
 const isDraggingFiles = ref(false);
 let dragDepth = 0;
 
@@ -771,9 +855,11 @@ function onPaneDrop(event: DragEvent): void {
     }
 }
 
-// The message being forwarded and whether the forward dialog is open. The dialog
-// picks a target channel (from the sidebar list — the channels the viewer can
-// post to) and an optional note.
+/**
+ * The message being forwarded and whether the forward dialog is open. The dialog
+ * picks a target channel (from the sidebar list — the channels the viewer can
+ * post to) and an optional note.
+ */
 const forwardTarget = ref<Message | null>(null);
 const forwardDialogOpen = ref(false);
 
@@ -781,8 +867,10 @@ const forwardableChannels = computed<Channel[]>(
     () => page.props.channels ?? [],
 );
 
-// Team members offered as DM forward targets; selecting one opens-or-creates the
-// 1:1 DM on the server.
+/**
+ * Team members offered as DM forward targets; selecting one opens-or-creates the
+ * 1:1 DM on the server.
+ */
 const forwardablePeople = computed<PersonRef[]>(
     () => page.props.teamMembers ?? [],
 );
@@ -792,8 +880,10 @@ function openForward(message: Message): void {
     forwardDialogOpen.value = true;
 }
 
-// Submit the forward dialog: hand the selected source and destination to the
-// actions engine, then clear the target so the dialog resets.
+/**
+ * Submit the forward dialog: hand the selected source and destination to the
+ * actions engine, then clear the target so the dialog resets.
+ */
 function submitForward(payload: { target: ForwardTarget; note: string }): void {
     const source = forwardTarget.value;
 
@@ -804,10 +894,12 @@ function submitForward(payload: { target: ForwardTarget; note: string }): void {
     forwardTarget.value = null;
 }
 
-// The member's unsent composer text is persisted per channel so it survives
-// navigation, reloads and other devices. This composable owns the debounce, the
-// channel-switch flush, and the flush-on-unmount; a send clears the draft
-// server-side, so only manual edits flow through `onDraftChange`.
+/**
+ * The member's unsent composer text is persisted per channel so it survives
+ * navigation, reloads and other devices. This composable owns the debounce, the
+ * channel-switch flush, and the flush-on-unmount; a send clears the draft
+ * server-side, so only manual edits flow through `onDraftChange`.
+ */
 const {
     onDraftChange,
     cancel: cancelDraft,
@@ -818,9 +910,11 @@ const {
     channelSlug: () => props.channel.slug,
 });
 
-// The realtime connection cue (reconnecting / back-online pill) and the offline
-// outbox: sends made while the socket is down queue here and flush on recovery.
-// The outbox persists per channel, so a refresh while offline keeps the queue.
+/**
+ * The realtime connection cue (reconnecting / back-online pill) and the offline
+ * outbox: sends made while the socket is down queue here and flush on recovery.
+ * The outbox persists per channel, so a refresh while offline keeps the queue.
+ */
 const connection = useConnectionState();
 const outbox = createOutbox({ storageKey: `outbox:${props.channel.id}` });
 
@@ -838,15 +932,19 @@ for (const item of outbox.items.value) {
     );
 }
 
-// Client uuids currently held in the outbox, so the timeline can mark each queued
-// row until it flushes.
+/**
+ * Client uuids currently held in the outbox, so the timeline can mark each queued
+ * row until it flushes.
+ */
 const queuedUuids = computed(() =>
     outbox.items.value.map((item) => item.clientUuid),
 );
 
-// The channel's optimistic-mutation engine: send/edit/delete/react/forward,
-// thread replies, scheduling, and reminders all follow the same optimistic-apply
-// → router-call → rollback-on-error shape, concentrated behind one seam.
+/**
+ * The channel's optimistic-mutation engine: send/edit/delete/react/forward,
+ * thread replies, scheduling, and reminders all follow the same optimistic-apply
+ * → router-call → rollback-on-error shape, concentrated behind one seam.
+ */
 const actions = useMessageActions({
     teamSlug: () => props.team.slug,
     channel: () => props.channel,
@@ -881,7 +979,7 @@ const {
     sendCommand,
 } = actions;
 
-// Discard the whole offline queue: drop the optimistic rows and clear the outbox.
+/** Discard the whole offline queue: drop the optimistic rows and clear the outbox. */
 function discardQueue(): void {
     for (const item of outbox.items.value) {
         mainStream.removePending(item.clientUuid);
@@ -924,30 +1022,34 @@ if (connection.isOnline.value && outbox.count.value > 0) {
     flushOutbox();
 }
 
-// The viewer's stored timezone, driving the schedule picker's presets and the
-// list's "sends at" labels so a scheduled time always reads in their own zone.
+/**
+ * The viewer's stored timezone, driving the schedule picker's presets and the
+ * list's "sends at" labels so a scheduled time always reads in their own zone.
+ */
 const { timezone } = useTimezone();
 
-// Whether the "Scheduled messages" management dialog is open.
+/** Whether the "Scheduled messages" management dialog is open. */
 const scheduledDialogOpen = ref(false);
 
-// The message a custom-time reminder is being set for, and whether the custom
-// date & time picker is open.
+/**
+ * The message a custom-time reminder is being set for, and whether the custom
+ * date & time picker is open.
+ */
 const reminderTargetId = ref<string | null>(null);
 const reminderCustomOpen = ref(false);
 
-// A preset was chosen from a message's reminder popover.
+/** A preset was chosen from a message's reminder popover. */
 function remindWith(message: Message, remindAt: string): void {
     setReminder(message.id, remindAt);
 }
 
-// The viewer chose "Custom date & time…"; remember the target and open the picker.
+/** The viewer chose "Custom date & time…"; remember the target and open the picker. */
 function openCustomReminder(message: Message): void {
     reminderTargetId.value = message.id;
     reminderCustomOpen.value = true;
 }
 
-// Confirm the custom reminder time picked in the dialog.
+/** Confirm the custom reminder time picked in the dialog. */
 function confirmCustomReminder(remindAt: string): void {
     if (reminderTargetId.value === null) {
         return;
@@ -957,10 +1059,10 @@ function confirmCustomReminder(remindAt: string): void {
     reminderTargetId.value = null;
 }
 
-// Drives the archive confirmation dialog opened from the channel header menu.
+/** Drives the archive confirmation dialog opened from the channel header menu. */
 const confirmingArchive = ref(false);
 
-// Drives the leave-channel confirmation modal opened from the header menu.
+/** Drives the leave-channel confirmation modal opened from the header menu. */
 const confirmingLeave = ref(false);
 
 function archive(): void {

--- a/resources/js/theme/contrast.test.ts
+++ b/resources/js/theme/contrast.test.ts
@@ -14,7 +14,8 @@ import { describe, expect, it } from 'vitest';
  */
 
 const AA_TEXT = 4.5;
-const AA_NON_TEXT = 3; // focus indicators / non-text (WCAG 1.4.11, 2.4.7)
+/** focus indicators / non-text (WCAG 1.4.11, 2.4.7) */
+const AA_NON_TEXT = 3;
 
 const cssPath = fileURLToPath(new URL('../../css/app.css', import.meta.url));
 const css = readFileSync(cssPath, 'utf8');

--- a/resources/js/types/channels.ts
+++ b/resources/js/types/channels.ts
@@ -1,5 +1,7 @@
-// A DM participant surfaced to the sidebar / masthead for the avatar stack and
-// participant-based name. Mirrors `App\Data\UserData`.
+/**
+ * A DM participant surfaced to the sidebar / masthead for the avatar stack and
+ * participant-based name. Mirrors `App\Data\UserData`.
+ */
 export type DmParticipant = App.Data.UserData;
 
 export type NotificationLevel = 'all' | 'mentions' | 'nothing';
@@ -21,45 +23,65 @@ export type Channel = {
     notificationLevel: NotificationLevel;
     unreadCount: number;
     mentionCount: number;
-    // Whether the viewer has unsent composer text saved for this channel; drives
-    // the sidebar's draft cue. The full `draft` text is only present on the open
-    // channel, so the composer can restore it.
+    /**
+     * Whether the viewer has unsent composer text saved for this channel; drives
+     * the sidebar's draft cue. The full `draft` text is only present on the open
+     * channel, so the composer can restore it.
+     */
     hasDraft: boolean;
     draft: string | null;
-    // Whether the viewer has starred (favorited) this channel, pinning it to the
-    // sidebar's "Starred" section.
+    /**
+     * Whether the viewer has starred (favorited) this channel, pinning it to the
+     * sidebar's "Starred" section.
+     */
     starred: boolean;
-    // The custom section the viewer has filed this channel under, or null for the
-    // default "Channels" group. Starred channels render in "Starred" regardless.
+    /**
+     * The custom section the viewer has filed this channel under, or null for the
+     * default "Channels" group. Starred channels render in "Starred" regardless.
+     */
     sectionId: string | null;
-    // The channel's manual order within whichever sidebar group it renders in;
-    // ties fall back to the alphabetical order the server applies.
+    /**
+     * The channel's manual order within whichever sidebar group it renders in;
+     * ties fall back to the alphabetical order the server applies.
+     */
     position: number;
-    // Whether this channel is a direct message — a 1:1 or a group. DMs render in
-    // the dedicated "Direct messages" sidebar group with a viewer-relative name
-    // and avatar instead of in the channel sections.
+    /**
+     * Whether this channel is a direct message — a 1:1 or a group. DMs render in
+     * the dedicated "Direct messages" sidebar group with a viewer-relative name
+     * and avatar instead of in the channel sections.
+     */
     isDirect: boolean;
-    // Whether this DM is a group conversation (3+ participants). A group renders
-    // an avatar stack + participant-joined name instead of the single other
-    // participant, and supports "Add people" / "Leave conversation".
+    /**
+     * Whether this DM is a group conversation (3+ participants). A group renders
+     * an avatar stack + participant-joined name instead of the single other
+     * participant, and supports "Add people" / "Leave conversation".
+     */
     isGroupDirect: boolean;
-    // For a 1:1 DM, the id of the participant the viewer sees (the other member,
-    // or themselves in a self-DM — labelled "You"); null for a group DM or a
-    // standard channel. Keys the presence dot and avatar.
+    /**
+     * For a 1:1 DM, the id of the participant the viewer sees (the other member,
+     * or themselves in a self-DM — labelled "You"); null for a group DM or a
+     * standard channel. Keys the presence dot and avatar.
+     */
     dmUserId: string | null;
-    // For a DM, the other participants (viewer excluded), ordered by name — the
-    // single other member of a 1:1, or the group's members. Empty for a self-DM,
-    // null for a standard channel. Drives the avatar stack, the participant-based
-    // name, and the same-member-set dedup check.
+    /**
+     * For a DM, the other participants (viewer excluded), ordered by name — the
+     * single other member of a 1:1, or the group's members. Empty for a self-DM,
+     * null for a standard channel. Drives the avatar stack, the participant-based
+     * name, and the same-member-set dedup check.
+     */
     dmParticipants: DmParticipant[] | null;
-    // ISO-8601 timestamp of the channel's most recent activity (latest message,
-    // falling back to when the channel was created), used to order the "Direct
-    // messages" group by recency.
+    /**
+     * ISO-8601 timestamp of the channel's most recent activity (latest message,
+     * falling back to when the channel was created), used to order the "Direct
+     * messages" group by recency.
+     */
     lastActivityAt: string | null;
 };
 
-// A user-created sidebar section, rendered between "Starred" and the default
-// "Channels" group. Mirrors `App\Data\ChannelSectionData`.
+/**
+ * A user-created sidebar section, rendered between "Starred" and the default
+ * "Channels" group. Mirrors `App\Data\ChannelSectionData`.
+ */
 export type ChannelSection = {
     id: string;
     name: string;

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -3,8 +3,10 @@ import type { AttachmentData } from '@/types/attachments';
 export type MessageAuthor = {
     id: string;
     name: string;
-    // The author's avatar URL (derived from their email's Gravatar), or null
-    // when they have none — the UI falls back to their initials.
+    /**
+     * The author's avatar URL (derived from their email's Gravatar), or null
+     * when they have none — the UI falls back to their initials.
+     */
     avatar?: string | null;
 };
 
@@ -23,8 +25,10 @@ export type MessageType = 'standard' | 'member_joined' | 'member_left';
 export type Mention = {
     id: string;
     name: string;
-    // The member's avatar URL (derived from their email's Gravatar), or null
-    // when they have none — the UI falls back to their initials.
+    /**
+     * The member's avatar URL (derived from their email's Gravatar), or null
+     * when they have none — the UI falls back to their initials.
+     */
     avatar?: string | null;
 };
 
@@ -63,8 +67,10 @@ export type MessageForward = {
     id: string;
     body: string;
     authorName: string;
-    // Null when the source is a direct message (a DM has no name); the client
-    // then renders "a direct message" instead of a "#channel" attribution.
+    /**
+     * Null when the source is a direct message (a DM has no name); the client
+     * then renders "a direct message" instead of a "#channel" attribution.
+     */
     channelName: string | null;
     isDeleted: boolean;
     mentions: Mention[];


### PR DESCRIPTION
Closes #513.

## What

Sweeps `resources/js/**` to cut inline `//` comment noise, applying one decision per comment:

- **Delete** inline `//` comments that merely restate what the code already says (pure *what* narration).
- **Promote** comments that document a *declaration* — a prop, emit, `type`/`interface` member, function, or exported symbol — into `/** … */` JSDoc/TSDoc blocks above that declaration, so editors and Volar surface them on hover.
- **Keep as `//`** genuine *why*/intent/edge-case/ordering notes that explain a statement or branch inside a body.

Existing `/** */` blocks, tooling directives (`// eslint-*`, `// @ts-*`, `// @vitest*`, `// v8 ignore`, `// TODO`), commented-out code, and `.vue` `<template>`/`<style>` blocks were left untouched.

Net: ~300 comments promoted to JSDoc/TSDoc, a handful of pure-*what* lines deleted, across 57 files.

## Prevent regression (per the issue)

- **`CLAUDE.md`** — new *Code Comments (JS/TS)* section codifying the delete / promote / keep rule as the JS/TS counterpart to the PHP "prefer PHPDoc over inline comments" convention.
- **`implement-issue` skill** — updated so newly generated code follows the same rule.

## Behavior / testing

Pure comment change — **no behavior change**. Verified by stripping all comments from both revisions of every changed file and diffing: code is byte-identical. Frontend gate stays green: `format:check`, `lint:check` (0 errors), `types:check`, and `build` all pass.

No i18n or operator-facing docs impact (comments only).