### PR TITLE
fix: give destructive inline text an AA-accessible token everywhere

### DIFF
--- a/eslint-rules/no-destructive-fill-as-text.js
+++ b/eslint-rules/no-destructive-fill-as-text.js
@@ -1,0 +1,101 @@
+/**
+ * Flags the `--destructive` *fill* token painted as text (`text-destructive`)
+ * and auto-fixes it to `text-destructive-text`, the accessible text form.
+ *
+ * The fill token is tuned to carry `--destructive-foreground` on a solid button,
+ * not to be read as ink: as inline text it measures 3.93:1 on the dark card and
+ * 3.60:1 on the `bg-destructive/10` tint, below the 4.5:1 WCAG AA bar the theme
+ * holds itself to (#678, #717). `--destructive-text` is the same hue tuned to
+ * clear AA on every surface destructive copy lands on, so text, error captions,
+ * status pills and the icons sitting beside them should all use it.
+ *
+ * `text-destructive-foreground` (ink *on* a solid destructive fill) and every
+ * non-text utility (`bg-destructive/10`, `border-destructive/25`) are untouched.
+ */
+
+/**
+ * Matches the `text-destructive` utility with any variant, `!` or opacity
+ * modifier around it, but not the longer `text-destructive-text` /
+ * `text-destructive-foreground` tokens, and not a utility that merely ends in
+ * the same word (`context-destructive`).
+ */
+const DESTRUCTIVE_TEXT = /(?<![\w-])text-destructive(?![\w-])/g;
+
+const SUGGESTION = 'text-destructive-text';
+
+/**
+ * @typedef {object} DestructiveTextMatch
+ * @property {number} start Offset of the utility within `text`.
+ * @property {string} original The flagged utility, always `text-destructive`.
+ * @property {string} suggestion The accessible replacement.
+ */
+
+/**
+ * Finds every use of the destructive *fill* token as a text colour in a class
+ * string.
+ *
+ * @param {string} text
+ * @returns {DestructiveTextMatch[]}
+ */
+export function findDestructiveTextUtilities(text) {
+    return [...text.matchAll(DESTRUCTIVE_TEXT)].map((match) => ({
+        start: match.index,
+        original: match[0],
+        suggestion: SUGGESTION,
+    }));
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+    meta: {
+        type: 'problem',
+        fixable: 'code',
+        docs: {
+            description:
+                'Use the accessible `text-destructive-text` token instead of painting the `--destructive` fill token as text.',
+        },
+        schema: [],
+        messages: {
+            preferDestructiveText:
+                "Use '{{ suggestion }}' instead of '{{ original }}'; the fill token drops below WCAG AA 4.5:1 as inline text on the dark card and on the `bg-destructive/10` tint.",
+        },
+    },
+    create(context) {
+        const sourceCode = context.sourceCode;
+
+        const check = (node) => {
+            const text = sourceCode.getText(node);
+
+            for (const {
+                start,
+                original,
+                suggestion,
+            } of findDestructiveTextUtilities(text)) {
+                const from = node.range[0] + start;
+                const to = from + original.length;
+
+                context.report({
+                    node,
+                    messageId: 'preferDestructiveText',
+                    data: { original, suggestion },
+                    fix: (fixer) => fixer.replaceTextRange([from, to], suggestion),
+                });
+            }
+        };
+
+        const scriptVisitor = { Literal: check, TemplateElement: check };
+        const defineTemplateBodyVisitor =
+            sourceCode.parserServices?.defineTemplateBodyVisitor;
+
+        if (defineTemplateBodyVisitor) {
+            return defineTemplateBodyVisitor(
+                { VLiteral: check, Literal: check, TemplateElement: check },
+                scriptVisitor,
+            );
+        }
+
+        return scriptVisitor;
+    },
+};
+
+export default rule;

--- a/eslint-rules/no-destructive-fill-as-text.test.ts
+++ b/eslint-rules/no-destructive-fill-as-text.test.ts
@@ -1,5 +1,9 @@
+import { RuleTester } from 'eslint';
 import { describe, expect, it } from 'vitest';
