### PR TITLE
feat: declare base-uri, form-action and object-src in the csp

### DIFF
--- a/app/Support/Csp/TheDeskPolicy.php
+++ b/app/Support/Csp/TheDeskPolicy.php
@@ -69,7 +69,22 @@ final class TheDeskPolicy implements Preset
             // Nothing uses workers today; this spares the next person the
             // baffling bug when something does.
             ->add(Directive::WORKER, Keyword::SELF)
-            ->add(Directive::FRAME, Keyword::NONE);
+            ->add(Directive::FRAME, Keyword::NONE)
+            // The three below do not fall back to default-src, so leaving them
+            // out leaves them unrestricted no matter how tight default-src is —
+            // the lesson a surface scan of the demo taught us the hard way.
+            //
+            // base-uri: an injected <base href> rewrites every relative URL on
+            // the page, which turns a markup injection into script loading from
+            // an attacker origin without ever writing a <script src>.
+            ->add(Directive::BASE, Keyword::SELF)
+            // form-action: nothing in the app posts off-origin, so this closes
+            // the injected-form credential-phishing path outright, and bounds
+            // the exfiltration left open by the wide img-src.
+            ->add(Directive::FORM_ACTION, Keyword::SELF)
+            // object-src: <object>/<embed> can execute plugin content and are
+            // not covered by script-src. The app renders none.
+            ->add(Directive::OBJECT, Keyword::NONE);
 
         $this->allowReverb($policy);
         $this->allowViteDevServer($policy);

--- a/app/Support/Csp/TheDeskPolicy.php
+++ b/app/Support/Csp/TheDeskPolicy.php
@@ -70,9 +70,10 @@ final class TheDeskPolicy implements Preset
             // baffling bug when something does.
             ->add(Directive::WORKER, Keyword::SELF)
             ->add(Directive::FRAME, Keyword::NONE)
-            // The three below do not fall back to default-src, so leaving them
-            // out leaves them unrestricted no matter how tight default-src is —
-            // the lesson a surface scan of the demo taught us the hard way.
+            // base-uri and form-action are document/navigation directives: they
+            // do not fall back to default-src, so omitting them leaves them
+            // unrestricted no matter how tight default-src is — the lesson a
+            // surface scan of the demo taught us the hard way.
             //
             // base-uri: an injected <base href> rewrites every relative URL on
             // the page, which turns a markup injection into script loading from
@@ -82,8 +83,10 @@ final class TheDeskPolicy implements Preset
             // the injected-form credential-phishing path outright, and bounds
             // the exfiltration left open by the wide img-src.
             ->add(Directive::FORM_ACTION, Keyword::SELF)
-            // object-src: <object>/<embed> can execute plugin content and are
-            // not covered by script-src. The app renders none.
+            // object-src does fall back to default-src, but 'self' is the wrong
+            // answer for it: <object>/<embed> load plugin documents that
+            // script-src never sees, and the app renders none, so state the
+            // stricter 'none' rather than inherit the laxer default.
             ->add(Directive::OBJECT, Keyword::NONE);
 
         $this->allowReverb($policy);

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -77,12 +77,14 @@ app's own inline script runs only because it carries a per-request nonce, and th
 page chunks the app loads as you navigate run only because `'strict-dynamic'`
 extends that trust to them. Injected markup gets neither.
 
-The last three are stated separately for a reason: `base-uri`, `form-action` and
-`object-src` do **not** fall back to `default-src`. A policy that omits them
-leaves them wide open however tight `default-src` is, so an injected
-`<base href="//attacker">` could still repoint every relative URL on the page, a
-fake login form could still post credentials off-origin, and `<object>` could
-still load plugin content that `script-src` never sees.
+`base-uri` and `form-action` are stated separately for a reason: they do **not**
+fall back to `default-src`. A policy that omits them leaves them wide open
+however tight `default-src` is, so an injected `<base href="//attacker">` could
+still repoint every relative URL on the page, and a fake login form could still
+post credentials off-origin. `object-src` does fall back, but only to
+`default-src 'self'`; nothing in The Desk renders an `<object>` or `<embed>`,
+and the plugin documents they load are outside what `script-src` governs, so it
+is denied outright instead.
 
 ### Accepted residuals
 

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -68,11 +68,21 @@ The policy sent is:
 | `media-src`   | `'self'`                                     |
 | `worker-src`  | `'self'`                                     |
 | `frame-src`   | `'none'`                                     |
+| `base-uri`    | `'self'`                                     |
+| `form-action` | `'self'`                                     |
+| `object-src`  | `'none'`                                     |
 
 Scripts are the directive that matters, and they carry no `'unsafe-inline'`: the
 app's own inline script runs only because it carries a per-request nonce, and the
 page chunks the app loads as you navigate run only because `'strict-dynamic'`
 extends that trust to them. Injected markup gets neither.
+
+The last three are stated separately for a reason: `base-uri`, `form-action` and
+`object-src` do **not** fall back to `default-src`. A policy that omits them
+leaves them wide open however tight `default-src` is, so an injected
+`<base href="//attacker">` could still repoint every relative URL on the page, a
+fake login form could still post credentials off-origin, and `<object>` could
+still load plugin content that `script-src` never sees.
 
 ### Accepted residuals
 

