### PR TITLE
feat: add CSP_EXTRA_FONT_SRC to allow-list an external font host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,12 +200,15 @@ CSP_ENABLED=true
 # instead of a blank page) and off by default everywhere else.
 CSP_REPORT_ONLY=true
 # Comma-separated extra origins, appended to (never replacing) the defaults —
-# for an analytics snippet, a corporate asset host, or an embedded frame.
+# for an analytics snippet, a corporate asset host, an embedded frame, or an
+# external font provider. A font provider needs both halves: the stylesheet host
+# on CSP_EXTRA_STYLE_SRC and the font-file host on CSP_EXTRA_FONT_SRC.
 # CSP_EXTRA_SCRIPT_SRC=
 # CSP_EXTRA_STYLE_SRC=
 # CSP_EXTRA_IMG_SRC=
 # CSP_EXTRA_CONNECT_SRC=
 # CSP_EXTRA_FRAME_SRC=
+# CSP_EXTRA_FONT_SRC=
 
 LOG_CHANNEL=stack
 LOG_STACK=single

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -71,12 +71,16 @@ CSP_ENABLED=true
 # adding scripts of your own, then turn it back off.
 # CSP_REPORT_ONLY=false
 # Comma-separated extra origins, appended to (never replacing) the defaults —
-# for an analytics snippet, a corporate asset host, or an embedded frame.
+# for an analytics snippet, a corporate asset host, an embedded frame, or a web
+# font of your own. Fonts take two keys: the host serving the stylesheet on
+# CSP_EXTRA_STYLE_SRC, the host serving the @font-face files on
+# CSP_EXTRA_FONT_SRC. The app's own fonts are self-hosted and need neither.
 # CSP_EXTRA_SCRIPT_SRC=
 # CSP_EXTRA_STYLE_SRC=
 # CSP_EXTRA_IMG_SRC=
 # CSP_EXTRA_CONNECT_SRC=
 # CSP_EXTRA_FRAME_SRC=
+# CSP_EXTRA_FONT_SRC=
 
 # --- Single sign-on (OpenID Connect) -----------------------------------------
 # SSO_OIDC_ISSUER=https://your-idp.example.com

--- a/app/Support/Csp/TheDeskPolicy.php
+++ b/app/Support/Csp/TheDeskPolicy.php
@@ -34,6 +34,7 @@ final class TheDeskPolicy implements Preset
         'img-src' => Directive::IMG,
         'connect-src' => Directive::CONNECT,
         'frame-src' => Directive::FRAME,
+        'font-src' => Directive::FONT,
     ];
 
     public function configure(Policy $policy): void

