### PR TITLE
feat: add an OpenAPI 3.1 spec for the public REST API v1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,6 +62,13 @@ jobs:
         run: npm ci
         working-directory: docs
 
+      # `docs/public/openapi.yaml` is hand-authored. The PHP suite keeps it in
+      # lockstep with the route table; this is what proves it is still a valid
+      # OpenAPI 3.1 document before the site renders it (#531).
+      - name: Lint OpenAPI Spec
+        run: npm run openapi:lint
+        working-directory: docs
+
       - name: Build Docs Site
         run: npm run build
         working-directory: docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,25 @@ The site has two parts:
 - **Documentation** under `/docs` — Starlight pages. Content lives in
   `src/content/docs/docs/`; site config (title, sidebar, edit links) is in
   `astro.config.mjs`.
+- **API reference** under `/docs/api-reference` — generated at build time by
+  [starlight-openapi](https://starlight-openapi.vercel.app/) from
+  `public/openapi.yaml`, the hand-authored OpenAPI 3.1 contract for the
+  application's `/api/v1` surface. Because the file sits in `public/`, it is
+  also served raw at `/openapi.yaml` for client generators.
+
+## The OpenAPI spec
+
+`public/openapi.yaml` is edited by hand, and two gates keep it honest:
+
+- `npm run openapi:lint` validates it against the OpenAPI 3.1 schema, using the
+  ruleset pinned in `redocly.yaml`. The `docs` CI workflow runs it before the
+  build.
+- `tests/Unit/OpenApiSpecTest.php` (in the **application's** PHP suite, not this
+  project) diffs every documented path, method, and scope against the live route
+  table, so adding an `/api/v1` route without documenting it fails the build.
+
+Edit the spec whenever `routes/api.php`, an `App\Http\Requests\Api\V1\*` rule, or
+an `App\Http\Resources\Api\V1\*` shape changes.
 
 ## Local development
 
@@ -57,6 +76,7 @@ automatically).
 | `npm run dev`     | Start the dev server at `localhost:4321`      |
 | `npm run build`   | Build the production site to `./dist/`        |
 | `npm run preview` | Preview the production build locally          |
+| `npm run openapi:lint` | Validate `public/openapi.yaml` against the OpenAPI 3.1 schema |
 
 ## Deployment (Cloudflare Pages)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,12 @@ The site has two parts:
 Edit the spec whenever `routes/api.php`, an `App\Http\Requests\Api\V1\*` rule, or
 an `App\Http\Resources\Api\V1\*` shape changes.
 
+`starlight-openapi` renders code samples through `httpsnippet`, which pins
+`form-data` to an exact version — so when that pin lands on a version carrying an
+advisory, npm cannot resolve it away and the repo's `dependency-review` gate
+fails the PR. The `form-data` entry in `overrides` forces a patched release
+instead. Drop it once `httpsnippet` pins a clean version on its own.
+
 ## Local development
 
 All commands run inside **this `docs/` directory** (`cd docs` from the repo root

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,6 +2,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import sitemap from '@astrojs/sitemap';
+import starlightOpenAPI, { openAPISidebarGroups } from 'starlight-openapi';
 import caddyfileGrammar from './src/grammars/caddyfile.tmLanguage.json' with { type: 'json' };
 import crontabGrammar from './src/grammars/crontab.tmLanguage.json' with { type: 'json' };
 
@@ -24,6 +25,19 @@ export default defineConfig({
 			],
 			// Brand theme override (The Desk): Newsreader/Instrument Sans + brass palette.
 			customCss: ['./src/styles/custom.css'],
+			// Renders `public/openapi.yaml` — the hand-authored, route-verified
+			// contract for /api/v1 — into a browsable reference at build time.
+			// The same file stays downloadable at /openapi.yaml because it lives
+			// in `public/`, so integrators can feed it straight to a generator.
+			plugins: [
+				starlightOpenAPI([
+					{
+						base: 'docs/api-reference',
+						label: 'API reference',
+						schema: './public/openapi.yaml',
+					},
+				]),
+			],
 			// Code blocks stay a dark terminal frame in BOTH light and dark site
 			// themes (per the design). A single dark syntax theme keeps the token
 			// colours readable in both modes; the frame background follows the
@@ -115,6 +129,9 @@ export default defineConfig({
 						{ label: 'SOC 2 & ISO 27001 control mapping', slug: 'docs/reference/security-and-compliance' },
 					],
 				},
+				// Generated from the OpenAPI document by starlight-openapi: one
+				// group per tag, listing every operation.
+				...openAPISidebarGroups,
 			],
 		}),
 	],

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -256,21 +256,22 @@
       }
     },
     "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.3.tgz",
-      "integrity": "sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz",
+      "integrity": "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.10.1",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
         "satteri": "^0.9.1"
       }
     },
     "node_modules/@astrojs/mdx": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.2.tgz",
-      "integrity": "sha512-l+sJY5U1KkGZUdr+bIL4Y6BefeS549qoSHVSkUSs6A9INwdCND+/0+vN0NroPBXwl5Vcg5u78t7VQRsJjePxbw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-7.0.3.tgz",
+      "integrity": "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.10.1",
@@ -1095,9 +1096,9 @@
       }
     },
     "node_modules/@expressive-code/core": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.44.0.tgz",
-      "integrity": "sha512-xgiF2P6tYUbrhi3+x0S8xHZWT1t3Bvb3U91tAtRbLb9HLejLvYc5GZUqKICKLaUN4iSGhhNJu2fM/aH8e5yCMg==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.44.1.tgz",
+      "integrity": "sha512-3dDo9N8D7hYrLNNMMWFovg3+aDUtnQm7c7z0GZc1c0LEFVBc0Q6lKG+tVT28gDadOvsgOANfCn35fgpe97Pmgg==",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.4",
@@ -1112,31 +1113,31 @@
       }
     },
     "node_modules/@expressive-code/plugin-frames": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.44.0.tgz",
-      "integrity": "sha512-V6M6+zVc1GzqCvXkQHc2m5rcFOIVzJgMq5gnfrMnVf2gwtj/sg4H93c1f/mGeqHycubwkHFUDyParAOiGeDZeA==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.44.1.tgz",
+      "integrity": "sha512-HC/bdRao9225ApcgO/e3jn8ZOhldKO7ob1O/Tcipvtv7Vb5nMphZhMtD9uuywpvxkPYBHJi3504WhrKg05Dwqg==",
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.44.0"
+        "@expressive-code/core": "^0.44.1"
       }
     },
     "node_modules/@expressive-code/plugin-shiki": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.44.0.tgz",
-      "integrity": "sha512-RZsdaqlbGqyAQKuoX4myQXxjmiE2l5KBpJ/gKPh62tCdIdpWyjbzVqSo8+5XsezZxkfi8AJ/J6EUaBTPROFX/Q==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.44.1.tgz",
+      "integrity": "sha512-YApiZt3buUzBwL5tqj8G+sYC5NjMjRCHgQwr9bmGl69rtcHy6fE9dooWUeKYB978fJT2BuxT5FeHcF47rA3SEg==",
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.44.0",
+        "@expressive-code/core": "^0.44.1",
         "shiki": "^4.0.2"
       }
     },
     "node_modules/@expressive-code/plugin-text-markers": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.44.0.tgz",
-      "integrity": "sha512-0/m3A5b+lz2upyNq+wzZ1S69HRoJmyFs5LsR42lVZ9pmGRlBiSBYQpvqlji4DBj1+Riamxc0AvcCr5kuzOQeWA==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.44.1.tgz",
+      "integrity": "sha512-B3BsJoJ8CFMlcIX9f+X9tcI3C4zPDO601+YuLi9GheSTNro7ZfqSjLptMQKBHOWZvxnAtY5zvIX7iO/qtBhNBg==",
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.44.0"
+        "@expressive-code/core": "^0.44.1"
       }
     },
     "node_modules/@humanwhocodes/momoa": {
@@ -2515,14 +2516,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.0.7.tgz",
-      "integrity": "sha512-swqrKDSI/B83GFroYPZYMFcxqbSe9+tkynu1WDBk3GLgBfV9++qVM4Z+2uFT6uu9A53Q0TROnxLketfMEENuqQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.1.3.tgz",
+      "integrity": "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler-rs": "^0.3.0",
+        "@astrojs/compiler-rs": "^0.3.1",
         "@astrojs/internal-helpers": "0.10.1",
-        "@astrojs/markdown-satteri": "0.3.3",
+        "@astrojs/markdown-satteri": "0.3.4",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2534,7 +2535,7 @@
         "ci-info": "^4.4.0",
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
-        "cookie": "^1.1.1",
+        "cookie": "^2.0.1",
         "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
@@ -2551,7 +2552,7 @@
         "magic-string": "^0.30.21",
         "magicast": "^0.5.2",
         "mrmime": "^2.0.1",
-        "neotraverse": "^0.6.18",
+        "neotraverse": "^1.0.1",
         "obug": "^2.1.1",
         "p-limit": "^7.3.0",
         "p-queue": "^9.1.0",
@@ -2599,12 +2600,12 @@
       }
     },
     "node_modules/astro-expressive-code": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.44.0.tgz",
