### PR TITLE
fix: give the browser-written cookies samesite and secure flags

### DIFF
--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -158,6 +158,53 @@ the matching key: the host serving the stylesheet in `CSP_EXTRA_STYLE_SRC`, and
 the host serving the `@font-face` files in `CSP_EXTRA_FONT_SRC`. Google Fonts
 splits those across two hosts and so needs both.
 
+## Cookies
+
+The Desk sets four cookies. Every one of them is either HTTP-only or holds
+nothing worth reading, and all four are `SameSite=Lax`, so none is sent on a
+cross-site subrequest.
+
+| Cookie                | Set by         | Contents                       | `HttpOnly` | Encrypted |
+| --------------------- | -------------- | ------------------------------ | ---------- | --------- |
+| `the-desk-session`    | Server         | The session identifier         | Yes        | Yes       |
+| `XSRF-TOKEN`          | Server         | The CSRF token                 | No         | Yes       |
+| `appearance`          | Browser        | `light`, `dark` or `system`    | No         | No        |
+| `sidebar_state`       | Browser        | `true` or `false`              | No         | No        |
+
+All four are marked `Secure` when the page is served over HTTPS. For the two
+server-set cookies that comes from `SESSION_SECURE_COOKIE`, which you should set
+to `true` in any production deployment (see
+[reverse proxy & TLS](/docs/self-hosting/reverse-proxy/)); the two written by the
+browser pick it up from the page's own scheme.
+
+The session cookie name follows `APP_NAME`, so it reads `the-desk-session` on a
+default install and something else if you renamed the app.
+
+### `XSRF-TOKEN` is readable by JavaScript on purpose
+
+A surface scanner will flag `XSRF-TOKEN` as a cookie missing `HttpOnly`. That is
+expected behaviour, not a defect, and we have accepted it deliberately.
+
+Laravel's CSRF middleware sets that cookie precisely so the frontend can read it
+and echo the value back in an `X-XSRF-TOKEN` header. The server then compares the
+header against the token in the session. Making the cookie `HttpOnly` would put
+the value out of the frontend's reach and break every non-form request in the app:
+Inertia visits, posting a message, reactions, uploads. It is not the session
+cookie, and it is encrypted at rest in the browser: stealing it grants no session,
+only the ability to pass CSRF on a request you could already forge if you were
+running script on the page.
+
+Which is the real point. The threat this flag is meant to blunt is a malicious
+script running on your origin, and the answer to that is stopping the script from
+running at all. That is what the [Content Security Policy](#content-security-policy)
+above is for.
+
+The two browser-set cookies are exempt from Laravel's cookie encryption for the
+same practical reason: the frontend writes them and the server reads them as
+plain text. They hold a theme name and a boolean, so there is nothing in them to
+protect. Nothing else is exempt, and a regression test asserts that the exemption
+list stays those two.
+
 ## Hardening your deployment
 
 Most security outcomes for a self-hosted instance depend on how you run it. Follow

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -160,9 +160,9 @@ splits those across two hosts and so needs both.
 
 ## Cookies
 
-The Desk sets four cookies. Every one of them is either HTTP-only or holds
-nothing worth reading, and all four are `SameSite=Lax`, so none is sent on a
-cross-site subrequest.
+The Desk sets four cookies. Only one of them, the session cookie, is worth
+stealing, and that one is HTTP-only so a script cannot read it. All four are
+`SameSite=Lax`, so none is sent on a cross-site subrequest.
 
 | Cookie                | Set by         | Contents                       | `HttpOnly` | Encrypted |
 | --------------------- | -------------- | ------------------------------ | ---------- | --------- |
@@ -171,11 +171,13 @@ cross-site subrequest.
 | `appearance`          | Browser        | `light`, `dark` or `system`    | No         | No        |
 | `sidebar_state`       | Browser        | `true` or `false`              | No         | No        |
 
-All four are marked `Secure` when the page is served over HTTPS. For the two
-server-set cookies that comes from `SESSION_SECURE_COOKIE`, which you should set
-to `true` in any production deployment (see
-[reverse proxy & TLS](/docs/self-hosting/reverse-proxy/)); the two written by the
-browser pick it up from the page's own scheme.
+The `Secure` flag comes from two different places. The two cookies the browser
+writes take it from the page's own scheme, so they are `Secure` on any HTTPS
+page with nothing to configure. The two the server sets are `Secure` only when
+`SESSION_SECURE_COOKIE=true`, which is **not** inferred from the request: set it
+explicitly in any production deployment, or your session cookie will keep being
+sent over plain HTTP. See
+[reverse proxy & TLS](/docs/self-hosting/reverse-proxy/).
 
 The session cookie name follows `APP_NAME`, so it reads `the-desk-session` on a
 default install and something else if you renamed the app.

--- a/resources/js/components/ui/sidebar/SidebarProvider.vue
+++ b/resources/js/components/ui/sidebar/SidebarProvider.vue
@@ -3,6 +3,7 @@ import type { HTMLAttributes, Ref } from "vue"
 import { defaultDocument, useEventListener, useMediaQuery, useVModel } from "@vueuse/core"
 import { TooltipProvider } from "reka-ui"
 import { computed, ref } from "vue"
+import { writeClientCookie } from "@/lib/cookies"
 import { cn } from "@/lib/utils"
 import { provideSidebarContext, SIDEBAR_COOKIE_MAX_AGE, SIDEBAR_COOKIE_NAME, SIDEBAR_KEYBOARD_SHORTCUT, SIDEBAR_WIDTH, SIDEBAR_WIDTH_ICON } from "./utils"
 
@@ -31,7 +32,7 @@ function setOpen(value: boolean) {
   open.value = value // emits('update:open', value)
 
   // This sets the cookie to keep the sidebar state.
-  document.cookie = `${SIDEBAR_COOKIE_NAME}=${open.value}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+  writeClientCookie(SIDEBAR_COOKIE_NAME, String(open.value), SIDEBAR_COOKIE_MAX_AGE)
 }
 
 function setOpenMobile(value: boolean) {

--- a/resources/js/composables/useAppearance.ts
+++ b/resources/js/composables/useAppearance.ts
@@ -1,5 +1,6 @@
 import type { ComputedRef, Ref } from 'vue';
 import { computed, onMounted, ref } from 'vue';
+import { writeClientCookie } from '@/lib/cookies';
 import type { Appearance, ResolvedAppearance } from '@/types';
 
 export type { Appearance, ResolvedAppearance };
@@ -31,13 +32,7 @@ export function updateTheme(value: Appearance): void {
 }
 
 const setCookie = (name: string, value: string, days = 365) => {
-    if (typeof document === 'undefined') {
-        return;
-    }
-
-    const maxAge = days * 24 * 60 * 60;
-
-    document.cookie = `${name}=${value};path=/;max-age=${maxAge};SameSite=Lax`;
+    writeClientCookie(name, value, days * 24 * 60 * 60);
 };
 
 const mediaQuery = () => {

--- a/resources/js/lib/cookies.test.ts
+++ b/resources/js/lib/cookies.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { buildClientCookie, writeClientCookie } from '@/lib/cookies';
+
+describe('buildClientCookie', () => {
+    it('pins the cookie to the site root and a lifetime', () => {
+        expect(buildClientCookie('appearance', 'dark', 3600, false)).toBe(
+            'appearance=dark; path=/; max-age=3600; SameSite=Lax',
+        );
+    });
+
+    it('marks the cookie Secure when the page is served over HTTPS', () => {
+        expect(buildClientCookie('sidebar_state', 'false', 60, true)).toBe(
+            'sidebar_state=false; path=/; max-age=60; SameSite=Lax; Secure',
+        );
+    });
+
+    it('encodes a value that would otherwise break the cookie string', () => {
+        expect(buildClientCookie('appearance', 'a b;c', 60, false)).toBe(
+            'appearance=a%20b%3Bc; path=/; max-age=60; SameSite=Lax',
+        );
+    });
+});
+
+describe('writeClientCookie', () => {
+    it('persists the cookie on the document', () => {
+        writeClientCookie('appearance', 'dark', 60);
+
+        expect(document.cookie).toContain('appearance=dark');
+    });
+});

--- a/resources/js/lib/cookies.ts
+++ b/resources/js/lib/cookies.ts
@@ -1,0 +1,51 @@
+/**
+ * Build the assignment string for a cookie the frontend writes itself.
+ *
+ * Only the two cookies excluded from Laravel's cookie encryption are written
+ * this way (`appearance` and `sidebar_state`), and neither carries anything
+ * sensitive. They still get the transport flags the server-set cookies get:
+ * `SameSite=Lax`, so they are not sent on cross-site subrequests, and `Secure`
+ * on an HTTPS page, so an active network attacker cannot plant or overwrite
+ * them over plain HTTP. Exposed separately from {@see writeClientCookie} so the
+ * string is testable without a DOM.
+ */
+export function buildClientCookie(
+    name: string,
+    value: string,
+    maxAgeSeconds: number,
+    secure: boolean,
+): string {
+    const attributes = [
+        `${name}=${encodeURIComponent(value)}`,
+        'path=/',
+        `max-age=${maxAgeSeconds}`,
+        'SameSite=Lax',
+    ];
+
+    if (secure) {
+        attributes.push('Secure');
+    }
+
+    return attributes.join('; ');
+}
+
+/**
+ * Persist a client-written cookie, marking it `Secure` whenever the page itself
+ * was served over HTTPS. No-ops outside the browser (server-side rendering).
+ */
+export function writeClientCookie(
+    name: string,
+    value: string,
+    maxAgeSeconds: number,
+): void {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    document.cookie = buildClientCookie(
+        name,
+        value,
+        maxAgeSeconds,
+        window.location.protocol === 'https:',
+    );
+}

--- a/resources/js/lib/cookies.ts
+++ b/resources/js/lib/cookies.ts
@@ -5,9 +5,9 @@
  * this way (`appearance` and `sidebar_state`), and neither carries anything
  * sensitive. They still get the transport flags the server-set cookies get:
  * `SameSite=Lax`, so they are not sent on cross-site subrequests, and `Secure`
- * on an HTTPS page, so an active network attacker cannot plant or overwrite
- * them over plain HTTP. Exposed separately from {@see writeClientCookie} so the
- * string is testable without a DOM.
+ * on an HTTPS page, so the browser never sends them back over plain HTTP.
+ * Exposed separately from {@see writeClientCookie} so the string is testable
+ * without a DOM.
  */
 export function buildClientCookie(
     name: string,

--- a/tests/Feature/CookiePostureTest.php
+++ b/tests/Feature/CookiePostureTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Cookie\CookieValuePrefix;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+
+/**
+ * Locks the cookie posture a surface scan keeps re-raising (issue #600): the
+ * session cookie is HttpOnly, `XSRF-TOKEN` is deliberately not, and the only
+ * cookies exempt from encryption are the two UI-preference ones.
+ */
+function cookieFromResponse(TestResponse $response, string $name): Cookie
+{
+    $cookie = collect($response->headers->getCookies())
+        ->first(fn (Cookie $cookie): bool => $cookie->getName() === $name);
+
+    expect($cookie)->not->toBeNull("Expected the response to set a [{$name}] cookie.");
+
+    return $cookie;
+}
+
+test('the session cookie is http-only and same-site lax', function (): void {
+    $response = $this->get('/login');
+
+    $cookie = cookieFromResponse($response, config('session.cookie'));
+
+    expect($cookie->isHttpOnly())->toBeTrue()
+        ->and($cookie->getSameSite())->toBe(Cookie::SAMESITE_LAX);
+});
+
+test('the session cookie is marked secure when SESSION_SECURE_COOKIE is on', function (): void {
+    expect(cookieFromResponse($this->get('/login'), config('session.cookie'))->isSecure())->toBeFalse();
+
+    config()->set('session.secure', true);
+
+    expect(cookieFromResponse($this->get('/login'), config('session.cookie'))->isSecure())->toBeTrue();
+});
+
+test('the XSRF-TOKEN cookie is readable by javascript by design, but encrypted and same-site lax', function (): void {
+    $response = $this->get('/login');
+
+    $cookie = cookieFromResponse($response, 'XSRF-TOKEN');
+
+    // Not HttpOnly on purpose: the XHR client reads it to echo the token back
+    // in the X-XSRF-TOKEN header, which is the whole CSRF mechanism.
+    expect($cookie->isHttpOnly())->toBeFalse()
+        ->and($cookie->getSameSite())->toBe(Cookie::SAMESITE_LAX)
+        ->and(CookieValuePrefix::remove(Crypt::decrypt($cookie->getValue(), false)))->toBe(session()->token());
+});
+
+test('only the two non-sensitive ui preference cookies skip encryption', function (): void {
+    $exempt = (new ReflectionClass(EncryptCookies::class))->getStaticPropertyValue('neverEncrypt');
+
+    expect($exempt)->toEqualCanonicalizing(['appearance', 'sidebar_state']);
+});
+
+test('the exempt cookies are read as plain text', function (): void {
+    $this->withUnencryptedCookies(['appearance' => 'dark', 'sidebar_state' => 'false'])
+        ->get('/login')
+        ->assertOk()
+        ->assertSee('class="dark"', escape: false);
+});

--- a/tests/Feature/CookiePostureTest.php
+++ b/tests/Feature/CookiePostureTest.php
@@ -30,12 +30,20 @@ test('the session cookie is http-only and same-site lax', function (): void {
         ->and($cookie->getSameSite())->toBe(Cookie::SAMESITE_LAX);
 });
 
-test('the session cookie is marked secure when SESSION_SECURE_COOKIE is on', function (): void {
-    expect(cookieFromResponse($this->get('/login'), config('session.cookie'))->isSecure())->toBeFalse();
+test('both server-set cookies are marked secure when SESSION_SECURE_COOKIE is on', function (): void {
+    config()->set('session.secure', false);
+
+    $response = $this->get('/login');
+
+    expect(cookieFromResponse($response, config('session.cookie'))->isSecure())->toBeFalse()
+        ->and(cookieFromResponse($response, 'XSRF-TOKEN')->isSecure())->toBeFalse();
 
     config()->set('session.secure', true);
 
-    expect(cookieFromResponse($this->get('/login'), config('session.cookie'))->isSecure())->toBeTrue();
+    $response = $this->get('/login');
+
+    expect(cookieFromResponse($response, config('session.cookie'))->isSecure())->toBeTrue()
+        ->and(cookieFromResponse($response, 'XSRF-TOKEN')->isSecure())->toBeTrue();
 });
 
 test('the XSRF-TOKEN cookie is readable by javascript by design, but encrypted and same-site lax', function (): void {


### PR DESCRIPTION
Closes #600.

## What

An Aikido surface scan flagged `XSRF-TOKEN` as a cookie missing `HttpOnly`. That
one is expected behaviour, so this closes it as accepted risk, but the audit the
issue asked for turned up two small real gaps in the cookies the *frontend*
writes.

- `sidebar_state` was written with no `SameSite` attribute at all (`appearance`
  had `SameSite=Lax`), so it fell back to per-browser defaults.
- Neither was marked `Secure`, so on an HTTPS deployment the browser would still
  send them back over plain HTTP.

Both writers now go through one helper, `resources/js/lib/cookies.ts`, that
applies `path=/`, `SameSite=Lax`, and `Secure` whenever the page itself was
served over HTTPS.

## Audit result

Verified against the live demo: `the-desk-session` is `httponly; secure;
samesite=lax` and encrypted, and `XSRF-TOKEN` is `secure; samesite=lax` and
encrypted, non-`HttpOnly` by design (the XHR client has to read it to echo the
`X-XSRF-TOKEN` header back). The two cookies exempt from Laravel's cookie
encryption hold a theme name and a boolean, so nothing sensitive travels in
plain text. No further gap found, so nothing was split out into its own issue.

`SESSION_SECURE_COOKIE` still has no production default; that is #598's scope,
and the docs now say plainly that it is not inferred from the request.

## Testing

- `tests/Feature/CookiePostureTest.php` locks the posture so a scan finding
  cannot quietly become true: session cookie `HttpOnly`+`SameSite=Lax`, both
  server-set cookies `Secure` under `SESSION_SECURE_COOKIE`, `XSRF-TOKEN`
  encrypted and deliberately not `HttpOnly`, and the encryption exemption list
  pinned to exactly `appearance` and `sidebar_state`.
- `resources/js/lib/cookies.test.ts` covers the attribute string and the writer.
- Full gate green at 100% coverage; frontend lint/format/types/vitest/build green;
  docs site builds.

## Docs

New **Cookies** section in `docs/src/content/docs/docs/reference/security.md`:
the four cookies and their flags, where `Secure` comes from for each, and why
`XSRF-TOKEN` is readable by JavaScript on purpose, so the next scan finding has
a written decision to point at.

No new user-facing copy, so no i18n keys.