### PR TITLE
fix: repair the poll composer panel mounted focus crash and dead controls

### DIFF
--- a/resources/js/components/PollComposerPanel.test.ts
+++ b/resources/js/components/PollComposerPanel.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import PollComposerPanel from './PollComposerPanel.vue';
+
+/**
+ * Mounts the panel with the real `Input`/`Switch`/`Button` primitives on
+ * purpose: issue #577 (dead controls + a `mounted` focus crash) was invisible
+ * to tests that stubbed them, because the crash came from treating the shadcn
+ * `Input` component instance as a bare `HTMLInputElement`.
+ */
+
+const routerPost = vi.fn();
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post: (...args: unknown[]) => routerPost(...args) },
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Channels/PollController', () => ({
+    store: () => ({ url: '/t/acme/c/general/polls' }),
+}));
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+function mountPanel() {
+    const closed: number[] = [];
+    const errors: unknown[] = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(PollComposerPanel as Component, {
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                    onClose: () => closed.push(1),
+                }),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+    app.config.errorHandler = (error) => errors.push(error);
+    app.mount(container);
+    active.push({ app, container });
+
+    return { container, closed, errors };
+}
+
+function optionInputs(container: HTMLElement): HTMLInputElement[] {
+    return Array.from(
+        container.querySelectorAll<HTMLInputElement>(
+            '[data-test="poll-option-input"]',
+        ),
+    );
+}
+
+function click(element: Element | null): Promise<void> {
+    element!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, cancelable: true }),
+    );
+
+    return nextTick();
+}
+
+async function fill(input: HTMLInputElement, value: string): Promise<void> {
+    input.value = value;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    await nextTick();
+}
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+    vi.clearAllMocks();
+});
+
+describe('PollComposerPanel', () => {
+    it('mounts without errors and focuses the question field', async () => {
+        const { container, errors } = mountPanel();
+
+        const question = container.querySelector<HTMLInputElement>(
+            '[data-test="poll-question-input"]',
+        );
+
+        // The focus is deferred a tick (mirroring GifPickerPanel) so it lands
+        // after the composer's own post-open focus work.
+        await nextTick();
+
+        expect(errors).toEqual([]);
+        expect(question).not.toBeNull();
+        expect(document.activeElement).toBe(question);
+    });
+
+    it('appends option rows up to the max of 10', async () => {
+        const { container } = mountPanel();
+
+        expect(optionInputs(container)).toHaveLength(2);
+
+        await click(container.querySelector('[data-test="poll-add-option"]'));
+        expect(optionInputs(container)).toHaveLength(3);
+
+        for (let rows = 3; rows < 10; rows++) {
+            await click(
+                container.querySelector('[data-test="poll-add-option"]'),
+            );
+        }
+
+        expect(optionInputs(container)).toHaveLength(10);
+
+        // At the max the add button is gone, so the count cannot grow further.
+        expect(
+            container.querySelector('[data-test="poll-add-option"]'),
+        ).toBeNull();
+    });
+
+    it('removes option rows down to the min of 2', async () => {
+        const { container } = mountPanel();
+
+        // At the minimum no remove buttons render at all.
+        expect(
+            container.querySelectorAll('[data-test="poll-option-remove"]'),
+        ).toHaveLength(0);
+
+        await click(container.querySelector('[data-test="poll-add-option"]'));
+        expect(optionInputs(container)).toHaveLength(3);
+
+        await click(
+            container.querySelector('[data-test="poll-option-remove"]'),
+        );
+        expect(optionInputs(container)).toHaveLength(2);
+        expect(
+            container.querySelectorAll('[data-test="poll-option-remove"]'),
+        ).toHaveLength(0);
+    });
+
+    it('removing a row keeps the other rows in order', async () => {
+        const { container } = mountPanel();
+
+        await click(container.querySelector('[data-test="poll-add-option"]'));
+
+        const inputs = optionInputs(container);
+        await fill(inputs[0], 'first');
+        await fill(inputs[1], 'second');
+        await fill(inputs[2], 'third');
+
+        const removeButtons = container.querySelectorAll(
+            '[data-test="poll-option-remove"]',
+        );
+        await click(removeButtons[1]);
+
+        expect(optionInputs(container).map((input) => input.value)).toEqual([
+            'first',
+            'third',
+        ]);
+    });
+
+    it('closes via the × button', async () => {
+        const { container, closed } = mountPanel();
+
+        await click(
+            container.querySelector('[data-test="poll-builder-close"]'),
+        );
+
+        expect(closed).toHaveLength(1);
+    });
+
+    it('closes via Escape', async () => {
+        const { container, closed } = mountPanel();
+
+        container.querySelector('[data-test="poll-builder"]')!.dispatchEvent(
+            new KeyboardEvent('keydown', {
+                key: 'Escape',
+                bubbles: true,
+                cancelable: true,
+            }),
+        );
+        await nextTick();
+
+        expect(closed).toHaveLength(1);
+    });
+
+    it('closes via the cancel button', async () => {
+        const { container, closed } = mountPanel();
+
+        await click(container.querySelector('[data-test="poll-cancel"]'));
+
+        expect(closed).toHaveLength(1);
+    });
+
+    it('toggles both switches and submits their values with the poll', async () => {
+        const { container } = mountPanel();
+
+        const question = container.querySelector<HTMLInputElement>(
+            '[data-test="poll-question-input"]',
+        )!;
+        await fill(question, 'Lunch spot?');
+
+        const inputs = optionInputs(container);
+        await fill(inputs[0], 'Tacos');
+        await fill(inputs[1], 'Ramen');
+
+        const allowMultiple = container.querySelector(
+            '[data-test="poll-allow-multiple"]',
+        )!;
+        const anonymous = container.querySelector(
+            '[data-test="poll-anonymous"]',
+        )!;
+
+        expect(allowMultiple.getAttribute('data-state')).toBe('unchecked');
+        expect(anonymous.getAttribute('data-state')).toBe('unchecked');
+
+        await click(allowMultiple);
+        await click(anonymous);
+
+        expect(allowMultiple.getAttribute('data-state')).toBe('checked');
+        expect(anonymous.getAttribute('data-state')).toBe('checked');
+
+        await click(container.querySelector('[data-test="poll-submit"]'));
+
+        expect(routerPost).toHaveBeenCalledTimes(1);
+        expect(routerPost.mock.calls[0][0]).toBe('/t/acme/c/general/polls');
+        expect(routerPost.mock.calls[0][1]).toMatchObject({
+            question: 'Lunch spot?',
+            options: ['Tacos', 'Ramen'],
+            allow_multiple: true,
+            is_anonymous: true,
+        });
+    });
+
+    it('a toggled switch can be toggled back off', async () => {
+        const { container } = mountPanel();
+
+        const allowMultiple = container.querySelector(
+            '[data-test="poll-allow-multiple"]',
+        )!;
+
+        await click(allowMultiple);
+        expect(allowMultiple.getAttribute('data-state')).toBe('checked');
+
+        await click(allowMultiple);
+        expect(allowMultiple.getAttribute('data-state')).toBe('unchecked');
+    });
+});

