### PR TITLE
feat: set a content-security-policy header on web responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,6 +190,23 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # SCIM_TOKEN=
 # SCIM_BASE_PATH=/scim
 
+# Every web response carries a Content-Security-Policy: the browser-side
+# allow-list that limits what injected markup could do. Set CSP_ENABLED=false
+# only if you serve your own policy from the reverse proxy instead.
+CSP_ENABLED=true
+# Report-only sends the policy as Content-Security-Policy-Report-Only, so
+# violations are logged to the browser console but nothing is blocked. It is on
+# here for local development (a policy mistake shows up as a console warning
+# instead of a blank page) and off by default everywhere else.
+CSP_REPORT_ONLY=true
+# Comma-separated extra origins, appended to (never replacing) the defaults —
+# for an analytics snippet, a corporate asset host, or an embedded frame.
+# CSP_EXTRA_SCRIPT_SRC=
+# CSP_EXTRA_STYLE_SRC=
+# CSP_EXTRA_IMG_SRC=
+# CSP_EXTRA_CONNECT_SRC=
+# CSP_EXTRA_FRAME_SRC=
+
 LOG_CHANNEL=stack
 LOG_STACK=single
 LOG_DEPRECATIONS_CHANNEL=null

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -61,6 +61,23 @@ UPDATE_CHECK_ENABLED=true
 GIPHY_API_KEY=
 GIPHY_CONTENT_RATING=g
 
+# --- Security headers --------------------------------------------------------
+# Every web response carries a Content-Security-Policy: the browser-side
+# allow-list that limits what injected markup could do. Leave it on. Set false
+# only if you serve your own policy from the reverse proxy instead.
+CSP_ENABLED=true
+# Send the policy as Content-Security-Policy-Report-Only: violations are logged
+# to the browser console but nothing is blocked. Use it for a dry run after
+# adding scripts of your own, then turn it back off.
+# CSP_REPORT_ONLY=false
+# Comma-separated extra origins, appended to (never replacing) the defaults —
+# for an analytics snippet, a corporate asset host, or an embedded frame.
+# CSP_EXTRA_SCRIPT_SRC=
+# CSP_EXTRA_STYLE_SRC=
+# CSP_EXTRA_IMG_SRC=
+# CSP_EXTRA_CONNECT_SRC=
+# CSP_EXTRA_FRAME_SRC=
+
 # --- Single sign-on (OpenID Connect) -----------------------------------------
 # SSO_OIDC_ISSUER=https://your-idp.example.com
 # SSO_OIDC_CLIENT_ID=

--- a/app/Http/Middleware/AddContentSecurityPolicyHeaders.php
+++ b/app/Http/Middleware/AddContentSecurityPolicyHeaders.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Support\Csp\TheDeskPolicy;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Vite;
+use Spatie\Csp\Policy;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Emit the Content-Security-Policy on web responses.
+ *
+ * This stands in for spatie/laravel-csp's own AddCspHeaders for two reasons: the
+ * enforcing/report-only choice has to be made per request from config (so tests
+ * and an operator's `php artisan config:cache` both see the current value rather
+ * than whichever preset list the config file was written with), and the nonce
+ * must be handed to Vite on the way *in*, before the Blade shell renders.
+ */
+final class AddContentSecurityPolicyHeaders
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // One nonce per request, shared by the Blade shell's inline appearance
+        // script (@cspNonce) and every @vite tag. Two independent generators
+        // would leave half the page unrunnable.
+        Vite::useCspNonce(app('csp-nonce'));
+
+        $response = $next($request);
+
+        if (! config('csp.enabled')) {
+            return $response;
+        }
+
+        $header = config('csp.report_only')
+            ? 'Content-Security-Policy-Report-Only'
+            : 'Content-Security-Policy';
+
+        $response->headers->set($header, Policy::create([TheDeskPolicy::class])->getContents());
+
+        return $response;
+    }
+}

--- a/app/Support/Csp/TheDeskPolicy.php
+++ b/app/Support/Csp/TheDeskPolicy.php
@@ -28,7 +28,7 @@ final class TheDeskPolicy implements Preset
      *
      * @var array<string, Directive>
      */
