### PR TITLE
feat: quick-react shortcuts and a frequently-used emoji strip

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -21,6 +21,7 @@ use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use App\SlashCommands\SlashCommandRegistry;
+use App\Support\FrequentEmoji;
 use App\Support\ReverbConfig;
 use App\Support\TranslationCatalog;
 use App\Support\UpdateChecker;
@@ -177,6 +178,12 @@ class HandleInertiaRequests extends Middleware
             // bodies and reaction pills can resolve `:name:` shortcodes to images.
             // A revoked emoji is simply absent, so its token falls back to text.
             'customEmojis' => fn (): array => $this->customEmojisForWorkspace($request, $user),
+            // The viewer's five most-used emoji in their current workspace,
+            // feeding the hover bar's quick-react cluster and the picker's
+            // "Frequently used" strip. Derived from reaction history per visit
+            // (frequently-used is slow-moving, so it is eventually consistent —
+            // a live reaction doesn't re-rank until the next Inertia visit).
+            'frequentEmojis' => fn (): array => FrequentEmoji::forUser($user),
             // The current team's mentionable user groups, feeding the composer's
             // `@` menu and the anti-spoof check that decides whether a
             // `group:<id>` token renders as a pill or as plain text. A deleted

--- a/app/Support/FrequentEmoji.php
+++ b/app/Support/FrequentEmoji.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Support;
+
+use App\Data\CustomEmojiData;
+use App\Models\MessageReaction;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * The viewer's frequently-used emoji, derived from their reaction history rather
+ * than tracked on a write path — a toggled-off reaction deletes its row, so the
+ * ranking un-counts it for free.
+ */
+class FrequentEmoji
+{
+    /**
+     * How many entries the ranking always carries: the channel hover bar shows
+     * all of them, the thread panel the leading three.
+     */
+    public const int COUNT = 5;
+
+    /**
+     * The tail the ranking is padded from when the viewer has too little (or no)
+     * reaction history. Frozen, not operator-configurable, and longer than
+     * `COUNT` so padding can always fill the list.
+     *
+     * @var list<string>
+     */
+    public const array DEFAULTS = ['👍', '❤️', '😂', '🎉', '👀', '🙏'];
+
+    /**
+     * The viewer's top `COUNT` emoji in their current workspace, ranked by
+     * lifetime use and padded from the default set. Native glyphs and custom
+     * `:name:` tokens intermix; a token whose emoji has since been revoked is
+     * dropped, since it would no longer resolve to an image.
+     *
+     * An unscoped viewer (a guest, or a user not in a workspace) gets the
+     * default set without touching the database.
+     *
+     * @return list<string>
+     */
+    public static function forUser(?User $user): array
+    {
+        $team = $user?->currentTeam;
+
+        if (! $user || ! $team instanceof Team) {
+            return self::padded([]);
+        }
+
+        $ranked = array_values(
+            MessageReaction::query()
+                ->select('message_reactions.emoji')
+                ->join('messages', 'messages.id', '=', 'message_reactions.message_id')
+                ->join('channels', 'channels.id', '=', 'messages.channel_id')
+                ->where('message_reactions.user_id', $user->id)
+                ->where('channels.team_id', $team->id)
+                ->groupBy('message_reactions.emoji')
+                ->orderByRaw('count(*) desc')
+                ->orderByRaw('max(message_reactions.created_at) desc')
+                ->orderBy('message_reactions.emoji')
+                ->get()
+                ->map(fn (MessageReaction $reaction): string => $reaction->emoji)
+                ->all()
+        );
+
+        return self::padded(self::withoutRevokedShortcodes($ranked, $team));
+    }
+
+    /**
+     * Drop every `:name:` token the team's live custom-emoji map no longer
+     * resolves; native glyphs are always kept.
+     *
+     * @param  list<string>  $emojis
+     * @return list<string>
+     */
+    protected static function withoutRevokedShortcodes(array $emojis, Team $team): array
+    {
+        $custom = CustomEmojiData::mapForTeam($team);
+
+        return array_values(array_filter($emojis, function (string $emoji) use ($custom): bool {
+            if (preg_match('/^:([a-z0-9]+(?:-[a-z0-9]+)*):$/', $emoji, $matches) !== 1) {
+                return true;
+            }
+
+            return array_key_exists($matches[1], $custom);
+        }));
+    }
+
+    /**
+     * Cut the ranking to exactly `COUNT` entries, topping it up from the default
+     * set (skipping anything already ranked) when it falls short.
+     *
+     * @param  list<string>  $emojis
+     * @return list<string>
+     */
+    protected static function padded(array $emojis): array
+    {
+        $padding = array_diff(self::DEFAULTS, $emojis);
+
+        return array_slice([...$emojis, ...$padding], 0, self::COUNT);
+    }
+}

