### PR TITLE
fix: make Reverb allowed_origins env-configurable via REVERB_ALLOWED_ORIGINS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -250,6 +250,11 @@ REVERB_HOST="reverb"
 REVERB_PORT=8080
 REVERB_SCHEME=http
 
+# Comma-separated list of origins allowed to open a WebSocket connection to
+# Reverb. Defaults to * (any origin); in production, lock it down to the host
+# the browser loads the app from (e.g. chat.example.com).
+# REVERB_ALLOWED_ORIGINS=
+
 # The browser connects to Reverb using REVERB_APP_KEY above, served to the SPA at
 # runtime (no VITE_* build args). The browser-facing host/port/scheme default to
 # the APP_URL host + REVERB_PORT + REVERB_SCHEME, which is correct for local dev.

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -143,6 +143,10 @@ REVERB_SCHEME=http
 REVERB_PORT_PUBLIC=443
 REVERB_SCHEME_PUBLIC=https
 # REVERB_HOST_PUBLIC=ws.example.com
+# Comma-separated origins allowed to open a WebSocket connection. Defaults to *
+# (any origin); recommended in production: lock to the host the browser loads
+# the app from.
+# REVERB_ALLOWED_ORIGINS=chat.example.com
 
 # --- Container port mapping (host side) --------------------------------------
 # APP_BIND=127.0.0.1

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -84,7 +84,7 @@ return [
                     'scheme' => env('REVERB_SCHEME', 'https'),
                     'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
                 ],
-                'allowed_origins' => ['*'],
+                'allowed_origins' => explode(',', (string) (env('REVERB_ALLOWED_ORIGINS') ?: '*')),
                 'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
                 'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
                 'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -98,6 +98,7 @@ production — see [Configuration](/docs/self-hosting/configuration/#reverb-webs
 | `REVERB_SCHEME_PUBLIC` | `https`       | Browser connects over TLS.                        |
 | `REVERB_PORT_PUBLIC`   | `443`         | Your proxy terminates `wss` on 443.               |
 | `REVERB_HOST_PUBLIC`   | *(APP_URL host)* | Only set for a dedicated WebSocket subdomain.  |
+| `REVERB_ALLOWED_ORIGINS` | `*`         | Comma-separated origins allowed to open a WebSocket connection. Lock to the app host in production (e.g. `chat.example.com`). |
 
 ## Feature toggles
 

--- a/tests/Feature/ReverbAllowedOriginsTest.php
+++ b/tests/Feature/ReverbAllowedOriginsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+test('reverb allowed origins default to any origin when the env var is absent', function (): void {
+    $this->reloadWithEnv(['REVERB_ALLOWED_ORIGINS' => '']);
+
+    expect(config('reverb.apps.apps.0.allowed_origins'))->toBe(['*']);
+});
+
+test('reverb allowed origins can be locked to a single origin via env', function (): void {
+    $this->reloadWithEnv(['REVERB_ALLOWED_ORIGINS' => 'chat.example.test']);
+
+    expect(config('reverb.apps.apps.0.allowed_origins'))->toBe(['chat.example.test']);
+});
+
+test('reverb allowed origins accept a comma-separated list of origins', function (): void {
+    $this->reloadWithEnv(['REVERB_ALLOWED_ORIGINS' => 'chat.example.test,ws.example.test']);
+
+    expect(config('reverb.apps.apps.0.allowed_origins'))->toBe(['chat.example.test', 'ws.example.test']);
+});


### PR DESCRIPTION
Closes #558.

## What

`config/reverb.php` hardcoded `'allowed_origins' => ['*']`, leaving a Cross-Site WebSocket Hijacking surface no operator could close without editing published config. The value now reads from `REVERB_ALLOWED_ORIGINS` (comma-separated, defaults to `*` for backward compatibility). An empty value falls back to `*` rather than producing `['']`, which would silently reject every origin.

## How tested

New feature test `tests/Feature/ReverbAllowedOriginsTest.php` reboots the app via the existing `reloadWithEnv()` seam and asserts the default, a single locked origin, and a comma-separated list. Full gate green: Pint, PHPStan, Rector, 100% coverage, frontend lint/format/types, docs build.

## Docs

- `.env.example`: documented `REVERB_ALLOWED_ORIGINS` with a production lock-down recommendation.
- `docs/…/reference/environment-variables.md`: new row in the Reverb browser-facing table.

## Notes

- Worktree bootstrap for this issue tripped over #563 (`bin/worktree` build fails when the main checkout's `.env` has `DEMO_MODE=true`); worked around locally by disabling demo mode in the worktree `.env`.
- Local CodeRabbit pass: clean, 0 findings.