### PR TITLE
feat: deny framing by default with frame-ancestors and X-Frame-Options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -199,6 +199,12 @@ CSP_ENABLED=true
 # here for local development (a policy mistake shows up as a console warning
 # instead of a blank page) and off by default everywhere else.
 CSP_REPORT_ONLY=true
+# Who may embed the app in a frame, sent as the CSP frame-ancestors directive
+# and as X-Frame-Options for older browsers. Denying every framer (the default)
+# closes the clickjacking path where an attacker overlays an invisible frame of
+# the app and steers a signed-in member's clicks into real controls. Use `self`,
+# or a comma-separated list of origins if you embed the app in your own portal.
+# CSP_FRAME_ANCESTORS=none
 # Comma-separated extra origins, appended to (never replacing) the defaults —
 # for an analytics snippet, a corporate asset host, or an embedded frame.
 # CSP_EXTRA_SCRIPT_SRC=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -70,6 +70,12 @@ CSP_ENABLED=true
 # to the browser console but nothing is blocked. Use it for a dry run after
 # adding scripts of your own, then turn it back off.
 # CSP_REPORT_ONLY=false
+# Who may embed the app in a frame, sent as the CSP frame-ancestors directive
+# and as X-Frame-Options. Denying every framer (the default) closes the
+# clickjacking path where an attacker overlays an invisible frame of the app and
+# steers a signed-in member's clicks into real controls. Use `self`, or a
+# comma-separated list of origins if you embed the app in your own portal.
+# CSP_FRAME_ANCESTORS=none
 # Comma-separated extra origins, appended to (never replacing) the defaults —
 # for an analytics snippet, a corporate asset host, or an embedded frame.
 # CSP_EXTRA_SCRIPT_SRC=

--- a/app/Http/Middleware/AddContentSecurityPolicyHeaders.php
+++ b/app/Http/Middleware/AddContentSecurityPolicyHeaders.php
@@ -14,7 +14,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Emit the Content-Security-Policy on web responses, plus the X-Frame-Options
- * that stands in for its frame-ancestors directive on browsers predating CSP3.
+ * that stands in for its frame-ancestors directive on browsers without CSP
+ * Level 2 support.
  * Both hang off `csp.enabled`: switching the app policy off means the operator
  * has taken ownership of these headers at their reverse proxy.
  *

--- a/app/Http/Middleware/AddContentSecurityPolicyHeaders.php
+++ b/app/Http/Middleware/AddContentSecurityPolicyHeaders.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Support\Csp\FrameAncestors;
 use App\Support\Csp\TheDeskPolicy;
 use Closure;
 use Illuminate\Http\Request;
@@ -12,7 +13,10 @@ use Spatie\Csp\Policy;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Emit the Content-Security-Policy on web responses.
+ * Emit the Content-Security-Policy on web responses, plus the X-Frame-Options
+ * that stands in for its frame-ancestors directive on browsers predating CSP3.
+ * Both hang off `csp.enabled`: switching the app policy off means the operator
+ * has taken ownership of these headers at their reverse proxy.
  *
  * This stands in for spatie/laravel-csp's own AddCspHeaders for two reasons: the
  * enforcing/report-only choice has to be made per request from config (so tests
@@ -38,11 +42,25 @@ final class AddContentSecurityPolicyHeaders
             return $response;
         }
 
-        $header = config('csp.report_only')
-            ? 'Content-Security-Policy-Report-Only'
-            : 'Content-Security-Policy';
+        if (config('csp.report_only')) {
+            $response->headers->set(
+                'Content-Security-Policy-Report-Only',
+                Policy::create([TheDeskPolicy::class])->getContents(),
+            );
 
-        $response->headers->set($header, Policy::create([TheDeskPolicy::class])->getContents());
+            // No X-Frame-Options: it has no report-only form, so sending it
+            // would enforce the framing rule the dry run is meant to only
+            // observe.
+            return $response;
+        }
+
+        $response->headers->set('Content-Security-Policy', Policy::create([TheDeskPolicy::class])->getContents());
+
+        $frameOptions = FrameAncestors::frameOptions();
+
+        if ($frameOptions !== null) {
+            $response->headers->set('X-Frame-Options', $frameOptions);
+        }
 
         return $response;
     }

