### PR TITLE
feat: quick theme and sidebar switchers in the user menu

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -11,6 +11,7 @@ use App\Data\UpdateStatusData;
 use App\Data\UserData;
 use App\Enums\MessageReminderStatus;
 use App\Enums\MessageType;
+use App\Enums\SidebarPosition;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Message;
@@ -115,6 +116,12 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $user,
             ],
+            // The selectable sidebar positions (left / right) ride every request
+            // so the user-menu quick switcher can offer them anywhere, not just on
+            // Settings → Appearance where the page-level prop is scoped. The enum
+            // is the single source of truth, shared the same way the settings page
+            // sources its own options.
+            'sidebarPositions' => SidebarPosition::options(),
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
             'teams' => fn () => $user?->toUserTeams(includeCurrent: true) ?? [],

--- a/resources/js/components/MenuSegmentedControl.test.ts
+++ b/resources/js/components/MenuSegmentedControl.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import MenuSegmentedControl from './MenuSegmentedControl.vue';
+
+const Dot = defineComponent({ render: () => h('svg') });
+
+const OPTIONS = [
+    { value: 'light', label: 'Light', icon: Dot },
+    { value: 'dark', label: 'Dark', icon: Dot },
+    { value: 'system', label: 'System', icon: Dot },
+];
+
+let app: App | null = null;
+
+function mount(modelValue: string) {
+    const updates: string[] = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    app = createApp({
+        render: () =>
+            h(MenuSegmentedControl, {
+                modelValue,
+                options: OPTIONS,
+                ariaLabel: 'Theme',
+                'onUpdate:modelValue': (value: string) => updates.push(value),
+            }),
+    });
+    app.mount(host);
+
+    const radios = Array.from(
+        host.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
+    );
+
+    return { host, radios, updates };
+}
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('MenuSegmentedControl', () => {
+    it('renders a labelled group with one menuitemradio per option, the current one checked', () => {
+        const { host, radios } = mount('dark');
+
+        const group = host.querySelector('[role="group"]');
+        expect(group?.getAttribute('aria-label')).toBe('Theme');
+        expect(radios).toHaveLength(3);
+        expect(radios.map((r) => r.getAttribute('aria-checked'))).toEqual([
+            'false',
+            'true',
+            'false',
+        ]);
+        // Each icon-only segment is named and carries a tooltip.
+        expect(radios.map((r) => r.getAttribute('aria-label'))).toEqual([
+            'Light',
+            'Dark',
+            'System',
+        ]);
+        expect(radios.map((r) => r.getAttribute('title'))).toEqual([
+            'Light',
+            'Dark',
+            'System',
+        ]);
+    });
+
+    it('gives only the checked radio a tabindex of 0 (roving tabindex)', () => {
+        const { radios } = mount('dark');
+
+        expect(radios.map((r) => r.getAttribute('tabindex'))).toEqual([
+            '-1',
+            '0',
+            '-1',
+        ]);
+    });
+
+    it('emits the new value on click but stays silent when the current one is re-clicked', () => {
+        const { radios, updates } = mount('dark');
+
+        radios[2].click();
+        radios[1].click();
+
+        expect(updates).toEqual(['system']);
+    });
+
+    it('moves selection with the arrow keys, wrapping at the ends', async () => {
+        const { radios, updates } = mount('dark');
+
+        radios[1].dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+        );
+        await nextTick();
+        radios[0].dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+        );
+
+        expect(updates).toEqual(['system', 'system']);
+    });
+
+    it('toggles with Space/Enter without letting the event bubble to the dropdown', () => {
+        const bubbled: string[] = [];
+        const { host, radios } = mount('dark');
+        host.addEventListener('keydown', (e) => bubbled.push(e.key));
+
+        const event = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            bubbles: true,
+            cancelable: true,
+        });
+        radios[1].dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(bubbled).toEqual([]);
+    });
+
+    it('slides the thumb to the active segment', () => {
+        const { host } = mount('system');
+
+        const thumb = host.querySelector<HTMLElement>('[data-slot="thumb"]');
+        expect(thumb?.style.transform).toBe('translateX(62px)');
+    });
+});

