### PR TITLE
ci: retry the PECL fetch so a pecl.php.net outage stops reddening the Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,7 +82,7 @@ jobs:
           push: false
           tags: the-desk:ci
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       # Decide once whether this tag is a candidate, and decide it strictly.
       # A substring test for `-rc.` would also match a tag that merely contains
@@ -155,7 +155,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
   # release-please creates the GitHub Release (CHANGELOG body + `v*` tag) BEFORE
   # the image exists — that tag is exactly what triggers the publish above. So

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,9 +62,27 @@ jobs:
 
       # ---- Build-only validation (pull requests, non-publishing branches) ----
       # Validates that the production image builds. Nothing is pushed.
+      #
+      # Buildx with the same `type=gha` cache the publish step uses, rather than
+      # a plain `docker build`: the extension layer fetches `redis` from
+      # pecl.php.net, so an uncached rebuild on every run turned each PECL outage
+      # into a red build on a commit that changed nothing (#626). Cached, that
+      # layer is only rebuilt when the Dockerfile lines above it actually change.
+      - name: Set up Docker Buildx (build-only)
+        if: env.PUBLISH != 'true'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - name: Build production image
         if: env.PUBLISH != 'true'
-        run: docker build --tag the-desk:ci --file Dockerfile .
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false
+          tags: the-desk:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Decide once whether this tag is a candidate, and decide it strictly.
       # A substring test for `-rc.` would also match a tag that merely contains

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,18 +91,38 @@ FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS runtime
 # driver (ATTACHMENT_IMAGE_DRIVER); GD is the fallback.
 # ldap: directory bind authentication (LdapRecord); required by the package even
 # when LDAP is not configured, since the extension is a hard dependency.
-RUN install-php-extensions \
-        pdo_pgsql \
-        redis \
-        pcntl \
-        posix \
-        intl \
-        zip \
-        opcache \
-        gd \
-        imagick \
-        ldap \
-    && apk add --no-cache curl
+#
+# The redis extension is fetched from pecl.php.net on every build, so a PECL
+# outage reds the whole Docker workflow on a commit that changed nothing (#626).
+# Retry with linear backoff: a transient 5xx clears on a later attempt, while a
+# genuine error (a missing or incompatible extension) still fails after
+# max_attempts tries and at most retry_delay * 3 = 30s of extra waiting — bounded,
+# not a multi-minute hang.
+RUN set -eu; \
+    max_attempts=3; \
+    retry_delay=10; \
+    attempt=1; \
+    until install-php-extensions \
+            pdo_pgsql \
+            redis \
+            pcntl \
+            posix \
+            intl \
+            zip \
+            opcache \
+            gd \
+            imagick \
+            ldap; do \
+        if [ "$attempt" -ge "$max_attempts" ]; then \
+            echo "php extension install failed after $max_attempts attempts; giving up" >&2; \
+            exit 1; \
+        fi; \
+        delay=$((attempt * retry_delay)); \
+        echo "php extension install failed (attempt $attempt/$max_attempts); retrying in ${delay}s" >&2; \
+        sleep "$delay"; \
+        attempt=$((attempt + 1)); \
+    done; \
+    apk add --no-cache curl
 
 # Production PHP/OPcache tuning.
 COPY docker/php/production.ini $PHP_INI_DIR/conf.d/zz-production.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,14 +92,14 @@ FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS runtime
 # ldap: directory bind authentication (LdapRecord); required by the package even
 # when LDAP is not configured, since the extension is a hard dependency.
 #
-# The redis extension is fetched from pecl.php.net on every build, so a PECL
-# outage reds the whole Docker workflow on a commit that changed nothing (#626).
-# Retry with linear backoff: a transient 5xx clears on a later attempt, while a
-# genuine error (a missing or incompatible extension) still fails after
-# max_attempts tries and at most retry_delay * 3 = 30s of extra waiting — bounded,
-# not a multi-minute hang.
+# The redis extension is fetched from pecl.php.net, so a PECL outage reds the
+# whole Docker workflow on a commit that changed nothing (#626). CI caches this
+# layer, so an outage is only ever reached on a real rebuild; retry with linear
+# backoff to ride out the rest. A genuine error (a missing or incompatible
+# extension) fails without touching the network, so it costs at most the 100s of
+# backoff before giving up — bounded, not a multi-minute hang.
 RUN set -eu; \
-    max_attempts=3; \
+    max_attempts=5; \
     retry_delay=10; \
     attempt=1; \
     until install-php-extensions \