--- a/app/Support/Csp/FrameAncestors.php
+++ b/app/Support/Csp/FrameAncestors.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Csp;
+
+use Spatie\Csp\Keyword;
+
+/**
+ * The operator's answer to "who may embed this app in a frame?", read once from
+ * `csp.frame_ancestors` and expressed two ways: as the CSP frame-ancestors
+ * sources, and as the legacy X-Frame-Options header browsers that predate CSP3
+ * read instead.
+ */
+final class FrameAncestors
+{
+    /**
+     * Sources for the frame-ancestors directive. Keywords come back as Keyword
+     * cases so the policy quotes them; origins are passed through verbatim.
+     *
+     * @return list<Keyword|string>
+     */
+    public static function sources(): array
+    {
+        $sources = array_values(array_filter(array_map(
+            self::normalise(...),
+            array_map(trim(...), explode(',', (string) config('csp.frame_ancestors', ''))),
+        )));
+
+        // Fail closed twice over: a blank key must not leave the app framable by
+        // anyone, and `none` written beside an origin is a contradiction whose
+        // safe reading is "deny" — a blocked embed is a visible bug, an
+        // accidentally framable app is not.
+        if ($sources === [] || in_array(Keyword::NONE, $sources, true)) {
+            return [Keyword::NONE];
+        }
+
+        return $sources;
+    }
+
+    /**
+     * The equivalent X-Frame-Options value, or null when the policy cannot be
+     * expressed in that header at all — it has no allow-list form, so an
+     * operator who named origins gets frame-ancestors only.
+     */
+    public static function frameOptions(): ?string
+    {
+        return match (self::sources()) {
+            [Keyword::NONE] => 'DENY',
+            [Keyword::SELF] => 'SAMEORIGIN',
+            default => null,
+        };
+    }
+
+    /**
+     * Map the keywords onto their enum cases, accepting the spellings an
+     * operator plausibly reaches for (`'self'` copied out of a policy, `NONE`
+     * shouted into an env file).
+     */
+    private static function normalise(string $source): Keyword|string
+    {
+        return match (mb_strtolower(trim($source, "'"))) {
+            'none' => Keyword::NONE,
+            'self' => Keyword::SELF,
+            default => $source,
+        };
+    }
+}

--- a/app/Support/Csp/TheDeskPolicy.php
+++ b/app/Support/Csp/TheDeskPolicy.php
@@ -70,6 +70,13 @@ final class TheDeskPolicy implements Preset
             // baffling bug when something does.
             ->add(Directive::WORKER, Keyword::SELF)
             ->add(Directive::FRAME, Keyword::NONE)
+            // frame-ancestors is the anti-clickjacking control: without it any
+            // site can embed the app in an invisible iframe and steer a
+            // signed-in member's clicks into real controls. It does not fall
+            // back to default-src either, and it is operator-configurable
+            // because an intranet portal embedding the app is a legitimate
+            // deployment.
+            ->add(Directive::FRAME_ANCESTORS, FrameAncestors::sources())
             // base-uri and form-action are document/navigation directives: they
             // do not fall back to default-src, so omitting them leaves them
             // unrestricted no matter how tight default-src is — the lesson a