--- a/resources/js/components/MenuSegmentedControl.vue
+++ b/resources/js/components/MenuSegmentedControl.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts" generic="T extends string">
+import type { Component } from 'vue';
+import { computed, ref } from 'vue';
+
+/**
+ * A single segment in the control: its stored value, an accessible name, and the
+ * icon drawn inside the icon-only pill.
+ */
+type SegmentOption = {
+    value: T;
+    label: string;
+    icon: Component;
+};
+
+const props = defineProps<{
+    /** The currently selected value; the matching segment reads as checked. */
+    modelValue: T;
+    options: SegmentOption[];
+    /** Names the radiogroup for assistive tech (e.g. "Theme"). */
+    ariaLabel: string;
+}>();
+
+const emit = defineEmits<{
+    'update:modelValue': [value: T];
+}>();
+
+/** Each segment's button, so arrow-key navigation can move focus. */
+const segments = ref<HTMLButtonElement[]>([]);
+
+const activeIndex = computed(() =>
+    props.options.findIndex((option) => option.value === props.modelValue),
+);
+
+/** The segment that Tab lands on: the checked one, or the first as a fallback. */
+const tabbableIndex = computed(() =>
+    activeIndex.value >= 0 ? activeIndex.value : 0,
+);
+
+function select(index: number): void {
+    const option = props.options[index];
+
+    if (option && option.value !== props.modelValue) {
+        emit('update:modelValue', option.value);
+    }
+}
+
+function focusSegment(index: number): void {
+    select(index);
+    segments.value[index]?.focus();
+}
+
+/**
+ * Drive the group from the keyboard per the radio-group pattern: arrows (and
+ * Home/End) move and select, Space/Enter re-selects the focused segment. The
+ * event is swallowed so the enclosing dropdown neither runs its own arrow
+ * roving/typeahead nor closes on Enter — the menu stays open under the cursor.
+ */
+function onKeydown(event: KeyboardEvent, index: number): void {
+    const count = props.options.length;
+    let next: number;
+
+    switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+            next = (index + 1) % count;
+            break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+            next = (index - 1 + count) % count;
+            break;
+        case 'Home':
+            next = 0;
+            break;
+        case 'End':
+            next = count - 1;
+            break;
+        case ' ':
+        case 'Enter':
+            next = index;
+            break;
+        default:
+            return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    focusSegment(next);
+}
+</script>
+
+<template>
+    <!--
+      Icon-only segmented control in the app's pill-track pattern (30×24 pills on
+      an inset muted track). The active segment takes the menu's pressed-row
+      treatment — an ink/cream `bg-primary` fill with a brass icon — and a single
+      thumb slides between segments in 120ms. Built as a `group` of
+      `menuitemradio`s so it is valid ARIA inside the parent `role="menu"`;
+      selecting applies instantly and never closes the dropdown.
+    -->
+    <div
+        role="group"
+        :aria-label="ariaLabel"
+        class="relative flex gap-px rounded-full border border-border bg-muted p-0.5"
+    >
+        <span
+            v-if="activeIndex >= 0"
+            aria-hidden="true"
+            data-slot="thumb"
+            class="pointer-events-none absolute top-0.5 left-0.5 h-6 w-7.5 rounded-full bg-primary shadow-[0_1px_4px_rgba(29,26,21,0.25)] transition-transform duration-[120ms] ease-out dark:shadow-[0_1px_4px_rgba(0,0,0,0.35)]"
+            :style="{ transform: `translateX(${activeIndex * 31}px)` }"
+        />
+
+        <!-- eslint-disable-next-line local/no-raw-button -- Bespoke roving-tabindex menuitemradio pill; needs a raw focusable element and carries none of the Button primitive's variant/size/ring. -->
+        <button
+            v-for="(option, index) in options"
+            :key="option.value"
+            :ref="
+                (el) => {
+                    if (el) {
+                        segments[index] = el as HTMLButtonElement;
+                    }
+                }
+            "
+            type="button"
+            role="menuitemradio"
+            :aria-checked="option.value === modelValue"
+            :aria-label="option.label"
+            :title="option.label"
+            :tabindex="index === tabbableIndex ? 0 : -1"
+            class="relative z-10 flex h-6 w-7.5 items-center justify-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-popover focus-visible:outline-none"
+            :class="
+                option.value === modelValue
+                    ? 'text-brass'
+                    : 'text-muted-foreground hover:bg-secondary hover:text-foreground'
+            "
+            @click="focusSegment(index)"
+            @keydown="onKeydown($event, index)"
+        >
+            <component :is="option.icon" class="size-3" :stroke-width="2" />
+        </button>
+    </div>
+</template>

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -1,20 +1,35 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
-import { Compass, Keyboard, LogOut, Settings } from '@lucide/vue';
+import {
+    Compass,
+    Keyboard,
+    LogOut,
+    Monitor,
+    Moon,
+    PanelLeft,
+    PanelRight,
+    Settings,
+    Sun,
+} from '@lucide/vue';
+import type { Component } from 'vue';
 import { computed } from 'vue';
