### PR TITLE
fix: hide reminders for messages the viewer can no longer access

### DIFF
--- a/app/Data/MessageReminderData.php
+++ b/app/Data/MessageReminderData.php
@@ -19,6 +19,7 @@ class MessageReminderData extends Data
         public string $authorName,
         public string $body,
         public bool $isDeleted,
+        public bool $isAccessible,
     ) {}
 
     /**
@@ -30,8 +31,15 @@ class MessageReminderData extends Data
      * quote and a working link back to the message. A since-deleted message
      * blanks its body, leaving only the `isDeleted` flag for a "message deleted"
      * stub — its channel and author still resolve so the link stays valid.
+     *
+     * `$isAccessible` carries the caller's `view` check on the channel, which
+     * has to be re-evaluated on every read because a viewer can lose access long
+     * after the reminder was set. When it is false the row survives — clearing it
+     * stays the owner's call, and regaining access restores it intact — but
+     * everything the viewer may no longer see is blanked: the body, the author,
+     * the channel name, and the channel slug the jump link is built from.
      */
-    public static function fromMessageReminder(MessageReminder $reminder): self
+    public static function fromMessageReminder(MessageReminder $reminder, bool $isAccessible = true): self
     {
         $message = $reminder->message;
         $channel = $message->channel;
@@ -42,11 +50,12 @@ class MessageReminderData extends Data
             messageId: $message->id,
             remindAt: $reminder->remind_at->toIso8601String(),
             teamSlug: $channel->team->slug,
-            channelSlug: $channel->slug,
-            channelName: $channel->name,
-            authorName: $message->user->name,
-            body: $isDeleted ? '' : $message->body,
+            channelSlug: $isAccessible ? $channel->slug : '',
+            channelName: $isAccessible ? $channel->name : null,
+            authorName: $isAccessible ? $message->user->name : '',
+            body: $isDeleted || ! $isAccessible ? '' : $message->body,
             isDeleted: $isDeleted,
+            isAccessible: $isAccessible,
         );
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -27,6 +27,7 @@ use App\Support\UpdateChecker;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Middleware;
 use Laravel\Fortify\Features;
@@ -337,6 +338,12 @@ class HandleInertiaRequests extends Middleware
      * row renders a quote and a working link back. Ordered by due time. Empty off
      * the channel workspace, where the surfaces are absent.
      *
+     * Visibility is re-checked here with the same `view` gate the write path
+     * uses, because access can be revoked long after the reminder was set. A row
+     * whose channel is no longer viewable is redacted rather than dropped, so the
+     * owner can still clear it and regaining access restores it. The verdict is
+     * memoised per channel — several reminders often share one.
+     *
      * @return array<int, MessageReminderData>
      */
     protected function remindersForSidebar(Request $request, ?User $user, MessageReminderStatus $status): array
@@ -355,7 +362,15 @@ class HandleInertiaRequests extends Middleware
             ->oldest('remind_at')
             ->get();
 
