### PR TITLE
fix: route every rendered HTML surface through a sanitizing SafeHtml component

### DIFF
--- a/docs/src/content/docs/reference/security.md
+++ b/docs/src/content/docs/reference/security.md
@@ -77,15 +77,15 @@ emits tags it writes itself. Then, whatever it produced is sanitized with
 tags and attributes just before the browser renders it.
 
 The second stage runs in exactly one component, `SafeHtml`, which is the only
-place in the app allowed to hand a string to the browser as markup. Every
-surface goes through it: message bodies, forwarded and quoted messages, the
-quick switcher, the threads list, search snippets, and the two-factor QR code.
-Each names the allow-list it renders under, so a search snippet can carry a
-highlight and nothing else, and a QR code can carry SVG shapes but no script.
+place in the interface allowed to render a string as markup. Every surface goes
+through it: message bodies, forwarded and quoted messages, the quick switcher,
+the threads list, search snippets, and the two-factor QR code. Each names the
+allow-list it renders under, so a search snippet can carry a highlight and
+nothing else, and a QR code can carry SVG shapes but no script.
 
 That rule is enforced mechanically rather than by review: the linter fails the
-build on any other component rendering raw HTML, so a new feature cannot open a
-second, unsanitized path by accident.
+build on any other component using Vue's `v-html` directive, so a new component
+cannot add a second, unsanitized rendering path by accident.
 
 None of this is configurable, and there is nothing to switch on. It is
 described here because it is the control that the policy below exists to back