-    private const EXTENDABLE_DIRECTIVES = [
+    private const array EXTENDABLE_DIRECTIVES = [
         'script-src' => Directive::SCRIPT,
         'style-src' => Directive::STYLE,
         'img-src' => Directive::IMG,

--- a/app/Support/Csp/TheDeskPolicy.php
+++ b/app/Support/Csp/TheDeskPolicy.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Csp;
+
+use App\Support\ReverbConfig;
+use Illuminate\Support\Facades\Vite;
+use Spatie\Csp\Directive;
+use Spatie\Csp\Keyword;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Preset;
+use Spatie\Csp\Scheme;
+
+/**
+ * The Content-Security-Policy every web response carries.
+ *
+ * CSP does not replace output escaping; it caps the blast radius when escaping
+ * fails. The-desk renders user-authored content nearly everywhere (messages,
+ * markdown, emoji names, link previews, uploaded file names) and ships as a
+ * self-hosted image, so this policy is part of what every operator inherits.
+ */
+final class TheDeskPolicy implements Preset
+{
+    /**
+     * Directives an operator may extend from the environment, keyed by the
+     * `csp.extra.*` config key that carries their comma-separated origins.
+     *
+     * @var array<string, Directive>
+     */
+    private const EXTENDABLE_DIRECTIVES = [
+        'script-src' => Directive::SCRIPT,
+        'style-src' => Directive::STYLE,
+        'img-src' => Directive::IMG,
+        'connect-src' => Directive::CONNECT,
+        'frame-src' => Directive::FRAME,
+    ];
+
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::DEFAULT, Keyword::SELF)
+            // 'strict-dynamic' is not optional here: the built app code-splits
+            // per page and Inertia pulls further chunks at runtime through
+            // dynamic import(). Those runtime-injected tags carry no nonce, so a
+            // nonce-only script-src would break every client-side navigation to
+            // a not-yet-loaded page. 'self' stays as the CSP2 fallback — CSP3
+            // browsers ignore it once 'strict-dynamic' is present.
+            ->add(Directive::SCRIPT, [Keyword::SELF, Keyword::STRICT_DYNAMIC])
+            ->addNonce(Directive::SCRIPT)
+            // Accepted residual, documented in the self-hosting security docs:
+            // reka-ui/shadcn popovers, dropdowns and the emoji picker position
+            // themselves by writing style *attributes* at runtime. A nonce here
+            // would make browsers ignore 'unsafe-inline', and style-src-attr is
+            // unsupported on Safari < 15.4. Script execution, the threat CSP is
+            // bought for, is covered by script-src above.
+            ->add(Directive::STYLE, [Keyword::SELF, Keyword::UNSAFE_INLINE])
+            // Accepted residual: link-preview thumbnails are scraped from
+            // arbitrary sites, Giphy results are hotlinked, and the Gravatar base
+            // URL is operator-configurable, so no enumerable host list exists.
+            // data:/blob: cover local upload previews.
+            ->add(Directive::IMG, [Keyword::SELF, Scheme::DATA, Scheme::BLOB, Scheme::HTTPS])
+            ->add(Directive::FONT, Keyword::SELF)
+            ->add(Directive::CONNECT, Keyword::SELF)
+            ->add(Directive::MEDIA, Keyword::SELF)
+            // worker-src does not fall back to default-src — the chain is
+            // worker-src → child-src → script-src, and our script-src carries a
+            // nonce plus 'strict-dynamic', under which new Worker() is blocked.
+            // Nothing uses workers today; this spares the next person the
+            // baffling bug when something does.
+            ->add(Directive::WORKER, Keyword::SELF)
+            ->add(Directive::FRAME, Keyword::NONE);
+
+        $this->allowReverb($policy);
+        $this->allowViteDevServer($policy);
+        $this->allowOperatorSources($policy);
+    }
+
+    /**
+     * Echo opens its WebSocket against an origin that is routinely a different
+     * port than the app itself (the common self-hosted layout serves the app on
+     * :443 and Reverb on :8080), and 'self' has not covered WebSocket schemes
+     * consistently across browsers — so the origin is always stated, derived
+     * from the same config the SPA is handed so the two cannot drift.
+     */
+    private function allowReverb(Policy $policy): void
+    {
+        $origin = ReverbConfig::websocketOrigin();
+
+        if ($origin !== null) {
+            $policy->add(Directive::CONNECT, $origin);
+        }
+    }
+
+    /**
+     * With `npm run dev` the assets, the injected styles and the HMR socket all
+     * come from the Vite dev server on a different origin. The policy stays on in
+     * development rather than being switched off: if it is absent locally, the
+     * first person to meet it is a self-hoster in production.
+     */
+    private function allowViteDevServer(Policy $policy): void
+    {
+        if (! Vite::isRunningHot()) {
+            return;
+        }
+
+        $origin = trim((string) file_get_contents(Vite::hotFile()));
+        $socket = str_replace(['https://', 'http://'], ['wss://', 'ws://'], $origin);
+
+        $policy
+            ->add(Directive::SCRIPT, $origin)
+            ->add(Directive::STYLE, $origin)
+            ->add(Directive::CONNECT, [$origin, $socket]);
+    }
+
+    /**
+     * Origins the operator added through the CSP_EXTRA_* env keys. Strictly
+     * additive: an operator allow-listing their analytics host must not be able
+     * to drop the nonce or 'strict-dynamic' and silently un-harden the app.
+     */
+    private function allowOperatorSources(Policy $policy): void
+    {
+        foreach (self::EXTENDABLE_DIRECTIVES as $key => $directive) {
+            $sources = array_values(array_filter(array_map(
+                trim(...),
+                explode(',', (string) config("csp.extra.{$key}", '')),
+            )));
+
+            if ($sources !== []) {
+                $policy->add($directive, $sources);
+            }
+        }
+    }
+}

--- a/app/Support/ReverbConfig.php
+++ b/app/Support/ReverbConfig.php
@@ -34,4 +34,30 @@ class ReverbConfig
             'scheme' => (string) ($reverb['public_scheme'] ?: $options['scheme'] ?? 'https'),
         ];
     }
