### PR TITLE
feat: send hsts on secure responses and default the secure session cookie

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,6 +215,19 @@ CSP_REPORT_ONLY=true
 # CSP_EXTRA_CONNECT_SRC=
 # CSP_EXTRA_FRAME_SRC=
 # CSP_EXTRA_FONT_SRC=
+# Responses that arrive over HTTPS carry Strict-Transport-Security, which stops
+# a browser that has seen the host once from ever speaking plain HTTP to it
+# again — closing the window where an on-path attacker downgrades the first
+# navigation and reads the session cookie. It is never sent on a plain-HTTP
+# request, so a LAN deployment cannot lock itself out. Set HSTS_ENABLED=false
+# only if you send the header from your reverse proxy instead.
+# HSTS_ENABLED=true
+# HSTS_MAX_AGE=31536000
+# HSTS_INCLUDE_SUBDOMAINS=true
+# Preloading is opt-in and effectively irreversible: it commits every subdomain
+# of the registrable domain to HTTPS in browsers that ship the list. Only turn
+# it on if you own the whole domain and intend to submit it at hstspreload.org.
+# HSTS_PRELOAD=false
 
 LOG_CHANNEL=stack
 LOG_STACK=single
@@ -233,6 +246,11 @@ SESSION_LIFETIME=120
 SESSION_ENCRYPT=false
 SESSION_PATH=/
 SESSION_DOMAIN=null
+# Withhold the session cookie from plain-HTTP requests. Defaults to whether
+# APP_URL is an https:// URL, so an HTTPS install is covered without setting it;
+# override only to force it either way (for instance while terminating TLS
+# somewhere APP_URL does not describe).
+# SESSION_SECURE_COOKIE=true
 
 BROADCAST_CONNECTION=reverb
 FILESYSTEM_DISK=local

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -87,6 +87,25 @@ CSP_ENABLED=true
 # CSP_EXTRA_CONNECT_SRC=
 # CSP_EXTRA_FRAME_SRC=
 # CSP_EXTRA_FONT_SRC=
+# Strict-Transport-Security pins the host to HTTPS in every browser that has
+# seen it, closing the window where an on-path attacker downgrades a first or
+# typed navigation and reads the session cookie. Sent only on requests that
+# arrived over HTTPS (your proxy's X-Forwarded-Proto is trusted), so a
+# plain-HTTP deployment cannot lock itself out of its own hostname. Set false
+# only if you send the header from your reverse proxy instead.
+# HSTS_ENABLED=true
+# How long a browser remembers the pin, in seconds. One year is what the
+# hardening guides and the preload list ask for. Lower it while rolling HSTS out
+# if you want a short escape hatch; 0 tells browsers to forget the host.
+# HSTS_MAX_AGE=31536000
+# Extend the pin to every subdomain. Turn off only if a subdomain of this host
+# must stay reachable over plain HTTP.
+# HSTS_INCLUDE_SUBDOMAINS=true
+# Opt the domain into browsers' built-in preload list, so even a first-ever
+# visit never touches HTTP. Off by default and deliberately so: submission is
+# effectively irreversible and commits every subdomain of the registrable
+# domain. Only for a domain you own outright, submitted at hstspreload.org.
+# HSTS_PRELOAD=false
 
 # --- Single sign-on (OpenID Connect) -----------------------------------------
 # SSO_OIDC_ISSUER=https://your-idp.example.com
@@ -131,6 +150,11 @@ SESSION_LIFETIME=120
 SESSION_ENCRYPT=false
 SESSION_PATH=/
 SESSION_DOMAIN=null
+# Withhold the session cookie from plain-HTTP requests, so a downgraded request
+# cannot carry it. Defaults to whether APP_URL is an https:// URL, which covers
+# the normal HTTPS install with no edit here. Set it explicitly only to force
+# the flag either way.
+# SESSION_SECURE_COOKIE=true
 
 BROADCAST_CONNECTION=reverb
 FILESYSTEM_DISK=local

