### PR TITLE
fix: stop background writes from cancelling the visit in flight

### DIFF
--- a/resources/js/composables/useChannelDraft.test.ts
+++ b/resources/js/composables/useChannelDraft.test.ts
@@ -11,6 +11,7 @@ import {
     useChannelDraft,
 } from '@/composables/useChannelDraft';
 import type { ChannelDraft } from '@/composables/useChannelDraft';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 
 /**
  * Run the composable inside a disposable effect scope so its channel-switch
@@ -98,6 +99,17 @@ describe('useChannelDraft', () => {
 
         expect(patch).toHaveBeenCalledOnce();
         expect(patch.mock.calls[0][1]).toEqual({ body: 'outlives unmount' });
+    });
+
+    it('saves in the background so it never interrupts a navigation', () => {
+        const { draft } = withScope(ref('alpha'), ref('id-alpha'));
+
+        draft.onDraftChange('typed while leaving');
+        vi.advanceTimersByTime(DRAFT_DEBOUNCE_MS);
+
+        // A draft save flushes on the very channel switch it must not cancel, so
+        // it has to stay off the synchronous queue (#586).
+        expect(patch.mock.calls[0][2]).toMatchObject(backgroundVisit);
     });
 
     it('clears the saved draft immediately, dropping any pending save', () => {

--- a/resources/js/composables/useChannelDraft.ts
+++ b/resources/js/composables/useChannelDraft.ts
@@ -2,6 +2,7 @@ import { router } from '@inertiajs/vue3';
 import { watch } from 'vue';
 import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 
 /**
  * How long to coalesce composer keystrokes before persisting the draft. Long
@@ -46,7 +47,15 @@ export function useChannelDraft(options: ChannelDraftOptions): ChannelDraft {
         router.patch(
             saveChannelDraft({ team: options.teamSlug(), channel: slug }).url,
             { body },
-            { preserveScroll: true, preserveState: true, only: ['channels'] },
+            {
+                // The channel-switch watcher below flushes this save *during* the
+                // navigation it must not cancel, so it can never ride the
+                // synchronous queue; see {@see backgroundVisit}.
+                ...backgroundVisit,
+                preserveScroll: true,
+                preserveState: true,
+                only: ['channels'],
+            },
         );
     }
 

--- a/resources/js/composables/useChannelPreferences.test.ts
+++ b/resources/js/composables/useChannelPreferences.test.ts
@@ -12,6 +12,7 @@ vi.mock('vue-sonner', () => ({ toast: { error: toastError } }));
 
 import { useChannelPreferences } from '@/composables/useChannelPreferences';
 import type { ChannelPreferences } from '@/composables/useChannelPreferences';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import type { Channel, NotificationLevel } from '@/types';
 
 type PrefState = Pick<Channel, 'notificationLevel' | 'muted' | 'starred'>;
@@ -128,6 +129,21 @@ describe('useChannelPreferences', () => {
         failPatch();
         expect(prefs.muted.value).toBe(false);
         expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('saves every preference in the background so none interrupts a navigation', () => {
+        const { prefs } = withScope(ref(channelState()), ref('id-1'));
+
+        // The UI has already moved on optimistically, so nothing waits on these
+        // writes — and a star clicked on the way out of a channel must not cancel
+        // the navigation that follows it (#586).
+        prefs.toggleStar();
+        prefs.onMuteChange(true);
+        prefs.onNotificationLevelChange('mentions' as NotificationLevel);
+
+        for (const call of patch.mock.calls) {
+            expect(call[2]).toMatchObject(backgroundVisit);
+        }
     });
 
     it('suppresses thread-unread dots when muted or below "all"', () => {

--- a/resources/js/composables/useChannelPreferences.ts
+++ b/resources/js/composables/useChannelPreferences.ts
@@ -5,6 +5,7 @@ import type { ComputedRef, Ref } from 'vue';
 import { toast } from 'vue-sonner';
 import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
 import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import { notificationIndicator } from '@/lib/notificationIndicator';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
 import type { Channel, NotificationLevel } from '@/types';
@@ -94,6 +95,10 @@ export function useChannelPreferences(
             }).url,
             { starred: starred.value },
             {
+                // Applied optimistically, so nothing on screen waits for it: it
+                // must not interrupt the navigation a user often fires right
+                // after starring; see {@see backgroundVisit}.
+                ...backgroundVisit,
                 preserveScroll: true,
                 preserveState: true,
                 only: ['channels'],
@@ -115,6 +120,9 @@ export function useChannelPreferences(
             }).url,
             { muted: muted.value, notification_level: notificationLevel.value },
             {
+                // Optimistic like the star above, and dismissing the menu often
+                // coincides with a navigation; see {@see backgroundVisit}.
+                ...backgroundVisit,
                 preserveScroll: true,
                 preserveState: true,
                 only: ['channels'],

--- a/resources/js/composables/useMessageReminders.ts
+++ b/resources/js/composables/useMessageReminders.ts
@@ -1,6 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
 import { computed, onBeforeUnmount, onMounted } from 'vue';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 
 /**
  * Slide in a reminder nudge the moment one comes due.
@@ -30,7 +31,13 @@ export function useMessageReminders(): void {
         echo()
             .private(channelName())
             .listen('MessageReminderDue', () => {
-                router.reload({ only: ['reminders', 'firedReminders'] });
+                // The per-minute dispatcher decides when this lands, so it must
+                // not interrupt whatever the user is doing; see
+                // {@see backgroundVisit}.
+                router.reload({
+                    ...backgroundVisit,
+                    only: ['reminders', 'firedReminders'],
+                });
             });
     });
 

--- a/resources/js/composables/useNewDirectMessages.ts
+++ b/resources/js/composables/useNewDirectMessages.ts
@@ -1,6 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
 import { computed, onBeforeUnmount, onMounted } from 'vue';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 
 /**
  * Surface a brand-new direct message in the sidebar live.
@@ -30,7 +31,9 @@ export function useNewDirectMessages(): void {
         echo()
             .private(channelName())
             .listen('DirectMessageStarted', () => {
-                router.reload({ only: ['channels'] });
+                // A teammate's action schedules this, so it fires at a moment the
+                // viewer did not choose; see {@see backgroundVisit}.
+                router.reload({ ...backgroundVisit, only: ['channels'] });
             });
     });
 

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -2,6 +2,7 @@ import { router, usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
 
 /** Coalesce a burst of arrivals into a single sidebar reload. */