--- a/database/migrations/2026_07_21_184825_add_user_emoji_index_to_message_reactions_table.php
+++ b/database/migrations/2026_07_21_184825_add_user_emoji_index_to_message_reactions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('message_reactions', function (Blueprint $table): void {
+            // The frequently-used ranking groups one user's reactions by emoji
+            // (see App\Support\FrequentEmoji); the existing unique index leads
+            // with `message_id`, so it cannot serve that scan.
+            $table->index(['user_id', 'emoji']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('message_reactions', function (Blueprint $table): void {
+            $table->dropIndex(['user_id', 'emoji']);
+        });
+    }
+};

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1174,5 +1174,8 @@
   "Play": "Lire",
   "Pause": "Mettre en pause",
   "Seek": "Se déplacer dans la piste",
-  ":elapsed of :total": ":elapsed sur :total"
+  ":elapsed of :total": ":elapsed sur :total",
+  "Frequently used": "Utilisés fréquemment",
+  "React with :emoji": "Réagir avec :emoji",
+  "Remove your :emoji": "Retirer votre :emoji"
 }

--- a/resources/js/components/EmojiPickerPopover.frequent.test.ts
+++ b/resources/js/components/EmojiPickerPopover.frequent.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, ref } from 'vue';
+import { translate } from '@/lib/i18n';
+
+/** Mutable stand-in for the shared Inertia props the strips read. */
+const props = vi.hoisted(() => ({
+    frequentEmojis: [] as string[],
+    customEmojis: {} as Record<string, string>,
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props }),
+}));
+
+// Flatten Reka's popover to passthroughs so the panel renders inline instead of
+// through a portal that only mounts once the trigger is clicked.
+vi.mock('reka-ui', () => {
+    const pass = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_p, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        PopoverContent: pass('PopoverContent'),
+        PopoverPortal: pass('PopoverPortal'),
+        PopoverRoot: pass('PopoverRoot'),
+        PopoverTrigger: pass('PopoverTrigger'),
+    };
+});
+
+vi.mock('@/components/ui/tooltip', () => {
+    const pass = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_p, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        Tooltip: pass('Tooltip'),
+        TooltipContent: pass('TooltipContent'),
+        TooltipTrigger: pass('TooltipTrigger'),
+    };
+});
+
+// The picker library reaches for indexedDB at module load; the strips under
+// test never need it, so stand the grid down to an empty component.
+vi.mock('vue3-emoji-picker/css', () => ({}));
+vi.mock('vue3-emoji-picker', () => ({
+    default: defineComponent({
+        name: 'EmojiPicker',
+        setup: () => () => h('div'),
+    }),
+}));
+
+vi.mock('@/composables/useAppearance', () => ({
+    useAppearance: () => ({ resolvedAppearance: ref('light') }),
+}));
+
+vi.mock('@/composables/useEmojiPickerA11y', () => ({
+    useEmojiPickerA11y: () => undefined,
+}));
+
+import EmojiPickerPopover from './EmojiPickerPopover.vue';
+
+let app: App | null = null;
+
+function mount(): { host: HTMLElement; selected: string[] } {
+    const selected: string[] = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    app = createApp({
+        render: () =>
+            h(
+                EmojiPickerPopover,
+                { onSelect: (emoji: string) => selected.push(emoji) },
+                { default: () => h('button', 'open') },
+            ),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+
+    return { host, selected };
+}
+
+function cells(host: HTMLElement): HTMLElement[] {
+    return [
+        ...host.querySelectorAll<HTMLElement>(
+            '[data-test="frequent-emoji-option"]',
+        ),
+    ];
+}
+
+beforeEach(() => {
+    props.frequentEmojis = ['👍', '❤️', ':shipit:'];
+    props.customEmojis = { shipit: 'https://desk.test/shipit.png' };
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('EmojiPickerPopover frequently-used strip', () => {
+    it('renders the strip above the custom strip', () => {
+        const { host } = mount();
+        const strips = [
+            ...host.querySelectorAll('[data-test$="-emoji-strip"]'),
+        ].map((node) => node.getAttribute('data-test'));
+
+        expect(strips).toEqual(['frequent-emoji-strip', 'custom-emoji-strip']);
+        expect(
+            host.querySelector('[data-test="frequent-emoji-strip"]')
+                ?.textContent,
+        ).toContain('Frequently used');
+    });
+
+    it('renders native glyphs as text and shortcodes as their image', () => {
+        const { host } = mount();
+
+        expect(cells(host)).toHaveLength(3);
+        expect(cells(host)[0].textContent?.trim()).toBe('👍');
+        expect(cells(host)[2].querySelector('img')?.getAttribute('src')).toBe(
+            'https://desk.test/shipit.png',
+        );
+    });
+
+    it('emits the picked emoji exactly like any other cell', () => {
+        const { host, selected } = mount();
+
+        cells(host)[0].click();
+        cells(host)[2].click();
+
+        expect(selected).toEqual(['👍', ':shipit:']);
+    });
+
+    it('omits the strip when the ranking is empty', () => {
+        props.frequentEmojis = [];
+
+        const { host } = mount();
+
+        expect(
+            host.querySelector('[data-test="frequent-emoji-strip"]'),
+        ).toBeNull();
+    });
+});

--- a/resources/js/components/EmojiPickerPopover.vue
+++ b/resources/js/components/EmojiPickerPopover.vue
@@ -14,6 +14,7 @@ import {
 import { useAppearance } from '@/composables/useAppearance';
 import { useCustomEmojis } from '@/composables/useCustomEmojis';
 import { useEmojiPickerA11y } from '@/composables/useEmojiPickerA11y';
+import { useFrequentEmojis } from '@/composables/useFrequentEmojis';
 import { useTranslations } from '@/composables/useTranslations';
 import type { CustomEmojiEntry } from '@/lib/customEmoji';
 
@@ -67,7 +68,12 @@ const open = ref(false);
 // picker. Selecting one emits its `:name:` token (the same opaque-string
 // contract as a native glyph), so reactions store it and the composer inserts it
 // with no downstream changes.
-const { list: customEmojis } = useCustomEmojis();
+const { list: customEmojis, parseToken } = useCustomEmojis();
+
+// The viewer's own ranked shortlist, surfaced as a strip above "Custom". Its
+// entries are opaque strings just like a reaction value — a native glyph or a
+// `:name:` token — so picking one goes through the same `select` contract.
+const { list: frequentEmojis } = useFrequentEmojis();
 
 /**
  * The picker's `select` event carries the chosen emoji as `.i`; surface it and
@@ -75,6 +81,15 @@ const { list: customEmojis } = useCustomEmojis();
  */
 function onPick(payload: { i: string }): void {
     emit('select', payload.i);
+    open.value = false;
+}
+
+/**
+ * Emit a chosen frequently-used entry verbatim (glyph or `:name:` token), then
+ * close — identical in effect to any other pick.
+ */
+function onPickFrequent(emoji: string): void {
+    emit('select', emoji);
     open.value = false;
 }
 
@@ -109,6 +124,38 @@ function onPickCustom(entry: CustomEmojiEntry): void {
                 :collision-padding="8"
                 class="emoji-picker-shell z-50 overflow-hidden rounded-2xl border bg-popover shadow-[0_10px_28px_rgba(29,26,21,0.14)] outline-none"
             >
+                <div
+                    v-if="frequentEmojis.length > 0"
+                    data-test="frequent-emoji-strip"
+                    class="border-b border-border px-3 py-2.5"
+                >
+                    <p
+                        class="mb-1.5 text-[10.5px] font-semibold tracking-[0.1em] text-muted-foreground uppercase"
+                    >
+                        {{ $t('Frequently used') }}
+                    </p>
+                    <div class="grid grid-cols-7 gap-1">
+                        <!-- eslint-disable-next-line local/no-raw-button -- bespoke emoji-grid cell -->
+                        <button
+                            v-for="emoji in frequentEmojis"
+                            :key="emoji"
+                            type="button"
+                            data-test="frequent-emoji-option"
+                            :title="emoji"
+                            :aria-label="emoji"
+                            class="flex aspect-square items-center justify-center rounded-lg text-[17px] leading-none hover:bg-accent"
+                            @click="onPickFrequent(emoji)"
+                        >
+                            <img
+                                v-if="parseToken(emoji)"
+                                :src="parseToken(emoji)!.url"
+                                :alt="emoji"
+                                class="custom-emoji size-5"
+                            />
+                            <span v-else aria-hidden="true">{{ emoji }}</span>
+                        </button>
+                    </div>
+                </div>
                 <div
                     v-if="customEmojis.length > 0"
                     data-test="custom-emoji-strip"

--- a/resources/js/components/MessageActions.quickReact.test.ts
+++ b/resources/js/components/MessageActions.quickReact.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Message, Reaction } from '@/types';
+
+/** Mutable stand-in for the shared Inertia props the bar reads. */
+const props = vi.hoisted(() => ({
+    frequentEmojis: [] as string[],
+    customEmojis: {} as Record<string, string>,
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props }),
+}));
+
+// The picker popover pulls in reka-ui portals and the emoji library; the quick
+// cluster only needs its trigger slot, so stub it down to a passthrough.
+vi.mock('@/components/EmojiPickerPopover.vue', () => ({
+    default: defineComponent({
+        name: 'EmojiPickerPopover',
+        setup:
+            (_p, { slots }) =>
+            () =>
+                h('div', slots.default?.({ open: false })),
+    }),
+}));
+
+vi.mock('@/components/ui/tooltip', () => {
+    const pass = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_p, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        Tooltip: pass('Tooltip'),
+        TooltipContent: pass('TooltipContent'),
+        TooltipProvider: pass('TooltipProvider'),
+        TooltipTrigger: pass('TooltipTrigger'),
+    };
+});
+
+vi.mock('@/components/MessageReminderPopover.vue', () => ({
+    default: defineComponent({
+        name: 'MessageReminderPopover',
+        setup:
+            (_p, { slots }) =>
+            () =>
+                h('div', slots.default?.({ open: false })),
+    }),
+}));
+
+import MessageActions from './MessageActions.vue';
+
+function reaction(emoji: string, reactorIds: string[]): Reaction {
+    return {
+        emoji,
+        count: reactorIds.length,
+        reactors: reactorIds.map((id) => ({ id, name: id })),
+    };
+}
+
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        ...overrides,
+    } as Message;
+}
+
+let app: App | null = null;
+
+function mount(componentProps: Record<string, unknown> = {}): {
+    host: HTMLElement;
+    reacted: string[];
+} {
+    const reacted: string[] = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    app = createApp({
+        render: () =>
+            h(MessageActions, {
+                message: message(),
+                currentUserId: 'me',
+                canReact: true,
+                viewerTimezone: null,
+                onReact: (emoji: string) => reacted.push(emoji),
+                ...componentProps,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+
+    return { host, reacted };
+}
+
+function shortcuts(host: HTMLElement): HTMLElement[] {
+    return [...host.querySelectorAll<HTMLElement>('[data-test="quick-react"]')];
+}
+
+beforeEach(() => {
+    props.frequentEmojis = ['👍', '❤️', '🎉', ':shipit:', '👀'];
+    props.customEmojis = { shipit: 'https://desk.test/shipit.png' };
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('MessageActions quick-react cluster', () => {
+    it('renders one shortcut per frequently-used emoji, ahead of the picker trigger', () => {
+        const { host } = mount();
+        const cells = shortcuts(host);
+
+        expect(cells.map((cell) => cell.dataset.emoji)).toEqual([
+            '👍',
+            '❤️',
+            '🎉',
+            ':shipit:',
+            '👀',
+        ]);
+
+        const order = [...host.querySelectorAll('[data-test]')].map((node) =>
+            node.getAttribute('data-test'),
+        );
+
+        expect(order.indexOf('message-react')).toBeGreaterThan(
+            order.lastIndexOf('quick-react'),
+        );
+    });
+
+    it('resolves a custom shortcode to its image and a native glyph to text', () => {
+        const { host } = mount();
+        const custom = shortcuts(host).find(
+            (cell) => cell.dataset.emoji === ':shipit:',
+        )!;
+
+        expect(custom.querySelector('img')?.getAttribute('src')).toBe(
+            'https://desk.test/shipit.png',
+        );
+        expect(shortcuts(host)[0].querySelector('img')).toBeNull();
+        expect(shortcuts(host)[0].textContent?.trim()).toBe('👍');
+    });
+
+    it('shows only the top three shortcuts inside a thread panel', () => {
+        const { host } = mount({ inThread: true });
+
+        expect(shortcuts(host).map((cell) => cell.dataset.emoji)).toEqual([
+            '👍',
+            '❤️',
+            '🎉',
+        ]);
+    });
+
+    it('hides the cluster when the viewer may not react', () => {
+        const { host } = mount({ canReact: false });
+
+        expect(shortcuts(host)).toHaveLength(0);
+    });
+
+    it('marks an already-reacted shortcut pressed and labels it as a retraction', () => {
+        const { host } = mount({
+            message: message({
+                reactions: [
+                    reaction('🎉', ['me', 'peer']),
+                    reaction('👍', ['peer']),
+                ],
+            }),
+        });
+        const cells = shortcuts(host);
+        const pressed = cells.find((cell) => cell.dataset.emoji === '🎉')!;
+        const unpressed = cells.find((cell) => cell.dataset.emoji === '👍')!;
+
+        expect(pressed.getAttribute('aria-pressed')).toBe('true');
+        expect(pressed.getAttribute('aria-label')).toBe('Remove your 🎉');
+        expect(unpressed.getAttribute('aria-pressed')).toBe('false');
+        expect(unpressed.getAttribute('aria-label')).toBe('React with 👍');
+    });
+
+    it('emits the react toggle on click, pressed or not', () => {
+        const { host, reacted } = mount({
+            message: message({ reactions: [reaction('🎉', ['me'])] }),
+        });
+
+        shortcuts(host)[0].click();
+        shortcuts(host)
+            .find((cell) => cell.dataset.emoji === '🎉')!
+            .click();
+
+        expect(reacted).toEqual(['👍', '🎉']);
+    });
+});

--- a/resources/js/components/MessageActions.vue
+++ b/resources/js/components/MessageActions.vue
@@ -19,6 +19,10 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useCustomEmojis } from '@/composables/useCustomEmojis';
+import { useFrequentEmojis } from '@/composables/useFrequentEmojis';
+import { useTranslations } from '@/composables/useTranslations';
+import type { CustomEmojiEntry } from '@/lib/customEmoji';
 import {
     canDeleteMessage,
     canEditMessage,
@@ -31,6 +35,7 @@ import {
     hasAnyMessageAction,
 } from '@/lib/messageActions';
 import type { MessageActionContext } from '@/lib/messageActions';
+import { hasReacted } from '@/lib/reactions';
 import type { Message } from '@/types';
 
 const props = defineProps<{
@@ -98,19 +103,76 @@ const showBar = computed(() =>
     hasAnyMessageAction(props.message, context.value),
 );
 
+const { t } = useTranslations();
+const { parseToken } = useCustomEmojis();
+const { list: frequentEmojis } = useFrequentEmojis();
+
 /**
- * The hairline divider only earns its place when it sits between two clusters:
- * the react/reply group and the forward/edit/delete group.
+ * The one-click shortcuts leading the bar. The thread panel is roughly half the
+ * channel's width, so it takes the leading three of the same ranked list rather
+ * than a list of its own.
  */
+const quickEmojis = computed(() =>
+    props.inThread ? frequentEmojis.value.slice(0, 3) : frequentEmojis.value,
+);
+
+/** The emoji the viewer has already reacted with on this message. */
+const ownReactions = computed(
+    () =>
+        new Set(
+            props.message.reactions
+                .filter((reaction) => hasReacted(reaction, props.currentUserId))
+                .map((reaction) => reaction.emoji),
+        ),
+);
+
+/**
+ * When a shortcut is a resolvable custom-emoji `:name:` token, its image entry;
+ * otherwise null (a native glyph, rendered as text).
+ */
+function quickCustomEmoji(emoji: string): CustomEmojiEntry | null {
+    return parseToken(emoji);
+}
+
+/** A pressed shortcut retracts on click, so its label flips with the state. */
+function quickLabel(emoji: string): string {
+    return ownReactions.value.has(emoji)
+        ? t('Remove your :emoji', { emoji })
+        : t('React with :emoji', { emoji });
+}
+
+/** Whether any of the trailing forward…delete cluster renders. */
+const showTrailingActions = computed(
+    () =>
+        showForward.value ||
+        showPin.value ||
+        showRemind.value ||
+        showEdit.value ||
+        showDelete.value,
+);
+
+/**
+ * A hairline divider only earns its place between two rendered clusters. The
+ * first sits after the quick-react cluster, the second after the thread/reply
+ * pair — each one folds away when either side of it is empty.
+ */
+const showQuickDivider = computed(
+    () =>
+        showReact.value &&
+        (showStartThread.value || showReply.value || showTrailingActions.value),
+);
 const showDivider = computed(
     () =>
-        (showReact.value || showStartThread.value || showReply.value) &&
-        (showForward.value ||
-            showPin.value ||
-            showRemind.value ||
-            showEdit.value ||
-            showDelete.value),
+        (showStartThread.value || showReply.value) && showTrailingActions.value,
 );
+
+/**
+ * The quick shortcuts share the bar's ghost icon button, adding the pressed
+ * (already-reacted) treatment: the brass inset ring + fill the reaction pill
+ * uses for the viewer's own reaction, driven by the same `aria-pressed`.
+ */
+const quickButtonClass =
+    'text-muted-foreground aria-pressed:bg-brass-fill aria-pressed:text-brass-fill-foreground aria-pressed:inset-ring-1 aria-pressed:inset-ring-brass-border';
 
 /**
  * The bar's icon buttons ride the `<Button variant="ghost" size="icon-sm">`
@@ -143,23 +205,62 @@ const deleteButtonClass =
         <div
             class="pointer-events-none absolute -top-4 right-3 z-10 flex items-center gap-0.5 rounded-lg border border-border bg-background p-0.5 opacity-0 shadow-md group-focus-within/message:pointer-events-auto group-focus-within/message:animate-in group-focus-within/message:opacity-100 group-focus-within/message:duration-100 group-focus-within/message:fade-in-0 group-focus-within/message:zoom-in-95 group-hover/message:pointer-events-auto group-hover/message:animate-in group-hover/message:opacity-100 group-hover/message:duration-100 group-hover/message:fade-in-0 group-hover/message:zoom-in-95 has-[[data-open]]:pointer-events-auto has-[[data-open]]:opacity-100"
         >
-            <EmojiPickerPopover
-                v-if="showReact"
-                v-slot="{ open }"
-                @select="(emoji) => emit('react', emoji)"
-            >
-                <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    type="button"
-                    data-test="message-react"
-                    :data-open="open || undefined"
-                    :aria-label="$t('Add reaction')"
-                    :class="open ? openStateClass : iconButtonClass"
+            <template v-if="showReact">
+                <Tooltip v-for="emoji in quickEmojis" :key="emoji">
+                    <TooltipTrigger as-child>
+                        <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            type="button"
+                            data-test="quick-react"
+                            :data-emoji="emoji"
+                            :aria-pressed="ownReactions.has(emoji)"
+                            :aria-label="quickLabel(emoji)"
+                            :class="quickButtonClass"
+                            @click="emit('react', emoji)"
+                        >
+                            <img
+                                v-if="quickCustomEmoji(emoji)"
+                                :src="quickCustomEmoji(emoji)!.url"
+                                :alt="emoji"
+                                class="custom-emoji size-4"
+                            />
+                            <span
+                                v-else
+                                class="text-[15px] leading-none"
+                                aria-hidden="true"
+                                >{{ emoji }}</span
+                            >
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" :side-offset="6">
+                        {{ quickLabel(emoji) }}
+                    </TooltipContent>
+                </Tooltip>
+
+                <EmojiPickerPopover
+                    v-slot="{ open }"
+                    @select="(emoji) => emit('react', emoji)"
                 >
-                    <SmilePlus />
-                </Button>
-            </EmojiPickerPopover>
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        type="button"
+                        data-test="message-react"
+                        :data-open="open || undefined"
+                        :aria-label="$t('Add reaction')"
+                        :class="open ? openStateClass : iconButtonClass"
+                    >
+                        <SmilePlus />
+                    </Button>
+                </EmojiPickerPopover>
+            </template>
+
+            <div
+                v-if="showQuickDivider"
+                aria-hidden="true"
+                class="mx-0.5 h-4 w-px bg-border"
+            ></div>
 
             <Tooltip v-if="showStartThread">
                 <TooltipTrigger as-child>

--- a/resources/js/composables/useFrequentEmojis.ts
+++ b/resources/js/composables/useFrequentEmojis.ts
@@ -1,0 +1,20 @@
+import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import type { ComputedRef } from 'vue';
+
+/**
+ * The viewer's frequently-used emoji, shared from the server already ranked,
+ * revoked-token-filtered, and padded to a fixed length (see
+ * `App\Support\FrequentEmoji`). Native glyphs and custom `:name:` tokens
+ * intermix, so consumers resolve shortcodes through `useCustomEmojis`.
+ *
+ * One source for the hover bar's quick-react cluster and the picker's
+ * "Frequently used" strip, so the two never drift.
+ */
+export function useFrequentEmojis(): { list: ComputedRef<string[]> } {
+    const page = usePage();
+
+    return {
+        list: computed<string[]>(() => page.props.frequentEmojis ?? []),
+    };
+}

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -45,6 +45,7 @@ declare module '@inertiajs/core' {
             teamMembers?: PersonRef[];
             channelSections?: ChannelSection[];
             customEmojis?: Record<string, string>;
+            frequentEmojis?: string[];
             userGroups?: App.Data.UserGroupData[];
             slashCommands?: App.Data.SlashCommandData[];
             collapsedChannelSections?: string[];

--- a/tests/Browser/A11yQuickReactionsTest.php
+++ b/tests/Browser/A11yQuickReactionsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Message;
+use App\Models\MessageReaction;
+use App\Models\User;
+
+/**
+ * Seed one of Bob's messages that Alice has already reacted to and read, so the
+ * hover bar carries both a pressed and an unpressed shortcut, with no unread
+ * divider to trip the contrast audit.
+ *
+ * @return array{owner: User, message: Message}
+ */
+function browserTeamWithReactedMessage(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $bob->id,
+        'body' => 'Hello from Bob',
+    ]);
+
+    // The default ranking leads with 👍, so reacting with it renders the first
+    // shortcut pressed (brass inset ring + fill) during the audit.
+    MessageReaction::factory()->for($message)->for($alice)->emoji('👍')->create();
+
+    $alice->channels()->updateExistingPivot($channel->id, [
+        'last_read_message_id' => $message->id,
+    ]);
+
+    return ['owner' => $alice, 'message' => $message];
+}
+
+test('the quick-react cluster names each shortcut and marks the reacted one pressed', function (): void {
+    ['owner' => $alice] = browserTeamWithReactedMessage();
+
+    signInThroughBrowser($alice)
+        ->assertSee('Hello from Bob')
+        ->hover('@message-body')
+        ->assertScript(
+            "document.querySelectorAll('[data-test=\"quick-react\"]').length",
+            5,
+        )
+        // Every shortcut is a real button carrying its own accessible name, and
+        // the picker trigger still closes the cluster.
+        ->assertScript(
+            "[...document.querySelectorAll('[data-test=\"quick-react\"]')].every(cell => cell.tagName === 'BUTTON' && (cell.getAttribute('aria-label') ?? '') !== '')",
+            true,
+        )
+        // `data-emoji` is shared with the reaction pills, so scope to the bar.
+        ->assertAriaAttribute('[data-test="quick-react"][data-emoji="👍"]', 'pressed', 'true')
+        ->assertAriaAttribute('[data-test="quick-react"][data-emoji="👍"]', 'label', 'Remove your 👍')
+        ->assertAriaAttribute('[data-test="quick-react"][data-emoji="❤️"]', 'pressed', 'false')
+        ->assertAriaAttribute('[data-test="quick-react"][data-emoji="❤️"]', 'label', 'React with ❤️');
+});
+
+test('the quick cluster and frequently-used strip pass the axe audit in either theme', function (): void {
+    ['owner' => $alice] = browserTeamWithReactedMessage();
+
+    $page = signInThroughBrowser($alice)
+        ->assertSee('Hello from Bob')
+        ->hover('@message-body')
+        ->click('@message-react')
+        ->assertPresent('[data-test="frequent-emoji-strip"]')
+        ->assertNoAccessibilityIssues();
+
+    // Re-audit against the dark palette, where the pressed shortcut swaps to the
+    // brass-tint fill. Persist the choice before applying the class so the
+    // appearance controller doesn't re-resolve 'system' back to light.
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});

--- a/tests/Feature/Support/FrequentEmojiTest.php
+++ b/tests/Feature/Support/FrequentEmojiTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Models\Channel;
+use App\Models\CustomEmoji;
+use App\Models\Message;
+use App\Models\MessageReaction;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\FrequentEmoji;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * A fresh owner with their own workspace and its default channel.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function frequentWorkspace(): array
+{
+    $user = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($user, 'Acme');
+    $channel = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$user, $team, $channel];
+}
+
+/**
+ * React `$times` times with `$emoji` in `$channel`, one distinct message each
+ * (the table allows a user one row per emoji per message).
+ */
+function reactTimes(Channel $channel, User $user, string $emoji, int $times = 1, ?string $at = null): void
+{
+    for ($index = 0; $index < $times; $index++) {
+        $message = Message::factory()->for($channel)->for($user)->create();
+
+        MessageReaction::factory()
+            ->for($message)
+            ->for($user)
+            ->emoji($emoji)
+            ->create(['created_at' => $at ?? now()]);
+    }
+}
+
+test('the ranking orders by lifetime count, then last use, then emoji', function (): void {
+    [$user, $team, $channel] = frequentWorkspace();
+    CustomEmoji::factory()->for($team)->name('alpha')->create();
+    CustomEmoji::factory()->for($team)->name('beta')->create();
+
+    reactTimes($channel, $user, '🎉', 3);
+    reactTimes($channel, $user, '👍', 2, at: now()->subDay()->toDateTimeString());
+    reactTimes($channel, $user, '👀', 2);
+    reactTimes($channel, $user, ':beta:');
+    reactTimes($channel, $user, ':alpha:');
+
+    expect(FrequentEmoji::forUser($user))->toBe(['🎉', '👀', '👍', ':alpha:', ':beta:']);
+});
+
+test('the ranking counts only the viewer, only in their current team', function (): void {
+    [$user, , $channel] = frequentWorkspace();
+    $other = User::factory()->create();
+    [, , $elsewhere] = frequentWorkspace();
+
+    reactTimes($channel, $user, '🙌');
+    reactTimes($channel, $other, '🚀', 4);
+    reactTimes($elsewhere, $user, '🔥', 4);
+
+    expect(FrequentEmoji::forUser($user)[0])->toBe('🙌')
+        ->and(FrequentEmoji::forUser($user))->not->toContain('🚀')
+        ->and(FrequentEmoji::forUser($user))->not->toContain('🔥');
+});
+
+test('a shortcode whose custom emoji was revoked drops out of the ranking', function (): void {
+    [$user, $team, $channel] = frequentWorkspace();
+    $emoji = CustomEmoji::factory()->for($team)->name('shipit')->create();
+
+    reactTimes($channel, $user, ':shipit:', 4);
+
+    expect(FrequentEmoji::forUser($user))->toContain(':shipit:');
+
+    $emoji->delete();
+
+    expect(FrequentEmoji::forUser($user))->not->toContain(':shipit:');
+});
+
+test('the ranking is padded from the default set to exactly five entries', function (): void {
+    [$user, , $channel] = frequentWorkspace();
+
+    reactTimes($channel, $user, '🚀', 3);
+
+    expect(FrequentEmoji::forUser($user))->toBe(['🚀', '👍', '❤️', '😂', '🎉']);
+});
+
+test('a ranking longer than five is truncated to the top five', function (): void {
+    [$user, , $channel] = frequentWorkspace();
+
+    foreach (['🚀' => 6, '🔥' => 5, '🙌' => 4, '🤝' => 3, '🧠' => 2, '🍕' => 1] as $emoji => $times) {
+        reactTimes($channel, $user, $emoji, $times);
+    }
+
+    expect(FrequentEmoji::forUser($user))->toBe(['🚀', '🔥', '🙌', '🤝', '🧠']);
+});
+
+test('an unscoped viewer gets the default set without querying reactions', function (): void {
+    // The factory hands every user a personal team, so drop it back out.
+    $teamless = User::factory()->create();
+    $teamless->forceFill(['current_team_id' => null])->save();
+    $teamless->unsetRelation('currentTeam');
+
+    $queries = [];
+    DB::listen(function ($query) use (&$queries): void {
+        $queries[] = $query->sql;
+    });
+
+    expect(FrequentEmoji::forUser(null))->toBe(['👍', '❤️', '😂', '🎉', '👀'])
+        ->and(FrequentEmoji::forUser($teamless))->toBe(['👍', '❤️', '😂', '🎉', '👀'])
+        ->and(collect($queries)->filter(fn (string $sql): bool => str_contains($sql, 'message_reactions')))->toBeEmpty();
+});
+
+test('the ranking rides every inertia response as a shared prop', function (): void {
+    [$user, $team, $channel] = frequentWorkspace();
+
+    reactTimes($channel, $user, '🚀', 3);
+
+    $this->actingAs($user)
+        ->get(route('channels.show', ['team' => $team, 'channel' => $channel]))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('frequentEmojis', 5)
+            ->where('frequentEmojis.0', '🚀')
+        );
+});

--- a/tests/Feature/Support/FrequentEmojiTest.php
+++ b/tests/Feature/Support/FrequentEmojiTest.php
@@ -129,3 +129,10 @@ test('the ranking rides every inertia response as a shared prop', function (): v
             ->where('frequentEmojis.0', '🚀')
         );
 });
+
+test('a guest still receives the default set on an inertia response', function (): void {
+    $this->get(route('login'))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('frequentEmojis', ['👍', '❤️', '😂', '🎉', '👀'])
+        );
+});


### PR DESCRIPTION
Closes #523.

## What

An app-owned **frequently-used emoji** ranking (per user, per workspace), surfaced in two places:

- **Quick-react cluster** — the 5 ranked emoji become a new leading cluster in the message hover bar, with the existing `SmilePlus` full-picker trigger moving to the tail of that cluster (same picker, same react/toggle contract). One click reacts; an already-reacted shortcut renders **pressed** (brass inset ring + fill, mirroring the reaction pill's own-reaction styling) and clicking it retracts. The thread panel takes the top 3 so the narrower bar still fits.
- **"Frequently used" strip** — above the existing "Custom" strip in the emoji picker, same 7-column grid cells. The library's own native recent row is left untouched.

Native glyphs and custom `:name:` tokens intermix everywhere; shortcodes resolve client-side through the existing `useCustomEmojis`.

## How

Ranking is **derived, not tracked** — no new counter table and no write-path change, so a toggled-off reaction naturally un-counts.

- `App\Support\FrequentEmoji` groups `message_reactions` joined through `messages → channels`, scoped to the viewer and `channels.team_id = current_team_id`, ordered `COUNT(*) DESC, MAX(created_at) DESC, emoji ASC` (deterministic, no random tie order).
- `:name:` entries that no longer resolve against the team's live custom-emoji map are dropped; the tail is padded from a frozen default set so the list is always exactly 5.
- An unscoped viewer (guest, or no `current_team_id`) gets the default set **without querying**.
- Delivered as a `frequentEmojis: string[]` Inertia shared prop, the same pattern as `customEmojis`. Eventually consistent: recomputed per visit, not on broadcast.
- New composite `(user_id, emoji)` index on `message_reactions` to serve the group-by — the existing unique index leads with `message_id`, so it can't.

Matches the approved "Quick Reactions" design (frames 1a–1e), verified side by side in the running app in both themes.

## Testing

- `tests/Feature/Support/FrequentEmojiTest.php` — ordering, per-user/per-team scoping, revoked-token filter, default padding, top-5 truncation, unscoped fallback (asserting no reaction query fires), and the shared prop for both an authenticated viewer and a guest.
- `resources/js/components/MessageActions.quickReact.test.ts` — cluster ordering ahead of the picker trigger, custom-vs-native rendering, thread top-3, `canReact` gate, pressed state + retraction label, react emission.
- `resources/js/components/EmojiPickerPopover.frequent.test.ts` — strip placement above "Custom", glyph/image rendering, pick contract, empty-ranking omission.
- `tests/Browser/A11yQuickReactionsTest.php` — accessible names, `aria-pressed`, and an **axe audit of the cluster + open picker strip in light and dark**.
- Full gate green: `composer test` at `Total: 100.0 %` (Pint, PHPStan, Rector clean), plus `lint:check`, `format:check`, `types:check`, `test:js`, `build`.
- Local CodeRabbit pass clean.

## i18n / docs

- New keys `Frequently used`, `React with :emoji`, `Remove your :emoji`, with `lang/fr.json` translations.
- Not operator-facing (no `.env` or config), so no Starlight docs change.