--- a/tests/Unit/DockerfileExtensionRetryTest.php
+++ b/tests/Unit/DockerfileExtensionRetryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * `install-php-extensions` fetches `redis` from pecl.php.net on every image build,
+ * so a PECL outage reds the whole Docker workflow on a commit that changed nothing
+ * (issue #626). The fetch must be wrapped in a bounded retry: a transient failure
+ * clears on a later attempt, while a genuine one (a missing or incompatible
+ * extension) still fails after a capped number of tries and a capped total wait.
+ */
+function dockerfileContents(): string
+{
+    return (string) file_get_contents(dirname(__DIR__, 2).'/Dockerfile');
+}
+
+test('every install-php-extensions invocation is wrapped in a retry loop', function (): void {
+    $invocations = array_filter(
+        array_map(trim(...), explode("\n", dockerfileContents())),
+        static fn (string $line): bool => str_contains($line, 'install-php-extensions') && ! str_starts_with($line, '#'),
+    );
+
+    expect($invocations)->not->toBeEmpty();
+
+    foreach ($invocations as $line) {
+        expect($line)->toStartWith('until install-php-extensions');
+    }
+});
+
+test('the extension install retries a bounded number of times with a bounded wait', function (): void {
+    $contents = dockerfileContents();
+
+    expect(preg_match('/max_attempts=(\d+)/', $contents, $attempts))->toBe(1, 'the retry must cap its attempts');
+    expect(preg_match('/retry_delay=(\d+)/', $contents, $delay))->toBe(1, 'the retry must cap its backoff');
+
+    $maxAttempts = (int) $attempts[1];
+    $baseDelay = (int) $delay[1];
+
+    expect($maxAttempts)->toBeGreaterThan(1)->toBeLessThanOrEqual(5);
+
+    $totalWait = array_sum(array_map(
+        static fn (int $attempt): int => $attempt * $baseDelay,
+        range(1, $maxAttempts - 1),
+    ));
+
+    expect($totalWait)->toBeLessThanOrEqual(60, 'a genuine failure must not hang the build for minutes');
+});
+
+test('the retry gives up with a legible message instead of looping forever', function (): void {
+    expect(dockerfileContents())->toContain('failed after');
+});
+
+test('the installed extension list is unchanged', function (): void {
+    expect(preg_match('/install-php-extensions((?:\s+\\\\\s+[a-z_0-9]+)+)/', dockerfileContents(), $matches))->toBe(1);
+
+    $extensions = preg_split('/[\s\\\\]+/', trim($matches[1]), flags: PREG_SPLIT_NO_EMPTY);
+
+    expect($extensions)->toBe([
+        'pdo_pgsql',
+        'redis',
+        'pcntl',
+        'posix',
+        'intl',
+        'zip',
+        'opcache',
+        'gd',
+        'imagick',
+        'ldap',
+    ]);
+});

--- a/tests/Unit/DockerfileExtensionRetryTest.php
+++ b/tests/Unit/DockerfileExtensionRetryTest.php
@@ -46,8 +46,16 @@ test('the extension install retries a bounded number of times with a bounded wai
     expect($totalWait)->toBeLessThanOrEqual(60, 'a genuine failure must not hang the build for minutes');
 });
 