--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -47,6 +47,19 @@ test('web responses carry the policy', function (): void {
         ->toContain("frame-src 'none'");
 });
 
+test('the directives that do not fall back to default-src are stated explicitly', function (string $directive): void {
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)->toContain($directive);
+})->with([
+    // None of these inherit default-src, so a policy that omits them leaves the
+    // matching attack (a swapped <base href>, a form posted off-origin, a plugin
+    // document) entirely unrestricted — which is exactly what the scanner flags.
+    'base-uri' => ["base-uri 'self'"],
+    'form-action' => ["form-action 'self'"],
+    'object-src' => ["object-src 'none'"],
+]);
+
 test('api responses carry no policy — they have no dom to protect', function (): void {
     $response = $this->getJson('/api/v1/channels');
 

--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -52,13 +52,20 @@ test('the directives that do not fall back to default-src are stated explicitly'
 
     expect($header)->toContain($directive);
 })->with([
-    // None of these inherit default-src, so a policy that omits them leaves the
-    // matching attack (a swapped <base href>, a form posted off-origin, a plugin
-    // document) entirely unrestricted — which is exactly what the scanner flags.
+    // Neither inherits default-src, so a policy that omits them leaves the
+    // matching attack (a swapped <base href>, a form posted off-origin)
+    // entirely unrestricted — which is exactly what the scanner flags.
     'base-uri' => ["base-uri 'self'"],
     'form-action' => ["form-action 'self'"],
-    'object-src' => ["object-src 'none'"],
 ]);
+
+test('object-src is denied outright rather than inheriting default-src', function (): void {
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    // It would fall back to default-src 'self'; nothing here renders an
+    // <object>/<embed>, and their plugin documents are outside script-src.
+    expect($header)->toContain("object-src 'none'");
+});
 
 test('api responses carry no policy — they have no dom to protect', function (): void {
     $response = $this->getJson('/api/v1/channels');


### PR DESCRIPTION
Closes #601.

Second change on the security-headers family, on top of the CSP foundation (#650). `frame-ancestors` and `X-Frame-Options` stay with #599, which owns making the allowed ancestors operator-configurable.

## What

Three directives added to `App\Support\Csp\TheDeskPolicy`:

| Directive | Value |
|---|---|
| `base-uri` | `'self'` |
| `form-action` | `'self'` |
| `object-src` | `'none'` |

## Why

`base-uri` and `form-action` are document/navigation directives: they do **not** fall back to `default-src`, so however tight `default-src 'self'` is, omitting them leaves an injected `<base href="//attacker">` free to repoint every relative URL on the page (script loading from an attacker origin without ever writing a `<script src>`), and a fake login form free to post credentials off-origin. `form-action 'self'` also bounds the exfiltration path left open by the deliberately wide `img-src https:`.

`object-src` *does* fall back to `default-src` — CodeRabbit caught me claiming otherwise in the first commit — but it would inherit `'self'`, and `<object>`/`<embed>` load plugin documents that `script-src` never governs. Nothing in the app renders one, so it is denied outright.

Verified safe against the codebase before flipping: no `<base>` tag anywhere in `resources/`, no form with an absolute cross-origin `action`, no `<object>`/`<embed>`. Socialite/OIDC hand off by redirect (a `GET`), not a cross-origin form post, so `form-action 'self'` does not touch SSO.

## The `/cdn-cgi` half of the issue

Confirmed Cloudflare's, not ours. `GET https://demo-the-desk.emmanuelpaul.com/cdn-cgi/content?id=x` answers `404` with `server: cloudflare` + `cf-ray` and no origin round-trip — while the app origin itself was returning `502` at the same moment, which is the proof: the edge served that path without the app being reachable at all. The app has no `/cdn-cgi` route, and `/cdn-cgi/` is Cloudflare's reserved namespace. The reported `default-src 'none'` is Cloudflare's own policy on that response.

**Action left for a human (needs Aikido access):** suppress/close finding 601 in Aikido with that note, and re-scan once this and #599 are deployed to confirm it does not reappear against an app-served URL.

## Testing

- `tests/Feature/Middleware/ContentSecurityPolicyTest.php` — a dataset asserting `base-uri 'self'` and `form-action 'self'` are present, plus a test for `object-src 'none'` naming the fall-back it is overriding.
- `./vendor/bin/sail composer test` green, `Total: 100.0 %`.
- Docs site builds clean.

## Docs

`docs/.../reference/security.md`: the three directives added to the policy table, with the fall-back reasoning spelled out so the next person does not "simplify" them away.

No new env keys, so no `environment-variables.md` / `feature-toggles.md` change. No user-facing copy, so no i18n keys.

## Found while doing this

- #651 — there is no `CSP_EXTRA_FONT_SRC`, so an operator who allow-lists a font CDN via `CSP_EXTRA_STYLE_SRC` still has its `@font-face` files blocked by `font-src 'self'`. The escape hatch is half-built. Filed, not fixed here.