### PR TITLE
feat: replace the native date inputs with shadcn date pickers

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -914,6 +914,7 @@
   "Format": "Format",
   "From %s": "À partir du %s",
   "From :date": "À partir du :date",
+  ":start – :end": "du :start au :end",
   "Generating…": "Génération…",
   "JSON": "JSON",
   "Learn more": "En savoir plus",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -955,6 +955,7 @@
   "Custom…": "Personnalisé…",
   "After": "Après",
   "Before": "Avant",
+  "Pick a date": "Choisir une date",
   "Since :date": "Depuis le :date",
   "Before :date": "Avant le :date",
   "from :name": "de :name",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
             "dependencies": {
                 "@inertiajs/vite": "^3.0.0",
                 "@inertiajs/vue3": "^3.0.0",
+                "@internationalized/date": "^3.12.2",
                 "@laravel/passkeys": "^0.2.0",
                 "@lucide/vue": "^1.24.0",
                 "@tanstack/vue-virtual": "^3.13.31",
@@ -2291,6 +2292,72 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+            "version": "2.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "dependencies": {
         "@inertiajs/vite": "^3.0.0",
         "@inertiajs/vue3": "^3.0.0",
+        "@internationalized/date": "^3.12.2",
         "@laravel/passkeys": "^0.2.0",
         "@lucide/vue": "^1.24.0",
         "@tanstack/vue-virtual": "^3.13.31",

--- a/resources/js/components/ui/date-picker/DatePicker.test.ts
+++ b/resources/js/components/ui/date-picker/DatePicker.test.ts
@@ -94,28 +94,4 @@ describe('DatePicker', () => {
 
         expect(selected.value).toBe('2026-07-15');
     });
-
-    it('clears the value when the clear control is used', async () => {
-        const selected = ref<string | null>('2026-07-10');
-
-        mount({
-            modelValue: selected.value,
-            clearable: true,
-            clearLabel: 'Clear date',
-            'onUpdate:modelValue': (day: string | null) => {
-                selected.value = day;
-            },
-        });
-
-        const clear = document.querySelector<HTMLElement>(
-            '[data-slot="date-picker-clear"]',
-        );
-
-        expect(clear).not.toBeNull();
-
-        clear?.click();
-        await nextTick();
-
-        expect(selected.value).toBeNull();
-    });
 });

--- a/resources/js/components/ui/date-picker/DatePicker.test.ts
+++ b/resources/js/components/ui/date-picker/DatePicker.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h, nextTick, ref } from 'vue';
+import { DatePicker } from '.';
+
+/**
+ * Mounts `<DatePicker>` for real — the reka-ui popover and calendar included —
+ * so the tests exercise the seam a page sees: an ISO `YYYY-MM-DD` model in, a
+ * locale-formatted trigger and an ISO day back out. `$t` echoes its key, which
+ * is all the component's own copy needs.
+ */
+let app: App | null = null;
+
+function mount(props: Record<string, unknown>): HTMLElement {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    app = createApp({ render: () => h(DatePicker, props) });
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(host);
+
+    return host;
+}
+
+function trigger(): HTMLElement {
+    const element = document.querySelector<HTMLElement>(
+        '[data-slot="date-picker-trigger"]',
+    );
+
+    if (element === null) {
+        throw new Error('The date picker trigger was not rendered.');
+    }
+
+    return element;
+}
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('DatePicker', () => {
+    it('shows the placeholder while nothing is selected', () => {
+        mount({ modelValue: null, placeholder: 'Start date' });
+
+        expect(trigger().textContent).toContain('Start date');
+    });
+
+    it('shows the selected day formatted for the active locale', () => {
+        mount({ modelValue: '2026-07-10' });
+
+        expect(trigger().textContent).toContain('Jul 10, 2026');
+    });
+
+    it('labels the trigger and flags an invalid value for assistive tech', () => {
+        mount({
+            modelValue: null,
+            ariaLabel: 'Start date',
+            invalid: true,
+            'data-test': 'audit-export-range-start',
+        });
+
+        expect(trigger().getAttribute('aria-label')).toBe('Start date');
+        expect(trigger().getAttribute('aria-invalid')).toBe('true');
+        expect(trigger().getAttribute('data-test')).toBe(
+            'audit-export-range-start',
+        );
+    });
+
+    it('emits the picked day as an ISO string', async () => {
+        const selected = ref<string | null>('2026-07-10');
+
+        mount({
+            modelValue: selected.value,
+            'onUpdate:modelValue': (day: string | null) => {
+                selected.value = day;
+            },
+        });
+
+        trigger().click();
+        await nextTick();
+        await nextTick();
+
+        const cell = document.querySelector<HTMLElement>(
+            '[data-reka-calendar-cell-trigger][data-value="2026-07-15"]',
+        );
+
+        expect(cell).not.toBeNull();
+
+        cell?.click();
+        await nextTick();
+
+        expect(selected.value).toBe('2026-07-15');
+    });
+
+    it('clears the value when the clear control is used', async () => {
+        const selected = ref<string | null>('2026-07-10');
+
+        mount({
+            modelValue: selected.value,
+            clearable: true,
+            clearLabel: 'Clear date',
+            'onUpdate:modelValue': (day: string | null) => {
+                selected.value = day;
+            },
+        });
+
+        const clear = document.querySelector<HTMLElement>(
+            '[data-slot="date-picker-clear"]',
+        );
+
+        expect(clear).not.toBeNull();
+
+        clear?.click();
+        await nextTick();
+
+        expect(selected.value).toBeNull();
+    });
+});

