### PR TITLE
feat: report and offer to append new .env settings during upgrade

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,10 +13,13 @@ vendor
 .zed
 .DS_Store
 
-# Secrets and local environment. .env.prod.example stays out of the image too;
-# it is only a template for the operator's .env.
+# Secrets and local environment. The one exception is .env.prod.example: it is
+# baked into the image so docker/upgrade.sh can compare the operator's .env
+# against the *target release's* template (its working-tree copy may be stale
+# or absent — installed hosts have no checkout at all).
 .env
 .env.*
+!.env.prod.example
 
 # Build artifacts generated inside the image.
 public/build

--- a/docker/env-sync.sh
+++ b/docker/env-sync.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+#
+# Compare an operator's .env against a release's .env.prod.example and report
+# the active (uncommented) settings the template has but the .env lacks.
+#
+#   ./docker/env-sync.sh ENV_FILE TEMPLATE_FILE [--apply]
+#
+# --apply appends the missing keys to ENV_FILE with the template's default
+# values, carrying each key's comment block from the template for context.
+# Keys already present in ENV_FILE are never touched, even when the template's
+# default changed.
+#
+# Exit codes follow diff semantics: 0 = nothing missing (or --apply appended
+# everything), 1 = missing keys were reported, 2 = usage or file errors.
+set -eu
+
+usage() {
+    echo "Usage: ./docker/env-sync.sh ENV_FILE TEMPLATE_FILE [--apply]"
+}
+
+ENV_FILE=""
+TEMPLATE_FILE=""
+APPLY="false"
+
+for arg in "$@"; do
+    case "$arg" in
+        --apply)
+            APPLY="true"
+            ;;
+        -*)
+            echo "Error: unknown option '$arg'." >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$ENV_FILE" ]; then
+                ENV_FILE="$arg"
+            elif [ -z "$TEMPLATE_FILE" ]; then
+                TEMPLATE_FILE="$arg"
+            else
+                echo "Error: unexpected argument '$arg'." >&2
+                usage >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$ENV_FILE" ] || [ -z "$TEMPLATE_FILE" ]; then
+    usage >&2
+    exit 2
+fi
+
+for file in "$ENV_FILE" "$TEMPLATE_FILE"; do
+    if [ ! -f "$file" ]; then
+        echo "Error: '$file' not found." >&2
+        exit 2
+    fi
+done
+
+# Active keys only: a line assigning KEY=... at column one. Commented-out
+# template keys (`# APP_PORT=8000`) are documentation, not settings.
+active_keys() {
+    sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' "$1"
+}
+
+MISSING=""
+
+for key in $(active_keys "$TEMPLATE_FILE"); do
+    if ! active_keys "$ENV_FILE" | grep -qx "$key"; then
+        MISSING="${MISSING}${key}
+"
+    fi
+done
+
+if [ -z "$MISSING" ]; then
+    exit 0
+fi
+
+echo "New settings in $TEMPLATE_FILE not present in $ENV_FILE:"
+printf '%s' "$MISSING" | sed 's/^/  /'
+
+if [ "$APPLY" != "true" ]; then
+    exit 1
+fi
+
+# A key's context is the contiguous run of comment lines directly above its
+# assignment in the template — stopping at a blank line or at a commented-out
+# key (`# APP_PORT=8000`), which documents a different setting, not this one.
+template_block() {
+    awk -v key="$1" '
+        { lines[NR] = $0 }
+        !found && $0 ~ "^" key "=" { found = NR }
+        END {
+            if (!found) { exit 1 }
+            start = found
+            while (start > 1 && lines[start - 1] ~ /^#/ && lines[start - 1] !~ /^#[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=/) {
+                start--
+            }
+            for (i = start; i <= found; i++) { print lines[i] }
+        }
+    ' "$TEMPLATE_FILE"
+}
+
+{
+    printf '\n# Added by docker/env-sync.sh from %s on %s.\n' "$TEMPLATE_FILE" "$(date +%Y-%m-%d)"
+
+    printf '%s' "$MISSING" | while IFS= read -r key; do
+        echo
+        template_block "$key"
+    done
+} >>"$ENV_FILE"
+
+COUNT="$(printf '%s' "$MISSING" | wc -l | tr -d '[:space:]')"
+echo "Appended $COUNT setting(s) to $ENV_FILE."

