### PR TITLE
feat: proxy remote images so img-src can drop the https: wildcard

### DIFF
--- a/app/Actions/Images/PurgeCachedProxyImages.php
+++ b/app/Actions/Images/PurgeCachedProxyImages.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Images;
+
+use App\Support\Images\FetchRemoteImage;
+use Illuminate\Support\Facades\Storage;
+
+class PurgeCachedProxyImages
+{
+    /**
+     * Delete proxied image bytes that have outlived their cache TTL.
+     *
+     * The cache-store entry pointing at each file expires on its own, but the
+     * file would otherwise sit on disk forever — an avatar or a link thumbnail
+     * nobody has loaded in a week is pure dead weight. A file that is still
+     * wanted is simply refetched on the next request.
+     *
+     * @return int the number of cached images deleted
+     */
+    public function handle(): int
+    {
+        $disk = Storage::disk(FetchRemoteImage::DISK);
+        $cutoff = now()->subSeconds(FetchRemoteImage::CACHE_TTL_SECONDS)->getTimestamp();
+
+        $purged = 0;
+
+        foreach ($disk->files(FetchRemoteImage::DIRECTORY) as $file) {
+            if ($disk->lastModified($file) >= $cutoff) {
+                continue;
+            }
+
+            $disk->delete($file);
+
+            $purged++;
+        }
+
+        return $purged;
+    }
+}

--- a/app/Data/LinkPreviewData.php
+++ b/app/Data/LinkPreviewData.php
@@ -3,6 +3,7 @@
 namespace App\Data;
 
 use App\Models\MessageLinkPreview;
+use App\Support\Images\ImageProxy;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
@@ -24,6 +25,10 @@ class LinkPreviewData extends Data
      * `status` is `pending` while the queued unfurl runs (the client shows a
      * skeleton) and `ready` once the metadata resolves. Failed rows are filtered
      * out upstream in {@see MessageData::fromMessage()} so they never reach here.
+     *
+     * `imageUrl` is rewritten to the first-party image proxy: the thumbnail was
+     * scraped from whatever site was linked, and hotlinking it would leak every
+     * reader's IP to that site and force `img-src` to allow any HTTPS host.
      */
     public static function fromModel(MessageLinkPreview $preview): self
     {
@@ -32,7 +37,7 @@ class LinkPreviewData extends Data
             status: $preview->status->value,
             title: $preview->title,
             description: $preview->description,
-            imageUrl: $preview->image_url,
+            imageUrl: ImageProxy::url($preview->image_url),
             siteName: $preview->site_name,
         );
     }

--- a/app/Http/Controllers/ImageProxyController.php
+++ b/app/Http/Controllers/ImageProxyController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Support\Images\FetchRemoteImage;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ImageProxyController extends Controller
+{
+    /**
+     * Serve a remote image from the app's own origin.
+     *
+     * The route is authenticated *and* signed: the session keeps it off the
+     * public internet, and the signature — checked by the `signed` middleware
+     * before this runs — pins the `url` parameter to one the server generated,
+     * so a member cannot turn the endpoint into an open proxy or an SSRF probe.
+     * Anything the fetcher declines (a non-public host, a non-image, an oversized
+     * body, an unreachable origin) is a 404, never a 500, so an instance without
+     * egress simply shows the initials avatar and no link thumbnail.
+     */
+    public function __invoke(Request $request, FetchRemoteImage $fetchRemoteImage): StreamedResponse
+    {
+        $url = trim((string) $request->query('url', ''));
+
+        $image = $url === '' ? null : $fetchRemoteImage->handle($url);
+
+        abort_if($image === null, 404);
+
+        return Storage::disk(FetchRemoteImage::DISK)->response(
+            $image['path'],
+            null,
+            [
+                'Content-Type' => $image['mime'],
+                'X-Content-Type-Options' => 'nosniff',
+                'Cache-Control' => 'private, max-age='.FetchRemoteImage::CACHE_TTL_SECONDS,
+            ],
+            'inline',
+        );
+    }
+}

--- a/app/Jobs/DeliverWebhook.php
+++ b/app/Jobs/DeliverWebhook.php
@@ -8,8 +8,8 @@ use App\Enums\AuditAction;
 use App\Enums\WebhookSubscriptionStatus;
 use App\Models\WebhookSubscription;
 use App\Support\AuditRecorder;
+use App\Support\Http\OutboundUrlGuard;
 use App\Support\Webhooks\WebhookSignature;
-use App\Support\Webhooks\WebhookUrlGuard;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Http\Client\Response;
@@ -71,7 +71,7 @@ class DeliverWebhook implements ShouldQueue
     /**
      * Attempt one delivery.
      */
-    public function handle(AuditRecorder $recorder, WebhookUrlGuard $guard): void
+    public function handle(AuditRecorder $recorder, OutboundUrlGuard $guard): void
     {
         if (! config('integrations.enabled')) {
             return;
@@ -83,7 +83,7 @@ class DeliverWebhook implements ShouldQueue
             return;
         }
 
-        if (! WebhookUrlGuard::isPublic($subscription->url)) {
+        if (! OutboundUrlGuard::isPublic($subscription->url)) {
             $this->recordFailure($subscription, $recorder, null, 'Blocked non-public webhook URL', 0);
 
             return;
@@ -109,7 +109,7 @@ class DeliverWebhook implements ShouldQueue
                 'X-Desk-Signature' => WebhookSignature::header($subscription->secret, $body, $timestamp),
             ])
                 ->timeout((int) config('integrations.webhooks.timeout'))
-                ->withOptions($this->transportOptions($subscription->url, $pinnedIp))
+                ->withOptions($guard->transportOptions($subscription->url, $pinnedIp))
                 ->withBody($body, 'application/json')
                 ->post($subscription->url);
         } catch (Throwable $exception) {
@@ -125,34 +125,6 @@ class DeliverWebhook implements ShouldQueue
         }
 
         $this->recordFailure($subscription, $recorder, $response->status(), 'HTTP '.$response->status(), $this->elapsedMs($startedAt));
