### PR TITLE
fix: re-check channel participation in message edit/delete policy

### DIFF
--- a/app/Policies/MessagePolicy.php
+++ b/app/Policies/MessagePolicy.php
@@ -11,9 +11,12 @@ class MessagePolicy
     /**
      * Determine whether the user can edit the message.
      *
-     * Only the author may edit their own message; edits are never a moderation
-     * action. System notices are inert and carry no editable body, so no one may
-     * edit them even though the actor is recorded as their author.
+     * A message may only be mutated in a channel the actor can currently
+     * participate in: the author must still be a channel member and the channel
+     * must not be archived (the same rule as posting). Edits are never a
+     * moderation action, so there is no admin branch. System notices are inert
+     * and carry no editable body, so no one may edit them even though the actor
+     * is recorded as their author.
      */
     public function update(User $user, Message $message): bool
     {
@@ -21,15 +24,20 @@ class MessagePolicy
             return false;
         }
 
-        return $message->user_id === $user->id;
+        return $message->user_id === $user->id
+            && $user->can('postMessage', $message->channel);
     }
 
     /**
      * Determine whether the user can delete the message.
      *
-     * The author may delete their own message, and a team Admin+ may delete any
-     * message in the team as a moderation action. System notices are inert, so
-     * neither the recorded actor nor a moderator may delete them.
+     * The author may delete their own message only in a channel they can
+     * currently participate in (still a member, channel not archived — the same
+     * rule as posting). A team Admin+ may delete any message in the team as a
+     * moderation action, deliberately independent of channel membership and
+     * archived state so moderation reaches private channels the admin isn't in
+     * and read-only archives. System notices are inert, so neither the recorded
+     * actor nor a moderator may delete them.
      */
     public function delete(User $user, Message $message): bool
     {
@@ -37,7 +45,10 @@ class MessagePolicy
             return false;
         }
 
-        return $message->user_id === $user->id
-            || ($user->teamRole($message->channel->team)?->isAtLeast(TeamRole::Admin) ?? false);
+        if ($message->user_id === $user->id && $user->can('postMessage', $message->channel)) {
+            return true;
+        }
+
+        return $user->teamRole($message->channel->team)?->isAtLeast(TeamRole::Admin) ?? false;
     }
 }

--- a/tests/Feature/Channels/MessagePolicyTest.php
+++ b/tests/Feature/Channels/MessagePolicyTest.php
@@ -24,6 +24,23 @@ function teamWithMessage(User $author): array
     return [$owner, $team, $general, $message];
 }
 
+/**
+ * Create a team and a private channel holding a message authored by $author.
+ *
+ * @return array{0: User, 1: Team, 2: Channel, 3: Message}
+ */
+function teamWithPrivateChannelMessage(User $author): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $team->memberships()->firstOrCreate(['user_id' => $author->id], ['role' => TeamRole::Member]);
+    $channel = Channel::factory()->for($team)->private()->create(['created_by' => $owner->id]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $author->id]);
+    $message = Message::factory()->for($channel)->for($author)->create();
+
+    return [$owner, $team, $channel, $message];
+}
+
 test('the author can edit their own message', function (): void {
     $author = User::factory()->create();
     [, , , $message] = teamWithMessage($author);
@@ -68,4 +85,61 @@ test('a plain member cannot delete another members message', function (): void {
     $team->memberships()->create(['user_id' => $member->id, 'role' => TeamRole::Member]);
 
     expect($member->can('delete', $message))->toBeFalse();
+});
+
+test('the author cannot edit their message after being removed from a private channel', function (): void {
+    $author = User::factory()->create();
+    [, , $channel, $message] = teamWithPrivateChannelMessage($author);
+
+    $channel->channelMembers()->where('user_id', $author->id)->delete();
+
+    expect($author->can('update', $message))->toBeFalse();
+});
+
+test('the author cannot edit their message in an archived channel', function (): void {
+    $author = User::factory()->create();
+    [, , $channel, $message] = teamWithPrivateChannelMessage($author);
+
+    $channel->update(['archived_at' => now()]);
+
+    expect($author->can('update', $message->fresh()))->toBeFalse();
+});
+
+test('the author cannot delete their message after being removed from a private channel', function (): void {
+    $author = User::factory()->create();
+    [, , $channel, $message] = teamWithPrivateChannelMessage($author);
+
+    $channel->channelMembers()->where('user_id', $author->id)->delete();
+
+    expect($author->can('delete', $message))->toBeFalse();
+});
+
+test('the author cannot delete their message in an archived channel', function (): void {
+    $author = User::factory()->create();
+    [, , $channel, $message] = teamWithPrivateChannelMessage($author);
+
+    $channel->update(['archived_at' => now()]);
+
+    expect($author->can('delete', $message->fresh()))->toBeFalse();
+});
+
+test('a team admin can delete a message in an archived channel', function (): void {
+    $author = User::factory()->create();
+    [, $team, $channel, $message] = teamWithPrivateChannelMessage($author);
+
+    $admin = User::factory()->create();
+    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+    $channel->update(['archived_at' => now()]);
+
+    expect($admin->can('delete', $message->fresh()))->toBeTrue();
+});
+
+test('a team admin can delete a message in a private channel they are not a member of', function (): void {
+    $author = User::factory()->create();
+    [, $team, , $message] = teamWithPrivateChannelMessage($author);
+
+    $admin = User::factory()->create();
+    $team->memberships()->create(['user_id' => $admin->id, 'role' => TeamRole::Admin]);
+
+    expect($admin->can('delete', $message))->toBeTrue();
 });


### PR DESCRIPTION
Closes #559.

## What

`MessagePolicy::update` and the author branch of `MessagePolicy::delete` now require the actor to still be able to post in the message's channel (`ChannelPolicy::postMessage` — current member **and** channel not archived). The team Admin+ moderation branch of `delete` stays deliberately membership- and archived-independent, so admins can still moderate private channels they aren't in and archived (read-only) channels. System messages remain non-editable/non-deletable (unchanged).

## Why

A user removed from a private channel (but still on the team) could edit/delete their own past messages there, broadcasting to current members; any author could mutate messages in an archived channel. Invariant now: **you can only mutate a message in a channel you can currently participate in**, with a moderation carve-out for admins. Decisions grilled in #559.

## Testing

New Pest policy tests: removed-private-member edit/delete denied, author edit/delete in archived channel denied, admin delete in archived / not-a-member private channel still allowed; existing tests pin normal author edit/delete and system-message immutability. Full gate green: Pint, PHPStan, Rector, 100% coverage, frontend lint/format/types/build. Local CodeRabbit pass: 0 findings.

No i18n or docs changes (policy-only, no user-facing copy or operator-facing behaviour).

Note: worktree bootstrap hit #563 (`bin/worktree` inheriting `DEMO_MODE=true` from the main checkout's `.env`) — worked around locally, no fix included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message authors can no longer edit or delete messages after losing access to the channel.
  * Messages in archived channels cannot be edited or deleted by authors.
  * System notices remain protected from editing and deletion.
  * Team admins can still delete messages in archived or private channels when authorized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->