### PR TITLE
ci: build the remote PHP extensions from pinned sources

### DIFF
--- a/.github/workflows/extension-pins.yml
+++ b/.github/workflows/extension-pins.yml
@@ -1,0 +1,82 @@
+name: extension-pins
+
+# The production image builds phpredis and imagick from pinned GitHub sources,
+# so that no pecl.php.net outage can red a build (#641). Nothing bumps those
+# pins on its own — dependabot sees GitHub Actions and lockfiles, not a Dockerfile
+# ARG — and a silently frozen extension is its own defect. So compare both pins
+# against upstream once a month and open an issue when either falls behind.
+
+on:
+  schedule:
+    - cron: "0 6 1 * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check-pins:
+    name: Check the pinned PHP extension sources
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Compare each pin against its latest upstream release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "deps: bump the pinned PHP extension sources"
+        run: |
+          set -euo pipefail
+
+          stale=''
+
+          for pin in PHPREDIS_VERSION:phpredis/phpredis IMAGICK_VERSION:Imagick/imagick; do
+            arg="${pin%%:*}"
+            repo="${pin#*:}"
+
+            pinned="$(sed -nE "s/^ARG ${arg}=(.+)$/\1/p" Dockerfile)"
+            if [ -z "$pinned" ]; then
+              echo "no ARG ${arg} in the Dockerfile — the pin was renamed or dropped" >&2
+              exit 1
+            fi
+
+            latest="$(gh api "repos/${repo}/releases/latest" --jq .tag_name | sed -E 's/^v//')"
+
+            if [ "$pinned" = "$latest" ]; then
+              echo "${repo}: up to date ($pinned)"
+              continue
+            fi
+
+            echo "${repo}: pinned at $pinned, latest is $latest"
+            stale="${stale}- \`${arg}\` (\`${repo}\`): pinned \`${pinned}\`, latest \`${latest}\`"$'\n'
+          done
+
+          if [ -z "$stale" ]; then
+            echo 'both pins are current'
+            exit 0
+          fi
+
+          # printf rather than a quoted literal: this whole script is a YAML block
+          # scalar, so an indented body would reach GitHub as a markdown code block.
+          body="$(printf '%s\n\n%s\n%s\n\n%s\n' \
+            'The production image builds these extensions from pinned GitHub sources (see `Dockerfile`). They have fallen behind upstream:' \
+            "$stale" \
+            'Bump the `ARG` values in `Dockerfile`, then let the Docker workflow rebuild the image.' \
+            'Opened by `.github/workflows/extension-pins.yml`.')"
+
+          # One rolling issue: comment on the open one rather than filing a
+          # duplicate every month the pins stay behind.
+          existing="$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')"
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$TITLE" --label tech-debt --body "$body"
+          fi

--- a/.github/workflows/extension-pins.yml
+++ b/.github/workflows/extension-pins.yml
@@ -58,8 +58,16 @@ jobs:
             stale="${stale}- \`${arg}\` (\`${repo}\`): pinned \`${pinned}\`, latest \`${latest}\`"$'\n'
           done
 
+          # One rolling issue: comment on the open one rather than filing a
+          # duplicate every month the pins stay behind, and close it once the
+          # bump lands so a current repo has no stale reminder sitting open.
+          existing="$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')"
+
           if [ -z "$stale" ]; then
             echo 'both pins are current'
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --comment 'Both pins now match their latest upstream release.'
+            fi
             exit 0
           fi
 
@@ -70,10 +78,6 @@ jobs:
             "$stale" \
             'Bump the `ARG` values in `Dockerfile`, then let the Docker workflow rebuild the image.' \
             'Opened by `.github/workflows/extension-pins.yml`.')"
-
-          # One rolling issue: comment on the open one rather than filing a
-          # duplicate every month the pins stay behind.
-          existing="$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')"
 
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,37 +92,63 @@ FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS runtime
 # ldap: directory bind authentication (LdapRecord); required by the package even
 # when LDAP is not configured, since the extension is a hard dependency.
 #
