### PR TITLE
docs: stop claiming SSO/OIDC/LDAP/SCIM are unavailable in comparison and FAQ

### DIFF
--- a/docs/src/content/docs/docs/comparison.md
+++ b/docs/src/content/docs/docs/comparison.md
@@ -31,15 +31,32 @@ established self-hosted alternatives. The Desk is the newcomer optimizing for
 
 - **Getting out of your way.** Channels, threads, and DMs plus the workflow
   features teams actually miss: [scheduled messages](/docs/), message reminders,
-  reactions and custom emoji, and instant full-text search.
+  [polls](/docs/reference/feature-toggles/#polls), reactions, custom emoji,
+  user-uploaded avatars, and instant full-text search.
 - **Being trivial to run.** A prebuilt image and a single compose file. No
   Kubernetes, no build step, no exotic dependencies — a small
   [2 vCPU / 2 GB VPS](/docs/self-hosting/requirements/) comfortably hosts a team.
 - **Being yours.** MIT-licensed, auditable, self-hosted. Your messages never
   leave your server, every user can export their data, and there's no per-seat
   meter.
-- **Real admin basics.** Roles, invitations, a moderation audit log, workspace
-  analytics, and device/session management are built in.
+- **Directory-managed logins.** [OIDC single
+  sign-on](/docs/reference/environment-variables/#single-sign-on-openid-connect)
+  with just-in-time provisioning,
+  [LDAP / Active Directory](/docs/reference/environment-variables/#single-sign-on-ldap--active-directory)
+  bind authentication with directory sync,
+  [SCIM 2.0 provisioning](/docs/reference/environment-variables/#directory-provisioning-scim-20)
+  for Okta / Entra ID / OneLogin, and an
+  [SSO-only mode](/docs/reference/feature-toggles/#sso-only-mode) that turns
+  password logins off entirely.
+- **Integrations you can build on.** [Bots and a versioned REST
+  API](/docs/reference/api/), plus
+  [incoming](/docs/reference/incoming-webhooks/) and
+  [outgoing](/docs/reference/webhooks/) webhooks, let external systems post into
+  a workspace and react to its events.
+- **Real admin basics.** Roles, invitations, optional
+  [two-factor authentication](/docs/reference/feature-toggles/#two-factor-authentication),
+  a moderation audit log, workspace analytics, and device/session management are
+  built in.
 
 ## When The Desk is *not* the right fit (yet)
 
@@ -47,13 +64,12 @@ Being honest saves you a wasted afternoon. As of **v1.10.1**, The Desk does **no
 have:
 
 - **Voice or video calls** — not planned for the near term.
-- **SSO / OIDC / LDAP / SCIM** — on the roadmap, not available today. If your org
-  *requires* directory-managed logins now, Mattermost or Rocket.Chat are the
-  safer pick.
 - **Native mobile apps** — the web app is fully responsive, but there's no
   dedicated iOS/Android app or push notifications yet.
-- **A large integration/bot marketplace** — if your workflow depends on hundreds
-  of prebuilt integrations, a bigger platform will serve you better.
+- **A prebuilt-integrations marketplace** — bots, a [REST
+  API](/docs/reference/api/), and [webhooks](/docs/reference/webhooks/) are built
+  in, but there's no directory of hundreds of ready-made apps. If your workflow
+  depends on one, a bigger platform will serve you better.
 
 If none of those are dealbreakers and you want the lightest self-hosted chat that
 still feels finished, The Desk is built for you.

--- a/docs/src/content/docs/docs/faq.md
+++ b/docs/src/content/docs/docs/faq.md
@@ -62,9 +62,15 @@ the near-term roadmap; if you need those now, see the
 
 ## Does it support SSO, OIDC, or LDAP?
 
-Not today — single sign-on and directory-managed users are on the roadmap but not
-available in v1.10.1. If your organization requires them now, a larger platform is <!-- x-release-please-version -->
-the safer choice for the moment. See the [comparison](/docs/comparison/).
+Yes. The Desk supports [OIDC single
+sign-on](/docs/reference/environment-variables/#single-sign-on-openid-connect)
+with just-in-time provisioning,
+[LDAP / Active Directory](/docs/reference/environment-variables/#single-sign-on-ldap--active-directory)
+bind authentication with directory sync, and
+[SCIM 2.0 provisioning](/docs/reference/environment-variables/#directory-provisioning-scim-20)
+for Okta, Entra ID, and OneLogin. You can also enforce
+[SSO-only sign-in](/docs/reference/feature-toggles/#sso-only-mode) to turn
+password logins off entirely.
 
 ## How do upgrades work?
 


### PR DESCRIPTION
Closes #552.

## What

The comparison page and FAQ still claimed SSO / OIDC / LDAP / SCIM were unavailable and steered enterprise evaluators to Mattermost/Rocket.Chat — while the reference section of the same docs site documents all of them (shipped in the v1.5.0 line).

- **`comparison.md`**: removed the SSO bullet from "not the right fit"; added a **Directory-managed logins** strength (OIDC + JIT, LDAP/AD, SCIM 2.0, SSO-only mode) and an **Integrations you can build on** strength (bots, REST API, incoming/outgoing webhooks), all linking to the reference pages; refreshed the marketplace bullet to be honest both ways (integrations exist, a prebuilt-app directory does not); mentioned polls, 2FA, and user avatars where they fit.
- **`faq.md`**: "Does it support SSO, OIDC, or LDAP?" is now a **yes**, summarizing OIDC, LDAP/AD, SCIM, and `AUTH_SSO_ONLY` with links to the environment-variable and feature-toggle references.
- Voice/video calls and native mobile apps remain honestly listed as unavailable.

## Release-version hygiene

- `comparison.md`'s `x-release-please-version` line is untouched (still one version, first-semver rule holds).
- `faq.md` no longer displays a current version, so its annotation went away with the rewritten answer; the file stays registered under `extra-files` (harmless).
- Diff grep for un-annotated version strings: clean.

## Testing

- `cd docs && npm run build` — 21 pages built, no errors (link anchors match the headings in `environment-variables.md` / `feature-toggles.md`, verified against existing cross-links).
- Docs are excluded from all app quality gates; no app code touched.

Local CodeRabbit review was rate-limited (free tier); relying on the PR review here.