+import MenuSegmentedControl from '@/components/MenuSegmentedControl.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
     DropdownMenuItem,
     DropdownMenuLabel,
     DropdownMenuShortcut,
 } from '@/components/ui/dropdown-menu';
+import { useAppearance } from '@/composables/useAppearance';
 import { useInitials } from '@/composables/useInitials';
 import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
 import { useOnboardingTour } from '@/composables/useOnboardingTour';
+import { useSidebarPosition } from '@/composables/useSidebarPosition';
+import { useTranslations } from '@/composables/useTranslations';
 import { useUpdateStatus } from '@/composables/useUpdateStatus';
 import { logout } from '@/routes';
 import { edit } from '@/routes/profile';
-import type { Team, User } from '@/types';
+import type { Appearance, SidebarPosition, Team, User } from '@/types';
 
 type Props = {
     user: User;
@@ -22,8 +37,35 @@ type Props = {
 
 const page = usePage();
 const { getInitials } = useInitials();
+const { t } = useTranslations();
 const { open: openKeyboardShortcuts } = useKeyboardShortcutsModal();
 const { open: replayOnboardingTour } = useOnboardingTour();
+
+// Quick theme + sidebar switchers reuse the same composables (and shared
+// `sidebarPositions` prop) as Settings → Appearance, so flipping either here
+// reflects there and back with no extra persistence.
+const { appearance, updateAppearance } = useAppearance();
+const { sidebarPosition, updateSidebarPosition } = useSidebarPosition();
+
+const themeOptions = computed<
+    { value: Appearance; label: string; icon: Component }[]
+>(() => [
+    { value: 'light', label: t('Light'), icon: Sun },
+    { value: 'dark', label: t('Dark'), icon: Moon },
+    { value: 'system', label: t('System'), icon: Monitor },
+]);
+
+const sidebarIcons: Record<SidebarPosition, Component> = {
+    left: PanelLeft,
+    right: PanelRight,
+};
+
+const sidebarOptions = computed(() =>
+    page.props.sidebarPositions.map((option) => ({
+        ...option,
+        icon: sidebarIcons[option.value],
+    })),
+);
 
 // The menu footer always shows the running version; when behind it becomes a
 // link to the release notes, so the fact stays reachable after the dock strip
@@ -112,6 +154,45 @@ const handleLogout = () => {
                 class="ml-auto rounded-full border border-brass/40 bg-brass-fill px-1.75 py-0.5 text-[9px] font-bold tracking-[0.09em] text-brass-fill-foreground uppercase"
                 >{{ $t('Later') }}</span
             >
+        </div>
+    </div>
+
+    <!-- Appearance: quick theme + sidebar switchers, grouped ahead of navigation.
+         Both are label-left / segmented-control-right rows wired to the same
+         composables as Settings → Appearance; selecting one applies instantly and
+         leaves the menu open. -->
+    <div class="px-2 pt-3 pb-1">
+        <DropdownMenuLabel
+            class="px-2.5 pb-1.5 text-[10px] font-semibold tracking-[0.12em] text-muted-foreground uppercase"
+            >{{ $t('Appearance') }}</DropdownMenuLabel
+        >
+        <div class="flex h-9.5 items-center gap-2.5 px-2.5">
+            <span class="flex-1 text-[13px] text-foreground">{{
+                $t('Theme')
+            }}</span>
+            <MenuSegmentedControl
+                :model-value="appearance"
+                :options="themeOptions"
+                :aria-label="$t('Theme')"
+                data-test="menu-theme-switcher"
+                @update:model-value="
+                    (value) => updateAppearance(value as Appearance)
+                "
+            />
+        </div>
+        <div class="flex h-9.5 items-center gap-2.5 px-2.5">
+            <span class="flex-1 text-[13px] text-foreground">{{
+                $t('Sidebar')
+            }}</span>
+            <MenuSegmentedControl
+                :model-value="sidebarPosition"
+                :options="sidebarOptions"
+                :aria-label="$t('Sidebar position')"
+                data-test="menu-sidebar-switcher"
+                @update:model-value="
+                    (value) => updateSidebarPosition(value as SidebarPosition)
+                "
+            />
         </div>
     </div>
 

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -3,6 +3,7 @@ import type { Auth } from '@/types/auth';
 import type { Channel, ChannelSection } from '@/types/channels';
 import type { MessageReminder } from '@/types/messages';
 import type { PersonRef } from '@/types/people';
+import type { SidebarPositionOption } from '@/types/sidebar';
 import type { DashboardInvitation, RoleOption, Team } from '@/types/teams';
 
 // Extend ImportMeta interface for Vite...
@@ -28,6 +29,7 @@ declare module '@inertiajs/core' {
             sso: { oidcEnabled: boolean; passwordLoginEnabled: boolean };
             attachments: { maxSizeMb: number; maxPerMessage: number };
             gifPickerEnabled: boolean;
+            sidebarPositions: SidebarPositionOption[];
             sidebarOpen: boolean;
             currentTeam: Team | null;
             teams: Team[];

--- a/tests/Browser/UserMenuSwitchersTest.php
+++ b/tests/Browser/UserMenuSwitchersTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The user menu carries quick Theme + Sidebar switchers that reuse the same
+ * composables as Settings → Appearance, so flipping either applies instantly,
+ * leaves the dropdown open, and stays in sync with the settings surface.
+ */
+test('the theme switcher repaints live from the menu without closing it', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@menu-theme-switcher')
+        // Let the dropdown settle past its open/pointer-grace window.
+        ->wait(0.5)
+        // Picking Dark toggles the root `.dark` class through useAppearance...
+        ->click('[data-test="menu-theme-switcher"] [aria-label="Dark"]')
+        ->assertScript('document.documentElement.classList.contains("dark")', true)
+        // ...and the menu stays open with the control still under the cursor.
+        ->assertPresent('@menu-theme-switcher')
+        ->assertAttribute(
+            '[data-test="menu-theme-switcher"] [aria-label="Dark"]',
+            'aria-checked',
+            'true',
+        );
+});
+
+test('the sidebar switcher moves the dock live from the menu without closing it', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->assertPresent('[data-slot="sidebar"][data-side="left"]')
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@menu-sidebar-switcher')
+        ->wait(0.5)
+        // Choosing Right PATCHes the preference; the redirect refreshes the shared
+        // user prop, re-binding :side with no reload, and the menu stays open.
+        ->click('[data-test="menu-sidebar-switcher"] [aria-label="Right"]')
+        ->assertPresent('[data-slot="sidebar"][data-side="right"]')
+        ->assertMissing('[data-slot="sidebar"][data-side="left"]')
+        ->assertPresent('@menu-sidebar-switcher');
+});
+
+test('the menu switchers are keyboard-operable groups of named menuitemradios', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@menu-theme-switcher')
+        ->wait(0.5)
+        // Each track is a named group (menuitemradio children are valid ARIA
+        // inside the parent role="menu"; a radiogroup would not be).
+        ->assertAriaAttribute('[data-test="menu-theme-switcher"]', 'label', 'Theme')
+        ->assertAriaAttribute(
+            '[data-test="menu-sidebar-switcher"]',
+            'label',
+            'Sidebar position',
+        )
+        ->assertAttribute(
+            '[data-test="menu-theme-switcher"] [aria-label="Dark"]',
+            'role',
+            'menuitemradio',
+        )
+        // Arrow keys move within a group and select: focusing Light then pressing
+        // ArrowRight advances to (and checks) the Dark segment.
+        ->keys('[data-test="menu-theme-switcher"] [aria-label="Light"]', 'ArrowRight')
+        ->assertAttribute(
+            '[data-test="menu-theme-switcher"] [aria-label="Dark"]',
+            'aria-checked',
+            'true',
+        )
+        // The menu stays open throughout (the segments are not closing menu items).
+        ->assertPresent('@menu-theme-switcher');
+});

--- a/tests/Feature/SidebarPositionsSharingTest.php
+++ b/tests/Feature/SidebarPositionsSharingTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Enums\SidebarPosition;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('the sidebar-position options are shared to the frontend so the user menu can offer the switcher anywhere', function (): void {
+    $this->get(route('home'))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('sidebarPositions', SidebarPosition::options())
+        );
+});


