### PR TITLE
fix: hide member emails and pending invitations from plain members on team edit page

### DIFF
--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Teams;
 use App\Actions\Teams\CreateTeam;
 use App\Enums\AuditAction;
 use App\Enums\SecurityEventType;
+use App\Enums\TeamPermission;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\DeleteTeamRequest;
@@ -49,10 +50,18 @@ class TeamController extends Controller
 
     /**
      * Show the team edit page.
+     *
+     * Member emails and the pending-invitation list are sensitive roster data,
+     * so they are only included for users who manage invitations (Owner and
+     * Admin via {@see TeamPermission::CreateInvitation}); plain Members get a
+     * null email per member and an empty invitation list.
      */
     public function edit(Request $request, Team $team): Response
     {
+        Gate::authorize('view', $team);
+
         $user = $request->user();
+        $canViewRoster = Gate::allows('inviteMember', $team);
 
         return Inertia::render('teams/Edit', [
             'team' => [
@@ -62,29 +71,31 @@ class TeamController extends Controller
                 'isPersonal' => $team->is_personal,
                 'role' => $user->teamRole($team)?->value,
             ],
-            'members' => $team->members()->get()->map(function (User $member): array {
+            'members' => $team->members()->get()->map(function (User $member) use ($canViewRoster): array {
                 /** @var Membership $membership */
                 $membership = $member->getRelation('pivot');
 
                 return [
                     'id' => $member->id,
                     'name' => $member->name,
-                    'email' => $member->email,
+                    'email' => $canViewRoster ? $member->email : null,
                     'avatar' => $member->avatar ?? null,
                     'role' => $membership->role->value,
                     'role_label' => $membership->role->label(),
                 ];
             }),
-            'invitations' => $team->invitations()
-                ->whereNull('accepted_at')
-                ->get()
-                ->map(fn ($invitation): array => [
-                    'code' => $invitation->code,
-                    'email' => $invitation->email,
-                    'role' => $invitation->role->value,
-                    'role_label' => $invitation->role->label(),
-                    'created_at' => $invitation->created_at->toISOString(),
-                ]),
+            'invitations' => $canViewRoster
+                ? $team->invitations()
+                    ->whereNull('accepted_at')
+                    ->get()
+                    ->map(fn ($invitation): array => [
+                        'code' => $invitation->code,
+                        'email' => $invitation->email,
+                        'role' => $invitation->role->value,
+                        'role_label' => $invitation->role->label(),
+                        'created_at' => $invitation->created_at->toISOString(),
+                    ])
+                : collect(),
             'permissions' => $user->toTeamPermissions($team),
             'availableRoles' => TeamRole::assignable(),
         ]);

--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Teams\DeleteTeamRequest;
 use App\Http\Requests\Teams\SaveTeamRequest;
 use App\Models\Membership;
 use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use App\Support\AuditRecorder;
 use App\Support\SecurityEventRecorder;
@@ -88,7 +89,7 @@ class TeamController extends Controller
                 ? $team->invitations()
                     ->whereNull('accepted_at')
                     ->get()
-                    ->map(fn ($invitation): array => [
+                    ->map(fn (TeamInvitation $invitation): array => [
                         'code' => $invitation->code,
                         'email' => $invitation->email,
                         'role' => $invitation->role->value,

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -327,7 +327,10 @@ const confirmTransferOwnership = (member: TeamMember) => {
                                 >{{ $t('(you)') }}</span
                             >
                         </Link>
-                        <div class="truncate text-sm text-muted-foreground">
+                        <div
+                            v-if="member.email"
+                            class="truncate text-sm text-muted-foreground"
+                        >
                             {{ member.email }}
                         </div>
                     </div>

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -14,7 +14,8 @@ export type Team = {
 export type TeamMember = {
     id: string;
     name: string;
-    email: string;
+    /** Only present for roster managers (Owner/Admin); null for plain Members. */
+    email: string | null;
     avatar?: string | null;
     role: TeamRole;
     role_label: string;

--- a/tests/Feature/Teams/TeamTest.php
+++ b/tests/Feature/Teams/TeamTest.php
@@ -4,6 +4,7 @@ use App\Enums\SecurityEventType;
 use App\Enums\TeamRole;
 use App\Models\SecurityEvent;
 use App\Models\Team;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
 
@@ -70,6 +71,61 @@ test('the team edit page can be rendered', function (): void {
             ->where('team.role', TeamRole::Owner->value)
             ->where('members.0.role', TeamRole::Owner->value)
             ->where('members.0.role_label', TeamRole::Owner->label()),
+        );
+});
+
+test('the team edit page hides member emails and invitations from plain members', function (): void {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'invited_by' => $owner->id,
+    ]);
+
+    $response = $this
+        ->actingAs($member)
+        ->get(route('teams.edit', $team));
+
+    $response
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('teams/Edit')
+            ->where('members.0.email', null)
+            ->where('members.1.email', null)
+            ->where('invitations', []),
+        );
+});
+
+test('the team edit page shows member emails and invitations to admins', function (): void {
+    $owner = User::factory()->create();
+    $admin = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($admin, ['role' => TeamRole::Admin->value]);
+
+    $invitation = TeamInvitation::factory()->create([
+        'team_id' => $team->id,
+        'invited_by' => $owner->id,
+    ]);
+
+    $response = $this
+        ->actingAs($admin)
+        ->get(route('teams.edit', $team));
+
+    $response
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('teams/Edit')
+            ->where('members.0.email', $owner->email)
+            ->where('members.1.email', $admin->email)
+            ->where('invitations.0.email', $invitation->email)
+            ->where('invitations.0.role', $invitation->role->value),
         );
 });
 

--- a/tests/Feature/Teams/TeamTest.php
+++ b/tests/Feature/Teams/TeamTest.php
@@ -74,6 +74,20 @@ test('the team edit page can be rendered', function (): void {
         );
 });
 
+test('the team edit page cannot be viewed by non-members', function (): void {
+    $owner = User::factory()->create();
+    $outsider = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $response = $this
+        ->actingAs($outsider)
+        ->get(route('teams.edit', $team));
+
+    $response->assertForbidden();
+});
+
 test('the team edit page hides member emails and invitations from plain members', function (): void {
     $owner = User::factory()->create();
     $member = User::factory()->create();


### PR DESCRIPTION
Closes #557.

## What

The team edit page (`GET settings/teams/{team}`) rendered every member's email address and the full pending-invitation list (emails + roles) to any team member, regardless of role.

- `TeamController::edit()` now calls `Gate::authorize('view', $team)` (defense-in-depth alongside the `EnsureTeamMembership` middleware).
- Member `email` and the `invitations` collection are only included when the viewer holds the `inviteMember` gate (`TeamPermission::CreateInvitation` — Owner and Admin). Plain Members receive `email: null` per member and an empty `invitations` list, so the pending-invitations card never renders for them.
- Frontend: `TeamMember.email` is now `string | null`; the email line on the member row is hidden when absent.

Note: the issue suggested gating on `updateMember`, but only Owner holds `UpdateMember` — that would have hidden the roster from Admins, violating the acceptance criterion "Admins/owners still see the full roster and invitations". The `inviteMember` gate (Owner + Admin) matches the criteria exactly.

## Testing

- New feature tests: plain Member GET → all member emails `null`, `invitations` empty; Admin GET → full emails + invitation email/role; non-member GET → 403.
- Full gate green: Pint, PHPStan, Rector, 100% coverage, `lint:check`, `format:check`, `types:check`, `build`.
- Local CodeRabbit review clean (0 findings). Applied from first pass: non-member 403 test, explicit `TeamInvitation` closure type hint. Skipped: a Vue rendering-level regression test for the email line — the leak is server-side and covered by the Inertia prop assertions; the `v-if` is trivial template logic with no component-test precedent in this repo.

No i18n changes (no new user-facing copy) and no docs changes (nothing operator-facing).