### PR TITLE
fix: order the team roster deterministically on the team edit page

### DIFF
--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -72,7 +72,7 @@ class TeamController extends Controller
                 'isPersonal' => $team->is_personal,
                 'role' => $user->teamRole($team)?->value,
             ],
-            'members' => $team->members()->get()->map(function (User $member) use ($canViewRoster): array {
+            'members' => $team->roster()->get()->map(function (User $member) use ($canViewRoster): array {
                 /** @var Membership $membership */
                 $membership = $member->getRelation('pivot');
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -83,6 +83,40 @@ class Team extends Model
     }
 
     /**
+     * SQL ranking a membership by role, most privileged first.
+     *
+     * Spelled out rather than folded from {@see TeamRole::level()} because raw
+     * SQL has to stay a literal expression to be provably injection-free, and a
+     * value built at runtime is not. That duplicates the hierarchy, so the test
+     * "the team edit page orders every role by its hierarchy level" walks
+     * TeamRole::cases() and fails if a new role is added without a rank here.
+     */
+    private const string ROLE_HIERARCHY_SQL = 'case team_members.role'
+        ." when '".TeamRole::Owner->value."' then 0"
+        ." when '".TeamRole::Admin->value."' then 1"
+        ." when '".TeamRole::Member->value."' then 2"
+        .' else 3 end';
+
+    /**
+     * Get all members of this team in a stable, total order.
+     *
+     * {@see members()} carries no ORDER BY, so Postgres is free to hand the rows
+     * back in a different order on every load and a rendered roster reshuffles
+     * itself between two visits to the same page (issue #722). This orders the
+     * most privileged roles first, then case-insensitively by name, with the id
+     * as the tie-break that makes the order total.
+     *
+     * @return BelongsToMany<User, $this, Membership, 'pivot'>
+     */
+    public function roster(): BelongsToMany
+    {
+        return $this->members()
+            ->orderByRaw(self::ROLE_HIERARCHY_SQL)
+            ->orderByRaw('lower(users.name)')
+            ->orderBy('users.id');
+    }
+
+    /**
      * Get all memberships for this team.
      *
      * @return HasMany<Membership, $this>

--- a/tests/Feature/Teams/TeamTest.php
+++ b/tests/Feature/Teams/TeamTest.php
@@ -6,7 +6,6 @@ use App\Models\SecurityEvent;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
-use Illuminate\Support\Collection;
 use Inertia\Testing\AssertableInertia as Assert;
 
 test('the teams index page can be rendered', function (): void {
@@ -75,6 +74,73 @@ test('the team edit page can be rendered', function (): void {
         );
 });
 
+test('the team edit page orders the roster by role, then name, then id', function (): void {
+    $team = Team::factory()->create();
+
+    $owner = User::factory()->create(['name' => 'Zoe Owner']);
+    $adminBob = User::factory()->create(['name' => 'Bob Admin']);
+    $adminAlice = User::factory()->create(['name' => 'alice Admin']);
+    $memberCarol = User::factory()->create(['name' => 'Carol Member']);
+    $memberCarolTwin = User::factory()->create(['name' => 'Carol Member']);
+
+    // Attached in an order that contradicts the expected one, so a roster that
+    // merely echoes insertion order cannot pass by accident (issue #722).
+    $team->members()->attach($memberCarolTwin, ['role' => TeamRole::Member->value]);
+    $team->members()->attach($adminBob, ['role' => TeamRole::Admin->value]);
+    $team->members()->attach($memberCarol, ['role' => TeamRole::Member->value]);
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $team->members()->attach($adminAlice, ['role' => TeamRole::Admin->value]);
+
+    $carolsById = collect([$memberCarol, $memberCarolTwin])->sortBy('id')->values();
+
+    $response = $this
+        ->actingAs($owner)
+        ->get(route('teams.edit', $team));
+
+    $response
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->component('teams/Edit')
+            ->where('members.0.id', $owner->id)
+            ->where('members.1.id', $adminAlice->id)
+            ->where('members.2.id', $adminBob->id)
+            ->where('members.3.id', $carolsById[0]->id)
+            ->where('members.4.id', $carolsById[1]->id)
+        );
+});
+
+test('the team edit page orders every role by its hierarchy level', function (): void {
+    $team = Team::factory()->create();
+
+    $expected = collect(TeamRole::cases())
+        ->sortByDesc(fn (TeamRole $role): int => $role->level())
+        ->values();
+
+    // Named in reverse of the expected order, so a roster that lost its role
+    // ranking and fell back to the name tie-break would come out backwards.
+    $membersByRole = [];
+
+    foreach ($expected as $rank => $role) {
+        $member = User::factory()->create(['name' => chr(ord('z') - $rank).' Member']);
+        $team->members()->attach($member, ['role' => $role->value]);
+        $membersByRole[$role->value] = $member;
+    }
+
+    $response = $this
+        ->actingAs($membersByRole[TeamRole::Owner->value])
+        ->get(route('teams.edit', $team));
+
+    $response
+        ->assertOk()
+        ->assertInertia(function (Assert $page) use ($expected, $membersByRole): void {
+            $page->component('teams/Edit')->has('members', $expected->count());
+
+            foreach ($expected as $position => $role) {
+                $page->where("members.{$position}.id", $membersByRole[$role->value]->id);
+            }
+        });
+});
+
 test('the team edit page cannot be viewed by non-members', function (): void {
     $owner = User::factory()->create();
     $outsider = User::factory()->create();
@@ -137,14 +203,9 @@ test('the team edit page shows member emails and invitations to admins', functio
         ->assertOk()
         ->assertInertia(fn (Assert $page): Assert => $page
             ->component('teams/Edit')
-            // The roster query carries no ORDER BY, so Postgres is free to hand
-            // the rows back in any order (issue #722). What this test is about is
-            // that an admin sees every member's email, not where each one lands.
             ->has('members', 2)
-            ->where('members', fn (Collection $members): bool => $members->pluck('email')
-                ->sort()
-                ->values()
-                ->all() === collect([$owner->email, $admin->email])->sort()->values()->all())
+            ->where('members.0.email', $owner->email)
+            ->where('members.1.email', $admin->email)
             ->where('invitations.0.email', $invitation->email)
             ->where('invitations.0.role', $invitation->role->value),
         );


### PR DESCRIPTION
Closes #722.

## What

`TeamController::edit()` built the roster with `$team->members()->get()` and no `ORDER BY`, so Postgres was free to return the rows in a different order on every load and the member list on `teams/Edit` could reshuffle itself between two visits to the same page.

The roster now comes from a new `Team::roster()` relation with a deterministic, total order: role hierarchy first (owner, then admin, then member), then `lower(users.name)`, then `users.id` as the tie-break.

## Why the role ranking is a literal constant

The ranking started out folded from `TeamRole::level()` at runtime, but PHPStan rejected it: `orderByRaw()` requires a `literal-string`, and a value built at runtime cannot be proven injection-free. Rather than suppress the error, the expression is a `private const string ROLE_HIERARCHY_SQL` (the same shape as the existing `Message::THREAD_FOLLOWED_SQL`), with the role *values* still coming from the enum via const expressions.

That duplicates the hierarchy, so a second test walks `TeamRole::cases()` sorted by `level()` and fails if a new role is ever added without a rank in the SQL.

## Testing

Two new feature tests in `tests/Feature/Teams/TeamTest.php`:

- *orders the roster by role, then name, then id* — five members attached in an order that contradicts the expected one, so a roster echoing insertion order cannot pass by accident. Covers case-insensitive name ordering (`alice` before `Bob`) and the id tie-break (two identically named members).
- *orders every role by its hierarchy level* — the guard described above.

Both were verified to bite: removing the `orderByRaw` line makes each of them fail.

`TeamTest > the team edit page shows member emails and invitations to admins` goes back to positional `members.0` / `members.1` assertions, dropping the order-independent workaround #698 had to introduce.

Gate: `composer test` green at `Total: 100.0 %`, plus `lint:check`, `format:check`, `types:check`, `test:js` and `build`. Local CodeRabbit pass: 0 findings.

No user-facing copy and no operator-facing behaviour changed, so no `lang/fr.json` or `docs/` updates were needed.

## Noted while working

The `bin/worktree` bootstrap for this issue failed part-way — it seeds the demo workspace before redis is started, and `WorkspaceSeeder` now reaches the redis-backed cache. Already tracked as #723; worked around locally rather than fixed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787312509&installation_model_id=428379&pr_number=727&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F727&signature=ee76f83da3cebc51c53032a3b03600517102a9bbef991a7ee5c110e23ee47ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->