--- a/docker/env-sync.sh
+++ b/docker/env-sync.sh
@@ -56,7 +56,22 @@ for file in "$ENV_FILE" "$TEMPLATE_FILE"; do
         echo "Error: '$file' not found." >&2
         exit 2
     fi
+
+    # An unreadable file would parse as empty, which reads as "in sync" for a
+    # template and as "every key is missing" for an .env. Refuse instead.
+    if [ ! -r "$file" ]; then
+        echo "Error: '$file' is not readable." >&2
+        exit 2
+    fi
 done
+
+# Checked up front so an unwritable .env fails as a usage error, rather than as
+# a redirection failure midway that would be indistinguishable from the exit 1
+# that means "missing keys were reported".
+if [ "$APPLY" = "true" ] && [ ! -w "$ENV_FILE" ]; then
+    echo "Error: '$ENV_FILE' is not writable." >&2
+    exit 2
+fi
 
 # Active keys only: a line assigning KEY=... at column one. Commented-out
 # template keys (`# APP_PORT=8000`) are documentation, not settings.

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -139,7 +139,7 @@ echo "Step 1/3: downloading the stack..."
 fetch "docker-compose.prod.yml" "docker-compose.prod.yml"
 fetch ".env.prod.example" ".env.prod.example"
 # The operational scripts, so backup / upgrade / restore are on the box too.
-for script in gen-secrets upgrade backup restore; do
+for script in gen-secrets upgrade backup restore env-sync; do
     fetch "docker/${script}.sh" "docker/${script}.sh"
     chmod +x "docker/${script}.sh"
 done

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -24,6 +24,16 @@
 # for air-gapped hosts or when you pulled ahead of the maintenance window.
 # Build-from-source setups never pull: the overlay is detected from COMPOSE_FILE.
 #
+# Before starting the new release, .env is compared against the target's
+# .env.prod.example (shipped inside the image) and any new settings are
+# reported, so a feature toggle introduced by the release is never silently
+# unset. On an interactive run you are offered to append them with the
+# template defaults (existing keys are never touched); non-interactive runs
+# only report. --sync-env appends without asking (for automation);
+# --no-sync-env skips the check entirely. The check is a courtesy: whatever
+# goes wrong with it (an image too old to ship the template, a missing
+# docker/env-sync.sh), the upgrade itself proceeds.
+#
 # IT NEVER ROLLS BACK ON ITS OWN. Rolling back is not a git revert here, it is a
 # destructive database restore, and this script cannot tell the two cases apart:
 # a migration that genuinely broke the schema, and an app that is fine but whose
@@ -45,9 +55,10 @@ TARGET=""
 TIMEOUT="300"
 PULL="true"
 POLL_INTERVAL="5"
+SYNC_ENV="ask"
 
 usage() {
-    echo "Usage: ./docker/upgrade.sh --target=X.Y.Z [BACKUP_DIR] [--timeout=SECONDS] [--no-pull]"
+    echo "Usage: ./docker/upgrade.sh --target=X.Y.Z [BACKUP_DIR] [--timeout=SECONDS] [--no-pull] [--sync-env|--no-sync-env]"
 }
 
 for arg in "$@"; do
@@ -60,6 +71,12 @@ for arg in "$@"; do
             ;;
         --no-pull)
             PULL="false"
+            ;;
+        --sync-env)
+            SYNC_ENV="always"
+            ;;
+        --no-sync-env)
+            SYNC_ENV="never"
             ;;
         -h | --help)
             usage
@@ -207,9 +224,14 @@ echo
 # which the failure path needs to hand back to the operator.
 echo "Step 1/3: backing up..."
 BACKUP_LOG="$(mktemp)"
+SYNC_TMP_DIR=""
 
 cleanup() {
     rm -f "$BACKUP_LOG"
+
+    if [ -n "$SYNC_TMP_DIR" ]; then
+        rm -rf "$SYNC_TMP_DIR"
+    fi
 }
 trap cleanup EXIT
 