--- a/config/csp.php
+++ b/config/csp.php
@@ -41,6 +41,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Who may embed the app in a frame
+    |--------------------------------------------------------------------------
+    |
+    | Drives the CSP's frame-ancestors directive and the X-Frame-Options header
+    | that older browsers read instead. The default denies every framer, which
+    | closes the clickjacking path where an attacker overlays an invisible frame
+    | of the app on their own page and steers a signed-in member into clicking
+    | real controls.
+    |
+    | Accepts the keywords `none` and `self`, or a comma-separated list of
+    | origins for an operator embedding the app in their own portal. A list of
+    | origins sends no X-Frame-Options: that header cannot express an allow-list
+    | (its ALLOW-FROM was never supported by Chrome and Firefox dropped it), so
+    | anything sent there would either break the embed or misstate the policy.
+    |
+    */
+
+    'frame_ancestors' => env('CSP_FRAME_ANCESTORS', 'none'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Extra allowed sources
     |--------------------------------------------------------------------------
     |

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -123,6 +123,7 @@ production — see [Configuration](/docs/self-hosting/configuration/#reverb-webs
 | `DEMO_MODE`                  | `false` | [Feature toggles → Demo mode](/docs/reference/feature-toggles/#demo-mode) |
 | `CSP_ENABLED`                | `true`  | [Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy) |
 | `CSP_REPORT_ONLY`            | `false` | [Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy) |
+| `CSP_FRAME_ANCESTORS`        | `none`  | [Feature toggles → Clickjacking protection](/docs/reference/feature-toggles/#clickjacking-protection) |
 
 ## Content Security Policy
 
@@ -138,6 +139,13 @@ only: none of them can remove the script nonce or `'strict-dynamic'`. See
 | `CSP_EXTRA_IMG_SRC`     | *(none)* | `img-src`     |
 | `CSP_EXTRA_CONNECT_SRC` | *(none)* | `connect-src` |
 | `CSP_EXTRA_FRAME_SRC`   | *(none)* | `frame-src`   |
+
+One more key controls who may embed the app **in** a frame, rather than what the
+app may load:
+
+| Variable               | Default | Effect                                                                 |
+| ---------------------- | ------- | ---------------------------------------------------------------------- |
+| `CSP_FRAME_ANCESTORS`  | `none`  | Sends `frame-ancestors` and `X-Frame-Options`. See [Feature toggles → Clickjacking protection](/docs/reference/feature-toggles/#clickjacking-protection). |
 
 ## Single sign-on (OpenID Connect)
 

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -277,7 +277,7 @@ your controls — leaving a workspace, deleting a channel, revoking a token.
 
 | Variable              | Default | Effect                                                                     |
 | --------------------- | ------- | -------------------------------------------------------------------------- |
-| `CSP_FRAME_ANCESTORS` | `none`  | Who may frame the app. Sent as the CSP `frame-ancestors` directive and as `X-Frame-Options`. |
+| `CSP_FRAME_ANCESTORS` | `none`  | Who may frame the app. Always sets the CSP `frame-ancestors` directive; also sends `X-Frame-Options` when the value maps to `DENY` or `SAMEORIGIN` and the policy is enforcing. |
 
 Accepted values:
 

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -268,6 +268,43 @@ it — set `CSP_ENABLED=false` and serve your own policy from the reverse proxy.
 There is deliberately no key that replaces the whole policy: an override that
 could drop the nonce would leave a header that looks protective and is not.
 
+## Clickjacking protection
+
+Nothing may embed the app in a frame by default. That closes **clickjacking**:
+an attacker loads your instance in an invisible iframe over their own page, and
+a signed-in member who thinks they are clicking that page is really clicking
+your controls — leaving a workspace, deleting a channel, revoking a token.
+
+| Variable              | Default | Effect                                                                     |
+| --------------------- | ------- | -------------------------------------------------------------------------- |
+| `CSP_FRAME_ANCESTORS` | `none`  | Who may frame the app. Sent as the CSP `frame-ancestors` directive and as `X-Frame-Options`. |
+
+Accepted values:
+
+| Value                     | `frame-ancestors`         | `X-Frame-Options` |
+| ------------------------- | ------------------------- | ----------------- |
+| `none` *(default)*        | `'none'` — nobody          | `DENY`            |
+| `self`                    | `'self'` — your own origin | `SAMEORIGIN`      |
+| One or more origins       | those origins             | *(not sent)*      |
+
+```bash
+# Embed the app in your intranet portal
+CSP_FRAME_ANCESTORS="https://portal.example.com"
+```
+
+:::note
+`X-Frame-Options` has no allow-list form — its `ALLOW-FROM` was never supported
+by Chrome and Firefox dropped it — so naming origins sends `frame-ancestors`
+alone. Every browser released in the last several years honours it; the legacy
+header is only a fallback for the ones that do not.
+:::
+
+Both headers ride on `CSP_ENABLED`. Turning the app policy off means you have
+taken ownership of these headers at your reverse proxy, so set them there too.
+Under `CSP_REPORT_ONLY=true` the directive is reported but not enforced, and
+`X-Frame-Options` is withheld — it has no report-only form, so sending it would
+enforce the very thing the dry run is meant to only observe.
+
 ## Search analytics
 
 | Variable                   | Default | Effect                                             |

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -68,6 +68,7 @@ The policy sent is:
 | `media-src`   | `'self'`                                     |
 | `worker-src`  | `'self'`                                     |
 | `frame-src`   | `'none'`                                     |
+| `frame-ancestors` | `'none'`, or whatever `CSP_FRAME_ANCESTORS` names |
 | `base-uri`    | `'self'`                                     |
 | `form-action` | `'self'`                                     |
 | `object-src`  | `'none'`                                     |
@@ -85,6 +86,15 @@ post credentials off-origin. `object-src` does fall back, but only to
 `default-src 'self'`; nothing in The Desk renders an `<object>` or `<embed>`,
 and the plugin documents they load are outside what `script-src` governs, so it
 is denied outright instead.
+
+`frame-ancestors` is the same kind of directive and answers the opposite
+question to `frame-src`: not what the app may embed, but who may embed *it*. It
+defaults to `'none'`, which is what stops an attacker overlaying an invisible
+frame of your instance on their own page and steering a signed-in member's
+clicks into real controls. It is paired with `X-Frame-Options: DENY` for
+browsers that predate CSP3, and both are configurable through
+[`CSP_FRAME_ANCESTORS`](/docs/reference/feature-toggles/#clickjacking-protection)
+if you embed the app in a portal of your own.
 
 ### Accepted residuals
 

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -92,7 +92,8 @@ question to `frame-src`: not what the app may embed, but who may embed *it*. It
 defaults to `'none'`, which is what stops an attacker overlaying an invisible
 frame of your instance on their own page and steering a signed-in member's
 clicks into real controls. It is paired with `X-Frame-Options: DENY` for
-browsers that predate CSP3, and both are configurable through
+browsers that do not support CSP Level 2 `frame-ancestors`, and both are
+configurable through
 [`CSP_FRAME_ANCESTORS`](/docs/reference/feature-toggles/#clickjacking-protection)
 if you embed the app in a portal of your own.
 

--- a/tests/Feature/Middleware/ClickjackingProtectionTest.php
+++ b/tests/Feature/Middleware/ClickjackingProtectionTest.php
@@ -98,6 +98,7 @@ test('report-only mode reports the ancestors without enforcing them', function (
 
     $response = $this->get(route('home'))->assertOk();
 
+    expect($response->headers->get('Content-Security-Policy'))->toBeNull();
     expect($response->headers->get('Content-Security-Policy-Report-Only'))
         ->toContain("frame-ancestors 'none'");
 
@@ -109,5 +110,6 @@ test('report-only mode reports the ancestors without enforcing them', function (
 test('api responses carry no framing headers — they are never rendered in a frame', function (): void {
     $response = $this->getJson('/api/v1/channels');
 
+    expect($response->headers->get('Content-Security-Policy'))->toBeNull();
     expect($response->headers->get('X-Frame-Options'))->toBeNull();
 });

--- a/tests/Feature/Middleware/ClickjackingProtectionTest.php
+++ b/tests/Feature/Middleware/ClickjackingProtectionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+beforeEach(function (): void {
+    // .env.example turns report-only on for local development, so every test
+    // states the posture it is asserting rather than inheriting the ambient one.
+    config([
+        'csp.enabled' => true,
+        'csp.report_only' => false,
+        'csp.frame_ancestors' => 'none',
+    ]);
+});
+
+test('web responses deny framing outright by default', function (): void {
+    $response = $this->get(route('home'))->assertOk();
+
+    expect($response->headers->get('Content-Security-Policy'))->toContain("frame-ancestors 'none'");
+    expect($response->headers->get('X-Frame-Options'))->toBe('DENY');
+});
+
+test('same-origin framing is allowed when the operator asks for it', function (): void {
+    config(['csp.frame_ancestors' => 'self']);
+
+    $response = $this->get(route('home'))->assertOk();
+
+    expect($response->headers->get('Content-Security-Policy'))->toContain("frame-ancestors 'self'");
+    expect($response->headers->get('X-Frame-Options'))->toBe('SAMEORIGIN');
+});
+
+test('the keyword is recognised however the operator cased or quoted it', function (string $value, string $expected): void {
+    config(['csp.frame_ancestors' => $value]);
+
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)->toContain("frame-ancestors {$expected}");
+})->with([
+    'upper-case none' => ['NONE', "'none'"],
+    'upper-case self' => ['Self', "'self'"],
+    'pre-quoted none' => ["'none'", "'none'"],
+    'pre-quoted self' => ["'self'", "'self'"],
+]);
+
+test('an operator can allow-list the portal that embeds the app', function (): void {
+    config(['csp.frame_ancestors' => 'https://portal.example.test']);
+
+    $response = $this->get(route('home'))->assertOk();
+
+    expect($response->headers->get('Content-Security-Policy'))
+        ->toContain('frame-ancestors https://portal.example.test');
+
+    // X-Frame-Options cannot express an allow-list — its ALLOW-FROM was never
+    // supported by Chrome and was dropped by Firefox — so sending anything here
+    // would either break the embed (DENY) or lie about it.
+    expect($response->headers->get('X-Frame-Options'))->toBeNull();
+});
+
+test('a comma-separated ancestor list allow-lists every origin in it', function (): void {
+    config(['csp.frame_ancestors' => 'https://one.example.test, https://two.example.test']);
+
+    $header = (string) $this->get(route('home'))->headers->get('Content-Security-Policy');
+
+    expect($header)->toContain('frame-ancestors https://one.example.test https://two.example.test');
+});
+
+test('a blank ancestor list falls back to denying every framer', function (): void {
+    config(['csp.frame_ancestors' => '']);
+
+    $response = $this->get(route('home'))->assertOk();
+
+    expect($response->headers->get('Content-Security-Policy'))->toContain("frame-ancestors 'none'");
+    expect($response->headers->get('X-Frame-Options'))->toBe('DENY');
+});
+
+test('none beside an origin fails closed rather than silently allowing the origin', function (): void {
+    config(['csp.frame_ancestors' => 'none, https://portal.example.test']);
+
+    $response = $this->get(route('home'))->assertOk();
+
+    // A contradictory list is a typo, and the safe reading of a typo in an
+    // anti-clickjacking control is "deny" — a blocked embed is a visible bug,
+    // an accidentally framable app is not.
+    expect($response->headers->get('Content-Security-Policy'))->toContain("frame-ancestors 'none'");
+    expect($response->headers->get('X-Frame-Options'))->toBe('DENY');
+});
+
+test('neither header is sent when the app policy is switched off', function (): void {
+    config(['csp.enabled' => false]);
+
+    $response = $this->get(route('home'))->assertOk();
+
+    expect($response->headers->get('Content-Security-Policy'))->toBeNull();
+    expect($response->headers->get('X-Frame-Options'))->toBeNull();
+});
+
+test('report-only mode reports the ancestors without enforcing them', function (): void {
+    config(['csp.report_only' => true]);
+
+    $response = $this->get(route('home'))->assertOk();
+
+    expect($response->headers->get('Content-Security-Policy-Report-Only'))
+        ->toContain("frame-ancestors 'none'");
+
+    // X-Frame-Options has no report-only form, so emitting it would enforce the
+    // very thing the dry run is meant to only observe.
+    expect($response->headers->get('X-Frame-Options'))->toBeNull();
+});
+
+test('api responses carry no framing headers — they are never rendered in a frame', function (): void {
+    $response = $this->getJson('/api/v1/channels');
+
+    expect($response->headers->get('X-Frame-Options'))->toBeNull();
+});

--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -24,6 +24,7 @@ beforeEach(function (): void {
     config([
         'csp.enabled' => true,
         'csp.report_only' => false,
+        'csp.frame_ancestors' => 'none',
         'csp.extra' => [
             'script-src' => '',
             'style-src' => '',


### PR DESCRIPTION
Closes #599.

## Why

Responses carried neither `X-Frame-Options` nor a CSP `frame-ancestors`
directive, so any site could embed the app in an invisible iframe and steer a
signed-in member's clicks into real controls (Aikido surface scan, risk 50).

## What

`frame-ancestors` now defaults to `'none'`, with `X-Frame-Options: DENY`
alongside it for browsers without CSP Level 2 support. Both are driven by a new
`CSP_FRAME_ANCESTORS` key, since embedding the app in an intranet portal is a
legitimate deployment.

- A list of origins sends `frame-ancestors` alone: `X-Frame-Options` has no
  allow-list form (`ALLOW-FROM` was never supported by Chrome and Firefox
  dropped it), so anything sent there would either break the embed or misstate
  the policy.
- A blank or self-contradictory value (`none` beside an origin) fails closed —
  a blocked embed is a visible bug, an accidentally framable app is not.
- Report-only mode withholds `X-Frame-Options`, which has no report-only form
  and would otherwise enforce the very thing the dry run is meant to observe.
- Both headers hang off `CSP_ENABLED`, so switching the app policy off keeps the
  "own your headers at the proxy" contract intact.

## Verified nothing relies on being framed

No `iframe` anywhere in `resources/`, `app/`, or `docs/src/`, and SSO/Socialite
uses full-page redirects rather than a framed flow — so default-deny breaks
nothing.

## How tested

13 feature tests in `tests/Feature/Middleware/ClickjackingProtectionTest.php`
covering the default deny, `self`, custom origins, comma-separated lists,
casing/quoting variants, the blank-value fallback, the fail-closed path, the
CSP-disabled case, report-only, and API responses. Full gate green at 100%
coverage.

## Docs

`.env.example`, `.env.prod.example`, and the environment-variables,
feature-toggles (new *Clickjacking protection* section) and security reference
pages. Docs site builds clean and the new anchor resolves from both linking
pages.