### PR TITLE
test: stop DEMO_MODE leaking across the suite from process-level env

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -33,6 +33,18 @@
         <env name="TELESCOPE_ENABLED" value="false"/>
         <env name="NIGHTWATCH_ENABLED" value="false"/>
         <!--
+            Keep the demo-mode tests hermetic. A developer previewing the public
+            demo locally has DEMO_MODE=true in their .env; without this pin that
+            ambient value boots every test with the destructive-action guard on
+            and the suite fails locally while CI (booting from .env.example)
+            stays green. Pinning also keeps DEMO_MODE defined at the process
+            level, so the immutable env repository never "adopts" the .env value
+            as its own and re-writes it on later application refreshes. `force`
+            makes the pin win even over an exported/process-level DEMO_MODE, so
+            the suite is deterministic no matter how the flag arrives.
+        -->
+        <env name="DEMO_MODE" value="false" force="true"/>
+        <!--
             Keep the SSO/LDAP feature tests hermetic. A developer running the
             `sso` dev-container profile has real LDAP_*/SSO_* values in their
             .env; without these pins that ambient config leaks into the test

--- a/tests/Feature/Auth/RegistrationFlagTest.php
+++ b/tests/Feature/Auth/RegistrationFlagTest.php
@@ -2,11 +2,6 @@
 
 use Inertia\Testing\AssertableInertia as Assert;
 