-    }
-
-    /**
-     * Guzzle options for the delivery request: redirects disabled (a redirect
-     * would bounce the signed POST onto a target the URL guard never vetted),
-     * and — when the guard resolved a hostname — the connection pinned to the
-     * vetted IP so a DNS rebind between validation and connect can't retarget
-     * it either.
-     *
-     * @return array<string, mixed>
-     */
-    private function transportOptions(string $url, ?string $pinnedIp): array
-    {
-        $options = ['allow_redirects' => false];
-
-        if ($pinnedIp === null) {
-            return $options;
-        }
-
-        $parts = parse_url($url);
-        $host = (string) ($parts['host'] ?? '');
-        $port = (int) ($parts['port'] ?? (strtolower((string) ($parts['scheme'] ?? '')) === 'http' ? 80 : 443));
-
-        $address = str_contains($pinnedIp, ':') ? '['.$pinnedIp.']' : $pinnedIp;
-
-        $options['curl'] = [CURLOPT_RESOLVE => [sprintf('%s:%d:%s', $host, $port, $address)]];
-
-        return $options;
     }
 
     /**

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\AttachmentSource;
 use App\Enums\AttachmentStatus;
+use App\Support\Images\ImageProxy;
 use Database\Factories\AttachmentFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -153,15 +154,17 @@ class Attachment extends Model
      * team are expected to be eager-loaded (via the message payload's relation
      * set) so building this per attachment stays N+1-free.
      *
-     * A remote attachment (Giphy) has no blob to serve, so its media is the
-     * CDN URL hotlinked directly — the blob-only serve route does not apply.
+     * A remote attachment (Giphy) has no blob to serve, so the blob-only serve
+     * route does not apply; its media goes through the first-party image proxy
+     * instead of being hotlinked, so the reader's IP never reaches Giphy's CDN
+     * and `img-src` needs no wildcard.
      *
      * @return Attribute<string, never>
      */
     protected function url(): Attribute
     {
         return Attribute::get(fn (): string => $this->source === AttachmentSource::Giphy
-            ? (string) $this->remote_url
+            ? (string) ImageProxy::url($this->remote_url)
             : route('channels.attachments.download', [
                 'team' => $this->channel->team->slug,
                 'channel' => $this->channel->slug,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use App\Enums\TeamRole;
 use App\Enums\UserType;
 use App\Observers\UserObserver;
 use App\Support\Gravatar;
+use App\Support\Images\ImageProxy;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Translation\HasLocalePreference;
@@ -112,15 +113,17 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
      * serialises a user (nav, team members, message authors, hover cards, read
      * receipts) reads this. An explicit `avatar_url` (an uploaded image, or the
      * demo seeder's generated identicons) wins; otherwise it derives from the
-     * email's Gravatar. Null when there is no stored URL and Gravatar is
-     * disabled, and — with the `404` default — a user without a Gravatar yields
-     * a URL that 404s so the frontend cleanly falls back to its initials avatar.
+     * email's Gravatar — routed through the first-party image proxy, so the
+     * browser never talks to gravatar.com and no reader's IP leaks to it. Null
+     * when there is no stored URL and Gravatar is disabled, and — with the `404`
+     * default — a user without a Gravatar yields a URL that 404s so the frontend
+     * cleanly falls back to its initials avatar.
      *
      * @return Attribute<covariant string|null, never>
      */
     protected function avatar(): Attribute
     {
-        return Attribute::get(fn (): ?string => $this->avatar_url ?? Gravatar::url($this->email));
+        return Attribute::get(fn (): ?string => $this->avatar_url ?? ImageProxy::url(Gravatar::url($this->email)));
     }
 
     /**

--- a/app/Rules/PublicWebhookUrl.php
+++ b/app/Rules/PublicWebhookUrl.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace App\Rules;
 
-use App\Support\Webhooks\WebhookUrlGuard;
+use App\Support\Http\OutboundUrlGuard;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
 /**
  * Validation rule rejecting webhook destination URLs that aren't public
  * http/https addresses — the request-time half of the SSRF guard (see
- * {@see WebhookUrlGuard}). Loopback, private, link-local, and cloud-metadata
+ * {@see OutboundUrlGuard}). Loopback, private, link-local, and cloud-metadata
  * targets fail here before a subscription is ever stored.
  */
 class PublicWebhookUrl implements ValidationRule
@@ -22,7 +22,7 @@ class PublicWebhookUrl implements ValidationRule
             return;
         }
 
-        if (! WebhookUrlGuard::isPublic($value)) {
+        if (! OutboundUrlGuard::isPublic($value)) {
             $fail(__('The webhook URL must be a public HTTP or HTTPS address.'));
         }
     }

--- a/app/Support/Csp/TheDeskPolicy.php
+++ b/app/Support/Csp/TheDeskPolicy.php
@@ -55,11 +55,12 @@ final class TheDeskPolicy implements Preset
             // unsupported on Safari < 15.4. Script execution, the threat CSP is
             // bought for, is covered by script-src above.
             ->add(Directive::STYLE, [Keyword::SELF, Keyword::UNSAFE_INLINE])
-            // Accepted residual: link-preview thumbnails are scraped from
-            // arbitrary sites, Giphy results are hotlinked, and the Gravatar base
-            // URL is operator-configurable, so no enumerable host list exists.
-            // data:/blob: cover local upload previews.
-            ->add(Directive::IMG, [Keyword::SELF, Scheme::DATA, Scheme::BLOB, Scheme::HTTPS])
+            // No remote hosts: link-preview thumbnails, Giphy renditions and
+            // Gravatar avatars are all fetched server-side and re-served from
+            // our own origin (see App\Support\Images\ImageProxy), so nothing the
+            // browser loads is off-origin. data:/blob: cover local upload
+            // previews, which never leave the page.
+            ->add(Directive::IMG, [Keyword::SELF, Scheme::DATA, Scheme::BLOB])
             ->add(Directive::FONT, Keyword::SELF)
             ->add(Directive::CONNECT, Keyword::SELF)
             ->add(Directive::MEDIA, Keyword::SELF)
@@ -80,8 +81,7 @@ final class TheDeskPolicy implements Preset
             // an attacker origin without ever writing a <script src>.
             ->add(Directive::BASE, Keyword::SELF)
             // form-action: nothing in the app posts off-origin, so this closes
-            // the injected-form credential-phishing path outright, and bounds
-            // the exfiltration left open by the wide img-src.
+            // the injected-form credential-phishing path outright.
             ->add(Directive::FORM_ACTION, Keyword::SELF)
             // object-src does fall back to default-src, but 'self' is the wrong
             // answer for it: <object>/<embed> load plugin documents that

--- a/app/Support/FetchLinkPreview.php
+++ b/app/Support/FetchLinkPreview.php
@@ -2,6 +2,7 @@
 
 namespace App\Support;
 
+use App\Support\Http\AbsoluteUrl;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Symfony\Component\DomCrawler\Crawler;
@@ -97,7 +98,7 @@ class FetchLinkPreview
                     return null;
                 }
 
-                $url = $this->absolutize($url, $location);
+                $url = AbsoluteUrl::from($url, $location);
 
                 continue;
             }
@@ -175,7 +176,7 @@ class FetchLinkPreview
         return [
             'title' => $title,
             'description' => $this->metaContent($crawler, 'og:description'),
-            'image' => $image === null ? null : $this->absolutize($baseUrl, $image),
+            'image' => $image === null ? null : AbsoluteUrl::from($baseUrl, $image),
             'siteName' => $this->metaContent($crawler, 'og:site_name') ?? (parse_url($baseUrl, PHP_URL_HOST) ?: null),
         ];
     }
@@ -211,26 +212,5 @@ class FetchLinkPreview
         $text = trim($node->text());
 
         return $text === '' ? null : $text;
-    }
-
-    /**
-     * Resolve a possibly-relative URL against a base: absolute URLs pass through,
-     * protocol-relative URLs inherit the base scheme, and everything else is
-     * hung off the base origin.
-     */
-    private function absolutize(string $baseUrl, string $url): string
-    {
-        if (preg_match('#^https?://#i', $url) === 1) {
-            return $url;
-        }
-
-        $base = parse_url($baseUrl);
-        $scheme = $base['scheme'] ?? 'https';
-
-        if (str_starts_with($url, '//')) {
-            return $scheme.':'.$url;
-        }
-
-        return $scheme.'://'.($base['host'] ?? '').'/'.ltrim($url, '/');
     }
 }

--- a/app/Support/GiphyClient.php
+++ b/app/Support/GiphyClient.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use App\Actions\Channels\CreateGiphyAttachment;
 use App\Data\GiphyGifData;
 use App\Data\GiphySearchData;
+use App\Models\Attachment;
+use App\Support\Images\ImageProxy;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -54,7 +57,7 @@ class GiphyClient
         );
 
         return new GiphySearchData(
-            results: array_map(GiphyGifData::from(...), $payload['results']),
+            results: array_map($this->toData(...), $payload['results']),
             nextOffset: $payload['nextOffset'],
         );
     }
@@ -89,7 +92,25 @@ class GiphyClient
 
         $normalized = $this->normalize($gif);
 
-        return $normalized === null ? null : GiphyGifData::from($normalized);
+        return $normalized === null ? null : $this->toData($normalized);
+    }
+
+    /**
+     * Build the DTO from a normalized payload, routing the picker's grid preview
+     * through the first-party image proxy so the browser never loads a tile from
+     * Giphy's CDN (and `img-src` needs no wildcard). `url` deliberately stays the
+     * raw CDN URL: it is what {@see CreateGiphyAttachment}
+     * stores as the attachment's `remote_url`, and the proxying happens when that
+     * attachment is serialised (see {@see Attachment::url()}) so a
+     * stored row never carries a signature.
+     *
+     * @param  array<string, mixed>  $normalized
+     */
+    private function toData(array $normalized): GiphyGifData
+    {
+        $normalized['previewUrl'] = ImageProxy::url((string) $normalized['previewUrl']);
+
+        return GiphyGifData::from($normalized);
     }
 
     /**

--- a/app/Support/Http/AbsoluteUrl.php
+++ b/app/Support/Http/AbsoluteUrl.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Http;
+
+class AbsoluteUrl
+{
+    /**
+     * Resolve a possibly-relative URL against a base: absolute URLs pass through,
+     * protocol-relative URLs inherit the base scheme, and everything else is
+     * hung off the base origin.
+     *
+     * Redirect `Location` headers and Open Graph `og:image` values are both
+     * routinely relative, and both feed a URL straight back into the SSRF guard,
+     * so the two callers resolve them the same way.
+     */
+    public static function from(string $baseUrl, string $url): string
+    {
+        if (preg_match('#^https?://#i', $url) === 1) {
+            return $url;
+        }
+
+        $base = parse_url($baseUrl);
+        $scheme = $base['scheme'] ?? 'https';
+
+        if (str_starts_with($url, '//')) {
+            return $scheme.':'.$url;
+        }
+
+        return $scheme.'://'.($base['host'] ?? '').'/'.ltrim($url, '/');
+    }
+}