--- a/resources/js/components/PollComposerPanel.vue
+++ b/resources/js/components/PollComposerPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { router } from '@inertiajs/vue3';
 import { BarChart3, Plus, X } from '@lucide/vue';
-import { computed, onMounted, ref } from 'vue';
+import { computed, nextTick, onMounted, ref, useTemplateRef } from 'vue';
 import { store as storePoll } from '@/actions/App/Http/Controllers/Channels/PollController';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -38,10 +38,10 @@ const allowMultiple = ref(false);
 const isAnonymous = ref(false);
 const posting = ref(false);
 
-const questionField = ref<HTMLInputElement | null>(null);
+const questionField = useTemplateRef('questionField');
 
 onMounted(() => {
-    questionField.value?.focus();
+    nextTick(() => questionField.value?.$el?.focus());
 });
 
 /** The trimmed, non-empty option labels, preserving row order. */
@@ -130,11 +130,13 @@ function submit(): void {
 </script>
 
 <template>
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- the panel is a dialog; the key handler routes Escape to close it -->
     <div
         role="dialog"
         :aria-label="$t('Create a poll')"
         data-test="poll-builder"
         class="absolute bottom-full left-0 z-20 mb-2 flex w-[25rem] max-w-full flex-col overflow-hidden rounded-2xl border bg-popover shadow-[0_16px_40px_rgba(29,26,21,0.18)]"
+        @keydown.esc="emit('close')"
     >
         <div
             class="flex items-center gap-2 border-b border-border px-3.5 py-2.5"

--- a/tests/Browser/PollComposerPanelTest.php
+++ b/tests/Browser/PollComposerPanelTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Regression coverage for issue #577: the poll builder rendered but was dead —
+ * a `mounted` focus crash wedged Vue's scheduler, so Add option, the × close
+ * button, and both switches never updated the panel. These run against the real
+ * app so a repeat of that crash fails loudly here.
+ */
+test('the poll builder opens focused and add/remove option rows work', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice);
+    $page->assertPresent('@message-composer-input');
+
+    $page
+        ->type('@message-composer-input', '/poll')
+        ->keys('@message-composer-input', ['Enter'])
+        ->assertPresent('@poll-builder')
+        ->assertNoJavaScriptErrors()
+        ->assertScript(
+            'document.activeElement?.dataset.test',
+            'poll-question-input',
+        )
+        ->assertScript(
+            'document.querySelectorAll(\'[data-test="poll-option-input"]\').length',
+            2,
+        );
+
+    $page
+        ->click('@poll-add-option')
+        ->assertScript(
+            'document.querySelectorAll(\'[data-test="poll-option-input"]\').length',
+            3,
+        )
+        ->click('@poll-option-remove')
+        ->assertScript(
+            'document.querySelectorAll(\'[data-test="poll-option-input"]\').length',
+            2,
+        )
+        ->assertMissing('@poll-option-remove');
+});
+
+test('the poll builder switches toggle and the × button closes the panel', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice);
+    $page->assertPresent('@message-composer-input');
+
+    $page
+        ->type('@message-composer-input', '/poll')
+        ->keys('@message-composer-input', ['Enter'])
+        ->assertPresent('@poll-builder')
+        ->assertAttribute('@poll-allow-multiple', 'data-state', 'unchecked')
+        ->assertAttribute('@poll-anonymous', 'data-state', 'unchecked')
+        ->click('@poll-allow-multiple')
+        ->assertAttribute('@poll-allow-multiple', 'data-state', 'checked')
+        ->click('@poll-anonymous')
+        ->assertAttribute('@poll-anonymous', 'data-state', 'checked')
+        ->click('@poll-allow-multiple')
+        ->assertAttribute('@poll-allow-multiple', 'data-state', 'unchecked');
+
+    $page
+        ->click('@poll-builder-close')
+        ->assertMissing('@poll-builder')
+        ->assertNoJavaScriptErrors();
+});