--- a/resources/js/components/ui/date-picker/DatePicker.test.ts
+++ b/resources/js/components/ui/date-picker/DatePicker.test.ts
@@ -12,11 +12,15 @@ import { DatePicker } from '.';
  */
 let app: App | null = null;
 
-function mount(props: Record<string, unknown>): HTMLElement {
+type DatePickerProps = InstanceType<typeof DatePicker>['$props'];
+
+function mount(props: DatePickerProps & Record<string, unknown>): HTMLElement {
     const host = document.createElement('div');
     document.body.appendChild(host);
 
-    app = createApp({ render: () => h(DatePicker, props) });
+    app = createApp({
+        render: () => h(DatePicker, props),
+    });
     app.config.globalProperties.$t = (key: string) => key;
     app.mount(host);
 
@@ -43,13 +47,17 @@ afterEach(() => {
 
 describe('DatePicker', () => {
     it('shows the placeholder while nothing is selected', () => {
-        mount({ modelValue: null, placeholder: 'Start date' });
+        mount({
+            modelValue: null,
+            placeholder: 'Start date',
+            fieldLabel: 'Start date',
+        });
 
         expect(trigger().textContent).toContain('Start date');
     });
 
     it('shows the selected day formatted for the active locale', () => {
-        mount({ modelValue: '2026-07-10' });
+        mount({ modelValue: '2026-07-10', fieldLabel: 'Start date' });
 
         expect(trigger().textContent).toContain('Jul 10, 2026');
     });
@@ -57,7 +65,7 @@ describe('DatePicker', () => {
     it('labels the trigger and flags an invalid value for assistive tech', () => {
         mount({
             modelValue: null,
-            ariaLabel: 'Start date',
+            fieldLabel: 'Start date',
             invalid: true,
             'data-test': 'audit-export-range-start',
         });
@@ -74,6 +82,7 @@ describe('DatePicker', () => {
 
         mount({
             modelValue: selected.value,
+            fieldLabel: 'Start date',
             'onUpdate:modelValue': (day: string | null) => {
                 selected.value = day;
             },

--- a/resources/js/components/ui/date-picker/DatePicker.vue
+++ b/resources/js/components/ui/date-picker/DatePicker.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { DateValue } from 'reka-ui';
 import type { HTMLAttributes } from 'vue';
-import { Calendar as CalendarIcon, X } from '@lucide/vue';
+import { Calendar as CalendarIcon } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
@@ -36,10 +36,6 @@ const props = withDefaults(
         /** Marks the trigger `aria-invalid`, e.g. when the range it belongs to is backwards. */
         invalid?: boolean;
         disabled?: boolean;
-        /** Renders an inline control that resets the value to `null`. */
-        clearable?: boolean;
-        /** Accessible name for the clear control. */
-        clearLabel?: string;
         class?: HTMLAttributes['class'];
     }>(),
     {
@@ -50,8 +46,6 @@ const props = withDefaults(
         ariaLabel: undefined,
         invalid: false,
         disabled: false,
-        clearable: false,
-        clearLabel: undefined,
         class: undefined,
     },
 );
@@ -81,8 +75,7 @@ function select(value: DateValue | undefined): void {
 </script>
 
 <template>
-    <div class="inline-flex items-center gap-1">
-        <Popover v-model:open="open">
+    <Popover v-model:open="open">
             <PopoverTrigger as-child>
                 <Button
                     variant="outline"
@@ -115,18 +108,5 @@ function select(value: DateValue | undefined): void {
                     @update:model-value="select"
                 />
             </PopoverContent>
-        </Popover>
-        <Button
-            v-if="clearable && modelValue"
-            variant="ghost"
-            size="icon-sm"
-            type="button"
-            class="rounded-full text-muted-foreground"
-            :aria-label="clearLabel"
-            data-slot="date-picker-clear"
-            @click="select(undefined)"
-        >
-            <X class="size-3.5" />
-        </Button>
-    </div>
+    </Popover>
 </template>

--- a/resources/js/components/ui/date-picker/DatePicker.vue
+++ b/resources/js/components/ui/date-picker/DatePicker.vue
@@ -31,8 +31,12 @@ const props = withDefaults(
         min?: string | null;
         /** Latest selectable day, as `YYYY-MM-DD`. */
         max?: string | null;
-        /** Accessible name for the trigger, since the value alone rarely says which field this is. */
-        ariaLabel?: string;
+        /**
+         * Accessible name for the trigger. Required: the trigger's visible text
+         * is the value (or a generic placeholder), which never says *which*
+         * date field it is — and is absent entirely before anything is picked.
+         */
+        fieldLabel: string;
         /** Marks the trigger `aria-invalid`, e.g. when the range it belongs to is backwards. */
         invalid?: boolean;
         disabled?: boolean;
@@ -43,7 +47,6 @@ const props = withDefaults(
         placeholder: undefined,
         min: null,
         max: null,
-        ariaLabel: undefined,
         invalid: false,
         disabled: false,
         class: undefined,
@@ -81,7 +84,7 @@ function select(value: DateValue | undefined): void {
                     variant="outline"
                     type="button"
                     :disabled="disabled"
-                    :aria-label="ariaLabel"
+                    :aria-label="fieldLabel"
                     :aria-invalid="invalid"
                     data-slot="date-picker-trigger"
                     :class="

--- a/resources/js/components/ui/date-picker/DatePicker.vue
+++ b/resources/js/components/ui/date-picker/DatePicker.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import type { DateValue } from 'reka-ui';
+import type { HTMLAttributes } from 'vue';
+import { Calendar as CalendarIcon, X } from '@lucide/vue';
+import { computed, ref } from 'vue';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
+import { toCalendarDate, toIsoDay } from '@/lib/calendarDate';
+import { formatIsoDay } from '@/lib/datetime';
+import { i18n } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
+
+/**
+ * A calendar-backed replacement for `<input type="date">`. Its model is a plain
+ * ISO `YYYY-MM-DD` day (or `null`), so a call site keeps the exact string it
+ * already sends to the server, while the reader gets a themed, locale-aware
+ * calendar instead of the browser's native picker.
+ */
+const props = withDefaults(
+    defineProps<{
+        /** The selected day as `YYYY-MM-DD`, or `null` when nothing is picked. */
+        modelValue?: string | null;
+        /** Trigger label shown while no day is selected. */
+        placeholder?: string;
+        /** Earliest selectable day, as `YYYY-MM-DD`. */
+        min?: string | null;
+        /** Latest selectable day, as `YYYY-MM-DD`. */
+        max?: string | null;
+        /** Accessible name for the trigger, since the value alone rarely says which field this is. */
+        ariaLabel?: string;
+        /** Marks the trigger `aria-invalid`, e.g. when the range it belongs to is backwards. */
+        invalid?: boolean;
+        disabled?: boolean;
+        /** Renders an inline control that resets the value to `null`. */
+        clearable?: boolean;
+        /** Accessible name for the clear control. */
+        clearLabel?: string;
+        class?: HTMLAttributes['class'];
+    }>(),
+    {
+        modelValue: null,
+        placeholder: undefined,
+        min: null,
+        max: null,
+        ariaLabel: undefined,
+        invalid: false,
+        disabled: false,
+        clearable: false,
+        clearLabel: undefined,
+        class: undefined,
+    },
+);
+
+const emits = defineEmits<{
+    'update:modelValue': [day: string | null];
+}>();
+
+defineOptions({
+    inheritAttrs: false,
+});
+
+const open = ref(false);
+
+const selected = computed<DateValue | undefined>(() =>
+    toCalendarDate(props.modelValue),
+);
+
+const label = computed(() =>
+    props.modelValue ? formatIsoDay(props.modelValue) : props.placeholder,
+);
+
+function select(value: DateValue | undefined): void {
+    emits('update:modelValue', toIsoDay(value));
+    open.value = false;
+}
+</script>
+
+<template>
+    <div class="inline-flex items-center gap-1">
+        <Popover v-model:open="open">
+            <PopoverTrigger as-child>
+                <Button
+                    variant="outline"
+                    type="button"
+                    :disabled="disabled"
+                    :aria-label="ariaLabel"
+                    :aria-invalid="invalid"
+                    data-slot="date-picker-trigger"
+                    :class="
+                        cn(
+                            'h-9 justify-start gap-2 rounded-lg px-3 font-normal',
+                            modelValue ? undefined : 'text-muted-foreground',
+                            props.class,
+                        )
+                    "
+                    v-bind="$attrs"
+                >
+                    <CalendarIcon class="size-3.5" aria-hidden="true" />
+                    {{ label }}
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent class="w-auto p-0" align="start">
+                <Calendar
+                    :model-value="selected"
+                    :min-value="toCalendarDate(min)"
+                    :max-value="toCalendarDate(max)"
+                    :locale="i18n.locale"
+                    weekday-format="short"
+                    initial-focus
+                    @update:model-value="select"
+                />
+            </PopoverContent>
+        </Popover>
+        <Button
+            v-if="clearable && modelValue"
+            variant="ghost"
+            size="icon-sm"
+            type="button"
+            class="rounded-full text-muted-foreground"
+            :aria-label="clearLabel"
+            data-slot="date-picker-clear"
+            @click="select(undefined)"
+        >
+            <X class="size-3.5" />
+        </Button>
+    </div>
+</template>

--- a/resources/js/components/ui/date-picker/index.ts
+++ b/resources/js/components/ui/date-picker/index.ts
@@ -1,0 +1,1 @@
+export { default as DatePicker } from "./DatePicker.vue"

--- a/resources/js/components/ui/popover/Popover.vue
+++ b/resources/js/components/ui/popover/Popover.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import type { PopoverRootEmits, PopoverRootProps } from "reka-ui"
+import { PopoverRoot, useForwardPropsEmits } from "reka-ui"
+
+const props = defineProps<PopoverRootProps>()
+const emits = defineEmits<PopoverRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <PopoverRoot
+    v-slot="slotProps"
+    data-slot="popover"
+    v-bind="forwarded"
+  >
+    <slot v-bind="slotProps" />
+  </PopoverRoot>
+</template>

--- a/resources/js/components/ui/popover/PopoverAnchor.vue
+++ b/resources/js/components/ui/popover/PopoverAnchor.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { PopoverAnchorProps } from "reka-ui"
+import { PopoverAnchor } from "reka-ui"
+
+const props = defineProps<PopoverAnchorProps>()
+</script>
+
+<template>
+  <PopoverAnchor
+    data-slot="popover-anchor"
+    v-bind="props"
+  >
+    <slot />
+  </PopoverAnchor>
+</template>

--- a/resources/js/components/ui/popover/PopoverContent.vue
+++ b/resources/js/components/ui/popover/PopoverContent.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { PopoverContentEmits, PopoverContentProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import {
+  PopoverContent,
+  PopoverPortal,
+  useForwardPropsEmits,
+} from "reka-ui"
+import { cn } from "@/lib/utils"
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(
+  defineProps<PopoverContentProps & { class?: HTMLAttributes["class"] }>(),
+  {
+    align: "center",
+    sideOffset: 4,
+  },
+)
+const emits = defineEmits<PopoverContentEmits>()
+
+const delegatedProps = reactiveOmit(props, "class")
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <PopoverPortal>
+    <PopoverContent
+      data-slot="popover-content"
+      v-bind="{ ...forwarded, ...$attrs }"
+      :class="
+        cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--reka-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          props.class,
+        )
+      "
+    >
+      <slot />
+    </PopoverContent>
+  </PopoverPortal>
+</template>

--- a/resources/js/components/ui/popover/PopoverTrigger.vue
+++ b/resources/js/components/ui/popover/PopoverTrigger.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import type { PopoverTriggerProps } from "reka-ui"
+import { PopoverTrigger } from "reka-ui"
+
+const props = defineProps<PopoverTriggerProps>()
+</script>
+
+<template>
+  <PopoverTrigger
+    data-slot="popover-trigger"
+    v-bind="props"
+  >
+    <slot />
+  </PopoverTrigger>
+</template>

--- a/resources/js/components/ui/popover/index.ts
+++ b/resources/js/components/ui/popover/index.ts
@@ -1,0 +1,4 @@
+export { default as Popover } from "./Popover.vue"
+export { default as PopoverAnchor } from "./PopoverAnchor.vue"
+export { default as PopoverContent } from "./PopoverContent.vue"
+export { default as PopoverTrigger } from "./PopoverTrigger.vue"

--- a/resources/js/lib/calendarDate.test.ts
+++ b/resources/js/lib/calendarDate.test.ts
@@ -1,0 +1,34 @@
+import { CalendarDate } from '@internationalized/date';
+import { describe, expect, it } from 'vitest';
+import { toCalendarDate, toIsoDay } from './calendarDate';
+
+describe('toCalendarDate', () => {
+    it('parses an ISO day into a calendar date', () => {
+        const parsed = toCalendarDate('2026-07-20');
+
+        expect(parsed).toEqual(new CalendarDate(2026, 7, 20));
+    });
+
+    it('returns undefined for an empty, null, or malformed day', () => {
+        expect(toCalendarDate('')).toBeUndefined();
+        expect(toCalendarDate(null)).toBeUndefined();
+        expect(toCalendarDate(undefined)).toBeUndefined();
+        expect(toCalendarDate('20/07/2026')).toBeUndefined();
+        expect(toCalendarDate('2026-13-01')).toBeUndefined();
+    });
+});
+
+describe('toIsoDay', () => {
+    it('serializes a calendar date as a zero-padded ISO day', () => {
+        expect(toIsoDay(new CalendarDate(2026, 7, 5))).toBe('2026-07-05');
+    });
+
+    it('returns null when there is no value', () => {
+        expect(toIsoDay(undefined)).toBeNull();
+        expect(toIsoDay(null)).toBeNull();
+    });
+
+    it('round-trips an ISO day unchanged', () => {
+        expect(toIsoDay(toCalendarDate('2026-01-09'))).toBe('2026-01-09');
+    });
+});

--- a/resources/js/lib/calendarDate.ts
+++ b/resources/js/lib/calendarDate.ts
@@ -5,8 +5,9 @@
  * field's model stays a plain ISO day, exactly as the server sends and expects it.
  */
 
+import type { CalendarDate } from '@internationalized/date';
+import { parseDate } from '@internationalized/date';
 import type { DateValue } from 'reka-ui';
-import { CalendarDate, parseDate } from '@internationalized/date';
 
 /**
  * Parse a `YYYY-MM-DD` day into a calendar date, or `undefined` when the value

--- a/resources/js/lib/calendarDate.ts
+++ b/resources/js/lib/calendarDate.ts
@@ -1,0 +1,43 @@
+/**
+ * The bridge between the `YYYY-MM-DD` strings our forms and query params speak
+ * and the `DateValue` objects the reka-ui calendar works on. Keeping it here
+ * means call sites never touch `@internationalized/date` themselves: a date
+ * field's model stays a plain ISO day, exactly as the server sends and expects it.
+ */
+
+import type { DateValue } from 'reka-ui';
+import { CalendarDate, parseDate } from '@internationalized/date';
+
+/**
+ * Parse a `YYYY-MM-DD` day into a calendar date, or `undefined` when the value
+ * is absent or not a valid day — an empty field and a malformed one both mean
+ * "nothing selected" to a picker.
+ */
+export function toCalendarDate(
+    day: string | null | undefined,
+): CalendarDate | undefined {
+    if (!day) {
+        return undefined;
+    }
+
+    try {
+        return parseDate(day);
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Serialize a calendar date back to a zero-padded `YYYY-MM-DD` day, or `null`
+ * when nothing is selected. The date is read field by field rather than via
+ * `toString()` so a zoned or date-time value can never leak a time offset in.
+ */
+export function toIsoDay(value: DateValue | null | undefined): string | null {
+    if (!value) {
+        return null;
+    }
+
+    const pad = (part: number): string => String(part).padStart(2, '0');
+
+    return `${String(value.year).padStart(4, '0')}-${pad(value.month)}-${pad(value.day)}`;
+}

--- a/resources/js/lib/datetime.test.ts
+++ b/resources/js/lib/datetime.test.ts
@@ -54,11 +54,18 @@ describe('formatIsoDay', () => {
      * A bare `YYYY-MM-DD` is parsed as UTC midnight by `new Date()`, which reads
      * as the previous day in any behind-UTC zone. The helper anchors the day to
      * local midnight instead, so a calendar day never shifts under the reader.
+     * Run in a behind-UTC zone, since the bug is invisible at or ahead of UTC.
      */
-    it('keeps the day stable regardless of the runtime time zone', () => {
-        expect(formatIsoDay('2026-01-01')).toContain('1');
-        expect(formatIsoDay('2026-01-01')).toContain('2026');
-        expect(formatIsoDay('2026-01-01')).toContain('Jan');
+    it('keeps the day stable in a behind-UTC time zone', () => {
+        const zone = process.env.TZ;
+        process.env.TZ = 'America/Los_Angeles';
+
+        try {
+            // The naive `new Date('2026-01-01')` would render "Dec 31, 2025" here.
+            expect(formatIsoDay('2026-01-01', 'en-US')).toBe('Jan 1, 2026');
+        } finally {
+            process.env.TZ = zone;
+        }
     });
 });
 

--- a/resources/js/lib/datetime.test.ts
+++ b/resources/js/lib/datetime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
     formatDateTime,
+    formatIsoDay,
     formatLocalTime,
     formatRelativeTime,
     formatTimeOfDay,
@@ -37,6 +38,27 @@ describe('formatDateTime', () => {
     it('rolls over to the next day in a far-ahead zone', () => {
         expect(formatDateTime(INSTANT, 'Asia/Tokyo')).toContain('11');
         expect(formatDateTime(INSTANT, 'Asia/Tokyo')).toContain('12:30');
+    });
+});
+
+describe('formatIsoDay', () => {
+    it('renders a calendar day with its month and year', () => {
+        expect(formatIsoDay('2026-07-10')).toBe('Jul 10, 2026');
+    });
+
+    it('follows the requested locale', () => {
+        expect(formatIsoDay('2026-07-10', 'fr')).toContain('juil');
+    });
+
+    /**
+     * A bare `YYYY-MM-DD` is parsed as UTC midnight by `new Date()`, which reads
+     * as the previous day in any behind-UTC zone. The helper anchors the day to
+     * local midnight instead, so a calendar day never shifts under the reader.
+     */
+    it('keeps the day stable regardless of the runtime time zone', () => {
+        expect(formatIsoDay('2026-01-01')).toContain('1');
+        expect(formatIsoDay('2026-01-01')).toContain('2026');
+        expect(formatIsoDay('2026-01-01')).toContain('Jan');
     });
 });
 

--- a/resources/js/lib/datetime.ts
+++ b/resources/js/lib/datetime.ts
@@ -55,6 +55,25 @@ export function formatCalendarDate(
 }
 
 /**
+ * Format a `YYYY-MM-DD` calendar day as an abbreviated date with its year
+ * (e.g. "Jul 10, 2026"), for date fields and date-range summaries.
+ *
+ * The day is anchored to local midnight before formatting: `new Date()` reads a
+ * bare `YYYY-MM-DD` as UTC midnight, which renders as the previous day in any
+ * behind-UTC zone.
+ */
+export function formatIsoDay(
+    day: string,
+    locale: string = i18n.locale,
+): string {
+    return new Date(`${day}T00:00:00`).toLocaleDateString(locale, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    });
+}
+
+/**
  * Format a date as an abbreviated month (e.g. "Jul"), for month-grouped charts.
  */
 export function formatMonthLabel(

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -728,7 +728,7 @@ function snippetHtml(snippet: string): string {
                                 <DatePicker
                                     :model-value="after"
                                     :placeholder="$t('Pick a date')"
-                                    :aria-label="$t('After')"
+                                    :field-label="$t('After')"
                                     :max="before"
                                     class="w-full text-xs"
                                     data-test="facet-date-after"
@@ -744,7 +744,7 @@ function snippetHtml(snippet: string): string {
                                 <DatePicker
                                     :model-value="before"
                                     :placeholder="$t('Pick a date')"
-                                    :aria-label="$t('Before')"
+                                    :field-label="$t('Before')"
                                     :min="after"
                                     class="w-full text-xs"
                                     data-test="facet-date-before"

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -15,12 +15,18 @@ import {
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { index as search } from '@/actions/App/Http/Controllers/Channels/SearchController';
 import { Button } from '@/components/ui/button';
+import { DatePicker } from '@/components/ui/date-picker';
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { getInitials } from '@/composables/useInitials';
@@ -668,8 +674,13 @@ function snippetHtml(snippet: string): string {
                         <X class="size-3" aria-hidden="true" />
                     </Button>
                 </span>
-                <DropdownMenu v-else>
-                    <DropdownMenuTrigger as-child>
+                <!--
+                    A Popover, not a DropdownMenu, because the custom range
+                    nests date pickers: a menu treats a click inside their
+                    portalled calendar as an outside click and closes itself.
+                -->
+                <Popover v-else>
+                    <PopoverTrigger as-child>
                         <Button
                             variant="unstyled"
                             size="none"
@@ -681,8 +692,8 @@ function snippetHtml(snippet: string): string {
                             {{ $t('Date') }}
                             <ChevronDown class="size-3" aria-hidden="true" />
                         </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" class="w-60 p-1.5">
+                    </PopoverTrigger>
+                    <PopoverContent align="start" class="w-60 p-1.5">
                         <Button
                             v-for="preset in datePresets"
                             :key="preset.key"
@@ -708,46 +719,43 @@ function snippetHtml(snippet: string): string {
                         </Button>
                         <div
                             v-if="showCustomRange"
-                            class="flex flex-col gap-1.5 border-t border-border px-2 pt-2"
-                            @click.stop
+                            class="flex flex-col gap-2 border-t border-border px-2 pt-2"
                         >
-                            <label
+                            <div
                                 class="flex flex-col gap-1 text-[11px] text-muted-foreground"
                             >
                                 {{ $t('After') }}
-                                <input
-                                    type="date"
-                                    :value="after ?? ''"
-                                    class="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
-                                    @change="
-                                        setDateRange(
-                                            ($event.target as HTMLInputElement)
-                                                .value || null,
-                                            before,
-                                        )
+                                <DatePicker
+                                    :model-value="after"
+                                    :placeholder="$t('Pick a date')"
+                                    :aria-label="$t('After')"
+                                    :max="before"
+                                    class="w-full text-xs"
+                                    data-test="facet-date-after"
+                                    @update:model-value="
+                                        setDateRange($event, before)
                                     "
                                 />
-                            </label>
-                            <label
+                            </div>
+                            <div
                                 class="flex flex-col gap-1 text-[11px] text-muted-foreground"
                             >
                                 {{ $t('Before') }}
-                                <input
-                                    type="date"
-                                    :value="before ?? ''"
-                                    class="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
-                                    @change="
-                                        setDateRange(
-                                            after,
-                                            ($event.target as HTMLInputElement)
-                                                .value || null,
-                                        )
+                                <DatePicker
+                                    :model-value="before"
+                                    :placeholder="$t('Pick a date')"
+                                    :aria-label="$t('Before')"
+                                    :min="after"
+                                    class="w-full text-xs"
+                                    data-test="facet-date-before"
+                                    @update:model-value="
+                                        setDateRange(after, $event)
                                     "
                                 />
-                            </label>
+                            </div>
                         </div>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                    </PopoverContent>
+                </Popover>
 
                 <Button
                     variant="unstyled"

--- a/resources/js/pages/teams/AuditExports.vue
+++ b/resources/js/pages/teams/AuditExports.vue
@@ -190,7 +190,10 @@ function rangeText(entry: AuditExport): string {
         return t('From :date', { date: formatIsoDay(entry.rangeStart) });
     }
 
-    return `${formatIsoDay(entry.rangeStart)} – ${formatIsoDay(entry.rangeEnd)}`;
+    return t(':start – :end', {
+        start: formatIsoDay(entry.rangeStart),
+        end: formatIsoDay(entry.rangeEnd),
+    });
 }
 
 function requestedAt(entry: AuditExport): string {

--- a/resources/js/pages/teams/AuditExports.vue
+++ b/resources/js/pages/teams/AuditExports.vue
@@ -302,7 +302,7 @@ function downloadUrl(entry: AuditExport): string {
                         <DatePicker
                             :model-value="rangeStart || null"
                             :placeholder="$t('Start date')"
-                            :aria-label="$t('Start date')"
+                            :field-label="$t('Start date')"
                             class="w-40"
                             data-test="audit-export-range-start"
                             @update:model-value="rangeStart = $event ?? ''"
@@ -313,7 +313,7 @@ function downloadUrl(entry: AuditExport): string {
                         <DatePicker
                             :model-value="rangeEnd || null"
                             :placeholder="$t('End date')"
-                            :aria-label="$t('End date')"
+                            :field-label="$t('End date')"
                             :invalid="rangeError"
                             :min="rangeStart || null"
                             class="w-40"

--- a/resources/js/pages/teams/AuditExports.vue
+++ b/resources/js/pages/teams/AuditExports.vue
@@ -12,12 +12,12 @@ import {
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import Heading from '@/components/Heading.vue';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { DatePicker } from '@/components/ui/date-picker';
 import { useTimezone } from '@/composables/useTimezone';
 import { useTranslations } from '@/composables/useTranslations';
 import { backgroundVisit } from '@/lib/backgroundVisit';
-import { formatDateTime } from '@/lib/datetime';
-import { i18n, translate } from '@/lib/i18n';
+import { formatDateTime, formatIsoDay } from '@/lib/datetime';
+import { translate } from '@/lib/i18n';
 import { edit, index } from '@/routes/teams';
 import {
     download,
@@ -175,28 +175,22 @@ function rowState(entry: AuditExport): RowState {
     return entry.isReady ? 'ready' : 'expired';
 }
 
-function formatDay(date: string): string {
-    return new Date(`${date}T00:00:00`).toLocaleDateString(i18n.locale, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-    });
-}
-
 function rangeText(entry: AuditExport): string {
     if (entry.rangeStart === null && entry.rangeEnd === null) {
         return t('All time');
     }
 
     if (entry.rangeStart === null) {
-        return t('Until :date', { date: formatDay(entry.rangeEnd as string) });
+        return t('Until :date', {
+            date: formatIsoDay(entry.rangeEnd as string),
+        });
     }
 
     if (entry.rangeEnd === null) {
-        return t('From :date', { date: formatDay(entry.rangeStart) });
+        return t('From :date', { date: formatIsoDay(entry.rangeStart) });
     }
 
-    return `${formatDay(entry.rangeStart)} – ${formatDay(entry.rangeEnd)}`;
+    return `${formatIsoDay(entry.rangeStart)} – ${formatIsoDay(entry.rangeEnd)}`;
 }
 
 function requestedAt(entry: AuditExport): string {
@@ -305,23 +299,26 @@ function downloadUrl(entry: AuditExport): string {
                         <span class="font-normal">· {{ $t('optional') }}</span>
                     </span>
                     <div class="flex items-center gap-2">
-                        <Input
-                            v-model="rangeStart"
-                            type="date"
-                            class="h-9 w-40 rounded-lg"
+                        <DatePicker
+                            :model-value="rangeStart || null"
+                            :placeholder="$t('Start date')"
                             :aria-label="$t('Start date')"
+                            class="w-40"
                             data-test="audit-export-range-start"
+                            @update:model-value="rangeStart = $event ?? ''"
                         />
                         <span class="text-sm text-muted-foreground">{{
                             $t('to')
                         }}</span>
-                        <Input
-                            v-model="rangeEnd"
-                            type="date"
-                            class="h-9 w-40 rounded-lg"
-                            :aria-invalid="rangeError"
+                        <DatePicker
+                            :model-value="rangeEnd || null"
+                            :placeholder="$t('End date')"
                             :aria-label="$t('End date')"
+                            :invalid="rangeError"
+                            :min="rangeStart || null"
+                            class="w-40"
                             data-test="audit-export-range-end"
+                            @update:model-value="rangeEnd = $event ?? ''"
                         />
                         <Button
                             v-if="rangeStart || rangeEnd"

--- a/tests/Browser/DatePickerTest.php
+++ b/tests/Browser/DatePickerTest.php
@@ -66,6 +66,7 @@ test('the audit export period is picked from a calendar and validates its order'
     JS);
 
     $page->wait(0.5)
+        ->assertPresent('html.dark')
         ->click('@audit-export-range-start')
         ->wait(0.3)
         ->assertPresent('[data-reka-calendar-cell-trigger]')

--- a/tests/Browser/DatePickerTest.php
+++ b/tests/Browser/DatePickerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Message;
+
+/**
+ * The two surfaces that dropped `<input type="date">` for the shadcn date
+ * picker. Both are driven through the real popover + calendar, because the
+ * behaviour that matters — a picked day reaching the model as an ISO string —
+ * only exists once the portalled calendar renders in a browser.
+ */
+test('the audit export period is picked from a calendar and validates its order', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // Reached through the settings sidebar — client-side Inertia visits, so the
+    // browser session survives (a full navigate() would drop it).
+    $page = signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@settings-menu-item')
+        // Let the dropdown settle past its open/pointer-grace window, otherwise
+        // the item click can be swallowed and never navigate.
+        ->wait(0.5)
+        ->click('@settings-menu-item')
+        ->assertPathContains('/settings')
+        ->click('@settings-nav-exports')
+        ->assertPathContains('/exports')
+        ->assertPresent('[data-test="audit-export-form"]')
+        // No native date input survives on the page.
+        ->assertMissing('input[type="date"]')
+        // The start trigger opens a calendar; picking today fills the field.
+        ->click('@audit-export-range-start')
+        ->wait(0.3)
+        ->assertPresent('[data-reka-calendar-cell-trigger]')
+        ->click('[data-reka-calendar-cell-trigger][data-today]')
+        ->wait(0.3)
+        // A picked day swaps the placeholder for the formatted date, and the
+        // clear control appears now that the period is no longer empty.
+        ->assertPresent('[data-test="audit-export-range-clear"]');
+
+    // The end picker cannot reach a day before the start: reka-ui disables
+    // everything under `min`, so the order can't be broken from the calendar.
+    $page->click('@audit-export-range-end')
+        ->wait(0.3)
+        ->assertPresent('[data-reka-calendar-cell-trigger][data-disabled]')
+        ->click('[data-reka-calendar-cell-trigger][data-today]')
+        ->wait(0.3)
+        // A same-day period is valid, so the export stays submittable.
+        ->assertMissing('[data-test="audit-export-range-error"]');
+
+    // Clearing empties both ends and takes the clear control away with them.
+    $page->click('@audit-export-range-clear')
+        ->wait(0.3)
+        ->assertMissing('[data-test="audit-export-range-clear"]')
+        ->assertNoAccessibilityIssues();
+
+    // Re-audit the open calendar against the dark palette (localStorage before
+    // the class, so the appearance controller doesn't re-resolve to light
+    // mid-audit) — the popover carries its own surface and border tokens.
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->click('@audit-export-range-start')
+        ->wait(0.3)
+        ->assertPresent('[data-reka-calendar-cell-trigger]')
+        ->assertNoAccessibilityIssues();
+});
+
+test('the search custom range picks its bounds from a calendar', function (): void {
+    ['owner' => $alice, 'channel' => $channel, 'member' => $bob] = browserTeamWithChannel();
+
+    Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $bob->id,
+        'body' => 'the quokka danced at dawn today',
+    ]);
+
+    signInThroughBrowser($alice)
+        ->click('@masthead-search')
+        ->assertPathContains('/search')
+        ->type('@search-input', 'quokka')
+        ->wait(0.8)
+        ->assertPresent('[data-test="search-result"]')
+        ->assertMissing('input[type="date"]')
+        // Open the date facet and reveal the custom range.
+        ->click('@facet-date-picker')
+        ->wait(0.3)
+        ->click('@facet-date-custom')
+        ->wait(0.3)
+        ->assertPresent('[data-test="facet-date-after"]')
+        // The nested calendar opens without dismissing the facet popover — the
+        // reason this facet is a Popover rather than a DropdownMenu.
+        ->click('@facet-date-after')
+        ->wait(0.3)
+        ->assertPresent('[data-reka-calendar-cell-trigger]')
+        ->click('[data-reka-calendar-cell-trigger][data-today]')
+        ->wait(0.8)
+        // The picked bound applies as the date chip, exactly as a preset does.
+        ->assertPresent('[data-test="facet-date"]')
+        ->assertNoAccessibilityIssues();
+});


### PR DESCRIPTION
Closes #540.

## What

Both surfaces that still used native `<input type="date">` now use a shadcn-based date picker: the team audit-export period (`/settings/teams/{team}/exports`) and the channel-search custom date range (`/t/{team}/search`).

The repo shipped no `popover` and no `date-picker` primitive, so this adds both:

- **`ui/popover`** — the standard shadcn-vue set (`Popover`, `PopoverTrigger`, `PopoverContent`, `PopoverAnchor`) over reka-ui, hand-adjusted for `@lucide/vue` the same way `ui/calendar` was.
- **`ui/date-picker`** — a Button trigger + Popover + the existing `ui/calendar`. **Its `v-model` is a plain ISO `YYYY-MM-DD` string**, with the `DateValue` bridge kept inside the component, so both call sites keep the exact string contract they already had with the server. Nothing downstream of the two pages changed.
- **`lib/calendarDate`** — the ISO ↔ `DateValue` bridge, so call sites never touch `@internationalized/date`.
- **`datetime.formatIsoDay`** — locale-aware `Jul 10, 2026`, anchored to *local* midnight (a bare `YYYY-MM-DD` is parsed as UTC midnight by `new Date()`, which renders as the previous day in behind-UTC zones). This also de-duplicates a hand-rolled formatter that lived in `AuditExports.vue`.

## Why the search facet became a `Popover`

The date facet was a `DropdownMenu`. A nested picker inside one breaks: the menu treats a click in the portalled calendar as an outside click and closes itself. reka-ui's dismissable-layer stack only nests correctly for Popover-in-Popover, so that facet's root is now a `Popover`. The presets, the `facet-date-picker` trigger, `setDateRange`/`clearDate`, and the emitted before/after bounds are all unchanged.

## Behaviour preserved

- ISO `YYYY-MM-DD` values in and out; existing `data-test` selectors kept (`audit-export-range-start` / `-end` / `-clear`, `facet-date-picker`, `facet-date-preset-*`, `facet-date-custom`).
- Exports: the start/end range and the "end on or after start" error still work. The end picker additionally gets `min` = start, so the order can't be broken from the calendar at all; the explicit error remains for the pick-end-then-a-later-start case, and the server still re-validates.
- Search: presets unchanged; the custom range emits the same bounds.

## Testing

- **Vitest** — `lib/calendarDate` (parse/serialize/round-trip, malformed input), `datetime.formatIsoDay` (including a case pinned to `America/Los_Angeles`; it fails with `Dec 31, 2025` against the naive UTC parse), and a real mounted `DatePicker` (placeholder, formatted value, accessible name + `aria-invalid`, and picking a day through the actual popover + calendar).
- **Pest browser** — `tests/Browser/DatePickerTest.php` drives both surfaces through the real portalled calendar, asserts `input[type="date"]` is gone from each page, checks the `min` bound disables earlier days, and runs axe in **both light and dark** themes with the calendar open.
- Full gate green: `composer ci:check` at `Total: 100.0 %`, Pint/PHPStan/Rector clean, frontend lint/format/types/build clean.

## i18n

One new key, `Pick a date`, plus `:start – :end` for the export range summary (previously an untranslated concatenation) — both added to `lang/fr.json`.

## Dependency

`@internationalized/date` is promoted from a transitive dep of reka-ui to a direct dependency. It was already imported directly by `ScheduleMessageDialog.vue`, so this fixes a latent breakage independent of this change. No new packages.

## Found while working on this

- #672 — `formatCalendarDate` parses a bare `YYYY-MM-DD` as UTC midnight, so the search date chip renders the previous day for behind-UTC viewers. Left alone here to keep this PR scoped.

## Review notes

Local CodeRabbit: applied the required-accessible-name finding (the picker's `fieldLabel` prop is now required and compiler-enforced) and the untranslated range separator. Declined one claim that the dark-theme `script()` block is never invoked — Playwright's `evaluate` does call a function-expression string; I verified it empirically and added `assertPresent('html.dark')` so the dark audit is now self-proving.