### PR TITLE
fix: derive typing indicator identity server-side

### DIFF
--- a/app/Events/UserTyping.php
+++ b/app/Events/UserTyping.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Data\UserData;
+use App\Models\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UserTyping implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * Announces that `typist` is composing a message in the channel, so peers
+     * can show the "X is typing…" indicator. The identity is derived server-side
+     * from the authenticated user — never from a client-supplied payload — so a
+     * channel member cannot impersonate another member's typing.
+     */
+    public function __construct(
+        public Channel $channel,
+        public UserData $typist,
+    ) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('channel.'.$this->channel->id),
+        ];
+    }
+
+    /**
+     * Get the data to broadcast: who is typing, in the shape the indicator
+     * roster consumes.
+     *
+     * @return array{id: string, name: string}
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'id' => $this->typist->id,
+            'name' => $this->typist->name,
+        ];
+    }
+}

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -17,6 +17,7 @@ use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
 use App\Enums\NotificationLevel;
 use App\Enums\UserType;
+use App\Events\UserTyping;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Models\Channel;
@@ -27,6 +28,7 @@ use App\Support\ChannelTimelineWindow;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response as HttpResponse;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -284,6 +286,23 @@ class ChannelController extends Controller
         $markChannelRead->handle($channel, $request->user());
 
         return back();
+    }
+
+    /**
+     * Broadcast that the current user is composing a message in the channel.
+     *
+     * The typist identity is taken from the authenticated user — never from the
+     * request body — so a channel member cannot spoof another member's typing
+     * indicator (the reason this replaced the client-to-client whisper). The
+     * broadcast goes to others only; the typist never sees their own indicator.
+     */
+    public function typing(Request $request, Team $team, Channel $channel): HttpResponse
+    {
+        Gate::authorize('postMessage', $channel);
+
+        broadcast(new UserTyping($channel, UserData::fromUser($request->user())))->toOthers();
+
+        return response()->noContent();
     }
 
     /**

--- a/resources/js/composables/useChannelRealtime.ts
+++ b/resources/js/composables/useChannelRealtime.ts
@@ -41,7 +41,7 @@ export interface ChannelRealtimeOptions {
     isNearBottom: () => boolean;
     /** Follow a live append down, or raise the "new messages" count instead. */
     notifyAppended: (wasNearBottom: boolean) => void;
-    /** The channel's typing indicator, for whisper receipt and settle-on-send. */
+    /** The channel's typing indicator, for broadcast receipt and settle-on-send. */
     typing: TypingIndicator;
     /** Advance the channel's read pointer (a message landed while focused). */
     markRead: () => void;