### PR DESCRIPTION
Closes #577.

## What

The poll builder (`/poll`) rendered but was unusable: a `TypeError` from the `mounted` hook, a dead **Add option** button, a dead × close button, and untogglable switches.

## Root cause

`PollComposerPanel.vue` typed its template ref as `HTMLInputElement` and called `.focus()` on it, but the ref was bound to the shadcn-vue `<Input>` **component**, so at runtime it held a component instance with no `focus` method. The `?.` didn't short-circuit (the instance exists), so the hook threw. In dev builds Vue rethrows that error from inside the scheduler's post-flush, which wedges the flush — reactive updates stop reaching the DOM, which is why *every* control in the panel looked dead. One crash, all four symptoms.

## Fix

- Focus through the component's root element — `useTemplateRef` + `questionField.value?.$el?.focus()` — deferred one tick after mount, matching the existing `PasswordInput`/`GifPickerPanel` pattern.
- Wired **Escape** to close the panel, matching the sibling GIF picker dialog.

## Testing

- New `PollComposerPanel.test.ts` (9 vitest cases) mounts the panel with the **real** `Input`/`Switch`/`Button` primitives — the prior composer test stubbed them, which is exactly why the crash was invisible. Covers mount-without-errors + focus, add rows to the max of 10, remove down to the min of 2, row-order preservation, close via ×/Escape/cancel, switch toggling both ways, and submitted `allow_multiple`/`is_anonymous` values.
- New `tests/Browser/PollComposerPanelTest.php` (2 Pest browser tests) exercises the real app end-to-end: opens `/poll`, asserts no JavaScript errors, focus lands on the question field, add/remove rows, switches toggle, × closes the panel. These fail loudly if the scheduler-wedging crash ever returns.
- Full gate green: `sail composer test` at 100.0 % coverage, plus `lint:check`, `format:check`, `types:check`, and `build`.
- Local CodeRabbit review: clean, 0 findings.

## Notes

- Found while working on this: fresh `bin/worktree` bootstraps can't run the Browser suite (Playwright browsers never installed) — filed #579 rather than fixing inline.
- No user-facing copy added, so no new i18n keys; no operator-facing changes, so no docs updates.