### PR TITLE
fix: anchor bare calendar days to the viewer's local midnight

### DIFF
--- a/resources/js/lib/datetime.test.ts
+++ b/resources/js/lib/datetime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    formatCalendarDate,
     formatDateTime,
     formatIsoDay,
     formatLocalTime,
@@ -38,6 +39,38 @@ describe('formatDateTime', () => {
     it('rolls over to the next day in a far-ahead zone', () => {
         expect(formatDateTime(INSTANT, 'Asia/Tokyo')).toContain('11');
         expect(formatDateTime(INSTANT, 'Asia/Tokyo')).toContain('12:30');
+    });
+});
+
+describe('formatCalendarDate', () => {
+    /**
+     * The search date-facet chip formats the bare `YYYY-MM-DD` the user filtered
+     * on. `new Date()` reads such a day as UTC midnight, so a behind-UTC viewer
+     * saw the chip name the day *before* the one the results were filtered from.
+     */
+    it('keeps a bare calendar day stable in a behind-UTC time zone', () => {
+        const zone = process.env.TZ;
+        process.env.TZ = 'America/Los_Angeles';
+
+        try {
+            expect(formatCalendarDate('2026-01-01', 'en-US')).toBe('Jan 1');
+        } finally {
+            process.env.TZ = zone;
+        }
+    });
+
+    it('leaves Date objects and full timestamps on their existing behaviour', () => {
+        const zone = process.env.TZ;
+        process.env.TZ = 'UTC';
+
+        try {
+            expect(formatCalendarDate(new Date(INSTANT), 'en-US')).toBe(
+                'Jul 10',
+            );
+            expect(formatCalendarDate(INSTANT, 'en-US')).toBe('Jul 10');
+        } finally {
+            process.env.TZ = zone;
+        }
     });
 });
 

--- a/resources/js/lib/datetime.test.ts
+++ b/resources/js/lib/datetime.test.ts
@@ -15,6 +15,26 @@ import { formatNumber } from './numbers';
  */
 const INSTANT = '2026-07-10T15:30:00Z';
 