@@ -58,8 +58,8 @@ function channelName(id: string): string {
 
 /**
  * Own the *active* channel's realtime lifecycle: subscribe to its Echo channel,
- * route the five broadcast events plus typing whispers into the two message
- * streams, and move the subscription when the open channel changes.
+ * route the broadcast events (including typing) into the two message streams,
+ * and move the subscription when the open channel changes.
  *
  * The subscribe/leave bookkeeping rides {@see createChannelFleet} — the same
  * engine behind {@see useChannelFleetSubscription} — driven as a single-element
@@ -217,7 +217,14 @@ export function useChannelRealtime(options: ChannelRealtimeOptions): void {
                         options.readers.value = next;
                     },
                 )
-                .listenForWhisper('typing', (user: TypingUser) => {
+                .listen('UserTyping', (user: TypingUser) => {
+                    // The server broadcasts to others only, but that exclusion
+                    // rides the X-Socket-ID header — if it was ever missing, the
+                    // typist's own signal would echo back, so drop it here too.
+                    if (user.id === options.currentUserId()) {
+                        return;
+                    }
+
                     options.typing.receiveTyping(user);
                 });
         },

--- a/resources/js/composables/useTypingIndicator.ts
+++ b/resources/js/composables/useTypingIndicator.ts
@@ -1,8 +1,9 @@
 import { computed, onBeforeUnmount, ref } from 'vue';
 
 /**
- * A channel member currently composing a message, as carried by the `typing`
- * client whisper. Mirrors the shape of `currentUser` in the channel view.
+ * A channel member currently composing a message, as carried by the
+ * server-broadcast `UserTyping` event. The identity is derived server-side from
+ * the authenticated session, so it cannot be spoofed by another member.
  */
 export type TypingUser = {
     id: string;
@@ -10,48 +11,49 @@ export type TypingUser = {
 };
 
 /**
- * Re-whisper at most this often while the local user keeps typing, so a burst
+ * Re-signal at most this often while the local user keeps typing, so a burst
  * of keystrokes turns into an occasional heartbeat rather than one event each.
  */
-const WHISPER_THROTTLE_MS = 2500;
+const SIGNAL_THROTTLE_MS = 2500;
 
 /**
- * Forget a remote typist this long after their last whisper. Comfortably longer
- * than the throttle so an actively-typing peer never flickers out between beats.
+ * Forget a remote typist this long after their last broadcast. Comfortably
+ * longer than the throttle so an actively-typing peer never flickers out
+ * between beats.
  */
 const TYPING_EXPIRY_MS = 4000;
 
 /**
  * Tracks who is typing on a channel. Outbound keystrokes are throttled into
- * periodic `typing` whispers; inbound whispers populate a self-expiring roster
- * so the indicator clears on its own when a peer goes idle. All timers are torn
- * down on `reset()` (channel switch) and on unmount.
+ * periodic typing signals (`notify`); inbound broadcasts populate a
+ * self-expiring roster so the indicator clears on its own when a peer goes
+ * idle. All timers are torn down on `reset()` (channel switch) and on unmount.
  */
-export function useTypingIndicator(whisper: (user: TypingUser) => void) {
+export function useTypingIndicator(notify: () => void) {
     // Roster of remote typists keyed by user id, mapped to their display name.
     const typists = ref<Map<string, string>>(new Map());
 
     // Pending expiry timers keyed by user id, kept outside reactivity.
     const timers = new Map<string, ReturnType<typeof setTimeout>>();
 
-    // Timestamp of the last outbound whisper, for leading-edge throttling.
-    let lastWhisperAt = 0;
+    // Timestamp of the last outbound signal, for leading-edge throttling.
+    let lastSignalAt = 0;
 
     const typingNames = computed<string[]>(() => [...typists.value.values()]);
 
     /**
-     * Signal that the local user is typing, whispering at most once per
+     * Signal that the local user is typing, notifying at most once per
      * throttle window.
      */
-    function signalTyping(user: TypingUser): void {
+    function signalTyping(): void {
         const now = Date.now();
 
-        if (now - lastWhisperAt < WHISPER_THROTTLE_MS) {
+        if (now - lastSignalAt < SIGNAL_THROTTLE_MS) {
             return;
         }
 
-        lastWhisperAt = now;
-        whisper(user);
+        lastSignalAt = now;
+        notify();
     }
 
     /**
@@ -95,7 +97,7 @@ export function useTypingIndicator(whisper: (user: TypingUser) => void) {
 
         timers.clear();
         typists.value = new Map();
-        lastWhisperAt = 0;
+        lastSignalAt = 0;
     }
 
     function clearExpiry(id: string): void {

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -14,6 +14,7 @@ import { toast } from 'vue-sonner';
 import {
     archive as archiveChannel,
     read as markChannelRead,
+    typing as postTypingSignal,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import AddDirectMessagePeopleModal from '@/components/AddDirectMessagePeopleModal.vue';
 import ChannelEmptyState from '@/components/ChannelEmptyState.vue';
@@ -58,12 +59,12 @@ import { useThreadPanel } from '@/composables/useThreadPanel';
 import { useTimezone } from '@/composables/useTimezone';
 import { useTranslations } from '@/composables/useTranslations';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
-import type { TypingUser } from '@/composables/useTypingIndicator';
 import { useUnreadDivider } from '@/composables/useUnreadDivider';
 import { formatDayLabel } from '@/lib/datetime';
 import { groupDmMastheadName } from '@/lib/groupDm';
 import { createOutbox } from '@/lib/outbox';
 import { buildTimelineItems } from '@/lib/timeline';
+import { parseXsrfToken } from '@/lib/uploadAttachment';
 import {
     isDividerVisible,
     shouldShowUnreadJump,
@@ -154,11 +155,39 @@ const currentUser = computed(() => ({
 }));
 
 /**
- * Peers currently composing on this channel, driven by `typing` client
- * whispers over the same private channel as the message events.
+ * Peers currently composing on this channel, driven by the server-broadcast
+ * `UserTyping` event on the same private channel as the message events. The
+ * outbound signal is a plain fire-and-forget POST — the server derives the
+ * typist identity from the authenticated session, so a member cannot spoof
+ * another member's indicator — carrying the Echo socket id so the resulting
+ * broadcast skips this tab.
  */
-const typing = useTypingIndicator((user: TypingUser) => {
-    echo().private(channelName(props.channel.id)).whisper('typing', user);
+const typing = useTypingIndicator(() => {
+    const headers: Record<string, string> = {
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    const xsrfToken = parseXsrfToken(document.cookie);
+
+    if (xsrfToken) {
+        headers['X-XSRF-TOKEN'] = xsrfToken;
+    }
+
+    const socketId = echo().socketId();
+
+    if (socketId) {
+        headers['X-Socket-ID'] = socketId;
+    }
+
+    void fetch(
+        postTypingSignal({
+            team: props.team.slug,
+            channel: props.channel.slug,
+        }).url,
+        { method: 'POST', headers },
+    ).catch(() => {
+        // A lost typing beat is invisible; the next keystroke sends another.
+    });
 });
 
 const typingNames = typing.typingNames;
@@ -185,7 +214,7 @@ function seedReaders(): void {
 const channelReadersList = computed(() => Array.from(readers.value.values()));
 
 function onTyping(): void {
-    typing.signalTyping(currentUser.value);
+    typing.signalTyping();
 }
 
 // You can't @mention yourself, and bots have no inbox to reach, so drop the
@@ -588,10 +617,6 @@ const stickyDayLabel = computed<string | null>(() => {
 
     return null;
 });
-
-function channelName(id: string): string {
-    return `channel.${id}`;
-}
 
 /**
  * Advance the read pointer for the open channel so its sidebar badge clears.

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,6 +81,10 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
     Route::post('t/{team}/c/{channel}/read', [ChannelController::class, 'read'])
         ->scopeBindings()
         ->name('channels.read');
+    Route::post('t/{team}/c/{channel}/typing', [ChannelController::class, 'typing'])
+        ->scopeBindings()
+        ->middleware('throttle:60,1')
+        ->name('channels.typing');
     Route::post('t/{team}/c/{channel}/threads/{message}/read', [ChannelController::class, 'readThread'])
         ->scopeBindings()
         ->withTrashed()

--- a/tests/Feature/Channels/TypingBroadcastTest.php
+++ b/tests/Feature/Channels/TypingBroadcastTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Events\UserTyping;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function typingTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+test('a member typing signal broadcasts UserTyping with the authenticated identity', function (): void {
+    Event::fake([UserTyping::class]);
+
+    [$owner, $team, $general] = typingTeamWithGeneral();
+    $owner->update(['name' => 'Ada Lovelace']);
+
+    $this->actingAs($owner)->post(route('channels.typing', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]))->assertNoContent();
+
+    Event::assertDispatched(UserTyping::class, function (UserTyping $event) use ($general, $owner): bool {
+        $target = $event->broadcastOn()[0];
+
+        expect($target)->toBeInstanceOf(PrivateChannel::class)
+            ->and($target->name)->toBe('private-channel.'.$general->id);
+
+        return $event->broadcastWith() === ['id' => $owner->id, 'name' => 'Ada Lovelace'];
+    });
+});
+
+test('a team member who is not in the channel cannot broadcast typing', function (): void {
+    Event::fake([UserTyping::class]);
+
+    [$owner, $team, $general] = typingTeamWithGeneral();
+    $outsider = User::factory()->create();
+    $team->memberships()->create(['user_id' => $outsider->id, 'role' => TeamRole::Member]);
+    $private = Channel::factory()->for($team)->private()->create();
+    $private->channelMembers()->firstOrCreate(['user_id' => $owner->id]);
+
+    $this->actingAs($outsider)->post(route('channels.typing', [
+        'team' => $team->slug,
+        'channel' => $private->slug,
+    ]))->assertForbidden();
+
+    Event::assertNotDispatched(UserTyping::class);
+});
+
+test('typing is rejected on an archived channel', function (): void {
+    Event::fake([UserTyping::class]);
+
+    [$owner, $team, $general] = typingTeamWithGeneral();
+    $archived = Channel::factory()->for($team)->archived()->create();
+    $archived->channelMembers()->firstOrCreate(['user_id' => $owner->id]);
+
+    $this->actingAs($owner)->post(route('channels.typing', [
+        'team' => $team->slug,
+        'channel' => $archived->slug,
+    ]))->assertForbidden();
+
+    Event::assertNotDispatched(UserTyping::class);
+});
+
+test('a guest is redirected to login instead of broadcasting typing', function (): void {
+    Event::fake([UserTyping::class]);
+
+    [, $team, $general] = typingTeamWithGeneral();
+
+    $this->post(route('channels.typing', [
+        'team' => $team->slug,
+        'channel' => $general->slug,
+    ]))->assertRedirect(route('login'));
+
+    Event::assertNotDispatched(UserTyping::class);
+});


### PR DESCRIPTION
Closes #562.

## What

The typing indicator relayed a client-supplied `{id, name}` payload via an Echo client whisper on `channel.{id}`, which Reverb relays with no server validation — any channel member could impersonate another member's "X is typing…" indicator.

Typing signals now go through the server:

- New `POST t/{team}/c/{channel}/typing` route (`channels.typing`, throttled `60,1`), gated by the existing `postMessage` policy (member of a non-archived channel).
- New `UserTyping` broadcast event on the same private channel; the `{id, name}` payload is derived from the authenticated user server-side, never from the request body.
- Broadcast goes `toOthers()` via the Echo socket id (sent as `X-Socket-ID` on the fire-and-forget `fetch`), with a client-side own-id guard as backstop.
- `useTypingIndicator` keeps its throttle/expiry roster; only the outbound callback changed (no more client payload). `useChannelRealtime` listens for `UserTyping` instead of `listenForWhisper('typing')`.

## Testing

- New `tests/Feature/Channels/TypingBroadcastTest.php`: member signal broadcasts `UserTyping` with the authenticated identity on the right private channel; non-member of a private channel → 403; archived channel → 403; guest → login redirect. None of the denied paths dispatch.
- Existing `tests/Browser/RealtimeTypingTest.php` covers the end-to-end indicator over Reverb (runs in CI's browser job).
- Full gate green: `sail composer test` at 100.0% coverage, plus `lint:check` / `format:check` / `types:check` / `build`.

## Notes

- No new user-facing copy (no i18n changes) and nothing operator-facing (no docs changes).
- Local CodeRabbit CLI review was rate-limited (free tier); leaning on the app's PR review as backstop.
- Worktree bootstrap hit the pre-existing `DEMO_MODE=true` build failure tracked in #563.