### PR TITLE
fix: prevent concurrent double-vote on single-choice polls

### DIFF
--- a/app/Actions/Channels/CastVote.php
+++ b/app/Actions/Channels/CastVote.php
@@ -23,10 +23,19 @@ class CastVote
      * vote on this poll is cleared first, so at most one stands. A multiple-choice
      * poll toggles each option independently. The tally is then re-aggregated
      * without a viewer and broadcast, so every open timeline patches live.
+     *
+     * Single-choice votes first take a FOR UPDATE lock on the poll row: without
+     * it, two concurrent requests for different options can both pass the clear
+     * step and leave two standing votes. Locking the user's existing vote rows
+     * instead would not close the race — a first-time voter has none to lock.
      */
     public function handle(Channel $channel, Poll $poll, PollOption $option, User $user): void
     {
         DB::transaction(function () use ($poll, $option, $user): void {
+            if (! $poll->allow_multiple) {
+                Poll::query()->whereKey($poll->getKey())->lockForUpdate()->first();
+            }
+
             $existing = $option->votes()->where('user_id', $user->id)->first();
 
             if ($existing !== null) {

--- a/tests/Feature/Polls/PollTest.php
+++ b/tests/Feature/Polls/PollTest.php
@@ -178,18 +178,39 @@ test('a single-choice vote can be cast, swapped, and retracted', function (): vo
 });
 
 /**
- * Collect the queries in the log that take a FOR UPDATE lock on the polls table.
+ * Record the queries a vote request runs, as full query-log entries.
  *
- * @param  list<array{query: string}>  $queryLog
- * @return list<string>
+ * @return list<array{query: string, bindings: array<int, mixed>}>
  */
-function pollRowLockQueries(array $queryLog): array
+function voteQueryLog(User $actor, Team $team, Channel $channel, Poll $poll, PollOption $option): array
 {
-    return collect($queryLog)
-        ->map(fn (array $query): string => $query['query'])
-        ->filter(fn (string $sql): bool => str_contains($sql, 'from "polls"') && str_contains($sql, 'for update'))
-        ->values()
-        ->all();
+    DB::connection()->flushQueryLog();
+    DB::enableQueryLog();
+
+    try {
+        votePoll($actor, $team, $channel, $poll, $option)->assertRedirect();
+
+        return DB::getQueryLog();
+    } finally {
+        DB::disableQueryLog();
+    }
+}
+
+/**
+ * The index of the first log entry matching every given SQL fragment, or null.
+ *
+ * @param  list<array{query: string, bindings: array<int, mixed>}>  $queryLog
+ * @param  list<string>  $fragments
+ */
+function queryIndexMatching(array $queryLog, array $fragments): ?int
+{
+    $index = collect($queryLog)->search(
+        fn (array $entry): bool => collect($fragments)->every(
+            fn (string $fragment): bool => str_contains($entry['query'], $fragment),
+        ),
+    );
+
+    return $index === false ? null : $index;
 }
 
 // The double-vote race itself (two requests interleaving between the clear and
@@ -202,24 +223,25 @@ test('a single-choice vote locks the poll row so concurrent votes serialize', fu
     [$owner, $team, $general] = pollTeam();
     $poll = makePoll($general, $owner, ['A', 'B']);
 
-    DB::enableQueryLog();
-    votePoll($owner, $team, $general, $poll, $poll->options[0])->assertRedirect();
-    $lockQueries = pollRowLockQueries(DB::getQueryLog());
-    DB::disableQueryLog();
+    $queryLog = voteQueryLog($owner, $team, $general, $poll, $poll->options[0]);
 
-    expect($lockQueries)->not->toBeEmpty();
+    $lockIndex = queryIndexMatching($queryLog, ['from "polls"', 'for update']);
+    $insertIndex = queryIndexMatching($queryLog, ['insert into "poll_votes"']);
+
+    expect($lockIndex)->not->toBeNull()
+        ->and($queryLog[$lockIndex]['bindings'])->toContain($poll->id)
+        ->and($insertIndex)->not->toBeNull()
+        ->and($lockIndex)->toBeLessThan($insertIndex);
 });
 
 test('a multiple-choice vote does not lock the poll row', function (): void {
     [$owner, $team, $general] = pollTeam();
     $poll = makePoll($general, $owner, ['A', 'B'], fn ($f) => $f->multiChoice());
 
-    DB::enableQueryLog();
-    votePoll($owner, $team, $general, $poll, $poll->options[0])->assertRedirect();
-    $lockQueries = pollRowLockQueries(DB::getQueryLog());
-    DB::disableQueryLog();
+    $queryLog = voteQueryLog($owner, $team, $general, $poll, $poll->options[0]);
 
-    expect($lockQueries)->toBeEmpty();
+    expect(queryIndexMatching($queryLog, ['from "polls"', 'for update']))->toBeNull()
+        ->and(queryIndexMatching($queryLog, ['insert into "poll_votes"']))->not->toBeNull();
 });
 
 test('a multiple-choice vote toggles each option independently', function (): void {

--- a/tests/Feature/Polls/PollTest.php
+++ b/tests/Feature/Polls/PollTest.php
@@ -13,6 +13,7 @@ use App\Models\PollVote;
 use App\Models\Team;
 use App\Models\User;
 use Database\Factories\PollFactory;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 
@@ -174,6 +175,51 @@ test('a single-choice vote can be cast, swapped, and retracted', function (): vo
 
     Event::assertDispatched(PollVoteChanged::class, fn (PollVoteChanged $event): bool => $event->messageId === $poll->message_id
         && $event->broadcastOn()[0]->name === 'private-channel.'.$general->id);
+});
+
+/**
+ * Collect the queries in the log that take a FOR UPDATE lock on the polls table.
+ *
+ * @param  list<array{query: string}>  $queryLog
+ * @return list<string>
+ */
+function pollRowLockQueries(array $queryLog): array
+{
+    return collect($queryLog)
+        ->map(fn (array $query): string => $query['query'])
+        ->filter(fn (string $sql): bool => str_contains($sql, 'from "polls"') && str_contains($sql, 'for update'))
+        ->values()
+        ->all();
+}
+
+// The double-vote race itself (two requests interleaving between the clear and
+// the insert) cannot be reproduced under RefreshDatabase — the test wraps in a
+// transaction a second connection could never see into — so these tests assert
+// the serializing poll-row lock that closes it. Locking the voter's existing
+// vote rows would not be enough: a first-time voter has none, so two concurrent
+// first votes on different options would each lock nothing and both insert.
+test('a single-choice vote locks the poll row so concurrent votes serialize', function (): void {
+    [$owner, $team, $general] = pollTeam();
+    $poll = makePoll($general, $owner, ['A', 'B']);
+
+    DB::enableQueryLog();
+    votePoll($owner, $team, $general, $poll, $poll->options[0])->assertRedirect();
+    $lockQueries = pollRowLockQueries(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    expect($lockQueries)->not->toBeEmpty();
+});
+
+test('a multiple-choice vote does not lock the poll row', function (): void {
+    [$owner, $team, $general] = pollTeam();
+    $poll = makePoll($general, $owner, ['A', 'B'], fn ($f) => $f->multiChoice());
+
+    DB::enableQueryLog();
+    votePoll($owner, $team, $general, $poll, $poll->options[0])->assertRedirect();
+    $lockQueries = pollRowLockQueries(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    expect($lockQueries)->toBeEmpty();
 });
 
 test('a multiple-choice vote toggles each option independently', function (): void {


### PR DESCRIPTION
Closes #561.

## What / why

`CastVote` cleared a single-choice voter's other votes and inserted the new one inside a transaction, but under READ COMMITTED two concurrent requests from the same user for different options could both pass the clear step and each insert — leaving two standing votes on a single-choice poll. The only DB guard (`unique(poll_option_id, user_id)`) prevents duplicates on the same option, not across options.

The fix takes a `FOR UPDATE` lock on the poll row before the clear+insert for single-choice polls. Locking the user's existing vote rows (the issue's first suggestion) would not close the race: a first-time voter has no rows to lock, so two concurrent first votes would each lock nothing and both insert (phantom-insert). The poll-row lock serializes the second request behind the first commit. Multi-choice polls take no lock and are unchanged.

## Testing

- New tests assert the single-choice vote path takes a `FOR UPDATE` lock on the polls row bound to the poll's id and that it precedes the vote insert, and that the multi-choice path takes no such lock. (The race itself is not reproducible under `RefreshDatabase` — the test wraps in a transaction a second connection could never see into — hence the query-log assertions; the comment in the test explains this.)
- Existing swap/toggle behavioural tests unchanged and green.
- Full gate green: Pint + PHPStan + Rector + 100% coverage; frontend lint/format/types/build pass.
- Local CodeRabbit review clean (2 initial test-robustness findings applied: query-log flush + guaranteed disable, and the stronger poll-id/ordering assertions).

No i18n or docs impact (backend-only, no user-facing copy or operator-facing config).