### PR TITLE
fix: target the built version in the upgrade CI jobs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -376,12 +376,16 @@ jobs:
           persist-credentials: false
 
       # The build overlay retags the app image to the-desk:latest and builds it
-      # from this checkout, so APP_IMAGE is not involved on this path.
+      # from this checkout, so APP_IMAGE is not involved on this path. APP_VERSION
+      # still is: it is what upgrade.sh targets, and the template gen-secrets.sh
+      # copies names the last stable release on `develop` while the image built
+      # from this checkout reports the candidate, so it comes from VERSION here.
       - name: Prepare a build-from-source .env
         run: |
           ./docker/gen-secrets.sh
           sed -i 's|^COMPOSE_FILE=.*|COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml|' .env
           echo "APP_URL=http://localhost:8000" >> .env
+          echo "APP_VERSION=$(sed -e 's/#.*//' VERSION | tr -d '[:space:]')" >> .env
           grep '^COMPOSE_FILE=' .env
 
       - name: Start the stack from source
@@ -443,12 +447,19 @@ jobs:
           tags: the-desk:ci
           cache-from: type=gha
 
+      # APP_VERSION is taken from the VERSION file rather than from the
+      # .env.prod.example gen-secrets.sh copies. The candidate line stamps
+      # VERSION alone (see tests/Unit/ReleaseFlowTest.php), so on `develop` the
+      # template still names the last stable release while the image built above
+      # reports the candidate — upgrade.sh would target a version the container
+      # never claims and fail its identity check. The last assignment wins.
       - name: Prepare a production .env
         run: |
           ./docker/gen-secrets.sh
           {
             echo "APP_IMAGE=the-desk:ci"
             echo "APP_URL=http://localhost:8000"
+            echo "APP_VERSION=$(sed -e 's/#.*//' VERSION | tr -d '[:space:]')"
           } >> .env
 
       # Start from a running stack, which is what an operator upgrades from.

--- a/tests/Unit/ReleaseFlowTest.php
+++ b/tests/Unit/ReleaseFlowTest.php
@@ -133,6 +133,36 @@ test('the stable line stamps the running version too', function (): void {
     expect(stampedPaths('release-please-config.json'))->toContain('VERSION');
 });
 
+/**
+ * The shell of the step in `$job` that seeds `.env` with gen-secrets.sh.
+ */
+function envPreparationScript(string $job): string
+{
+    /** @var array<int, array<string, mixed>> $steps */
+    $steps = readWorkflow('docker.yml')['jobs'][$job]['steps'];
+
+    foreach ($steps as $step) {
+        if (str_contains((string) ($step['run'] ?? ''), 'gen-secrets.sh')) {
+            return (string) $step['run'];
+        }
+    }
+
+    throw new RuntimeException("docker.yml job `{$job}` has no step seeding .env.");
+}
+
+/*
+ * The two upgrade jobs run an image built from the checkout, and upgrade.sh
+ * targets APP_VERSION in .env — which gen-secrets.sh seeds from
+ * .env.prod.example, an operator-facing file the candidate line deliberately
+ * leaves naming the last *stable* release. So on `develop` the target would be
+ * 1.13.0 while the container reports 1.14.0-rc.0, and upgrade.sh would fail its
+ * identity check on every push. Overriding APP_VERSION from VERSION is what
+ * keeps the two agreeing on both lines.
+ */
+test('the upgrade jobs target the version the image under test reports', function (string $job): void {
+    expect(envPreparationScript($job))->toContain("APP_VERSION=$(sed -e 's/#.*//' VERSION | tr -d '[:space:]')");
+})->with(['upgrade', 'upgrade-build-from-source']);
+
 /*
  * The acceptance criterion this file exists for: merging `develop` into `master`
  * must not be able to make `master` cut a candidate. It cannot, because the two


### PR DESCRIPTION
The `docker` workflow has been red on `develop` since the `1.14.0-rc.0` release commit: both **Upgrade script** and **Upgrade script (build from source)** fail with

```
Error: the stack is running 1.14.0-rc.0, not 1.13.0.
```

## Cause

Both jobs seed `.env` with `docker/gen-secrets.sh`, which copies `.env.prod.example` — an operator-facing file the candidate release line deliberately does **not** stamp (`release-please-config.develop.json` lists only `VERSION`, and `tests/Unit/ReleaseFlowTest.php` asserts exactly that, so `curl | sh` and the docs keep naming the latest stable release).

So on `develop` the template still says `APP_VERSION=1.13.0` while the image built from the checkout reports `1.14.0-rc.0` from `VERSION`. `upgrade.sh` takes its target from `APP_VERSION` and fails the identity check that compares it against what the started container claims. On `master` the two values coincide, which is why this never fired before — and it will fire on every `develop` push until the next promotion.

## Fix

Both jobs now append `APP_VERSION` read from `VERSION` after `gen-secrets.sh` runs (the last assignment in `.env` wins, and `upgrade.sh`'s target validation already accepts `-rc.N`). That also makes each job's existing `grep -q "Upgraded to $(… VERSION …)"` assertion self-consistent.

A guard in `ReleaseFlowTest` asserts both jobs keep doing so, since nothing else would catch the regression until the next release candidate turned CI red.