### PR TITLE
fix(docs): resync the docs lockfile so npm ci succeeds

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -236,7 +236,6 @@
       "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.3.tgz",
       "integrity": "sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/internal-helpers": "0.10.1",
         "@astrojs/prism": "4.0.2",
@@ -598,6 +597,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2220,7 +2241,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2319,7 +2339,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-7.0.7.tgz",
       "integrity": "sha512-swqrKDSI/B83GFroYPZYMFcxqbSe9+tkynu1WDBk3GLgBfV9++qVM4Z+2uFT6uu9A53Q0TROnxLketfMEENuqQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler-rs": "^0.3.0",
         "@astrojs/internal-helpers": "0.10.1",
@@ -2952,7 +2971,6 @@
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5461,7 +5479,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -6613,7 +6630,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",


### PR DESCRIPTION
Hotfix routed straight to `master` (CONTRIBUTING → *Hotfixes*): the released docs site is broken in production, and `develop` is carrying `1.12.0-rc.0` so it cannot be promoted as it stands.

## Problem

Cloudflare Pages fails during dependency install on every docs deploy:

```
npm error code EUSAGE
npm error Missing: @emnapi/runtime@1.11.2 from lock file
npm error Missing: @emnapi/core@1.11.2 from lock file
```

`docs/package-lock.json` was generated on macOS and had no top-level `node_modules/@emnapi/core` / `@emnapi/runtime` entry — only nested copies pinned at `1.11.1` under the optional, platform-gated wasm32-wasi packages. `@napi-rs/wasm-runtime` declares those as peer deps with a floating `^1.7.1` range, so on Cloudflare's Linux builder npm resolves them to `1.11.2`, finds nothing matching in the lock, and `npm ci` refuses.

## Fix

Regenerated `docs/package-lock.json` with `npm install` inside `node:22.16.0` — the same Node/npm pair Cloudflare uses (`nodejs@22.16.0`, `npm@10.9.2`) — so the lock is resolved against the Linux resolution set. Both `@emnapi/core` and `@emnapi/runtime` now have top-level entries.

Lockfile only; no `package.json` change.

## Verification

From a clean checkout in `node:22.16.0` (Linux, not macOS):

- `npm ci` — succeeds, no EUSAGE
- `npm run build` — 21 pages built, sitemap + Pagefind index generated

## Deferred

The remaining acceptance criteria on #614 are hardening, not the production break, and are deliberately left out of a `master`-first PR — the CI guard (`npm ci` + `npm run build` on `ubuntu-latest` for PRs touching `docs/**`) and pinning the docs Node version will follow via `develop`.

Closes #614