-# The redis extension is fetched from pecl.php.net, so a PECL outage reds the
-# whole Docker workflow on a commit that changed nothing (#626). CI caches this
-# layer, so an outage is only ever reached on a real rebuild; retry with linear
-# backoff to ride out the rest. A genuine error (a missing or incompatible
-# extension) fails without touching the network, so it costs at most the 100s of
-# backoff before giving up — bounded, not a multi-minute hang.
+# Nothing here is resolved through pecl.php.net (#641). Everything but redis and
+# imagick is bundled with PHP and compiled from the local source; those two are
+# built from pinned GitHub sources instead. A PECL outage used to red the whole
+# Docker workflow on a commit that changed nothing (#626), and the bounded retry
+# below could only ride out a short one — `Upgrade script (build from source)`
+# builds cold and uncached on purpose, so it had no other shield and failed
+# through a multi-hour outage.
+#
+# The pins are compared against upstream monthly by
+# .github/workflows/extension-pins.yml, which opens an issue when either falls
+# behind: a silently frozen extension is its own defect.
+ARG IMAGICK_VERSION=3.8.1
+ARG PHPREDIS_VERSION=6.3.0
+
+# The retry still earns its place — the clone, the archive fetch and apk all
+# reach the network. A genuine error (a missing or incompatible extension) fails
+# without touching the network, so it costs at most the 100s of backoff before
+# giving up — bounded, not a multi-minute hang.
+#
+# phpredis is cloned rather than fetched as an archive: the codeload tarball
+# omits the liblzf submodule and the build fails on the missing sources.
 RUN set -eu; \
     max_attempts=5; \
     retry_delay=10; \
-    attempt=1; \
-    until install-php-extensions \
+    retry() { \
+        attempt=1; \
+        until "$@"; do \
+            if [ "$attempt" -ge "$max_attempts" ]; then \
+                echo "$1 failed after $max_attempts attempts; giving up" >&2; \
+                exit 1; \
+            fi; \
+            delay=$((attempt * retry_delay)); \
+            echo "$1 failed (attempt $attempt/$max_attempts); retrying in ${delay}s" >&2; \
+            sleep "$delay"; \
+            attempt=$((attempt + 1)); \
+        done; \
+    }; \
+    retry apk add --no-cache --virtual .phpredis-source git; \
+    retry git clone \
+            --depth 1 \
+            --recurse-submodules \
+            --branch "$PHPREDIS_VERSION" \
+            https://github.com/phpredis/phpredis.git /tmp/phpredis; \
+    retry install-php-extensions \
             pdo_pgsql \
-            redis \
             pcntl \
             posix \
             intl \
             zip \
             opcache \
             gd \
-            imagick \
-            ldap; do \
-        if [ "$attempt" -ge "$max_attempts" ]; then \
-            echo "php extension install failed after $max_attempts attempts; giving up" >&2; \
-            exit 1; \
-        fi; \
-        delay=$((attempt * retry_delay)); \
-        echo "php extension install failed (attempt $attempt/$max_attempts); retrying in ${delay}s" >&2; \
-        sleep "$delay"; \
-        attempt=$((attempt + 1)); \
-    done; \
-    apk add --no-cache curl
+            ldap \
+            /tmp/phpredis \
+            "https://github.com/Imagick/imagick/archive/refs/tags/${IMAGICK_VERSION}.tar.gz"; \
+    apk del --no-network .phpredis-source; \
+    rm -rf /tmp/phpredis; \
+    retry apk add --no-cache curl
 
 # Production PHP/OPcache tuning.
 COPY docker/php/production.ini $PHP_INI_DIR/conf.d/zz-production.ini

