### PR TITLE
fix: stamp the running version on the candidate release line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,15 +196,40 @@ contains both jobs, and the pushed branch decides which one runs.
 
 Two consequences worth knowing:
 
-- **The candidate config declares no `extra-files`**, so an rc bump never stamps
-  `1.12.0-rc.0` into `VERSION`, `.env.prod.example`, `docker/install.sh`, or the
-  docs pages that quote a version. Those lines only ever carry stable versions.
+- **The candidate config stamps `VERSION` and nothing else.** An rc bump never
+  writes `1.12.0-rc.0` into `.env.prod.example`, `docker/install.sh`, or the docs
+  pages that quote a version: those are install instructions, and a self-hoster
+  following them must land on the latest *stable* release. `VERSION` is the one
+  exception because it is not an instruction — it is the running build's
+  self-description, read by `config('app.version')` for the user-menu footer and
+  the update-available check, so an rc image has to report `-rc.N`. Leaving it
+  unstamped made every candidate image claim the previous stable version
+  ([#660](https://github.com/emmpaul/the-desk/issues/660)).
 - **The candidate config sets `skip-changelog`**, so `CHANGELOG.md` belongs to
   `master` alone. Candidates still get full release notes on their GitHub
   release; they just don't write them to the file.
 
 These invariants are enforced by `tests/Unit/ReleaseFlowTest.php` rather than by
 convention — change the release setup and that file will tell you what broke.
+
+#### `VERSION` is the one line both release lines write
+
+Because each line stamps `VERSION` from its own manifest, the two branches hold
+different values between releases, and that has two expected consequences worth
+recognising rather than reacting to:
+
+- **`master` briefly reads `-rc.N`.** A promotion carries `develop`'s candidate
+  value across, and `master` keeps it until the stable release PR rewrites it to
+  the released number. Only images built in that window are affected — that is
+  the moving `edge` tag, never a published release, which is built from the `v*`
+  tag cut after the stamp.
+- **A promotion can conflict on that single line.** It only happens when *both*
+  lines moved `VERSION` since their last common point — in practice a hotfix
+  released on `master` while `develop` was cutting candidates. Normal releases
+  merge cleanly, because only one side has touched the file. When it does
+  conflict, auto-merge on the promotion PR stops and the resolution is to take
+  `develop`'s candidate value: `master`'s own release PR stamps the stable
+  number over it moments later either way.
 
 After each stable release, a job moves `develop`'s candidate baseline onto the
 version just released, so the next feature there starts a fresh `-rc.0` series

--- a/config/app.php
+++ b/config/app.php
@@ -23,10 +23,12 @@ return [
     |--------------------------------------------------------------------------
     |
     | The running release, read from the committed VERSION file so a single
-    | built image knows which version it is at runtime. release-please keeps
-    | VERSION in lockstep with the git tag (see release-please-config.json),
-    | so this is the source of truth the update-available check compares
-    | against the latest published release.
+    | built image knows which version it is at runtime. Both release lines keep
+    | VERSION in lockstep with the git tag they cut — the stable one through
+    | release-please-config.json and the candidate one through
+    | release-please-config.develop.json — so a candidate build reports its own
+    | `-rc.N` version, and this stays the source of truth the update-available
+    | check compares against the latest published release.
     |
     */
 

--- a/release-please-config.develop.json
+++ b/release-please-config.develop.json
@@ -13,7 +13,8 @@
         { "type": "perf", "section": "Performance" },
         { "type": "refactor", "section": "Code Refactoring" },
         { "type": "deps", "section": "Dependencies" }
-      ]
+      ],
+      "extra-files": [{ "type": "generic", "path": "VERSION" }]
     }
   }
 }

--- a/tests/Feature/Updates/UpdateCheckTest.php
+++ b/tests/Feature/Updates/UpdateCheckTest.php
@@ -51,6 +51,30 @@ test('the same or an older release is not flagged as an update', function (strin
         ->and($status->updateAvailable)->toBeFalse();
 })->with(['v1.4.2', 'v1.4.1', 'v1.0.0']);
 
