### PR TITLE
fix: throttle the forgot-password and reset-password endpoints

### DIFF
--- a/app/Http/Middleware/ThrottlePasswordResetRequests.php
+++ b/app/Http/Middleware/ThrottlePasswordResetRequests.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Symfony\Component\HttpFoundation\Response;
+
+class ThrottlePasswordResetRequests extends ThrottleRequests
+{
+    /**
+     * Apply the `password-reset` rate limiter to the password-reset POSTs.
+     *
+     * Fortify exposes limiter hooks for its login, two-factor, and passkey
+     * routes but none for `password.email` / `password.update`, so this runs as
+     * a global web middleware matched by route name — the same pattern
+     * PreventDestructiveDemoActions uses to cover package-registered routes
+     * without redefining them (a runtime route patch would not survive
+     * `route:cache`, which production runs). Everything else passes through
+     * untouched.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    #[\Override]
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = ''): Response
+    {
+        if (! $request->routeIs('password.email', 'password.update')) {
+            return $next($request);
+        }
+
+        return parent::handle($request, $next, 'password-reset');
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -195,6 +195,15 @@ class FortifyServiceProvider extends ServiceProvider
         RateLimiter::for('passkeys', fn (Request $request): Limit => Limit::perMinute(5)
             ->by('passkeys|'.($request->user()?->getAuthIdentifier() ?? $request->ip())));
 
+        // Both password-reset POSTs are guest endpoints, so the IP is the only
+        // stable identity to key on. The route name is part of the key so the
+        // request and completion endpoints get independent buckets — burning the
+        // forgot-password limit must not lock a user out of finishing a reset.
+        // Applied by the ThrottlePasswordResetRequests web middleware (Fortify
+        // has no limiter hook for these routes).
+        RateLimiter::for('password-reset', fn (Request $request): Limit => Limit::perMinute(5)
+            ->by('password-reset|'.$request->route()?->getName().'|'.$request->ip()));
+
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,6 +12,7 @@ use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\PreventDestructiveDemoActions;
 use App\Http\Middleware\SetLocale;
 use App\Http\Middleware\SetTeamUrlDefaults;
+use App\Http\Middleware\ThrottlePasswordResetRequests;
 use App\Http\Middleware\TrackActiveSession;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -64,6 +65,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             EnsurePasswordLoginEnabled::class,
             EnsurePasskeysEnabled::class,
+            ThrottlePasswordResetRequests::class,
             PreventDestructiveDemoActions::class,
             HandleAppearance::class,
             SetLocale::class,

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -76,3 +76,52 @@ test('password cannot be reset with invalid token', function (): void {
 
     $response->assertSessionHasErrors('email');
 });
+
+test('the forgot-password endpoint is rate limited by ip', function (): void {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    foreach (range(1, 5) as $attempt) {
+        $this->post(route('password.email'), ['email' => $user->email])->assertRedirect();
+    }
+
+    $this->post(route('password.email'), ['email' => $user->email])->assertTooManyRequests();
+});
+
+test('the reset-password endpoint is rate limited by ip', function (): void {
+    $user = User::factory()->create();
+
+    foreach (range(1, 5) as $attempt) {
+        $this->post(route('password.update'), [
+            'token' => 'invalid-token',
+            'email' => $user->email,
+            'password' => 'newpassword123',
+            'password_confirmation' => 'newpassword123',
+        ])->assertRedirect();
+    }
+
+    $this->post(route('password.update'), [
+        'token' => 'invalid-token',
+        'email' => $user->email,
+        'password' => 'newpassword123',
+        'password_confirmation' => 'newpassword123',
+    ])->assertTooManyRequests();
+});
+
+test('the forgot-password and reset-password throttles use separate buckets', function (): void {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    foreach (range(1, 5) as $attempt) {
+        $this->post(route('password.email'), ['email' => $user->email])->assertRedirect();
+    }
+
+    $this->post(route('password.update'), [
+        'token' => 'invalid-token',
+        'email' => $user->email,
+        'password' => 'newpassword123',
+        'password_confirmation' => 'newpassword123',
+    ])->assertRedirect();
+});


### PR DESCRIPTION
Closes #560.

## What

`POST /forgot-password` and `POST /reset-password` ran with no IP rate limit (forgot-password relied solely on the broker's per-user 60s throttle). `POST /passkeys/login` — the third endpoint in the issue — was already covered by the `passkeys` limiter added in #565.

- New `password-reset` limiter in `FortifyServiceProvider::configureRateLimiting()`: 5/min keyed by route name + IP, so the request and completion endpoints get independent buckets.
- Fortify exposes no limiter hook for `password.email` / `password.update`, so the limiter is applied by a new `ThrottlePasswordResetRequests` global web middleware (a `ThrottleRequests` subclass scoped by route name) — the same pattern `PreventDestructiveDemoActions` uses to cover package-registered Fortify routes. A runtime route patch was rejected because it would not survive `route:cache`, which production runs.

## Testing

Three new feature tests in `PasswordResetTest`:

- forgot-password returns 429 after 5 requests from the same IP;
- reset-password returns 429 after 5 attempts;
- the two throttles use separate buckets (burning the forgot-password limit does not block completing a reset).

Full gate green: `sail composer test` (Pint + PHPStan + Rector + 100% coverage) and frontend `lint:check` / `format:check` / `types:check` / `build`.

No i18n or docs changes: no user-facing copy and no new operator-facing setting.

Notes:
- Local CodeRabbit CLI pass was rate-limited (free OSS tier, ~49 min wait), so the app-side PR review is the backstop here.
- Worktree bootstrap initially failed because the main checkout's `.env` has `DEMO_MODE=true` — pre-existing tooling defect already tracked in #563.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rate limiting to password reset requests, allowing up to 5 requests per minute per IP address.
  - Forgot-password and password-reset submissions now use separate limits, so activity on one endpoint does not affect the other.

- **Tests**
  - Added coverage confirming request limits, IP-based throttling, and independent limits for each password reset step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->