-afterEach(function (): void {
-    putenv('REGISTRATION_ENABLED');
-    unset($_ENV['REGISTRATION_ENABLED'], $_SERVER['REGISTRATION_ENABLED']);
-});
-
 test('registration routes respond when registration is enabled', function (): void {
     $this->reloadWithRegistrationEnabled(true);
 

--- a/tests/Feature/Demo/DemoLockoutTest.php
+++ b/tests/Feature/Demo/DemoLockoutTest.php
@@ -4,11 +4,6 @@ use App\Enums\TeamRole;
 use App\Models\Team;
 use App\Models\User;
 
-afterEach(function (): void {
-    putenv('DEMO_MODE');
-    unset($_ENV['DEMO_MODE'], $_SERVER['DEMO_MODE']);
-});
-
 /**
  * Attach the user to the team as its owner and make it their current team, the
  * shape every visitor lands in on the public demo.

--- a/tests/Feature/Demo/DemoMailTest.php
+++ b/tests/Feature/Demo/DemoMailTest.php
@@ -3,15 +3,6 @@
 use Illuminate\Mail\Transport\ArrayTransport;
 use Illuminate\Support\Facades\Mail;
 
-afterEach(function (): void {
-    putenv('DEMO_MODE');
-    putenv('MAIL_MAILER');
-    unset(
-        $_ENV['DEMO_MODE'], $_SERVER['DEMO_MODE'],
-        $_ENV['MAIL_MAILER'], $_SERVER['MAIL_MAILER'],
-    );
-});
-
 test('demo mode forces the array mail transport regardless of the configured mailer', function (): void {
     $this->reloadWithEnv(['MAIL_MAILER' => 'smtp', 'DEMO_MODE' => true]);
 

--- a/tests/Feature/Demo/DemoModeIsolationTest.php
+++ b/tests/Feature/Demo/DemoModeIsolationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Regression guard for the DEMO_MODE cross-suite leak (#549): the two tests
+ * below are an intentionally ordered pair. The first overrides DEMO_MODE via
+ * reloadWithDemoMode(); the second asserts the override was fully unwound by
+ * TestCase::tearDown() — no env store may still carry the override's "true",
+ * and a freshly booted application must read demo mode as off again, whether
+ * DEMO_MODE arrived via the phpunit.xml pin, a process-level export, or a
+ * developer's .env. (The exact restored string is not asserted: PHPUnit
+ * normalizes the pin's value="false" to an empty string.)
+ */
+
+test('overriding demo mode reboots the application with the flag on', function (): void {
+    $this->reloadWithDemoMode(true);
+
+    expect(config('demo.mode'))->toBeTrue();
+});
+
+test('the demo mode override from the previous test is fully unwound', function (): void {
+    expect(getenv('DEMO_MODE'))->not->toBe('true');
+    expect($_ENV['DEMO_MODE'] ?? null)->not->toBe('true');
+    expect(config('demo.mode'))->toBeFalse();
+});

--- a/tests/Feature/Demo/DemoModeTest.php
+++ b/tests/Feature/Demo/DemoModeTest.php
@@ -2,11 +2,6 @@
 
 use Inertia\Testing\AssertableInertia as Assert;
 
-afterEach(function (): void {
-    putenv('DEMO_MODE');
-    unset($_ENV['DEMO_MODE'], $_SERVER['DEMO_MODE']);
-});
-
 test('demo mode is off by default', function (): void {
     expect(config('demo.mode'))->toBeFalse();
 });

--- a/tests/Feature/Demo/DemoRateLimitTest.php
+++ b/tests/Feature/Demo/DemoRateLimitTest.php
@@ -4,11 +4,6 @@ use App\Actions\Teams\CreateTeam;
 use App\Models\Channel;
 use App\Models\User;
 
-afterEach(function (): void {
-    putenv('DEMO_MODE');
-    unset($_ENV['DEMO_MODE'], $_SERVER['DEMO_MODE']);
-});
-
 /**
  * A team owner in their seeded #general channel, plus the message-store URL.
  *

--- a/tests/Feature/Demo/DemoResetScheduleTest.php
+++ b/tests/Feature/Demo/DemoResetScheduleTest.php
@@ -4,11 +4,6 @@ use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Artisan;
 
-afterEach(function (): void {
-    putenv('DEMO_MODE');
-    unset($_ENV['DEMO_MODE'], $_SERVER['DEMO_MODE']);
-});
-
 /**
  * The scheduled `demo:seed` reset event, loading the console schedule first so a
  * fresh (post-reload) application has its events registered.

--- a/tests/Feature/Providers/FortifyServiceProviderTest.php
+++ b/tests/Feature/Providers/FortifyServiceProviderTest.php
@@ -6,11 +6,6 @@ use App\Models\User;
 use Database\Seeders\DemoSeeder;
 use Inertia\Testing\AssertableInertia as Assert;
 
-afterEach(function (): void {
-    putenv('DEMO_MODE');
-    unset($_ENV['DEMO_MODE'], $_SERVER['DEMO_MODE']);
-});
-
 test('the login page exposes a pending invitation when the code is valid', function (): void {
     $team = Team::factory()->create(['name' => 'Laravel Team']);
     $invitation = TeamInvitation::factory()->create([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,6 +42,15 @@ abstract class TestCase extends BaseTestCase
             }
         }
 
+        if ($this->originalEnv !== []) {
+            // Also reset the memoized env repository. Its immutable writer keeps
+            // a "loaded by Dotenv" ledger; any key still on that ledger would be
+            // re-written from .env on the next application boot, clobbering the
+            // values restored above. A fresh repository treats them as external
+            // definitions that reloading .env leaves untouched.
+            Env::enablePutenv();
+        }
+
         $this->originalEnv = [];
 
         // The LDAP directory-bind path registers a custom Fortify auth callback


### PR DESCRIPTION
Closes #549.

## What

Fixes the cross-suite `DEMO_MODE=true` leak: with the flag present at the process/`getenv` level (an export, `sail exec -e`, or a phpunit.xml pin) and `DEMO_MODE=true` in the developer's `.env`, running `tests/Feature/Demo` flipped the `PreventDestructiveDemoActions` guard on for unrelated destructive-action tests (SecurityTest & co).

## Root cause

Seven test files carried `afterEach` hooks that force-unset `DEMO_MODE` (and `MAIL_MAILER` / `REGISTRATION_ENABLED`) from `putenv`/`$_ENV`/`$_SERVER`. Leaving the variable *undefined* let the immutable Dotenv repository "adopt" the `.env` value on the next application boot and record it on its loaded ledger — after which every refresh re-wrote the `.env` value, and `TestCase::reloadWithEnv()` captured that poisoned value as the "original" to restore on teardown. The leak then persisted for the rest of the suite.

## Changes

- Remove the force-unset `afterEach` hooks (5 demo files + `RegistrationFlagTest` + `FortifyServiceProviderTest`); the `TestCase::$originalEnv` machinery already restores overrides deterministically.
- Reset the memoized `Env` repository in `TestCase::tearDown()` after restoring overrides, so a stale "loaded by Dotenv" ledger can never clobber the restored values on the next boot.
- Pin `<env name="DEMO_MODE" value="false" force="true"/>` in `phpunit.xml` (matching the SSO/LDAP pins); `force` makes the pin win even over an exported process-level value, so the suite is hermetic no matter how the flag arrives.
- Add `DemoModeIsolationTest`: an intentionally ordered pair asserting a demo-mode override is fully unwound for the next test.

Note: PHPUnit normalizes `value="false"` to boolean `false`, so pinned vars reach PHP as `''` (also true of the existing `PULSE_ENABLED`-style pins) — the regression test asserts semantics, not exact strings.

## Testing

- Repro from the issue (`sail exec -e DEMO_MODE=false … tests/Feature/Demo tests/Feature/Settings/SecurityTest.php`) reproduced 3 failures before, green after.
- Verified green in all three arrival modes with `.env` `DEMO_MODE=true`: no process env, `-e DEMO_MODE=false`, `-e DEMO_MODE=true`.
- Full gate green: Pint, PHPStan, Rector, `--min=100` coverage at 100.0 %.