@@ -283,6 +305,71 @@ echo "Step 2/3: starting $TARGET..."
 if [ "$PULL" = "true" ]; then
     if ! docker compose pull </dev/null; then
         fail_with_restore "could not pull the image for $TARGET; nothing was restarted."
+    fi
+fi
+
+# ---- New settings check -------------------------------------------------
+# Compare .env against the target release's .env.prod.example so a setting
+# introduced by the new version (a feature toggle, a new tunable) is surfaced
+# before that version boots with it silently unset. The template is read from
+# the image just pulled — never the working tree's stale copy — except on
+# build-from-source setups, where the working tree IS what gets built. Every
+# failure path here is a note, not an error: this check must never be the
+# reason an upgrade dies.
+if [ "$SYNC_ENV" != "never" ]; then
+    TEMPLATE_PATH=""
+
+    if [ "$BUILD_FROM_SOURCE" = "true" ]; then
+        if [ -f ".env.prod.example" ]; then
+            TEMPLATE_PATH=".env.prod.example"
+        else
+            echo "  note: .env.prod.example not found in the working tree; skipping the new-settings check."
+        fi
+    else
+        SYNC_TMP_DIR="$(mktemp -d)"
+
+        # --entrypoint bypasses docker/entrypoint.sh: a one-off `cat` must not
+        # run migrations or wait on the database.
+        if docker compose run --rm --no-deps --entrypoint cat app /app/.env.prod.example \
+            >"$SYNC_TMP_DIR/.env.prod.example" 2>/dev/null </dev/null; then
+            TEMPLATE_PATH="$SYNC_TMP_DIR/.env.prod.example"
+        else
+            echo "  note: the $TARGET image does not ship .env.prod.example (older releases do not); skipping the new-settings check."
+        fi
+    fi
+
+    if [ -n "$TEMPLATE_PATH" ]; then
+        if [ ! -x "docker/env-sync.sh" ]; then
+            echo "  note: docker/env-sync.sh is missing or not executable; skipping the new-settings check."
+        else
+            SYNC_STATUS=0
+            ./docker/env-sync.sh .env "$TEMPLATE_PATH" || SYNC_STATUS=$?
+
+            if [ "$SYNC_STATUS" -eq 1 ]; then
+                APPLY="false"
+
+                if [ "$SYNC_ENV" = "always" ]; then
+                    APPLY="true"
+                elif [ -t 0 ]; then
+                    printf 'Append them to .env with the template defaults? [Y/n] '
+                    read -r SYNC_ANSWER || SYNC_ANSWER=""
+
+                    case "$SYNC_ANSWER" in
+                        [Nn]*) ;;
+                        *) APPLY="true" ;;
+                    esac
+                else
+                    echo "  (non-interactive run: nothing appended. Pass --sync-env to append automatically.)"
+                fi
+
+                if [ "$APPLY" = "true" ]; then
+                    ./docker/env-sync.sh .env "$TEMPLATE_PATH" --apply \
+                        || echo "  note: appending failed; .env is untouched. The report above lists the keys."
+                fi
+            elif [ "$SYNC_STATUS" -ge 2 ]; then
+                echo "  note: the new-settings check could not run; continuing."
+            fi
+        fi
     fi
 fi
 

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -41,8 +41,10 @@ It does three things, stopping at the first that fails:
 
 1. **Backs up** by running [`docker/backup.sh`](#backups) for you, into the
    directory you name (the current one by default).
-2. **Starts the new release.** Migrations run automatically on boot, via the
-   `app` container's entrypoint.
+2. **Starts the new release.** Just before starting it, your `.env` is
+   [checked for settings the new release added](#new-settings-in-a-release);
+   migrations then run automatically on boot, via the `app` container's
+   entrypoint.
 3. **Verifies the upgrade landed.** It waits for `/up` to answer, then asks the
    instance what it is actually running and compares that with `APP_VERSION`.
 
@@ -62,6 +64,41 @@ Useful flags:
 | `--target=X.Y.Z` | The release to upgrade to. Written to `APP_VERSION` before pulling, and the version the verify step expects. Omit it to use whatever `APP_VERSION` already holds. |
 | `--timeout=SECONDS` | How long to wait for `/up` (default 300). A cold boot runs migrations and rebuilds the search index first, so raise it on a slow host or a large database. |
 | `--no-pull` | Use the image already on the host, for air-gapped hosts or when you pulled ahead of the window. |
+| `--sync-env` | Append any [new settings](#new-settings-in-a-release) to `.env` without asking, for unattended runs that should adopt the template defaults. |
+| `--no-sync-env` | Skip the new-settings check entirely. |
+
+### New settings in a release
+
+A new release often introduces settings — a feature toggle, a new tunable — that
+your `.env` predates. Without them the app silently falls back to its built-in
+defaults, and nothing tells you the option now exists. So before starting the
+new release, `upgrade.sh` compares your `.env` against the **target release's**
+`.env.prod.example` (read from the image it just pulled, never from a stale
+working-tree copy; build-from-source setups use the tree they are about to
+build) and reports any active settings the template has that your `.env` lacks.
+
+On an interactive run it then offers to append them with the template's default
+values, carrying the template's comment block for each key so the context
+travels along. Only *missing* keys are ever appended — a key you already set is
+never touched, even when its default changed. Declining leaves `.env` alone and
+keeps the report on screen.
+
+Non-interactive runs (cron, CI — anything without a TTY) never block on a
+prompt: the report still prints, and nothing is appended unless you pass
+`--sync-env`. The check is a courtesy, not a gate — if it cannot run (for
+example, the target image predates the template being shipped inside it), the
+upgrade proceeds with a note.
+
+You can run the same comparison yourself at any time, against any template
+copy:
+
+```bash
+./docker/env-sync.sh .env .env.prod.example          # report only
+./docker/env-sync.sh .env .env.prod.example --apply  # append what is missing
+```
+
+It exits `0` when nothing is missing, `1` after reporting missing keys, and `2`
+on usage errors, so it also scripts cleanly.
 
 ### If it fails, it stops and hands you the backup
 

--- a/tests/Unit/EnvSyncScriptTest.php
+++ b/tests/Unit/EnvSyncScriptTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Drive docker/env-sync.sh as an operator would: a plain POSIX shell process
+ * against fixture files. Exit codes follow diff semantics: 0 = in sync,
+ * 1 = missing keys found, 2 = usage or file errors.
+ */
+function runEnvSync(string ...$arguments): Process
+{
+    $process = new Process(['sh', dirname(__DIR__, 2).'/docker/env-sync.sh', ...$arguments]);
+    $process->run();
+
+    return $process;
+}
+
+function envSyncFixture(string $contents): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'env-sync-test-');
+    file_put_contents($path, $contents);
+
+    return $path;
+}
+
+test('report mode lists active template keys missing from the env file and exits 1', function (): void {
+    $env = envSyncFixture("APP_NAME=\"My Desk\"\n");
+    $template = envSyncFixture(<<<'EOT'
+        APP_NAME="The Desk"
+
+        # --- Feature toggles ---
+        NEW_TOGGLE=true
+        NEW_URL=
+        EOT."\n");
+
+    $process = runEnvSync($env, $template);
+
+    expect($process->getExitCode())->toBe(1)
+        ->and($process->getOutput())->toContain('NEW_TOGGLE')
+        ->and($process->getOutput())->toContain('NEW_URL')
+        ->and($process->getOutput())->not->toContain('APP_NAME');
+});
+
+test('commented-out template keys are not treated as missing', function (): void {
+    $env = envSyncFixture("APP_NAME=\"My Desk\"\n");
+    $template = envSyncFixture(<<<'EOT'
+        APP_NAME="The Desk"
+        # APP_PORT=8000
+        #SSO_OIDC_ISSUER=https://idp.example.com
+        EOT."\n");
+
+    $process = runEnvSync($env, $template);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->not->toContain('APP_PORT')
+        ->and($process->getOutput())->not->toContain('SSO_OIDC_ISSUER');
+});
+
+test('an env file already carrying every active template key reports nothing and exits 0', function (): void {
+    $env = envSyncFixture("APP_NAME=\"My Desk\"\nNEW_TOGGLE=false\n");
+    $template = envSyncFixture("APP_NAME=\"The Desk\"\nNEW_TOGGLE=true\n");
+
+    $process = runEnvSync($env, $template);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toBe('');
+});
+
+test('--apply appends missing keys with their template comment blocks and never touches existing keys', function (): void {
+    $env = envSyncFixture("APP_NAME=\"My Desk\"\nEXISTING=keep\n");
+    $template = envSyncFixture(<<<'EOT'
+        APP_NAME="The Desk"
+
+        # --- Feature toggles ---
+        # Turn the new thing on or off.
+        NEW_TOGGLE=true
+        # NEW_TOGGLE_URL=https://example.com
+        NEW_URL=
+        EOT."\n");
+
+    $process = runEnvSync($env, $template, '--apply');
+    $result = file_get_contents($env);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($result)->toStartWith("APP_NAME=\"My Desk\"\nEXISTING=keep\n")
+        ->and($result)->toContain("# Turn the new thing on or off.\nNEW_TOGGLE=true\n")
+        ->and($result)->toContain("NEW_URL=\n")
+        ->and($result)->not->toContain('NEW_TOGGLE_URL')
+        ->and($result)->not->toContain('APP_NAME="The Desk"')
+        ->and(substr_count($result, 'APP_NAME='))->toBe(1);
+
+    $recheck = runEnvSync($env, $template);
+
+    expect($recheck->getExitCode())->toBe(0);
+});
+
+test('usage and file errors exit 2', function (array $arguments): void {
+    $process = runEnvSync(...$arguments);
+
+    expect($process->getExitCode())->toBe(2)
+        ->and($process->getErrorOutput())->not->toBe('');
+})->with([
+    'no arguments' => [[]],
+    'one argument' => [['only-one']],
+    'unknown option' => [['a', 'b', '--frobnicate']],
+    'missing files' => [['/nonexistent/.env', '/nonexistent/.env.prod.example']],
+    'extra argument' => [['a', 'b', 'c']],
+]);
+
+test('a copy of the shipped template is already in sync with the template', function (): void {
+    $template = dirname(__DIR__, 2).'/.env.prod.example';
+    $env = envSyncFixture(file_get_contents($template));
+
+    $process = runEnvSync($env, $template);
+
+    expect($process->getExitCode())->toBe(0);
+});

--- a/tests/Unit/EnvSyncScriptTest.php
+++ b/tests/Unit/EnvSyncScriptTest.php
@@ -109,6 +109,37 @@ test('usage and file errors exit 2', function (array $arguments): void {
     'extra argument' => [['a', 'b', 'c']],
 ]);
 
+test('an unreadable file exits 2 rather than reading as empty', function (): void {
+    $env = envSyncFixture("APP_NAME=\"My Desk\"\n");
+    $template = envSyncFixture("APP_NAME=\"The Desk\"\nNEW_TOGGLE=true\n");
+    chmod($template, 0o000);
+
+    if (is_readable($template)) {
+        $this->markTestSkipped('The test process can read mode-000 files (running as root).');
+    }
+
+    $process = runEnvSync($env, $template);
+
+    expect($process->getExitCode())->toBe(2)
+        ->and($process->getErrorOutput())->toContain('not readable');
+});
+
+test('--apply against an unwritable env file exits 2 instead of failing mid-append', function (): void {
+    $env = envSyncFixture("APP_NAME=\"My Desk\"\n");
+    $template = envSyncFixture("APP_NAME=\"The Desk\"\nNEW_TOGGLE=true\n");
+    chmod($env, 0o400);
+
+    if (is_writable($env)) {
+        $this->markTestSkipped('The test process can write mode-400 files (running as root).');
+    }
+
+    $process = runEnvSync($env, $template, '--apply');
+
+    expect($process->getExitCode())->toBe(2)
+        ->and($process->getErrorOutput())->toContain('not writable')
+        ->and(file_get_contents($env))->toBe("APP_NAME=\"My Desk\"\n");
+});
+
 test('a copy of the shipped template is already in sync with the template', function (): void {
     $template = dirname(__DIR__, 2).'/.env.prod.example';
     $env = envSyncFixture(file_get_contents($template));


### PR DESCRIPTION
Closes #585.

## What

Upgrading never reconciled the operator's `.env` with the release they were moving to, so a setting introduced by that release (a feature toggle, a new tunable) silently stayed unset and nothing said so. `./docker/upgrade.sh` now compares the two and offers to close the gap.

- **New `docker/env-sync.sh`** — a standalone POSIX tool: `env-sync.sh ENV_FILE TEMPLATE_FILE [--apply]`. It reports the *active* (uncommented) settings the template has that the env file lacks, and with `--apply` appends them with the template's default values, carrying each key's contiguous comment block along for context. A key already present is never touched, even when its default changed. Exit codes follow diff semantics (`0` in sync, `1` missing keys reported, `2` usage/file errors), so it scripts cleanly and an operator can run it any time, outside an upgrade.
- **`docker/upgrade.sh`** — runs the check between `docker compose pull` and `up -d`, so the new release boots with the new settings already in place. Interactive runs are offered the append (`[Y/n]`, Enter accepts); runs without a TTY only report, so cron never blocks. `--sync-env` appends unattended, `--no-sync-env` skips the check. Every failure path here is a note, not an error: the check must never be the reason an upgrade dies.
- **The template comes from the target release, not the working tree.** The upgrade flow is deliberately git-checkout-free (#476), so a checkout's `.env.prod.example` is whatever the operator last pulled. `.env.prod.example` is now baked into the image (a `!.env.prod.example` negation in `.dockerignore`; `.env` itself still never ships) and read out of the pulled image with a one-off `docker compose run --rm --no-deps --entrypoint cat`. `--entrypoint` matters: it bypasses `docker/entrypoint.sh` so a `cat` cannot run migrations. Build-from-source setups read the tree they are about to build, which matches by construction. An image too old to carry the template degrades to a printed note. This keeps `--no-pull` and air-gapped hosts working — nothing here reaches the network.
- **`docker/install.sh`** fetches `env-sync.sh` alongside the other ops scripts, so freshly installed hosts have it.

## Why this shape

The alternative was fetching the template from `raw.githubusercontent.com/.../vX.Y.Z/.env.prod.example`, which works for every existing tag but conflicts with `--no-pull` and air-gapped hosts and adds a host-side `curl` dependency to a script that has none. Baking it into the image costs one release cycle of coverage and buys version-exactness by construction.

Commented-out template keys (`# APP_PORT=8000`) are ignored entirely rather than listed informationally — the template carries dozens of them, and repeating that list on every upgrade is recurring noise with no action attached.

## How tested

- `tests/Unit/EnvSyncScriptTest.php` drives the real script as a shell process against fixture files: missing-key detection, commented-key exclusion, the in-sync quiet path, `--apply` appending with comment blocks and leaving existing keys alone (plus a re-check proving the result is idempotent), usage/file errors, unreadable and unwritable inputs, and a guard that a copy of the shipped `.env.prod.example` reports in sync against itself.
- Full gate green: `composer test` at **Total: 100.0 %** with Pint, PHPStan, and Rector clean; `lint:check`, `format:check`, `types:check`, and `build` all pass.
- `sh -n` on all three touched scripts.
- The `.dockerignore` negation was verified with a real `docker build`: `.env.prod.example` lands in the context, `.env` and `.env.testing` do not.
- Smoke-tested end to end against the real template with keys removed from a copied `.env`: reported, appended with the right comment blocks, and a re-run reports in sync.

## Docs & i18n

`docs/src/content/docs/docs/self-hosting/upgrading.md` gains a *New settings in a release* section covering the behaviour, the interactive/non-interactive split, the standalone command, and the two new flags; the flag table and the three-step overview are updated. Docs site builds clean. No user-facing app copy changed, so no i18n catalog changes.