-test('the retry gives up with a legible message instead of looping forever', function (): void {
-    expect(dockerfileContents())->toContain('failed after');
+test('the retry loop advances, backs off, and gives up with a legible message', function (): void {
+    $contents = dockerfileContents();
+
+    expect($contents)
+        ->toContain('attempt=$((attempt + 1))')
+        ->toContain('delay=$((attempt * retry_delay))')
+        ->toContain('sleep "$delay"')
+        ->toContain('if [ "$attempt" -ge "$max_attempts" ]; then')
+        ->toContain('exit 1')
+        ->toMatch('/echo "[^"]*failed after \$max_attempts attempts[^"]*" >&2/');
 });
 
 test('the installed extension list is unchanged', function (): void {

--- a/tests/Unit/DockerfileExtensionRetryTest.php
+++ b/tests/Unit/DockerfileExtensionRetryTest.php
@@ -37,7 +37,8 @@ test('the extension install retries a bounded number of times with a bounded wai
     $maxAttempts = (int) $attempts[1];
     $baseDelay = (int) $delay[1];
 
-    expect($maxAttempts)->toBeGreaterThan(1)->toBeLessThanOrEqual(5);
+    expect($maxAttempts)->toBeGreaterThan(1)->toBeLessThanOrEqual(5)
+        ->and($baseDelay)->toBeGreaterThan(0, 'a zero backoff would hammer an outage rather than ride it out');
 
     $totalWait = array_sum(array_map(
         static fn (int $attempt): int => $attempt * $baseDelay,
@@ -57,6 +58,9 @@ test('the retry loop advances, backs off, and gives up with a legible message', 
         ->toContain('if [ "$attempt" -ge "$max_attempts" ]; then')
         ->toContain('exit 1')
         ->toMatch('/echo "[^"]*failed after \$max_attempts attempts[^"]*" >&2/');
+
+    expect(strpos($contents, 'if [ "$attempt" -ge "$max_attempts" ]; then'))
+        ->toBeLessThan(strpos($contents, 'sleep "$delay"'), 'the last attempt must give up, not sleep first');
 });
 
 test('the build-only validation caches its layers so PECL is not refetched every run', function (): void {
@@ -67,7 +71,7 @@ test('the build-only validation caches its layers so PECL is not refetched every
     expect($build)->not->toBeNull()
         ->and($build['uses'] ?? '')->toStartWith('docker/build-push-action@')
         ->and($build['with']['cache-from'] ?? null)->toBe('type=gha')
-        ->and($build['with']['cache-to'] ?? null)->toBe('type=gha,mode=max')
+        ->and($build['with']['cache-to'] ?? '')->toStartWith('type=gha,mode=max')
         ->and($build['with']['push'] ?? null)->toBeFalse();
 });
 

--- a/tests/Unit/DockerfileExtensionRetryTest.php
+++ b/tests/Unit/DockerfileExtensionRetryTest.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * `install-php-extensions` fetches `redis` from pecl.php.net on every image build,
@@ -43,7 +44,7 @@ test('the extension install retries a bounded number of times with a bounded wai
         range(1, $maxAttempts - 1),
     ));
 
-    expect($totalWait)->toBeLessThanOrEqual(60, 'a genuine failure must not hang the build for minutes');
+    expect($totalWait)->toBeLessThanOrEqual(120, 'a genuine failure must not hang the build for minutes');
 });
 
 test('the retry loop advances, backs off, and gives up with a legible message', function (): void {
@@ -56,6 +57,18 @@ test('the retry loop advances, backs off, and gives up with a legible message', 
         ->toContain('if [ "$attempt" -ge "$max_attempts" ]; then')
         ->toContain('exit 1')
         ->toMatch('/echo "[^"]*failed after \$max_attempts attempts[^"]*" >&2/');
+});
+
+test('the build-only validation caches its layers so PECL is not refetched every run', function (): void {
+    $steps = Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/docker.yml')['jobs']['build']['steps'];
+
+    $build = collect($steps)->firstWhere('name', 'Build production image');
+
+    expect($build)->not->toBeNull()
+        ->and($build['uses'] ?? '')->toStartWith('docker/build-push-action@')
+        ->and($build['with']['cache-from'] ?? null)->toBe('type=gha')
+        ->and($build['with']['cache-to'] ?? null)->toBe('type=gha,mode=max')
+        ->and($build['with']['push'] ?? null)->toBeFalse();
 });
 
 test('the installed extension list is unchanged', function (): void {


### PR DESCRIPTION
Closes #626.

## What

`install-php-extensions` at `Dockerfile:94` fetches `redis` from pecl.php.net — the only remote (PECL) module in the image; every other extension is bundled or comes from apk. Two things made a PECL outage red the workflow on a commit that changed nothing:

1. **No retry** around the install.
2. **The build-only validation had no layer cache.** It ran a bare `docker build` while the publish step used `cache-from/to: type=gha`, so *every* PR and branch push recompiled the extension layer and re-hit pecl.

## Changes

- **`.github/workflows/docker.yml`** — the build-only validation now runs through buildx with the same `type=gha` cache as the publish step. The extension layer is then only rebuilt when the Dockerfile lines above it actually change, so most runs never contact pecl at all.
- **`Dockerfile`** — the install is wrapped in a bounded `until` retry: 5 attempts, linear backoff (10/20/30/40s = 100s total), then a legible give-up message on stderr and `exit 1`. A genuine error (missing/incompatible extension) fails without touching the network, so it costs at most that backoff — bounded, not a multi-minute hang.
- Both `cache-to` entries carry `ignore-error=true` so a GHA cache-export hiccup can't red a build (or a release publish) either.

`apk add --no-cache curl` stays in the same layer, unretried (alpine CDN, out of scope).

## Scope

Only the runtime stage installs extensions. `reverb`, `queue` and `scheduler` run the *same* image, so there is no second site to patch (`grep -rn install-php-extensions` confirms).

## Verified

- Built the extracted `RUN` block on the same base with `--add-host pecl.php.net:127.0.0.1`: every attempt ran, backoff observed, gave up with `php extension install failed after N attempts; giving up`, and the build failed rather than hung.
- Built it unblocked: all ten extensions present in `php -m` — image contents unchanged (`redis=6.3.0`, matching the published `ghcr.io/emmpaul/the-desk:latest`).
- The retry also proved itself unintentionally: the first CI run on this branch hit a live pecl outage, exhausted its attempts, and failed with the intended message.
- `tests/Unit/DockerfileExtensionRetryTest.php` locks the invariants: every invocation sits behind `until`, attempts and total wait are capped, the delay is positive, the give-up guard precedes the sleep, and the extension list is byte-for-byte the same — plus the workflow assertion that the build-only step is cached.

Backend gate green at 100% coverage. No i18n or docs impact (nothing operator-facing changed).

## Residual exposure

`Upgrade script (build from source)` does a deliberate cold build (`docker compose up -d --build`, no cache) to validate the operator's path, so the retry is its only shield. It failed on this branch while pecl.php.net stayed down past 1.5 hours — no bounded retry spans that. Tracked in #641; the `build` job on the same run went green through the new cache during the same outage.

Note for the record: **imagick is also resolved through pecl**, not apk — a plain `install-php-extensions imagick` fails with `No releases available for package "pecl.php.net/imagick"` when the host is blocked. Removing PECL entirely would mean pinning both it and redis; that trade-off is captured in #641.
