### PR TITLE
chore: force registration-friendly auth toggles in worktree bootstrap .env

### DIFF
--- a/bin/worktree
+++ b/bin/worktree
@@ -306,6 +306,17 @@ cmd_create() {
         upsert_env "${path}/.env" FORWARD_DB_PORT "$db_port"
         upsert_env "${path}/.env" COMPOSE_PROJECT_NAME "$project"
         upsert_env "${path}/.env" APP_URL "http://localhost:${app_port}"
+        # Auth toggles inherited from the main checkout can strip the register
+        # route (config/fortify.php gates Features::registration() on
+        # REGISTRATION_ENABLED / AUTH_SSO_ONLY / DEMO_MODE), and without it
+        # Wayfinder never emits resources/js/routes/register, so the bootstrap's
+        # `npm run build` dies on an unresolvable import (issue #563). Force the
+        # registration-friendly defaults; like the port overrides above, this
+        # only runs when generating a fresh .env, so a manually edited worktree
+        # .env is preserved on resume.
+        upsert_env "${path}/.env" DEMO_MODE false
+        upsert_env "${path}/.env" REGISTRATION_ENABLED true
+        upsert_env "${path}/.env" AUTH_SSO_ONLY false
     fi
 
     # --- compose override -----------------------------------------------------


### PR DESCRIPTION
Closes #563.

## What

`bin/worktree create` copies the main checkout's `.env` verbatim into a new worktree. When the main checkout runs with `DEMO_MODE=true` (or `REGISTRATION_ENABLED=false` / `AUTH_SSO_ONLY=true` with a configured SSO provider), `config/fortify.php` drops `Features::registration()`, the `register` route never exists, Wayfinder does not emit `resources/js/routes/register`, and the bootstrap's `npm run build` dies on an unresolvable import — leaving the worktree without a Vite manifest.

This forces the registration-friendly defaults (`DEMO_MODE=false`, `REGISTRATION_ENABLED=true`, `AUTH_SSO_ONLY=false`) in the generated `.env`, alongside the existing port/`APP_URL` overrides. The overrides only run when generating a fresh `.env`, so a manually edited worktree `.env` is preserved on resume (existing behaviour).

## How tested

End-to-end against the live repro condition (main checkout `.env` has `DEMO_MODE=true`):

- `bin/worktree create 563` bootstrapped a fresh worktree to `.worktree-ready` with a Vite manifest — `npm run build` succeeded; generated `.env` had all three toggles forced.
- Ready re-entry: manually set `DEMO_MODE=true` in the worktree `.env`, re-ran `create` — edit preserved, fast re-entry.
- Interrupted resume (sentinel removed): re-ran `create` — manually edited `.env` still untouched.
- Test worktree torn down with `bin/worktree remove 563` afterwards.

No PHP/frontend code touched, so the app quality gates are unaffected. Local CodeRabbit review skipped — free-tier rate limit hit; relying on the PR review.