### PR TITLE
fix: give linkDestructive an accessible destructive-text token

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -296,6 +296,7 @@
   "Email verification": "Vérification de l’e-mail",
   "Emoji": "Emoji",
   "Emoji added.": "Emoji ajouté.",
+  "Emoji image": "Image de l'emoji",
   "Emoji removed.": "Emoji supprimé.",
   "Ensure your account is using a long, random password to stay secure": "Assurez-vous que votre compte utilise un mot de passe long et aléatoire pour rester sécurisé",
   "Enter team name": "Saisissez le nom de l’équipe",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -45,6 +45,7 @@
 
     --color-destructive: var(--destructive);
     --color-destructive-foreground: var(--destructive-foreground);
+    --color-destructive-text: var(--destructive-text);
 
     --color-border: var(--border);
     --color-input: var(--input);
@@ -136,6 +137,11 @@
     --accent-foreground: #1d1a15;
     --destructive: hsl(0 72% 45%);
     --destructive-foreground: #f3efe4;
+    /* Destructive as inline *text* (the `linkDestructive` <Button> variant, down
+       to text-xs). Darkened a touch from --destructive so it clears WCAG AA
+       4.5:1 on both --card and --background, which the fill token only just met
+       on the page background (#678). */
+    --destructive-text: #bd1f1f;
     --border: #e3dfd5;
     --input: #e0dbcd;
     /* Focus indicator — decoupled from --brass and darkened to a bronze so the
@@ -198,6 +204,10 @@
     --accent-foreground: #f3efe4;
     --destructive: hsl(0 72% 55%);
     --destructive-foreground: #f3efe4;
+    /* Lightened from --destructive so destructive inline text (the
+       `linkDestructive` variant) clears WCAG AA 4.5:1 on the dark card; the fill
+       token measured 3.92:1 as text there (#678). */
+    --destructive-text: #e75555;
     --border: #2e2a21;
     --input: #2a271f;
     --ring: #c9a35c;

--- a/resources/js/components/ui/button/Button.test.ts
+++ b/resources/js/components/ui/button/Button.test.ts
@@ -61,13 +61,18 @@ describe("Button variants and sizes", () => {
     expect(buttonVariants({ size: "pill" })).toContain("rounded-full")
   })
 