+
+    /**
+     * The browser-facing Reverb origin as a WebSocket URL (`wss://host:port`),
+     * derived from the very same values the SPA is handed by forFrontend() so the
+     * two cannot drift.
+     *
+     * This is what the Content-Security-Policy `connect-src` directive must
+     * allow-list: Echo opens its socket against this origin, and it is routinely
+     * a different port than the app itself (the common self-hosted layout serves
+     * the app on :443 and Reverb on :8080).
+     *
+     * Null when no browser-facing host can be resolved (neither an override nor a
+     * parseable APP_URL), in which case there is no origin to allow-list.
+     */
+    public static function websocketOrigin(): ?string
+    {
+        $connection = self::forFrontend();
+
+        if ($connection['host'] === null) {
+            return null;
+        }
+
+        $scheme = $connection['scheme'] === 'https' ? 'wss' : 'ws';
+
+        return "{$scheme}://{$connection['host']}:{$connection['port']}";
+    }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Middleware\AddContentSecurityPolicyHeaders;
 use App\Http\Middleware\EnsureIntegrationsEnabled;
 use App\Http\Middleware\EnsurePasskeysEnabled;
 use App\Http\Middleware\EnsurePasswordLoginEnabled;
@@ -62,7 +63,12 @@ return Application::configure(basePath: dirname(__DIR__))
             'scope' => EnsureTokenScope::class,
         ]);
 
