### PR TITLE
fix: fork worktrees from the remote base branch

### DIFF
--- a/bin/worktree
+++ b/bin/worktree
@@ -20,6 +20,9 @@
 #                         Prints the worktree's absolute path on stdout so it is
 #                         composable:  cd "$(bin/worktree create 441)"
 #                         `base` is the branch to fork from (default: master).
+#                         It is fetched and forked from its remote-tracking ref
+#                         when it has one, so a stale local branch of the same
+#                         name cannot be inherited as the baseline.
 #   list                  Show active worktrees with their slots and ports.
 #   remove <NNN>          Tear down containers + volumes, remove the git worktree,
 #                         and free the registry slot. Leaves the branch intact.
@@ -197,12 +200,14 @@ validate_issue() {
 # dropping -b. The worktree ends up on the shared release line, and every commit
 # made in it lands there (issue #619). Naming the remote-tracking ref explicitly
 # disables the guess, so resolve the base before handing it to git.
+#
+# The remote copy also WINS over a local branch of the same name: a local
+# `develop` that is merely behind origin silently forks the worktree from a
+# stale baseline, and the omission only surfaces later as a conflict or a
+# missing commit (issue #639). The local branch is used only when the base
+# exists nowhere on a remote.
 resolve_base_ref() {
     local base="$1"
-    if git -C "$MAIN_ROOT" show-ref --verify --quiet "refs/heads/${base}"; then
-        printf '%s' "$base"
-        return 0
-    fi
 
     # HEAD/@ name the current checkout, but refs/remotes/*/HEAD exists in any
     # clone, so the remote lookup below would silently redirect them to
@@ -213,6 +218,16 @@ resolve_base_ref() {
         printf '%s' "$base"
         return 0
     fi
+
+    # Refresh the remote-tracking refs so the branch below is the remote's
+    # current tip rather than whatever the last fetch left behind. Failures
+    # (offline, no such branch on that remote) are non-fatal: resolution then
+    # falls back to the refs already in the clone.
+    local remote
+    while read -r remote; do
+        [ -n "$remote" ] || continue
+        git -C "$MAIN_ROOT" fetch --quiet "$remote" "$base" >/dev/null 2>&1 || true
+    done <<< "$(git -C "$MAIN_ROOT" remote)"
 
     local remote_refs count
     remote_refs="$(git -C "$MAIN_ROOT" for-each-ref --format='%(refname:short)' "refs/remotes/*/${base}")"

--- a/dev-docs/concurrent-worktrees.md
+++ b/dev-docs/concurrent-worktrees.md
@@ -34,7 +34,10 @@ bin/worktree remove <NNN>          # tear down containers + volumes, remove the
 a lock, and derives the whole port block from it (`WORKTREE_PORT_BASE`, default
 `20000`; slot 0 → app 20000 / vite 20001 / reverb 20002 / db 20003). It forks
 from `master` by default; pass a foundation branch as `base` for a stacked-epic
-child. The worktrees live in `../the-desk-worktrees/<NNN>-<slug>/` with an
+child. The base is fetched and resolved to its **remote-tracking** ref
+(`origin/<base>`) before forking, so a local branch lagging behind the remote
+cannot hand the worktree a stale baseline; a base that exists only locally is
+still forked from the local branch. The worktrees live in `../the-desk-worktrees/<NNN>-<slug>/` with an
 explicit `COMPOSE_PROJECT_NAME=desk-<NNN>`. State lives in
 `~/.the-desk/worktrees.json`.
 

--- a/tests/Unit/WorktreeScriptTest.php
+++ b/tests/Unit/WorktreeScriptTest.php
@@ -75,19 +75,36 @@ test('a base branch that exists only on the remote still forks the issue branch'
         ->and(runGit($clone, 'branch', '--list', 'develop')->getOutput())->toBe('');
 });
 
-test('a base branch that exists locally is forked from the local ref', function (): void {
+test('a local base branch behind its remote is fetched and forked from the remote', function (): void {
     [$clone, $root] = worktreeFixtureClone();
     runGit($clone, 'checkout', '--quiet', '-b', 'develop', 'origin/develop');
-    file_put_contents($clone.'/README.md', "local develop only\n");
-    runGit($clone, 'commit', '--quiet', '-am', 'local develop only');
     runGit($clone, 'checkout', '--quiet', 'master');
+
+    runGit($root.'/upstream', 'checkout', '--quiet', 'develop');
+    file_put_contents($root.'/upstream/README.md', "develop moved on\n");
+    runGit($root.'/upstream', 'commit', '--quiet', '-am', 'develop moved on');
+    runGit($root.'/upstream', 'checkout', '--quiet', 'master');
 
     $process = runWorktreeLib($clone, 'attach_worktree '.escapeshellarg($root.'/wt').' 619-slug develop');
 
     expect($process->getExitCode())->toBe(0)
         ->and(trim(runGit($root.'/wt', 'rev-parse', '--abbrev-ref', 'HEAD')->getOutput()))->toBe('619-slug')
-        ->and(gitRevision($root.'/wt', 'HEAD'))->toBe(gitRevision($clone, 'develop'))
-        ->and(gitRevision($root.'/wt', 'HEAD'))->not->toBe(gitRevision($clone, 'origin/develop'));
+        ->and(gitRevision($root.'/wt', 'HEAD'))->toBe(gitRevision($root.'/upstream', 'develop'))
+        ->and(gitRevision($root.'/wt', 'HEAD'))->not->toBe(gitRevision($clone, 'develop'));
+});
+
+test('a base branch that exists only locally is forked from that local branch', function (): void {
+    [$clone, $root] = worktreeFixtureClone();
+    runGit($clone, 'checkout', '--quiet', '-b', 'epic', 'origin/develop');
+    file_put_contents($clone.'/README.md', "epic only\n");
+    runGit($clone, 'commit', '--quiet', '-am', 'epic only');
+    runGit($clone, 'checkout', '--quiet', 'master');
+
+    $process = runWorktreeLib($clone, 'attach_worktree '.escapeshellarg($root.'/wt').' 619-slug epic');
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(trim(runGit($root.'/wt', 'rev-parse', '--abbrev-ref', 'HEAD')->getOutput()))->toBe('619-slug')
+        ->and(gitRevision($root.'/wt', 'HEAD'))->toBe(gitRevision($clone, 'epic'));
 });
 
 test('HEAD as a base forks from the local checkout, not origin/HEAD', function (): void {


### PR DESCRIPTION
`bin/worktree create NNN <base>` resolved the base to the **local** branch whenever one existed, so a local `develop` merely behind `origin/develop` silently handed the worktree a stale baseline — only visible later as a conflict or a missing commit.

`resolve_base_ref` now fetches the base from every configured remote and prefers the remote-tracking ref. A base that exists only locally still forks from the local branch, `HEAD`/`@` still mean the current checkout, and the remote-only (#619/#627) and ambiguous-remote behaviours are unchanged. Fetch failures (offline, no such branch on that remote) are non-fatal and fall back to the refs already in the clone.

Covered by `tests/Unit/WorktreeScriptTest.php`; `dev-docs/concurrent-worktrees.md` and the script header document the resolution order.

Closes #639