--- a/tests/Unit/DockerfileExtensionPinsTest.php
+++ b/tests/Unit/DockerfileExtensionPinsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * A bounded retry cannot ride out a multi-hour pecl.php.net outage, and
+ * `Upgrade script (build from source)` builds cold and uncached on purpose, so
+ * the retry is its only shield (issue #641). The image therefore resolves
+ * nothing through PECL: the two remote extensions are built from pinned GitHub
+ * sources, which no PECL outage can touch. Pins that no one bumps are their own
+ * defect, so a scheduled workflow has to flag a stale one.
+ */
+function productionDockerfile(): string
+{
+    return (string) file_get_contents(dirname(__DIR__, 2).'/Dockerfile');
+}
+
+/**
+ * @return array<string, string>
+ */
+function extensionPins(): array
+{
+    preg_match_all('/^ARG (PHPREDIS_VERSION|IMAGICK_VERSION)=(\S+)$/m', productionDockerfile(), $matches, PREG_SET_ORDER);
+
+    return array_column($matches, 2, 1);
+}
+
+test('both remote extensions are pinned to a concrete released version', function (): void {
+    $pins = extensionPins();
+
+    expect($pins)->toHaveKeys(['PHPREDIS_VERSION', 'IMAGICK_VERSION']);
+
+    foreach ($pins as $name => $version) {
+        expect($version)->toMatch('/^\d+\.\d+\.\d+$/', "$name must pin an exact release, not a branch or a range");
+    }
+});
+
+test('neither redis nor imagick is requested by the name that resolves through pecl', function (): void {
+    $arguments = collect(explode("\n", productionDockerfile()))
+        ->map(trim(...))
+        ->reject(static fn (string $line): bool => str_starts_with($line, '#'))
+        ->map(static fn (string $line): string => rtrim($line, '\\ '))
+        ->filter();
+
+    foreach (['redis', 'imagick'] as $module) {
+        expect($arguments)->not->toContain($module, "a bare `$module` argument is fetched from pecl.php.net");
+    }
+});
+
+test('phpredis is built from its git tag with the submodule it needs', function (): void {
+    $contents = productionDockerfile();
+
+    // The codeload tarball omits the liblzf submodule, so the source has to come
+    // from a clone that carries submodules rather than an archive.
+    expect($contents)
+        ->toContain('https://github.com/phpredis/phpredis.git')
+        ->toContain('--branch "$PHPREDIS_VERSION"')
+        ->toContain('--recurse-submodules');
+
+    expect($contents)->toMatch(
+        '/install-php-extensions(?:[^\n]|\\\\\n)*\s\/tmp\/phpredis(\s|\\\\)/',
+        'the cloned source directory must be handed to install-php-extensions instead of the module name',
+    );
+});
+
+test('imagick is built from its GitHub release archive', function (): void {
+    expect(productionDockerfile())->toContain(
+        'https://github.com/Imagick/imagick/archive/refs/tags/${IMAGICK_VERSION}.tar.gz',
+    );
+});
+
+test('a scheduled workflow flags a pin that has fallen behind upstream', function (): void {
+    $workflow = Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/extension-pins.yml');
+
+    // `on:` parses as the boolean key `true` in YAML 1.1, which is what Symfony's
+    // parser follows.
+    $triggers = $workflow[true] ?? $workflow['on'];
+
+    expect($triggers)->toHaveKey('schedule')
+        ->and($triggers['schedule'][0]['cron'] ?? null)->toBeString()
+        // On demand too, so a stale pin can be checked without waiting a month.
+        ->and(array_key_exists('workflow_dispatch', $triggers))->toBeTrue();
+
+    $job = $workflow['jobs']['check-pins'];
+
+    expect($job['permissions']['issues'] ?? null)->toBe('write', 'the check reports by opening an issue');
+
+    $run = collect($job['steps'])->pluck('run')->filter()->implode("\n");
+
+    expect($run)
+        ->toContain('phpredis/phpredis')
+        ->toContain('Imagick/imagick')
+        ->toContain('PHPREDIS_VERSION')
+        ->toContain('IMAGICK_VERSION')
+        ->toContain('gh issue create');
+});

--- a/tests/Unit/DockerfileExtensionPinsTest.php
+++ b/tests/Unit/DockerfileExtensionPinsTest.php
@@ -17,6 +17,39 @@ function productionDockerfile(): string
 }
 
 /**
+ * Every argument handed to `install-php-extensions`, with line continuations
+ * folded in so an argument is found wherever it sits on the command.
+ *
+ * @return list<string>
+ */
+function installPhpExtensionsArguments(): array
+{
+    $folded = (string) preg_replace('/\\\\\s*\n\s*/', ' ', productionDockerfile());
+
+    $arguments = [];
+
+    foreach (explode("\n", $folded) as $line) {
+        $line = trim($line);
+        $position = strpos($line, 'install-php-extensions');
+        if (str_starts_with($line, '#')) {
+            continue;
+        }
+        if ($position === false) {
+            continue;
+        }
+
+        $tokens = preg_split('/\s+/', substr($line, $position), flags: PREG_SPLIT_NO_EMPTY) ?: [];
+        array_shift($tokens);
+
+        foreach ($tokens as $token) {
+            $arguments[] = rtrim($token, ';');
+        }
+    }
+
+    return $arguments;
+}
+
+/**
  * @return array<string, string>
  */
 function extensionPins(): array
