### PR TITLE
fix: dark-mode contrast on Version available badge (About page)

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -179,6 +179,9 @@
     --input: #2a271f;
     --ring: #c9a35c;
     --brass: #c9a35c;
+    /* Light brass so badge/pill text stays legible on the dark brass fill; the
+       light value (#1d1a15) would render near-black on the dark surface (#518). */
+    --brass-foreground: #dcb56a;
     --brass-border: #c9a35c;
     --brass-fill: rgba(201, 163, 92, 0.14);
     --brass-fill-foreground: #dcb56a;

--- a/resources/js/theme/contrast.test.ts
+++ b/resources/js/theme/contrast.test.ts
@@ -167,6 +167,36 @@ describe('theme contrast (WCAG AA)', () => {
     // which measured 2.94:1 (#278); lock the surfaces it renders on so the brass
     // debt can't creep back. The channel axe audit can't guard it: to stay scoped
     // to #268 it seeds a *read* message, so the divider never renders there.
+    // The "Version X.Y.Z available" badge (settings/About.vue, `isBehind`) paints
+    // --brass-foreground on a `bg-brass/10` fill composited over the settings
+    // card. Dark mode overrode --brass but not --brass-foreground, leaving
+    // near-black text on the dark fill (#518); lock body-text AA in both themes.
+    const BADGE_FILL_ALPHA = 0.1; // matches the `bg-brass/10` utility
+
+    it('light --brass-foreground meets AA on the version badge', () => {
+        const badge = flatten(
+            hexToRgb(light['brass']),
+            BADGE_FILL_ALPHA,
+            hexToRgb(light['card']),
+        );
+
+        expect(
+            contrast(hexToRgb(light['brass-foreground']), badge),
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+    });
+
+    it('dark --brass-foreground meets AA on the version badge', () => {
+        const badge = flatten(
+            hexToRgb(dark['brass']),
+            BADGE_FILL_ALPHA,
+            hexToRgb(dark['card']),
+        );
+
+        expect(
+            contrast(hexToRgb(dark['brass-foreground']), badge),
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+    });
+
     const dividerSurfaces = ['card', 'background'] as const;
 
     it.each(dividerSurfaces)(


### PR DESCRIPTION
Closes #518.

## What
In dark mode, the "Version X.Y.Z available" pill on **Settings → About this instance** rendered near-black text (`text-brass-foreground`) on the dark `bg-brass/10` fill, making the label invisible.

## Why
The `.dark` block in `resources/css/app.css` overrode `--brass`, `--brass-border`, `--brass-fill`, and `--brass-fill-foreground`, but **not** `--brass-foreground`, so the badge text kept the light theme's near-black value (`#1d1a15`).

## Fix
Add a dark-theme override `--brass-foreground: #dcb56a` (light brass, matching the sibling `--brass-fill-foreground`). Light mode is untouched. Measured contrast on the composited badge fill is ~7.5:1 (dark) — well past WCAG AA 4.5:1.

## Tested
Extended `resources/js/theme/contrast.test.ts` with badge-contrast assertions in both themes (`--brass-foreground` on `bg-brass/10` over the settings card). Red before the token was added, green after. Full frontend gate (test:js, lint, format, types, build) passes. No PHP changed.

No i18n or docs impact (token-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contrast for brass-colored version badges in dark mode.
  * Ensured the “Version X.Y.Z available” badge meets WCAG AA text-contrast requirements in both light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->