### PR TITLE
test: accept a prerelease version in the app:version file assertion

### DIFF
--- a/tests/Feature/Console/AppVersionCommandTest.php
+++ b/tests/Feature/Console/AppVersionCommandTest.php
@@ -14,7 +14,11 @@ it('prints the running version and nothing else', function (): void {
 it('prints the version from the VERSION file, stripped of its release-please annotation', function (): void {
     Artisan::call('app:version');
 
+    /**
+     * The candidate line stamps `VERSION` too, so on `develop` this file legitimately
+     * holds a prerelease string (`1.14.0-rc.0`) between releases.
+     */
     expect(trim(Artisan::output()))
         ->toBe(trim((string) preg_replace('/#.*/', '', (string) file_get_contents(base_path('VERSION')))))
-        ->toMatch('/^\d+\.\d+\.\d+$/');
+        ->toMatch('/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/');
 });


### PR DESCRIPTION
## What

Widens the SemVer pattern in `tests/Feature/Console/AppVersionCommandTest.php` from `/^\d+\.\d+\.\d+$/` to `/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/`, so the assertion accepts a prerelease suffix.

## Why

#668 added `VERSION` to `extra-files` in `release-please-config.develop.json`, so the candidate line now stamps that file. The develop release PR (#669) is the first ever to write a prerelease string into it, and CI fails there:

```
FAILED  Tests\Feature\Console\AppVersionCommandTest > it prints the versi…
Failed asserting that '1.14.0-rc.0' matches PCRE pattern "/^\d+\.\d+\.\d+$/".
```

That is exactly the behaviour #668 intended — on `develop` a build should report `-rc.N` — so the assertion is the thing that's stale, not the version. #668 narrowed the matching guard in `ReleaseFlowTest` but missed this second one. The pattern stays anchored and still rejects junk (`1.14.0-`, `x1.2.3`, an unstripped `1.2.3 # x-release-please-version`), so the annotation-stripping half of the test keeps its teeth.

Every release PR on `develop` is blocked until this lands.

## How tested

- `php artisan test tests/Feature/Console/AppVersionCommandTest.php` green.
- Re-run with `VERSION` temporarily set to `1.14.0-rc.0` — the exact CI failure — now passes; it fails on the old pattern.
- Pint and Rector dry-run clean.

## Docs

None: no operator-facing setting, copy, or behaviour changed. No i18n keys added.