### PR TITLE
fix: refuse a candidate release below develop's baseline

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -72,6 +72,156 @@ jobs:
           config-file: release-please-config.develop.json
           manifest-file: .release-please-manifest.develop.json
 
+  # A candidate release pull request may only ever move the baseline forwards.
+  # release-please decides what to propose from the release it can reach walking
+  # `develop`, so a baseline naming a version whose tag was cut on `master` — the
+  # window between the baseline sync and the back-merge — leaves it unable to find
+  # any release at all, and it falls back to its initial 1.0.0 with the whole
+  # history as release notes. That happened at 1.12.2 (#637): the proposal is a
+  # *downgrade*, and merging it would tag `v1.0.0`, publish a GitHub release and
+  # let a GHCR image claim the moving `latest` aliases ahead of every real
+  # version.
+  #
+  # The sync below now waits for the back-merge, so the window is closed. This is
+  # the belt to that braces: it refuses to leave such a proposal open regardless
+  # of *why* release-please made it, and it reads the branch rather than the
+  # action's outputs so a proposal left over from an earlier run — which is how
+  # #636 outlived the topology that produced it — is caught on the next push too.
+  candidate-guard:
+    name: Refuse a candidate below the baseline
+    needs: prerelease
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse a candidate that does not move the baseline forwards
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          manifest=".release-please-manifest.develop.json"
+          branch="release-please--branches--develop"
+
+          number="$(gh pr list --repo "$REPO" --base develop --head "$branch" --state open --json number --jq '.[0].number // empty')"
+
+          if [ -z "$number" ]; then
+            echo "No candidate release pull request is open; there is nothing to check."
+            exit 0
+          fi
+
+          # The manifest is read off each ref rather than from a checkout: the
+          # proposal only exists on release-please's branch, and develop keeps
+          # moving while this runs.
+          baseline_on() {
+            gh api "repos/$REPO/contents/$manifest?ref=$1" -H 'Accept: application/vnd.github.raw' \
+              | sed -n 's/.*"\."[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+          }
+
+          is_version() {
+            printf '%s' "$1" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+          }
+
+          is_numeric() {
+            printf '%s' "$1" | grep -Eq '^[0-9]+$'
+          }
+
+          # SemVer precedence over the dot-separated identifiers of two prerelease
+          # strings: numeric ones compare as numbers and rank below alphanumeric
+          # ones, and a longer identifier list wins when the shorter is a prefix.
+          # Succeeds when the first ranks strictly higher.
+          prerelease_gt() {
+            local field=1 left right
+
+            while true; do
+              left="$(printf '%s' "$1" | cut -d. -f"$field")"
+              right="$(printf '%s' "$2" | cut -d. -f"$field")"
+
+              if [ -z "$left" ]; then
+                return 1
+              fi
+
+              if [ -z "$right" ]; then
+                return 0
+              fi
+
+              if [ "$left" != "$right" ]; then
+                if is_numeric "$left" && is_numeric "$right"; then
+                  [ "$left" -gt "$right" ]
+                  return
+                fi
+
+                if is_numeric "$left"; then
+                  return 1
+                fi
+
+                if is_numeric "$right"; then
+                  return 0
+                fi
+
+                [ "$left" \> "$right" ]
+                return
+              fi
+
+              field=$((field + 1))
+            done
+          }
+
+          # Succeeds when the first version ranks strictly higher than the second.
+          # A string comparison would not do: `1.12.2-rc.0` reads as the larger of
+          # the pair against `1.12.2`, and it is the exact shape a stale candidate
+          # takes once its version has been released.
+          version_gt() {
+            local left_core="${1%%-*}" right_core="${2%%-*}"
+            local left_pre="" right_pre=""
+            local field left right
+
+            case "$1" in *-*) left_pre="${1#*-}" ;; esac
+            case "$2" in *-*) right_pre="${2#*-}" ;; esac
+
+            for field in 1 2 3; do
+              left="$(printf '%s' "$left_core" | cut -d. -f"$field")"
+              right="$(printf '%s' "$right_core" | cut -d. -f"$field")"
+
+              if [ "$left" -ne "$right" ]; then
+                [ "$left" -gt "$right" ]
+                return
+              fi
+            done
+
+            # Same core version: a release outranks any candidate for it.
+            if [ -z "$left_pre" ]; then
+              [ -n "$right_pre" ]
+              return
+            fi
+
+            if [ -z "$right_pre" ]; then
+              return 1
+            fi
+
+            prerelease_gt "$left_pre" "$right_pre"
+          }
+
+          proposed="$(baseline_on "$branch")"
+          current="$(baseline_on develop)"
+
+          # An unreadable version is not evidence that the proposal is safe.
+          if ! is_version "$proposed" || ! is_version "$current"; then
+            echo "::error::Could not compare the candidate: read '$proposed' from $branch and '$current' from develop." >&2
+            exit 1
+          fi
+
+          if version_gt "$proposed" "$current"; then
+            echo "Candidate $proposed is ahead of the baseline $current."
+            exit 0
+          fi
+
+          gh pr close "$number" --repo "$REPO" --delete-branch \
+            --comment "Closed automatically: $proposed does not move develop's candidate baseline ($current) forwards, so merging it would tag a version below the one already released. See #637."
+
+          echo "::error::Candidate release PR #$number proposes $proposed, which is not ahead of develop's baseline $current; it has been closed." >&2
+          exit 1
+
   # The candidate manifest is a separate file, so nothing in a stable release
   # tells `develop` that the version it was building candidates for has shipped.
   # Left alone it would keep incrementing `1.12.0-rc.N` forever, long after
