### PR TITLE
ci: enforce lint:check in the quality job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,15 @@ jobs:
       - name: Check Release Version References
         run: php artisan release:check-version-refs
 
+      # `resources/js/actions` and `resources/js/routes` are git-ignored Wayfinder
+      # output, normally produced as a side effect of `npm run build` — which this
+      # job does not run. Without them, eslint cannot resolve `@/actions/*` and
+      # `@/routes/*`, and `import/order` mis-groups those imports against `@/types`,
+      # failing on sources that are clean locally. `--with-form` matches the
+      # `formVariants` option vite.config.ts passes the plugin (see #414).
+      - name: Generate Wayfinder Routes
+        run: php artisan wayfinder:generate --with-form
+
       - name: Run Pint
         run: composer lint
 
@@ -67,4 +76,4 @@ jobs:
         run: npm run format:check
 
       - name: Lint Frontend
-        run: npm run lint
+        run: npm run lint:check

--- a/tests/Unit/LintCheckGateTest.php
+++ b/tests/Unit/LintCheckGateTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * `resources/js/actions` and `resources/js/routes` are git-ignored, Wayfinder-generated
+ * files, so a fresh runner has neither — and with `@/actions/*` / `@/routes/*`
+ * unresolvable, `import/order` mis-groups them against `@/types` and fails on sources
+ * that are clean locally. The `quality` job papered over that by running the auto-fixing
+ * `npm run lint` (always exit 0, rewrites discarded with the runner), so CI enforced
+ * nothing. These tests pin the generation step and the check variant together: the check
+ * only stays honest while the generation that makes it reproducible runs first (#414).
+ */
+function qualityJobSteps(): array
+{
+    return Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/lint.yml')['jobs']['quality']['steps'];
+}
+
+/**
+ * The step must *be* the command: an echoed or `|| true`-suffixed invocation would
+ * satisfy a substring search while gating nothing.
+ */
+function runsLintCheck(array $step): bool
+{
+    return trim((string) ($step['run'] ?? '')) === 'npm run lint:check';
+}
+
+function generatesWayfinderFiles(array $step): bool
+{
+    return str_contains((string) ($step['run'] ?? ''), 'artisan wayfinder:generate');
+}
+
+test('the quality job lints with the check variant, not the auto-fixing one', function (): void {
+    $steps = collect(qualityJobSteps());
+
+    expect($steps->first(runsLintCheck(...)))->not->toBeNull('CI must run `npm run lint:check`, which fails on violations')
+        ->and($steps->contains(static fn (array $step): bool => trim((string) ($step['run'] ?? '')) === 'npm run lint'))
+        ->toBeFalse('`npm run lint` rewrites files and always exits 0, so it gates nothing on a runner');
+});
+
+test('the quality job generates the wayfinder files before linting', function (): void {
+    $steps = collect(qualityJobSteps());
+
+    $generate = $steps->search(generatesWayfinderFiles(...));
+    $install = $steps->search(static fn (array $step): bool => ($step['run'] ?? '') === 'npm ci');
+    $lint = $steps->search(runsLintCheck(...));
+
+    expect($generate)->not->toBeFalse('without `@/actions` and `@/routes`, `import/order` fails on sources that are clean locally')
+        ->and($generate)->toBeGreaterThan($install, 'wayfinder generation needs the node dependencies in place')
+        ->and($generate)->toBeLessThan($lint, 'the generated files must exist before eslint resolves imports against them');
+});
+
+test('the wayfinder generation matches the form variants vite builds', function (): void {
+    $step = collect(qualityJobSteps())->first(generatesWayfinderFiles(...));
+
+    expect(str_contains((string) $step['run'], '--with-form'))
+        ->toBeTrue('vite.config.ts enables `formVariants`, so CI must generate the same surface');
+});
+
+test('the lint:check script is the non-fixing eslint entry point the gate assumes', function (): void {
+    $scripts = json_decode((string) file_get_contents(dirname(__DIR__, 2).'/package.json'), true)['scripts'];
+
+    expect($scripts['lint:check'] ?? '')->toContain('eslint')
+        ->and($scripts['lint:check'] ?? '')->not->toContain('--fix');
+});

--- a/tests/Unit/LintCheckGateTest.php
+++ b/tests/Unit/LintCheckGateTest.php
@@ -17,25 +17,43 @@ function qualityJobSteps(): array
     return Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/lint.yml')['jobs']['quality']['steps'];
 }
 
+function qualityStepCommand(array $step): string
+{
+    return trim((string) ($step['run'] ?? ''));
+}
+
 /**
  * The step must *be* the command: an echoed or `|| true`-suffixed invocation would
  * satisfy a substring search while gating nothing.
  */
 function runsLintCheck(array $step): bool
 {
-    return trim((string) ($step['run'] ?? '')) === 'npm run lint:check';
+    return qualityStepCommand($step) === 'npm run lint:check';
 }
 