--- a/app/Support/Http/OutboundUrlGuard.php
+++ b/app/Support/Http/OutboundUrlGuard.php
@@ -2,22 +2,26 @@
 
 declare(strict_types=1);
 
-namespace App\Support\Webhooks;
+namespace App\Support\Http;
 
 use App\Support\HostResolver;
 
 /**
- * Decides whether a webhook destination URL is safe to deliver to, guarding the
- * outgoing-webhook feature against SSRF: a bot-token holder (or settings admin)
- * could otherwise point a subscription at `http://169.254.169.254/` (cloud
- * metadata), `http://localhost/`, or an internal service and have the app POST a
- * signed workspace event straight to it.
+ * Decides whether a member-controlled URL is safe for the server to open a
+ * connection to, guarding every outbound fetch against SSRF: a bot-token holder
+ * (or settings admin) could otherwise point a webhook subscription at
+ * `http://169.254.169.254/` (cloud metadata), `http://localhost/`, or an
+ * internal service and have the app POST a signed workspace event straight to
+ * it — and the image proxy fetches whatever URL a link preview or Giphy
+ * rendition points at.
  *
  * One config knob tunes the guard (see `config/integrations.php`):
  *
  *  - `integrations.webhooks.block_private_urls` (default true) — the master
  *    switch. When false the guard passes everything, for a locked-down
  *    self-hosted instance that deliberately targets internal-only endpoints.
+ *    The key kept its webhook-era name so existing `.env` files keep working;
+ *    it now governs every outbound fetch, not just webhook delivery.
  *
  * The static {@see self::isPublic()} check blocks by scheme, by literal
  * non-public IP (v4 and v6), and by local hostname — no DNS lookup, so it's
@@ -27,7 +31,7 @@ use App\Support\HostResolver;
  * is non-public, returning the vetted IP so the delivery can pin its connection
  * to it (closing the DNS-rebinding window between validation and connect).
  */
-class WebhookUrlGuard
+class OutboundUrlGuard
 {
     public function __construct(private readonly HostResolver $resolver) {}
 
@@ -113,6 +117,35 @@ class WebhookUrlGuard
         }
 
         return $ips[0];
+    }
+
+    /**
+     * Guzzle options for an outbound request the guard has vetted: redirects
+     * disabled (a redirect would bounce the request onto a target the guard
+     * never saw), and — when the guard resolved a hostname — the connection
+     * pinned to the vetted IP so a DNS rebind between the check and the connect
+     * can't retarget it either.
+     *
+     * @param  string|null  $pinnedIp  the value {@see self::resolveDeliveryIp()} returned
+     * @return array<string, mixed>
+     */
+    public function transportOptions(string $url, ?string $pinnedIp): array
+    {
+        $options = ['allow_redirects' => false];
+
+        if ($pinnedIp === null) {
+            return $options;
+        }
+
+        $parts = parse_url($url);
+        $host = (string) ($parts['host'] ?? '');
+        $port = (int) ($parts['port'] ?? (strtolower((string) ($parts['scheme'] ?? '')) === 'http' ? 80 : 443));
+
+        $address = str_contains($pinnedIp, ':') ? '['.$pinnedIp.']' : $pinnedIp;
+
+        $options['curl'] = [CURLOPT_RESOLVE => [sprintf('%s:%d:%s', $host, $port, $address)]];
+
+        return $options;
     }
 
     /**

--- a/app/Support/Images/FetchRemoteImage.php
+++ b/app/Support/Images/FetchRemoteImage.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Images;
+
+use App\Actions\Images\PurgeCachedProxyImages;
+use App\Support\Http\AbsoluteUrl;
+use App\Support\Http\OutboundUrlGuard;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+/**
+ * Fetches a remote image once and keeps the bytes on a local disk, so the app
+ * can serve every image from its own origin (see {@see ImageProxy}).
+ *
+ * The URL comes from a member — a scraped `og:image`, a Giphy rendition, the
+ * operator's Gravatar base — so every hop goes through {@see OutboundUrlGuard}:
+ * public http(s) hosts only, connection pinned to the vetted IP, redirects
+ * followed manually so each new target is re-checked rather than handed to curl.
+ *
+ * Every failure path returns null rather than throwing. An instance with no
+ * egress therefore degrades to a 404 per image (initials avatar, no link
+ * thumbnail) instead of hanging or 500ing, and the negative result is cached
+ * briefly so a dead host is not re-dialled on every page render.
+ */
+class FetchRemoteImage
+{
+    /**
+     * The disk cached image bytes live on. Private, since the proxy route — not
+     * a public URL — is what serves them.
+     */
+    public const string DISK = 'local';
+
+    /**
+     * The directory holding cached image bytes, swept by
+     * {@see PurgeCachedProxyImages}.
+     */
+    public const string DIRECTORY = 'image-proxy';
+
+    /**
+     * How long a fetched image stays cached, on disk and in the cache store.
+     */
+    public const int CACHE_TTL_SECONDS = 604800; // 7 days
+
+    /**
+     * How long a failed fetch is remembered. Far shorter than a success: a
+     * timeout is usually transient, and re-dialling a dead host on every render
+     * is what the negative cache exists to prevent.
+     */
+    private const int FAILURE_TTL_SECONDS = 600; // 10 minutes
+
+    /**
+     * Total time budget for a single hop, in seconds.
+     */
+    private const int TIMEOUT_SECONDS = 5;
+
+    /**
+     * How many redirect hops to follow before giving up. Each hop is re-validated
+     * against the SSRF guard so a public URL can't bounce us onto an internal one.
+     */
+    private const int MAX_REDIRECTS = 3;
+
+    /**
+     * Hard cap on the bytes read from a remote image.
+     */
+    private const int MAX_BYTES = 5242880; // 5 MB
+
+    /**
+     * The image types worth proxying. SVG is deliberately absent: it is a
+     * document that can carry script, and serving one from our own origin is
+     * exactly what the tightened `img-src` is meant to prevent.
+     *
+     * @var list<string>
+     */
+    private const array ALLOWED_MIMES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/avif'];
+
+    /**
+     * Cached sentinel for a URL that could not be fetched.
+     */
+    private const string FAILED = '__failed__';
+
+    public function __construct(private readonly OutboundUrlGuard $guard) {}
+
+    /**
+     * Resolve a remote image URL to its cached bytes, fetching it on first use.
+     *
+     * Concurrent first requests for the same URL may each fetch it; the write is
+     * idempotent (same URL, same path, same bytes), so a lock would buy nothing
+     * but a blocked web worker.
+     *
+     * @return array{path: string, mime: string}|null null when the URL cannot be fetched
+     */
+    public function handle(string $url): ?array
+    {
+        $key = 'image-proxy:'.hash('sha256', $url);
+        $cached = Cache::get($key);
+
+        if ($cached === self::FAILED) {
+            return null;
+        }
+
+        if (is_array($cached) && Storage::disk(self::DISK)->exists($cached['path'])) {
+            /** @var array{path: string, mime: string} $cached */
+            return $cached;
+        }
+
+        $stored = $this->fetch($url);
+
+        Cache::put(
+            $key,
+            $stored ?? self::FAILED,
+            now()->addSeconds($stored === null ? self::FAILURE_TTL_SECONDS : self::CACHE_TTL_SECONDS),
+        );
+
+        return $stored;
+    }
+
+    /**
+     * Request the URL, manually following redirects, and store the bytes.
+     *
+     * @return array{path: string, mime: string}|null
+     */
+    private function fetch(string $url): ?array
+    {
+        $target = $url;
+
+        for ($hop = 0; $hop <= self::MAX_REDIRECTS; $hop++) {
+            if (! OutboundUrlGuard::isPublic($target)) {
+                return null;
+            }
+
+            $pinnedIp = $this->guard->resolveDeliveryIp($target);
+
+            if ($pinnedIp === false) {
+                return null;
+            }
+
+            try {
+                $response = Http::timeout(self::TIMEOUT_SECONDS)
+                    ->withOptions($this->guard->transportOptions($target, $pinnedIp))
+                    ->get($target);
+            } catch (Throwable) {
+                // DNS/connect/timeout failure — degrade to no image rather than
+                // surfacing a 500 on an air-gapped instance.
+                return null;
+            }
+
+            if ($response->redirect()) {
+                $location = (string) $response->header('Location');
+
+                if ($location === '') {
+                    return null;
+                }
+
+                $target = AbsoluteUrl::from($target, $location);
+
+                continue;
+            }
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            $mime = strtolower(trim(explode(';', (string) $response->header('Content-Type'))[0]));
+
+            if (! in_array($mime, self::ALLOWED_MIMES, true)) {
+                return null;
+            }
+
+            if ((int) $response->header('Content-Length') > self::MAX_BYTES) {
+                return null;
+            }
+
+            $body = $response->body();
+
+            if ($body === '' || strlen($body) > self::MAX_BYTES) {
+                return null;
+            }
+
+            $path = self::DIRECTORY.'/'.hash('sha256', $url);
+
+            Storage::disk(self::DISK)->put($path, $body);
+
+            return ['path' => $path, 'mime' => $mime];
+        }
+
+        return null;
+    }
+}