--- a/docs/src/content/docs/reference/security.md
+++ b/docs/src/content/docs/reference/security.md
@@ -63,14 +63,42 @@ and [`SESSION_SECURE_COOKIE`](/reference/environment-variables/#session-cookies)
 `preload` is opt-in and off by default: it is effectively irreversible for a
 domain and commits every subdomain with it.
 
+## Rendered HTML is sanitized
+
+A chat app has to turn what people type into markup: bold text, mention pills,
+autolinked URLs, custom emoji, highlighted search hits. That is the classic
+cross-site-scripting surface, where a crafted message becomes script running in
+every reader's session.
+
+The Desk handles it in two stages. The code that builds that markup escapes
+every character of user input before it goes anywhere near a tag, and only ever
+emits tags it writes itself. Then, whatever it produced is sanitized with
+[DOMPurify](https://github.com/cure53/DOMPurify) against a fixed allow-list of
+tags and attributes just before the browser renders it.
+
+The second stage runs in exactly one component, `SafeHtml`, which is the only
+place in the app allowed to hand a string to the browser as markup. Every
+surface goes through it: message bodies, forwarded and quoted messages, the
+quick switcher, the threads list, search snippets, and the two-factor QR code.
+Each names the allow-list it renders under, so a search snippet can carry a
+highlight and nothing else, and a QR code can carry SVG shapes but no script.
+
+That rule is enforced mechanically rather than by review: the linter fails the
+build on any other component rendering raw HTML, so a new feature cannot open a
+second, unsanitized path by accident.
+
+None of this is configurable, and there is nothing to switch on. It is
+described here because it is the control that the policy below exists to back
+up.
+
 ## Content Security Policy
 
 Every web response carries a `Content-Security-Policy` header: the browser-side
 allow-list that decides which scripts, styles, images and connections a page may
-use. It does not replace output escaping. It caps the damage when escaping fails,
-which matters here because The Desk renders user-authored content nearly
-everywhere: messages, markdown, emoji names, link-preview titles, uploaded file
-names.
+use. It does not replace the output escaping and sanitization described above.
+It caps the damage if those ever fail, which matters here because The Desk
+renders user-authored content nearly everywhere: messages, markdown, emoji
+names, link-preview titles, uploaded file names.
 
 It is **on by default** and ships in the image, so every deployment inherits it
 without extra proxy configuration. See

--- a/eslint-rules/no-v-html-policy.test.ts
+++ b/eslint-rules/no-v-html-policy.test.ts
@@ -1,0 +1,36 @@
+import { ESLint } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the wiring rather than a rule implementation: `vue/no-v-html` is what
+ * keeps the DOMPurify trust boundary from being bypassed, and it only does that
+ * if it is an error everywhere except the one component that owns the boundary.
+ * Resolving the project config per file path is what proves both halves — a
+ * config typo, a stray `files` glob, or someone flipping the rule off would fail
+ * here.
+ */
+const eslint = new ESLint();
+
+async function severityFor(filePath: string): Promise<unknown> {
+    const config = await eslint.calculateConfigForFile(filePath);
+
+    return config.rules?.['vue/no-v-html']?.[0];
+}
+
+describe('the v-html policy', () => {
+    it('errors on v-html in an ordinary component', async () => {
+        expect(await severityFor('resources/js/components/Probe.vue')).toBe(2);
+    });
+
+    it('errors on v-html in a page', async () => {
+        expect(await severityFor('resources/js/pages/channels/Probe.vue')).toBe(
+            2,
+        );
+    });
+
+    it('allows v-html in the SafeHtml primitive that owns the trust boundary', async () => {
+        expect(await severityFor('resources/js/components/SafeHtml.vue')).toBe(
+            0,
+        );
+    });
+});

--- a/eslint-rules/no-v-html-policy.test.ts
+++ b/eslint-rules/no-v-html-policy.test.ts
@@ -11,10 +11,13 @@ import { describe, expect, it } from 'vitest';
  */
 const eslint = new ESLint();
 
-async function severityFor(filePath: string): Promise<unknown> {
+async function severityFor(
+    filePath: string,
+    rule = 'vue/no-v-html',
+): Promise<unknown> {
     const config = await eslint.calculateConfigForFile(filePath);
 
-    return config.rules?.['vue/no-v-html']?.[0];
+    return config.rules?.[rule]?.[0];
 }
 
 describe('the v-html policy', () => {
@@ -32,5 +35,21 @@ describe('the v-html policy', () => {
         expect(await severityFor('resources/js/components/SafeHtml.vue')).toBe(
             0,
         );
+    });
+
+    it('also clears the on-component variant for SafeHtml, whose directive sits on a dynamic <component>', async () => {
+        expect(
+            await severityFor(
+                'resources/js/components/SafeHtml.vue',
+                'vue/no-v-text-v-html-on-component',
+            ),
+        ).toBe(0);
+
+        expect(
+            await severityFor(
+                'resources/js/components/Probe.vue',
+                'vue/no-v-text-v-html-on-component',
+            ),
+        ).toBe(2);
     });
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,6 +78,27 @@ export default defineConfigWithVueTs(
             // new stray ones. Genuinely bespoke controls opt out per-occurrence
             // with `<!-- eslint-disable-next-line local/no-raw-button -- reason -->`.
             'local/no-raw-button': 'error',
+            // XSS trust boundary. Every run of HTML the client renders as markup
+            // must go through `<SafeHtml>`, which sanitizes it with DOMPurify
+            // against a named allowlist; a raw `v-html` anywhere else would
+            // bypass that boundary with nothing to catch it. Exempted for
+            // `SafeHtml.vue` itself just below — the one place the directive is
+            // allowed to appear.
+            'vue/no-v-html': 'error',
+        },
+    },
+    {
+        // `<SafeHtml>` owns the app's only `v-html`: it sanitizes its input
+        // before rendering it, which is precisely what the rule exists to
+        // guarantee everywhere else.
+        files: ['resources/js/components/SafeHtml.vue'],
+        rules: {
+            'vue/no-v-html': 'off',
+            // The directive sits on a `<component :is="as">`, which the rule
+            // reads as a component (where `v-html` would not render). `as` is
+            // typed to a closed set of plain HTML tags, so the case the rule
+            // guards against is unreachable here.
+            'vue/no-v-text-v-html-on-component': 'off',
         },
     },
     {

--- a/resources/js/components/MessageForward.vue
+++ b/resources/js/components/MessageForward.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Forward } from '@lucide/vue';
 import { computed } from 'vue';
+import SafeHtml from '@/components/SafeHtml.vue';
 import { useCustomEmojis } from '@/composables/useCustomEmojis';
 import { useUserGroups } from '@/composables/useUserGroups';
 import { renderMessageBody } from '@/lib/messageBody';
@@ -65,7 +66,7 @@ const rendered = computed(() =>
                 <p
                     class="mt-0.5 text-[13.5px] leading-[1.5] break-words whitespace-pre-wrap text-foreground/85"
                 >
-                    <span v-html="rendered"></span>
+                    <SafeHtml :html="rendered" variant="messageBody" />
                 </p>
             </template>
         </div>

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -10,6 +10,7 @@ import MessageForward from '@/components/MessageForward.vue';
 import MessagePoll from '@/components/MessagePoll.vue';
 import MessageQuote from '@/components/MessageQuote.vue';
 import MessageReactions from '@/components/MessageReactions.vue';
+import SafeHtml from '@/components/SafeHtml.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import {
@@ -1068,10 +1069,11 @@ function confirmDelete(): void {
                                         )"
                                         :key="index"
                                     >
-                                        <span
+                                        <SafeHtml
                                             v-if="segment.kind === 'html'"
-                                            v-html="segment.html"
-                                        ></span>
+                                            :html="segment.html"
+                                            variant="messageBody"
+                                        />
                                         <InlineMarks
                                             v-else-if="
                                                 segment.kind === 'mention'

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -8,6 +8,7 @@ import {
     index as searchPage,
     suggest as suggestMessages,
 } from '@/actions/App/Http/Controllers/Channels/SearchController';
+import SafeHtml from '@/components/SafeHtml.vue';
 import {
     CommandDialog,
     CommandGroup,
@@ -315,8 +316,8 @@ function openReminders(): void {
                         <p
                             class="mt-0.5 line-clamp-1 text-[13px] text-foreground/80"
                         >
-                            <span
-                                v-html="
+                            <SafeHtml
+                                :html="
                                     renderMessageBody(
                                         result.message.body,
                                         result.message.mentions,
@@ -324,7 +325,8 @@ function openReminders(): void {
                                         userGroups,
                                     )
                                 "
-                            ></span>
+                                variant="messageBody"
+                            />
                         </p>
                     </div>
                 </CommandItem>

--- a/resources/js/components/SafeHtml.test.ts
+++ b/resources/js/components/SafeHtml.test.ts
@@ -9,13 +9,20 @@ import SafeHtml from './SafeHtml.vue';
 
 let app: App | null = null;
 
+/**
+ * Mount `SafeHtml` into a fresh host, tearing down any app a previous call in the
+ * same test left behind — several cases render the component twice to compare
+ * two variants or two elements.
+ */
 function mount(props: {
     html: string;
     variant: SanitizeVariant;
-    as?: 'span' | 'div';
+    as?: 'span' | 'div' | 'p';
     class?: string;
     'data-test'?: string;
 }) {
+    unmount();
+
     const host = document.createElement('div');
     document.body.appendChild(host);
 
@@ -25,11 +32,13 @@ function mount(props: {
     return host;
 }
 
-afterEach(() => {
+function unmount(): void {
     app?.unmount();
     app = null;
     document.body.innerHTML = '';
-});
+}
+
+afterEach(unmount);
 
 describe('SafeHtml', () => {
     it('renders allowlisted markup as real elements', () => {
@@ -61,10 +70,6 @@ describe('SafeHtml', () => {
 
         expect(snippet.querySelector('mark')).not.toBeNull();
 
-        app?.unmount();
-        app = null;
-        document.body.innerHTML = '';
-
         const body = mount({
             html: '<mark>hit</mark>',
             variant: 'messageBody',
@@ -93,13 +98,17 @@ describe('SafeHtml', () => {
 
         expect(span.firstElementChild?.tagName).toBe('SPAN');
 
-        app?.unmount();
-        app = null;
-        document.body.innerHTML = '';
-
         const div = mount({ html: 'hi', variant: 'messageBody', as: 'div' });
 
         expect(div.firstElementChild?.tagName).toBe('DIV');
+
+        const paragraph = mount({
+            html: 'hi',
+            variant: 'messageBody',
+            as: 'p',
+        });
+
+        expect(paragraph.firstElementChild?.tagName).toBe('P');
     });
 
     it('passes attributes through to the rendered element', () => {

--- a/resources/js/components/SafeHtml.test.ts
+++ b/resources/js/components/SafeHtml.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+// DOMPurify needs a DOM; jsdom gives this file a `window` so the component
+// sanitizes exactly as it does in the browser.
+import { afterEach, describe, expect, it } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h, nextTick, ref } from 'vue';
+import type { SanitizeVariant } from '@/lib/sanitizeHtml';
+import SafeHtml from './SafeHtml.vue';
+
+let app: App | null = null;
+
+function mount(props: {
+    html: string;
+    variant: SanitizeVariant;
+    as?: 'span' | 'div';
+    class?: string;
+    'data-test'?: string;
+}) {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    app = createApp({ render: () => h(SafeHtml, props) });
+    app.mount(host);
+
+    return host;
+}
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('SafeHtml', () => {
+    it('renders allowlisted markup as real elements', () => {
+        const host = mount({
+            html: '<strong>bold</strong> and <em>italic</em>',
+            variant: 'messageBody',
+        });
+
+        expect(host.querySelector('strong')?.textContent).toBe('bold');
+        expect(host.querySelector('em')?.textContent).toBe('italic');
+    });
+
+    it('strips markup the variant does not allow', () => {
+        const host = mount({
+            html: '<img src=x onerror="alert(1)"><strong>kept</strong>',
+            variant: 'searchSnippet',
+        });
+
+        expect(host.querySelector('img')).toBeNull();
+        expect(host.querySelector('strong')).toBeNull();
+        expect(host.textContent).toBe('kept');
+    });
+
+    it('sanitizes under the variant it is given, not a shared allowlist', () => {
+        const snippet = mount({
+            html: '<mark>hit</mark>',
+            variant: 'searchSnippet',
+        });
+
+        expect(snippet.querySelector('mark')).not.toBeNull();
+
+        app?.unmount();
+        app = null;
+        document.body.innerHTML = '';
+
+        const body = mount({
+            html: '<mark>hit</mark>',
+            variant: 'messageBody',
+        });
+
+        expect(body.querySelector('mark')).toBeNull();
+        expect(body.textContent).toBe('hit');
+    });
+
+    it('keeps a QR code SVG intact under the qrCode variant', () => {
+        const host = mount({
+            html:
+                '<svg viewBox="0 0 1 1"><rect x="0" y="0" fill="#fff"/>' +
+                '<script>alert(1)</script></svg>',
+            variant: 'qrCode',
+            as: 'div',
+        });
+
+        expect(host.querySelector('svg')).not.toBeNull();
+        expect(host.querySelector('rect')?.getAttribute('fill')).toBe('#fff');
+        expect(host.querySelector('script')).toBeNull();
+    });
+
+    it('renders a span by default and the requested element otherwise', () => {
+        const span = mount({ html: 'hi', variant: 'messageBody' });
+
+        expect(span.firstElementChild?.tagName).toBe('SPAN');
+
+        app?.unmount();
+        app = null;
+        document.body.innerHTML = '';
+
+        const div = mount({ html: 'hi', variant: 'messageBody', as: 'div' });
+
+        expect(div.firstElementChild?.tagName).toBe('DIV');
+    });
+
+    it('passes attributes through to the rendered element', () => {
+        const host = mount({
+            html: 'hi',
+            variant: 'messageBody',
+            class: 'text-sm',
+            'data-test': 'body',
+        });
+
+        const element = host.firstElementChild;
+
+        expect(element?.getAttribute('class')).toBe('text-sm');
+        expect(element?.getAttribute('data-test')).toBe('body');
+    });
+
+    it('re-sanitizes when the html changes', async () => {
+        const html = ref('<strong>first</strong>');
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+
+        app = createApp({
+            render: () =>
+                h(SafeHtml, { html: html.value, variant: 'messageBody' }),
+        });
+        app.mount(host);
+
+        expect(host.querySelector('strong')?.textContent).toBe('first');
+
+        html.value = '<script>alert(1)</script><em>second</em>';
+        await nextTick();
+
+        expect(host.querySelector('script')).toBeNull();
+        expect(host.querySelector('em')?.textContent).toBe('second');
+    });
+});

--- a/resources/js/components/SafeHtml.vue
+++ b/resources/js/components/SafeHtml.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { SANITIZE_CONFIGS, sanitizeHtml } from '@/lib/sanitizeHtml';
+import type { SanitizeVariant } from '@/lib/sanitizeHtml';
+
+/**
+ * The single `v-html` surface in the app. Every run of HTML the client renders
+ * as markup — message bodies, search snippets, the two-factor QR code — goes
+ * through here, so the DOMPurify trust boundary is one component rather than a
+ * convention each call site has to remember. `vue/no-v-html` is an error
+ * everywhere except this file (see `eslint.config.js`), which is what keeps a
+ * new raw `v-html` from slipping in.
+ */
+const props = withDefaults(
+    defineProps<{
+        /** The HTML to render. Assumed hostile; the allowlist is what makes it safe. */
+        html: string;
+        /** Which allowlist to sanitize against {@see @/lib/sanitizeHtml}. */
+        variant: SanitizeVariant;
+        /**
+         * The element to render the sanitized markup into. Deliberately a
+         * closed set of plain HTML tags: a component here would receive the
+         * markup as a `v-html` on a component, which does not render.
+         */
+        as?: 'span' | 'div' | 'p';
+    }>(),
+    { as: 'span' },
+);
+
+const sanitized = computed(() =>
+    sanitizeHtml(props.html, SANITIZE_CONFIGS[props.variant]),
+);
+</script>
+
+<template>
+    <component :is="as" v-html="sanitized" />
+</template>

--- a/resources/js/components/TwoFactorAuthentication.vue
+++ b/resources/js/components/TwoFactorAuthentication.vue
@@ -3,6 +3,7 @@ import { router, useForm } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
 import DemoLock from '@/components/DemoLock.vue';
 import FormField from '@/components/FormField.vue';
+import SafeHtml from '@/components/SafeHtml.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { confirm, disable, enable, recoveryCodes } from '@/routes/two-factor';
@@ -98,11 +99,13 @@ function regenerateRecoveryCodes(): void {
                 }}
             </p>
 
-            <div
+            <SafeHtml
                 v-if="state.qrSvg"
+                as="div"
                 class="inline-flex rounded-xl border border-border bg-white p-4"
                 data-test="two-factor-qr"
-                v-html="state.qrSvg"
+                :html="state.qrSvg"
+                variant="qrCode"
             />
 
             <p v-if="state.secretKey" class="text-sm text-muted-foreground">

--- a/resources/js/lib/sanitizeHtml.test.ts
+++ b/resources/js/lib/sanitizeHtml.test.ts
@@ -4,9 +4,35 @@
 import { describe, expect, it } from 'vitest';
 import {
     MESSAGE_BODY_SANITIZE_CONFIG,
+    QR_CODE_SANITIZE_CONFIG,
+    SANITIZE_CONFIGS,
     sanitizeHtml,
     SEARCH_SNIPPET_SANITIZE_CONFIG,
 } from '@/lib/sanitizeHtml';
+
+/**
+ * A shortened but structurally faithful sample of what Fortify's
+ * `twoFactorQrCodeSvg()` emits — every element and attribute the real output
+ * carries is represented, so the allowlist is asserted against the actual shape
+ * rather than an invented one.
+ */
+const QR_SVG =
+    '<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="192" height="192" viewBox="0 0 192 192">' +
+    '<rect x="0" y="0" width="192" height="192" fill="#ffffff"/>' +
+    '<g transform="scale(4.683)"><g transform="translate(0,0)">' +
+    '<path fill-rule="evenodd" d="M8 0L8 1L9 1L9 0Z" fill="#2d3748"/>' +
+    '</g></g></svg>';
+
+/**
+ * The same QR code as DOMPurify re-serializes it: identical elements and
+ * attributes, with the self-closing `<rect/>`/`<path/>` written as explicit
+ * open/close pairs. The distinction is textual only — both parse to the same DOM
+ * and render the same code.
+ */
+const QR_SVG_REPARSED = QR_SVG.replace(
+    /<(rect|path)([^>]*)\/>/g,
+    '<$1$2></$1>',
+);
 
 describe('sanitizeHtml', () => {
     it('keeps the tags and attributes on the allowlist', () => {
@@ -63,5 +89,33 @@ describe('sanitizeHtml', () => {
                 SEARCH_SNIPPET_SANITIZE_CONFIG,
             ),
         ).toBe('<mark>hit</mark>');
+    });
+
+    it('keeps every element and attribute a two-factor QR code carries', () => {
+        expect(sanitizeHtml(QR_SVG, QR_CODE_SANITIZE_CONFIG)).toBe(
+            QR_SVG_REPARSED,
+        );
+    });
+
+    it('strips scripting smuggled into a QR code SVG', () => {
+        expect(
+            sanitizeHtml(
+                '<svg viewBox="0 0 1 1"><script>alert(1)</script>' +
+                    '<rect x="0" y="0" onload="alert(1)"/>' +
+                    '<foreignObject><iframe src="https://evil.test"></iframe></foreignObject>' +
+                    '</svg>',
+                QR_CODE_SANITIZE_CONFIG,
+            ),
+        ).toBe('<svg viewBox="0 0 1 1"><rect x="0" y="0"></rect></svg>');
+    });
+});
+
+describe('SANITIZE_CONFIGS', () => {
+    it('exposes each allowlist under its variant name', () => {
+        expect(SANITIZE_CONFIGS).toEqual({
+            messageBody: MESSAGE_BODY_SANITIZE_CONFIG,
+            searchSnippet: SEARCH_SNIPPET_SANITIZE_CONFIG,
+            qrCode: QR_CODE_SANITIZE_CONFIG,
+        });
     });
 });

--- a/resources/js/lib/sanitizeHtml.ts
+++ b/resources/js/lib/sanitizeHtml.ts
@@ -28,6 +28,45 @@ export const SEARCH_SNIPPET_SANITIZE_CONFIG: SanitizeConfig = {
 };
 
 /**
+ * The allowlist for the two-factor enrolment QR code, whose SVG is rendered
+ * server-side by Fortify. Only the four elements and the geometry/paint
+ * attributes that renderer emits are permitted, so nothing scriptable (`script`,
+ * `foreignObject`, an `on*` handler) survives even though the source is trusted.
+ * Attribute names are matched lower-cased, hence `viewbox`.
+ */
+export const QR_CODE_SANITIZE_CONFIG: SanitizeConfig = {
+    ALLOWED_TAGS: ['svg', 'g', 'rect', 'path'],
+    ALLOWED_ATTR: [
+        'xmlns',
+        'version',
+        'width',
+        'height',
+        'viewbox',
+        'transform',
+        'x',
+        'y',
+        'd',
+        'fill',
+        'fill-rule',
+    ],
+};
+
+/**
+ * Every allowlist a `v-html` surface may be rendered under, keyed by the
+ * `variant` {@see @/components/SafeHtml} takes. Enumerating them here keeps the
+ * choice of allowlist reviewable in one place instead of spread across the call
+ * sites.
+ */
+export const SANITIZE_CONFIGS = {
+    messageBody: MESSAGE_BODY_SANITIZE_CONFIG,
+    searchSnippet: SEARCH_SNIPPET_SANITIZE_CONFIG,
+    qrCode: QR_CODE_SANITIZE_CONFIG,
+} as const satisfies Record<string, SanitizeConfig>;
+
+/** The name of one of the {@see SANITIZE_CONFIGS} allowlists. */
+export type SanitizeVariant = keyof typeof SANITIZE_CONFIGS;
+
+/**
  * Sanitize a run of HTML against a fixed allowlist. This is the single XSS trust
  * boundary in front of every `v-html` surface: a string reaching one of them
  * passes through here first, so an attacker-authored tag or `javascript:` URL

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -14,6 +14,7 @@ import {
     show,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { index as search } from '@/actions/App/Http/Controllers/Channels/SearchController';
+import SafeHtml from '@/components/SafeHtml.vue';
 import { Button } from '@/components/ui/button';
 import { DatePicker } from '@/components/ui/date-picker';
 import {
@@ -32,10 +33,6 @@ import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { getInitials } from '@/composables/useInitials';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatCalendarDate, formatDateTime } from '@/lib/datetime';
-import {
-    sanitizeHtml,
-    SEARCH_SNIPPET_SANITIZE_CONFIG,
-} from '@/lib/sanitizeHtml';
 import { groupSearchResults } from '@/lib/searchResultGroups';
 import {
     emptyFilters,
@@ -423,16 +420,6 @@ function jumpHref(result: MessageSearchResult): string {
         { team: result.teamSlug, channel: result.channelSlug },
         { query: { message: result.message.id } },
     ).url;
-}
-
-/**
- * The snippet arrives fully escaped from `App\Support\MessageSnippet`, with
- * `<mark>` as its only markup. Sanitizing it again on the client keeps the
- * `v-html` surface behind the same trust boundary as every other one, so a
- * future server-side change can't turn this into an injection point.
- */
-function snippetHtml(snippet: string): string {
-    return sanitizeHtml(snippet, SEARCH_SNIPPET_SANITIZE_CONFIG);
 }
 </script>
 
@@ -884,10 +871,12 @@ function snippetHtml(snippet: string): string {
                                     }}
                                 </span>
                             </div>
-                            <p
+                            <SafeHtml
+                                as="p"
                                 class="search-snippet mt-0.5 line-clamp-2 text-[14px] leading-[1.55] break-words text-foreground/90"
-                                v-html="snippetHtml(result.snippet)"
-                            ></p>
+                                :html="result.snippet"
+                                variant="searchSnippet"
+                            />
                             <span
                                 v-if="result.message.threadReplyCount > 0"
                                 class="mt-1.5 inline-flex items-center gap-1.5 text-[11px] text-muted-foreground"
@@ -915,9 +904,9 @@ function snippetHtml(snippet: string): string {
 
 <style scoped>
 /*
- * Server-sanitized `<mark>` highlights ride in via v-html; style them with the
- * brass reaction-pill tokens, which carry an AA-contrast foreground in both
- * light and dark themes.
+ * Server-built `<mark>` highlights are rendered through `<SafeHtml>`; style them
+ * with the brass reaction-pill tokens, which carry an AA-contrast foreground in
+ * both light and dark themes.
  */
 .search-snippet :deep(mark) {
     background-color: var(--brass-fill);

--- a/resources/js/pages/channels/Threads.vue
+++ b/resources/js/pages/channels/Threads.vue
@@ -5,6 +5,7 @@ import {
     index,
     show,
 } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import SafeHtml from '@/components/SafeHtml.vue';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { useCustomEmojis } from '@/composables/useCustomEmojis';
 import { getInitials } from '@/composables/useInitials';
@@ -131,8 +132,8 @@ function formatTimestamp(iso: string): string {
                                     v-if="!item.root.isDeleted"
                                     class="mt-0.5 line-clamp-2 text-[14px] leading-[1.5] break-words text-foreground/90"
                                 >
-                                    <span
-                                        v-html="
+                                    <SafeHtml
+                                        :html="
                                             renderMessageBody(
                                                 item.root.body,
                                                 item.root.mentions,
@@ -140,7 +141,8 @@ function formatTimestamp(iso: string): string {
                                                 userGroups,
                                             )
                                         "
-                                    ></span>
+                                        variant="messageBody"
+                                    />
                                 </p>
 
                                 <div

--- a/tests/Browser/A11ySearchTest.php
+++ b/tests/Browser/A11ySearchTest.php
@@ -52,6 +52,24 @@ test('the search page highlights matches, groups them by date, and has no seriou
         ->assertSee('Today')
         ->assertNoAccessibilityIssues();
 
+    // The highlight styling is scoped CSS reaching through `<SafeHtml>`'s root
+    // into markup it rendered; assert it actually lands, since a browser-default
+    // <mark> would still satisfy the presence check above while losing the brass
+    // palette this test audits for contrast.
+    $highlight = $page->script(<<<'JS'
+    () => {
+        const mark = document.querySelector('[data-test="search-result"] mark');
+        const styles = getComputedStyle(mark);
+
+        return {
+            fontWeight: styles.fontWeight,
+            borderRadius: styles.borderRadius,
+        };
+    }
+    JS);
+
+    expect($highlight)->toBe(['fontWeight' => '600', 'borderRadius' => '3px']);
+
     // Re-audit the results against the dark palette (localStorage before the
     // class, so the appearance controller doesn't re-resolve to light mid-audit).
     $page->script(<<<'JS'

--- a/tests/Browser/TwoFactorSettingsTest.php
+++ b/tests/Browser/TwoFactorSettingsTest.php
@@ -37,6 +37,11 @@ test('a user can start two-factor enrolment from the security page', function ()
         ->click('@enable-two-factor-button')
         ->assertPresent('@two-factor-setup')
         ->assertPresent('@two-factor-qr')
+        // The QR is server-rendered SVG sanitized against the `qrCode` allowlist
+        // on its way through `<SafeHtml>`; assert the scannable markup itself
+        // survives, not just the box it sits in — an allowlist that dropped
+        // `<path>` would leave an empty container that still passes the check above.
+        ->assertPresent('[data-test="two-factor-qr"] svg path')
         ->assertPresent('@two-factor-recovery-codes')
         ->assertPresent('@confirm-two-factor-button');
 });


### PR DESCRIPTION
Closes #701.

## What

Introduces `<SafeHtml>`, the only component in the app permitted to render a string as markup. It sanitizes its input with DOMPurify against a **named allowlist** chosen per call site, and `vue/no-v-html` is now an `error` everywhere else, so the XSS trust boundary is enforced by the linter instead of by convention.

All six `v-html` sites move onto it:

| Surface | Variant |
| --- | --- |
| `MessageList` body segments | `messageBody` |
| `MessageForward` quoted body | `messageBody` |
| `QuickSwitcher` result preview | `messageBody` |
| `Threads` root preview | `messageBody` |
| `Search` snippet | `searchSnippet` |
| `TwoFactorAuthentication` QR code | `qrCode` (new) |

## Why

The Aikido finding flags `v-html` in `MessageForward.vue` and `MessageList.vue`. Both were already behind DOMPurify (`resources/js/lib/sanitizeHtml.ts`), and the "defend in depth with a strict CSP" advice already ships (nonce + `strict-dynamic`, `base-uri`/`form-action`/`object-src` locked down). So this is hardening rather than a live vulnerability.

The genuine gap was that the boundary was a convention held together by doc comments: nothing stopped the next component writing `v-html="props.html"`. Two concrete improvements here:

- The boundary is now mechanically enforced, and adding a surface means naming an allowlist.
- The two-factor QR code (`TwoFactorAuthentication.vue`) was the one `v-html` outside the boundary entirely, rendering server-generated SVG unsanitized. It now passes through a `qrCode` allowlist that permits only the four elements and geometry/paint attributes Fortify's renderer emits, so nothing scriptable survives even though the source is trusted.

`Search.vue`'s local `snippetHtml` helper is gone, since the component now names the allowlist.

## How tested

- `sanitizeHtml.test.ts`: the `qrCode` allowlist against a structurally faithful sample of real Fortify output, plus a case smuggling `<script>` / `onload` / `<foreignObject><iframe>` into an SVG.
- `SafeHtml.test.ts` (7 cases): sanitizes per variant, strips off-allowlist markup, honours `as`, forwards attributes, re-sanitizes on change.
- `eslint-rules/no-v-html-policy.test.ts`: resolves the project ESLint config per file path to prove `vue/no-v-html` is an error for ordinary components and pages, and off only for `SafeHtml.vue`.
- Two existing browser tests strengthened where the refactor could silently degrade: the search highlight now asserts the scoped `:deep(mark)` styling still reaches through the component boundary (a browser-default `<mark>` would have passed the old presence check), and the 2FA test asserts `svg path` survives the allowlist rather than just the container being present.
- Full gate green: `composer test` at **Total: 100.0 %**, browser suite 69/69, `test:js` 889/889, lint/format/types/build clean, `docs` builds.

## Docs

`docs/src/content/docs/reference/security.md` gains a *Rendered HTML is sanitized* section describing the two-stage escape-then-sanitize model and the single-component boundary, placed ahead of the CSP section it backs up.

## i18n

No new user-facing copy, so no catalog changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787312079&installation_model_id=428379&pr_number=726&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F726&signature=d1a9efa55effd341314b1f35e89b1578bc419c03d0535a5b503659149371dcba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->