+/**
+ * Run `assertions` with the runtime's local zone pinned to `timeZone`, restoring
+ * the previous setting afterwards — including the unset case, where assigning
+ * `undefined` back would leave the literal string "undefined" behind.
+ */
+function inTimeZone(timeZone: string, assertions: () => void): void {
+    const previous = process.env.TZ;
+    process.env.TZ = timeZone;
+
+    try {
+        assertions();
+    } finally {
+        if (previous === undefined) {
+            delete process.env.TZ;
+        } else {
+            process.env.TZ = previous;
+        }
+    }
+}
+
 describe('formatTimeOfDay', () => {
     it('renders the time in the given zone', () => {
         expect(formatTimeOfDay(INSTANT, 'UTC')).toContain('3:30');
@@ -49,28 +69,25 @@ describe('formatCalendarDate', () => {
      * saw the chip name the day *before* the one the results were filtered from.
      */
     it('keeps a bare calendar day stable in a behind-UTC time zone', () => {
-        const zone = process.env.TZ;
-        process.env.TZ = 'America/Los_Angeles';
-
-        try {
+        inTimeZone('America/Los_Angeles', () => {
             expect(formatCalendarDate('2026-01-01', 'en-US')).toBe('Jan 1');
-        } finally {
-            process.env.TZ = zone;
-        }
+        });
     });
 
+    /**
+     * An instant just after UTC midnight, read in a behind-UTC zone, still falls
+     * on the previous local day — so it fails loudly if a full timestamp were
+     * ever mistaken for a bare day and re-anchored to local midnight.
+     */
     it('leaves Date objects and full timestamps on their existing behaviour', () => {
-        const zone = process.env.TZ;
-        process.env.TZ = 'UTC';
+        const boundary = '2026-07-10T00:30:00Z';
 
-        try {
-            expect(formatCalendarDate(new Date(INSTANT), 'en-US')).toBe(
-                'Jul 10',
+        inTimeZone('America/Los_Angeles', () => {
+            expect(formatCalendarDate(new Date(boundary), 'en-US')).toBe(
+                'Jul 9',
             );
-            expect(formatCalendarDate(INSTANT, 'en-US')).toBe('Jul 10');
-        } finally {
-            process.env.TZ = zone;
-        }
+            expect(formatCalendarDate(boundary, 'en-US')).toBe('Jul 9');
+        });
     });
 });
 
@@ -90,15 +107,10 @@ describe('formatIsoDay', () => {
      * Run in a behind-UTC zone, since the bug is invisible at or ahead of UTC.
      */
     it('keeps the day stable in a behind-UTC time zone', () => {
-        const zone = process.env.TZ;
-        process.env.TZ = 'America/Los_Angeles';
-
-        try {
+        inTimeZone('America/Los_Angeles', () => {
             // The naive `new Date('2026-01-01')` would render "Dec 31, 2025" here.
             expect(formatIsoDay('2026-01-01', 'en-US')).toBe('Jan 1, 2026');
-        } finally {
-            process.env.TZ = zone;
-        }
+        });
     });
 });
 

--- a/resources/js/lib/datetime.ts
+++ b/resources/js/lib/datetime.ts
@@ -40,6 +40,23 @@ export function formatDateTime(
     });
 }
 
+/** A bare calendar day with no time part, e.g. `2026-07-10`. */
+const CALENDAR_DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Read a date input as a `Date`, anchoring a bare `YYYY-MM-DD` calendar day to
+ * local midnight: the spec parses such a day as UTC midnight, which renders as
+ * the previous day in any behind-UTC zone. `Date` objects and full timestamps
+ * carry their own instant and are passed through untouched.
+ */
+function toLocalDate(date: Date | string): Date {
+    if (typeof date === 'string' && CALENDAR_DAY.test(date)) {
+        return new Date(`${date}T00:00:00`);
+    }
+
+    return new Date(date);
+}
+
 /**
  * Format a date as an abbreviated month and day (e.g. "Jul 10"), for chart axes
  * and other date-only labels.
@@ -48,7 +65,7 @@ export function formatCalendarDate(
     date: Date | string,
     locale: string = i18n.locale,
 ): string {
-    return new Date(date).toLocaleDateString(locale, {
+    return toLocalDate(date).toLocaleDateString(locale, {
         month: 'short',
         day: 'numeric',
     });
@@ -66,7 +83,7 @@ export function formatIsoDay(
     day: string,
     locale: string = i18n.locale,
 ): string {
-    return new Date(`${day}T00:00:00`).toLocaleDateString(locale, {
+    return toLocalDate(day).toLocaleDateString(locale, {
         month: 'short',
         day: 'numeric',
         year: 'numeric',


### PR DESCRIPTION
Closes #672.

## What

`formatCalendarDate()` formatted with `new Date(date)`, which the spec parses as **UTC midnight** for a bare `YYYY-MM-DD`. The search date-facet chip (`Since :date` / `Before :date` / `a – b`) passes exactly such a day, so a viewer in a behind-UTC zone saw the chip name the day *before* the one the results were filtered from — the label contradicting the filter on the one surface whose job is to show what is filtered.

## How

Extracted a small `toLocalDate()` helper in `resources/js/lib/datetime.ts` that anchors a bare `YYYY-MM-DD` to local midnight (`${day}T00:00:00`) and passes `Date` objects and full timestamps straight through. `formatCalendarDate` now reads its input through it; `formatIsoDay` (which already did this inline, from #540) reuses the same helper.

Deliberately unchanged: the Analytics chart axes build real `Date` objects before calling in, so their behaviour is untouched.

## Testing

- New Vitest cases in `resources/js/lib/datetime.test.ts`: the bare calendar day stays put in `America/Los_Angeles` (fails with `Dec 31` before the fix), and a `00:30Z` boundary instant still renders the previous local day — so a full timestamp being mistaken for a bare day would fail loudly.
- Zone pinning moved to an `inTimeZone()` helper that restores an originally-unset `TZ` by deleting it rather than assigning the string `"undefined"`; the pre-existing `formatIsoDay` test now uses it too.
- Full gate green: `composer test` at 100% coverage, plus `lint:check`, `format:check`, `types:check`, `test:js` (749 passing), and `build`.

No user-facing copy changed, so no i18n or docs updates are needed.