### PR TITLE
fix: disable Inertia SSR in the testing environment

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -18,7 +18,7 @@ return [
     */
 
     'ssr' => [
-        'enabled' => true,
+        'enabled' => env('INERTIA_SSR_ENABLED', true),
         'url' => 'http://127.0.0.1:13714',
         // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -70,6 +70,16 @@
         <env name="SSO_DEFAULT_TEAM_ID" value=""/>
         <env name="SCIM_TOKEN" value=""/>
         <env name="GIPHY_API_KEY" value=""/>
+        <!--
+            Keep the suite independent of a locally-built SSR bundle. Inertia
+            dispatches to the SSR render server whenever a bundle exists at
+            bootstrap/ssr/ (a git-ignored artifact CI never builds). A developer
+            who has run the SSR build then has one on disk, and from that point
+            every Inertia render inside a test fires an outbound POST to
+            127.0.0.1:13714 that pollutes Http::fake(). Forcing SSR off here
+            makes the gate deterministic no matter whether that artifact exists.
+        -->
+        <env name="INERTIA_SSR_ENABLED" value="false"/>
         <!-- Avatars resolve through the image proxy, which fetches the remote
              image server-side. Left enabled, every rendered avatar would make the
              suite reach gravatar.com — and in the browser tests that fetch blocks

--- a/tests/Feature/Inertia/SsrDisabledInTestingTest.php
+++ b/tests/Feature/Inertia/SsrDisabledInTestingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Inertia\Ssr\Gateway;
+
+/**
+ * The SSR gateway only dispatches to the render server when a bundle is present
+ * on disk. CI never builds one, but a developer who has run the SSR build has
+ * `bootstrap/ssr/app.js` locally, and from then on every Inertia render inside a
+ * test fires an outbound POST to the SSR server that pollutes `Http::fake()`.
+ * Point the bundle at a temp file we control so the detector reports a bundle
+ * without touching (or depending on) the git-ignored `bootstrap/ssr/` directory.
+ */
+beforeEach(function (): void {
+    $this->ssrBundle = storage_path('framework/testing/ssr-bundle-fixture.js');
+
+    File::ensureDirectoryExists(dirname($this->ssrBundle));
+    File::put($this->ssrBundle, '// fixture SSR bundle');
+
+    config(['inertia.ssr.bundle' => $this->ssrBundle]);
+});
+
+afterEach(function (): void {
+    File::delete($this->ssrBundle);
+});
+
+it('issues no SSR request when dispatching an Inertia page under the testing environment', function (): void {
+    Http::preventStrayRequests();
+    Http::fake();
+
+    $response = app(Gateway::class)->dispatch([
+        'component' => 'Welcome',
+        'props' => [],
+        'url' => '/',
+        'version' => null,
+    ]);
+
+    expect($response)->toBeNull();
+
+    Http::assertNothingSent();
+});


### PR DESCRIPTION
Closes #690.

## What

`config/inertia.php` enabled SSR unconditionally, and Inertia dispatches to the SSR render server whenever a bundle exists at `bootstrap/ssr/`. CI never builds one, so the suite is green there, but a developer who has run the SSR build locally has `bootstrap/ssr/app.js` on disk, and from then on every Inertia render inside a test fires an outbound `POST http://127.0.0.1:13714/render`. That stray request is recorded by `Http::fake()`, so tests asserting on the recorded request set (e.g. `ImageProxyTest`) fail on code they never touched.

## Why

The gate is meant to be deterministic and env-independent. Today it silently depends on whether a git-ignored build artifact happens to exist, so a developer can chase failures in unrelated code, or dismiss a real failure as "the SSR thing".

## How

- `config/inertia.php`: `ssr.enabled` is now env-backed (`INERTIA_SSR_ENABLED`, default `true`) so production behaviour is unchanged.
- `phpunit.xml`: pins `INERTIA_SSR_ENABLED=false`, alongside the existing hermetic toggles (`DEMO_MODE`, SSO/LDAP, `GRAVATAR_ENABLED`), so SSR is off in the test environment regardless of whether `bootstrap/ssr/` exists.
- Added a regression test that dispatches through the SSR gateway with a bundle present and asserts no outbound request is issued under `APP_ENV=testing`.

## Testing

- New `tests/Feature/Inertia/SsrDisabledInTestingTest.php` (red before the config change, green after).
- Verified `ImageProxyTest` passes with a `bootstrap/ssr/app.js` bundle present (previously red).
- Full gate green: Pint, PHPStan (0 errors), Rector (clean), 2075 tests, 100% coverage.

No i18n or operator-facing docs changes: SSR is not part of the shipped production stack and the toggle defaults to on, so nothing changes for operators.