### PR DESCRIPTION
Closes #520.

## What
Adds an **Appearance** section to the user-menu dropdown (`UserMenuContent.vue`), slotted between **Status** and **Account**, with two icon-only segmented switchers:

- **Theme** — light / dark / system (sun / moon / monitor)
- **Sidebar** — left / right (panel-left / panel-right)

Matches the linked design in both light and dark, including the ink/cream `bg-primary` active fill with a brass icon and the 120ms sliding thumb.

## Why / how
- Both switchers reuse the existing `useAppearance` and `useSidebarPosition` composables, so flipping either here reflects on **Settings → Appearance** and back — **no new persistence**.
- The sidebar options are sourced from a newly shared `sidebarPositions` Inertia prop (the `SidebarPosition` enum), not hardcoded. The settings page already scoped this prop; it's now shared globally so the always-present menu can offer it anywhere.
- Selecting a segment applies **instantly and keeps the menu open** (the segments are not menu items).

## Accessibility
- Each control is a `role="group"` of `role="menuitemradio"` segments — valid ARIA inside the parent `role="menu"` (a `radiogroup` is not, and axe flags it). Named group + named, `aria-checked` segments, roving `tabindex`, arrow / Home / End / Space / Enter keyboard support, tooltips on the icon-only pills.
- Verified with axe that the change introduces no new violations.

## i18n
No new keys — all of `Appearance` / `Theme` / `Sidebar` / `Light` / `Dark` / `System` / `Left` / `Right` already exist in `lang/fr.json`.

## Tests
- `tests/Feature/SidebarPositionsSharingTest.php` — the shared prop.
- `resources/js/components/MenuSegmentedControl.test.ts` — widget semantics + keyboard (vitest).
- `tests/Browser/UserMenuSwitchersTest.php` — theme + sidebar apply live without closing the menu; ARIA/keyboard contract.
- Full gate green: Pint, PHPStan, Rector, `php artisan test --coverage --min=100` (100%), lint/format/types/build.

CodeRabbit: one minor defensive nit (extra wait in the sidebar browser test) declined — the test mirrors the existing `SidebarPositionTest` pattern and `assertPresent` already auto-waits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick appearance controls to the user menu for switching themes and sidebar positions.
  * Changes apply immediately while keeping the menu open.
  * Added keyboard navigation and accessibility support for the new controls.

* **Bug Fixes**
  * Sidebar position options are now consistently available across pages.

* **Tests**
  * Added coverage for rendering, keyboard interaction, accessibility states, and live theme/sidebar updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->