### PR TITLE
deps: clear the open Dependabot alerts (guzzle, shell-quote)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1435,16 +1435,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.0",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "90bd104afeb0fcc2190c9eb6fd8a441447e4b30d"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/90bd104afeb0fcc2190c9eb6fd8a441447e4b30d",
-                "reference": "90bd104afeb0fcc2190c9eb6fd8a441447e4b30d",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
@@ -1543,7 +1543,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -1559,7 +1559,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-17T12:26:48+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11411,9 +11411,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
         "types:check": "vue-tsc --noEmit",
         "test:js": "vitest run"
     },
+    "overrides": {
+        "shell-quote": "^1.9.0"
+    },
     "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@laravel/echo-vue": "^2.3.7",


### PR DESCRIPTION
Closes #685.

## What

Clears the four open Dependabot alerts, both fixable without touching a Composer constraint.

| Package | Lockfile | Before | After |
|---|---|---|---|
| `guzzlehttp/guzzle` | `composer.lock` | 7.15.0 | 7.15.1 |
| `shell-quote` | `package-lock.json` | 1.8.4 | 1.10.0 |

- **guzzle** (alerts 3/4/5, medium, runtime) — a plain in-range lockfile bump via `composer update guzzlehttp/guzzle --with-dependencies`. Guzzle is a transitive dependency with no entry in `composer.json`, so nothing else moved: the lock diff is a single `version` line plus the package's own metadata.
- **shell-quote** (alert 2, high, dev-only) — this one could *not* be fixed by refreshing the lockfile. `concurrently` pins `shell-quote` at an **exact** `1.8.4`, and the current latest (`concurrently@10.0.3`, already what we were on) still does. So there is no upstream release to update to, and an npm `overrides` entry is the only way to lift the resolution. Added `"overrides": { "shell-quote": "^1.9.0" }`, which resolves to 1.10.0. `npm ls shell-quote` confirms the single `concurrently -> shell-quote@1.10.0` edge; the remaining `1.8.4` string in the lock is `concurrently`'s *declared* spec, not a resolution.

Alert 1 (`astro`) was already stale and dismissed, per the issue.

## Testing

Both gates green in the issue's isolated worktree:

- `./vendor/bin/sail composer test` — Pint, PHPStan, Rector, `Total: 100.0 %`
- `./vendor/bin/sail npm run lint:check` / `format:check` / `types:check` / `test:js` (88 files, 856 tests) / `build`
- `./vendor/bin/sail composer audit` — no advisories.

No i18n or docs changes: nothing here is user-visible or operator-facing.

## Note on `npm audit`

`npm audit` still reports 3 **pre-existing, moderate, dev-only** advisories unrelated to this issue and not raised by Dependabot: a path-traversal in `@hono/node-server` (<2.0.5) reached via `shadcn-vue -> @modelcontextprotocol/sdk -> @hono/node-server`. It is a CLI dev dependency, never shipped, and out of scope here.

CodeRabbit's local pass hit the free-tier rate limit, so this relies on the PR-side review.