-  it("carries the destructive token on the link-destructive variant", () => {
-    const classes = buttonVariants({ variant: "linkDestructive" })
+  it("carries the accessible destructive-text token on the link-destructive variant", () => {
+    const classNames = buttonVariants({ variant: "linkDestructive" }).split(/\s+/)
 
-    expect(classes).toContain("text-destructive")
-    expect(classes).toContain("hover:underline")
+    // The dedicated text form of the destructive colour, tuned to clear WCAG AA
+    // on card/background surfaces at small sizes — not the `--destructive` fill,
+    // which is too low-contrast as inline text on the dark card (#678).
+    expect(classNames).toContain("text-destructive-text")
+    // Guard against a revert to the low-contrast fill token as inline text.
+    expect(classNames).not.toContain("text-destructive")
+    expect(classNames).toContain("hover:underline")
     // Not the default primary link colour.
-    expect(classes).not.toContain("text-primary")
+    expect(classNames).not.toContain("text-primary")
   })
 
   it("drops the button silhouette for the unstyled escape hatch but keeps the focus ring", () => {

--- a/resources/js/components/ui/button/index.ts
+++ b/resources/js/components/ui/button/index.ts
@@ -31,8 +31,10 @@ export const buttonVariants = cva(interaction, {
       ghost: `${shape} hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50`,
       link: `${shape} text-primary underline-offset-4 hover:underline`,
       // Same underline treatment as `link` but carrying the destructive token,
-      // for inline "Remove"/"Clear all"/"Discard" actions that read as text.
-      linkDestructive: `${shape} text-destructive underline-offset-4 hover:underline`,
+      // for inline "Remove"/"Clear all"/"Discard" actions that read as text. Uses
+      // the accessible `--destructive-text` form (not the `--destructive` fill),
+      // so it clears WCAG AA on card/background surfaces even at text-xs (#678).
+      linkDestructive: `${shape} text-destructive-text underline-offset-4 hover:underline`,
       // Radio-like toggle in a segmented control. The selected option is driven
       // by `aria-pressed`, so call-sites bind `:aria-pressed` and drop their
       // hand-rolled `selected ? … : …` class ternary.

--- a/resources/js/pages/teams/Emojis.vue
+++ b/resources/js/pages/teams/Emojis.vue
@@ -169,6 +169,7 @@ function addedAt(iso: string): string {
                             type="file"
                             accept="image/png,image/gif"
                             data-test="emoji-image-input"
+                            :aria-label="$t('Emoji image')"
                             class="block w-full text-sm text-muted-foreground file:mr-3 file:rounded-full file:border file:border-border file:bg-background file:px-3 file:py-1.5 file:text-sm file:font-medium hover:file:bg-muted"
                             @change="onFileChange"
                         />

--- a/resources/js/theme/contrast.test.ts
+++ b/resources/js/theme/contrast.test.ts
@@ -223,4 +223,35 @@ describe('theme contrast (WCAG AA)', () => {
             ).toBeGreaterThanOrEqual(AA_TEXT);
         },
     );
+
+    // The `linkDestructive` <Button> variant paints --destructive-text as inline
+    // text (e.g. the "Delete"/"Revoke" row action in teams/Emojis.vue), down to
+    // `text-xs`. Reusing the --destructive *fill* token there measured 3.92:1 on
+    // the dark card (#678); this dedicated text form must clear body-text AA on
+    // both the card row and the bare page background, in each theme.
+    const destructiveTextSurfaces = ['card', 'background'] as const;
+
+    it.each(destructiveTextSurfaces)(
+        'light --destructive-text meets AA on --%s',
+        (surface) => {
+            expect(
+                contrast(
+                    hexToRgb(light['destructive-text']),
+                    hexToRgb(light[surface]),
+                ),
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+        },
+    );
+
+    it.each(destructiveTextSurfaces)(
+        'dark --destructive-text meets AA on --%s',
+        (surface) => {
+            expect(
+                contrast(
+                    hexToRgb(dark['destructive-text']),
+                    hexToRgb(dark[surface]),
+                ),
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+        },
+    );
 });

--- a/tests/Browser/A11yEmojiSettingsTest.php
+++ b/tests/Browser/A11yEmojiSettingsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\CustomEmoji;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Seed a workspace whose team owns one custom emoji created by the owner, so the
+ * settings list renders a row with its `linkDestructive` "Delete" action — the
+ * shared button variant whose destructive text was 3.92:1 on the dark card (#678).
+ *
+ * @return array{owner: User, team: Team}
+ */
+function browserTeamWithCustomEmoji(): array
+{
+    ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
+
+    CustomEmoji::factory()->create([
+        'team_id' => $team->id,
+        'created_by' => $alice->id,
+        'name' => 'party-parrot',
+    ]);
+
+    return ['owner' => $alice, 'team' => $team];
+}
+
+test('the custom emoji settings page passes the axe audit in either theme', function (): void {
+    ['owner' => $alice, 'team' => $team] = browserTeamWithCustomEmoji();
+
+    $page = signInThroughBrowser($alice)
+        ->navigate("/settings/teams/{$team->slug}/emojis")
+        ->assertSee('Custom emoji')
+        // The row action is the `linkDestructive` <Button> at text-xs on `bg-card`
+        // that the audit exists to guard.
+        ->assertPresent('[data-test="emoji-remove-party-parrot"]')
+        ->assertNoAccessibilityIssues();
+
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});


### PR DESCRIPTION
Closes #678.

## What

The shared `linkDestructive` `<Button>` variant painted the `--destructive` *fill* token as inline text. At `text-xs` on `bg-card` in the dark theme it measured **3.92:1** — a serious `color-contrast` violation (WCAG AA needs 4.5:1).

`--destructive` can't simply be darkened/lightened to fix this: it doubles as the solid delete-button background (`bg-destructive` + `text-white`), where the two roles pull the value in opposite directions. So this introduces a **dedicated `--destructive-text` token**, tuned per theme, and points the variant at it via a new `text-destructive-text` utility.

## Contrast (measured on the shipped hex, no compositing)

| surface | light | dark (was) | dark (now) |
|---|---|---|---|
| `bg-card` | 6.11 | **3.92** | **4.77** |
| `bg-background` | 4.89 | ~4.1 | 5.27 |

All four clear 4.5:1 with headroom.

## How tested

- `resources/js/theme/contrast.test.ts` — asserts `--destructive-text` ≥ 4.5:1 on card + background in both themes (parses the real `app.css`, the established source-of-truth pattern).
- `resources/js/components/ui/button/Button.test.ts` — the `linkDestructive` variant carries `text-destructive-text` and no longer the fill token.
- `tests/Browser/A11yEmojiSettingsTest.php` — **new** axe audit of the emoji settings page (whose "Delete"/"Revoke" row action is a `linkDestructive` call site) in both themes, so the regression can't return silently.
- Full gate green: Pint, PHPStan, Rector clean, 100% coverage, and the frontend lint/format/types/876 vitest/build.

While adding the axe audit it also surfaced a **pre-existing** unrelated violation on the same page — the emoji image file input had no accessible name — which blocked the required audit, so it's fixed inline with an `$t`-backed `aria-label` (+ `lang/fr.json` key).

## i18n / docs

- Added the `Emoji image` key to `lang/fr.json`.
- No docs change: this is a theme token, not an operator-facing setting.

## Scope note

Criterion 4 (no other `linkDestructive` call site regresses) holds: all five call sites route through the single variant, and the change only raises contrast. Separately, several **non-Button** `text-destructive` usages at small sizes (e.g. `AuditExports.vue`, `integrations/Index.vue`, `RevealSecretDialog.vue`) share the same latent debt on the fill-as-text token — out of scope here; I'll file a follow-up to migrate/audit those.