-        return MessageReminderData::collect($reminders, 'array');
+        /** @var array<string, bool> $viewable */
+        $viewable = [];
+
+        return $reminders->map(function (MessageReminder $reminder) use ($user, &$viewable): MessageReminderData {
+            $channel = $reminder->message->channel;
+            $viewable[$channel->id] ??= Gate::forUser($user)->allows('view', $channel);
+
+            return MessageReminderData::fromMessageReminder($reminder, $viewable[$channel->id]);
+        })->all();
     }
 
     /**

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1174,5 +1174,7 @@
   "Play": "Lire",
   "Pause": "Mettre en pause",
   "Seek": "Se déplacer dans la piste",
-  ":elapsed of :total": ":elapsed sur :total"
+  ":elapsed of :total": ":elapsed sur :total",
+  "No longer available": "Plus disponible",
+  "You no longer have access to this channel.": "Vous n’avez plus accès à ce canal."
 }

--- a/resources/js/components/ReminderNudge.test.ts
+++ b/resources/js/components/ReminderNudge.test.ts
@@ -34,16 +34,15 @@ async function render(
 
 describe('ReminderNudge inaccessible reminders', () => {
     it('drops the open and snooze actions once the channel is out of reach', async () => {
-        const html = await render({
-            isAccessible: false,
-            body: '',
-            authorName: '',
-            channelName: null,
-            channelSlug: '',
-        });
+        // The payload is left populated on purpose: the nudge must not surface
+        // the body or the author even if the server ever stopped blanking them.
+        const html = await render({ isAccessible: false, channelName: null });
 
         expect(html).not.toContain('data-test="reminder-nudge-open"');
         expect(html).not.toContain('data-test="reminder-nudge-snooze"');
+        expect(html).not.toContain('Jordan West');
+        expect(html).not.toContain('the secret plan');
+        expect(html).toContain('No longer available');
         expect(html).toContain('You no longer have access to this channel.');
         // Acknowledging is the one thing still on offer.
         expect(html).toContain('data-test="reminder-nudge-done"');

--- a/resources/js/components/ReminderNudge.test.ts
+++ b/resources/js/components/ReminderNudge.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { createSSRApp, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import type { MessageReminder } from '@/types';
+import ReminderNudge from './ReminderNudge.vue';
+
+function reminder(overrides: Partial<MessageReminder> = {}): MessageReminder {
+    return {
+        id: 'rem-1',
+        messageId: 'msg-1',
+        remindAt: '2030-01-01T10:00:00+00:00',
+        teamSlug: 'acme',
+        channelSlug: 'war-room',
+        channelName: 'war-room',
+        authorName: 'Jordan West',
+        body: 'the secret plan',
+        isDeleted: false,
+        isAccessible: true,
+        ...overrides,
+    };
+}
+
+async function render(
+    overrides: Partial<MessageReminder> = {},
+): Promise<string> {
+    const app = createSSRApp({
+        render: () => h(ReminderNudge, { reminder: reminder(overrides) }),
+    });
+
+    app.config.globalProperties.$t = (key: string) => key;
+
+    return renderToString(app);
+}
+
+describe('ReminderNudge inaccessible reminders', () => {
+    it('drops the open and snooze actions once the channel is out of reach', async () => {
+        const html = await render({
+            isAccessible: false,
+            body: '',
+            authorName: '',
+            channelName: null,
+            channelSlug: '',
+        });
+
+        expect(html).not.toContain('data-test="reminder-nudge-open"');
+        expect(html).not.toContain('data-test="reminder-nudge-snooze"');
+        expect(html).toContain('You no longer have access to this channel.');
+        // Acknowledging is the one thing still on offer.
+        expect(html).toContain('data-test="reminder-nudge-done"');
+        expect(html).toContain('data-test="reminder-nudge-close"');
+    });
+
+    it('keeps every action and the quote for a reminder still in reach', async () => {
+        const html = await render();
+
+        expect(html).toContain('data-test="reminder-nudge-open"');
+        expect(html).toContain('data-test="reminder-nudge-snooze"');
+        expect(html).toContain('the secret plan');
+    });
+});

--- a/resources/js/components/ReminderNudge.vue
+++ b/resources/js/components/ReminderNudge.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { AlarmClock, X } from '@lucide/vue';
+import { AlarmClock, Lock, X } from '@lucide/vue';
 import { computed } from 'vue';
 import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
@@ -63,12 +63,17 @@ const channelLabel = computed(() =>
                 aria-hidden="true"
                 class="flex size-7 shrink-0 items-center justify-center rounded-lg bg-primary-foreground/15 text-[10px] font-semibold"
             >
-                {{ getInitials(reminder.authorName) }}
+                <Lock v-if="!reminder.isAccessible" class="size-3.5" />
+                <template v-else>{{
+                    getInitials(reminder.authorName)
+                }}</template>
             </div>
             <div class="flex min-w-0 flex-col gap-0.5">
                 <div class="flex items-baseline gap-1.5">
                     <span class="text-[13px] font-semibold">{{
-                        reminder.authorName
+                        reminder.isAccessible
+                            ? reminder.authorName
+                            : $t('No longer available')
                     }}</span>
                     <span
                         v-if="channelLabel"
@@ -79,7 +84,14 @@ const channelLabel = computed(() =>
                     >
                 </div>
                 <span
-                    v-if="reminder.isDeleted"
+                    v-if="!reminder.isAccessible"
+                    class="text-[13px] text-primary-foreground/70 italic"
+                    >{{
+                        $t('You no longer have access to this channel.')
+                    }}</span
+                >
+                <span
+                    v-else-if="reminder.isDeleted"
                     class="text-[13px] text-primary-foreground/50 italic"
                     >{{ $t('This message was deleted.') }}</span
                 >
@@ -92,7 +104,10 @@ const channelLabel = computed(() =>
         </div>
 
         <div class="flex items-center gap-2.5">
+            <!-- With no channel access left there is nothing to jump to and
+                 nothing worth deferring: only acknowledging remains. -->
             <Button
+                v-if="reminder.isAccessible"
                 variant="unstyled"
                 size="none"
                 type="button"
@@ -103,6 +118,7 @@ const channelLabel = computed(() =>
                 {{ $t('Open message') }}
             </Button>
             <Button
+                v-if="reminder.isAccessible"
                 variant="unstyled"
                 size="none"
                 type="button"

--- a/resources/js/components/RemindersDialog.test.ts
+++ b/resources/js/components/RemindersDialog.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
-import { createSSRApp, h } from 'vue';
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, createSSRApp, h } from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import type { MessageReminder } from '@/types';
 
@@ -66,22 +68,87 @@ async function render(
     return renderToString(app);
 }
 
+/**
+ * Mounts the dialog under jsdom with the emitted `open` reminders and
+ * `update:open` calls captured, so a click on a row can be checked for both the
+ * jump it would request and the dialog close that comes with it.
+ */
+function mount(overrides: Partial<MessageReminder> = {}): {
+    app: App;
+    root: HTMLElement;
+    opened: MessageReminder[];
+    openStates: boolean[];
+} {
+    const root = document.createElement('div');
+    document.body.append(root);
+
+    const opened: MessageReminder[] = [];
+    const openStates: boolean[] = [];
+
+    const app = createApp({
+        render: () =>
+            h(RemindersDialog, {
+                reminders: [reminder(overrides)],
+                timezone: 'UTC',
+                open: true,
+                onOpen: (value: MessageReminder) => opened.push(value),
+                'onUpdate:open': (value: boolean) => openStates.push(value),
+            }),
+    });
+
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(root);
+
+    return { app, root, opened, openStates };
+}
+
+let mounted: App | null = null;
+
+afterEach(() => {
+    mounted?.unmount();
+    mounted = null;
+    document.body.innerHTML = '';
+});
+
 describe('RemindersDialog inaccessible rows', () => {
     it('renders a redacted row with no jump control once the channel is out of reach', async () => {
-        const html = await render({
-            isAccessible: false,
-            body: '',
-            authorName: '',
-            channelName: null,
-            channelSlug: '',
-        });
+        // The payload is left populated on purpose: the row must not surface the
+        // body or the author even if the server ever stopped blanking them.
+        const html = await render({ isAccessible: false, channelName: null });
 
         expect(html).toContain('data-test="reminder-unavailable"');
         expect(html).not.toContain('data-test="reminder-open"');
+        expect(html).not.toContain('Jordan West');
+        expect(html).not.toContain('the secret plan');
         expect(html).toContain('You no longer have access to this channel.');
         expect(html).toContain('No longer available');
         // The clear control survives: the owner can still get rid of the row.
         expect(html).toContain('data-test="reminder-clear"');
+    });
+
+    it('ignores a click on an inaccessible row rather than jumping', () => {
+        const { app, root, opened, openStates } = mount({
+            isAccessible: false,
+            channelName: null,
+        });
+        mounted = app;
+
+        root.querySelector<HTMLElement>(
+            '[data-test="reminder-unavailable"]',
+        )?.click();
+
+        expect(opened).toEqual([]);
+        expect(openStates).toEqual([]);
+    });
+
+    it('jumps to the message when an accessible row is clicked', () => {
+        const { app, root, opened, openStates } = mount();
+        mounted = app;
+
+        root.querySelector<HTMLElement>('[data-test="reminder-open"]')?.click();
+
+        expect(opened).toHaveLength(1);
+        expect(openStates).toEqual([false]);
     });
 
     it('keeps the jump control and the quote for a row still in reach', async () => {

--- a/resources/js/components/RemindersDialog.test.ts
+++ b/resources/js/components/RemindersDialog.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSSRApp, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import type { MessageReminder } from '@/types';
+
+/**
+ * The dialog chrome is stubbed away so the list rows render inline: reka's
+ * `DialogContent` teleports and never reaches the SSR string otherwise.
+ * `stub(tag)` builds a passthrough component; hoisted so the vi.mock factories
+ * (which run before the module body) can reach it.
+ */
+const { stub } = await vi.hoisted(async () => {
+    const { defineComponent, h: hyper } = await import('vue');
+
+    return {
+        stub: (tag: string) =>
+            defineComponent({
+                setup:
+                    (_: unknown, ctx: { slots: { default?: () => unknown } }) =>
+                    () =>
+                        hyper(tag, ctx.slots.default?.() as never),
+            }),
+    };
+});
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: stub('div'),
+    DialogContent: stub('div'),
+    DialogDescription: stub('p'),
+    DialogHeader: stub('div'),
+    DialogTitle: stub('h2'),
+}));
+
+import RemindersDialog from './RemindersDialog.vue';
+
+function reminder(overrides: Partial<MessageReminder> = {}): MessageReminder {
+    return {
+        id: 'rem-1',
+        messageId: 'msg-1',
+        remindAt: '2030-01-01T10:00:00+00:00',
+        teamSlug: 'acme',
+        channelSlug: 'war-room',
+        channelName: 'war-room',
+        authorName: 'Jordan West',
+        body: 'the secret plan',
+        isDeleted: false,
+        isAccessible: true,
+        ...overrides,
+    };
+}
+
+async function render(
+    overrides: Partial<MessageReminder> = {},
+): Promise<string> {
+    const app = createSSRApp({
+        render: () =>
+            h(RemindersDialog, {
+                reminders: [reminder(overrides)],
+                timezone: 'UTC',
+                open: true,
+            }),
+    });
+
+    app.config.globalProperties.$t = (key: string) => key;
+
+    return renderToString(app);
+}
+
+describe('RemindersDialog inaccessible rows', () => {
+    it('renders a redacted row with no jump control once the channel is out of reach', async () => {
+        const html = await render({
+            isAccessible: false,
+            body: '',
+            authorName: '',
+            channelName: null,
+            channelSlug: '',
+        });
+
+        expect(html).toContain('data-test="reminder-unavailable"');
+        expect(html).not.toContain('data-test="reminder-open"');
+        expect(html).toContain('You no longer have access to this channel.');
+        expect(html).toContain('No longer available');
+        // The clear control survives: the owner can still get rid of the row.
+        expect(html).toContain('data-test="reminder-clear"');
+    });
+
+    it('keeps the jump control and the quote for a row still in reach', async () => {
+        const html = await render();
+
+        expect(html).toContain('data-test="reminder-open"');
+        expect(html).not.toContain('data-test="reminder-unavailable"');
+        expect(html).toContain('the secret plan');
+        expect(html).toContain('Jordan West');
+    });
+});

--- a/resources/js/components/RemindersDialog.vue
+++ b/resources/js/components/RemindersDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { AlarmClock, Clock, X } from '@lucide/vue';
+import { AlarmClock, Clock, Lock, X } from '@lucide/vue';
 import { computed } from 'vue';
 import { Button } from '@/components/ui/button';
 import {
@@ -66,6 +66,12 @@ function excerpt(reminder: MessageReminder): string {
 }
 
 function openReminder(reminder: MessageReminder): void {
+    // A row whose channel the viewer lost access to renders as a non-interactive
+    // stub, and the server blanked the slug its link would need.
+    if (!reminder.isAccessible) {
+        return;
+    }
+
     emit('open', reminder);
     open.value = false;
 }
@@ -147,11 +153,21 @@ function openReminder(reminder: MessageReminder): void {
                             :data-reminder="reminder.id"
                             class="flex items-center gap-3 rounded-xl border border-border bg-card p-3"
                         >
+                            <!-- An inaccessible row keeps the same shape but drops to a
+                                 plain element: it carries no jump link, and the
+                                 server blanked everything it would have quoted. -->
                             <Button
+                                :as="reminder.isAccessible ? 'button' : 'div'"
                                 variant="unstyled"
                                 size="none"
-                                type="button"
-                                data-test="reminder-open"
+                                :type="
+                                    reminder.isAccessible ? 'button' : undefined
+                                "
+                                :data-test="
+                                    reminder.isAccessible
+                                        ? 'reminder-open'
+                                        : 'reminder-unavailable'
+                                "
                                 class="flex min-w-0 flex-1 items-center gap-3 text-left"
                                 @click="openReminder(reminder)"
                             >
@@ -159,13 +175,23 @@ function openReminder(reminder: MessageReminder): void {
                                     aria-hidden="true"
                                     class="flex size-8 shrink-0 items-center justify-center rounded-[10px] bg-primary/10 text-[10px] font-semibold text-primary"
                                 >
-                                    {{ getInitials(reminder.authorName) }}
+                                    <Lock
+                                        v-if="!reminder.isAccessible"
+                                        class="size-3.5"
+                                    />
+                                    <template v-else>{{
+                                        getInitials(reminder.authorName)
+                                    }}</template>
                                 </div>
                                 <div class="flex min-w-0 flex-col gap-0.5">
                                     <div class="flex items-baseline gap-1.5">
                                         <span
                                             class="text-[13px] font-semibold text-foreground"
-                                            >{{ reminder.authorName }}</span
+                                            >{{
+                                                reminder.isAccessible
+                                                    ? reminder.authorName
+                                                    : $t('No longer available')
+                                            }}</span
                                         >
                                         <span
                                             v-if="channelLabel(reminder)"
@@ -181,7 +207,16 @@ function openReminder(reminder: MessageReminder): void {
                                         >
                                     </div>
                                     <span
-                                        v-if="reminder.isDeleted"
+                                        v-if="!reminder.isAccessible"
+                                        class="truncate text-[13px] text-muted-foreground italic"
+                                        >{{
+                                            $t(
+                                                'You no longer have access to this channel.',
+                                            )
+                                        }}</span
+                                    >
+                                    <span
+                                        v-else-if="reminder.isDeleted"
                                         class="truncate text-[13px] text-muted-foreground italic"
                                         >{{
                                             $t('This message was deleted.')

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -262,6 +262,11 @@ export type ScheduledMessage = {
  * link back), and the UTC `remindAt` instant the client renders in the viewer's
  * zone. The workspace shares the viewer's pending rows in `reminders` and the
  * due-and-unacknowledged ones in `firedReminders`.
+ *
+ * `isAccessible` is false once the viewer can no longer view the channel the
+ * message lives in: the server blanks the body, author, channel name and channel
+ * slug, so such a row renders as a stub with no jump link — only a way to clear
+ * it. Regaining access restores the row.
  */
 export type MessageReminder = {
     id: string;
@@ -273,6 +278,7 @@ export type MessageReminder = {
     authorName: string;
     body: string;
     isDeleted: boolean;
+    isAccessible: boolean;
 };
 
 /**

--- a/tests/Feature/Channels/MessageReminderListTest.php
+++ b/tests/Feature/Channels/MessageReminderListTest.php
@@ -81,6 +81,82 @@ test('a reminder on a since-deleted message blanks its body but keeps the link',
         );
 });
 
+test('a reminder whose channel the viewer can no longer see is redacted to a stub', function (): void {
+    [$owner, $team] = reminderListTeamWithGeneral();
+
+    $private = Channel::factory()->for($team)->private()->create(['name' => 'war-room']);
+    $membership = $private->channelMembers()->create(['user_id' => $owner->id]);
+    $message = Message::factory()->for($private)->for($owner)->create(['body' => 'secret plan']);
+    $reminder = MessageReminder::factory()->for($owner)->for($message)->create();
+
+    $membership->delete();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => 'general']))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('reminders', 1)
+            ->where('reminders.0.id', $reminder->id)
+            ->where('reminders.0.isAccessible', false)
+            ->where('reminders.0.body', '')
+            ->where('reminders.0.authorName', '')
+            ->where('reminders.0.channelName', null)
+            ->where('reminders.0.channelSlug', '')
+        );
+});
+
+test('regaining access to the channel restores the reminder intact', function (): void {
+    [$owner, $team] = reminderListTeamWithGeneral();
+
+    $private = Channel::factory()->for($team)->private()->create(['name' => 'war-room']);
+    $message = Message::factory()->for($private)->for($owner)->create(['body' => 'secret plan']);
+    MessageReminder::factory()->for($owner)->for($message)->create();
+
+    $private->channelMembers()->create(['user_id' => $owner->id]);
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => 'general']))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('reminders.0.isAccessible', true)
+            ->where('reminders.0.body', 'secret plan')
+            ->where('reminders.0.authorName', $owner->name)
+            ->where('reminders.0.channelName', 'war-room')
+        );
+});
+
+test('a reminder in an archived channel stays fully visible', function (): void {
+    [$owner, $team] = reminderListTeamWithGeneral();
+
+    $archived = Channel::factory()->for($team)->archived()->create(['name' => 'retro']);
+    $archived->channelMembers()->create(['user_id' => $owner->id]);
+    $message = Message::factory()->for($archived)->for($owner)->create(['body' => 'still readable']);
+    MessageReminder::factory()->for($owner)->for($message)->create();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => 'general']))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('reminders', 1)
+            ->where('reminders.0.isAccessible', true)
+            ->where('reminders.0.body', 'still readable')
+            ->where('reminders.0.channelName', 'retro')
+        );
+});
+
+test('a fired reminder is redacted the same way as a pending one', function (): void {
+    [$owner, $team] = reminderListTeamWithGeneral();
+
+    $private = Channel::factory()->for($team)->private()->create(['name' => 'war-room']);
+    $message = Message::factory()->for($private)->for($owner)->create(['body' => 'secret plan']);
+    MessageReminder::factory()->for($owner)->for($message)->fired()->create();
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => 'general']))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('firedReminders', 1)
+            ->where('firedReminders.0.isAccessible', false)
+            ->where('firedReminders.0.body', '')
+        );
+});
+
 test('reminders are scoped to the current team', function (): void {
     [$owner, $team, $general] = reminderListTeamWithGeneral();
     $message = Message::factory()->for($general)->for($owner)->create(['body' => 'in acme']);


### PR DESCRIPTION
Closes #684.

## What

A message reminder kept rendering the full message body, author and channel name in the viewer's sidebar even after the viewer lost access to the channel the message lives in. Authorization only ever happened on the write path (`SetMessageReminderRequest::authorize()`); nothing re-checked it on read.

## How

- `HandleInertiaRequests::remindersForSidebar()` now re-checks `Gate::allows('view', $channel)` — the same gate the write path uses — for every row it shares, memoised per channel since several reminders usually share one.
- `MessageReminderData` gained an `isAccessible` flag. When it is false the row is **redacted, not dropped and not deleted**: the body, author name, channel name and channel slug are blanked, so clearing it stays the owner's call and regaining access restores the row intact.
- Archived channels are unaffected: `ChannelPolicy::view()` deliberately ignores `archived_at` (archived channels are readable, just not postable), so their reminders stay fully visible.
- `RemindersDialog.vue` and `ReminderNudge.vue` render inaccessible rows as a lock-icon "No longer available" stub, following the existing `isDeleted` stub pattern. The row drops from a `<button>` to a plain element so there is no jump link, and the nudge drops its "Open message" and "Snooze" actions — only clear/dismiss remain.

### One deviation from the acceptance criteria

The issue lists `body` / `authorName` / `channelName` as the fields to blank. This also blanks **`channelSlug`**: it is the slugified channel name, so leaving it would leak the same information `channelName: null` is hiding, and would keep a constructible jump URL.

## Testing

- 5 new Pest feature tests in `tests/Feature/Channels/MessageReminderListTest.php`: membership revoked after the reminder was set, regaining access restores the row, an archived channel stays fully visible, and a fired reminder is redacted the same way.
- 6 new Vitest component tests (`RemindersDialog.test.ts`, `ReminderNudge.test.ts`) covering the stub markup, the absent jump control, and that a click on an inaccessible row emits nothing. They render with a *populated* payload on purpose, so the components are proven not to leak even if the server ever stopped blanking.
- `composer test` green at **Total: 100.0 %**; `lint:check`, `format:check`, `types:check`, `test:js`, `build` all pass.

## i18n

New keys `No longer available` and `You no longer have access to this channel.` added to `lang/fr.json`.

No operator-facing change, so no `docs/` update.