### PR TITLE
chore: install playwright browsers and start reverb when bootstrapping a worktree

### DIFF
--- a/bin/worktree
+++ b/bin/worktree
@@ -15,6 +15,11 @@
 # laravel.test's depends_on to pgsql; `sail up -d laravel.test` then starts those
 # two containers only.
 #
+# The Browser suite (tests/Browser) is the exception: it drives a real Chromium
+# and points the broadcaster at a live Reverb. So the bootstrap also installs the
+# Playwright browsers into the app container and brings `reverb` (and, via its
+# own depends_on, `redis`) up — four containers in total.
+#
 # Subcommands:
 #   create <NNN> [base]   Create (or re-enter) an isolated worktree for issue NNN.
 #                         Prints the worktree's absolute path on stdout so it is
@@ -362,7 +367,11 @@ cmd_create() {
         release_lock
     fi
 
-    log "issue #${nnn} -> slot ${slot} (project ${project}); ports app=${app_port} vite=${vite_port} reverb=${reverb_port} db=${db_port}"
+    # Derived rather than stored: the whole block comes from the slot anyway, and
+    # deriving keeps registry entries written by older versions readable on resume.
+    local redis_port=$((db_port + 1))
+
+    log "issue #${nnn} -> slot ${slot} (project ${project}); ports app=${app_port} vite=${vite_port} reverb=${reverb_port} db=${db_port} redis=${redis_port}"
 
     # --- git worktree (idempotent) -------------------------------------------
     mkdir -p "$WORKTREES_DIR"
@@ -370,33 +379,16 @@ cmd_create() {
 
     # --- .env (generated once; preserves manual edits on resume) -------------
     if [ ! -f "${path}/.env" ]; then
-        if [ -f "${MAIN_ROOT}/.env" ]; then
-            cp "${MAIN_ROOT}/.env" "${path}/.env"
-        else
+        local env_source="${MAIN_ROOT}/.env"
+        if [ ! -f "$env_source" ]; then
             log "no .env in main checkout; falling back to .env.example"
-            cp "${path}/.env.example" "${path}/.env"
+            env_source="${path}/.env.example"
         fi
-        upsert_env "${path}/.env" APP_PORT "$app_port"
-        upsert_env "${path}/.env" VITE_PORT "$vite_port"
-        upsert_env "${path}/.env" REVERB_PORT "$reverb_port"
-        upsert_env "${path}/.env" FORWARD_DB_PORT "$db_port"
-        upsert_env "${path}/.env" COMPOSE_PROJECT_NAME "$project"
-        upsert_env "${path}/.env" APP_URL "http://localhost:${app_port}"
-        # Auth toggles inherited from the main checkout can strip the register
-        # route (config/fortify.php gates Features::registration() on
-        # REGISTRATION_ENABLED / AUTH_SSO_ONLY / DEMO_MODE), and without it
-        # Wayfinder never emits resources/js/routes/register, so the bootstrap's
-        # `npm run build` dies on an unresolvable import (issue #563). Force the
-        # registration-friendly defaults; like the port overrides above, this
-        # only runs when generating a fresh .env, so a manually edited worktree
-        # .env is preserved on resume.
-        upsert_env "${path}/.env" DEMO_MODE false
-        upsert_env "${path}/.env" REGISTRATION_ENABLED true
-        upsert_env "${path}/.env" AUTH_SSO_ONLY false
+        write_env "$path" "$env_source" "$app_port" "$vite_port" "$db_port" "$redis_port" "$project"
     fi
 
     # --- compose override -----------------------------------------------------
-    write_override "$path" "$nnn"
+    write_override "$path" "$nnn" "$reverb_port"
 
     # --- dependencies ---------------------------------------------------------
     # The lightweight composer image lacks the app's runtime extensions
@@ -428,6 +420,16 @@ cmd_create() {
     log "installing JS dependencies via Sail (Linux-only native bindings)"
     (cd "$path" && ./vendor/bin/sail npm install --no-progress)
 
+    install_playwright_browsers "$path"
+
+    # The Browser suite points the broadcaster at the reverb container
+    # (tests/Pest.php calls useReverbForBrowserTests for the whole suite), so a
+    # worktree that can only run Unit+Feature is not enough. Started here rather
+    # than through laravel.test's depends_on so it boots after APP_KEY exists —
+    # reverb:start exits on a missing key and nothing would restart it.
+    log "starting reverb (+ redis) for the Browser suite"
+    (cd "$path" && ./vendor/bin/sail up -d reverb)
+
     # The feature suite renders Inertia pages, which fail with a 500 unless a Vite
     # manifest exists, so a testable worktree must build assets. Regenerate the
     # git-ignored App.Data/App.Enums ambient types first (the transformer needs
@@ -443,22 +445,94 @@ cmd_create() {
     printf '%s\n' "$path"
 }
 
+# Playwright ships its browser binaries out of band: `npm install` fetches the
+# driver but not Chromium, so every tests/Browser run in a fresh worktree dies
+# with "Playwright is outdated" (issue #579). The shared libraries Chromium links
+# against are installed with apt and need root, hence root-shell; the browser
+# itself installs as the sail user so it is readable by the test run. Both steps
+# are slow, so skip them when the build is already unpacked — that keeps
+# re-entry fast.
+#
+# Where "unpacked" is depends on PLAYWRIGHT_BROWSERS_PATH (the Sail image pins it
+# to 0, which means inside node_modules rather than a shared ~/.cache), so ask
+# Playwright itself where the build belongs instead of hardcoding a directory.
+PLAYWRIGHT_PROBE='loc=$(npx playwright install --dry-run chromium 2>/dev/null | sed -n "s/^ *Install location: *//p" | head -1); [ -n "$loc" ] && [ -d "$loc" ]'
+
+install_playwright_browsers() {
+    local path="$1"
+
+    if (cd "$path" && ./vendor/bin/sail shell -c "$PLAYWRIGHT_PROBE" >/dev/null 2>&1); then
+        log "Playwright chromium already present — skipping browser install"
+        return 0
+    fi
+
+    log "installing Playwright chromium and its system dependencies"
+    (cd "$path" && ./vendor/bin/sail root-shell -c "npx playwright install-deps chromium")
+    (cd "$path" && ./vendor/bin/sail npx playwright install chromium)
+}
+
+# Copy $source to the worktree's .env, offsetting the ports it publishes on the
+# host and pinning the ones that are container-internal.
+write_env() {
+    local path="$1" source="$2" app_port="$3" vite_port="$4" db_port="$5" redis_port="$6" project="$7"
+
+    cp "$source" "${path}/.env"
+    upsert_env "${path}/.env" APP_PORT "$app_port"
+    upsert_env "${path}/.env" VITE_PORT "$vite_port"
+    upsert_env "${path}/.env" FORWARD_DB_PORT "$db_port"
+    # reverb pulls redis in through its own depends_on, and redis publishes
+    # '${FORWARD_REDIS_PORT:-6379}:6379' — so without an offset the second
+    # worktree to start reverb dies on "Bind for :::6379 failed".
+    upsert_env "${path}/.env" FORWARD_REDIS_PORT "$redis_port"
+    upsert_env "${path}/.env" COMPOSE_PROJECT_NAME "$project"
+    upsert_env "${path}/.env" APP_URL "http://localhost:${app_port}"
+
+    # REVERB_PORT is overloaded in compose.yaml: it is BOTH the host side of
+    # '${REVERB_PORT}:8080' and — via config/broadcasting.php — the port the app
+    # dials at reverb:<port>. Offsetting it per worktree therefore points the
+    # broadcaster at a port nothing listens on, and the realtime browser tests
+    # hang. Pin the container-internal value (the reverb container is started
+    # with --port=8080) and let write_override remap the host side instead.
+    upsert_env "${path}/.env" REVERB_PORT 8080
+
+    # Auth toggles inherited from the main checkout can strip the register
+    # route (config/fortify.php gates Features::registration() on
+    # REGISTRATION_ENABLED / AUTH_SSO_ONLY / DEMO_MODE), and without it
+    # Wayfinder never emits resources/js/routes/register, so the bootstrap's
+    # `npm run build` dies on an unresolvable import (issue #563). Force the
+    # registration-friendly defaults; like the port overrides above, this
+    # only runs when generating a fresh .env, so a manually edited worktree
+    # .env is preserved on resume.
+    upsert_env "${path}/.env" DEMO_MODE false
+    upsert_env "${path}/.env" REGISTRATION_ENABLED true
+    upsert_env "${path}/.env" AUTH_SSO_ONLY false
+}
+
 write_override() {
-    local path="$1" nnn="$2"
+    local path="$1" nnn="$2" reverb_port="$3"
     cat > "${path}/compose.override.yaml" <<EOF
 # Generated by bin/worktree for issue #${nnn} — do not edit by hand.
 #
 # Trims laravel.test to the test-runner essentials: the gate only touches
-# Postgres (phpunit.xml uses array/sync/collection/null drivers), so redis,
-# meilisearch, mailpit, reverb and queue are never needed. With depends_on cut
-# to pgsql, \`sail up -d laravel.test\` starts exactly two containers.
+# Postgres (phpunit.xml uses array/sync/collection/null drivers), so
+# meilisearch, mailpit and queue are never needed. With depends_on cut to
+# pgsql, \`sail up -d laravel.test\` starts exactly two containers. The Browser
+# suite additionally needs a live WebSocket server, so bin/worktree starts
+# reverb (and, through its own depends_on, redis) as a separate step.
 #
-# Host ports and COMPOSE_PROJECT_NAME are offset per worktree in .env; Compose
-# auto-loads this override file alongside compose.yaml.
+# .env pins REVERB_PORT to the container-internal 8080 because the app dials
+# reverb:\${REVERB_PORT}; the per-worktree host offset lives here instead, so
+# concurrent worktrees still don't fight over the host port.
+#
+# Other host ports and COMPOSE_PROJECT_NAME are offset per worktree in .env;
+# Compose auto-loads this override file alongside compose.yaml.
 services:
     laravel.test:
         depends_on: !override
             - pgsql
+    reverb:
+        ports: !override
+            - '${reverb_port}:8080'
 EOF
 }
 

--- a/dev-docs/concurrent-worktrees.md
+++ b/dev-docs/concurrent-worktrees.md
@@ -20,6 +20,24 @@ isolated worktree runs just **`laravel.test` + `pgsql`** (2 containers). A
 generated `compose.override.yaml` trims `laravel.test`'s `depends_on` to
 `pgsql`, and `sail up -d laravel.test` then starts exactly those two.
 
+The **Browser suite** (`tests/Browser`) is the exception: it drives a real
+Chromium and `tests/Pest.php` points the broadcaster at a live Reverb for the
+whole suite. So the bootstrap additionally installs the Playwright browsers into
+the app container and starts `reverb` (which pulls in `redis` through its own
+`depends_on`) — four containers in total. Two details make that work:
+
+- Playwright's browser binaries ship out of band; `npm install` fetches only the
+  driver. They install in two steps because the shared libraries Chromium links
+  against need `apt` and therefore root (`sail root-shell -c "npx playwright
+  install-deps chromium"`), while the browser itself installs as the `sail` user
+  so its cache lands in the `HOME` Pest reads it back from. Re-entry probes the
+  cache and skips both when a chromium build is already unpacked.
+- `REVERB_PORT` is overloaded in `compose.yaml`: it is both the host side of
+  `${REVERB_PORT}:8080` and — via `config/broadcasting.php` — the port the app
+  dials at `reverb:<port>`. The generated `.env` therefore pins it to the
+  container-internal `8080`, and the per-worktree host offset moves into the
+  override's `reverb.ports`, so concurrent worktrees still don't fight over it.
+
 ## Commands
 
 ```bash
@@ -32,7 +50,8 @@ bin/worktree remove <NNN>          # tear down containers + volumes, remove the
 
 `create` allocates the lowest free **slot** (default 10, `WORKTREE_SLOTS`) under
 a lock, and derives the whole port block from it (`WORKTREE_PORT_BASE`, default
-`20000`; slot 0 → app 20000 / vite 20001 / reverb 20002 / db 20003). It forks
+`20000`; slot 0 → app 20000 / vite 20001 / reverb 20002 / db 20003 / redis
+20004). It forks
 from `master` by default; pass a foundation branch as `base` for a stacked-epic
 child. The base is fetched and resolved to its **remote-tracking** ref
 (`origin/<base>`) before forking, so a local branch lagging behind the remote

--- a/tests/Unit/WorktreeScriptTest.php
+++ b/tests/Unit/WorktreeScriptTest.php
@@ -59,6 +59,63 @@ function worktreeFixtureClone(): array
     return [$root.'/main', $root];
 }
 
+/**
+ * A throwaway directory that is itself a git repository, so it can serve as the
+ * cwd for runWorktreeLib: sourcing bin/worktree aborts unless it is invoked from
+ * inside a work tree. The repo root is not usable here — inside a worktree's
+ * container its .git file points at a host path that does not exist there.
+ */
+function tempGitDir(string $prefix): string
+{
+    $path = sys_get_temp_dir().'/'.$prefix.'-'.bin2hex(random_bytes(6));
+    mkdir($path, 0o755, true);
+    runGit($path, 'init', '--quiet', '--initial-branch=master', '.');
+
+    return $path;
+}
+
+/**
+ * Stand up a throwaway worktree directory whose ./vendor/bin/sail is a stub that
+ * records every invocation, so the Playwright bootstrap can be driven without
+ * Docker. The stub answers the "is chromium already there?" probe (`sail shell`)
+ * with $probeExit and succeeds for everything else.
+ *
+ * @return array{0: string, 1: string} the fake worktree path and its call log
+ */
+function fakeSailWorktree(int $probeExit): array
+{
+    $path = tempGitDir('worktree-sail');
+    mkdir($path.'/vendor/bin', 0o755, true);
+
+    $log = $path.'/sail-calls.log';
+    file_put_contents($path.'/vendor/bin/sail', <<<BASH
+        #!/usr/bin/env bash
+        printf '%s\n' "\$*" >> {$log}
+        [ "\$1" = "shell" ] && exit {$probeExit}
+        exit 0
+        BASH);
+    chmod($path.'/vendor/bin/sail', 0o755);
+
+    return [$path, $log];
+}
+
+/**
+ * The stub's recorded invocations, one per line, so a test can assert on whole
+ * commands instead of substrings (the "already installed?" probe shells out to
+ * `playwright install --dry-run`, so a substring match cannot tell a probe from
+ * a real install).
+ *
+ * @return list<string>
+ */
+function sailCalls(string $log): array
+{
+    if (! is_file($log)) {
+        return [];
+    }
+
+    return array_values(array_filter(explode("\n", (string) file_get_contents($log)), strlen(...)));
+}
+
 function gitRevision(string $cwd, string $revision): string
 {
     return trim(runGit($cwd, 'rev-parse', $revision)->getOutput());
@@ -172,4 +229,56 @@ test('a worktree sitting on the wrong branch aborts the bootstrap', function ():
     expect($process->getExitCode())->not->toBe(0)
         ->and($process->getErrorOutput())->toContain('619-slug')
         ->and($process->getErrorOutput())->toContain('other');
+});
+
+test('a fresh worktree installs the Playwright system deps as root and the chromium browser', function (): void {
+    [$path, $log] = fakeSailWorktree(probeExit: 1);
+
+    $process = runWorktreeLib($path, 'install_playwright_browsers '.escapeshellarg($path));
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(sailCalls($log))->toContain('root-shell -c npx playwright install-deps chromium')
+        ->and(sailCalls($log))->toContain('npx playwright install chromium');
+});
+
+test('a worktree that already has chromium skips the Playwright install', function (): void {
+    [$path, $log] = fakeSailWorktree(probeExit: 0);
+
+    $process = runWorktreeLib($path, 'install_playwright_browsers '.escapeshellarg($path));
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(sailCalls($log))->not->toContain('root-shell -c npx playwright install-deps chromium')
+        ->and(sailCalls($log))->not->toContain('npx playwright install chromium');
+});
+
+test('the generated override rebinds Reverb to the worktree host port and keeps the container on 8080', function (): void {
+    $path = tempGitDir('worktree-override');
+
+    $process = runWorktreeLib($path, 'write_override '.escapeshellarg($path).' 579 20002');
+    $override = (string) file_get_contents($path.'/compose.override.yaml');
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($override)->toContain("'20002:8080'")
+        ->and($override)->toContain('ports: !override');
+});
+
+test('the generated env pins the container-internal Reverb port while offsetting the host ports', function (): void {
+    $path = tempGitDir('worktree-env');
+    file_put_contents($path.'/source.env', "APP_NAME=Desk\nAPP_PORT=80\nREVERB_PORT=443\nDEMO_MODE=true\n");
+
+    $process = runWorktreeLib(
+        $path,
+        'write_env '.escapeshellarg($path).' '.escapeshellarg($path.'/source.env').' 20000 20001 20003 20004 desk-579',
+    );
+    $env = (string) file_get_contents($path.'/.env');
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($env)->toContain("\nREVERB_PORT=8080\n")
+        ->and($env)->toContain("\nAPP_PORT=20000\n")
+        ->and($env)->toContain("\nVITE_PORT=20001\n")
+        ->and($env)->toContain("\nFORWARD_DB_PORT=20003\n")
+        ->and($env)->toContain("\nFORWARD_REDIS_PORT=20004\n")
+        ->and($env)->toContain("\nCOMPOSE_PROJECT_NAME=desk-579\n")
+        ->and($env)->toContain("\nAPP_URL=http://localhost:20000\n")
+        ->and($env)->toContain("\nDEMO_MODE=false\n");
 });


### PR DESCRIPTION
Closes #579.

## What

`bin/worktree create NNN` now leaves a worktree that can run `./vendor/bin/sail artisan test tests/Browser` green with no manual steps.

Three things were missing, not one:

1. **Playwright browsers were never installed.** `npm install` fetches only the driver, so every browser test died with *"Playwright is outdated"*. The bootstrap now installs them: `install-deps` via `root-shell` (the shared libraries Chromium links against come from apt and need root) and the browser itself as the `sail` user.
2. **Reverb was never started.** `tests/Pest.php` calls `useReverbForBrowserTests()` for the whole Browser suite, but the generated `compose.override.yaml` trimmed `laravel.test`'s `depends_on` to `pgsql`. The bootstrap now brings `reverb` up (pulling in `redis` through its own `depends_on`) *after* `APP_KEY` exists, since `reverb:start` exits on a missing key and nothing would restart it.
3. **Two host ports collided.** `REVERB_PORT` is overloaded in `compose.yaml` — it is both the host side of `${REVERB_PORT}:8080` and, via `config/broadcasting.php`, the port the app dials at `reverb:<port>`. Offsetting it per worktree pointed the broadcaster at a dead port. It is now pinned to the container-internal `8080` and the per-worktree offset moved into the override's `reverb.ports`. `redis` publishes `${FORWARD_REDIS_PORT:-6379}:6379`, so that is offset too (slot block + 4) — otherwise the second worktree to start reverb dies on `Bind for :::6379 failed`.

The `.env` generation moved out of `cmd_create` into a `write_env` helper so it is testable at the `WORKTREE_LIB=1` seam.

## How tested

- 5 new Pest tests in `tests/Unit/WorktreeScriptTest.php` drive `install_playwright_browsers`, `write_env` and `write_override` through the existing `WORKTREE_LIB=1` seam, with a stubbed `./vendor/bin/sail` that records its invocations — no Docker needed.
- End to end: tore down worktree #579, re-bootstrapped it from scratch with the new script, then ran `sail artisan test tests/Browser` there — **62 passed, 0 failed**, no manual steps. All four containers came up on offset host ports with no collisions against the main checkout.
- Idempotency verified both ways: the probe reports "already present" on a ready worktree, and `create 579` re-entry returns in 0.15s.
- Full gate green in a clean worktree: Pint, PHPStan, Rector, and `--coverage --min=100` at **Total: 100.0%**. Frontend gate green (ESLint, Prettier, `vue-tsc`, 735 Vitest tests).

## Notes

- The idempotency probe asks Playwright itself where the build belongs (`install --dry-run`) rather than hardcoding a cache path: the Sail image pins `PLAYWRIGHT_BROWSERS_PATH=0`, so browsers land in `node_modules/playwright-core/.local-browsers/`, not `~/.cache/ms-playwright`.
- The new tests create their own throwaway git repo for the cwd. Using the repo root breaks inside a worktree's container, where `.git` is a file pointing at a host path that does not exist there — caught by running the gate in the worktree itself.
- No i18n impact (developer tooling, no user-facing copy). `dev-docs/concurrent-worktrees.md` updated in the same change; no `docs/` (operator-facing) impact.