### PR TITLE
fix: point live-demo link at demo.thedeskhq.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 <p align="center">
-  <a href="https://demo-the-desk.emmanuelpaul.com/"><strong>Live&nbsp;demo</strong></a> ·
+  <a href="https://demo.thedeskhq.app/"><strong>Live&nbsp;demo</strong></a> ·
   <a href="https://thedeskhq.app">Website</a> ·
   <a href="https://docs.thedeskhq.app/">Docs</a> ·
   <a href="https://docs.thedeskhq.app/self-hosting/installation/">Install</a> ·
@@ -49,7 +49,7 @@ upgrades) live at
 
 ### Public demo
 
-Try it live at **[demo-the-desk.emmanuelpaul.com](https://demo-the-desk.emmanuelpaul.com/)** — the login page shows the shared credentials.
+Try it live at **[demo.thedeskhq.app](https://demo.thedeskhq.app/)** — the login page shows the shared credentials.
 
 Set `DEMO_MODE=true` to run a public, single-shared-account demo off the seeded
 "Northwind Labs" workspace (`php artisan demo:seed`). Every visitor signs in as


### PR DESCRIPTION
Closes #711.

Updates both live-demo links in `README.md` from the old personal host (`demo-the-desk.emmanuelpaul.com`) to the new `demo.thedeskhq.app` host on the `thedeskhq.app` domain. Part of the move to the `deskhq` org (#692).

- `README.md:22` — header nav "Live demo" link
- `README.md:52` — "Try it live at ..." sentence (link text + href)

Verified these are the only two references in the tree (outside the release-please-owned `CHANGELOG.md`).

**Out of scope here / operator action:** the instance-side cutover (DNS + TLS for `demo.thedeskhq.app`, `APP_URL` update + restart, `DEMO_MODE` reset/seed check, optional redirect of the old host) still needs to happen on the demo deployment per the issue checklist. Sequence that alongside the merge so the README never advertises a URL that 404s.

**Note:** targeting `master` per request. Since this lands only on `master`, `develop` will still show the old URL until the next `master` -> `develop` backmerge.