@@ -171,11 +321,48 @@ jobs:
           # on top of a develop that has moved; the branch is this job's alone.
           git push --quiet --force origin "$branch"
 
+          # The baseline may only land on develop *after* the back-merge has, and
+          # the two are queued in parallel — at 1.12.2 the baseline won that race
+          # by 34 seconds. It names a version whose tag was cut on `master`, so
+          # until master is contained in develop that tag is unreachable from the
+          # candidate line: release-please then finds no release at all, falls back
+          # to its initial 1.0.0, and proposes a downgrade (#637).
+          #
+          # So the merge is queued only once the comparison says develop already
+          # contains master. The interval and attempt count are overridable so the
+          # tests can drive the same loop without the clock; the defaults give the
+          # back-merge half an hour, which is the full CI suite several times over.
+          wait_for_containment() {
+            local attempts="${CONTAINMENT_ATTEMPTS:-60}"
+
+            while [ "$attempts" -gt 0 ]; do
+              if [ "$(gh api "repos/$REPO/compare/develop...master" --jq '.ahead_by')" -eq 0 ]; then
+                return 0
+              fi
+
+              sleep "${CONTAINMENT_INTERVAL:-30}"
+              attempts=$((attempts - 1))
+            done
+
+            return 1
+          }
+
           # A repository without auto-merge enabled must not fail a release that
           # has already been tagged and published — say so and move on. Asked for
           # on a reused PR too: the earlier run may have opened it at a point when
           # auto-merge could not be queued.
+          #
+          # A back-merge that never arrives is different: the proposal itself is
+          # sound and stays open, but nothing may merge it yet, so the run goes red
+          # rather than queueing it. The release is already tagged and published —
+          # only this follow-up is unfinished, and it is finished by merging the
+          # back-merge and then the PR this job left behind.
           queue_merge() {
+            if ! wait_for_containment; then
+              echo "::error::develop does not contain master yet, so the baseline PR must not merge; land the back-merge first, then merge it." >&2
+              return 1
+            fi
+
             gh pr merge --repo "$REPO" --auto --squash "$branch" \
               || echo "Could not queue the baseline PR to merge itself; merge it by hand."
           }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,32 @@ request rather than a push, because `develop` — like `master` — only accepts
 changes through one; the job asks for auto-merge, so unless the repository has it
 turned off the PR merges itself once the checks pass.
 