--- a/app/Http/Middleware/AddStrictTransportSecurityHeader.php
+++ b/app/Http/Middleware/AddStrictTransportSecurityHeader.php
@@ -19,6 +19,12 @@ use Symfony\Component\HttpFoundation\Response;
 final class AddStrictTransportSecurityHeader
 {
     /**
+     * The shortest max-age (one year, in seconds) the browsers' preload list
+     * accepts a submission with.
+     */
+    private const int PRELOAD_MINIMUM_MAX_AGE = 31536000;
+
+    /**
      * @param  Closure(Request): Response  $next
      */
     public function handle(Request $request, Closure $next): Response
@@ -41,13 +47,19 @@ final class AddStrictTransportSecurityHeader
     {
         // Floored at zero: a negative max-age is a typo the browser rejects,
         // and it would take the whole header down with it.
-        $directives = ['max-age='.max(0, (int) config('security.hsts.max_age'))];
+        $maxAge = max(0, (int) config('security.hsts.max_age'));
+        $includeSubdomains = (bool) config('security.hsts.include_subdomains');
 
-        if (config('security.hsts.include_subdomains')) {
+        $directives = ['max-age='.$maxAge];
+
+        if ($includeSubdomains) {
             $directives[] = 'includeSubDomains';
         }
 
-        if (config('security.hsts.preload')) {
+        // The preload list rejects anything under a year or excluding
+        // subdomains, so advertising `preload` beside either states an intent
+        // the policy cannot back. Send what is true instead.
+        if (config('security.hsts.preload') && $includeSubdomains && $maxAge >= self::PRELOAD_MINIMUM_MAX_AGE) {
             $directives[] = 'preload';
         }
 

--- a/app/Http/Middleware/AddStrictTransportSecurityHeader.php
+++ b/app/Http/Middleware/AddStrictTransportSecurityHeader.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Emit Strict-Transport-Security so a browser that has seen this host once
+ * refuses to speak plain HTTP to it again, closing the SSL-strip window a
+ * first or typed navigation would otherwise leave open.
+ *
+ * Global rather than web-only: the pin is a property of the transport, so the
+ * REST API earns it on the same terms.
+ */
+final class AddStrictTransportSecurityHeader
+{
+    /**
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        // Never on plain HTTP: a LAN deployment served over http:// would pin
+        // its own hostname to a scheme it does not answer on, and there is no
+        // way back other than waiting out the max-age on every browser.
+        if (! config('security.hsts.enabled') || ! $request->isSecure()) {
+            return $response;
+        }
+
+        $response->headers->set('Strict-Transport-Security', $this->policy());
+
+        return $response;
+    }
+
+    private function policy(): string
+    {
+        // Floored at zero: a negative max-age is a typo the browser rejects,
+        // and it would take the whole header down with it.
+        $directives = ['max-age='.max(0, (int) config('security.hsts.max_age'))];
+
+        if (config('security.hsts.include_subdomains')) {
+            $directives[] = 'includeSubDomains';
+        }
+
+        if (config('security.hsts.preload')) {
+            $directives[] = 'preload';
+        }
+
+        return implode('; ', $directives);
+    }
+}

--- a/app/Support/Http/SecureSessionCookie.php
+++ b/app/Support/Http/SecureSessionCookie.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Http;
+
+/**
+ * Whether the session cookie should carry the `Secure` flag when the operator
+ * has not said either way.
+ *
+ * Laravel ships `SESSION_SECURE_COOKIE` with no default, which resolves to
+ * `false` — so an HTTPS install would hand out session cookies a browser is
+ * happy to replay over plain HTTP unless the operator knew to set the key. The
+ * app's own APP_URL already states the scheme it is served on, so read the
+ * answer from there instead of asking for it twice.
+ */
+final class SecureSessionCookie
+{
+    /**
+     * Read from config/session.php, so it takes the raw APP_URL rather than
+     * touching the container — config is loaded before anything is bound.
+     */
+    public static function defaultFor(mixed $appUrl): bool
+    {
+        return is_string($appUrl)
+            && str_starts_with(mb_strtolower(trim($appUrl)), 'https://');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Middleware\AddContentSecurityPolicyHeaders;
+use App\Http\Middleware\AddStrictTransportSecurityHeader;
 use App\Http\Middleware\EnsureIntegrationsEnabled;
 use App\Http\Middleware\EnsurePasskeysEnabled;
 use App\Http\Middleware\EnsurePasswordLoginEnabled;
@@ -47,6 +48,12 @@ return Application::configure(basePath: dirname(__DIR__))
                 | Request::HEADER_X_FORWARDED_PORT
                 | Request::HEADER_X_FORWARDED_PROTO,
         );
+
+        // Global, not web-only: the HTTPS pin describes the transport, so the
+        // REST API and the /up health check carry it on the same terms as a
+        // page. It runs before the web group so a response short-circuited
+        // anywhere inside it still leaves with the header.
+        $middleware->append(AddStrictTransportSecurityHeader::class);
 
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 

--- a/config/security.php
+++ b/config/security.php
@@ -49,6 +49,9 @@ return [
         | commits every subdomain of the registrable domain, not just this app.
         | Only turn it on if you own the whole domain and intend to submit it at
         | https://hstspreload.org.
+        |
+        | The directive is only emitted when the rest of the policy would pass
+        | that submission — a max-age of at least a year, subdomains included.
         */
         'preload' => (bool) env('HSTS_PRELOAD', false),
 

--- a/config/security.php
+++ b/config/security.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTP Strict Transport Security
+    |--------------------------------------------------------------------------
+    |
+    | Tells the browser to reach this host over HTTPS only, for the configured
+    | number of seconds. Without it the very first (or a typed) navigation still
+    | goes out as plain HTTP, which is the window an on-path attacker uses to
+    | SSL-strip the connection and read the session cookie before the redirect
+    | to HTTPS ever happens.
+    |
+    | The header is only ever sent on a request that arrived over HTTPS (the
+    | reverse proxy's X-Forwarded-Proto is trusted for exactly this), so a
+    | plain-HTTP LAN deployment can never lock itself out of its own hostname.
+    |
+    | Set HSTS_ENABLED=false only if you send the header from your reverse proxy
+    | instead — two sources would fight over the max-age.
+    |
+    */
+
+    'hsts' => [
+
+        'enabled' => (bool) env('HSTS_ENABLED', true),
+
+        /*
+        | Seconds the browser should remember the pin. One year is the value the
+        | preload list requires and what every hardening guide asks for. Lower it
+        | while rolling HSTS out if you want a short escape hatch; 0 tells
+        | browsers to forget the host again.
+        */
+        'max_age' => (int) env('HSTS_MAX_AGE', 31536000),
+
+        /*
+        | Extends the pin to every subdomain. Turn it off only if a subdomain of
+        | your app's host must stay reachable over plain HTTP.
+        */
+        'include_subdomains' => (bool) env('HSTS_INCLUDE_SUBDOMAINS', true),
+
+        /*
+        | Opts the domain into the browsers' built-in preload list, so even a
+        | first-ever visit never touches HTTP. Off by default and deliberately
+        | so: submission is effectively irreversible on a human timescale, and it
+        | commits every subdomain of the registrable domain, not just this app.
+        | Only turn it on if you own the whole domain and intend to submit it at
+        | https://hstspreload.org.
+        */
+        'preload' => (bool) env('HSTS_PRELOAD', false),
+
+    ],
+
+];

--- a/config/session.php
+++ b/config/session.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Support\Http\SecureSessionCookie;
 use Illuminate\Support\Str;
 
 return [
@@ -169,9 +170,15 @@ return [
     | to the server if the browser has a HTTPS connection. This will keep
     | the cookie from being sent to you when it can't be done securely.
     |
+    | Laravel leaves this key with no default, which resolves to false — an
+    | HTTPS install would then hand out session cookies a browser will happily
+    | replay over plain HTTP. APP_URL already states the scheme the app is
+    | served on, so the default is read from there; set SESSION_SECURE_COOKIE
+    | explicitly to override it either way.
+    |
     */
 
-    'secure' => env('SESSION_SECURE_COOKIE'),
+    'secure' => env('SESSION_SECURE_COOKIE', SecureSessionCookie::defaultFor(env('APP_URL'))),
 
     /*
     |--------------------------------------------------------------------------

--- a/docs/src/content/docs/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/docs/reference/environment-variables.md
@@ -124,6 +124,10 @@ production — see [Configuration](/docs/self-hosting/configuration/#reverb-webs
 | `CSP_ENABLED`                | `true`  | [Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy) |
 | `CSP_REPORT_ONLY`            | `false` | [Feature toggles → Content Security Policy](/docs/reference/feature-toggles/#content-security-policy) |
 | `CSP_FRAME_ANCESTORS`        | `none`  | [Feature toggles → Clickjacking protection](/docs/reference/feature-toggles/#clickjacking-protection) |
+| `HSTS_ENABLED`               | `true`  | [Feature toggles → HTTPS enforcement (HSTS)](/docs/reference/feature-toggles/#https-enforcement-hsts) |
+| `HSTS_MAX_AGE`               | `31536000` | [Feature toggles → HTTPS enforcement (HSTS)](/docs/reference/feature-toggles/#https-enforcement-hsts) |
+| `HSTS_INCLUDE_SUBDOMAINS`    | `true`  | [Feature toggles → HTTPS enforcement (HSTS)](/docs/reference/feature-toggles/#https-enforcement-hsts) |
+| `HSTS_PRELOAD`               | `false` | [Feature toggles → HTTPS enforcement (HSTS)](/docs/reference/feature-toggles/#https-enforcement-hsts) |
 
 ## Content Security Policy
 
@@ -162,6 +166,21 @@ app may load:
 | Variable               | Default | Effect                                                                 |
 | ---------------------- | ------- | ---------------------------------------------------------------------- |
 | `CSP_FRAME_ANCESTORS`  | `none`  | Sends `frame-ancestors` and `X-Frame-Options`. See [Feature toggles → Clickjacking protection](/docs/reference/feature-toggles/#clickjacking-protection). |
+
+## Session cookies
+
+| Variable                | Default                         | Notes                                                                                              |
+| ----------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `SESSION_SECURE_COOKIE` | *(derived from `APP_URL`)*      | Adds the `Secure` flag, so the browser never sends the session cookie over plain HTTP. Defaults to `true` when `APP_URL` starts with `https://`, `false` otherwise. |
+| `SESSION_LIFETIME`      | `120`                           | Minutes of inactivity before a session expires.                                                     |
+| `SESSION_ENCRYPT`       | `false`                         | Encrypt session payloads at rest in Redis.                                                          |
+| `SESSION_DOMAIN`        | `null`                          | Cookie domain. Leave unset unless you deliberately share the cookie across subdomains.              |
+
+You only need to set `SESSION_SECURE_COOKIE` explicitly if the scheme in
+`APP_URL` does not describe how browsers actually reach the app — for example
+when TLS is terminated at a hostname other than the one `APP_URL` names. Setting
+it to `true` on a deployment served over plain HTTP means the browser will never
+return the cookie and nobody can stay signed in.
 
 ## Single sign-on (OpenID Connect)
 

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -362,6 +362,12 @@ months to reach users. Only enable it if you own the whole domain and intend to
 submit it deliberately.
 :::
 
+`preload` is only sent when the rest of the policy would actually qualify for
+the list — `HSTS_MAX_AGE` of at least `31536000` **and**
+`HSTS_INCLUDE_SUBDOMAINS=true`. Set it beside a shorter max-age or with
+subdomains excluded and the directive is left off rather than advertising an
+intent the policy cannot back.
+
 Turn `HSTS_INCLUDE_SUBDOMAINS` off if a subdomain of your app's host still has to
 answer over plain HTTP — the pin would otherwise make it unreachable too.
 

--- a/docs/src/content/docs/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/docs/reference/feature-toggles.md
@@ -327,6 +327,44 @@ Under `CSP_REPORT_ONLY=true` the directive is reported but not enforced, and
 `X-Frame-Options` is withheld — it has no report-only form, so sending it would
 enforce the very thing the dry run is meant to only observe.
 
+## HTTPS enforcement (HSTS)
+
+Responses that arrive over HTTPS carry
+`Strict-Transport-Security`, which tells the browser to reach the host over
+HTTPS only from then on. Without it the first visit, or any later one typed
+without a scheme, still goes out as plain HTTP — the window an on-path attacker
+uses to strip TLS and read the session cookie before your redirect to HTTPS ever
+happens.
+
+| Variable                   | Default    | Effect                                                                 |
+| -------------------------- | ---------- | ---------------------------------------------------------------------- |
+| `HSTS_ENABLED`             | `true`     | Send the header at all. Turn off only if your reverse proxy sends it.  |
+| `HSTS_MAX_AGE`             | `31536000` | Seconds the browser remembers the pin (one year). `0` forgets the host. |
+| `HSTS_INCLUDE_SUBDOMAINS`  | `true`     | Extend the pin to every subdomain.                                     |
+| `HSTS_PRELOAD`             | `false`    | Add `preload`. See the warning below.                                  |
+
+The defaults send:
+
+```http
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+```
+
+The header is **never** sent on a request that arrived over plain HTTP, so a LAN
+deployment served over `http://` cannot lock itself out of its own hostname.
+TLS is detected from your proxy's `X-Forwarded-Proto`, which the app already
+trusts — see [Reverse proxy & TLS](/docs/self-hosting/reverse-proxy/).
+
+:::caution
+`HSTS_PRELOAD` is effectively irreversible. Submitting a domain to
+[hstspreload.org](https://hstspreload.org) bakes it into browsers themselves, it
+commits **every** subdomain of the registrable domain to HTTPS, and removal takes
+months to reach users. Only enable it if you own the whole domain and intend to
+submit it deliberately.
+:::
+
+Turn `HSTS_INCLUDE_SUBDOMAINS` off if a subdomain of your app's host still has to
+answer over plain HTTP — the pin would otherwise make it unreachable too.
+
 ## Search analytics
 
 | Variable                   | Default | Effect                                             |

--- a/docs/src/content/docs/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/docs/reference/security-and-compliance.md
@@ -107,10 +107,14 @@ both the view and future exports.
 A self-hosted deployment delegates several controls to you. An auditor will expect
 evidence for each of these from **your** environment, not from this project:
 
-- **TLS termination and HSTS.** The Desk's containers speak plain HTTP. Terminate
-  TLS at your reverse proxy, redirect HTTP to HTTPS, and set HSTS. See
-  [Reverse proxy & TLS](/docs/self-hosting/reverse-proxy/), and set
-  `SESSION_SECURE_COOKIE=true` and the browser-facing `REVERB_SCHEME_PUBLIC=https`.
+- **TLS termination.** The Desk's containers speak plain HTTP. Terminate TLS at
+  your reverse proxy and redirect HTTP to HTTPS. See
+  [Reverse proxy & TLS](/docs/self-hosting/reverse-proxy/), and set the
+  browser-facing `REVERB_SCHEME_PUBLIC=https`. HSTS and the `Secure` session
+  cookie are handled by the app once TLS is in front of it — see
+  [HTTPS enforcement (HSTS)](/docs/reference/feature-toggles/#https-enforcement-hsts)
+  and [`SESSION_SECURE_COOKIE`](/docs/reference/environment-variables/#session-cookies)
+  for the evidence an auditor will ask for.
 - **Encryption at rest.** Encrypt the disk or volume that holds the PostgreSQL
   database and the uploaded-files volume. This is provided by your host or storage
   layer, not the app.

--- a/docs/src/content/docs/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/docs/reference/security-and-compliance.md
@@ -110,8 +110,10 @@ evidence for each of these from **your** environment, not from this project:
 - **TLS termination.** The Desk's containers speak plain HTTP. Terminate TLS at
   your reverse proxy and redirect HTTP to HTTPS. See
   [Reverse proxy & TLS](/docs/self-hosting/reverse-proxy/), and set the
-  browser-facing `REVERB_SCHEME_PUBLIC=https`. HSTS and the `Secure` session
-  cookie are handled by the app once TLS is in front of it — see
+  browser-facing `REVERB_SCHEME_PUBLIC=https`. The app then sends HSTS itself on
+  every request that arrived over HTTPS, and marks the session cookie `Secure`
+  whenever `APP_URL` is an `https://` URL — so make sure `APP_URL` names the
+  HTTPS address, or set `SESSION_SECURE_COOKIE=true` explicitly. See
   [HTTPS enforcement (HSTS)](/docs/reference/feature-toggles/#https-enforcement-hsts)
   and [`SESSION_SECURE_COOKIE`](/docs/reference/environment-variables/#session-cookies)
   for the evidence an auditor will ask for.

--- a/docs/src/content/docs/docs/reference/security.md
+++ b/docs/src/content/docs/docs/reference/security.md
@@ -41,6 +41,28 @@ CodeQL does not support PHP, so the Laravel backend is covered by PHPStan
 gates in the repository for details.
 :::
 
+## HTTPS is pinned once it is available
+
+Every response that arrives over HTTPS carries
+`Strict-Transport-Security: max-age=31536000; includeSubDomains`. A browser that
+has seen your instance once will not speak plain HTTP to it again for a year,
+which closes the SSL-strip window: without the header, a first visit or a URL
+typed without a scheme goes out unencrypted, and an attacker on the path can
+answer it themselves and take the session cookie before your redirect to HTTPS
+is ever reached.
+
+It is sent only when the request really was secure — the app reads your proxy's
+`X-Forwarded-Proto`. A deployment served over plain HTTP therefore never pins
+itself to a scheme it cannot answer on. Session cookies pick up the matching
+`Secure` flag by default whenever `APP_URL` is an `https://` URL, so a
+downgraded request carries no session at all.
+
+Both are configurable:
+[HTTPS enforcement (HSTS)](/docs/reference/feature-toggles/#https-enforcement-hsts)
+and [`SESSION_SECURE_COOKIE`](/docs/reference/environment-variables/#session-cookies).
+`preload` is opt-in and off by default: it is effectively irreversible for a
+domain and commits every subdomain with it.
+
 ## Content Security Policy
 
 Every web response carries a `Content-Security-Policy` header: the browser-side

--- a/docs/src/content/docs/docs/self-hosting/reverse-proxy.md
+++ b/docs/src/content/docs/docs/self-hosting/reverse-proxy.md
@@ -125,6 +125,25 @@ little headroom for multipart encoding overhead:
 - **Caddy / Traefik:** no request-body cap by default, so nothing to change unless you added one.
 - **PHP:** `upload_max_filesize` and `post_max_size` must both comfortably exceed the cap.
 
+## HSTS
+
+Once TLS is terminated, the app sends
+`Strict-Transport-Security: max-age=31536000; includeSubDomains` on every
+response that arrived over HTTPS, so a browser that has seen your instance once
+refuses to speak plain HTTP to it again. Nothing to configure — it rides on the
+same `X-Forwarded-Proto: https` your proxy already sets, and is withheld
+entirely on plain-HTTP requests so a `http://` deployment cannot lock itself out
+of its own hostname.
+
+If your proxy already sends the header, set `HSTS_ENABLED=false` so the two do
+not disagree about the `max-age`. The knobs (`HSTS_MAX_AGE`,
+`HSTS_INCLUDE_SUBDOMAINS`, and the deliberately opt-in `HSTS_PRELOAD`) are in
+[Feature toggles → HTTPS enforcement (HSTS)](/docs/reference/feature-toggles/#https-enforcement-hsts).
+
+Session cookies pick up the matching `Secure` flag automatically when `APP_URL`
+is an `https://` URL — see
+[`SESSION_SECURE_COOKIE`](/docs/reference/environment-variables/#session-cookies).
+
 ## Verifying
 
 After wiring up the proxy:

--- a/tests/Feature/Middleware/StrictTransportSecurityTest.php
+++ b/tests/Feature/Middleware/StrictTransportSecurityTest.php
@@ -56,6 +56,35 @@ test('preload is opt-in only — it is effectively irreversible for a domain', f
         ->toBe('max-age=31536000; includeSubDomains; preload');
 });
 
+test('preload is withheld when the rest of the policy would not qualify for the list', function (array $overrides): void {
+    config(['security.hsts.preload' => true, ...$overrides]);
+
+    // hstspreload.org rejects a submission whose max-age is under a year or
+    // whose subdomains are excluded. Advertising `preload` anyway states an
+    // intent the policy cannot back, so send the directives that are true.
+    expect($this->get('https://localhost/')->headers->get('Strict-Transport-Security'))
+        ->not->toContain('preload');
+})->with([
+    'max-age under a year' => [['security.hsts.max_age' => 300]],
+    'subdomains excluded' => [['security.hsts.include_subdomains' => false]],
+]);
+
+test('an error response is pinned too — it is the same connection', function (): void {
+    // The pin has to survive the paths a visitor hits by accident, or a browser
+    // that only ever saw a 404 stays willing to downgrade.
+    $response = $this->get('https://localhost/definitely-not-a-route')->assertNotFound();
+
+    expect($response->headers->get('Strict-Transport-Security'))
+        ->toBe('max-age=31536000; includeSubDomains');
+});
+
+test('the health check is pinned too — it answers before any route', function (): void {
+    $response = $this->get('https://localhost/up')->assertOk();
+
+    expect($response->headers->get('Strict-Transport-Security'))
+        ->toBe('max-age=31536000; includeSubDomains');
+});
+
 test('the header is dropped entirely when the operator owns it at the proxy', function (): void {
     config(['security.hsts.enabled' => false]);
 

--- a/tests/Feature/Middleware/StrictTransportSecurityTest.php
+++ b/tests/Feature/Middleware/StrictTransportSecurityTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+beforeEach(function (): void {
+    config([
+        'security.hsts.enabled' => true,
+        'security.hsts.max_age' => 31536000,
+        'security.hsts.include_subdomains' => true,
+        'security.hsts.preload' => false,
+    ]);
+});
+
+test('a secure response pins the host to https for a year, subdomains included', function (): void {
+    $response = $this->get('https://localhost/')->assertOk();
+
+    expect($response->headers->get('Strict-Transport-Security'))
+        ->toBe('max-age=31536000; includeSubDomains');
+});
+
+test('a plain-http response carries no policy at all', function (): void {
+    // Emitting it here would let a LAN deployment lock itself out of its own
+    // hostname: the browser would refuse the only scheme the host answers on.
+    $response = $this->get('http://localhost/')->assertOk();
+
+    expect($response->headers->get('Strict-Transport-Security'))->toBeNull();
+});
+
+test('an operator can shorten the max-age while rolling the policy out', function (): void {
+    config(['security.hsts.max_age' => 300]);
+
+    expect($this->get('https://localhost/')->headers->get('Strict-Transport-Security'))
+        ->toBe('max-age=300; includeSubDomains');
+});
+
+test('a negative max-age is floored at zero rather than emitted verbatim', function (): void {
+    config(['security.hsts.max_age' => -1]);
+
+    // max-age=0 is the standard "forget this host" value; a negative one is a
+    // typo the browser would reject, taking the whole header with it.
+    expect($this->get('https://localhost/')->headers->get('Strict-Transport-Security'))
+        ->toBe('max-age=0; includeSubDomains');
+});
+
+test('subdomains can be left out for a host that serves some of them over http', function (): void {
+    config(['security.hsts.include_subdomains' => false]);
+
+    expect($this->get('https://localhost/')->headers->get('Strict-Transport-Security'))
+        ->toBe('max-age=31536000');
+});
+
+test('preload is opt-in only — it is effectively irreversible for a domain', function (): void {
+    config(['security.hsts.preload' => true]);
+
+    expect($this->get('https://localhost/')->headers->get('Strict-Transport-Security'))
+        ->toBe('max-age=31536000; includeSubDomains; preload');
+});
+
+test('the header is dropped entirely when the operator owns it at the proxy', function (): void {
+    config(['security.hsts.enabled' => false]);
+
+    expect($this->get('https://localhost/')->headers->get('Strict-Transport-Security'))->toBeNull();
+});
+
+test('api responses are pinned too — the transport is the same one', function (): void {
+    $response = $this->getJson('https://localhost/api/v1/channels');
+
+    expect($response->headers->get('Strict-Transport-Security'))
+        ->toBe('max-age=31536000; includeSubDomains');
+});

--- a/tests/Feature/SecureSessionCookieTest.php
+++ b/tests/Feature/SecureSessionCookieTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Support\Http\SecureSessionCookie;
 use Illuminate\Testing\TestResponse;
 use Symfony\Component\HttpFoundation\Cookie;
 
@@ -19,7 +20,7 @@ function sessionCookie(TestResponse $response): Cookie
     return $cookie;
 }
 
-test('the session cookie is withheld from plain http once the flag is on', function (): void {
+test('the session cookie is marked Secure once the flag is on, so a browser withholds it from plain http', function (): void {
     config(['session.secure' => true]);
 
     expect(sessionCookie($this->get('https://localhost/'))->isSecure())->toBeTrue();
@@ -29,4 +30,11 @@ test('the flag can be turned off for a deployment that never speaks https', func
     config(['session.secure' => false]);
 
     expect(sessionCookie($this->get('https://localhost/'))->isSecure())->toBeFalse();
+});
+
+test('the flag is wired to APP_URL rather than left at Laravel’s insecure default', function (): void {
+    // config/session.php is the only place the two are joined up, and nothing
+    // else would notice if that expression were dropped: Laravel's own default
+    // resolves to false, which is exactly the gap this closes.
+    expect(config('session.secure'))->toBe(SecureSessionCookie::defaultFor(env('APP_URL')));
 });

--- a/tests/Feature/SecureSessionCookieTest.php
+++ b/tests/Feature/SecureSessionCookieTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+
+function sessionCookie(TestResponse $response): Cookie
+{
+    $name = config('session.cookie');
+
+    /** @var Cookie|null $cookie */
+    $cookie = collect($response->headers->getCookies())->first(
+        fn (Cookie $cookie): bool => $cookie->getName() === $name,
+    );
+
+    expect($cookie)->not->toBeNull();
+
+    return $cookie;
+}
+
+test('the session cookie is withheld from plain http once the flag is on', function (): void {
+    config(['session.secure' => true]);
+
+    expect(sessionCookie($this->get('https://localhost/'))->isSecure())->toBeTrue();
+});
+
+test('the flag can be turned off for a deployment that never speaks https', function (): void {
+    config(['session.secure' => false]);
+
+    expect(sessionCookie($this->get('https://localhost/'))->isSecure())->toBeFalse();
+});

--- a/tests/Unit/Support/Http/SecureSessionCookieTest.php
+++ b/tests/Unit/Support/Http/SecureSessionCookieTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Http\SecureSessionCookie;
+
+test('a deployment served over https gets the Secure flag without being asked', function (string $appUrl): void {
+    expect(SecureSessionCookie::defaultFor($appUrl))->toBeTrue();
+})->with([
+    'plain host' => ['https://desk.example.com'],
+    'with a port' => ['https://desk.example.com:8443'],
+    'shouted scheme' => ['HTTPS://desk.example.com'],
+    'padded value' => ['  https://desk.example.com  '],
+]);
+
+test('a plain-http deployment keeps the flag off so its own cookies still arrive', function (?string $appUrl): void {
+    expect(SecureSessionCookie::defaultFor($appUrl))->toBeFalse();
+})->with([
+    'http' => ['http://desk.example.test'],
+    'no scheme' => ['desk.example.test'],
+    'blank' => [''],
+    'unset' => [null],
+]);


### PR DESCRIPTION
Closes #598.

## What

Two halves of the same Aikido finding (risk 89) on the demo instance.

**HSTS.** A new global `AddStrictTransportSecurityHeader` emits
`Strict-Transport-Security: max-age=31536000; includeSubDomains` on every
response, so a browser that has seen the host once refuses to speak plain HTTP
to it again — closing the SSL-strip window where an on-path attacker answers a
first (or typed) navigation and harvests the session cookie before the redirect
to HTTPS is ever reached.

**Secure session cookies.** `config/session.php` read `SESSION_SECURE_COOKIE`
with no default, which resolves to `false` — so a default self-hosted install
handed out session cookies without the `Secure` flag even when served over
HTTPS. It now defaults from the `APP_URL` scheme via
`App\Support\Http\SecureSessionCookie`, and stays overridable either way.

## Why these shapes

- **Never on plain HTTP.** The header is withheld unless `$request->isSecure()`,
  so a LAN deployment served over `http://` cannot pin itself to a scheme it
  does not answer on — there is no way back other than waiting out the max-age
  in every browser that saw it. TLS is read from the proxy's
  `X-Forwarded-Proto`, which `bootstrap/app.php` already trusts.
- **Global, not web-only.** Unlike CSP, the pin describes the transport, so the
  REST API, error responses, and `/up` carry it on the same terms. Tests lock
  all three in.
- **`preload` is opt-in and guarded.** Off by default — submission is
  effectively irreversible and commits every subdomain of the registrable
  domain. It is also withheld unless the rest of the policy would actually pass
  a hstspreload.org submission (max-age ≥ 1 year, subdomains included), rather
  than advertising an intent the policy cannot back.
- **Negative max-age floored at zero.** A browser rejects a negative value and
  drops the whole header with it; `0` remains the documented way to tell
  browsers to forget the host.
- **New knobs**, all in `config/security.php`: `HSTS_ENABLED` (true),
  `HSTS_MAX_AGE` (31536000), `HSTS_INCLUDE_SUBDOMAINS` (true), `HSTS_PRELOAD`
  (false). Set `HSTS_ENABLED=false` if you send the header from your proxy.

## Testing

`./vendor/bin/sail composer test` — green, `Total: 100.0 %`, clean Pint /
PHPStan / Rector.

New tests: `tests/Feature/Middleware/StrictTransportSecurityTest.php` (secure vs.
plain-HTTP paths, each directive, the preload guard, error + health + API
responses), `tests/Feature/SecureSessionCookieTest.php` (the `Secure` flag, and
that `session.secure` is really wired to `APP_URL` rather than left at Laravel's
insecure default), `tests/Unit/Support/Http/SecureSessionCookieTest.php`.

## Docs

- `reference/environment-variables.md` — the four `HSTS_*` keys, plus a new
  **Session cookies** section for `SESSION_SECURE_COOKIE`.
- `reference/feature-toggles.md` — new **HTTPS enforcement (HSTS)** section
  including the irreversibility warning on preloading.
- `self-hosting/reverse-proxy.md` — an **HSTS** section: nothing to configure
  once TLS is terminated, and when to set `HSTS_ENABLED=false`.
- `reference/security.md` and `reference/security-and-compliance.md` — the
  latter's "operator responsibilities" no longer claims HSTS and the `Secure`
  cookie are entirely yours to arrange.
- `.env.example` and `.env.prod.example` carry the same keys.

Docs site builds clean (`cd docs && npm run build`); the new anchors resolve.

No user-facing copy, so no i18n catalog changes.

## Review

A local CodeRabbit pass ran before opening. Applied: the preload prerequisite
guard, `/up` and error-response coverage, a test asserting the `config/session.php`
wiring, clearer `SESSION_SECURE_COOKIE` wording in the compliance page, and a
test rename that had overclaimed what it asserted. Declined: two findings
claiming exception-path responses miss the header — verified empirically that a
404 does carry it (global middleware sits outside the pipeline's exception
handling), and added a regression test rather than the suggested extra hook. The
re-check hit the free tier's rate limit.