### PR TITLE
perf: run the local Pest gate in parallel like CI does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,8 @@ Vue components must have a single root element.
 ## Code Coverage
 
 - **100% code coverage is required — this is non-negotiable.** The test suite is gated at `--min=100` (see the `test` script in `composer.json`), so any line left uncovered fails the build.
-- **Always check coverage before pushing.** Run the full gate — which also runs Pint, PHPStan, and Rector — with `./vendor/bin/sail composer test` (this executes `lint:check`, `types:check`, `refactor:check`, and `php artisan test --coverage --min=100`). Do not push or open/update a PR until it reports `Total: 100.0 %` with a clean Rector dry-run.
+- **Always check coverage before pushing.** Run the full gate — which also runs Pint, PHPStan, and Rector — with `./vendor/bin/sail composer test` (this executes `lint:check`, `types:check`, `refactor:check`, and `php artisan test --parallel --coverage --min=100`). Do not push or open/update a PR until it reports `Total: 100.0 %` with a clean Rector dry-run.
+- **The gate runs the suite in parallel, like CI does.** Paratest gives each worker its own `testing_N` database and merges the per-worker PCOV reports, so `--min=100` still bites while the run takes roughly a third of the serial wall clock. The browser suite (`composer test:browser`) stays single-process — it binds Reverb and a live server, so it cannot be sharded.
 - If new code drops coverage, add or update tests until it is back at 100%. When a line reads as uncovered even though a test exercises it (e.g. the `: null` branch of a multi-line ternary is a known PCOV line-attribution quirk), collapse it onto a single line rather than leaving the gate red.
 
 ## Reporting Bugs Found While Doing Something Else

--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
             "@lint:check",
             "@types:check",
             "@refactor:check",
-            "@php artisan test --coverage --min=100"
+            "@php artisan test --parallel --coverage --min=100"
         ],
         "test:browser": [
             "pest tests/Browser"

--- a/tests/Unit/LocalTestGateTest.php
+++ b/tests/Unit/LocalTestGateTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * CI has run the Pest suite with `--parallel` since #582 while the local gate
+ * stayed single-process, so every pre-push run paid ~3x the wall clock CI did.
+ * These tests pin the local gate to the parallel run, keep the coverage floor
+ * attached to it, and keep the browser suite — which binds Reverb and a live
+ * server — out of the parallel path.
+ */
+function composerScript(string $name): string
+{
+    $scripts = json_decode((string) file_get_contents(dirname(__DIR__, 2).'/composer.json'), true)['scripts'];
+
+    return implode(' ', (array) $scripts[$name]);
+}
+
+test('the local gate runs the suite in parallel', function (): void {
+    expect(composerScript('test'))->toContain('artisan test --parallel');
+});
+
+test('the local gate still enforces the coverage floor', function (): void {
+    expect(composerScript('test'))->toContain('--coverage')
+        ->and(composerScript('test'))->toContain('--min=100');
+});
+
+test('the browser suite stays single-process', function (): void {
+    expect(composerScript('test:browser'))->not->toContain('--parallel');
+});
+
+test('the documented local gate spells out the parallel run', function (): void {
+    $documented = (string) file_get_contents(dirname(__DIR__, 2).'/CLAUDE.md');
+
+    expect($documented)->toContain('artisan test --parallel --coverage --min=100');
+});


### PR DESCRIPTION
Closes #647.

## What

`composer test` now runs `php artisan test --parallel --coverage --min=100`, matching what CI has run since #582. The local pre-push gate was the only place still paying the serial cost.

## Why

Measured in this worktree (12 cores, Sail / Postgres 18):

| Run | Wall clock | Result |
| --- | --- | --- |
| serial (baseline, from the issue) | 2 min 45 s | Total: 100.0 % |
| `--parallel` (run 1 / 2 / 3) | 46 s / 39 s / 42 s | Total: 100.0 % |

Paratest gives each worker its own `testing_N` database (the `laravel` Postgres role owns the server in `compose.yaml`, so no config change is needed) and merges the per-worker PCOV reports, so `--min=100` keeps biting.

## Testing

- Three consecutive `--parallel --coverage --min=100` runs, all clean at `Total: 100.0 %` — no flakiness surfaced, so no `--processes` cap or per-test escape hatch was needed.
- Full gate green: `./vendor/bin/sail composer test` (Pint + PHPStan + Rector dry-run + the parallel suite at 100%).
- New `tests/Unit/LocalTestGateTest.php` pins the gate: the `test` script must run in parallel, must keep `--coverage`/`--min=100`, `test:browser` must stay single-process, and `CLAUDE.md` must document the parallel command.

## Notes

- **Browser suite unchanged** — `composer test:browser` stays `pest tests/Browser`, single-process, since it binds Reverb and a live server.
- **The "filtered run prints no coverage table" oddity** from the issue is not a paratest problem: Pest 4 switches to its agent JSON reporter (`{"tool":"pest",…}`) when it detects an agent shell, and that reporter omits the coverage table. A plain terminal prints it normally, filtered or not. Nothing to document.
- **Docs:** `CLAUDE.md` is the only doc that spells the gate command out; it now names `--parallel` and explains why the browser suite is exempt. `README.md`/`CONTRIBUTING.md` only reference `composer test`, which is unchanged.
- No frontend files touched, so the JS gate is unaffected.