+#### The quiet window between a release and the next feature
+
+The baseline PR is deliberately **not** merged before the back-merge is. The tag
+it names — `v1.12.2`, say — sits on a commit cut on `master`, so until `master`
+has been merged back it is unreachable from `develop`. release-please decides
+what to propose from the release it can reach walking the branch it targets: with
+the baseline naming a version it cannot find, it concludes there has been no
+release at all, falls back to its initial `1.0.0`, and proposes that — a
+*downgrade*, whose merge would tag `v1.0.0`, publish a GitHub release, and let a
+GHCR image claim the moving `latest` aliases ahead of every real version. That is
+what happened at 1.12.2 ([#637](https://github.com/emmpaul/the-desk/issues/637)),
+where the baseline PR won the race by 34 seconds. So the sync job waits for the
+comparison to say `develop` already contains `master` before it queues its own
+merge; if that never happens it leaves the PR open and goes red rather than
+merging it early.
+
+Once both have landed, the candidate line has nothing to do until the next
+`feat:`/`fix:` arrives: `chore:` and the merge commit are not user-facing, so
+release-please proposes **nothing** at all, and no candidate PR is open. The
+first feature after that cuts `1.12.3-rc.0` from the released baseline as usual.
+
+A candidate that is proposed anyway and does not move the baseline forwards is
+closed automatically by the `candidate-guard` job, which fails the run with it.
+It compares versions by SemVer precedence rather than as strings, so a stale
+`1.12.2-rc.0` proposed after `1.12.2` shipped is caught as well.
+
 ### Hotfixes: releasing when develop is not releasable
 
 Promotion is all-or-nothing. If `master` is at `1.12.0` and `develop` is carrying

--- a/tests/Unit/ReleaseFlowTest.php
+++ b/tests/Unit/ReleaseFlowTest.php
@@ -483,17 +483,21 @@ const CREATED_PULL_REQUEST = 'https://github.com/emmpaul/the-desk/pull/99';
  * already open pull request, and the URL `pr create` prints.
  *
  * @param  list<string>|null  $branches  branches to list, or null to make `gh` fail
- * @param  int  $ahead  commits `master` is ahead of `develop` by
+ * @param  int|list<int>  $ahead  commits `master` is ahead of `develop` by; a list is answered one
+ *                                entry per call, the last repeating, which is how a back-merge
+ *                                landing part-way through a wait is played back
  * @param  string  $existing  number of an already open pull request, or none
  * @param  bool  $mergeFails  whether `pr merge` refuses, as it does on a repository without auto-merge
  * @param  bool  $createFails  whether `pr create` refuses, as it does when a pull request is already open
  * @param  string  $raced  number of a pull request that appears only once `pr create` has been refused
  * @return string the sandbox: `bin/gh` is the stub, `calls` its log
  */
-function ghSandbox(?array $branches = ['master', 'develop'], int $ahead = 1, string $existing = '', bool $mergeFails = false, bool $createFails = false, string $raced = ''): string
+function ghSandbox(?array $branches = ['master', 'develop'], int|array $ahead = 1, string $existing = '', bool $mergeFails = false, bool $createFails = false, string $raced = ''): string
 {
     $sandbox = sys_get_temp_dir().'/gh-'.bin2hex(random_bytes(6));
     mkdir($sandbox.'/bin', 0o777, true);
+
+    file_put_contents($sandbox.'/ahead', implode("\n", array_map(strval(...), (array) $ahead))."\n");
 
     $listing = $branches === null
         ? "echo 'gh: API rate limit exceeded' >&2; exit 1"
@@ -523,7 +527,13 @@ function ghSandbox(?array $branches = ['master', 'develop'], int $ahead = 1, str
         printf '%s\\n' "\$*" >> '{$sandbox}/calls'
         case "\$1 \${2-}" in
             'api '*/branches) {$listing} ;;
-            'api '*/compare/*) echo '{$ahead}' ;;
+            'api '*/compare/*)
+                head -n 1 '{$sandbox}/ahead'
+                if [ "\$(wc -l < '{$sandbox}/ahead')" -gt 1 ]; then
+                    tail -n +2 '{$sandbox}/ahead' > '{$sandbox}/ahead.next'
+                    mv '{$sandbox}/ahead.next' '{$sandbox}/ahead'
+                fi
+                ;;
             'pr list') {$lookup} ;;
             'pr create') {$create} ;;
             'pr merge') {$merge} ;;
@@ -557,6 +567,10 @@ function runBaselineSync(string $clone, string $version, string $sandbox): Proce
             'REPO' => 'emmpaul/the-desk',
             'GH_TOKEN' => 'stub',
             'VERSION' => $version,
+            // The wait for the back-merge is measured in half-hours on a runner;
+            // the test drives the same loop with the clock taken out of it.
+            'CONTAINMENT_ATTEMPTS' => '3',
+            'CONTAINMENT_INTERVAL' => '0',
         ],
     );
     $process->run();
@@ -650,7 +664,7 @@ test('an unreadable branch listing fails loudly rather than reporting develop ab
 
 test('a stable release proposes the new candidate baseline to develop', function (): void {
     [$clone, $origin] = developSandbox('{".":"1.11.0"}');
-    $sandbox = ghSandbox();
+    $sandbox = ghSandbox(ahead: 0);
 
     $process = runBaselineSync($clone, '1.12.0', $sandbox);
 
@@ -674,7 +688,7 @@ test('a stable release proposes the new candidate baseline to develop', function
 test('the candidate baseline is never pushed straight to develop', function (): void {
     [$clone, $origin] = developSandbox('{".":"1.11.0"}');
 
-    $process = runBaselineSync($clone, '1.12.0', ghSandbox());
+    $process = runBaselineSync($clone, '1.12.0', ghSandbox(ahead: 0));
 
     expect($process->isSuccessful())->toBeTrue()
         ->and(baselineOf($origin))->toBe('{".":"1.11.0"}')
@@ -688,7 +702,7 @@ test('the candidate baseline is never pushed straight to develop', function (): 
  */
 test('the baseline PR is queued to merge itself', function (): void {
     [$clone] = developSandbox('{".":"1.11.0"}');
-    $sandbox = ghSandbox();
+    $sandbox = ghSandbox(ahead: 0);
 
     runBaselineSync($clone, '1.12.0', $sandbox);
 
@@ -698,7 +712,7 @@ test('the baseline PR is queued to merge itself', function (): void {
 
 test('moving the baseline twice is a no-op the second time', function (): void {
     [$clone, $origin] = developSandbox('{".":"1.12.0"}');
-    $sandbox = ghSandbox();
+    $sandbox = ghSandbox(ahead: 0);
 
     $process = runBaselineSync($clone, '1.12.0', $sandbox);
 
@@ -715,7 +729,7 @@ test('moving the baseline twice is a no-op the second time', function (): void {
  */
 test('an open baseline PR is updated rather than duplicated', function (): void {
     [$clone, $origin] = developSandbox('{".":"1.11.0"}');
-    $sandbox = ghSandbox(existing: '7');
+    $sandbox = ghSandbox(ahead: 0, existing: '7');
 
     $process = runBaselineSync($clone, '1.12.0', $sandbox);
 
@@ -735,7 +749,7 @@ test('an open baseline PR is updated rather than duplicated', function (): void 
  */
 test('an open baseline PR is looked for on the branch it would be opened from', function (): void {
     [$clone] = developSandbox('{".":"1.11.0"}');
-    $sandbox = ghSandbox();
+    $sandbox = ghSandbox(ahead: 0);
 
     runBaselineSync($clone, '1.12.0', $sandbox);
 
@@ -760,7 +774,7 @@ test('the baseline is proposed on top of whatever develop has moved to', functio
     (new Process(['git', 'add', '.'], $origin))->mustRun();
     (new Process(['git', 'commit', '--quiet', '-m', 'feat: land something else'], $origin))->mustRun();
 
-    $process = runBaselineSync($clone, '1.12.0', ghSandbox());
+    $process = runBaselineSync($clone, '1.12.0', ghSandbox(ahead: 0));
     $branch = 'chore/candidate-baseline-1.12.0';
 
     expect($process->isSuccessful())->toBeTrue()
@@ -1073,4 +1087,184 @@ test('an integration pull request that cannot be queued is left open', function 
         ->and($process->getOutput())->toContain('by hand')
         ->and(ghCalls($sandbox))->toContain('pr merge')
         ->toContain('42');
+});
+
+/*
+ * The ordering the 1.0.0 proposal came out of (#637): the baseline PR merged 34
+ * seconds before the back-merge did, so `develop` carried a baseline of 1.12.2
+ * while `v1.12.2`'s commit — cut on `master` — was still unreachable from it.
+ * release-please matched the release by version, took its `master`-only sha,
+ * failed to find it walking `develop`, discarded the release and bootstrapped at
+ * its initial 1.0.0 with the whole history as release notes. The baseline is only
+ * safe to land once `master` is contained in `develop`, which is what the
+ * back-merge does — so the sync waits for it rather than racing it.
+ */
+test('the baseline is not merged before develop contains master', function (): void {
+    [$clone, $origin] = developSandbox('{".":"1.11.0"}');
+    $sandbox = ghSandbox(ahead: 1);
+
+    $process = runBaselineSync($clone, '1.12.0', $sandbox);
+
+    expect($process->isSuccessful())->toBeFalse()
+        ->and(ghCalls($sandbox))->toContain('pr create')
+        ->not->toContain('pr merge')
+        ->and($process->getErrorOutput())->toContain('back-merge')
+        // The proposal itself is sound and stays open: only merging it early is
+        // unsafe, so it is left for the back-merge to be followed by hand.
+        ->and(baselineOnBranch($origin, 'chore/candidate-baseline-1.12.0'))->toBe('{".":"1.12.0"}');
+});
+
+test('the baseline merges itself once the back-merge lands', function (): void {
+    [$clone] = developSandbox('{".":"1.11.0"}');
+    $sandbox = ghSandbox(ahead: [1, 1, 0]);
+
+    $process = runBaselineSync($clone, '1.12.0', $sandbox);
+
+    expect($process->isSuccessful())->toBeTrue()
+        ->and(ghCalls($sandbox))->toContain('pr merge')
+        ->toContain('--auto');
+});
+
+/**
+ * The shell body of the step that refuses a candidate below develop's baseline.
+ */
+function candidateGuardScript(): string
+{
+    $workflow = readWorkflow('release-please.yml');
+
+    /** @var array<int, array<string, mixed>> $steps */
+    $steps = $workflow['jobs']['candidate-guard']['steps'];
+
+    return (string) $steps[0]['run'];
+}
+
+/**
+ * Run the guard against a stubbed `gh` serving the two manifests it compares.
+ *
+ * @param  string|null  $proposed  version on the release-please branch, or null when no candidate PR is open
+ * @return array{closed: string|null, output: string, errors: string, succeeded: bool}
+ */
+function runCandidateGuard(?string $proposed, string $baseline = '1.12.2', string $number = '636'): array
+{
+    $sandbox = sys_get_temp_dir().'/guard-'.bin2hex(random_bytes(6));
+    mkdir($sandbox.'/bin', 0o777, true);
+
+    $open = $proposed === null ? '' : $number;
+
+    // The two reads differ only by the ref they ask for, which is exactly what
+    // the guard has to get right: the proposal lives on release-please's branch,
+    // the baseline on develop.
+    file_put_contents($sandbox.'/bin/gh', <<<BASH
+        #!/usr/bin/env bash
+        printf '%s\\n' "\$*" >> '{$sandbox}/calls'
+        case "\$1 \${2-}" in
+            'pr list') printf '%s' '{$open}' ;;
+            'api '*ref=release-please*) printf '{"."%s"%s"}\\n' ':' '{$proposed}' ;;
+            'api '*ref=develop*) printf '{"."%s"%s"}\\n' ':' '{$baseline}' ;;
+        esac
+        BASH);
+    chmod($sandbox.'/bin/gh', 0o755);
+
+    $process = new Process(
+        ['bash', '-c', candidateGuardScript()],
+        env: [
+            'PATH' => $sandbox.'/bin:'.getenv('PATH'),
+            'REPO' => 'emmpaul/the-desk',
+            'GH_TOKEN' => 'stub',
+        ],
+    );
+    $process->run();
+
+    return [
+        'closed' => collect(explode("\n", ghCalls($sandbox)))->first(fn (string $call): bool => str_starts_with($call, 'pr close')),
+        'output' => $process->getOutput(),
+        'errors' => $process->getErrorOutput(),
+        'succeeded' => $process->isSuccessful(),
+    ];
+}
+
+/*
+ * The proposal that has to be caught: below the baseline, and a stable tag at
+ * that — merging it would publish `v1.12.2`'s predecessor as a GitHub release and
+ * hand a GHCR image the moving `latest` aliases ahead of every real version.
+ */
+test('a candidate below the baseline is closed and fails the run', function (): void {
+    $result = runCandidateGuard('1.0.0');
+
+    expect($result['succeeded'])->toBeFalse()
+        ->and($result['closed'])->toContain('636')
+        ->and($result['errors'])->toContain('1.0.0')
+        ->toContain('1.12.2');
+});
+
+test('a candidate that merely repeats the baseline is refused too', function (): void {
+    $result = runCandidateGuard('1.12.2');
+
+    expect($result['succeeded'])->toBeFalse()
+        ->and($result['closed'])->toContain('636');
+});
+
+/*
+ * The stale-rc shape: a candidate for a version already released is behind the
+ * baseline under SemVer precedence even though it reads as the same number, so a
+ * plain string comparison would wave it through.
+ */
+test('a candidate for an already released version is refused', function (): void {
+    expect(runCandidateGuard('1.12.2-rc.0')['succeeded'])->toBeFalse();
+});
+
+test('a candidate ahead of the baseline is left alone', function (string $proposed): void {
+    $result = runCandidateGuard($proposed);
+
+    expect($result['succeeded'])->toBeTrue()
+        ->and($result['closed'])->toBeNull();
+})->with(['1.12.3-rc.0', '1.13.0-rc.0', '2.0.0-rc.0', '1.12.3']);
+
+test('a later candidate in the same series is left alone', function (): void {
+    expect(runCandidateGuard('1.12.0-rc.10', baseline: '1.12.0-rc.9'))
+        ->toMatchArray(['succeeded' => true, 'closed' => null]);
+});
+
+test('the guard passes when no candidate pull request is open', function (): void {
+    $result = runCandidateGuard(null);
+
+    expect($result['succeeded'])->toBeTrue()
+        ->and($result['closed'])->toBeNull();
+});
+
+/*
+ * A version the guard cannot parse is not evidence that the proposal is safe: it
+ * fails rather than passing, and closes nothing, since nothing was compared.
+ */
+test('an unreadable version fails the guard rather than passing it', function (string $proposed): void {
+    $result = runCandidateGuard($proposed);
+
+    expect($result['succeeded'])->toBeFalse()
+        ->and($result['closed'])->toBeNull();
+})->with(['', 'banana', '1.12', 'v1.12.3']);
+
+test('the guard runs after the candidate line, on develop only', function (): void {
+    $job = readWorkflow('release-please.yml')['jobs']['candidate-guard'];
+
+    expect($job['needs'])->toContain('prerelease')
+        ->and($job['if'])->toContain('refs/heads/develop');
+});
+
+/*
+ * The guard reads the proposal off release-please's own branch rather than
+ * trusting the action's outputs: a PR left open by an earlier run — which is how
+ * #636 survived the topology healing around it — is caught on the next push all
+ * the same.
+ */
+test('the guard inspects the release-please branch', function (): void {
+    expect(candidateGuardScript())
+        ->toContain('release-please--branches--develop')
+        ->toContain('.release-please-manifest.develop.json');
+});
+
+test('the guard talks to GitHub with the release token', function (): void {
+    /** @var array<int, array<string, mixed>> $steps */
+    $steps = readWorkflow('release-please.yml')['jobs']['candidate-guard']['steps'];
+
+    expect($steps[0]['env']['GH_TOKEN'])->toBe('${{ secrets.RELEASE_PLEASE_TOKEN }}');
 });


### PR DESCRIPTION
Closes #637.

## What was actually happening

Not what the issue supposed. PR #636 was opened by run [29742075016](https://github.com/emmpaul/the-desk/actions/runs/29742075016) — the develop run on `chore: move the candidate baseline to 1.12.2 (#634)` — **34 seconds before** the back-merge landed. The later back-merge run (29742110722) behaved correctly: `No user facing commits found since 2ef4618 - skipping`.

The mechanism, from that run's log and release-please 17.6.0:

1. The baseline sync wrote `{".":"1.12.2"}` to develop. `v1.12.2` points at **2ef4618**, a `master`-only commit — the back-merge had not merged, so it was **unreachable from develop**.
2. release-please matches a release by *version*, took that sha, then walked develop's merge commits looking for it — never found it, paged back to `init` (`⚠ No latest release pull request found`).
3. Release discarded → `latestRelease` undefined in `Strategy.buildNewVersion` → falls through to `initialReleaseVersion()` = **1.0.0**, with 355 commits of notes, so the `changelogEmpty` skip did not fire.

So it is an **ordering** bug, and it recurs every cycle: `chore(master): release X` is always a `master`-only commit, and the back-merge only heals it afterwards.

## What this changes

- **`sync-candidate-baseline` waits for containment.** The baseline PR is still opened immediately, but auto-merge is queued only once `compare/develop...master` reports `ahead_by == 0` — i.e. after the back-merge. Bounded (60 × 30 s); on timeout the PR is left open, unqueued, and the job goes red rather than merging it early. The release itself is already tagged and published and is not affected.
- **New `candidate-guard` job on the develop line.** It reads the proposed version off `release-please--branches--develop` and develop's baseline off `develop`, and if the proposal is not strictly greater it **closes the PR and fails the run**. It reads the branch rather than the action's outputs, so a proposal left over from an earlier run — how #636 outlived the topology that produced it — is caught on the next push too.
- Comparison is **SemVer precedence**, not string comparison: `1.12.2-rc.0` after `1.12.2` shipped is a downgrade, and `1.12.3-rc.0 > 1.12.2` must pass. An unparseable version fails the guard rather than passing it.

## Testing

`tests/Unit/ReleaseFlowTest.php` executes the real workflow shell bodies against a stubbed `gh` (the pattern already used for the back-merge and the tag classifier) — no new script file, and the comparison logic is genuinely run:

- the baseline is not merged before develop contains master, and does merge itself once the back-merge lands (the `gh` stub answers a sequence of comparisons);
- `1.0.0`, `1.12.2`, `1.12.2-rc.0` against a `1.12.2` baseline → closed + red;
- `1.12.3-rc.0`, `1.13.0-rc.0`, `2.0.0-rc.0`, `1.12.3`, `1.12.0-rc.10` over `1.12.0-rc.9` → left alone;
- no open candidate PR → passes; unreadable version → fails, closes nothing.

Full gate green at `Total: 100.0 %`; local CodeRabbit pass clean (0 findings).

## Docs

`CONTRIBUTING.md` → *Releases* now describes the quiet window: why the baseline waits for the back-merge, that the candidate line proposes **nothing** until the next `feat:`/`fix:`, and that `candidate-guard` closes anything that does not move the baseline forwards.

## Note on #636

Left open deliberately: once this lands on develop, the guard runs on that push and closes it — which is the end-to-end proof that the guard works.

## Found in passing

`bin/worktree create 637 develop` forked from the **stale local** `develop` (79615e0) rather than `origin/develop` (9fdd23b), so the branch had to be rebased by hand. Related to #627 but a different case — the base exists locally, it is just behind. Will file separately.