@@ -37,15 +70,14 @@ test('both remote extensions are pinned to a concrete released version', functio
 });
 
 test('neither redis nor imagick is requested by the name that resolves through pecl', function (): void {
-    $arguments = collect(explode("\n", productionDockerfile()))
-        ->map(trim(...))
-        ->reject(static fn (string $line): bool => str_starts_with($line, '#'))
-        ->map(static fn (string $line): string => rtrim($line, '\\ '))
-        ->filter();
+    $arguments = installPhpExtensionsArguments();
 
-    foreach (['redis', 'imagick'] as $module) {
-        expect($arguments)->not->toContain($module, "a bare `$module` argument is fetched from pecl.php.net");
-    }
+    expect($arguments)->not->toBeEmpty();
+
+    // A bare module name is what sends install-php-extensions to pecl.php.net;
+    // a source path or archive URL is resolved without it.
+    expect($arguments)->not->toContain('redis');
+    expect($arguments)->not->toContain('imagick');
 });
 
 test('phpredis is built from its git tag with the submodule it needs', function (): void {
@@ -58,10 +90,9 @@ test('phpredis is built from its git tag with the submodule it needs', function 
         ->toContain('--branch "$PHPREDIS_VERSION"')
         ->toContain('--recurse-submodules');
 
-    expect($contents)->toMatch(
-        '/install-php-extensions(?:[^\n]|\\\\\n)*\s\/tmp\/phpredis(\s|\\\\)/',
-        'the cloned source directory must be handed to install-php-extensions instead of the module name',
-    );
+    // The cloned source directory is what install-php-extensions must be handed,
+    // in place of the module name it would otherwise resolve through pecl.
+    expect(installPhpExtensionsArguments())->toContain('/tmp/phpredis');
 });
 
 test('imagick is built from its GitHub release archive', function (): void {
@@ -94,4 +125,12 @@ test('a scheduled workflow flags a pin that has fallen behind upstream', functio
         ->toContain('PHPREDIS_VERSION')
         ->toContain('IMAGICK_VERSION')
         ->toContain('gh issue create');
+
+    // One rolling issue, not a fresh one every month: the open one is found
+    // first, commented on while the pins stay behind, and closed once they are
+    // current again.
+    expect($run)
+        ->toContain('gh issue list')
+        ->toContain('gh issue comment')
+        ->toContain('gh issue close');
 });

--- a/tests/Unit/DockerfileExtensionRetryTest.php
+++ b/tests/Unit/DockerfileExtensionRetryTest.php
@@ -4,27 +4,31 @@ declare(strict_types=1);
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * `install-php-extensions` fetches `redis` from pecl.php.net on every image build,
- * so a PECL outage reds the whole Docker workflow on a commit that changed nothing
- * (issue #626). The fetch must be wrapped in a bounded retry: a transient failure
+ * Building the extensions reaches the network — GitHub, Alpine's mirrors — so a
+ * transient failure must not red a build on a commit that changed nothing
+ * (issue #626). Every fetch is wrapped in a bounded retry: a transient failure
  * clears on a later attempt, while a genuine one (a missing or incompatible
  * extension) still fails after a capped number of tries and a capped total wait.
+ * The source of those extensions is covered by DockerfileExtensionPinsTest.
  */
 function dockerfileContents(): string
 {
     return (string) file_get_contents(dirname(__DIR__, 2).'/Dockerfile');
 }
 
-test('every install-php-extensions invocation is wrapped in a retry loop', function (): void {
-    $invocations = array_filter(
-        array_map(trim(...), explode("\n", dockerfileContents())),
-        static fn (string $line): bool => str_contains($line, 'install-php-extensions') && ! str_starts_with($line, '#'),
+test('every network fetch in the runtime stage is wrapped in the retry helper', function (): void {
+    $runtimeStage = substr(dockerfileContents(), (int) strpos(dockerfileContents(), 'AS runtime'));
+
+    $fetches = array_filter(
+        array_map(trim(...), explode("\n", $runtimeStage)),
+        static fn (string $line): bool => (bool) preg_match('/^\S*\s*(install-php-extensions|git clone|apk add)/', $line)
+            && ! str_starts_with($line, '#'),
     );
 
-    expect($invocations)->not->toBeEmpty();
+    expect($fetches)->not->toBeEmpty();
 
-    foreach ($invocations as $line) {
-        expect($line)->toStartWith('until install-php-extensions');
+    foreach ($fetches as $line) {
+        expect($line)->toStartWith('retry ');
     }
 });
 
@@ -75,21 +79,21 @@ test('the build-only validation caches its layers so PECL is not refetched every
         ->and($build['with']['push'] ?? null)->toBeFalse();
 });
 
-test('the installed extension list is unchanged', function (): void {
+test('the bundled extension list is unchanged', function (): void {
     expect(preg_match('/install-php-extensions((?:\s+\\\\\s+[a-z_0-9]+)+)/', dockerfileContents(), $matches))->toBe(1);
 
     $extensions = preg_split('/[\s\\\\]+/', trim($matches[1]), flags: PREG_SPLIT_NO_EMPTY);
 
+    // redis and imagick are absent by design: they are the two extensions PHP
+    // does not bundle, and they are built from pinned sources further down.
     expect($extensions)->toBe([
         'pdo_pgsql',
-        'redis',
         'pcntl',
         'posix',
         'intl',
         'zip',
         'opcache',
         'gd',
-        'imagick',
         'ldap',
     ]);
 });

--- a/tests/Unit/DockerfileExtensionRetryTest.php
+++ b/tests/Unit/DockerfileExtensionRetryTest.php
@@ -17,7 +17,11 @@ function dockerfileContents(): string
 }
 
 test('every network fetch in the runtime stage is wrapped in the retry helper', function (): void {
-    $runtimeStage = substr(dockerfileContents(), (int) strpos(dockerfileContents(), 'AS runtime'));
+    $runtimeStageStart = strpos(dockerfileContents(), 'AS runtime');
+
+    expect($runtimeStageStart)->not->toBeFalse('the runtime stage must stay named, or this test silently scans nothing');
+
+    $runtimeStage = substr(dockerfileContents(), (int) $runtimeStageStart);
 
     $fetches = array_filter(
         array_map(trim(...), explode("\n", $runtimeStage)),


### PR DESCRIPTION
Closes #641.

## What

`install-php-extensions` resolved `redis` and `imagick` through pecl.php.net, so every cold image build depended on PECL being up. Both are now built from pinned GitHub sources, and nothing in the image touches PECL:

- **phpredis** — a tagged `git clone --depth 1 --recurse-submodules` at `ARG PHPREDIS_VERSION=6.3.0`, handed to `install-php-extensions` as a source directory. A clone, not the codeload tarball, because the tarball omits the `liblzf` submodule and the build dies on the missing sources.
- **imagick** — its GitHub release archive at `ARG IMAGICK_VERSION=3.8.1`.

## Why

#640 hardened the two cached paths, but `Upgrade script (build from source)` builds cold and uncached **on purpose** — it validates the path a self-hoster takes — so the bounded retry was its only shield, and ~100s of backoff cannot span a multi-hour outage. It exhausted all 5 attempts during the 2026-07-20 outage. Removing the dependency is immune to any outage and leaves the job still doing a genuine operator cold build (nothing was cached, no CI-only config was added to the operator-facing compose file).

The retry stays: the clone, the archive fetch and `apk` all still reach the network.

## Bumping the pins

Frozen pins are their own defect, and dependabot sees lockfiles and Actions, not a Dockerfile `ARG`. `.github/workflows/extension-pins.yml` runs monthly (and on demand), compares each pin against the latest upstream release, and keeps **one rolling issue**: it opens it when a pin falls behind, comments while it stays behind, and closes it once both are current.

## How tested

- `tests/Unit/DockerfileExtensionPinsTest.php` (new) — pins are exact releases, no bare `redis`/`imagick` argument reaches `install-php-extensions`, phpredis comes from the tagged clone with submodules, imagick from the release archive, and the staleness workflow is scheduled, dispatchable and issue-writing.
- `tests/Unit/DockerfileExtensionRetryTest.php` — updated for the new shape: every network fetch in the runtime stage goes through the `retry` helper, and the bundled extension list is asserted without the two source-built ones.
- **Verified against a blocked PECL** (the issue's acceptance criterion): `docker build --no-cache --add-host pecl.php.net:127.0.0.1 --target runtime .` succeeds, `pecl.php.net` appears nowhere in the build log, and the image loads `redis 6.3.0` and `imagick 3.8.1` alongside the rest.
- Full gate green: Pint, PHPStan, Rector, `Total: 100.0 %`, plus `lint:check`, `format:check`, `types:check`, `build`.

No i18n or docs changes: no user-facing copy, and the operator-facing docs/commands are unchanged (same extensions, same build command).