-      "integrity": "sha512-b1wN/ZvbJprzxlGKIpIes2kQrCY5KRLwys2tWbZAZyjGZcW5ZtgneZnBwzNRiBna9/48d4mQl19KLjcRuhO1hw==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.44.1.tgz",
+      "integrity": "sha512-DT1LnCqbHasBKlvzJ3m6LR4VI94wwx3W9EV/YbP1te4rqjOHsvsezHYuqb5MeLWLftXms/1FA9QBbwCo43DnJQ==",
       "license": "MIT",
       "dependencies": {
-        "rehype-expressive-code": "^0.44.0",
+        "rehype-expressive-code": "^0.44.1",
         "url-extras": "^0.1.0"
       },
       "peerDependencies": {
@@ -2868,12 +2869,12 @@
       }
     },
     "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "type": "opencollective",
@@ -3067,9 +3068,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
-      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
+      "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -3479,15 +3480,15 @@
       "license": "MIT"
     },
     "node_modules/expressive-code": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.44.0.tgz",
-      "integrity": "sha512-JXVWVNCKlLuZLMQH8cOiDUSosT0Bb+elwE/dbAkpwFwDFmyFyWlECoWZIohh2FkIF1iI67TQJ+Ts9k7oNDh2qA==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.44.1.tgz",
+      "integrity": "sha512-GakidxhapWDzpKLqEaFQ8wGk6gAqEtPQibu8+yPBfnDLgev5Vdsh1pasTxnrXL/mzIknyqeTwhMHTghdaiUrTg==",
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.44.0",
-        "@expressive-code/plugin-frames": "^0.44.0",
-        "@expressive-code/plugin-shiki": "^0.44.0",
-        "@expressive-code/plugin-text-markers": "^0.44.0"
+        "@expressive-code/core": "^0.44.1",
+        "@expressive-code/plugin-frames": "^0.44.1",
+        "@expressive-code/plugin-shiki": "^0.44.1",
+        "@expressive-code/plugin-text-markers": "^0.44.1"
       }
     },
     "node_modules/extend": {
@@ -3590,16 +3591,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4416,9 +4417,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -4431,23 +4432,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -4465,9 +4466,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -4485,9 +4486,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -4505,9 +4506,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -4525,9 +4526,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -4545,9 +4546,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -4565,9 +4566,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -4585,9 +4586,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -4605,9 +4606,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -4625,9 +4626,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -4645,9 +4646,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -5860,9 +5861,9 @@
       }
     },
     "node_modules/neotraverse": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
-      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+      "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -5915,9 +5916,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -5969,9 +5970,9 @@
       "peer": true
     },
     "node_modules/p-limit": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.2.1"
@@ -5984,9 +5985,9 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
-      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.2.tgz",
+      "integrity": "sha512-pCsnA4piiqkrwAJ555Xh/lc717SijJrTBr96P1q6BRnUdm2XPB4v91oiXVAUr5HbIbXW4D8kIslfJUE28Rud6A==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -6012,9 +6013,9 @@
       }
     },
     "node_modules/package-manager-detector": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
-      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
     },
     "node_modules/pagefind": {
@@ -6127,9 +6128,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
-      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6146,7 +6147,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6347,12 +6348,12 @@
       }
     },
     "node_modules/rehype-expressive-code": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.44.0.tgz",
-      "integrity": "sha512-5r74C5F2sMR3X+QJH8OKWgZBO/cqRw5W1fLT6GVlSfLqepk+4j8tGFkyPqZYWjwntsBHzKPDH2zI68sZ7ScLfA==",
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.44.1.tgz",
+      "integrity": "sha512-+VZgs7Evw4LXRN3owpoBNSTpYuW6GeOdjqcUT1TuY8o/4MGPtbd0EU7Bgrju7X8KrQ6SslOBAuGWJ5fV5TriJQ==",
       "license": "MIT",
       "dependencies": {
-        "expressive-code": "^0.44.0"
+        "expressive-code": "^0.44.1"
       }
     },
     "node_modules/rehype-format": {
@@ -7419,15 +7420,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -11,11 +11,31 @@
         "@astrojs/sitemap": "^3.7.3",
         "@astrojs/starlight": "^0.41.3",
         "astro": "^7.0.2",
-        "sharp": "^0.34.5"
+        "sharp": "^0.34.5",
+        "starlight-openapi": "^0.26.0"
+      },
+      "devDependencies": {
+        "@redocly/cli": "^2.39.0"
       },
       "engines": {
         "node": "22.16.0",
         "npm": "10.9.2"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-13.0.5.tgz",
+      "integrity": "sha512-xfh4xVJD62gG6spIc7lwxoWT+l16nZu1ELyU8FkjaP/oD2yP09EvLAU6KhtudN9aML2Khhs9pY6Slr7KGTES3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@astrojs/compiler-binding": {
@@ -365,6 +385,20 @@
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -396,6 +430,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -1096,6 +1139,15 @@
         "@expressive-code/core": "^0.44.0"
       }
     },
+    "node_modules/@humanwhocodes/momoa": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
+      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1734,6 +1786,70 @@
         "win32"
       ]
     },
+    "node_modules/@readme/better-ajv-errors": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@readme/better-ajv-errors/-/better-ajv-errors-2.4.0.tgz",
+      "integrity": "sha512-9WODaOAKSl/mU+MYNZ2aHCrkoRSvmQ+1YkLj589OEqqjOAhbn8j7Z+ilYoiTu/he6X63/clsxxAB4qny9/dDzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/code-frame": "^7.22.5",
+        "@babel/runtime": "^7.22.5",
+        "@humanwhocodes/momoa": "^2.0.3",
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ajv": "4.11.8 - 8"
+      }
+    },
+    "node_modules/@readme/openapi-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-4.1.2.tgz",
+      "integrity": "sha512-lAFH88r/CHs5VZDUocEda0OSMSQsr6801sziIjOKyVA+0hSFN+BPuelPF5XvkMROHecnPd+XEJN1iNQqCgER/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^13.0.5",
+        "@readme/better-ajv-errors": "^2.3.2",
+        "@readme/openapi-schemas": "^3.1.0",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^8.12.0",
+        "ajv-draft-04": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@readme/openapi-schemas": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-schemas/-/openapi-schemas-3.1.0.tgz",
+      "integrity": "sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "2.39.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.39.0.tgz",
+      "integrity": "sha512-xA0Z9YMEhlzbpn/BVErlE2UzuKfahp9llBwEnVtAYuhWdF8UCIm+cgYX8f/gHQIJ/TKwB93awAewTOgEsbZFZw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -2180,6 +2296,12 @@
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2261,6 +2383,36 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/am-i-vibing": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
@@ -2271,6 +2423,30 @@
       },
       "bin": {
         "am-i-vibing": "dist/cli.mjs"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -2435,6 +2611,12 @@
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2485,6 +2667,19 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -2493,6 +2688,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -2565,6 +2776,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2582,6 +2807,36 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -2778,6 +3033,15 @@
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2919,6 +3183,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2931,11 +3221,56 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -3008,6 +3343,15 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3113,6 +3457,21 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -3137,6 +3496,12 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -3151,6 +3516,22 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",
@@ -3208,6 +3589,28 @@
         "node": ">=20"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3220,6 +3623,67 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "license": "ISC"
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -3243,6 +3707,18 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
@@ -3258,6 +3734,60 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/har-validator-compiled": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/har-validator-compiled/-/har-validator-compiled-1.0.0.tgz",
+      "integrity": "sha512-dher7nFSx+Ef6OoqVveLClh8itAR3vd8Qx70Lh/hEgP1iGeARAolbci7Y8JBrHIYgFCT6xRdvvL16AR9Zh07Dw==",
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-embedded": {
@@ -3657,6 +4187,26 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/httpsnippet": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/httpsnippet/-/httpsnippet-3.0.10.tgz",
+      "integrity": "sha512-1P102HsVslaT3IVfuUfVwxenfbogFiihqosnaKUScd/sON1omdZZCWdmzm6baRz4u1Va0CTI/7svLckCu9iNBw==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "event-stream": "4.0.1",
+        "form-data": "4.0.4",
+        "har-validator-compiled": "^1.0.0",
+        "stringify-object": "3.3.0",
+        "yargs": "^17.4.0"
+      },
+      "bin": {
+        "httpsnippet": "bin/httpsnippet"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/i18next": {
       "version": "26.3.6",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
@@ -3749,6 +4299,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-hexadecimal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
@@ -3757,6 +4316,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3770,6 +4338,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -3793,11 +4376,26 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/klona": {
       "version": "2.0.6",
@@ -3806,6 +4404,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -4096,6 +4703,12 @@
         "source-map-js": "^1.2.1"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "license": "MIT"
+    },
     "node_modules/markdown-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