--- a/config/csp.php
+++ b/config/csp.php
@@ -53,6 +53,10 @@ return [
     | script-src, so an extra script host only takes effect for a script tag that
     | is itself loaded by an already-trusted (nonced) script.
     |
+    | An external font provider needs both halves: the stylesheet host on
+    | CSP_EXTRA_STYLE_SRC and the host its @font-face src: URLs point at on
+    | CSP_EXTRA_FONT_SRC. One without the other still fails.
+    |
     */
 
     'extra' => [
@@ -61,6 +65,7 @@ return [
         'img-src' => env('CSP_EXTRA_IMG_SRC', ''),
         'connect-src' => env('CSP_EXTRA_CONNECT_SRC', ''),
         'frame-src' => env('CSP_EXTRA_FRAME_SRC', ''),
+        'font-src' => env('CSP_EXTRA_FONT_SRC', ''),
     ],
 
     /*

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -127,8 +127,9 @@ production — see [Configuration](/docs/self-hosting/configuration/#reverb-webs
 ## Content Security Policy
 
 Comma-separated origins **appended** to the shipped policy, for a script,
-stylesheet, image host, API or embedded frame of your own. They are additive
-only: none of them can remove the script nonce or `'strict-dynamic'`. See
+stylesheet, image host, API, embedded frame or font provider of your own. They
+are additive only: none of them can remove the script nonce or
+`'strict-dynamic'`. See
 [Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy).
 
 | Variable                | Default | Adds to       |
@@ -138,6 +139,19 @@ only: none of them can remove the script nonce or `'strict-dynamic'`. See
 | `CSP_EXTRA_IMG_SRC`     | *(none)* | `img-src`     |
 | `CSP_EXTRA_CONNECT_SRC` | *(none)* | `connect-src` |
 | `CSP_EXTRA_FRAME_SRC`   | *(none)* | `frame-src`   |
+| `CSP_EXTRA_FONT_SRC`    | *(none)* | `font-src`    |
+
+An external font provider needs **both** halves, because the stylesheet and the
+font files it points at are served from different hosts and governed by
+different directives:
+
+```bash
+CSP_EXTRA_STYLE_SRC="https://fonts.googleapis.com"
+CSP_EXTRA_FONT_SRC="https://fonts.gstatic.com"
+```
+
+One without the other still fails. The app self-hosts its own fonts, so you only
+need this if you deliberately add a web font of your own.
 
 ## Single sign-on (OpenID Connect)
 

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -141,16 +141,18 @@ are additive only: none of them can remove the script nonce or
 | `CSP_EXTRA_FRAME_SRC`   | *(none)* | `frame-src`   |
 | `CSP_EXTRA_FONT_SRC`    | *(none)* | `font-src`    |
 
-An external font provider needs **both** halves, because the stylesheet and the
-font files it points at are served from different hosts and governed by
-different directives:
+A stylesheet origin belongs in `CSP_EXTRA_STYLE_SRC` and a font-file origin in
+`CSP_EXTRA_FONT_SRC`, independently. Google Fonts serves the two from different
+hosts, so it needs both:
 
 ```bash
 CSP_EXTRA_STYLE_SRC="https://fonts.googleapis.com"
 CSP_EXTRA_FONT_SRC="https://fonts.gstatic.com"
 ```
 
-One without the other still fails. The app self-hosts its own fonts, so you only
+There, one without the other still fails. A provider serving both from one
+origin needs that origin in both keys, and a font referenced from your own CSS
+needs only `CSP_EXTRA_FONT_SRC`. The app self-hosts its own fonts, so you only
 need this if you deliberately add a web font of your own.
 
 ## Single sign-on (OpenID Connect)

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -238,11 +238,11 @@ it on permanently protects nobody.
 
 ### Allow-listing your own origins
 
-If you add a script, stylesheet, image host, API or embedded frame of your own,
-name it in the matching key rather than disabling the policy. Values are
-comma-separated and **appended** to the defaults — they can never remove the
-script nonce or `'strict-dynamic'`, so an allow-list entry cannot silently
-un-harden the app.
+If you add a script, stylesheet, image host, API, embedded frame or font
+provider of your own, name it in the matching key rather than disabling the
+policy. Values are comma-separated and **appended** to the defaults — they can
+never remove the script nonce or `'strict-dynamic'`, so an allow-list entry
+cannot silently un-harden the app.
 
 | Variable                | Adds to       |
 | ----------------------- | ------------- |
@@ -251,11 +251,27 @@ un-harden the app.
 | `CSP_EXTRA_IMG_SRC`     | `img-src`     |
 | `CSP_EXTRA_CONNECT_SRC` | `connect-src` |
 | `CSP_EXTRA_FRAME_SRC`   | `frame-src`   |
+| `CSP_EXTRA_FONT_SRC`    | `font-src`    |
 
 ```bash
 CSP_EXTRA_SCRIPT_SRC="https://analytics.example.com"
 CSP_EXTRA_CONNECT_SRC="https://analytics.example.com"
 ```
+
+An external font provider takes **two** keys, because the stylesheet and the
+font files it references live on different hosts and are governed by different
+directives. Google Fonts is the worked example:
+
+```bash
+CSP_EXTRA_STYLE_SRC="https://fonts.googleapis.com"
+CSP_EXTRA_FONT_SRC="https://fonts.gstatic.com"
+```
+
+Setting only `CSP_EXTRA_STYLE_SRC` lets the stylesheet load and then blocks
+every `@font-face` file it asks for, so the text still falls back. You need
+both, or neither. The app self-hosts its own fonts, so reach for this only if
+you deliberately add a web font of your own — see
+[Security → Content Security Policy](/docs/reference/security/#content-security-policy).
 
 :::note
 `script-src` uses `'strict-dynamic'`, and browsers that understand it ignore host

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -258,19 +258,23 @@ CSP_EXTRA_SCRIPT_SRC="https://analytics.example.com"
 CSP_EXTRA_CONNECT_SRC="https://analytics.example.com"
 ```
 
-An external font provider takes **two** keys, because the stylesheet and the
-font files it references live on different hosts and are governed by different
-directives. Google Fonts is the worked example:
+An external font is governed by two directives, because a stylesheet and the
+font files it references are different resource types: the host serving the CSS
+goes in `CSP_EXTRA_STYLE_SRC`, and the host serving the `@font-face` files goes
+in `CSP_EXTRA_FONT_SRC`. Google Fonts splits those across two hosts, so it needs
+both:
 
 ```bash
 CSP_EXTRA_STYLE_SRC="https://fonts.googleapis.com"
 CSP_EXTRA_FONT_SRC="https://fonts.gstatic.com"
 ```
 
-Setting only `CSP_EXTRA_STYLE_SRC` lets the stylesheet load and then blocks
-every `@font-face` file it asks for, so the text still falls back. You need
-both, or neither. The app self-hosts its own fonts, so reach for this only if
-you deliberately add a web font of your own — see
+Setting only `CSP_EXTRA_STYLE_SRC` there lets the stylesheet load and then
+blocks every `@font-face` file it asks for, so the text still falls back — the
+half-configured case is the one that looks mysterious. A provider that serves
+both from a single origin needs that origin in both keys; a font referenced from
+your own CSS needs only `CSP_EXTRA_FONT_SRC`. The app self-hosts its own fonts,
+so reach for this only if you deliberately add a web font of your own — see
 [Security → Content Security Policy](/docs/reference/security/#content-security-policy).
 
 :::note

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -114,15 +114,17 @@ challenge that renders in a frame).
 ### Fonts are self-hosted
 
 The app ships its own font files: they are downloaded at build time and served
-from your own origin, which is why `font-src` is just `'self'`. The app never
-requests `fonts.googleapis.com` or `fonts.gstatic.com`.
+from your own origin, which is why `font-src` defaults to `'self'` — anything
+you add with `CSP_EXTRA_FONT_SRC` is appended to it. The app never requests
+`fonts.googleapis.com` or `fonts.gstatic.com`.
 
 So a Google Fonts violation in the browser console does **not** come from the
 app. Something else is injecting stylesheets into the page — a browser
 extension, or an edge feature that rewrites your HTML. Check those first. If you
-have genuinely added a web font of your own, allow-list both halves of it with
-`CSP_EXTRA_STYLE_SRC` (the stylesheet host) and `CSP_EXTRA_FONT_SRC` (the host
-the `@font-face` files come from); one without the other still fails.
+have genuinely added a web font of your own, allow-list each origin it uses in
+the matching key: the host serving the stylesheet in `CSP_EXTRA_STYLE_SRC`, and
+the host serving the `@font-face` files in `CSP_EXTRA_FONT_SRC`. Google Fonts
+splits those across two hosts and so needs both.
 
 ## Hardening your deployment
 

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -111,6 +111,19 @@ any of them, either turn that Cloudflare feature off for the app's hostname or
 allow-list it with `CSP_EXTRA_SCRIPT_SRC` (and `CSP_EXTRA_FRAME_SRC` for a
 challenge that renders in a frame).
 
+### Fonts are self-hosted
+
+The app ships its own font files: they are downloaded at build time and served
+from your own origin, which is why `font-src` is just `'self'`. The app never
+requests `fonts.googleapis.com` or `fonts.gstatic.com`.
+
+So a Google Fonts violation in the browser console does **not** come from the
+app. Something else is injecting stylesheets into the page — a browser
+extension, or an edge feature that rewrites your HTML. Check those first. If you
+have genuinely added a web font of your own, allow-list both halves of it with
+`CSP_EXTRA_STYLE_SRC` (the stylesheet host) and `CSP_EXTRA_FONT_SRC` (the host
+the `@font-face` files come from); one without the other still fails.
+
 ## Hardening your deployment
 
 Most security outcomes for a self-hosted instance depend on how you run it. Follow

--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -30,6 +30,7 @@ beforeEach(function (): void {
             'img-src' => '',
             'connect-src' => '',
             'frame-src' => '',
+            'font-src' => '',
         ],
     ]);
 });
@@ -164,7 +165,21 @@ test('each extra source is appended without dropping our defaults', function (st
     'image' => ['img-src', 'img-src', 'https://images.example.test'],
     'connect' => ['connect-src', 'connect-src', 'https://api.example.test'],
     'frame' => ['frame-src', 'frame-src', 'https://embed.example.test'],
+    'font' => ['font-src', 'font-src', 'https://fonts.example.test'],
 ]);
+
+test('allow-listing an external font pairing takes both the stylesheet host and the font host', function (): void {
+    config([
+        'csp.extra.style-src' => 'https://fonts.googleapis.test',
+        'csp.extra.font-src' => 'https://fonts.gstatic.test',
+    ]);
+
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)
+        ->toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.test")
+        ->toContain("font-src 'self' https://fonts.gstatic.test");
+});
 
 test('a comma-separated extra list allow-lists every origin in it', function (): void {
     config(['csp.extra.img-src' => 'https://one.example.test, https://two.example.test']);


### PR DESCRIPTION
Closes #651.

## What

`font-src` was the one directive with no `CSP_EXTRA_*` escape hatch, which left
the allow-list half-built: an operator could get an external stylesheet through
with `CSP_EXTRA_STYLE_SRC`, and then the `@font-face` `src:` URLs it points at
were blocked by `font-src 'self'` with no key left to turn.

This adds `CSP_EXTRA_FONT_SRC`, wired into `TheDeskPolicy::EXTENDABLE_DIRECTIVES`
exactly like the existing five — strictly additive, so it can never drop the
nonce or `'strict-dynamic'`.

## Why

Reported against a deployment running `CSP_REPORT_ONLY=true` that logged Google
Fonts stylesheet violations. The app does not load Google Fonts: it self-hosts
its two families through `laravel-vite-plugin/fonts`, downloaded at build time
and served same-origin. Those tags were injected by something outside the app (a
browser extension or an edge feature), which is CSP doing its job. But the
report surfaced the real gap above.

## How tested

- `font` case added to the existing extendable-directives dataset in
  `tests/Feature/Middleware/ContentSecurityPolicyTest.php`.
- A new test for the style + font pairing, asserting both hosts land on their
  own directive without displacing the defaults.
- Both were red before the change, green after. Full gate green at
  `Total: 100.0 %`, frontend gate and docs build clean.

## Docs

- `reference/environment-variables.md` and `reference/feature-toggles.md`: the
  new key in the allow-list tables, with Google Fonts as the worked example and
  a note that the half-configured case is the one that looks mysterious.
- `reference/security.md`: a new "Fonts are self-hosted" section, so the next
  person who sees a Google Fonts violation checks extensions and edge
  script-injection before allow-listing anything.
- `.env.example`: commented `CSP_EXTRA_FONT_SRC=`.

No new user-facing UI copy, so no i18n catalog changes.