--- a/app/Support/Images/ImageProxy.php
+++ b/app/Support/Images/ImageProxy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Images;
+
+use App\Support\Csp\TheDeskPolicy;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Rewrites a remote image URL into a first-party one served by the app.
+ *
+ * Every image the browser loads then comes from our own origin, which is what
+ * lets `img-src` drop the `https:` wildcard (see
+ * {@see TheDeskPolicy}) and stops a reader's IP, user agent and
+ * referring page leaking to Giphy, Gravatar and whatever site someone linked.
+ *
+ * The URL is signed, and the signature is what keeps the route from being an
+ * open proxy: only a URL the server itself emitted resolves, so an authenticated
+ * member cannot hand us an arbitrary target to fetch. It carries no expiry on
+ * purpose — a proxied URL is embedded in Inertia props and in the browser's
+ * image cache, and an expiring signature would break images on a page left open.
+ * Rotating `APP_KEY` invalidates every one of them, which is the intended
+ * revocation path.
+ */
+class ImageProxy
+{
+    /**
+     * Sign a remote image URL for the proxy route, or null when there is nothing
+     * to proxy — so a caller can pass a nullable URL straight through and keep
+     * its own "no image" fallback (initials avatar, no link thumbnail).
+     */
+    public static function url(?string $remoteUrl): ?string
+    {
+        if ($remoteUrl === null || trim($remoteUrl) === '') {
+            return null;
+        }
+
+        if (preg_match('#^https?://#i', $remoteUrl) !== 1) {
+            return null;
+        }
+
+        return URL::signedRoute('images.proxy', ['url' => $remoteUrl], absolute: false);
+    }
+}

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -205,9 +205,11 @@ without a Gravatar falls back cleanly to their initials.
 | `GRAVATAR_DEFAULT`  | `404`                              | The `d=` fallback. `404` is what makes users without a Gravatar fall back to initials; `mp`, `identicon`, or a URL are alternatives. |
 
 :::tip