+/**
+ * Matches the auto-fixing variant in any position — chained, wrapped or
+ * argument-bearing — while the negative lookahead keeps `npm run lint:check` out.
+ */
+function runsAutoFixingLint(array $step): bool
+{
+    return preg_match('/(?:^|[\n;&|]\s*)npm run lint(?![:\w-])/', qualityStepCommand($step)) === 1;
+}
+
+/**
+ * Anchored to a command position so a mention of the generator (in an `echo`, say)
+ * cannot stand in for actually running it.
+ */
 function generatesWayfinderFiles(array $step): bool
 {
-    return str_contains((string) ($step['run'] ?? ''), 'artisan wayfinder:generate');
+    return preg_match('/(?:^|[\n;&|]\s*)php artisan wayfinder:generate\b/', qualityStepCommand($step)) === 1;
 }
 
 test('the quality job lints with the check variant, not the auto-fixing one', function (): void {
     $steps = collect(qualityJobSteps());
 
     expect($steps->first(runsLintCheck(...)))->not->toBeNull('CI must run `npm run lint:check`, which fails on violations')
-        ->and($steps->contains(static fn (array $step): bool => trim((string) ($step['run'] ?? '')) === 'npm run lint'))
+        ->and($steps->contains(runsAutoFixingLint(...)))
         ->toBeFalse('`npm run lint` rewrites files and always exits 0, so it gates nothing on a runner');
 });
 
@@ -43,24 +61,27 @@ test('the quality job generates the wayfinder files before linting', function ()
     $steps = collect(qualityJobSteps());
 
     $generate = $steps->search(generatesWayfinderFiles(...));
-    $install = $steps->search(static fn (array $step): bool => ($step['run'] ?? '') === 'npm ci');
+    $install = $steps->search(static fn (array $step): bool => qualityStepCommand($step) === 'npm ci');
     $lint = $steps->search(runsLintCheck(...));
 
     expect($generate)->not->toBeFalse('without `@/actions` and `@/routes`, `import/order` fails on sources that are clean locally')
-        ->and($generate)->toBeGreaterThan($install, 'wayfinder generation needs the node dependencies in place')
+        ->and($install)->not->toBeFalse('the job installs the node dependencies eslint runs from')
+        ->and($lint)->not->toBeFalse('the lint step is what the generated files exist for')
+        ->and($generate)->toBeGreaterThan($install, 'wayfinder generation belongs with the rest of the prepared environment')
         ->and($generate)->toBeLessThan($lint, 'the generated files must exist before eslint resolves imports against them');
 });
 
 test('the wayfinder generation matches the form variants vite builds', function (): void {
     $step = collect(qualityJobSteps())->first(generatesWayfinderFiles(...));
 
-    expect(str_contains((string) $step['run'], '--with-form'))
+    expect($step)->not->toBeNull('there is no generation step to check the options of')
+        ->and(str_contains(qualityStepCommand($step ?? []), '--with-form'))
         ->toBeTrue('vite.config.ts enables `formVariants`, so CI must generate the same surface');
 });
 
 test('the lint:check script is the non-fixing eslint entry point the gate assumes', function (): void {
     $scripts = json_decode((string) file_get_contents(dirname(__DIR__, 2).'/package.json'), true)['scripts'];
 
-    expect($scripts['lint:check'] ?? '')->toContain('eslint')
+    expect($scripts['lint:check'] ?? '')->toStartWith('eslint')
         ->and($scripts['lint:check'] ?? '')->not->toContain('--fix');
 });


### PR DESCRIPTION
Closes #414.

## What

- The `quality` job now runs `npm run lint:check` instead of `npm run lint`. The write variant auto-fixes, always exits 0, and discards its rewrites with the ephemeral runner, so CI enforced nothing while CLAUDE.md listed `lint:check` as a required frontend gate.
- Added a `Generate Wayfinder Routes` step (`php artisan wayfinder:generate --with-form`) ahead of the lint steps, mirroring the generation `tests.yml` already does for TypeScript types.

## Why

`resources/js/actions` and `resources/js/routes` are git-ignored Wayfinder output, normally produced as a side effect of `npm run build` — which the `quality` job does not run. Without them eslint cannot resolve `@/actions/*` / `@/routes/*`, and `import/order` mis-groups those imports against `@/types`, which is what made #412's attempted switch go red with CI-only errors.

`--with-form` matches the `formVariants: true` option `vite.config.ts` passes the plugin, so CI generates the same surface a local build does.

## How tested

Reproduced the CI-only failure locally by moving `resources/js/actions` and `resources/js/routes` aside: `lint:check` failed with 85 `import/order` errors, all of the form ``@/types` type import should occur before import of `@/routes/…``. Running `php artisan wayfinder:generate --with-form` and re-running produced **0 errors** (57 pre-existing `warn`-level a11y/tailwind findings remain, as before) — confirming the errors were purely the missing generated files and that no source changes are needed.

New `tests/Unit/LintCheckGateTest.php` pins the fix, following the `FrontendTestGateTest` pattern: the job must run the check variant (and never the auto-fixing one, in any chained or argument-bearing form), must generate the Wayfinder files between `npm ci` and the lint step, must pass `--with-form`, and `lint:check` itself must be a non-`--fix` eslint invocation. Verified the guard genuinely bites by reverting the workflow step and watching it go red.

Full gate green: `composer test` at 100% coverage, plus `lint:check`, `format:check`, `types:check`, `test:js`, and `build`.

## i18n / docs

None — no user-facing copy and nothing operator-facing.

## Review note

The local CodeRabbit pass returned 5 findings, all hardening of the new test file (assert `npm ci` exists before comparing step indexes, anchor the command matchers so an `echo` cannot stand in for a real invocation, null-check before dereferencing the found step). All five were applied. The follow-up pass hit the free-tier rate limit, so this PR gets the first CodeRabbit review server-side.