+/*
+ * Candidate builds now report their own `-rc.N` version rather than the stable
+ * one they were cut from (#660), so the comparison has to read that suffix the
+ * SemVer way: a candidate is *ahead* of the stable release it precedes and
+ * *behind* the one it becomes.
+ */
+test('a candidate ahead of the latest stable is not flagged as an update', function (): void {
+    config(['app.version' => '1.5.0-rc.2']);
+    fakeLatestRelease('v1.4.2');
+
+    $this->artisan('updates:check')->assertSuccessful();
+
+    expect(app(UpdateChecker::class)->status()->updateAvailable)->toBeFalse();
+});
+
+test('a candidate is behind the stable release it becomes', function (): void {
+    config(['app.version' => '1.5.0-rc.2']);
+    fakeLatestRelease('v1.5.0');
+
+    $this->artisan('updates:check')->assertSuccessful();
+
+    expect(app(UpdateChecker::class)->status()->updateAvailable)->toBeTrue();
+});
+
 test('the check makes no outbound request when disabled', function (): void {
     config(['updates.enabled' => false]);
     Http::fake();

--- a/tests/Unit/ReleaseFlowTest.php
+++ b/tests/Unit/ReleaseFlowTest.php
@@ -15,8 +15,11 @@ use Symfony\Component\Yaml\Yaml;
  *
  * These tests pin that arrangement to the checked-in files, because every failure
  * mode here is silent: a missing `prerelease` flag publishes a candidate as the
- * latest stable release, and an `extra-files` entry on the candidate config
- * stamps `-rc` strings into the install instructions we ship to self-hosters.
+ * latest stable release, and an operator-facing `extra-files` entry on the
+ * candidate config stamps `-rc` strings into the install instructions we ship to
+ * self-hosters. The candidate line stamps VERSION and nothing else — that file
+ * is the running build's self-description rather than an instruction, so it has
+ * to say `-rc.N` on a candidate build (#660).
  */
 function repositoryPath(string $relative): string
 {
@@ -81,10 +84,53 @@ test('the stable line keeps ownership of the changelog', function (): void {
         ->not->toHaveKey('changelog-path');
 });
 
-test('the candidate config stamps no version references', function (): void {
-    $package = releaseConfigPackage('release-please-config.develop.json');
+/**
+ * The paths a release line stamps the new version into, in config order.
+ *
+ * @return array<int, string>
+ */
+function stampedPaths(string $relative): array
+{
+    $package = releaseConfigPackage($relative);
 
-    expect($package)->not->toHaveKey('extra-files');
+    expect($package)->toHaveKey('extra-files');
+
+    /** @var array<int, array<string, mixed>> $files */
+    $files = $package['extra-files'];
+
+    return array_map(static fn (array $file): string => (string) $file['path'], $files);
+}
+
+/*
+ * The candidate line stamps exactly one file, and the allow-list is asserted as
+ * an equality rather than a "contains" so adding a second one fails here.
+ *
+ * VERSION is the running build's self-description — `config('app.version')`
+ * reads it, so an rc image that does not carry `-rc.N` misreports itself and
+ * feeds the update-available check a stale baseline (#660). That is the one
+ * file the candidate line *must* stamp.
+ */
+test('the candidate line stamps the running version', function (): void {
+    expect(stampedPaths('release-please-config.develop.json'))->toBe(['VERSION']);
+});
+
+/*
+ * Everything else the stable line stamps is operator-facing instruction — the
+ * `DEFAULT_VERSION` a plain `curl | sh` installs, the image pin in the env
+ * template, and the versions quoted in the published docs. Those must keep
+ * naming the latest *stable* release, so a candidate release must never rewrite
+ * them. Derived from the stable config rather than hardcoded, so a sixth
+ * operator-facing file added there is covered by this guard automatically.
+ */
+test('the candidate line stamps no operator-facing file', function (): void {
+    $operatorFacing = array_values(array_diff(stampedPaths('release-please-config.json'), ['VERSION']));
+
+    expect($operatorFacing)->not->toBeEmpty()
+        ->and(array_intersect($operatorFacing, stampedPaths('release-please-config.develop.json')))->toBeEmpty();
+});
+
+test('the stable line stamps the running version too', function (): void {
+    expect(stampedPaths('release-please-config.json'))->toContain('VERSION');
 });
 
 /*


### PR DESCRIPTION
Closes #660.

## What

Adds `VERSION` — and only `VERSION` — to `release-please-config.develop.json`'s `extra-files`, so a candidate release stamps the running build's self-description the same way the stable line already does.

## Why

`config('app.version')` reads the committed `VERSION` file, which the candidate line never bumped: the 1.13.0-rc.1 release commit touched the manifest alone. So every rc image ever published misreported itself (`ghcr.io/emmpaul/the-desk:1.13.0-rc.1` showed `The Desk v1.12.2` in the user-menu footer), and the update-available check compared that stale baseline against the latest published release.

The omission was deliberate and pinned by a test, for a reason that holds for five of the six stable entries but not for `VERSION`: `docker/install.sh`, `.env.prod.example`, and the three docs pages are install instructions a self-hoster follows, and they must keep naming the latest **stable** release. `VERSION` is not an instruction — it is what the running build says it is, and on an rc build that should read `-rc.N`. So the guard is narrowed rather than deleted.

The issue offered a second approach (derive the version from a Docker build ARG). Approach A was chosen: a build ARG only fixes images built by `docker.yml` from a `v*` tag, leaving the documented source install (`git checkout vX.Y.Z-rc.N` + `docker-compose.build.yml`) still reporting the last stable number, and it splits the source of truth between the repo and the workflow.

## How tested

- `tests/Unit/ReleaseFlowTest.php` — the blanket `not->toHaveKey('extra-files')` assertion is replaced by three narrower ones: the candidate stamped set is *exactly* `["VERSION"]`; no operator-facing file is stamped on the candidate line (the expected set is derived from the stable config by diff, so a sixth stable entry is covered without touching the test); and the stable line still stamps `VERSION`. Adding `docker/install.sh` or a docs page to the candidate config fails both of the first two.
- `tests/Feature/Updates/UpdateCheckTest.php` — pins the downstream consequence now that a candidate reports its own version: an rc ahead of the latest stable shows no update banner, and an rc is correctly behind the stable release it becomes.
- Full gate green: Pint, PHPStan, Rector clean, `php artisan test --parallel --coverage --min=100` at `Total: 100.0 %`. Local CodeRabbit pass against `develop`: 0 findings.

## Docs

`CONTRIBUTING.md` -> *Releases*: the "candidate config declares no `extra-files`" bullet is rewritten, and a new subsection documents the two expected consequences of both lines writing that one file — `master` reads `-rc.N` in the window between a promotion merging and its stable release PR merging (which affects only the moving `edge` image, never a published release), and a promotion can conflict on that single line when both lines moved it since their last common point (a hotfix on `master` during a candidate series), with the resolution being to take `develop`'s value.

The stale comment in `config/app.php`, which credited `release-please-config.json` alone with keeping `VERSION` in lockstep, is corrected. No operator-facing setting changed, so no `docs/` page needed updating. No i18n keys added.

## Noticed while working on this

The Meilisearch volume-scoping defect from the tail of #660 was unfiled; opened as #667. Not touched here.