+        // AddContentSecurityPolicyHeaders comes first: it sets the request's CSP
+        // nonce on the Vite facade on the way in, so it has to run before
+        // HandleInertiaRequests renders the Blade shell. The API group is left
+        // out deliberately — a JSON response has no DOM for a policy to protect.
         $middleware->web(append: [
+            AddContentSecurityPolicyHeaders::class,
             EnsurePasswordLoginEnabled::class,
             EnsurePasskeysEnabled::class,
             ThrottlePasswordResetRequests::class,

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "laravel/wayfinder": "^0.1.14",
         "meilisearch/meilisearch-php": "^1.16",
         "spatie/laravel-activitylog": "^5.0",
+        "spatie/laravel-csp": "^3.26",
         "spatie/laravel-data": "^4.23",
         "spatie/laravel-typescript-transformer": "^3.3",
         "symfony/dom-crawler": "^8.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ac0bb9135e7a3d62e7188e7da608a9f",
+    "content-hash": "79ebe866239e2387006d879c0046c4ad",
     "packages": [
         {
             "name": "arietimmerman/laravel-scim-server",
@@ -6622,6 +6622,91 @@
                 }
             ],
             "time": "2026-03-25T10:04:54+00:00"
+        },
+        {
+            "name": "spatie/laravel-csp",
+            "version": "3.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-csp.git",
+                "reference": "4e0e0298276adb866818804981674dc27027ed79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-csp/zipball/4e0e0298276adb866818804981674dc27027ed79",
+                "reference": "4e0e0298276adb866818804981674dc27027ed79",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "^11.36.1|^12.0|^13.0",
+                "illuminate/support": "^11.36.1|^12.0|^13.0",
+                "php": "^8.3",
+                "spatie/laravel-package-tools": "^1.17"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.9|^10.0|^11.0",
+                "pestphp/pest": "^3.0|^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Csp\\CspServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Csp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Verhelst",
+                    "email": "tvke91@gmail.com",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Add CSP headers to the responses of a Laravel app",
+            "homepage": "https://github.com/spatie/laravel-csp",
+            "keywords": [
+                "content-security-policy",
+                "csp",
+                "headers",
+                "laravel",
+                "laravel-csp",
+                "security",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-csp/issues",
+                "source": "https://github.com/spatie/laravel-csp/tree/3.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-06-26T19:20:01+00:00"
         },
         {
             "name": "spatie/laravel-data",

--- a/config/csp.php
+++ b/config/csp.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Content-Security-Policy
+    |--------------------------------------------------------------------------
+    |
+    | When enabled (the default), every web response carries the policy built by
+    | App\Support\Csp\TheDeskPolicy — the browser-side allow-list that limits the
+    | blast radius of any markup injection that gets past output escaping.
+    |
+    | Set CSP_ENABLED=false only if you intend to serve your own policy from the
+    | reverse proxy instead. There is deliberately no "replace the whole policy"
+    | env key: an override that could drop the script nonce would silently
+    | un-harden the app. Use the additive CSP_EXTRA_* keys below to allow-list
+    | extra origins, or turn the app policy off entirely and own it at the proxy.
+    |
+    */
+
+    'enabled' => (bool) env('CSP_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Report-only mode
+    |--------------------------------------------------------------------------
+    |
+    | Sends the policy as Content-Security-Policy-Report-Only instead: the browser
+    | logs violations to its console but blocks nothing. Useful for a dry run
+    | after adding your own scripts. Defaults to false — a policy that enforces
+    | nothing protects nobody — and .env.example turns it on for local
+    | development so a policy bug surfaces as a warning rather than a blank page.
+    |
+    */
+
+    'report_only' => (bool) env('CSP_REPORT_ONLY', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Extra allowed sources
+    |--------------------------------------------------------------------------
+    |
+    | Comma-separated origins appended to the matching directive — for an
+    | operator-added analytics snippet, a corporate asset host, or an embedded
+    | third-party frame. These are strictly additive: they can never remove the
+    | nonce, 'strict-dynamic', or any of our defaults.
+    |
+    | Note that 'strict-dynamic' makes browsers ignore host allow-lists in
+    | script-src, so an extra script host only takes effect for a script tag that
+    | is itself loaded by an already-trusted (nonced) script.
+    |
+    */
+
+    'extra' => [
+        'script-src' => env('CSP_EXTRA_SCRIPT_SRC', ''),
+        'style-src' => env('CSP_EXTRA_STYLE_SRC', ''),
+        'img-src' => env('CSP_EXTRA_IMG_SRC', ''),
+        'connect-src' => env('CSP_EXTRA_CONNECT_SRC', ''),
+        'frame-src' => env('CSP_EXTRA_FRAME_SRC', ''),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Nonce generation (spatie/laravel-csp)
+    |--------------------------------------------------------------------------
+    |
+    | Consumed by the package's service provider, which binds the per-request
+    | `csp-nonce`. Nonces are never optional here: script-src carries no
+    | 'unsafe-inline', so the app's own inline script only runs because it is
+    | nonced. The package's CSP_NONCE_ENABLED env key is deliberately not honoured
+    | — switching it off would break every page rather than loosen the policy.
+    |
+    */
+
+    'nonce_enabled' => true,
+
+    'nonce_generator' => Spatie\Csp\Nonce\RandomString::class,
+
+];

--- a/config/csp.php
+++ b/config/csp.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Spatie\Csp\Nonce\RandomString;
 
 return [
 
@@ -77,6 +78,6 @@ return [
 
     'nonce_enabled' => true,
 
-    'nonce_generator' => Spatie\Csp\Nonce\RandomString::class,
+    'nonce_generator' => RandomString::class,
 
 ];

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -121,6 +121,23 @@ production — see [Configuration](/docs/self-hosting/configuration/#reverb-webs
 | `WEBHOOKS_DISABLE_AFTER`     | `5`     | [Feature toggles → Integrations platform](/docs/reference/feature-toggles/#outgoing-webhooks) |
 | `WEBHOOKS_BLOCK_PRIVATE_URLS`| `true`  | [Feature toggles → Integrations platform](/docs/reference/feature-toggles/#outgoing-webhooks) |
 | `DEMO_MODE`                  | `false` | [Feature toggles → Demo mode](/docs/reference/feature-toggles/#demo-mode) |
+| `CSP_ENABLED`                | `true`  | [Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy) |
+| `CSP_REPORT_ONLY`            | `false` | [Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy) |
+
+## Content Security Policy
+
+Comma-separated origins **appended** to the shipped policy, for a script,
+stylesheet, image host, API or embedded frame of your own. They are additive
+only: none of them can remove the script nonce or `'strict-dynamic'`. See
+[Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy).
+
+| Variable                | Default | Adds to       |
+| ----------------------- | ------- | ------------- |
+| `CSP_EXTRA_SCRIPT_SRC`  | *(none)* | `script-src`  |
+| `CSP_EXTRA_STYLE_SRC`   | *(none)* | `style-src`   |
+| `CSP_EXTRA_IMG_SRC`     | *(none)* | `img-src`     |
+| `CSP_EXTRA_CONNECT_SRC` | *(none)* | `connect-src` |
+| `CSP_EXTRA_FRAME_SRC`   | *(none)* | `frame-src`   |
 
 ## Single sign-on (OpenID Connect)
 

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -219,6 +219,55 @@ The Desk records an activity log (audit trail) of notable actions.
 | `ACTIVITYLOG_ENABLED`       | `true`  | Records activity to the database. Set `false` to disable logging entirely. |
 | `ACTIVITYLOG_BUFFER_ENABLED`| `false` | Buffers log writes and flushes them in a batch (advanced; reduces write volume). |
 
+## Content Security Policy
+
+Every web response carries a `Content-Security-Policy` header — the browser-side
+allow-list that limits what injected markup could do. It is **on** by default and
+needs no proxy configuration. See
+[Security & compliance → Content Security Policy](/docs/reference/security/#content-security-policy)
+for the policy itself and the two accepted residuals.
+
+| Variable           | Default | Effect                                                        |
+| ------------------ | ------- | ------------------------------------------------------------- |
+| `CSP_ENABLED`      | `true`  | Sends the policy. Set `false` only to serve your own from the reverse proxy. |
+| `CSP_REPORT_ONLY`  | `false` | Sends it as `Content-Security-Policy-Report-Only`: violations are logged to the browser console but nothing is blocked. |
+
+Report-only is the safe way to try a change: turn it on, browse the app with the
+developer console open, fix whatever is reported, then turn it back off. Leaving
+it on permanently protects nobody.
+
+### Allow-listing your own origins
+
+If you add a script, stylesheet, image host, API or embedded frame of your own,
+name it in the matching key rather than disabling the policy. Values are
+comma-separated and **appended** to the defaults — they can never remove the
+script nonce or `'strict-dynamic'`, so an allow-list entry cannot silently
+un-harden the app.
+
+| Variable                | Adds to       |
+| ----------------------- | ------------- |
+| `CSP_EXTRA_SCRIPT_SRC`  | `script-src`  |
+| `CSP_EXTRA_STYLE_SRC`   | `style-src`   |
+| `CSP_EXTRA_IMG_SRC`     | `img-src`     |
+| `CSP_EXTRA_CONNECT_SRC` | `connect-src` |
+| `CSP_EXTRA_FRAME_SRC`   | `frame-src`   |
+
+```bash
+CSP_EXTRA_SCRIPT_SRC="https://analytics.example.com"
+CSP_EXTRA_CONNECT_SRC="https://analytics.example.com"
+```
+
+:::note
+`script-src` uses `'strict-dynamic'`, and browsers that understand it ignore host
+allow-lists in that directive. An extra script host therefore only takes effect
+for a tag loaded by an already-trusted script. If a third-party snippet has to be
+pasted into the page as inline `<script>`, there is no allow-list that reaches
+it — set `CSP_ENABLED=false` and serve your own policy from the reverse proxy.
+:::
+
+There is deliberately no key that replaces the whole policy: an override that
+could drop the nonce would leave a header that looks protective and is not.
+
 ## Search analytics
 
 | Variable                   | Default | Effect                                             |

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -41,6 +41,64 @@ CodeQL does not support PHP, so the Laravel backend is covered by PHPStan
 gates in the repository for details.
 :::
 
+## Content Security Policy
+
+Every web response carries a `Content-Security-Policy` header: the browser-side
+allow-list that decides which scripts, styles, images and connections a page may
+use. It does not replace output escaping. It caps the damage when escaping fails,
+which matters here because The Desk renders user-authored content nearly
+everywhere: messages, markdown, emoji names, link-preview titles, uploaded file
+names.
+
+It is **on by default** and ships in the image, so every deployment inherits it
+without extra proxy configuration. See
+[Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy)
+for the switches.
+
+The policy sent is:
+
+| Directive     | Value                                        |
+| ------------- | -------------------------------------------- |
+| `default-src` | `'self'`                                     |
+| `script-src`  | `'self' 'nonce-…' 'strict-dynamic'`          |
+| `style-src`   | `'self' 'unsafe-inline'`                     |
+| `img-src`     | `'self' data: blob: https:`                  |
+| `font-src`    | `'self'`                                     |
+| `connect-src` | `'self'` plus your Reverb WebSocket origin   |
+| `media-src`   | `'self'`                                     |
+| `worker-src`  | `'self'`                                     |
+| `frame-src`   | `'none'`                                     |
+
+Scripts are the directive that matters, and they carry no `'unsafe-inline'`: the
+app's own inline script runs only because it carries a per-request nonce, and the
+page chunks the app loads as you navigate run only because `'strict-dynamic'`
+extends that trust to them. Injected markup gets neither.
+
+### Accepted residuals
+
+Two directives are deliberately looser than they look, and both are limited to
+resources that cannot execute script:
+
+- **`style-src 'unsafe-inline'`.** Popovers, dropdowns and the emoji picker
+  position themselves by writing style *attributes* at runtime. A nonce here
+  would make browsers ignore `'unsafe-inline'` entirely, and the narrower
+  `style-src-attr` is unsupported on Safari before 15.4, which would silently
+  break every floating element. The exposure is CSS, not code execution.
+- **`img-src https:`.** Link-preview thumbnails are fetched from whatever site
+  was linked, Giphy results are hotlinked from Giphy's CDN, and the Gravatar
+  base URL is yours to configure — so there is no enumerable host list to write
+  down. Images cannot execute, and the risk this leaves (a crafted URL signalling
+  that a page was viewed) is bounded by the tight `connect-src`.
+
+### Running behind Cloudflare or a script-injecting proxy
+
+Cloudflare features that inject their own JavaScript into your pages — Email
+Obfuscation, Rocket Loader, a managed challenge — serve those scripts from
+`/cdn-cgi/` without the app's nonce, so `script-src` will block them. If you use
+any of them, either turn that Cloudflare feature off for the app's hostname or
+allow-list it with `CSP_EXTRA_SCRIPT_SRC` (and `CSP_EXTRA_FRAME_SRC` for a
+challenge that renders in a frame).
+
 ## Hardening your deployment
 
 Most security outcomes for a self-hosted instance depend on how you run it. Follow

--- a/docs/src/content/docs/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/docs/self-hosting/upgrading.md
@@ -142,6 +142,21 @@ copy:
 It exits `0` when nothing is missing, `1` after reporting missing keys, and `2`
 on usage errors, so it also scripts cleanly.
 
+:::caution[Content Security Policy]
+A setting that defaults to *on* takes effect at the upgrade whether or not you
+adopt the new key, because the app falls back to its built-in default. The
+[Content Security Policy](/docs/reference/security/#content-security-policy) is
+one such setting: from the release that introduces it, every page is served with
+an enforcing policy.
+
+The app itself is tested against it, so nothing of ours breaks. What can break is
+JavaScript **you** added — an analytics snippet, or a script your CDN injects
+(Cloudflare's Email Obfuscation and Rocket Loader both do). If you run anything
+like that, set `CSP_REPORT_ONLY=true` for the first boot, browse the app with the
+browser console open, and allow-list what it reports with the `CSP_EXTRA_*` keys
+before turning enforcement back on.
+:::
+
 ### If it fails, it stops and hands you the backup
 
 The script **never rolls back on its own**, and that is deliberate.

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -5,7 +5,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
-        <script>
+        <script @cspNonce>
             (function() {
                 const appearance = '{{ $appearance ?? "system" }}';
 

--- a/tests/Browser/ContentSecurityPolicyTest.php
+++ b/tests/Browser/ContentSecurityPolicyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The policy is enforcing by default, but .env.example turns report-only on for
+ * local development (and CI boots the browser suite from it), so state the
+ * posture under test: violations must block here, not just warn.
+ */
+beforeEach(function (): void {
+    config([
+        'csp.enabled' => true,
+        'csp.report_only' => false,
+    ]);
+});
+
+test('the app runs under an enforcing content security policy', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // Reaching the composer at all means the entry bundle and the channel page's
+    // own chunk both executed — that is the nonce and 'strict-dynamic' working.
+    $page = signInThroughBrowser($alice)
+        ->assertPresent('@message-composer-input');
+
+    $page->script(<<<'JS'
+        () => {
+            window.__cspViolations = [];
+            document.addEventListener('securitypolicyviolation', (event) => {
+                window.__cspViolations.push(event.violatedDirective + ' ' + event.blockedURI);
+            });
+        }
+        JS);
+
+    // A client-side Inertia visit to a page whose chunk has not been loaded yet:
+    // the import() the browser makes carries no nonce of its own and only runs
+    // because 'strict-dynamic' extends trust to it. This is the exact path a
+    // nonce-only script-src would break.
+    $violations = $page
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@settings-menu-item')
+        // Let the dropdown settle past its open/pointer-grace window, otherwise
+        // the item click can be swallowed and never navigate.
+        ->wait(0.5)
+        ->click('@settings-menu-item')
+        ->assertPathContains('/settings')
+        ->assertPresent('[data-test="settings-nav-profile"]')
+        ->script('() => window.__cspViolations');
+
+    expect($violations)->toBe([]);
+});

--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Csp\TheDeskPolicy;
+use Illuminate\Support\Facades\Vite;
+use Spatie\Csp\Policy;
+
+/**
+ * Pull the nonce out of a `script-src 'nonce-…'` source expression.
+ */
+function cspNonceFrom(string $header): string
+{
+    expect($header)->toMatch("/'nonce-[A-Za-z0-9+\/=_-]+'/");
+
+    preg_match("/'nonce-([A-Za-z0-9+\/=_-]+)'/", $header, $matches);
+
+    return $matches[1];
+}
+
+beforeEach(function (): void {
+    // .env.example turns report-only on for local development, so every test
+    // states the posture it is asserting rather than inheriting the ambient one.
+    config([
+        'csp.enabled' => true,
+        'csp.report_only' => false,
+        'csp.extra' => [
+            'script-src' => '',
+            'style-src' => '',
+            'img-src' => '',
+            'connect-src' => '',
+            'frame-src' => '',
+        ],
+    ]);
+});
+
+test('web responses carry the policy', function (): void {
+    $header = $this->get(route('home'))->assertOk()->headers->get('Content-Security-Policy');
+
+    expect($header)
+        ->toContain("default-src 'self'")
+        ->toContain("style-src 'self' 'unsafe-inline'")
+        ->toContain("img-src 'self' data: blob: https:")
+        ->toContain("font-src 'self'")
+        ->toContain("media-src 'self'")
+        ->toContain("worker-src 'self'")
+        ->toContain("frame-src 'none'");
+});
+
+test('api responses carry no policy — they have no dom to protect', function (): void {
+    $response = $this->getJson('/api/v1/channels');
+
+    expect($response->headers->get('Content-Security-Policy'))->toBeNull();
+    expect($response->headers->get('Content-Security-Policy-Report-Only'))->toBeNull();
+});
+
+test('script-src is a nonce plus strict-dynamic, never unsafe-inline', function (): void {
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)
+        ->toContain("'strict-dynamic'")
+        ->not->toContain("script-src 'self' 'unsafe-inline'");
+});
+
+test('the nonce in the header is the one rendered into the blade shell', function (): void {
+    $response = $this->get(route('home'))->assertOk();
+
+    $nonce = cspNonceFrom((string) $response->headers->get('Content-Security-Policy'));
+
+    expect($response->getContent())->toContain('nonce="'.$nonce.'"');
+});
+
+test('the nonce differs across requests', function (): void {
+    $first = cspNonceFrom((string) $this->get(route('home'))->headers->get('Content-Security-Policy'));
+
+    // Every real request builds a fresh container, which is what makes the
+    // scoped nonce single-use; a test reuses one app, so drop the scoped
+    // instances the way the request lifecycle would.
+    $this->app->forgetScopedInstances();
+
+    $second = cspNonceFrom((string) $this->get(route('home'))->headers->get('Content-Security-Policy'));
+
+    expect($second)->not->toBe($first);
+});
+
+test('connect-src allow-lists the derived reverb websocket origin', function (): void {
+    config([
+        'app.url' => 'https://chat.example.test',
+        'broadcasting.connections.reverb.public_host' => null,
+        'broadcasting.connections.reverb.public_port' => null,
+        'broadcasting.connections.reverb.public_scheme' => null,
+        'broadcasting.connections.reverb.options.port' => 8080,
+        'broadcasting.connections.reverb.options.scheme' => 'https',
+    ]);
+
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)->toContain("connect-src 'self' wss://chat.example.test:8080");
+});
+
+test('connect-src falls back to self when no websocket origin resolves', function (): void {
+    config([
+        'app.url' => '',
+        'broadcasting.connections.reverb.public_host' => null,
+    ]);
+
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)->toContain("connect-src 'self';");
+});
+
+test('the policy is not sent when csp is disabled', function (): void {
+    config(['csp.enabled' => false]);
+
+    $response = $this->get(route('home'))->assertOk();
+
+    expect($response->headers->get('Content-Security-Policy'))->toBeNull();
+    expect($response->headers->get('Content-Security-Policy-Report-Only'))->toBeNull();
+});
+
+test('report-only mode sends the report-only header and nothing to enforce', function (): void {
+    config(['csp.report_only' => true]);
+
+    $response = $this->get(route('home'))->assertOk();
+
+    expect($response->headers->get('Content-Security-Policy'))->toBeNull();
+    expect($response->headers->get('Content-Security-Policy-Report-Only'))
+        ->toContain("default-src 'self'");
+});
+
+test('each extra source is appended without dropping our defaults', function (string $key, string $directive, string $value): void {
+    config(["csp.extra.{$key}" => $value]);
+
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)
+        ->toContain($directive)
+        ->toContain($value)
+        ->toContain("'strict-dynamic'")
+        ->toMatch("/'nonce-[A-Za-z0-9+\/=_-]+'/");
+})->with([
+    'script' => ['script-src', 'script-src', 'https://analytics.example.test'],
+    'style' => ['style-src', 'style-src', 'https://styles.example.test'],
+    'image' => ['img-src', 'img-src', 'https://images.example.test'],
+    'connect' => ['connect-src', 'connect-src', 'https://api.example.test'],
+    'frame' => ['frame-src', 'frame-src', 'https://embed.example.test'],
+]);
+
+test('a comma-separated extra list allow-lists every origin in it', function (): void {
+    config(['csp.extra.img-src' => 'https://one.example.test, https://two.example.test']);
+
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)
+        ->toContain('https://one.example.test')
+        ->toContain('https://two.example.test');
+});
+
+test('an extra frame source replaces the none placeholder rather than sitting beside it', function (): void {
+    config(['csp.extra.frame-src' => 'https://embed.example.test']);
+
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)->toContain("frame-src https://embed.example.test")
+        ->not->toContain("frame-src 'none'");
+});
+
+test('hot mode allow-lists the vite dev server so npm run dev keeps working', function (): void {
+    $hotFile = tempnam(sys_get_temp_dir(), 'vite-hot-');
+    file_put_contents($hotFile, "http://localhost:5173\n");
+    Vite::useHotFile($hotFile);
+
+    try {
+        $contents = Policy::create([TheDeskPolicy::class])->getContents();
+    } finally {
+        unlink($hotFile);
+    }
+
+    expect($contents)
+        ->toContain('script-src')
+        ->toContain('http://localhost:5173')
+        ->toContain('ws://localhost:5173');
+});

--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -161,7 +161,7 @@ test('an extra frame source replaces the none placeholder rather than sitting be
 
     $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
 
-    expect($header)->toContain("frame-src https://embed.example.test")
+    expect($header)->toContain('frame-src https://embed.example.test')
         ->not->toContain("frame-src 'none'");
 });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -28,6 +28,10 @@ pest()->extend(TestCase::class)->in('Unit/SlashCommands');
 // application booted (but no database).
 pest()->extend(TestCase::class)->in('Unit/Support/GiphyClientTest.php');
 
+// The Reverb config unit test reads the broadcasting config, so it needs the
+// application booted (but no database).
+pest()->extend(TestCase::class)->in('Unit/Support/ReverbConfigTest.php');
+
 /*
 |--------------------------------------------------------------------------
 | Browser (E2E) Test Case

--- a/tests/Unit/Support/ReverbConfigTest.php
+++ b/tests/Unit/Support/ReverbConfigTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\ReverbConfig;
+
+test('the websocket origin maps an https connection to wss', function (): void {
+    config([
+        'app.url' => 'https://chat.example.test',
+        'broadcasting.connections.reverb.public_host' => null,
+        'broadcasting.connections.reverb.public_port' => null,
+        'broadcasting.connections.reverb.public_scheme' => null,
+        'broadcasting.connections.reverb.options.port' => 443,
+        'broadcasting.connections.reverb.options.scheme' => 'https',
+    ]);
+
+    expect(ReverbConfig::websocketOrigin())->toBe('wss://chat.example.test:443');
+});
+
+test('the websocket origin maps a plain http connection to ws', function (): void {
+    config([
+        'app.url' => 'http://localhost',
+        'broadcasting.connections.reverb.public_host' => null,
+        'broadcasting.connections.reverb.public_port' => null,
+        'broadcasting.connections.reverb.public_scheme' => null,
+        'broadcasting.connections.reverb.options.port' => 8080,
+        'broadcasting.connections.reverb.options.scheme' => 'http',
+    ]);
+
+    expect(ReverbConfig::websocketOrigin())->toBe('ws://localhost:8080');
+});
+
+test('the websocket origin honours the browser-facing overrides', function (): void {
+    // A TLS-terminating reverse proxy: the container speaks http on 8080, but the
+    // browser reaches Reverb as wss on 443 at a dedicated WebSocket host.
+    config([
+        'app.url' => 'https://chat.example.test',
+        'broadcasting.connections.reverb.public_host' => 'ws.example.test',
+        'broadcasting.connections.reverb.public_port' => 443,
+        'broadcasting.connections.reverb.public_scheme' => 'https',
+        'broadcasting.connections.reverb.options.port' => 8080,
+        'broadcasting.connections.reverb.options.scheme' => 'http',
+    ]);
+
+    expect(ReverbConfig::websocketOrigin())->toBe('wss://ws.example.test:443');
+});
+
+test('the websocket origin is null when no browser-facing host can be resolved', function (): void {
+    config([
+        'app.url' => '',
+        'broadcasting.connections.reverb.public_host' => null,
+    ]);
+
+    expect(ReverbConfig::websocketOrigin())->toBeNull();
+});


### PR DESCRIPTION
Closes #597.

Foundation of the `597-security-headers` base branch. #601 (non-fallback directives), #599 (`frame-ancestors` + `X-Frame-Options`), #598 (HSTS) and #600 (cookie-flag audit) land on this branch next, sequentially — they all edit the same policy class.

## What

Every web response now carries a `Content-Security-Policy`. `spatie/laravel-csp` supplies the `Policy`/`Preset` primitives and the per-request nonce; `App\Support\Csp\TheDeskPolicy` is the policy itself.

| Directive | Value |
|---|---|
| `default-src` | `'self'` |
| `script-src` | `'self' 'nonce-…' 'strict-dynamic'` |
| `style-src` | `'self' 'unsafe-inline'` |
| `img-src` | `'self' data: blob: https:` |
| `font-src` | `'self'` |
| `connect-src` | `'self'` + the derived Reverb origin |
| `media-src` | `'self'` |
| `worker-src` | `'self'` |
| `frame-src` | `'none'` |

`base-uri`, `form-action`, `object-src` and `frame-ancestors` are deferred to #601/#599 as designed.

## Why these choices

- **`'strict-dynamic'`, not nonce-only.** The built app code-splits per page and Inertia pulls further chunks at runtime via dynamic `import()`. Those tags carry no nonce, so nonce-only would break every client-side navigation to a not-yet-loaded page. `'self'` stays as the CSP2 fallback.
- **One nonce, bridged.** `AddContentSecurityPolicyHeaders` sets `Vite::useCspNonce(app('csp-nonce'))` on the way *in*, so the Blade shell's inline appearance script (`@cspNonce`) and every `@vite` tag share one value. Verified: all 17 asset tags plus the inline script carry the same nonce.
- **`connect-src` derived, not hardcoded.** New `ReverbConfig::websocketOrigin()` maps the same browser-facing config the SPA is handed (`http`→`ws`, `https`→`wss`, host + port), so the policy and the Echo client cannot drift.
- **`style-src 'unsafe-inline'` and `img-src https:` are accepted residuals**, documented in the security docs with their reasons (runtime style *attributes* from reka-ui/shadcn; unenumerable link-preview/Giphy/Gravatar hosts). Neither can execute script.
- **Enforcing by default.** A policy that ships opt-in protects nobody. The `CSP_EXTRA_*` keys are strictly additive — they can never drop the nonce or `'strict-dynamic'` — so the honest escape hatch for a bespoke policy is `CSP_ENABLED=false` plus an operator-set proxy header.
- **Not switched off in dev.** Hot mode appends the Vite dev-server origin (read from the hot file) to `script-src`/`style-src`/`connect-src` plus its `ws://`; `.env.example` ships `CSP_REPORT_ONLY=true` locally as the safety net.

The middleware replaces spatie's own `AddCspHeaders` for two reasons, both in its docblock: the enforcing/report-only choice has to be read from config per request (spatie's is baked into the config file's preset lists, so `config()->set()` and a runtime flip cannot reach it), and the nonce must reach Vite before the shell renders.

## Middleware placement

Appended to the **web** group only, first in the list so it runs ahead of `HandleInertiaRequests`. The API group is left out — a JSON response has no DOM to protect.

## Env

Additive-only, picked up by the #588 new-key detection: `CSP_ENABLED`, `CSP_REPORT_ONLY`, and `CSP_EXTRA_{SCRIPT,STYLE,IMG,CONNECT,FRAME}_SRC`. Added to `.env.example` (report-only on for local) and `.env.prod.example` (enforcing).

## Testing

- 17 feature tests: header present on web / absent on `api/*`; nonce in the header matches the one rendered into the Blade shell; nonce differs across requests; `CSP_ENABLED=false`; report-only; each `CSP_EXTRA_*` appends without dropping the nonce or `'strict-dynamic'`; comma-separated lists; an extra `frame-src` replacing `'none'`; the derived websocket origin and its `'self'`-only fallback; the hot-mode branch (faked via `Vite::useHotFile`).
- 4 unit tests for `ReverbConfig::websocketOrigin()`.
- One browser test drives login → channel → an Inertia client-side visit under an **enforcing** policy and asserts no `securitypolicyviolation` fired. Its teeth were verified: with `script-src 'none'` it fails.
- Ten browser tests were additionally run with `CSP_REPORT_ONLY=false` and pass.
- `./vendor/bin/sail composer test` reports `Total: 100.0 %` with clean Pint/PHPStan/Rector; `lint:check`, `format:check`, `types:check`, `build` and `test:js` all pass; `cd docs && npm run build` passes and the new anchors resolve.

Static scan backing the tighter directives: no `new Function(`/eval in any built bundle, no `<iframe>`, no `new Worker`, no `<video>`/`<audio>`. Attachments are served through first-party routes even on an S3 disk, so `media-src 'self'` holds.

## Docs

- `reference/security.md` — the policy table, the two accepted residuals, and a note on Cloudflare features that inject `/cdn-cgi/` scripts (they carry no nonce and will be blocked).
- `reference/feature-toggles.md` — `CSP_ENABLED` / `CSP_REPORT_ONLY` and the allow-listing keys.
- `reference/environment-variables.md` — the seven keys.
- `self-hosting/upgrading.md` — a caution that an enforcing policy takes effect on upgrade without adopting the new key, with the report-only dry-run recipe.

## Follow-ups

- #648 — a first-party image proxy, which would let `img-src` drop the `https:` wildcard.
- The `/cdn-cgi` verification against the live demo stays with #601.