-Turning `GRAVATAR_ENABLED=false` is the privacy-conscious choice if you don't want
-your instance making per-user requests to gravatar.com — everyone then shows their
-initials.
+Avatars are fetched by the server and re-served from your own origin (see
+[Remote images are proxied](/docs/reference/security/#remote-images-are-proxied)),
+so no reader's browser ever talks to gravatar.com. Turning `GRAVATAR_ENABLED=false`
+goes further and stops the instance itself making per-user requests — everyone
+then shows their initials.
 :::
 
 ## Activity logging

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -62,7 +62,7 @@ The policy sent is:
 | `default-src` | `'self'`                                     |
 | `script-src`  | `'self' 'nonce-…' 'strict-dynamic'`          |
 | `style-src`   | `'self' 'unsafe-inline'`                     |
-| `img-src`     | `'self' data: blob: https:`                  |
+| `img-src`     | `'self' data: blob:`                         |
 | `font-src`    | `'self'`                                     |
 | `connect-src` | `'self'` plus your Reverb WebSocket origin   |
 | `media-src`   | `'self'`                                     |
@@ -86,9 +86,13 @@ post credentials off-origin. `object-src` does fall back, but only to
 and the plugin documents they load are outside what `script-src` governs, so it
 is denied outright instead.
 
+`img-src` allows no remote host, which is only possible because the app never
+asks the browser to load one. See [Remote images are proxied](#remote-images-are-proxied)
+below.
+
 ### Accepted residuals
 
-Two directives are deliberately looser than they look, and both are limited to
+One directive is deliberately looser than it looks, and it is limited to
 resources that cannot execute script:
 
 - **`style-src 'unsafe-inline'`.** Popovers, dropdowns and the emoji picker
@@ -96,11 +100,28 @@ resources that cannot execute script:
   would make browsers ignore `'unsafe-inline'` entirely, and the narrower
   `style-src-attr` is unsupported on Safari before 15.4, which would silently
   break every floating element. The exposure is CSS, not code execution.
-- **`img-src https:`.** Link-preview thumbnails are fetched from whatever site
-  was linked, Giphy results are hotlinked from Giphy's CDN, and the Gravatar
-  base URL is yours to configure — so there is no enumerable host list to write
-  down. Images cannot execute, and the risk this leaves (a crafted URL signalling
-  that a page was viewed) is bounded by the tight `connect-src`.
+
+### Remote images are proxied
+
+Three things The Desk renders are images it does not host: link-preview
+thumbnails scraped from whatever site someone linked, Giphy renditions, and
+Gravatar avatars. Loading those directly would hand every reader's IP address,
+user agent and referring page to those sites without the reader choosing to
+visit them, and would force `img-src` to allow any HTTPS host.
+
+Instead the server fetches each one and re-serves it from your own origin, under
+a signed, session-authenticated URL. The signature pins the target to a URL the
+server itself generated, so the endpoint cannot be used as an open proxy; the
+fetch goes through the same SSRF guard as outgoing webhooks (see
+[`WEBHOOKS_BLOCK_PRIVATE_URLS`](/docs/reference/environment-variables/)), with a
+5-second timeout, a 5 MB cap, redirects re-checked hop by hop, and a
+raster-images-only content-type allowlist that excludes SVG. Fetched bytes are
+cached on the private disk for seven days and swept daily.
+
+Nothing needs configuring, and there is no toggle: an instance with no outbound
+egress simply degrades — avatars fall back to initials and link previews render
+without a thumbnail — rather than hanging or erroring. Setting
+`GRAVATAR_ENABLED=false` stops the avatar fetch being attempted at all.
 
 ### Running behind Cloudflare or a script-injecting proxy
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -70,5 +70,11 @@
         <env name="SSO_DEFAULT_TEAM_ID" value=""/>
         <env name="SCIM_TOKEN" value=""/>
         <env name="GIPHY_API_KEY" value=""/>
+        <!-- Avatars resolve through the image proxy, which fetches the remote
+             image server-side. Left enabled, every rendered avatar would make the
+             suite reach gravatar.com — and in the browser tests that fetch blocks
+             the single-process app server the page is talking to. Tests that
+             exercise Gravatar itself opt back in with config()->set(). -->
+        <env name="GRAVATAR_ENABLED" value="false"/>
     </php>
 </phpunit>

--- a/resources/js/components/LinkPreview.vue
+++ b/resources/js/components/LinkPreview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { previewHost } from '@/lib/linkPreview';
 import type { MessagePreview } from '@/types';
 
@@ -12,6 +12,14 @@ const props = defineProps<{
 const siteLabel = computed(
     () => props.preview.siteName ?? previewHost(props.preview.url),
 );
+
+/**
+ * Whether the thumbnail failed to load. The image is fetched server-side by the
+ * first-party proxy, which 404s when the source site is unreachable (an
+ * air-gapped instance, a dead link), so the card drops the image entirely rather
+ * than showing a broken-image glyph.
+ */
+const thumbnailFailed = ref(false);
 </script>
 
 <template>
@@ -28,11 +36,12 @@ const siteLabel = computed(
     </div>
     <div v-else data-test="link-preview">
         <img
-            v-if="preview.imageUrl"
+            v-if="preview.imageUrl && !thumbnailFailed"
             :src="preview.imageUrl"
             alt=""
             loading="lazy"
             class="w-full"
+            @error="thumbnailFailed = true"
         />
         <div class="px-3.75 py-3.25">
             <p

--- a/routes/console.php
+++ b/routes/console.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\Channels\DispatchDueMessageReminders;
 use App\Actions\Channels\DispatchDueScheduledMessages;
 use App\Actions\Channels\PurgeExpiredAttachments;
+use App\Actions\Images\PurgeCachedProxyImages;
 use App\Actions\Teams\PurgeExpiredAuditExports;
 use App\Models\TeamInvitation;
 use Illuminate\Support\Facades\Schedule;
@@ -39,6 +40,12 @@ Schedule::call(fn (PurgeExpiredAuditExports $purge): int => $purge->handle())
     ->daily()
     ->withoutOverlapping()
     ->description('Purge expired audit-log exports (files and rows)');
+
+Schedule::call(fn (PurgeCachedProxyImages $purge): int => $purge->handle())
+    ->name('purge-cached-proxy-images')
+    ->daily()
+    ->withoutOverlapping()
+    ->description('Purge proxied remote images past their cache TTL');
 
 Schedule::command('updates:check')
     ->daily()

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\Channels\ScheduledMessageController;
 use App\Http\Controllers\Channels\SearchController;
 use App\Http\Controllers\Channels\SlashCommandController;
 use App\Http\Controllers\Channels\ThreadsController;
+use App\Http\Controllers\ImageProxyController;
 use App\Http\Controllers\LocaleCatalogController;
 use App\Http\Controllers\OnboardingController;
 use App\Http\Controllers\SidebarSectionController;
@@ -198,6 +199,16 @@ Route::middleware(['auth', 'verified', EnsureTeamMembership::class])->group(func
 });
 
 Route::middleware(['auth'])->group(function (): void {
+    // Every remote image (link-preview thumbnails, Giphy renditions, Gravatar)
+    // is served through here so the browser only ever loads images from our own
+    // origin. `signed:relative` pins the `url` parameter to one the server
+    // generated — without it an authenticated member could point the endpoint at
+    // any host — and stays relative so the signature survives a reverse proxy
+    // presenting a different host than APP_URL.
+    Route::get('images/proxy', ImageProxyController::class)
+        ->middleware('signed:relative')
+        ->name('images.proxy');
+
     Route::patch('sidebar/sections', [SidebarSectionController::class, 'update'])->name('sidebar.sections.update');
 
     Route::patch('onboarding', [OnboardingController::class, 'update'])->name('onboarding.update');

--- a/tests/Feature/Channels/GiphyPickerTest.php
+++ b/tests/Feature/Channels/GiphyPickerTest.php
@@ -9,6 +9,7 @@ use App\Models\Attachment;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\Images\ImageProxy;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 
@@ -111,7 +112,7 @@ test('picking a GIF re-resolves its id and stores a pending remote attachment', 
 
     $response->assertCreated()
         ->assertJsonPath('source', 'giphy')
-        ->assertJsonPath('url', 'https://media.giphy.com/abc/200.gif')
+        ->assertJsonPath('url', ImageProxy::url('https://media.giphy.com/abc/200.gif'))
         ->assertJsonPath('description', 'a dog waving')
         ->assertJsonPath('isImage', true)
         ->assertJsonPath('mimeType', 'image/gif');

--- a/tests/Feature/Channels/RemoteAttachmentDataTest.php
+++ b/tests/Feature/Channels/RemoteAttachmentDataTest.php
@@ -3,14 +3,15 @@
 use App\Data\AttachmentData;
 use App\Enums\AttachmentSource;
 use App\Models\Attachment;
+use App\Support\Images\ImageProxy;
 
-it('serves the remote CDN url for a giphy attachment, bypassing the blob route', function (): void {
+it('serves a giphy attachment through the first-party image proxy, bypassing the blob route', function (): void {
     $attachment = Attachment::factory()->giphy()->create([
         'remote_url' => 'https://media.giphy.com/media/abc123/giphy.gif',
     ]);
 
     expect($attachment->source)->toBe(AttachmentSource::Giphy)
-        ->and($attachment->url)->toBe('https://media.giphy.com/media/abc123/giphy.gif')
+        ->and($attachment->url)->toBe(ImageProxy::url('https://media.giphy.com/media/abc123/giphy.gif'))
         ->and($attachment->thumb_url)->toBeNull();
 });
 
@@ -25,7 +26,7 @@ it('exposes source, remote url and description through AttachmentData for a giph
     $data = AttachmentData::fromAttachment($attachment);
 
     expect($data->source)->toBe(AttachmentSource::Giphy)
-        ->and($data->url)->toBe('https://media.giphy.com/media/abc123/giphy.gif')
+        ->and($data->url)->toBe(ImageProxy::url('https://media.giphy.com/media/abc123/giphy.gif'))
         ->and($data->thumbUrl)->toBeNull()
         ->and($data->description)->toBe('a cat waving')
         ->and($data->filename)->toBeNull()

--- a/tests/Feature/Data/UserAvatarDataTest.php
+++ b/tests/Feature/Data/UserAvatarDataTest.php
@@ -8,19 +8,20 @@ use App\Models\Membership;
 use App\Models\Team;
 use App\Models\User;
 use App\Support\Gravatar;
+use App\Support\Images\ImageProxy;
 
 test('UserData carries the user avatar so message authors and readers light up', function (): void {
     config()->set('gravatar.enabled', true);
     $user = User::factory()->create(['email' => 'author@example.com']);
 
-    expect(UserData::fromUser($user)->avatar)->toBe(Gravatar::url('author@example.com'));
+    expect(UserData::fromUser($user)->avatar)->toBe(ImageProxy::url(Gravatar::url('author@example.com')));
 });
 
 test('MentionData carries the user avatar so mentions and thread participants light up', function (): void {
     config()->set('gravatar.enabled', true);
     $user = User::factory()->create(['email' => 'mentioned@example.com']);
 
-    expect(MentionData::fromUser($user)->avatar)->toBe(Gravatar::url('mentioned@example.com'));
+    expect(MentionData::fromUser($user)->avatar)->toBe(ImageProxy::url(Gravatar::url('mentioned@example.com')));
 });
 
 test('UserProfileData carries the member avatar so hover cards and the profile page light up', function (): void {
@@ -33,7 +34,7 @@ test('UserProfileData carries the member avatar so hover cards and the profile p
 
     $data = UserProfileData::forMember($member, $membership, $member);
 
-    expect($data->avatar)->toBe(Gravatar::url('member@example.com'));
+    expect($data->avatar)->toBe(ImageProxy::url(Gravatar::url('member@example.com')));
 });
 
 test('the avatar is null across DTOs when gravatar is disabled', function (): void {

--- a/tests/Feature/DemoSeederTest.php
+++ b/tests/Feature/DemoSeederTest.php
@@ -42,6 +42,11 @@ function demoOwner(): User
 }
 
 beforeEach(function (): void {
+    // The seeder gives every fixture user a generated `identicon` avatar, which
+    // is a Gravatar URL — and the suite disables Gravatar by default so no test
+    // reaches gravatar.com. Opt back in for the seeded workspace.
+    config()->set('gravatar.enabled', true);
+
     artisan('demo:seed')->assertSuccessful();
 });
 

--- a/tests/Feature/Images/ImageProxyTest.php
+++ b/tests/Feature/Images/ImageProxyTest.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Images\PurgeCachedProxyImages;
+use App\Data\LinkPreviewData;
+use App\Enums\LinkPreviewStatus;
+use App\Models\MessageLinkPreview;
+use App\Models\User;
+use App\Support\HostResolver;
+use App\Support\Images\FetchRemoteImage;
+use App\Support\Images\ImageProxy;
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Point every hostname at a public IP so the SSRF guard's delivery-time
+ * resolution can run without touching real DNS.
+ *
+ * @param  array<int, string>  $ips
+ */
+function resolveHostsTo(array $ips = ['93.184.216.34']): void
+{
+    app()->bind(HostResolver::class, fn (): HostResolver => new class($ips) extends HostResolver
+    {
+        /**
+         * @param  array<int, string>  $ips
+         */
+        public function __construct(private readonly array $ips) {}
+
+        public function resolve(string $host): array
+        {
+            return $this->ips;
+        }
+    });
+}
+
+/**
+ * A remote-image response with the given type and body.
+ */
+function imageResponse(string $mime = 'image/png', string $body = 'PNGBYTES', array $headers = []): PromiseInterface
+{
+    return Http::response($body, 200, array_merge(['Content-Type' => $mime], $headers));
+}
+
+beforeEach(function (): void {
+    Storage::fake(FetchRemoteImage::DISK);
+    resolveHostsTo();
+});
+
+it('signs a remote url into a relative first-party route', function (): void {
+    $url = ImageProxy::url('https://cdn.example.test/cat.png');
+
+    expect($url)->toStartWith('/images/proxy?')
+        ->and($url)->toContain('signature=')
+        ->and($url)->toContain(urlencode('https://cdn.example.test/cat.png'));
+});
+
+it('has nothing to proxy for a null, blank or non-http url', function (?string $input): void {
+    expect(ImageProxy::url($input))->toBeNull();
+})->with([
+    'null' => [null],
+    'blank' => ['   '],
+    'data uri' => ['data:image/png;base64,AAAA'],
+    'javascript' => ['javascript:alert(1)'],
+]);
+
+it('fetches, caches and serves a remote image from our own origin', function (): void {
+    Http::fake(['cdn.example.test/*' => imageResponse('image/png', 'PNGBYTES')]);
+
+    $response = $this->actingAs(User::factory()->create())
+        ->get((string) ImageProxy::url('https://cdn.example.test/cat.png'));
+
+    $response->assertOk()
+        ->assertHeader('Content-Type', 'image/png')
+        ->assertHeader('X-Content-Type-Options', 'nosniff');
+
+    expect($response->streamedContent())->toBe('PNGBYTES');
+
+    Storage::disk(FetchRemoteImage::DISK)
+        ->assertExists(FetchRemoteImage::DIRECTORY.'/'.hash('sha256', 'https://cdn.example.test/cat.png'));
+});
+
+it('serves a second request from the cache without refetching', function (): void {
+    Http::fake(['cdn.example.test/*' => imageResponse()]);
+
+    $user = User::factory()->create();
+    $url = (string) ImageProxy::url('https://cdn.example.test/cat.png');
+
+    $this->actingAs($user)->get($url)->assertOk();
+    $this->actingAs($user)->get($url)->assertOk();
+
+    Http::assertSentCount(1);
+});
+
+it('refetches when the cached file has been purged from disk', function (): void {
+    Http::fake(['cdn.example.test/*' => imageResponse()]);
+
+    $user = User::factory()->create();
+    $url = (string) ImageProxy::url('https://cdn.example.test/cat.png');
+
+    $this->actingAs($user)->get($url)->assertOk();
+
+    Storage::disk(FetchRemoteImage::DISK)
+        ->delete(FetchRemoteImage::DIRECTORY.'/'.hash('sha256', 'https://cdn.example.test/cat.png'));
+
+    $this->actingAs($user)->get($url)->assertOk();
+
+    Http::assertSentCount(2);
+});
+
+it('follows a redirect, re-checking each hop against the guard', function (): void {
+    Http::fake([
+        'cdn.example.test/cat.png' => Http::response('', 302, ['Location' => '/real/cat.png']),
+        'cdn.example.test/real/cat.png' => imageResponse('image/gif', 'GIFBYTES'),
+    ]);
+
+    $response = $this->actingAs(User::factory()->create())
+        ->get((string) ImageProxy::url('https://cdn.example.test/cat.png'));
+
+    $response->assertOk()->assertHeader('Content-Type', 'image/gif');
+});
+
+it('rejects an unsigned or tampered url', function (): void {
+    $signed = (string) ImageProxy::url('https://cdn.example.test/cat.png');
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->get('/images/proxy?url='.urlencode('https://evil.test/probe.png'))
+        ->assertForbidden();
+
+    $this->actingAs($user)->get(str_replace('cat.png', 'other.png', $signed))
+        ->assertForbidden();
+});
+
+it('requires an authenticated session', function (): void {
+    $this->get((string) ImageProxy::url('https://cdn.example.test/cat.png'))
+        ->assertRedirect('/login');
+});
+
+it('404s rather than fetching a target the SSRF guard blocks', function (string $url, array $resolvesTo): void {
+    Http::fake();
+    resolveHostsTo($resolvesTo);
+
+    $this->actingAs(User::factory()->create())
+        ->get((string) ImageProxy::url($url))
+        ->assertNotFound();
+
+    Http::assertNothingSent();
+})->with([
+    // Rejected by name/literal address, before any DNS lookup.
+    'literal loopback' => ['http://127.0.0.1/cat.png', ['93.184.216.34']],
+    'localhost' => ['http://localhost/cat.png', ['93.184.216.34']],
+    'cloud metadata' => ['http://169.254.169.254/latest/meta-data', ['93.184.216.34']],
+    // Rejected at delivery-time resolution: a public-looking name pointing inside.
+    'rebound hostname' => ['https://internal.example.test/cat.png', ['127.0.0.1']],
+]);
+
+it('404s on a response that is not a proxyable image', function (string $mime): void {
+    Http::fake(['cdn.example.test/*' => imageResponse($mime, 'BODY')]);
+
+    $this->actingAs(User::factory()->create())
+        ->get((string) ImageProxy::url('https://cdn.example.test/cat.png'))
+        ->assertNotFound();
+})->with([
+    'html' => ['text/html'],
+    // SVG can carry script, so serving one from our own origin is exactly what
+    // the tightened img-src exists to prevent.
+    'svg' => ['image/svg+xml'],
+]);
+
+it('404s on an error response, an empty body, or an oversized image', function (Closure $fake): void {
+    Http::fake(['cdn.example.test/*' => $fake()]);
+
+    $this->actingAs(User::factory()->create())
+        ->get((string) ImageProxy::url('https://cdn.example.test/cat.png'))
+        ->assertNotFound();
+})->with([
+    'not found' => [fn (): Closure => fn () => Http::response('nope', 404)],
+    'empty body' => [fn (): Closure => fn (): PromiseInterface => imageResponse('image/png', '')],
+    'declared oversize' => [fn (): Closure => fn (): PromiseInterface => imageResponse('image/png', 'X', ['Content-Length' => (string) (6 * 1024 * 1024)])],
+    'actual oversize' => [fn (): Closure => fn (): PromiseInterface => imageResponse('image/png', str_repeat('X', 5242881))],
+    'redirect with no location' => [fn (): Closure => fn () => Http::response('', 302)],
+]);
+
+it('404s when the remote host is unreachable, and does not retry it immediately', function (): void {
+    $attempts = 0;
+
+    Http::fake(function () use (&$attempts): never {
+        $attempts++;
+
+        throw new ConnectionException('no route to host');
+    });
+
+    $user = User::factory()->create();
+    $url = (string) ImageProxy::url('https://cdn.example.test/cat.png');
+
+    $this->actingAs($user)->get($url)->assertNotFound();
+    $this->actingAs($user)->get($url)->assertNotFound();
+
+    expect($attempts)->toBe(1);
+});
+
+it('404s on a redirect loop that never reaches an image', function (): void {
+    Http::fake(['cdn.example.test/*' => Http::response('', 302, ['Location' => '/again.png'])]);
+
+    $this->actingAs(User::factory()->create())
+        ->get((string) ImageProxy::url('https://cdn.example.test/cat.png'))
+        ->assertNotFound();
+});
+
+it('404s when the signed url carries no target', function (): void {
+    $url = URL::signedRoute('images.proxy', ['url' => ''], absolute: false);
+
+    $this->actingAs(User::factory()->create())->get($url)->assertNotFound();
+});
+
+it('purges cached images past their TTL and keeps fresh ones', function (): void {
+    $disk = Storage::disk(FetchRemoteImage::DISK);
+    $disk->put(FetchRemoteImage::DIRECTORY.'/stale', 'old');
+    $disk->put(FetchRemoteImage::DIRECTORY.'/fresh', 'new');
+
+    touch(
+        $disk->path(FetchRemoteImage::DIRECTORY.'/stale'),
+        now()->subSeconds(FetchRemoteImage::CACHE_TTL_SECONDS + 60)->getTimestamp(),
+    );
+
+    expect(app(PurgeCachedProxyImages::class)->handle())->toBe(1);
+
+    $disk->assertMissing(FetchRemoteImage::DIRECTORY.'/stale');
+    $disk->assertExists(FetchRemoteImage::DIRECTORY.'/fresh');
+});
+
+it('remembers a fetched image across requests in the cache store', function (): void {
+    Http::fake(['cdn.example.test/*' => imageResponse()]);
+
+    app(FetchRemoteImage::class)->handle('https://cdn.example.test/cat.png');
+
+    expect(Cache::get('image-proxy:'.hash('sha256', 'https://cdn.example.test/cat.png')))
+        ->toBeArray();
+});
+
+it('routes a link-preview thumbnail through the proxy so the linked site never sees the reader', function (): void {
+    $preview = new MessageLinkPreview([
+        'url' => 'https://news.example.test/story',
+        'status' => LinkPreviewStatus::Ready,
+        'title' => 'A story',
+        'description' => null,
+        'image_url' => 'https://news.example.test/hero.jpg',
+        'site_name' => 'News',
+    ]);
+
+    expect(LinkPreviewData::fromModel($preview)->imageUrl)
+        ->toBe(ImageProxy::url('https://news.example.test/hero.jpg'));
+});
+
+it('leaves a link preview without a thumbnail alone', function (): void {
+    $preview = new MessageLinkPreview([
+        'url' => 'https://news.example.test/story',
+        'status' => LinkPreviewStatus::Ready,
+        'title' => 'A story',
+        'description' => null,
+        'image_url' => null,
+        'site_name' => 'News',
+    ]);
+
+    expect(LinkPreviewData::fromModel($preview)->imageUrl)->toBeNull();
+});

--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -40,7 +40,7 @@ test('web responses carry the policy', function (): void {
     expect($header)
         ->toContain("default-src 'self'")
         ->toContain("style-src 'self' 'unsafe-inline'")
-        ->toContain("img-src 'self' data: blob: https:")
+        ->toContain("img-src 'self' data: blob:")
         ->toContain("font-src 'self'")
         ->toContain("media-src 'self'")
         ->toContain("worker-src 'self'")

--- a/tests/Feature/Models/UserAvatarTest.php
+++ b/tests/Feature/Models/UserAvatarTest.php
@@ -2,13 +2,14 @@
 
 use App\Models\User;
 use App\Support\Gravatar;
+use App\Support\Images\ImageProxy;
 
 test('a user exposes its gravatar url as the avatar attribute', function (): void {
     config()->set('gravatar.enabled', true);
 
     $user = User::factory()->create(['email' => 'person@example.com']);
 
-    expect($user->avatar)->toBe(Gravatar::url('person@example.com'));
+    expect($user->avatar)->toBe(ImageProxy::url(Gravatar::url('person@example.com')));
 });
 
 test('the avatar is appended to the serialised user so every frontend surface receives it', function (): void {
@@ -17,7 +18,7 @@ test('the avatar is appended to the serialised user so every frontend surface re
     $user = User::factory()->create(['email' => 'person@example.com']);
 
     expect($user->toArray())
-        ->toHaveKey('avatar', Gravatar::url('person@example.com'));
+        ->toHaveKey('avatar', ImageProxy::url(Gravatar::url('person@example.com')));
 });
 
 test('the avatar attribute is null when gravatar is disabled', function (): void {

--- a/tests/Feature/Support/OutboundUrlGuardTest.php
+++ b/tests/Feature/Support/OutboundUrlGuardTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use App\Rules\PublicWebhookUrl;
 use App\Support\HostResolver;
-use App\Support\Webhooks\WebhookUrlGuard;
+use App\Support\Http\OutboundUrlGuard;
 use Illuminate\Support\Facades\Validator;
 
 /**
@@ -13,9 +13,9 @@ use Illuminate\Support\Facades\Validator;
  *
  * @param  array<int, string>  $ips
  */
-function guardResolving(array $ips): WebhookUrlGuard
+function guardResolving(array $ips): OutboundUrlGuard
 {
-    return new WebhookUrlGuard(new class($ips) extends HostResolver
+    return new OutboundUrlGuard(new class($ips) extends HostResolver
     {
         /**
          * @param  array<int, string>  $ips
@@ -30,22 +30,22 @@ function guardResolving(array $ips): WebhookUrlGuard
 }
 
 it('accepts a public https URL', function (): void {
-    expect(WebhookUrlGuard::isPublic('https://example.test/hooks'))->toBeTrue();
-    expect(WebhookUrlGuard::isPublic('http://example.test/hooks'))->toBeTrue();
+    expect(OutboundUrlGuard::isPublic('https://example.test/hooks'))->toBeTrue();
+    expect(OutboundUrlGuard::isPublic('http://example.test/hooks'))->toBeTrue();
 });
 
 it('rejects non-http schemes', function (): void {
-    expect(WebhookUrlGuard::isPublic('ftp://example.test/x'))->toBeFalse();
-    expect(WebhookUrlGuard::isPublic('file:///etc/passwd'))->toBeFalse();
+    expect(OutboundUrlGuard::isPublic('ftp://example.test/x'))->toBeFalse();
+    expect(OutboundUrlGuard::isPublic('file:///etc/passwd'))->toBeFalse();
 });
 
 it('rejects an unparseable URL or one missing a host', function (): void {
-    expect(WebhookUrlGuard::isPublic('http://:80'))->toBeFalse();
-    expect(WebhookUrlGuard::isPublic('not a url'))->toBeFalse();
+    expect(OutboundUrlGuard::isPublic('http://:80'))->toBeFalse();
+    expect(OutboundUrlGuard::isPublic('not a url'))->toBeFalse();
 });
 
 it('rejects literal private, loopback, link-local, and metadata IPs', function (string $url): void {
-    expect(WebhookUrlGuard::isPublic($url))->toBeFalse();
+    expect(OutboundUrlGuard::isPublic($url))->toBeFalse();
 })->with([
     'loopback' => 'http://127.0.0.1/x',
     'private-10' => 'http://10.0.0.5/x',
@@ -55,11 +55,11 @@ it('rejects literal private, loopback, link-local, and metadata IPs', function (
 ]);
 
 it('accepts a literal public IP', function (): void {
-    expect(WebhookUrlGuard::isPublic('https://8.8.8.8/x'))->toBeTrue();
+    expect(OutboundUrlGuard::isPublic('https://8.8.8.8/x'))->toBeTrue();
 });
 
 it('rejects local hostnames without a DNS lookup', function (string $url): void {
-    expect(WebhookUrlGuard::isPublic($url))->toBeFalse();
+    expect(OutboundUrlGuard::isPublic($url))->toBeFalse();
 })->with([
     'localhost' => 'http://localhost/x',
     'dot-localhost' => 'http://api.localhost/x',
@@ -71,7 +71,7 @@ it('rejects local hostnames without a DNS lookup', function (string $url): void 
 it('passes any URL when the guard is disabled', function (): void {
     config(['integrations.webhooks.block_private_urls' => false]);
 
-    expect(WebhookUrlGuard::isPublic('http://127.0.0.1/x'))->toBeTrue();
+    expect(OutboundUrlGuard::isPublic('http://127.0.0.1/x'))->toBeTrue();
 });
 
 it('resolves a hostname to its vetted public IP for delivery pinning', function (): void {

--- a/tests/Feature/Webhooks/WebhookDeliveryTest.php
+++ b/tests/Feature/Webhooks/WebhookDeliveryTest.php
@@ -13,8 +13,8 @@ use App\Models\Team;
 use App\Models\WebhookSubscription;
 use App\Support\AuditRecorder;
 use App\Support\HostResolver;
+use App\Support\Http\OutboundUrlGuard;
 use App\Support\Webhooks\WebhookSignature;
-use App\Support\Webhooks\WebhookUrlGuard;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
@@ -146,7 +146,7 @@ it('skips an already-queued job once the platform is disabled', function (): voi
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
     expect($this->subscription->deliveries()->count())->toBe(0);
@@ -162,7 +162,7 @@ it('refuses to deliver to a non-public URL and logs the blocked attempt', functi
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+        ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -184,7 +184,7 @@ it('blocks delivery when the hostname resolves to a private address', function (
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+        ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -210,7 +210,7 @@ it('auto-disables a subscription whose hostname resolves private once it hits th
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
@@ -225,7 +225,7 @@ it('delivers to a hostname resolving to a public IPv6 address', function (): voi
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     Http::assertSentCount(1);
     expect($this->subscription->deliveries()->sole()->succeeded)->toBeTrue();
@@ -240,7 +240,7 @@ it('delivers to a literal public IP without pinning', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     Http::assertSentCount(1);
     expect($this->subscription->deliveries()->sole()->succeeded)->toBeTrue();
@@ -258,7 +258,7 @@ it('does not follow a redirect to an internal address and records the attempt as
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+        ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -286,7 +286,7 @@ it('auto-disables a subscription whose URL is blocked once it hits the threshold
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
@@ -308,7 +308,7 @@ it('retries a failing endpoint, then auto-disables after the threshold and logs 
     // final attempt reaches the threshold and disables without throwing.
     for ($attempt = 1; $attempt < $threshold; $attempt++) {
         try {
-            (new DeliverWebhook($this->subscription->id, $envelope))->handle($recorder, app(WebhookUrlGuard::class));
+            (new DeliverWebhook($this->subscription->id, $envelope))->handle($recorder, app(OutboundUrlGuard::class));
         } catch (RuntimeException) {
             // expected retry signal
         }
@@ -318,7 +318,7 @@ it('retries a failing endpoint, then auto-disables after the threshold and logs 
             ->and($this->subscription->status)->toBe(WebhookSubscriptionStatus::Active);
     }
 
-    (new DeliverWebhook($this->subscription->id, $envelope))->handle($recorder, app(WebhookUrlGuard::class));
+    (new DeliverWebhook($this->subscription->id, $envelope))->handle($recorder, app(OutboundUrlGuard::class));
 
     $this->subscription->refresh();
     expect($this->subscription->status)->toBe(WebhookSubscriptionStatus::Disabled)
@@ -337,7 +337,7 @@ it('resets the failure streak after a success', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     expect($this->subscription->refresh()->consecutive_failures)->toBe(0);
 });
@@ -351,7 +351,7 @@ it('records a transport error as a failed attempt with no status code', function
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+        ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -374,7 +374,7 @@ it('auto-disables on a transport error that reaches the threshold', function ():
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
 });
@@ -388,7 +388,7 @@ it('is a no-op when the subscription has since been disabled', function (): void
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
     expect($this->subscription->deliveries()->count())->toBe(0);
@@ -402,7 +402,7 @@ it('is a no-op when the subscription no longer exists', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(WebhookUrlGuard::class));
+    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
 });

--- a/tests/Unit/Support/GiphyClientTest.php
+++ b/tests/Unit/Support/GiphyClientTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Support\GiphyClient;
+use App\Support\Images\ImageProxy;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -50,7 +51,9 @@ it('fetches trending when the query is blank and normalizes the renditions', fun
     $gif = $page->results[0];
     expect($gif->id)->toBe('abc')
         ->and($gif->url)->toBe('https://media.giphy.com/abc/200.gif')
-        ->and($gif->previewUrl)->toBe('https://media.giphy.com/abc/100.gif')
+        // The grid tile is proxied; `url` stays the raw CDN URL because it is
+        // what CreateGiphyAttachment stores as the attachment's remote_url.
+        ->and($gif->previewUrl)->toBe(ImageProxy::url('https://media.giphy.com/abc/100.gif'))
         ->and($gif->width)->toBe(360)
         ->and($gif->height)->toBe(200)
         ->and($gif->description)->toBe('a happy cat');


### PR DESCRIPTION
Closes #648.

## What

Every image the browser loads now comes from the app's own origin, which lets `img-src` drop the `https:` wildcard: it is `'self' data: blob:`.

Three sources were previously loaded remotely, and all three now route through a first-party proxy:

- link-preview thumbnails (`LinkPreviewData::fromModel()`)
- Giphy attachments (`Attachment::url()`) **and** the GIF picker's grid tiles (`GiphyClient::toData()`) — the picker was hotlinking Giphy's CDN too, which the issue didn't mention but which `'self'` would equally have broken
- Gravatar avatars (`User::avatar()`)

All four rewrites are server-side, so the Vue side is untouched apart from one fallback.

## Why

Beyond the weaker policy (an injected `<img>` could reach any HTTPS host — enough to signal that a page was viewed), every reader's IP address, user agent and referring page leaked to Giphy, Gravatar and every site anyone ever linked, without the reader choosing to visit them.

## How

- **`GET /images/proxy`** (`images.proxy`) — `auth` + `signed:relative`. The session keeps it off the public internet; the signature pins the `url` parameter to one the server generated, so a member cannot turn it into an open proxy or an SSRF probe. The signature is deliberately non-expiring: a proxied URL lives in Inertia props and the browser image cache, and an expiring one would break images on a page left open. Rotating `APP_KEY` is the revocation path. It is relative so it survives a reverse proxy presenting a host other than `APP_URL`.
- **`FetchRemoteImage`** — fetch once, bytes to the private disk, metadata in the cache store. 5 s timeout, 5 MB cap (declared *and* actual), 3 redirect hops each re-checked, and a raster-only content-type allowlist. SVG is excluded on purpose: it can carry script, and serving one from our own origin is exactly what the tightened `img-src` exists to prevent.
- **SSRF guard reused, not reimplemented.** `WebhookUrlGuard` moved to `App\Support\Http\OutboundUrlGuard` since it is no longer webhook-specific, and `transportOptions()` (redirects off + `CURLOPT_RESOLVE` IP pinning) moved onto it from `DeliverWebhook`, its only previous caller. The `WEBHOOKS_BLOCK_PRIVATE_URLS` env key keeps its name so existing `.env` files keep working.
- **No `IMAGE_PROXY_ENABLED` toggle.** An off state would have to re-admit the wildcard, defeating the issue. Air-gapped instances degrade instead: a failed fetch is a 404, so avatars fall back to initials and previews render without a thumbnail. `GRAVATAR_ENABLED=false` still short-circuits before any request.
- Cached bytes are swept daily by `PurgeCachedProxyImages`; failures are negative-cached for 10 minutes so a dead host isn't re-dialled per render.
- Small extraction: `AbsoluteUrl::from()`, now shared by the fetcher and `FetchLinkPreview` instead of duplicating relative-URL resolution.

## Testing

`tests/Feature/Images/ImageProxyTest.php` covers signing, the auth and signature rejections (unsigned, tampered, unauthenticated), disk caching and refetch-after-purge, redirect following, both SSRF rejection paths (pre-DNS literal/hostname and delivery-time resolution), every 404 path (non-image, SVG, error, empty, oversized declared and actual, unreachable host, redirect loop), the negative cache, and the purge action. Existing CSP, avatar, Giphy and remote-attachment tests were updated to assert the proxied URLs.

`./vendor/bin/sail composer test` reports `Total: 100.0 %` with Pint, PHPStan and Rector clean; the frontend gate (`lint:check`, `format:check`, `types:check`, `test:js`, `build`) and the docs build all pass.

## Docs & i18n

`security.md` swaps the img-src accepted residual for a "Remote images are proxied" section and updates the directive table; `feature-toggles.md`'s Gravatar privacy tip now reflects that the fetch is server-side. No user-facing copy was added, so no new translation keys.

## Found while working on this

`bin/worktree create` exits 0 when the Docker daemon is unreachable — composer fails, the script continues and reports "worktree ready" with an empty `vendor/`. Not fixed here (unrelated to this change); worth its own `tech-debt` issue.