@@ -30,9 +31,16 @@ export function useSidebarBadges(): void {
 
     // reload defaults to preserving scroll and page state; it re-evaluates the
     // shared `channels` prop to recompute every badge count, plus the aggregate
-    // `hasUnreadThreads` flag behind the sidebar's Threads dot.
+    // `hasUnreadThreads` flag behind the sidebar's Threads dot. A teammate's
+    // message decides when it fires, so it runs as a background visit
+    // ({@see backgroundVisit}) — otherwise an arrival landing mid-navigation
+    // cancels the visit the user actually asked for.
     const refresh = useDebouncedPost(
-        () => router.reload({ only: ['channels', 'hasUnreadThreads'] }),
+        () =>
+            router.reload({
+                ...backgroundVisit,
+                only: ['channels', 'hasUnreadThreads'],
+            }),
         { delay: REFRESH_DEBOUNCE_MS },
     );
 

--- a/resources/js/composables/useTeamPresence.ts
+++ b/resources/js/composables/useTeamPresence.ts
@@ -2,6 +2,7 @@ import { router } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
 import { onBeforeUnmount, onMounted, ref, toValue, watch } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 
 /**
  * How long to coalesce a burst of profile updates before reloading, so many
@@ -39,11 +40,13 @@ export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
 
     // A teammate changed their profile (today: their avatar). Reload the current
     // page's props so every avatar surface re-reads the new image, preserving
-    // scroll and local state so the refresh is invisible.
+    // scroll and local state so the refresh is invisible. A teammate's timing is
+    // not the viewer's, and this one reloads *every* prop, so interrupting a
+    // visit with it is especially costly; see {@see backgroundVisit}.
     function scheduleProfileReload(): void {
         clearTimeout(profileReloadTimer);
         profileReloadTimer = setTimeout(() => {
-            router.reload();
+            router.reload({ ...backgroundVisit });
         }, PROFILE_RELOAD_DEBOUNCE_MS);
     }
 

--- a/resources/js/composables/useThreadPanel.ts
+++ b/resources/js/composables/useThreadPanel.ts
@@ -7,6 +7,7 @@ import {
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { useMessageStream } from '@/composables/useMessageStream';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import type { Message, MessagePage, Thread } from '@/types';
 
 type MessageStream = ReturnType<typeof useMessageStream>;
@@ -103,12 +104,10 @@ export function useThreadPanel(options: ThreadPanelOptions): ThreadPanel {
                 }).url,
                 {},
                 {
-                    // A background write: `async` keeps it from interrupting an
-                    // in-flight visit (interrupting the openThread GET strands
-                    // the panel empty, #581), and `preserveUrl` keeps its
-                    // redirect-follow from dropping the `?thread=` param.
-                    async: true,
-                    preserveUrl: true,
+                    // Interrupting the openThread GET strands the panel empty
+                    // (#581) and the redirect-follow would drop the `?thread=`
+                    // param; see {@see backgroundVisit}.
+                    ...backgroundVisit,
                     preserveScroll: true,
                     preserveState: true,
                     only: ['channels'],

--- a/resources/js/composables/useTimezone.test.ts
+++ b/resources/js/composables/useTimezone.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { patch, pageProps } = vi.hoisted(() => ({
+    patch: vi.fn(),
+    pageProps: {
+        value: { auth: { user: { timezone: null as string | null } } },
+    },
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { patch },
+    usePage: () => ({ props: pageProps.value }),
+}));
+
+import { backgroundVisit } from '@/lib/backgroundVisit';
+
+/**
+ * Import a fresh copy of the composable. Auto-detection is guarded by a
+ * module-level "already fired" flag, so each test needs its own module instance
+ * to exercise the first-load path.
+ */
+async function freshUseTimezone() {
+    vi.resetModules();
+
+    return (await import('@/composables/useTimezone')).useTimezone();
+}
+
+/** Options of the first recorded timezone patch. */
+function firstOptions(): Record<string, unknown> {
+    return patch.mock.calls[0][2] as Record<string, unknown>;
+}
+
+describe('useTimezone', () => {
+    beforeEach(() => {
+        patch.mockClear();
+        pageProps.value = { auth: { user: { timezone: null } } };
+        vi.spyOn(
+            Intl.DateTimeFormat.prototype,
+            'resolvedOptions',
+        ).mockReturnValue({
+            timeZone: 'Europe/Paris',
+        } as Intl.ResolvedDateTimeFormatOptions);
+    });
+
+    it('persists a manual choice as an ordinary foreground write', async () => {
+        const { setTimezone } = await freshUseTimezone();
+
+        setTimezone('Europe/Paris');
+
+        expect(patch.mock.calls[0][1]).toEqual({ timezone: 'Europe/Paris' });
+        expect(firstOptions().async).toBeUndefined();
+    });
+
+    it('auto-detects in the background so it never interrupts the first navigation', async () => {
+        const { syncDetectedTimezone } = await freshUseTimezone();
+
+        syncDetectedTimezone();
+
+        // It fires shortly after the first authenticated load, right when the
+        // user is likely to be clicking into a channel (#586).
+        expect(patch).toHaveBeenCalledOnce();
+        expect(patch.mock.calls[0][1]).toEqual({ timezone: 'Europe/Paris' });
+        expect(firstOptions()).toMatchObject(backgroundVisit);
+    });
+
+    it('does not auto-detect once a zone is already known', async () => {
+        pageProps.value = { auth: { user: { timezone: 'America/New_York' } } };
+
+        const { syncDetectedTimezone } = await freshUseTimezone();
+
+        syncDetectedTimezone();
+
+        expect(patch).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/composables/useTimezone.ts
+++ b/resources/js/composables/useTimezone.ts
@@ -1,5 +1,6 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import { update } from '@/routes/timezone';
 
 /**
@@ -20,15 +21,20 @@ export function useTimezone() {
         () => page.props.auth.user.timezone ?? null,
     );
 
-    /**
-     * Persist a timezone choice (manual override or auto-detection).
-     */
-    function setTimezone(value: string): void {
+    function persist(value: string, options: Record<string, unknown>): void {
         router.patch(
             update().url,
             { timezone: value },
-            { preserveScroll: true, preserveState: true },
+            { preserveScroll: true, preserveState: true, ...options },
         );
+    }
+
+    /**
+     * Persist a manual timezone choice. The user picked it and is watching the
+     * settings form, so this stays a foreground visit.
+     */
+    function setTimezone(value: string): void {
+        persist(value, {});
     }
 
     /**
@@ -45,7 +51,10 @@ export function useTimezone() {
         const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
         if (detected) {
-            setTimezone(detected);
+            // Nobody asked for this write and it lands moments after the first
+            // authenticated render, when the user is most likely mid-click; see
+            // {@see backgroundVisit}.
+            persist(detected, backgroundVisit);
         }
     }
 

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -96,6 +96,7 @@ import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
 import { useTimezone } from '@/composables/useTimezone';
 import { useTranslations } from '@/composables/useTranslations';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import {
     partitionChannels,
     toggleCollapsedSection,
@@ -682,8 +683,10 @@ const { timezone, syncDetectedTimezone } = useTimezone();
 const { sidebarPosition } = useSidebarPosition();
 
 onMounted(() => {
-    // Lazily pull the (optional) shared invitations so the post-login prompt appears.
-    router.reload({ only: ['pendingInvitations'] });
+    // Lazily pull the (optional) shared invitations so the post-login prompt
+    // appears. It lands moments after the first render, when the user may already
+    // be navigating, so it stays off the synchronous queue ({@see backgroundVisit}).
+    router.reload({ ...backgroundVisit, only: ['pendingInvitations'] });
 
     // Persist the browser's timezone on first login when none is stored yet.
     syncDetectedTimezone();

--- a/resources/js/lib/backgroundVisit.test.ts
+++ b/resources/js/lib/backgroundVisit.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { backgroundVisit } from '@/lib/backgroundVisit';
+
+const SOURCE_ROOT = 'resources/js';
+
+/**
+ * The `router.reload` call sites that are deliberately foreground, each with the
+ * reason it is the user's own request rather than a background refresh. Anything
+ * not listed here must spread {@see backgroundVisit}, so a new reload forces a
+ * conscious choice instead of silently inheriting interrupt semantics (#586).
+ */
+const FOREGROUND_RELOADS: { file: string; call: string; reason: string }[] = [
+    {
+        file: 'composables/useTeamSwitch.ts',
+        call: 'router.reload()',
+        reason: 'the tail of the user-initiated team switch itself',
+    },
+    {
+        file: 'components/PasskeyManagement.vue',
+        call: "router.reload({ only: ['passkeys'] })",
+        reason: 'refreshes the list the user just registered a passkey into',
+    },
+    {
+        file: 'pages/channels/Show.vue',
+        call: "router.reload({ only: ['pins', 'pinCount'] })",
+        reason: 'the user opened the pins popover and is waiting on it',
+    },
+];
+
+/** Every source file under `resources/js`, tests excluded. */
+function sourceFiles(directory = SOURCE_ROOT): string[] {
+    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            return sourceFiles(path);
+        }
+
+        return /\.(ts|vue)$/.test(entry.name) &&
+            !entry.name.endsWith('.test.ts')
+            ? [path]
+            : [];
+    });
+}
+
+/** The full source text of each `router.reload(...)` call in `source`. */
+function reloadCalls(source: string): string[] {
+    const calls: string[] = [];
+    const marker = 'router.reload(';
+
+    for (
+        let start = source.indexOf(marker);
+        start !== -1;
+        start = source.indexOf(marker, start + 1)
+    ) {
+        let depth = 0;
+
+        for (
+            let index = start + marker.length - 1;
+            index < source.length;
+            index++
+        ) {
+            depth +=
+                Number(source[index] === '(') - Number(source[index] === ')');
+
+            if (depth === 0) {
+                calls.push(source.slice(start, index + 1));
+                break;
+            }
+        }
+    }
+
+    return calls;
+}
+
+/** Collapse the whitespace a formatter may have wrapped a call across. */
+function normalize(call: string): string {
+    return call.replace(/\s+/g, ' ').replace(/,(?= })/g, '');
+}
+
+describe('backgroundVisit', () => {
+    it('takes the request out of the sync queue and off the address bar', () => {
+        // Both halves matter and are asserted at every call site that spreads
+        // this: `async` so the request cannot interrupt an in-flight visit, and
+        // `preserveUrl` so its redirect-follow cannot rewrite the URL underneath
+        // the user.
+        expect(backgroundVisit).toEqual({ async: true, preserveUrl: true });
+    });
+
+    it('is spread by every router.reload that is not an explicit foreground one', () => {
+        const allowed = new Set(
+            FOREGROUND_RELOADS.map(
+                (entry) => `${entry.file} ${normalize(entry.call)}`,
+            ),
+        );
+
+        const unguarded = sourceFiles().flatMap((path) => {
+            const file = path.slice(`${SOURCE_ROOT}/`.length);
+
+            return reloadCalls(readFileSync(path, 'utf8'))
+                .filter((call) => !call.includes('backgroundVisit'))
+                .map((call) => `${file} ${normalize(call)}`)
+                .filter((entry) => !allowed.has(entry));
+        });
+
+        expect(unguarded).toEqual([]);
+    });
+});

--- a/resources/js/lib/backgroundVisit.ts
+++ b/resources/js/lib/backgroundVisit.ts
@@ -1,0 +1,30 @@
+/**
+ * The visit options every fire-and-forget Inertia request must carry.
+ *
+ * A background request is one the user never asked for: a debounced write, a
+ * timer poll, a websocket-driven refresh, an auto-detection on first load. It
+ * fires at a moment nobody chose, and as a *synchronous* visit it interrupts
+ * whatever visit is in flight — which is how a mark-read POST cancelled the
+ * thread panel's partial GET and stranded the panel empty (#581), and how any
+ * of the rest can silently kill a real user navigation (#586).
+ *
+ * - `async` takes the request out of the synchronous queue, so it neither
+ *   interrupts an in-flight visit nor is interrupted by one. It also drops the
+ *   progress bar, which a request the user never triggered has no business
+ *   showing.
+ * - `preserveUrl` keeps the redirect-follow from rewriting the address bar.
+ *   Without it a background response can drop query state the user is looking at
+ *   (`?thread=`), or land the URL back on the page they just navigated away from
+ *   when it resolves after their visit.
+ *
+ * Spread it into the options of any such request:
+ * `{ ...backgroundVisit, preserveScroll: true, only: ['channels'] }`.
+ *
+ * Requests the user *did* ask for stay synchronous: form submits, navigations,
+ * and reloads whose whole point is to rewrite the URL (the search page's
+ * filter reload) — there the interrupt semantics are the correct ones.
+ */
+export const backgroundVisit = {
+    async: true,
+    preserveUrl: true,
+} as const;

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -60,6 +60,7 @@ import { useTimezone } from '@/composables/useTimezone';
 import { useTranslations } from '@/composables/useTranslations';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import { useUnreadDivider } from '@/composables/useUnreadDivider';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import { formatDayLabel } from '@/lib/datetime';
 import { groupDmMastheadName } from '@/lib/groupDm';
 import { createOutbox } from '@/lib/outbox';
@@ -633,12 +634,10 @@ const readPost = useDebouncedPost(
             }).url,
             {},
             {
-                // A background write: `async` keeps it from interrupting an
-                // in-flight visit (interrupting a thread-panel GET strands the
-                // panel empty, #581), and `preserveUrl` keeps its
-                // redirect-follow from dropping the `?thread=` param.
-                async: true,
-                preserveUrl: true,
+                // Interrupting a thread-panel GET strands the panel empty (#581)
+                // and the redirect-follow would drop the `?thread=` param; see
+                // {@see backgroundVisit}.
+                ...backgroundVisit,
                 preserveScroll: true,
                 preserveState: true,
                 only: ['channels'],
@@ -1049,7 +1048,9 @@ connection.onConnected(({ isReconnect }) => {
         return;
     }
 
-    router.reload({ only: ['messages'] });
+    // A reconnect is the socket's timing, not the user's; see
+    // {@see backgroundVisit}.
+    router.reload({ ...backgroundVisit, only: ['messages'] });
 
     if (flushed > 0) {
         toast.success(

--- a/resources/js/pages/teams/AuditExports.vue
+++ b/resources/js/pages/teams/AuditExports.vue
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useTimezone } from '@/composables/useTimezone';
 import { useTranslations } from '@/composables/useTranslations';
+import { backgroundVisit } from '@/lib/backgroundVisit';
 import { formatDateTime } from '@/lib/datetime';
 import { i18n, translate } from '@/lib/i18n';
 import { edit, index } from '@/routes/teams';
@@ -148,7 +149,8 @@ let pollTimer: ReturnType<typeof setInterval> | undefined;
 onMounted(() => {
     pollTimer = setInterval(() => {
         if (hasPending.value) {
-            router.reload({ only: ['exports'] });
+            // A timer tick, not a click; see {@see backgroundVisit}.
+            router.reload({ ...backgroundVisit, only: ['exports'] });
         }
     }, 4000);
 });


### PR DESCRIPTION
Closes #586.

## What

Every fire-and-forget Inertia request now runs as an async visit. #583 fixed the two mark-read posts that stranded the thread panel empty (#581); this sweeps the rest of the class.

A new `resources/js/lib/backgroundVisit.ts` holds the options (`async: true` + `preserveUrl: true`) and the reasoning behind them, so the convention has one documented home instead of a copy of the same comment at each site. The two sites fixed in #583 were refactored onto it too.

**Converted** — the three the issue named, plus four more of the same class found by sweeping every `router.*` call in `resources/js`:

- `useTimezone` — the auto-detected timezone PATCH (the manual picker stays foreground)
- `useChannelDraft` — draft persistence, which flushes *during* the channel switch it must not cancel
- `useChannelPreferences` — both optimistic PATCHes (star, and mute/notification level)
- `useSidebarBadges` — the debounced badge refresh
- `useNewDirectMessages`, `useMessageReminders` — realtime-driven reloads on the viewer's private channel
- `useTeamPresence` — the debounced profile reload (a full reload with no `only`, so the costliest to fire mid-visit)
- `MainLayout` — the on-mount `pendingInvitations` pull
- `channels/Show.vue` — the reconnect message backfill
- `teams/AuditExports.vue` — the readiness poll

**Left synchronous, deliberately** — requests the user actually asked for, where interrupt semantics are correct: the search page's filter reload (its whole point is rewriting the URL), the manual timezone picker, the read-receipt/locale/chime/sidebar-position settings writes, message actions, the pins popover, the passkey-list refresh, and the team-switch tail.

## Testing

- Unit tests pin the options at each testable call site: `useChannelDraft`, `useChannelPreferences`, and a new `useTimezone.test.ts` (which also asserts the manual write stays foreground).
- `backgroundVisit.test.ts` adds a drift test: any `router.reload` in `resources/js` that neither spreads `backgroundVisit` nor appears in an explicit foreground allowlist (each entry carrying its reason) fails the suite, so a new reload forces a conscious choice. Verified it fails by removing a guard.
- Full gate green: Pint, PHPStan, Rector, 1866 Pest tests at 100% coverage, 731 vitest tests, lint/format/types/build.
- Full browser suite run locally: 61 passed, including the thread-panel and timeline tests covering the #581 regression.

No user-facing copy, config, or operator-facing behaviour changed, so no i18n or docs updates apply.