@@ -4116,6 +4729,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -5183,6 +5805,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5318,6 +5961,13 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/p-limit": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
@@ -5438,6 +6088,18 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
       }
     },
     "node_modules/piccolore": {
@@ -5878,6 +6540,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -6153,11 +6833,67 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/starlight-openapi": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/starlight-openapi/-/starlight-openapi-0.26.0.tgz",
+      "integrity": "sha512-+WJnS7nIW42KfgmtBvTdj0Sx0LR+3kYPCdXMoiiMxKWDTF9TBd8KhTRDqNiPPrksej+gItZV/ROKwsXoF2/qZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@readme/openapi-parser": "^4.1.2",
+        "github-slugger": "^2.0.0",
+        "httpsnippet": "^3.0.10",
+        "url-template": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-satteri": ">=0.3.2",
+        "@astrojs/starlight": ">=0.41.0",
+        "astro": ">=7.0.2"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -6171,6 +6907,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/style-to-js": {
@@ -6189,6 +6951,18 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svgo": {
@@ -6215,6 +6989,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
@@ -6581,6 +7361,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/url-template": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-3.1.1.tgz",
+      "integrity": "sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6735,11 +7524,55 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
@@ -6748,6 +7581,15 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,15 +12,20 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "openapi:lint": "redocly lint public/openapi.yaml"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.3",
     "@astrojs/starlight": "^0.41.3",
     "astro": "^7.0.2",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "starlight-openapi": "^0.26.0"
   },
   "overrides": {
     "inline-style-parser@<=0.2.9": "0.2.9"
+  },
+  "devDependencies": {
+    "@redocly/cli": "^2.39.0"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,8 @@
     "starlight-openapi": "^0.26.0"
   },
   "overrides": {
-    "inline-style-parser@<=0.2.9": "0.2.9"
+    "inline-style-parser@<=0.2.9": "0.2.9",
+    "form-data": "4.0.6"
   },
   "devDependencies": {
     "@redocly/cli": "^2.39.0"

--- a/docs/public/openapi.yaml
+++ b/docs/public/openapi.yaml
@@ -1,0 +1,1110 @@
+# The machine-readable contract for The Desk's public REST API v1.
+#
+# This document is hand-authored and kept in lockstep with the live surface by
+# tests/Unit/OpenApiSpecTest.php, which diffs every path, method, and scope
+# against the routes registered in routes/api.php. Adding a route without
+# documenting it here fails the build, and so does documenting one that does not
+# exist. `npm run openapi:lint` (docs/) validates it against the OpenAPI 3.1
+# schema on every docs CI run.
+openapi: 3.1.0
+
+info:
+  title: The Desk REST API
+  version: '1.0.0'
+  summary: Read and write into a The Desk workspace from an external system.
+  description: |
+    The Desk exposes a small, URI-versioned REST API so external systems can read
+    and post into a workspace. It is part of the integrations platform and shares
+    its `INTEGRATIONS_ENABLED` master switch: with the platform off, every route
+    below returns `404`.
+
+    Requests authenticate with a bearer token minted from **Team settings →
+    Integrations**, which is either a **bot token** (acting as a non-human
+    workspace member, limited to the channels it belongs to) or a **personal
+    access token** (acting as the human who created it, with their own
+    memberships and permissions). Tokens are displayed once at creation and
+    stored only as a hash.
+
+    Every operation requires exactly one `resource:action` scope, granted to the
+    token when it is minted. A token missing the scope an operation requires is
+    answered with `403`.
+  license:
+    name: MIT
+    identifier: MIT
+
+servers:
+  - url: https://{host}/api/v1
+    description: A self-hosted The Desk instance.
+    variables:
+      host:
+        default: desk.example.com
+        description: The host your instance is served from (its `APP_URL`).
+
+security:
+  - bearerAuth: []
+
+tags:
+  - name: Channels
+    description: Read, create, and archive channels.
+  - name: Messages
+    description: Read, post, edit, and delete messages in a channel.
+  - name: Reactions
+    description: Add and remove emoji reactions on a message.
+  - name: Members
+    description: Read and manage channel membership.
+  - name: Webhooks
+    description: Manage outgoing-webhook subscriptions for the workspace.
+
+paths:
+  /channels:
+    get:
+      operationId: listChannels
+      summary: List channels
+      description: |
+        Lists the channels the token's subject may view within its acting team,
+        ordered by name. A bot sees only the channels it belongs to; a personal
+        access token sees what the person sees in the app — every public channel
+        in the team plus the private ones they belong to.
+      tags: [Channels]
+      security:
+        - bearerAuth: ['channels:read']
+      responses:
+        '200':
+          description: The channels the subject may view.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Channel'
+                required: [data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+    post:
+      operationId: createChannel
+      summary: Create a channel
+      description: |
+        Creates a channel in the subject's acting team and seeds the subject as
+        its first member. A leading `#` in the name is stripped; a name that
+        slugs to an existing channel in the team is rejected with `422`.
+      tags: [Channels]
+      security:
+        - bearerAuth: ['channels:write']
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  description: The channel name, without a leading `#`.
+                  examples: ['deploys']
+                visibility:
+                  $ref: '#/components/schemas/ChannelVisibility'
+                topic:
+                  type: [string, 'null']
+                  maxLength: 255
+                  examples: ['Release announcements']
+              required: [name, visibility]
+      responses:
+        '201':
+          description: The channel was created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelEnvelope'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationFailed' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /channels/{channel}:
+    get:
+      operationId: showChannel
+      summary: Show a channel
+      tags: [Channels]
+      security:
+        - bearerAuth: ['channels:read']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The channel.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelEnvelope'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /channels/{channel}/archive:
+    post:
+      operationId: archiveChannel
+      summary: Archive a channel
+      description: |
+        Archives a channel, making it read-only. A bot may archive only a
+        channel it created, and never `#general`, a direct message, or an
+        already-archived channel. A personal access token defers to the same
+        rule the app applies: the channel's creator, or a team admin or above.
+      tags: [Channels]
+      security:
+        - bearerAuth: ['channels:write']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The archived channel.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelEnvelope'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /channels/{channel}/messages:
+    get:
+      operationId: listMessages
+      summary: List a channel's messages
+      description: A page of the channel's messages, newest first, 50 per page.
+      tags: [Messages]
+      security:
+        - bearerAuth: ['messages:read']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+        - name: page
+          in: query
+          required: false
+          description: The page to fetch, 1-based.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+      responses:
+        '200':
+          description: A page of messages.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Message'
+                    required: [data]
+                  - $ref: '#/components/schemas/Pagination'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+    post:
+      operationId: postMessage
+      summary: Post a message
+      description: |
+        Posts a message to the channel as the token's subject. Supply
+        `client_uuid` to make the call idempotent: resending the same uuid
+        resolves to the message already created rather than a duplicate.
+      tags: [Messages]
+      security:
+        - bearerAuth: ['messages:write']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                body:
+                  type: string
+                  maxLength: 8000
+                  description: The message text. Surrounding whitespace is trimmed.
+                  examples: ['Deploy finished ✅']
+                client_uuid:
+                  type: [string, 'null']
+                  format: uuid
+                  description: |
+                    An idempotency key you generate. One is generated for you
+                    when omitted.
+                reply_to_id:
+                  type: [string, 'null']
+                  format: uuid
+                  description: The id of a live standard message in this channel to reply to inline.
+                thread_root_id:
+                  type: [string, 'null']
+                  format: uuid
+                  description: |
+                    The id of a live standard message in this channel to reply to
+                    in a thread. The target must not itself be a thread reply —
+                    threads are one level deep.
+                sent_to_channel:
+                  type: boolean
+                  default: false
+                  description: Whether a thread reply is also echoed into the channel.
+              required: [body]
+      responses:
+        '201':
+          description: The message was posted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageEnvelope'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationFailed' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /channels/{channel}/messages/{message}:
+    get:
+      operationId: showMessage
+      summary: Show a message
+      tags: [Messages]
+      security:
+        - bearerAuth: ['messages:read']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+        - name: message
+          in: path
+          required: true
+          description: The message's id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The message.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageEnvelope'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+    patch:
+      operationId: editMessage
+      summary: Edit a message
+      description: Only the message's own author may edit it.
+      tags: [Messages]
+      security:
+        - bearerAuth: ['messages:write']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+        - name: message
+          in: path
+          required: true
+          description: The message's id.
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                body:
+                  type: string
+                  maxLength: 8000
+                  description: The replacement text. Surrounding whitespace is trimmed.
+              required: [body]
+      responses:
+        '200':
+          description: The edited message, carrying an `edited_at` stamp.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageEnvelope'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationFailed' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+    delete:
+      operationId: deleteMessage
+      summary: Delete a message
+      description: |
+        Deletes a message, leaving a tombstone in the channel so the
+        conversation keeps its shape. Only the message's own author may delete
+        it.
+      tags: [Messages]
+      security:
+        - bearerAuth: ['messages:write']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+        - name: message
+          in: path
+          required: true
+          description: The message's id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: The message was deleted.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /channels/{channel}/messages/{message}/reactions/{emoji}:
+    put:
+      operationId: addReaction
+      summary: Add a reaction
+      description: |
+        Adds the subject's reaction to a message. Idempotent — re-adding a
+        reaction the subject already left is a no-op. System messages cannot be
+        reacted to.
+      tags: [Reactions]
+      security:
+        - bearerAuth: ['reactions:write']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+        - name: message
+          in: path
+          required: true
+          description: The message's id.
+          schema:
+            type: string
+            format: uuid
+        - name: emoji
+          in: path
+          required: true
+          description: |
+            A native unicode emoji, or a `:name:` shortcode naming a custom
+            emoji that exists in the workspace. URL-encode the segment.
+          schema:
+            type: string
+            maxLength: 32
+          examples:
+            unicode:
+              value: '🎉'
+            custom:
+              value: ':shipit:'
+      responses:
+        '204':
+          description: The reaction is present.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationFailed' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+    delete:
+      operationId: removeReaction
+      summary: Remove a reaction
+      description: |
+        Removes the subject's reaction from a message. Idempotent — removing a
+        reaction that is not there is a no-op.
+      tags: [Reactions]
+      security:
+        - bearerAuth: ['reactions:write']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+        - name: message
+          in: path
+          required: true
+          description: The message's id.
+          schema:
+            type: string
+            format: uuid
+        - name: emoji
+          in: path
+          required: true
+          description: The reaction to remove. URL-encode the segment.
+          schema:
+            type: string
+            maxLength: 32
+      responses:
+        '204':
+          description: The reaction is absent.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /channels/{channel}/members:
+    get:
+      operationId: listChannelMembers
+      summary: List a channel's members
+      description: The channel's members, ordered by name.
+      tags: [Members]
+      security:
+        - bearerAuth: ['members:read']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The channel's members.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/User'
+                required: [data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+    post:
+      operationId: addChannelMember
+      summary: Add a channel member
+      description: |
+        Adds a team member to a private channel. A bot may do this on any
+        private channel it belongs to; a personal access token defers to the
+        same rule the app applies — an existing member of the private channel,
+        or a team admin or above.
+      tags: [Members]
+      security:
+        - bearerAuth: ['members:write']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: string
+                  format: uuid
+                  description: The id of a team member who is not already in the channel.
+              required: [user_id]
+      responses:
+        '201':
+          description: The member was added.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserEnvelope'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationFailed' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /channels/{channel}/members/{user}:
+    delete:
+      operationId: removeChannelMember
+      summary: Remove a channel member
+      description: |
+        Removes a member from a private channel. A member who is not in the
+        channel is answered with `404`.
+      tags: [Members]
+      security:
+        - bearerAuth: ['members:write']
+      parameters:
+        - name: channel
+          in: path
+          required: true
+          description: The channel's id.
+          schema:
+            type: string
+            format: uuid
+        - name: user
+          in: path
+          required: true
+          description: The member's user id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: The member was removed.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /webhooks:
+    get:
+      operationId: listWebhookSubscriptions
+      summary: List webhook subscriptions
+      description: The workspace's outgoing-webhook subscriptions, newest first.
+      tags: [Webhooks]
+      security:
+        - bearerAuth: ['webhooks:read']
+      responses:
+        '200':
+          description: The workspace's subscriptions.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/WebhookSubscription'
+                required: [data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+    post:
+      operationId: createWebhookSubscription
+      summary: Create a webhook subscription
+      description: |
+        Registers an outgoing-webhook subscription in the workspace. The signing
+        secret is returned in plaintext here **exactly once** and never again —
+        store it now; it is what you verify delivery signatures with.
+      tags: [Webhooks]
+      security:
+        - bearerAuth: ['webhooks:write']
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  examples: ['Deploy bot']
+                url:
+                  type: string
+                  format: uri
+                  maxLength: 2048
+                  description: |
+                    A publicly reachable HTTPS endpoint. Loopback and private
+                    network addresses are rejected.
+                  examples: ['https://hooks.example.com/the-desk']
+                events:
+                  type: array
+                  minItems: 1
+                  items:
+                    $ref: '#/components/schemas/WebhookEvent'
+                channel_ids:
+                  type: [array, 'null']
+                  description: |
+                    Restrict delivery to these channels, all of which must belong
+                    to the workspace. Omit to subscribe workspace-wide.
+                  items:
+                    type: string
+                    format: uuid
+              required: [name, url, events]
+      responses:
+        '201':
+          description: The subscription was created, with its one-time signing secret.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/WebhookSubscription'
+                  secret:
+                    type: string
+                    description: The signing secret, shown only here.
+                required: [data, secret]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '422': { $ref: '#/components/responses/ValidationFailed' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+  /webhooks/{webhookSubscription}:
+    get:
+      operationId: showWebhookSubscription
+      summary: Show a webhook subscription
+      description: The subscription, with its 20 most recent delivery attempts.
+      tags: [Webhooks]
+      security:
+        - bearerAuth: ['webhooks:read']
+      parameters:
+        - name: webhookSubscription
+          in: path
+          required: true
+          description: The subscription's id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The subscription and its recent deliveries.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    allOf:
+                      - $ref: '#/components/schemas/WebhookSubscription'
+                      - type: object
+                        properties:
+                          deliveries:
+                            type: array
+                            items:
+                              $ref: '#/components/schemas/WebhookDelivery'
+                        required: [deliveries]
+                required: [data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+    delete:
+      operationId: revokeWebhookSubscription
+      summary: Revoke a webhook subscription
+      description: Deletes the subscription, stopping all future delivery.
+      tags: [Webhooks]
+      security:
+        - bearerAuth: ['webhooks:write']
+      parameters:
+        - name: webhookSubscription
+          in: path
+          required: true
+          description: The subscription's id.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: The subscription was revoked.
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '429': { $ref: '#/components/responses/TooManyRequests' }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |
+        A bot token or personal access token minted from **Team settings →
+        Integrations**, sent as `Authorization: Bearer <token>`. The scopes
+        listed on each operation are the abilities the token must carry.
+
+  schemas:
+    ChannelVisibility:
+      type: string
+      enum: [public, private]
+      description: Whether the channel is open to the whole team or invite-only.
+
+    MessageType:
+      type: string
+      enum: [standard, member_joined, member_left, poll]
+      description: |
+        `standard` is an authored message; `member_joined` and `member_left` are
+        system notices the app writes itself.
+
+    UserType:
+      type: string
+      enum: [human, bot]
+
+    WebhookEvent:
+      type: string
+      enum:
+        - message.created
+        - message.updated
+        - message.deleted
+        - reaction.added
+        - channel.member_added
+      description: An event an outgoing-webhook subscription can listen for.
+
+    WebhookSubscriptionStatus:
+      type: string
+      enum: [active, disabled]
+      description: |
+        A subscription is disabled automatically after repeated delivery
+        failures.
+
+    Channel:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        slug:
+          type: string
+        visibility:
+          $ref: '#/components/schemas/ChannelVisibility'
+        topic:
+          type: [string, 'null']
+        is_general:
+          type: boolean
+          description: Whether this is the workspace's default channel.
+        is_archived:
+          type: boolean
+        is_direct:
+          type: boolean
+          description: Whether this is a direct-message conversation.
+        created_at:
+          type: [string, 'null']
+          format: date-time
+      required:
+        - id
+        - name
+        - slug
+        - visibility
+        - topic
+        - is_general
+        - is_archived
+        - is_direct
+        - created_at
+
+    User:
+      type: object
+      description: A workspace member, human or bot.
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/UserType'
+      required: [id, name, type]
+
+    ReactionSummary:
+      type: object
+      description: One emoji and how many members reacted with it.
+      properties:
+        emoji:
+          type: string
+        count:
+          type: integer
+          minimum: 1
+      required: [emoji, count]
+
+    Message:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        channel_id:
+          type: string
+          format: uuid
+        body:
+          type: string
+        type:
+          $ref: '#/components/schemas/MessageType'
+        author:
+          $ref: '#/components/schemas/User'
+        reply_to_id:
+          type: [string, 'null']
+          format: uuid
+        thread_root_id:
+          type: [string, 'null']
+          format: uuid
+        reactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReactionSummary'
+        created_at:
+          type: [string, 'null']
+          format: date-time
+        edited_at:
+          type: [string, 'null']
+          format: date-time
+          description: Null until the message is edited.
+      required:
+        - id
+        - channel_id
+        - body
+        - type
+        - author
+        - reply_to_id
+        - thread_root_id
+        - reactions
+        - created_at
+        - edited_at
+
+    WebhookDelivery:
+      type: object
+      description: One attempt to deliver an event to a subscription's endpoint.
+      properties:
+        id:
+          type: string
+          format: uuid
+        event_type:
+          $ref: '#/components/schemas/WebhookEvent'
+        event_id:
+          type: string
+          format: uuid
+          description: The id of the event delivered, for de-duplicating on your side.
+        succeeded:
+          type: boolean
+        response_status:
+          type: [integer, 'null']
+          description: The endpoint's HTTP status, or null when the request never completed.
+        error:
+          type: [string, 'null']
+        created_at:
+          type: [string, 'null']
+          format: date-time
+      required: [id, event_type, event_id, succeeded, response_status, error, created_at]
+
+    WebhookSubscription:
+      type: object
+      description: |
+        An outgoing-webhook subscription. The signing secret is deliberately
+        absent — it is returned only by the create operation.
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        url:
+          type: string
+          format: uri
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/WebhookEvent'
+        channel_ids:
+          type: [array, 'null']
+          description: Null when the subscription is workspace-wide.
+          items:
+            type: string
+            format: uuid
+        status:
+          $ref: '#/components/schemas/WebhookSubscriptionStatus'
+        consecutive_failures:
+          type: integer
+          minimum: 0
+        last_success_at:
+          type: [string, 'null']
+          format: date-time
+        disabled_at:
+          type: [string, 'null']
+          format: date-time
+        created_at:
+          type: [string, 'null']
+          format: date-time
+      required:
+        - id
+        - name
+        - url
+        - events
+        - channel_ids
+        - status
+        - consecutive_failures
+        - last_success_at
+        - disabled_at
+        - created_at
+
+    ChannelEnvelope:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Channel'
+      required: [data]
+
+    MessageEnvelope:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Message'
+      required: [data]
+
+    UserEnvelope:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/User'
+      required: [data]
+
+    Pagination:
+      type: object
+      description: The page cursor a paginated collection carries alongside its `data`.
+      properties:
+        links:
+          type: object
+          properties:
+            first:
+              type: [string, 'null']
+            last:
+              type: [string, 'null']
+            prev:
+              type: [string, 'null']
+            next:
+              type: [string, 'null']
+        meta:
+          type: object
+          properties:
+            current_page:
+              type: integer
+            from:
+              type: [integer, 'null']
+            last_page:
+              type: integer
+            path:
+              type: string
+            per_page:
+              type: integer
+            to:
+              type: [integer, 'null']
+            total:
+              type: integer
+
+    Error:
+      type: object
+      description: The shape every error response carries.
+      properties:
+        message:
+          type: string
+      required: [message]
+
+    ValidationError:
+      type: object
+      properties:
+        message:
+          type: string
+        errors:
+          type: object
+          description: The failing fields, each mapped to its messages.
+          additionalProperties:
+            type: array
+            items:
+              type: string
+      required: [message, errors]
+
+  responses:
+    Unauthorized:
+      description: The token is missing, malformed, or revoked.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    Forbidden:
+      description: |
+        The token lacks the scope this operation requires, or its subject may
+        see the resource but not perform this action on it.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    NotFound:
+      description: |
+        The resource does not exist, is outside the token's workspace, or the
+        integrations platform is disabled. A channel the subject cannot see is
+        reported here rather than as a `403`, so the API never leaks its
+        existence.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    ValidationFailed:
+      description: The request body failed validation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ValidationError'
+
+    TooManyRequests:
+      description: |
+        The per-token rate limit (`INTEGRATIONS_API_RATE_LIMIT` requests per
+        minute) was exceeded. Retry after the `Retry-After` header.
+      headers:
+        Retry-After:
+          description: Seconds to wait before retrying.
+          schema:
+            type: integer
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/docs/public/openapi.yaml
+++ b/docs/public/openapi.yaml
@@ -61,13 +61,16 @@ paths:
       operationId: listChannels
       summary: List channels
       description: |
+        **Required scope:** `channels:read`
+
         Lists the channels the token's subject may view within its acting team,
         ordered by name. A bot sees only the channels it belongs to; a personal
         access token sees what the person sees in the app — every public channel
         in the team plus the private ones they belong to.
       tags: [Channels]
       security:
-        - bearerAuth: ['channels:read']
+        - bearerAuth: []
+      x-required-scope: channels:read
       responses:
         '200':
           description: The channels the subject may view.
@@ -90,12 +93,15 @@ paths:
       operationId: createChannel
       summary: Create a channel
       description: |
+        **Required scope:** `channels:write`
+
         Creates a channel in the subject's acting team and seeds the subject as
         its first member. A leading `#` in the name is stripped; a name that
         slugs to an existing channel in the team is rejected with `422`.
       tags: [Channels]
       security:
-        - bearerAuth: ['channels:write']
+        - bearerAuth: []
+      x-required-scope: channels:write
       requestBody:
         required: true
         content:
@@ -132,9 +138,12 @@ paths:
     get:
       operationId: showChannel
       summary: Show a channel
+      description: |
+        **Required scope:** `channels:read`
       tags: [Channels]
       security:
-        - bearerAuth: ['channels:read']
+        - bearerAuth: []
+      x-required-scope: channels:read
       parameters:
         - name: channel
           in: path
@@ -160,13 +169,16 @@ paths:
       operationId: archiveChannel
       summary: Archive a channel
       description: |
+        **Required scope:** `channels:write`
+
         Archives a channel, making it read-only. A bot may archive only a
         channel it created, and never `#general`, a direct message, or an
         already-archived channel. A personal access token defers to the same
         rule the app applies: the channel's creator, or a team admin or above.
       tags: [Channels]
       security:
-        - bearerAuth: ['channels:write']
+        - bearerAuth: []
+      x-required-scope: channels:write
       parameters:
         - name: channel
           in: path
@@ -191,10 +203,14 @@ paths:
     get:
       operationId: listMessages
       summary: List a channel's messages
-      description: A page of the channel's messages, newest first, 50 per page.
+      description: |
+        **Required scope:** `messages:read`
+
+        A page of the channel's messages, newest first, 50 per page.
       tags: [Messages]
       security:
-        - bearerAuth: ['messages:read']
+        - bearerAuth: []
+      x-required-scope: messages:read
       parameters:
         - name: channel
           in: path
@@ -235,12 +251,15 @@ paths:
       operationId: postMessage
       summary: Post a message
       description: |
+        **Required scope:** `messages:write`
+
         Posts a message to the channel as the token's subject. Supply
         `client_uuid` to make the call idempotent: resending the same uuid
         resolves to the message already created rather than a duplicate.
       tags: [Messages]
       security:
-        - bearerAuth: ['messages:write']
+        - bearerAuth: []
+      x-required-scope: messages:write
       parameters:
         - name: channel
           in: path
@@ -300,9 +319,12 @@ paths:
     get:
       operationId: showMessage
       summary: Show a message
+      description: |
+        **Required scope:** `messages:read`
       tags: [Messages]
       security:
-        - bearerAuth: ['messages:read']
+        - bearerAuth: []
+      x-required-scope: messages:read
       parameters:
         - name: channel
           in: path
@@ -333,10 +355,14 @@ paths:
     patch:
       operationId: editMessage
       summary: Edit a message
-      description: Only the message's own author may edit it.
+      description: |
+        **Required scope:** `messages:write`
+
+        Only the message's own author may edit it.
       tags: [Messages]
       security:
-        - bearerAuth: ['messages:write']
+        - bearerAuth: []
+      x-required-scope: messages:write
       parameters:
         - name: channel
           in: path
@@ -381,12 +407,15 @@ paths:
       operationId: deleteMessage
       summary: Delete a message
       description: |
+        **Required scope:** `messages:write`
+
         Deletes a message, leaving a tombstone in the channel so the
         conversation keeps its shape. Only the message's own author may delete
         it.
       tags: [Messages]
       security:
-        - bearerAuth: ['messages:write']
+        - bearerAuth: []
+      x-required-scope: messages:write
       parameters:
         - name: channel
           in: path
@@ -415,12 +444,15 @@ paths:
       operationId: addReaction
       summary: Add a reaction
       description: |
+        **Required scope:** `reactions:write`
+
         Adds the subject's reaction to a message. Idempotent — re-adding a
         reaction the subject already left is a no-op. System messages cannot be
         reacted to.
       tags: [Reactions]
       security:
-        - bearerAuth: ['reactions:write']
+        - bearerAuth: []
+      x-required-scope: reactions:write
       parameters:
         - name: channel
           in: path
@@ -463,11 +495,14 @@ paths:
       operationId: removeReaction
       summary: Remove a reaction
       description: |
+        **Required scope:** `reactions:write`
+
         Removes the subject's reaction from a message. Idempotent — removing a
         reaction that is not there is a no-op.
       tags: [Reactions]
       security:
-        - bearerAuth: ['reactions:write']
+        - bearerAuth: []
+      x-required-scope: reactions:write
       parameters:
         - name: channel
           in: path
@@ -502,10 +537,14 @@ paths:
     get:
       operationId: listChannelMembers
       summary: List a channel's members
-      description: The channel's members, ordered by name.
+      description: |
+        **Required scope:** `members:read`
+
+        The channel's members, ordered by name.
       tags: [Members]
       security:
-        - bearerAuth: ['members:read']
+        - bearerAuth: []
+      x-required-scope: members:read
       parameters:
         - name: channel
           in: path
@@ -536,13 +575,16 @@ paths:
       operationId: addChannelMember
       summary: Add a channel member
       description: |
+        **Required scope:** `members:write`
+
         Adds a team member to a private channel. A bot may do this on any
         private channel it belongs to; a personal access token defers to the
         same rule the app applies — an existing member of the private channel,
         or a team admin or above.
       tags: [Members]
       security:
-        - bearerAuth: ['members:write']
+        - bearerAuth: []
+      x-required-scope: members:write
       parameters:
         - name: channel
           in: path
@@ -581,11 +623,14 @@ paths:
       operationId: removeChannelMember
       summary: Remove a channel member
       description: |
+        **Required scope:** `members:write`
+
         Removes a member from a private channel. A member who is not in the
         channel is answered with `404`.
       tags: [Members]
       security:
-        - bearerAuth: ['members:write']
+        - bearerAuth: []
+      x-required-scope: members:write
       parameters:
         - name: channel
           in: path
@@ -613,10 +658,14 @@ paths:
     get:
       operationId: listWebhookSubscriptions
       summary: List webhook subscriptions
-      description: The workspace's outgoing-webhook subscriptions, newest first.
+      description: |
+        **Required scope:** `webhooks:read`
+
+        The workspace's outgoing-webhook subscriptions, newest first.
       tags: [Webhooks]
       security:
-        - bearerAuth: ['webhooks:read']
+        - bearerAuth: []
+      x-required-scope: webhooks:read
       responses:
         '200':
           description: The workspace's subscriptions.
@@ -639,12 +688,15 @@ paths:
       operationId: createWebhookSubscription
       summary: Create a webhook subscription
       description: |
+        **Required scope:** `webhooks:write`
+
         Registers an outgoing-webhook subscription in the workspace. The signing
         secret is returned in plaintext here **exactly once** and never again —
         store it now; it is what you verify delivery signatures with.
       tags: [Webhooks]
       security:
-        - bearerAuth: ['webhooks:write']
+        - bearerAuth: []
+      x-required-scope: webhooks:write
       requestBody:
         required: true
         content:
@@ -661,8 +713,9 @@ paths:
                   format: uri
                   maxLength: 2048
                   description: |
-                    A publicly reachable HTTPS endpoint. Loopback and private
-                    network addresses are rejected.
+                    A publicly reachable `http://` or `https://` endpoint.
+                    Loopback, private, link-local, and cloud-metadata addresses
+                    are rejected.
                   examples: ['https://hooks.example.com/the-desk']
                 events:
                   type: array
@@ -702,10 +755,14 @@ paths:
     get:
       operationId: showWebhookSubscription
       summary: Show a webhook subscription
-      description: The subscription, with its 20 most recent delivery attempts.
+      description: |
+        **Required scope:** `webhooks:read`
+
+        The subscription, with its 20 most recent delivery attempts.
       tags: [Webhooks]
       security:
-        - bearerAuth: ['webhooks:read']
+        - bearerAuth: []
+      x-required-scope: webhooks:read
       parameters:
         - name: webhookSubscription
           in: path
@@ -741,10 +798,14 @@ paths:
     delete:
       operationId: revokeWebhookSubscription
       summary: Revoke a webhook subscription
-      description: Deletes the subscription, stopping all future delivery.
+      description: |
+        **Required scope:** `webhooks:write`
+
+        Deletes the subscription, stopping all future delivery.
       tags: [Webhooks]
       security:
-        - bearerAuth: ['webhooks:write']
+        - bearerAuth: []
+      x-required-scope: webhooks:write
       parameters:
         - name: webhookSubscription
           in: path
@@ -768,8 +829,12 @@ components:
       scheme: bearer
       description: |
         A bot token or personal access token minted from **Team settings →
-        Integrations**, sent as `Authorization: Bearer <token>`. The scopes
-        listed on each operation are the abilities the token must carry.
+        Integrations**, sent as `Authorization: Bearer <token>`.
+
+        OpenAPI 3.1 requires the security requirement array to be empty for a
+        scheme that is not `oauth2` or `openIdConnect`, so the one scope each
+        operation demands is carried in its `x-required-scope` extension (and
+        repeated at the top of its description).
 
   schemas:
     ChannelVisibility:

--- a/docs/redocly.yaml
+++ b/docs/redocly.yaml
@@ -1,0 +1,4 @@
+# Pins the ruleset `npm run openapi:lint` enforces on public/openapi.yaml, so a
+# Redocly upgrade cannot silently change what the docs CI gate accepts.
+extends:
+  - recommended

--- a/docs/src/content/docs/docs/reference/api.md
+++ b/docs/src/content/docs/docs/reference/api.md
@@ -9,10 +9,29 @@ platform](/docs/reference/feature-toggles/#integrations-platform) and shares its
 `INTEGRATIONS_ENABLED` master switch — with the platform off, every route below
 returns **404**.
 
+This page is the narrative introduction. The full operation-by-operation
+contract — request bodies, response schemas, and the exact scope each endpoint
+requires — lives in the generated
+**[API reference](/docs/api-reference/)**.
+
 ## Base URL and versioning
 
 All endpoints live under `${APP_URL}/api/v1`. The version is in the path, so a
 future `v2` never breaks a `v1` client.
+
+## Machine-readable spec
+
+The API is described by an **OpenAPI 3.1** document, published at
+[`/openapi.yaml`](/openapi.yaml). Point a generator at it to get a typed client
+in your language, or import it into Postman or Insomnia:
+
+```bash
+curl -O https://the-desk.emmanuelpaul.com/openapi.yaml
+```
+
+The document is kept in lockstep with the running code by a test that diffs
+every path, method, and scope against the application's route table, so an
+endpoint cannot change without the spec changing with it.
 
 ## Authenticating
 
@@ -53,6 +72,8 @@ Every endpoint requires exactly one scope; a token missing it gets a `403`.
 | `webhooks:write`   | Create and revoke outgoing-webhook subscriptions. |
 
 ## Endpoints
+
+Each one is documented in full in the [API reference](/docs/api-reference/).
 
 | Method & path                                        | Scope             |
 | ---------------------------------------------------- | ----------------- |

--- a/docs/src/content/docs/docs/reference/api.md
+++ b/docs/src/content/docs/docs/reference/api.md
@@ -21,9 +21,10 @@ future `v2` never breaks a `v1` client.
 
 ## Machine-readable spec
 
-The API is described by an **OpenAPI 3.1** document, published at
-[`/openapi.yaml`](/openapi.yaml). Point a generator at it to get a typed client
-in your language, or import it into Postman or Insomnia:
+The API is described by an **OpenAPI 3.1** document, published on this site at
+[`/openapi.yaml`](/openapi.yaml) (not on your own instance). Point a generator
+at it to get a typed client in your language, or import it into Postman or
+Insomnia:
 
 ```bash
 curl -O https://the-desk.emmanuelpaul.com/openapi.yaml

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -32,6 +32,10 @@ pest()->extend(TestCase::class)->in('Unit/Support/GiphyClientTest.php');
 // application booted (but no database).
 pest()->extend(TestCase::class)->in('Unit/Support/ReverbConfigTest.php');
 
+// The OpenAPI spec test diffs the document against the live route table, so it
+// needs the application booted (but no database).
+pest()->extend(TestCase::class)->in('Unit/OpenApiSpecTest.php');
+
 /*
 |--------------------------------------------------------------------------
 | Browser (E2E) Test Case

--- a/tests/Unit/DocsBuildGateTest.php
+++ b/tests/Unit/DocsBuildGateTest.php
@@ -90,6 +90,24 @@ test('the declared engines agree with the node pin', function () use ($docsPath)
         ->and($engines['npm'])->toBe('10.9.2');
 });
 
+/**
+ * The OpenAPI document is hand-authored, so nothing but a validator proves it
+ * still parses as OpenAPI 3.1. `tests/Unit/OpenApiSpecTest.php` keeps it in
+ * lockstep with the routes; this lint is what keeps it a *valid* spec (#531).
+ */
+test('the docs job lints the openapi spec against the 3.1 schema', function () use ($docsJob): void {
+    $step = collect($docsJob()['steps'])->first(static fn (array $step): bool => runsInDocs($step, 'npm run openapi:lint'));
+
+    expect($step)->not->toBeNull('the hand-authored spec must be schema-validated in CI');
+});
+
+test('the docs project provides the openapi lint script and its linter', function () use ($docsPath): void {
+    $package = json_decode((string) file_get_contents($docsPath('package.json')), true);
+
+    expect($package['scripts'])->toHaveKey('openapi:lint')
+        ->and($package['devDependencies'] ?? [])->toHaveKey('@redocly/cli');
+});
+
 test('the docs readme documents the pin a contributor must regenerate the lockfile with', function () use ($docsPath): void {
     $readme = (string) file_get_contents($docsPath('README.md'));
 

--- a/tests/Unit/DocsBuildGateTest.php
+++ b/tests/Unit/DocsBuildGateTest.php
@@ -104,7 +104,10 @@ test('the docs job lints the openapi spec against the 3.1 schema', function () u
 test('the docs project provides the openapi lint script and its linter', function () use ($docsPath): void {
     $package = json_decode((string) file_get_contents($docsPath('package.json')), true);
 
-    expect($package['scripts'])->toHaveKey('openapi:lint')
+    // The script must actually validate the spec: a placeholder that merely
+    // exists under the right key would satisfy the workflow gate above while
+    // checking nothing.
+    expect($package['scripts']['openapi:lint'] ?? '')->toBe('redocly lint public/openapi.yaml')
         ->and($package['devDependencies'] ?? [])->toHaveKey('@redocly/cli');
 });
 

--- a/tests/Unit/OpenApiSpecTest.php
+++ b/tests/Unit/OpenApiSpecTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\IntegrationScope;
+use Illuminate\Routing\Route as RoutingRoute;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * `docs/public/openapi.yaml` is the machine-readable contract for the public
+ * REST API: integrators generate clients from it and the docs site renders it.
+ * Nothing in the framework keeps it honest, so a route added to
+ * `routes/api.php` — or a scope quietly widened on an existing one — would ship
+ * a spec that lies. These tests pin the document to the live route table in
+ * both directions, so the surface and its contract can only move together.
+ * See issue #531.
+ */
+$repositoryPath = fn (string $file): string => dirname(__DIR__, 2).'/'.$file;
+
+$spec = function () use ($repositoryPath): array {
+    /** @var array<string, mixed> $document */
+    $document = Yaml::parseFile($repositoryPath('docs/public/openapi.yaml'));
+
+    return $document;
+};
+
+/**
+ * The single scope the route's `scope:` middleware enforces, or null when it
+ * enforces none.
+ */
+function routeScope(RoutingRoute $route): ?string
+{
+    $middleware = collect($route->gatherMiddleware())
+        ->first(static fn (mixed $entry): bool => is_string($entry) && str_starts_with($entry, 'scope:'));
+
+    return is_string($middleware) ? Str::after($middleware, 'scope:') : null;
+}
+
+/**
+ * The live `/api/v1` surface as `"<method> <path>" => "<scope>"`, keyed exactly
+ * the way the spec's paths object is flattened below.
+ *
+ * @return array<string, string|null>
+ */
+function liveApiOperations(): array
+{
+    $operations = [];
+
+    foreach (Route::getRoutes() as $route) {
+        if (! str_starts_with((string) $route->getName(), 'api.v1.')) {
+            continue;
+        }
+
+        $path = '/'.trim(Str::after($route->uri(), 'api/v1'), '/');
+
+        foreach ($route->methods() as $method) {
+            if (in_array($method, ['HEAD', 'OPTIONS'], true)) {
+                continue;
+            }
+
+            $operations[strtolower((string) $method).' '.$path] = routeScope($route);
+        }
+    }
+
+    ksort($operations);
+
+    return $operations;
+}
+
+/**
+ * The documented surface as `"<method> <path>" => "<scope>"`, reading the scope
+ * out of each operation's `bearerAuth` security requirement.
+ *
+ * @param  array<string, mixed>  $spec
+ * @return array<string, string|null>
+ */
+function documentedApiOperations(array $spec): array
+{
+    $operations = [];
+
+    foreach ($spec['paths'] as $path => $methods) {
+        foreach ($methods as $method => $operation) {
+            $operations[$method.' '.$path] = $operation['security'][0]['bearerAuth'][0] ?? null;
+        }
+    }
+
+    ksort($operations);
+
+    return $operations;
+}
+
+/**
+ * Every operation object in the document, keyed by `"<method> <path>"`.
+ *
+ * @param  array<string, mixed>  $spec
+ * @return array<string, array<string, mixed>>
+ */
+function specOperations(array $spec): array
+{
+    $operations = [];
+
+    foreach ($spec['paths'] as $path => $methods) {
+        foreach ($methods as $method => $operation) {
+            $operations[$method.' '.$path] = $operation;
+        }
+    }
+
+    return $operations;
+}
+
+/**
+ * Collect every `$ref` target in the document, however deeply nested.
+ *
+ * @param  array<array-key, mixed>  $node
+ * @return list<string>
+ */
+function collectRefs(array $node): array
+{
+    $refs = [];
+
+    foreach ($node as $key => $value) {
+        if ($key === '$ref' && is_string($value)) {
+            $refs[] = $value;
+
+            continue;
+        }
+
+        if (is_array($value)) {
+            $refs = [...$refs, ...collectRefs($value)];
+        }
+    }
+
+    return $refs;
+}
+
+test('the spec is an OpenAPI 3.1 document', function () use ($spec): void {
+    expect($spec()['openapi'])->toStartWith('3.1')
+        ->and($spec()['info']['title'])->toBeString()
+        ->and($spec()['info']['version'])->toBeString();
+});
+
+test('the spec documents exactly the live /api/v1 surface', function () use ($spec): void {
+    expect(array_keys(documentedApiOperations($spec())))
+        ->toBe(array_keys(liveApiOperations()), 'every /api/v1 route must be documented, and only those');
+});
+
+test('every documented operation declares the scope its route enforces', function () use ($spec): void {
+    expect(documentedApiOperations($spec()))->toBe(liveApiOperations());
+});
+
+test('the documented scopes all come from the IntegrationScope vocabulary', function () use ($spec): void {
+    expect(array_values(array_unique(documentedApiOperations($spec()))))
+        ->each->toBeIn(IntegrationScope::values());
+});
+
+test('the spec describes the bearer token security scheme the API authenticates with', function () use ($spec): void {
+    $scheme = $spec()['components']['securitySchemes']['bearerAuth'];
+
+    expect($scheme['type'])->toBe('http')
+        ->and($scheme['scheme'])->toBe('bearer');
+});
+
+test('every operation carries an operationId, a summary and a tag', function () use ($spec): void {
+    foreach (specOperations($spec()) as $name => $operation) {
+        expect(array_keys($operation))->toContain('operationId', 'summary', 'tags')
+            ->and($operation['tags'])->not->toBeEmpty($name.' must be grouped under a tag');
+    }
+});
+
+test('operation ids are unique so generated clients do not collide', function () use ($spec): void {
+    $ids = array_column(array_values(specOperations($spec())), 'operationId');
+
+    expect($ids)->toBe(array_unique($ids));
+});
+
+test('every tag an operation uses is declared at the document root', function () use ($spec): void {
+    $declared = array_column($spec()['tags'], 'name');
+
+    foreach (specOperations($spec()) as $name => $operation) {
+        expect($operation['tags'])->each->toBeIn($declared, $name.' uses an undeclared tag');
+    }
+});
+
+test('every operation documents the shared error responses', function (string $status) use ($spec): void {
+    $missing = array_keys(array_filter(
+        specOperations($spec()),
+        static fn (array $operation): bool => ! array_key_exists($status, $operation['responses']),
+    ));
+
+    expect($missing)->toBeEmpty('these operations must document a '.$status.': '.implode(', ', $missing));
+})->with([
+    // Every route sits behind the same three guards: the Sanctum token, its
+    // scope, and the per-token throttle. The 404 is universal too — the whole
+    // surface disappears when INTEGRATIONS_ENABLED is off.
+    '401', '403', '404', '429',
+]);
+
+test('every operation that accepts a body documents the validation failure', function () use ($spec): void {
+    $missing = array_keys(array_filter(
+        specOperations($spec()),
+        static fn (array $operation): bool => isset($operation['requestBody'])
+            && ! array_key_exists('422', $operation['responses']),
+    ));
+
+    expect($missing)->toBeEmpty('these operations must document a 422: '.implode(', ', $missing));
+});
+
+test('every path parameter the template declares is described', function () use ($spec): void {
+    foreach ($spec()['paths'] as $path => $methods) {
+        preg_match_all('/\{(\w+)}/', (string) $path, $matches);
+
+        foreach ($methods as $method => $operation) {
+            $described = array_column(
+                array_filter($operation['parameters'] ?? [], static fn (array $parameter): bool => ($parameter['in'] ?? null) === 'path'),
+                'name',
+            );
+
+            sort($described);
+            $expected = $matches[1];
+            sort($expected);
+
+            expect($described)->toBe($expected, $method.' '.$path.' must describe each path parameter');
+        }
+    }
+});
+
+test('every $ref in the spec resolves to a component that exists', function () use ($spec): void {
+    $document = $spec();
+
+    foreach (array_unique(collectRefs($document)) as $ref) {
+        expect($ref)->toStartWith('#/components/');
+
+        $target = $document;
+
+        foreach (explode('/', Str::after($ref, '#/')) as $segment) {
+            expect(array_key_exists($segment, $target))->toBeTrue($ref.' does not resolve');
+            $target = $target[$segment];
+        }
+    }
+});
+
+test('the spec is published as a static asset alongside the rendered docs', function () use ($repositoryPath): void {
+    expect($repositoryPath('docs/public/openapi.yaml'))->toBeReadableFile();
+});

--- a/tests/Unit/OpenApiSpecTest.php
+++ b/tests/Unit/OpenApiSpecTest.php
@@ -49,11 +49,16 @@ function liveApiOperations(): array
     $operations = [];
 
     foreach (Route::getRoutes() as $route) {
-        if (! str_starts_with((string) $route->getName(), 'api.v1.')) {
+        // Selected by URI, not by route name: a route registered under /api/v1
+        // with some other name would otherwise be invisible to this gate, which
+        // is precisely the drift it exists to catch.
+        $uri = trim((string) $route->uri(), '/');
+
+        if ($uri !== 'api/v1' && ! str_starts_with($uri, 'api/v1/')) {
             continue;
         }
 
-        $path = '/'.trim(Str::after($route->uri(), 'api/v1'), '/');
+        $path = '/'.trim(Str::after($uri, 'api/v1'), '/');
 
         foreach ($route->methods() as $method) {
             if (in_array($method, ['HEAD', 'OPTIONS'], true)) {
@@ -152,6 +157,20 @@ test('the spec documents exactly the live /api/v1 surface', function () use ($sp
 
 test('every documented operation declares the scope its route enforces', function () use ($spec): void {
     expect(documentedApiOperations($spec()))->toBe(liveApiOperations());
+});
+
+test('every /api/v1 route is named under the api.v1 prefix', function (): void {
+    $unnamed = [];
+
+    foreach (Route::getRoutes() as $route) {
+        $uri = trim((string) $route->uri(), '/');
+
+        if (str_starts_with($uri, 'api/v1/') && ! str_starts_with((string) $route->getName(), 'api.v1.')) {
+            $unnamed[] = $uri;
+        }
+    }
+
+    expect($unnamed)->toBeEmpty('these routes must be named api.v1.*: '.implode(', ', $unnamed));
 });
 
 test('the documented scopes all come from the IntegrationScope vocabulary', function () use ($spec): void {

--- a/tests/Unit/OpenApiSpecTest.php
+++ b/tests/Unit/OpenApiSpecTest.php
@@ -70,21 +70,21 @@ function liveApiOperations(): array
 }
 
 /**
- * The documented surface as `"<method> <path>" => "<scope>"`, reading the scope
- * out of each operation's `bearerAuth` security requirement.
+ * The documented surface as `"<method> <path>" => "<scope>"`.
+ *
+ * OpenAPI 3.1 requires the security requirement array to be empty for any
+ * scheme that is not `oauth2`/`openIdConnect`, so the scope cannot live in the
+ * `bearerAuth` entry — it is carried in the `x-required-scope` extension.
  *
  * @param  array<string, mixed>  $spec
  * @return array<string, string|null>
  */
 function documentedApiOperations(array $spec): array
 {
-    $operations = [];
-
-    foreach ($spec['paths'] as $path => $methods) {
-        foreach ($methods as $method => $operation) {
-            $operations[$method.' '.$path] = $operation['security'][0]['bearerAuth'][0] ?? null;
-        }
-    }
+    $operations = array_map(
+        static fn (array $operation): ?string => $operation['x-required-scope'] ?? null,
+        specOperations($spec),
+    );
 
     ksort($operations);
 
@@ -94,15 +94,19 @@ function documentedApiOperations(array $spec): array
 /**
  * Every operation object in the document, keyed by `"<method> <path>"`.
  *
+ * A path item may also carry non-operation keys (`summary`, `parameters`, …),
+ * so only the HTTP verbs OpenAPI defines are treated as operations.
+ *
  * @param  array<string, mixed>  $spec
  * @return array<string, array<string, mixed>>
  */
 function specOperations(array $spec): array
 {
+    $verbs = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
     $operations = [];
 
-    foreach ($spec['paths'] as $path => $methods) {
-        foreach ($methods as $method => $operation) {
+    foreach ($spec['paths'] as $path => $pathItem) {
+        foreach (array_intersect_key($pathItem, array_flip($verbs)) as $method => $operation) {
             $operations[$method.' '.$path] = $operation;
         }
     }
@@ -162,6 +166,27 @@ test('the spec describes the bearer token security scheme the API authenticates 
         ->and($scheme['scheme'])->toBe('bearer');
 });
 
+test('every operation requires the bearer scheme with the empty array 3.1 mandates', function () use ($spec): void {
+    foreach (specOperations($spec()) as $name => $operation) {
+        expect($operation['security'])->toBe([['bearerAuth' => []]], $name.' must require bearerAuth with no in-band scopes');
+    }
+});
+
+test('every operation repeats its required scope in its description', function () use ($spec): void {
+    // The rendered reference does not surface `x-required-scope`, so the scope
+    // is restated at the top of the description. Pinning the two together keeps
+    // the human-readable copy from drifting from the machine-readable one.
+    $missing = array_keys(array_filter(
+        specOperations($spec()),
+        static fn (array $operation): bool => ! str_contains(
+            (string) $operation['description'],
+            '**Required scope:** `'.$operation['x-required-scope'].'`',
+        ),
+    ));
+
+    expect($missing)->toBeEmpty('these operations must state their scope: '.implode(', ', $missing));
+});
+
 test('every operation carries an operationId, a summary and a tag', function () use ($spec): void {
     foreach (specOperations($spec()) as $name => $operation) {
         expect(array_keys($operation))->toContain('operationId', 'summary', 'tags')
@@ -208,21 +233,27 @@ test('every operation that accepts a body documents the validation failure', fun
 });
 
 test('every path parameter the template declares is described', function () use ($spec): void {
-    foreach ($spec()['paths'] as $path => $methods) {
-        preg_match_all('/\{(\w+)}/', (string) $path, $matches);
+    $document = $spec();
 
-        foreach ($methods as $method => $operation) {
-            $described = array_column(
-                array_filter($operation['parameters'] ?? [], static fn (array $parameter): bool => ($parameter['in'] ?? null) === 'path'),
-                'name',
-            );
+    foreach (specOperations($document) as $name => $operation) {
+        $path = Str::after($name, ' ');
 
-            sort($described);
-            $expected = $matches[1];
-            sort($expected);
+        preg_match_all('/\{(\w+)}/', $path, $matches);
 
-            expect($described)->toBe($expected, $method.' '.$path.' must describe each path parameter');
-        }
+        // A path item may hoist parameters shared by all its operations, so the
+        // two levels are merged before the comparison.
+        $parameters = [...$document['paths'][$path]['parameters'] ?? [], ...$operation['parameters'] ?? []];
+
+        $described = array_unique(array_column(
+            array_filter($parameters, static fn (array $parameter): bool => ($parameter['in'] ?? null) === 'path'),
+            'name',
+        ));
+
+        sort($described);
+        $expected = $matches[1];
+        sort($expected);
+
+        expect($described)->toBe($expected, $name.' must describe each path parameter');
     }
 });
 


### PR DESCRIPTION
Closes #531.

## What

Adds `docs/public/openapi.yaml`, a hand-authored **OpenAPI 3.1** document describing the whole `/api/v1` surface — all 18 operations across channels, messages, reactions, members, and outgoing-webhook subscriptions — with Sanctum bearer auth, request/response schemas, and the shared `401` / `403` / `404` / `422` / `429` error shapes.

It is rendered into the Starlight docs at **`/docs/api-reference`** by `starlight-openapi` (one page per operation, grouped by tag, generated at build time — no CDN script, so no CSP impact), and served raw at **`/openapi.yaml`** so integrators can feed it straight to a client generator, Postman, or Insomnia. The existing `reference/api` page stays as the narrative introduction and links across to both.

## Why the scope lives in `x-required-scope`

OpenAPI 3.1 requires the security requirement array to be **empty** for any scheme that is not `oauth2` / `openIdConnect`, so the scope cannot ride inside the `bearerAuth` entry. Each operation therefore declares `security: [{bearerAuth: []}]` plus an `x-required-scope` extension, and restates the scope at the top of its description so it still shows up in the rendered reference. A test pins those two to each other.

## How it stays honest

Two gates, because a hand-authored spec rots silently:

- `tests/Unit/OpenApiSpecTest.php` (PHP suite, runs on every PR) diffs the document against the **live route table** in both directions — every path, method, and enforced `scope:` middleware. Routes are selected by URI (`api/v1/…`), not by route name, so a route registered under a different name still can't hide from it. It also checks the scope vocabulary against `IntegrationScope`, that `$ref`s resolve, that path parameters are described, and that operation ids are unique.
- `npm run openapi:lint` (`@redocly/cli`, ruleset pinned in `docs/redocly.yaml`) validates the document against the OpenAPI 3.1 schema. Wired into `.github/workflows/docs.yml` ahead of the build, and `tests/Unit/DocsBuildGateTest.php` keeps that step and the script from being quietly removed.

Mutation-checked both directions: flipping a documented scope and dropping a path each fail the suite.

## Testing

- `composer test` — green, `Total: 100.0 %`
- `npm run lint:check` / `format:check` / `types:check` / `test:js` / `build` — green
- `cd docs && npm run openapi:lint && npm run build` — spec validates, 45 pages built (18 operation pages + the reference index)
- Local CodeRabbit pass: clean

## Notes

- New `docs/` dependencies only (`starlight-openapi`, `@redocly/cli`); the application's `composer.json` and root `package.json` are untouched. `docs/package-lock.json` was regenerated on the pinned Node 22.16.0 per `docs/.nvmrc`.
- No new user-facing application copy, so no `lang/fr.json` changes.