-import { findDestructiveTextUtilities } from './no-destructive-fill-as-text.js';
+import vueParser from 'vue-eslint-parser';
+import rule, {
+    findDestructiveTextUtilities,
+} from './no-destructive-fill-as-text.js';
 
 describe('findDestructiveTextUtilities', () => {
     it('flags the bare fill utility with the accessible text token', () => {
@@ -64,4 +68,57 @@ describe('findDestructiveTextUtilities', () => {
             findDestructiveTextUtilities('context-destructive'),
         ).toEqual([]);
     });
+});
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parser: vueParser,
+        ecmaVersion: 2022,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('no-destructive-fill-as-text', rule, {
+    valid: [
+        {
+            filename: 'resources/js/components/InputError.vue',
+            code: '<template><p class="text-sm text-destructive-text">Nope</p></template>',
+        },
+        {
+            filename: 'resources/js/components/ui/alert/index.ts',
+            code: 'export const variant = "bg-destructive text-destructive-foreground"',
+        },
+        {
+            filename: 'resources/js/components/SecurityActivity.vue',
+            code: '<template><span class="border-destructive/25 bg-destructive/10" /></template>',
+        },
+    ],
+    invalid: [
+        {
+            filename: 'resources/js/components/InputError.vue',
+            code: '<template><p class="text-sm text-destructive">Nope</p></template>',
+            output: '<template><p class="text-sm text-destructive-text">Nope</p></template>',
+            errors: [{ messageId: 'preferDestructiveText' }],
+        },
+        {
+            // Every occurrence is flagged, and the variant, `!` and opacity
+            // modifiers wrapped around the utility survive the fix.
+            filename: 'resources/js/components/MessageActions.vue',
+            code: "<template><span :class=\"'hover:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive'\" /></template>",
+            output: "<template><span :class=\"'hover:text-destructive-text data-[variant=destructive]:*:[svg]:!text-destructive-text'\" /></template>",
+            errors: [
+                { messageId: 'preferDestructiveText' },
+                { messageId: 'preferDestructiveText' },
+            ],
+        },
+        {
+            filename: 'resources/js/components/ui/alert/index.ts',
+            code: 'export const variant = "text-destructive bg-card"',
+            output: 'export const variant = "text-destructive-text bg-card"',
+            errors: [{ messageId: 'preferDestructiveText' }],
+        },
+    ],
 });

--- a/eslint-rules/no-destructive-fill-as-text.test.ts
+++ b/eslint-rules/no-destructive-fill-as-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { findDestructiveTextUtilities } from './no-destructive-fill-as-text.js';
+
+describe('findDestructiveTextUtilities', () => {
+    it('flags the bare fill utility with the accessible text token', () => {
+        expect(
+            findDestructiveTextUtilities('flex text-xs text-destructive'),
+        ).toEqual([
+            {
+                start: 13,
+                original: 'text-destructive',
+                suggestion: 'text-destructive-text',
+            },
+        ]);
+    });
+
+    it('reports every occurrence in a class string', () => {
+        expect(
+            findDestructiveTextUtilities(
+                'text-destructive hover:text-destructive focus:text-destructive',
+            ),
+        ).toHaveLength(3);
+    });
+
+    it('keeps variant, important and opacity modifiers around the utility', () => {
+        const variants = findDestructiveTextUtilities(
+            "data-[variant=destructive]:text-destructive *:[svg]:!text-destructive *:data-[slot=alert-description]:text-destructive/90",
+        );
+
+        expect(variants).toHaveLength(3);
+        expect(variants.map((match) => match.original)).toEqual([
+            'text-destructive',
+            'text-destructive',
+            'text-destructive',
+        ]);
+    });
+
+    it('leaves the accessible text token alone', () => {
+        expect(
+            findDestructiveTextUtilities(
+                'text-destructive-text hover:text-destructive-text',
+            ),
+        ).toEqual([]);
+    });
+
+    it('leaves the on-fill foreground token alone', () => {
+        expect(
+            findDestructiveTextUtilities(
+                'bg-destructive text-destructive-foreground',
+            ),
+        ).toEqual([]);
+    });
+
+    it('leaves non-text destructive utilities alone', () => {
+        expect(
+            findDestructiveTextUtilities(
+                'bg-destructive/10 border-destructive/25 ring-destructive',
+            ),
+        ).toEqual([]);
+    });
+
+    it('ignores utilities that merely end in the same word', () => {
+        expect(
+            findDestructiveTextUtilities('context-destructive'),
+        ).toEqual([]);
+    });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -83,8 +83,8 @@ export default defineConfigWithVueTs(
             // Keep the `--destructive` fill token out of text colours: it reads
             // below WCAG AA as inline text on the dark card and on the
             // `bg-destructive/10` tint (#678, #717). `error` (auto-fixable via
-            // `npm run lint`) because every occurrence was migrated to
-            // `text-destructive-text`, so the gate stays clean.
+            // `./vendor/bin/sail npm run lint`) because every occurrence was
+            // migrated to `text-destructive-text`, so the gate stays clean.
             'local/no-destructive-fill-as-text': 'error',
         },
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import importPlugin from 'eslint-plugin-import';
 import vue from 'eslint-plugin-vue';
 import vuejsAccessibility from 'eslint-plugin-vuejs-accessibility';
 import noArbitraryTailwindSpacing from './eslint-rules/no-arbitrary-tailwind-spacing.js';
+import noDestructiveFillAsText from './eslint-rules/no-destructive-fill-as-text.js';
 import noRawButton from './eslint-rules/no-raw-button.js';
 
 const controlStatements = [
@@ -34,6 +35,7 @@ export default defineConfigWithVueTs(
             local: {
                 rules: {
                     'no-arbitrary-tailwind-spacing': noArbitraryTailwindSpacing,
+                    'no-destructive-fill-as-text': noDestructiveFillAsText,
                     'no-raw-button': noRawButton,
                 },
             },
@@ -78,6 +80,12 @@ export default defineConfigWithVueTs(
             // new stray ones. Genuinely bespoke controls opt out per-occurrence
             // with `<!-- eslint-disable-next-line local/no-raw-button -- reason -->`.
             'local/no-raw-button': 'error',
+            // Keep the `--destructive` fill token out of text colours: it reads
+            // below WCAG AA as inline text on the dark card and on the
+            // `bg-destructive/10` tint (#678, #717). `error` (auto-fixable via
+            // `npm run lint`) because every occurrence was migrated to
+            // `text-destructive-text`, so the gate stays clean.
+            'local/no-destructive-fill-as-text': 'error',
         },
     },
     {
@@ -138,11 +146,13 @@ export default defineConfigWithVueTs(
         },
     },
     {
-        // The rule's own tests embed arbitrary `[Npx]` utilities as fixtures;
-        // don't let the rule rewrite them.
-        files: ['eslint-rules/**/*.test.ts'],
+        // The rules' own tests embed the utilities they flag as fixtures, and
+        // `no-destructive-fill-as-text` matches its own detection regex; don't
+        // let the rules rewrite either.
+        files: ['eslint-rules/**'],
         rules: {
             'local/no-arbitrary-tailwind-spacing': 'off',
+            'local/no-destructive-fill-as-text': 'off',
         },
     },
     {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -137,11 +137,12 @@
     --accent-foreground: #1d1a15;
     --destructive: hsl(0 72% 45%);
     --destructive-foreground: #f3efe4;
-    /* Destructive as inline *text* (the `linkDestructive` <Button> variant, down
-       to text-xs). Darkened a touch from --destructive so it clears WCAG AA
-       4.5:1 on both --card and --background, which the fill token only just met
-       on the page background (#678). */
-    --destructive-text: #bd1f1f;
+    /* Destructive as inline *text* (error captions, status pills, the
+       `linkDestructive` <Button> variant, down to text-xs). Darkened from
+       --destructive so it clears WCAG AA 4.5:1 on both --card and --background,
+       which the fill token only just met on the page background (#678), and on
+       the dimmer `bg-destructive/10` tint composited over either (#717). */
+    --destructive-text: hsl(0 72% 40%);
     --border: #e3dfd5;
     --input: #e0dbcd;
     /* Focus indicator — decoupled from --brass and darkened to a bronze so the
@@ -204,10 +205,12 @@
     --accent-foreground: #f3efe4;
     --destructive: hsl(0 72% 55%);
     --destructive-foreground: #f3efe4;
-    /* Lightened from --destructive so destructive inline text (the
-       `linkDestructive` variant) clears WCAG AA 4.5:1 on the dark card; the fill
-       token measured 3.92:1 as text there (#678). */
-    --destructive-text: #e75555;
+    /* Lightened from --destructive so destructive inline text (error captions,
+       status pills, the `linkDestructive` variant) clears WCAG AA 4.5:1 on the
+       dark card; the fill token measured 3.92:1 as text there (#678). Lightened
+       again for the `bg-destructive/10` tint, which composites *up* on a dark
+       surface and left the text at 4.37:1 (#717). */
+    --destructive-text: hsl(0 72% 64%);
     --border: #2e2a21;
     --input: #2a271f;
     --ring: #c9a35c;

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -492,7 +492,7 @@ const groupParticipantCount = computed(
                         />
                         <DropdownMenuItem
                             data-test="archive-channel"
-                            class="text-destructive focus:text-destructive"
+                            class="text-destructive-text focus:text-destructive-text"
                             @select="emit('archive')"
                         >
                             <Archive class="size-4" />
@@ -507,7 +507,7 @@ const groupParticipantCount = computed(
                         />
                         <DropdownMenuItem
                             data-test="leave-channel"
-                            class="text-destructive focus:text-destructive"
+                            class="text-destructive-text focus:text-destructive-text"
                             @select="emit('leave')"
                         >
                             <LogOut class="size-4" />

--- a/resources/js/components/DataPrivacy.vue
+++ b/resources/js/components/DataPrivacy.vue
@@ -133,7 +133,7 @@ function formatDate(iso: string): string {
                 </p>
             </template>
             <template v-else-if="hasFailed">
-                <p class="text-sm font-semibold text-destructive">
+                <p class="text-sm font-semibold text-destructive-text">
                     {{ $t("We couldn't prepare your last export") }}
                 </p>
                 <p class="text-xs text-muted-foreground">

--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -14,7 +14,7 @@ const { demoMode } = useDemoMode();
     <DemoLock v-if="demoMode" v-slot="{ disabled }">
         <Button
             variant="outline"
-            class="rounded-full border-destructive/40 text-destructive hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive"
+            class="rounded-full border-destructive/40 text-destructive-text hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive-text"
             data-test="delete-user-button"
             :disabled="disabled"
             >{{ $t('Delete account…') }}</Button
@@ -32,7 +32,7 @@ const { demoMode } = useDemoMode();
         <template #trigger>
             <Button
                 variant="outline"
-                class="rounded-full border-destructive/40 text-destructive hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive"
+                class="rounded-full border-destructive/40 text-destructive-text hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive-text"
                 data-test="delete-user-button"
                 >{{ $t('Delete account…') }}</Button
             >

--- a/resources/js/components/InputError.vue
+++ b/resources/js/components/InputError.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 <template>
     <div v-show="message">
-        <p class="text-sm text-destructive">
+        <p class="text-sm text-destructive-text">
             {{ message }}
         </p>
     </div>

--- a/resources/js/components/MessageActions.vue
+++ b/resources/js/components/MessageActions.vue
@@ -186,7 +186,7 @@ const openStateClass = 'bg-accent text-accent-foreground';
 
 /** Delete recolors to the destructive token on hover instead of neutral. */
 const deleteButtonClass =
-    'text-muted-foreground hover:bg-destructive/10 hover:text-destructive';
+    'text-muted-foreground hover:bg-destructive/10 hover:text-destructive-text';
 </script>
 
 <template>

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1508,7 +1508,7 @@ function onKeydown(event: KeyboardEvent): void {
                             class="relative flex h-19 min-w-50 items-center gap-2.5 rounded-xl border border-destructive/40 bg-destructive/10 px-3"
                         >
                             <span
-                                class="flex size-9.5 shrink-0 items-center justify-center rounded-[10px] bg-destructive/15 text-destructive"
+                                class="flex size-9.5 shrink-0 items-center justify-center rounded-[10px] bg-destructive/15 text-destructive-text"
                             >
                                 <CircleAlert class="size-4.5" />
                             </span>
@@ -1518,7 +1518,7 @@ function onKeydown(event: KeyboardEvent): void {
                                 >
                                     {{ item.name }}
                                 </span>
-                                <span class="text-[11px] text-destructive">
+                                <span class="text-[11px] text-destructive-text">
                                     {{ $t('Upload failed') }} ·
                                     <Button
                                         variant="unstyled"
@@ -1695,7 +1695,7 @@ function onKeydown(event: KeyboardEvent): void {
                         class="text-sm font-semibold tabular-nums"
                         :class="
                             recorder.isNearingLimit.value
-                                ? 'text-destructive'
+                                ? 'text-destructive-text'
                                 : 'text-foreground'
                         "
                         aria-live="off"

--- a/resources/js/components/PollComposerPanel.vue
+++ b/resources/js/components/PollComposerPanel.vue
@@ -234,7 +234,7 @@ function submit(): void {
                         <span
                             v-if="isDuplicate(index)"
                             data-test="poll-duplicate-error"
-                            class="pl-0.5 text-[12px] text-destructive"
+                            class="pl-0.5 text-[12px] text-destructive-text"
                         >
                             {{
                                 $t('Options must be different from each other.')

--- a/resources/js/components/RemindersDialog.vue
+++ b/resources/js/components/RemindersDialog.vue
@@ -105,7 +105,7 @@ function openReminder(reminder: MessageReminder): void {
                         size="none"
                         type="button"
                         data-test="reminders-clear-all"
-                        class="ml-auto font-sans text-[12.5px] font-medium text-muted-foreground transition-colors hover:text-destructive"
+                        class="ml-auto font-sans text-[12.5px] font-medium text-muted-foreground transition-colors hover:text-destructive-text"
                         @click="emit('clearAll')"
                     >
                         {{ $t('Clear all') }}
@@ -242,7 +242,7 @@ function openReminder(reminder: MessageReminder): void {
                                 type="button"
                                 data-test="reminder-clear"
                                 :aria-label="$t('Clear reminder')"
-                                class="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:text-destructive"
+                                class="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:text-destructive-text"
                                 @click="emit('clear', reminder.id)"
                             >
                                 <X class="size-4" />

--- a/resources/js/components/ScheduleMessageDialog.vue
+++ b/resources/js/components/ScheduleMessageDialog.vue
@@ -293,7 +293,7 @@ function confirm(): void {
                 <p
                     v-else-if="preview"
                     data-test="schedule-past"
-                    class="text-[12.5px] text-destructive"
+                    class="text-[12.5px] text-destructive-text"
                 >
                     {{ $t('Pick a time in the future.') }}
                 </p>

--- a/resources/js/components/ScheduledMessagesDialog.vue
+++ b/resources/js/components/ScheduledMessagesDialog.vue
@@ -229,7 +229,7 @@ function bodyPreview(body: string): string {
                                     type="button"
                                     :aria-label="$t('Cancel scheduled message')"
                                     data-test="scheduled-cancel"
-                                    class="size-7 rounded-full text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                                    class="size-7 rounded-full text-muted-foreground hover:bg-destructive/10 hover:text-destructive-text"
                                     @click="cancelSend(scheduled)"
                                 >
                                     <Trash2 class="size-3.5" />

--- a/resources/js/components/SecurityActivity.vue
+++ b/resources/js/components/SecurityActivity.vue
@@ -60,7 +60,7 @@ function occurredAt(iso: string): string {
                     <span class="truncate">{{ event.label }}</span>
                     <span
                         v-if="event.isNewDevice"
-                        class="inline-flex h-4.75 shrink-0 items-center rounded-full border border-destructive/25 bg-destructive/10 px-2.5 text-[10.5px] font-semibold tracking-[0.05em] text-destructive uppercase"
+                        class="inline-flex h-4.75 shrink-0 items-center rounded-full border border-destructive/25 bg-destructive/10 px-2.5 text-[10.5px] font-semibold tracking-[0.05em] text-destructive-text uppercase"
                         data-test="new-device-badge"
                     >
                         {{ $t('New device') }}

--- a/resources/js/components/SettingsPaneSection.vue
+++ b/resources/js/components/SettingsPaneSection.vue
@@ -22,7 +22,7 @@ defineProps<{
             <div class="flex min-w-0 flex-col gap-0.5">
                 <h3
                     class="font-serif text-[17px] font-semibold"
-                    :class="destructive ? 'text-destructive' : ''"
+                    :class="destructive ? 'text-destructive-text' : ''"
                 >
                     {{ title
                     }}<span

--- a/resources/js/components/integrations/RevealSecretDialog.vue
+++ b/resources/js/components/integrations/RevealSecretDialog.vue
@@ -124,7 +124,7 @@ function close(): void {
                         </Button>
                     </div>
                     <p
-                        class="flex items-start gap-1.5 text-xs text-destructive"
+                        class="flex items-start gap-1.5 text-xs text-destructive-text"
                     >
                         <TriangleAlert class="mt-0.5 size-3.5 shrink-0" />
                         <span>{{ caption }}</span>

--- a/resources/js/components/settings/AvatarUpload.vue
+++ b/resources/js/components/settings/AvatarUpload.vue
@@ -121,7 +121,7 @@ function removePhoto(): void {
                     type="button"
                     variant="outline"
                     size="sm"
-                    class="rounded-full text-destructive hover:text-destructive"
+                    class="rounded-full text-destructive-text hover:text-destructive-text"
                     :disabled="uploadForm.processing || removeForm.processing"
                     data-test="remove-avatar-button"
                     @click="removePhoto"
@@ -133,7 +133,7 @@ function removePhoto(): void {
             <p
                 v-if="uploadForm.errors.photo"
                 role="alert"
-                class="text-sm text-destructive"
+                class="text-sm text-destructive-text"
                 data-test="avatar-error"
             >
                 {{ uploadForm.errors.photo }}

--- a/resources/js/components/ui/alert/index.ts
+++ b/resources/js/components/ui/alert/index.ts
@@ -11,8 +11,11 @@ export const alertVariants = cva(
     variants: {
       variant: {
         default: "bg-card text-card-foreground",
+        // --destructive-text, not the --destructive fill: the fill reads at
+        // 3.93:1 as body copy on the dark card (#717). The description keeps the
+        // same token at full opacity — dimming it to /90 dropped it to 4.35:1.
         destructive:
-          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+          "text-destructive-text bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive-text",
       },
     },
     defaultVariants: {

--- a/resources/js/components/ui/dropdown-menu/DropdownMenuItem.vue
+++ b/resources/js/components/ui/dropdown-menu/DropdownMenuItem.vue
@@ -19,12 +19,16 @@ const forwardedProps = useForwardProps(delegatedProps)
 </script>
 
 <template>
+  <!-- The destructive variant paints --destructive-text rather than the
+       --destructive fill (3.93:1 as menu text on the dark popover, #717), and
+       keeps the /10 focus tint in both themes: shadcn's dark-mode bump to /20
+       lightens the fill enough to pull that text back under AA. -->
   <DropdownMenuItem
     data-slot="dropdown-menu-item"
     :data-inset="inset ? '' : undefined"
     :data-variant="variant"
     v-bind="forwardedProps"
-    :class="cn('focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*=\'text-\'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4', props.class)"
+    :class="cn('focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive-text data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive-text data-[variant=destructive]:*:[svg]:!text-destructive-text [&_svg:not([class*=\'text-\'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4', props.class)"
   >
     <slot />
   </DropdownMenuItem>

--- a/resources/js/components/ui/dropdown-menu/DropdownMenuSubTrigger.vue
+++ b/resources/js/components/ui/dropdown-menu/DropdownMenuSubTrigger.vue
@@ -21,7 +21,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     v-bind="forwardedProps"
     :data-inset="inset ? '' : undefined"
     :class="cn(
-      'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4 data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*=\'text-\'])]:text-muted-foreground',
+      'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4 data-[variant=destructive]:*:[svg]:!text-destructive-text [&_svg:not([class*=\'text-\'])]:text-muted-foreground',
       props.class,
     )"
   >

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -112,7 +112,7 @@ const {
                 <p
                     v-if="passkeyError"
                     role="alert"
-                    class="text-center text-sm text-destructive"
+                    class="text-center text-sm text-destructive-text"
                     data-test="passkey-login-error"
                 >
                     {{ passkeyError }}

--- a/resources/js/pages/teams/AuditExports.vue
+++ b/resources/js/pages/teams/AuditExports.vue
@@ -353,7 +353,7 @@ function downloadUrl(entry: AuditExport): string {
 
             <p
                 v-if="rangeError"
-                class="flex items-center gap-1.5 text-xs font-medium text-destructive"
+                class="flex items-center gap-1.5 text-xs font-medium text-destructive-text"
                 data-test="audit-export-range-error"
             >
                 <AlertCircle class="size-3.5" />
@@ -496,7 +496,7 @@ function downloadUrl(entry: AuditExport): string {
                         <!-- Failed -->
                         <template v-else-if="rowState(entry) === 'failed'">
                             <span
-                                class="inline-flex items-center rounded-full border border-destructive/25 bg-destructive/10 px-3 py-1 text-[11.5px] font-semibold text-destructive"
+                                class="inline-flex items-center rounded-full border border-destructive/25 bg-destructive/10 px-3 py-1 text-[11.5px] font-semibold text-destructive-text"
                                 data-test="audit-export-status-failed"
                             >
                                 {{ $t('Failed') }}

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -772,7 +772,9 @@ const confirmTransferOwnership = (member: TeamMember) => {
             class="py-6"
         >
             <div class="mb-3">
-                <h2 class="font-serif text-lg font-semibold text-destructive">
+                <h2
+                    class="font-serif text-lg font-semibold text-destructive-text"
+                >
                     {{ $t('Delete team') }}
                 </h2>
                 <p class="mt-0.5 max-w-xl text-sm text-muted-foreground">
@@ -787,7 +789,7 @@ const confirmTransferOwnership = (member: TeamMember) => {
                 <Button
                     data-test="delete-team-button"
                     variant="outline"
-                    class="rounded-full border-destructive/40 text-destructive hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive"
+                    class="rounded-full border-destructive/40 text-destructive-text hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive-text"
                     :disabled="disabled"
                     @click="deleteDialogOpen = true"
                     >{{ $t('Delete team…') }}</Button

--- a/resources/js/pages/teams/Groups.vue
+++ b/resources/js/pages/teams/Groups.vue
@@ -335,7 +335,7 @@ function confirmRemoval(): void {
                     type="button"
                     :data-test="`group-remove-${group.slug}`"
                     :aria-label="$t('Delete :name', { name: group.name })"
-                    class="shrink-0 rounded-full text-destructive"
+                    class="shrink-0 rounded-full text-destructive-text"
                     @click="pendingRemoval = group"
                 >
                     <Trash2 class="size-4" />

--- a/resources/js/pages/teams/SecurityLog.vue
+++ b/resources/js/pages/teams/SecurityLog.vue
@@ -183,7 +183,7 @@ function dotClass(event: TeamSecurityEvent): string {
                         <span class="truncate">{{ event.actorName }}</span>
                         <span
                             v-if="event.isNewDevice"
-                            class="inline-flex h-4.75 shrink-0 items-center rounded-full border border-destructive/25 bg-destructive/10 px-2.5 text-[10.5px] font-semibold tracking-[0.05em] text-destructive uppercase"
+                            class="inline-flex h-4.75 shrink-0 items-center rounded-full border border-destructive/25 bg-destructive/10 px-2.5 text-[10.5px] font-semibold tracking-[0.05em] text-destructive-text uppercase"
                             data-test="security-log-new-device-badge"
                         >
                             {{ $t('New device') }}

--- a/resources/js/pages/teams/integrations/Bot.vue
+++ b/resources/js/pages/teams/integrations/Bot.vue
@@ -382,7 +382,9 @@ function confirmDeleteBot(): void {
         <!-- Danger zone -->
         <section class="flex flex-col gap-3 border-t border-border pt-6">
             <div class="flex flex-col gap-0.5">
-                <h2 class="font-serif text-lg font-semibold text-destructive">
+                <h2
+                    class="font-serif text-lg font-semibold text-destructive-text"
+                >
                     {{ $t('Delete bot') }}
                 </h2>
                 <p class="text-xs text-muted-foreground">
@@ -396,7 +398,7 @@ function confirmDeleteBot(): void {
             <Button
                 type="button"
                 variant="outline"
-                class="self-start rounded-full border-destructive/40 text-destructive hover:bg-destructive/10"
+                class="self-start rounded-full border-destructive/40 text-destructive-text hover:bg-destructive/10"
                 data-test="delete-bot-button"
                 @click="showDeleteBot = true"
             >

--- a/resources/js/pages/teams/integrations/Index.vue
+++ b/resources/js/pages/teams/integrations/Index.vue
@@ -454,7 +454,7 @@ function submitOutgoing(): void {
                     </span>
                     <span
                         v-else
-                        class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-destructive"
+                        class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-destructive-text"
                     >
                         <span
                             class="size-1.5 rounded-full bg-destructive"

--- a/resources/js/pages/teams/integrations/Webhook.vue
+++ b/resources/js/pages/teams/integrations/Webhook.vue
@@ -139,7 +139,7 @@ function confirmRevoke(): void {
                     </h1>
                     <span
                         v-if="isDisabled"
-                        class="inline-flex items-center gap-1.5 rounded-full border border-destructive/35 bg-destructive/10 px-2.5 py-0.5 text-xs font-semibold text-destructive"
+                        class="inline-flex items-center gap-1.5 rounded-full border border-destructive/35 bg-destructive/10 px-2.5 py-0.5 text-xs font-semibold text-destructive-text"
                     >
                         <span
                             class="size-1.5 rounded-full bg-destructive"
@@ -183,7 +183,7 @@ function confirmRevoke(): void {
         <!-- Auto-disable banner -->
         <div
             v-if="isDisabled"
-            class="flex items-start gap-2 rounded-xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+            class="flex items-start gap-2 rounded-xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive-text"
             data-test="auto-disable-banner"
         >
             <TriangleAlert class="mt-0.5 size-4 shrink-0" />
@@ -269,7 +269,7 @@ function confirmRevoke(): void {
                                 :class="
                                     delivery.succeeded
                                         ? 'text-green-600 dark:text-green-500'
-                                        : 'text-destructive'
+                                        : 'text-destructive-text'
                                 "
                             >
                                 {{
@@ -330,7 +330,7 @@ function confirmRevoke(): void {
             <Button
                 type="button"
                 variant="outline"
-                class="self-start rounded-full border-destructive/40 text-destructive hover:bg-destructive/10"
+                class="self-start rounded-full border-destructive/40 text-destructive-text hover:bg-destructive/10"
                 data-test="revoke-subscription-button"
                 @click="showRevoke = true"
             >

--- a/resources/js/theme/contrast.test.ts
+++ b/resources/js/theme/contrast.test.ts
@@ -28,6 +28,36 @@ function hexToRgb(hex: string): Rgb {
     return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16)) as Rgb;
 }
 
+/** Convert an `hsl(H S% L%)` triple to RGB (CSS Color 4 space-separated form). */
+function hslToRgb(hue: number, saturation: number, lightness: number): Rgb {
+    const s = saturation / 100;
+    const l = lightness / 100;
+    const a = s * Math.min(l, 1 - l);
+    const channel = (n: number): number => {
+        const k = (n + hue / 30) % 12;
+
+        return Math.round(
+            (l - a * Math.max(-1, Math.min(k - 3, Math.min(9 - k, 1)))) * 255,
+        );
+    };
+
+    return [channel(0), channel(8), channel(4)] as Rgb;
+}
+
+/**
+ * Parse a token value into RGB. Surfaces ship as `#rrggbb`, but the fill tokens
+ * (`--destructive`) ship as `hsl(H S% L%)`, so both forms must resolve.
+ */
+function parseColor(value: string): Rgb {
+    const hsl = /hsl\(\s*([\d.]+)\s+([\d.]+)%\s+([\d.]+)%\s*\)/.exec(value);
+
+    if (hsl) {
+        return hslToRgb(Number(hsl[1]), Number(hsl[2]), Number(hsl[3]));
+    }
+
+    return hexToRgb(value);
+}
+
 /** Composite a translucent foreground over an opaque background. */
 function flatten(fg: Rgb, alpha: number, bg: Rgb): Rgb {
     return fg.map((c, i) => c * alpha + bg[i] * (1 - alpha)) as Rgb;
@@ -236,7 +266,7 @@ describe('theme contrast (WCAG AA)', () => {
         (surface) => {
             expect(
                 contrast(
-                    hexToRgb(light['destructive-text']),
+                    parseColor(light['destructive-text']),
                     hexToRgb(light[surface]),
                 ),
             ).toBeGreaterThanOrEqual(AA_TEXT);
@@ -248,9 +278,47 @@ describe('theme contrast (WCAG AA)', () => {
         (surface) => {
             expect(
                 contrast(
-                    hexToRgb(dark['destructive-text']),
+                    parseColor(dark['destructive-text']),
                     hexToRgb(dark[surface]),
                 ),
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+        },
+    );
+
+    // Destructive status pills, the failed-attachment chip, the auto-disable
+    // banner and the destructive dropdown item's focus state all paint that same
+    // text on a translucent `bg-destructive/10` tint rather than a bare surface
+    // (#717). The tint composites against whatever sits behind it — `--card` on
+    // desktop, `--background` on the mobile full-bleed pane — and each composite
+    // is dimmer for the text than the bare surface was, so both must be locked.
+    const DESTRUCTIVE_TINT_ALPHA = 0.1; // matches the `bg-destructive/10` utility
+
+    it.each(destructiveTextSurfaces)(
+        'light --destructive-text meets AA on the destructive tint over --%s',
+        (surface) => {
+            const tint = flatten(
+                parseColor(light['destructive']),
+                DESTRUCTIVE_TINT_ALPHA,
+                hexToRgb(light[surface]),
+            );
+
+            expect(
+                contrast(parseColor(light['destructive-text']), tint),
+            ).toBeGreaterThanOrEqual(AA_TEXT);
+        },
+    );
+
+    it.each(destructiveTextSurfaces)(
+        'dark --destructive-text meets AA on the destructive tint over --%s',
+        (surface) => {
+            const tint = flatten(
+                parseColor(dark['destructive']),
+                DESTRUCTIVE_TINT_ALPHA,
+                hexToRgb(dark[surface]),
+            );
+
+            expect(
+                contrast(parseColor(dark['destructive-text']), tint),
             ).toBeGreaterThanOrEqual(AA_TEXT);
         },
     );

--- a/tests/Browser/A11yDestructiveTextTest.php
+++ b/tests/Browser/A11yDestructiveTextTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\WebhookSubscription;
+
+/**
+ * Seed a workspace holding an auto-disabled webhook subscription, so its detail
+ * page renders the two shapes destructive copy takes outside the
+ * `linkDestructive` <Button> covered by #678: the "Auto-disabled" pill and the
+ * auto-disable banner, both painting destructive text on a translucent
+ * `bg-destructive/10` tint composited over the settings surface (#717).
+ *
+ * @return array{owner: User, team: Team, subscription: WebhookSubscription}
+ */
+function browserTeamWithDisabledWebhook(): array
+{
+    ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
+
+    $subscription = WebhookSubscription::factory()->disabled()->create([
+        'team_id' => $team->id,
+        'created_by' => $alice->id,
+        'name' => 'Deploy notifier',
+    ]);
+
+    return ['owner' => $alice, 'team' => $team, 'subscription' => $subscription];
+}
+
+test('destructive status text passes the axe audit in either theme', function (): void {
+    [
+        'owner' => $alice,
+        'team' => $team,
+        'subscription' => $subscription,
+    ] = browserTeamWithDisabledWebhook();
+
+    $page = signInThroughBrowser($alice)
+        ->navigate("/settings/teams/{$team->slug}/integrations/webhooks/{$subscription->id}")
+        ->assertSee('Auto-disabled')
+        // The banner is the destructive text-sm copy on the tinted fill; the pill
+        // is the same token at text-xs. Both are what the audit exists to guard.
+        ->assertPresent('[data-test="auto-disable-banner"]')
+        ->assertNoAccessibilityIssues();
+
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});


### PR DESCRIPTION
Closes #717.

## What

`#678` gave the `linkDestructive` `<Button>` variant a dedicated `--destructive-text` token because the `--destructive` *fill* measured 3.92:1 as inline text on the dark card. The same fill token was still painted as text all over the app — this finishes the job.

Audited every `text-destructive` occurrence against the surfaces it actually renders on (`--card` on desktop / `--background` on the mobile full-bleed pane, plus the dialog and popover surfaces that sit between them). As text the fill token measures:

| | light | dark |
|---|---|---|
| on `--card` | 5.74 | **3.93** |
| on `--background` | 4.59 | **4.35** |
| on `bg-destructive/10` over `--card` | 4.87 | **3.60** |
| on `bg-destructive/10` over `--background` | **3.94** | **4.02** |

## How

- **Migrated every text use to `text-destructive-text`** — the 6 call sites named in the issue plus the rest the grep turned up: `InputError`, `AlertError`/`ui/alert`, the login error, `DataPrivacy`, `AvatarUpload`, the danger-zone headings and outline buttons in `teams/Edit`, `Bot`, `Webhook`, `Groups`, the `hover:` states in `MessageActions`/`RemindersDialog`/`ScheduledMessagesDialog`, and the destructive `DropdownMenuItem`/`DropdownMenuSubTrigger` variants.
- **Retuned `--destructive-text`** (`hsl(0 72% 43%)`→`40%` light, `55%`→`64%` dark) so it also clears AA on the translucent `bg-destructive/10` tint composited over either surface — the status pills, the failed-attachment chip and the auto-disable banner all paint on that tint, and it is dimmer for the text than the bare surface. Worst case is now 4.66:1 (dark) / 4.71:1 (light). The shift is small enough to be invisible side by side; verified in the running app in both themes.
- **Audited the badge/pill uses on their real composited background** rather than assuming: they are the reason for the token nudge above.
- **Dropped shadcn's dark-only `focus:bg-destructive/20`** on the destructive dropdown item to `/10`, matching light. Its extra darkening lightens the fill enough to pull the item's text back under AA (4.18:1) whatever the text token.
- **Removed the `/90` dim** on the destructive alert description — at 90% opacity it read 4.35:1 on the dark card.

## Testing

- `resources/js/theme/contrast.test.ts` now locks `--destructive-text` on the `bg-destructive/10` composite over both `--card` and `--background` in each theme, on top of the bare-surface cases. Both new cases failed before the token change (4.20:1 light, 4.37:1 dark) and pass after. The parser gained `hsl()` support, since the fill token ships as `hsl()`.
- `tests/Browser/A11yDestructiveTextTest.php` runs the axe audit over an auto-disabled webhook's detail page in both themes — the pill *and* the banner, i.e. the tinted-fill shapes. It failed against the pre-fix assets with exactly the contrast violations above.
- New `local/no-destructive-fill-as-text` ESLint rule (`error`, auto-fixable) so a bare `text-destructive` can't come back silently. Covered by unit tests over the matcher and `RuleTester` cases asserting the fix output. The shadcn `components/ui/` tree is ESLint-ignored, so those files were migrated by hand.
- Full gate green: `composer test` at 100% coverage, `lint:check`/`format:check`/`types:check`/`test:js`/`build`, and all 34 a11y browser tests.

No user-facing copy changed, so no i18n keys; nothing operator-facing, so no docs change.

Filed #723 for an unrelated `bin/worktree` bootstrap bug hit while setting up this worktree (it seeds before redis is started).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787311156&installation_model_id=428379&pr_number=724&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F724&signature=d658ab1941e99ab8d21d1df2d4cb194240c914f84daffd16c2fbb26c07ffb15a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->