### PR TITLE
fix: start redis before bin/worktree seeds the demo workspace

### DIFF
--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -10,7 +10,7 @@ Every issue is implemented in its **own isolated worktree + Sail instance** (ste
 
 ## 0. Isolate: self-bootstrap into a worktree
 
-**Do all of the work below in a dedicated worktree, not the main checkout.** `bin/worktree` (committed at the repo root) allocates a free port block + Compose project for issue `NNN`, creates `../the-desk-worktrees/<NNN>-<slug>/`, generates its `.env` (offset ports, `COMPOSE_PROJECT_NAME=desk-<NNN>`, `APP_URL`) and a trimmed `compose.override.yaml` (`laravel.test` + `pgsql` only — the gate touches nothing else), installs its own `vendor/` + `node_modules/`, and starts the two containers.
+**Do all of the work below in a dedicated worktree, not the main checkout.** `bin/worktree` (committed at the repo root) allocates a free port block + Compose project for issue `NNN`, creates `../the-desk-worktrees/<NNN>-<slug>/`, generates its `.env` (offset ports, `COMPOSE_PROJECT_NAME=desk-<NNN>`, `APP_URL`) and a trimmed `compose.override.yaml` (`laravel.test` + `pgsql` + `redis` only — the gate needs Postgres, the bootstrap's demo seed needs the cache), installs its own `vendor/` + `node_modules/`, and starts those three containers.
 
 ```bash
 cd "$(bin/worktree create NNN)"   # prints the worktree path on stdout; cd into it

--- a/bin/worktree
+++ b/bin/worktree
@@ -10,15 +10,18 @@
 # unique port block and its own Compose project, and installs its deps.
 #
 # The test gate only touches Postgres (phpunit.xml: cache/session=array,
-# queue=sync, scout=collection, broadcast=null), so an isolated worktree runs
-# just `laravel.test` + `pgsql`. A generated compose.override.yaml trims
-# laravel.test's depends_on to pgsql; `sail up -d laravel.test` then starts those
-# two containers only.
+# queue=sync, scout=collection, broadcast=null), but the bootstrap itself runs
+# artisan against the worktree's own .env, where CACHE_STORE/QUEUE_CONNECTION are
+# redis — the demo seed reaches the cache through CreateChannel/JoinChannel and
+# dies on an unstarted `redis` host otherwise (issue #723). So an isolated
+# worktree runs `laravel.test` + `pgsql` + `redis`: a generated
+# compose.override.yaml trims laravel.test's depends_on to those two backing
+# services, and `sail up -d laravel.test` then starts those three containers only.
 #
 # The Browser suite (tests/Browser) is the exception: it drives a real Chromium
 # and points the broadcaster at a live Reverb. So the bootstrap also installs the
-# Playwright browsers into the app container and brings `reverb` (and, via its
-# own depends_on, `redis`) up — four containers in total.
+# Playwright browsers into the app container and brings `reverb` up — four
+# containers in total.
 #
 # Because the worktree's .env is copied from the main checkout, it can name
 # services those four don't include (the opt-in `sso` profile's ldap/oidc,
@@ -62,9 +65,9 @@ DEFAULT_BASE="${WORKTREE_BASE:-master}"
 COMPOSER_IMAGE="${WORKTREE_COMPOSER_IMAGE:-laravelsail/php84-composer:latest}"
 
 # The compose services a worktree ever brings up: `sail up -d laravel.test` with
-# the trimmed depends_on, plus reverb pulling redis in through its own. Every
-# other service in compose.yaml stays down, so the generated .env must not point
-# at one (see write_env); tests/Unit/WorktreeScriptTest.php holds that line.
+# the trimmed depends_on, plus reverb. Every other service in compose.yaml stays
+# down, so the generated .env must not point at one (see write_env);
+# tests/Unit/WorktreeScriptTest.php holds that line.
 WORKTREE_STARTED_SERVICES="laravel.test pgsql reverb redis"
 
 REGISTRY_DIR="${HOME}/.the-desk"
@@ -418,7 +421,7 @@ cmd_create() {
                 --ignore-platform-reqs --no-scripts
     fi
 
-    log "starting laravel.test + pgsql (building image on first run may take a while)"
+    log "starting laravel.test + pgsql + redis (building image on first run may take a while)"
     (cd "$path" && ./vendor/bin/sail up -d laravel.test)
 
     log "finalizing PHP dependencies inside the app container (runs post-install scripts)"
@@ -441,7 +444,7 @@ cmd_create() {
     # worktree that can only run Unit+Feature is not enough. Started here rather
     # than through laravel.test's depends_on so it boots after APP_KEY exists —
     # reverb:start exits on a missing key and nothing would restart it.
-    log "starting reverb (+ redis) for the Browser suite"
+    log "starting reverb for the Browser suite"
     (cd "$path" && ./vendor/bin/sail up -d reverb)
 
     # The feature suite renders Inertia pages, which fail with a 500 unless a Vite
@@ -474,22 +477,27 @@ PLAYWRIGHT_PROBE='loc=$(npx playwright install --dry-run chromium 2>/dev/null | 
 
 # Each worktree gets its own Postgres volume, so the bootstrap starts on an empty
 # database and the login form has no account to accept — signing in to the
-# isolated instance is the point (issue #680). Migrations run on every entry so a
-# rebased worktree picks up new ones; the seed is guarded by its own sentinel
-# because WorkspaceSeeder builds a fresh fixture workspace on each run.
+# isolated instance is the point (issue #680). The seed is guarded by its own
+# sentinel because WorkspaceSeeder builds a fresh fixture workspace on each run;
+# migrations still run on every later entry so a rebased worktree picks up new ones.
+#
+# Until that sentinel exists the schema is rebuilt rather than migrated in place.
+# A seed that dies partway through — as it did whenever it ran before redis was
+# up (issue #723) — leaves rows behind, and the next `create` then dies on
+# `duplicate key value violates unique constraint "users_email_unique"` instead
+# of resuming. Dropping the tables first is safe precisely because the sentinel
+# is missing: no seed has ever completed against them.
 migrate_and_seed() {
     local path="$1"
 
-    log "running database migrations"
-    (cd "$path" && ./vendor/bin/sail artisan migrate --force)
-
     if [ -f "${path}/.worktree-seeded" ]; then
-        log "database already seeded — skipping"
+        log "running database migrations (demo workspace already seeded)"
+        (cd "$path" && ./vendor/bin/sail artisan migrate --force)
         return 0
     fi
 
-    log "seeding the demo workspace"
-    (cd "$path" && ./vendor/bin/sail artisan db:seed --force)
+    log "migrating a fresh database and seeding the demo workspace"
+    (cd "$path" && ./vendor/bin/sail artisan migrate:fresh --seed --force)
     touch "${path}/.worktree-seeded"
 }
 
@@ -580,12 +588,13 @@ write_override() {
     cat > "${path}/compose.override.yaml" <<EOF
 # Generated by bin/worktree for issue #${nnn} — do not edit by hand.
 #
-# Trims laravel.test to the test-runner essentials: the gate only touches
-# Postgres (phpunit.xml uses array/sync/collection/null drivers), so
-# meilisearch, mailpit and queue are never needed. With depends_on cut to
-# pgsql, \`sail up -d laravel.test\` starts exactly two containers. The Browser
-# suite additionally needs a live WebSocket server, so bin/worktree starts
-# reverb (and, through its own depends_on, redis) as a separate step.
+# Trims laravel.test to the essentials: the gate only touches Postgres
+# (phpunit.xml uses array/sync/collection/null drivers) and the bootstrap's own
+# artisan calls only add redis (the worktree .env runs cache and queue on it), so
+# meilisearch, mailpit and queue are never needed. With depends_on cut to pgsql
+# and redis, \`sail up -d laravel.test\` starts exactly three containers. The
+# Browser suite additionally needs a live WebSocket server, so bin/worktree
+# starts reverb as a separate step.
 #
 # .env pins REVERB_PORT to the container-internal 8080 because the app dials
 # reverb:\${REVERB_PORT}; the per-worktree host offset lives here instead, so
@@ -597,6 +606,7 @@ services:
     laravel.test:
         depends_on: !override
             - pgsql
+            - redis
     reverb:
         ports: !override
             - '${reverb_port}:8080'

--- a/dev-docs/concurrent-worktrees.md
+++ b/dev-docs/concurrent-worktrees.md
@@ -15,16 +15,20 @@ concurrent worktrees are **host port bindings** and each worktree's own on-host
 block and its own Compose project, and installs its deps.
 
 The test gate only touches Postgres — `phpunit.xml` sets cache/session to
-`array`, queue to `sync`, Scout to `collection`, and broadcast to `null`. So an
-isolated worktree runs just **`laravel.test` + `pgsql`** (2 containers). A
-generated `compose.override.yaml` trims `laravel.test`'s `depends_on` to
-`pgsql`, and `sail up -d laravel.test` then starts exactly those two.
+`array`, queue to `sync`, Scout to `collection`, and broadcast to `null`. The
+bootstrap's own `artisan` calls do not run under `phpunit.xml` though: they read
+the worktree's `.env`, where `CACHE_STORE` and `QUEUE_CONNECTION` are `redis`, so
+the demo seed reaches the cache (`WorkspaceSeeder` → `CreateChannel` →
+`JoinChannel`) and needs a live `redis` to talk to. An isolated worktree
+therefore runs **`laravel.test` + `pgsql` + `redis`** (3 containers): a generated
+`compose.override.yaml` trims `laravel.test`'s `depends_on` to those two backing
+services, and `sail up -d laravel.test` then starts exactly those three.
 
 The **Browser suite** (`tests/Browser`) is the exception: it drives a real
 Chromium and `tests/Pest.php` points the broadcaster at a live Reverb for the
 whole suite. So the bootstrap additionally installs the Playwright browsers into
-the app container and starts `reverb` (which pulls in `redis` through its own
-`depends_on`) — four containers in total. Two details make that work:
+the app container and starts `reverb` — four containers in total. Two details
+make that work:
 
 - Playwright's browser binaries ship out of band; `npm install` fetches only the
   driver. They install in two steps because the shared libraries Chromium links
@@ -77,6 +81,10 @@ cd "$(bin/worktree create 441)"    # drops you into the isolated worktree
   merged. The branch is left intact (it may have unpushed commits or an open PR).
 - **Re-entry is idempotent.** Re-running `create` on a ready worktree just
   re-prints its path; an interrupted bootstrap resumes on the next `create`.
+  The demo seed is guarded by a `.worktree-seeded` sentinel, and until that
+  sentinel exists the schema is rebuilt (`migrate:fresh --seed`) rather than
+  migrated in place — so a seed that died partway through cannot leave rows that
+  fail the unique constraints on the retry.
 
 ## Notes & limits
 

--- a/tests/Unit/WorktreeScriptTest.php
+++ b/tests/Unit/WorktreeScriptTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Tag\TaggedValue;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -329,9 +330,19 @@ test('a fresh worktree migrates and seeds so the demo account can sign in', func
     $process = runWorktreeLib($path, 'migrate_and_seed '.escapeshellarg($path));
 
     expect($process->getExitCode())->toBe(0)
-        ->and(sailCalls($log))->toContain('artisan migrate --force')
-        ->and(sailCalls($log))->toContain('artisan db:seed --force')
+        ->and(sailCalls($log))->toContain('artisan migrate:fresh --seed --force')
         ->and(is_file($path.'/.worktree-seeded'))->toBeTrue();
+});
+
+test('an unseeded worktree is seeded onto a rebuilt schema, never onto a half-seeded one', function (): void {
+    [$path] = fakeSailWorktree(probeExit: 0);
+    $log = $path.'/sail-calls.log';
+
+    $process = runWorktreeLib($path, 'migrate_and_seed '.escapeshellarg($path));
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(sailCalls($log))->not->toContain('artisan migrate --force')
+        ->and(sailCalls($log))->not->toContain('artisan db:seed --force');
 });
 
 test('re-entering an already seeded worktree migrates but does not re-seed', function (): void {
@@ -343,7 +354,8 @@ test('re-entering an already seeded worktree migrates but does not re-seed', fun
 
     expect($process->getExitCode())->toBe(0)
         ->and(sailCalls($log))->toContain('artisan migrate --force')
-        ->and(sailCalls($log))->not->toContain('artisan db:seed --force');
+        ->and(sailCalls($log))->not->toContain('artisan db:seed --force')
+        ->and(sailCalls($log))->not->toContain('artisan migrate:fresh --seed --force');
 });
 
 test('the generated override rebinds Reverb to the worktree host port and keeps the container on 8080', function (): void {
@@ -355,6 +367,20 @@ test('the generated override rebinds Reverb to the worktree host port and keeps 
     expect($process->getExitCode())->toBe(0)
         ->and($override)->toContain("'20002:8080'")
         ->and($override)->toContain('ports: !override');
+});
+
+test('the trimmed override still brings redis up, so the bootstrap seed can reach the cache', function (): void {
+    $path = tempGitDir('worktree-override-redis');
+
+    $process = runWorktreeLib($path, 'write_override '.escapeshellarg($path).' 723 20002');
+    /** @var array<string, array<string, array<string, mixed>>> $override */
+    $override = Yaml::parseFile($path.'/compose.override.yaml', Yaml::PARSE_CUSTOM_TAGS);
+    $dependsOn = $override['services']['laravel.test']['depends_on'];
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($dependsOn)->toBeInstanceOf(TaggedValue::class)
+        ->and($dependsOn->getTag())->toBe('override')
+        ->and($dependsOn->getValue())->toEqualCanonicalizing(['pgsql', 'redis']);
 });
 
 test('the generated env pins the container-internal Reverb port while offsetting the host ports', function (): void {


### PR DESCRIPTION
Closes #723.

## What

`bin/worktree create NNN <base>` died partway through bootstrap with
`RedisException: php_network_getaddresses: getaddrinfo for redis failed`, and a
re-run then died on `duplicate key value violates unique constraint
"users_email_unique"` instead of resuming. Two separate causes, fixed together.

### 1. Redis was not up when the seed ran

The generated `compose.override.yaml` trimmed `laravel.test`'s `depends_on` to
`pgsql` alone, on the reasoning that the test gate only touches Postgres. That
holds for the gate (`phpunit.xml` pins cache/session to `array`, queue to
`sync`), but *not* for the bootstrap's own `artisan` calls: those read the
worktree's `.env`, where `CACHE_STORE`/`QUEUE_CONNECTION` are `redis`. The demo
seed reaches the cache through `WorkspaceSeeder` -> `CreateChannel` ->
`JoinChannel`, so it dialled a `redis` host nothing had started yet — redis only
came up later, pulled in by the `reverb` step.

The override now trims `depends_on` to `pgsql` **and** `redis`, so
`sail up -d laravel.test` starts all three containers before `migrate_and_seed`.
Declaring it on `depends_on` rather than adding `redis` to the `sail up`
arguments also means a plain `sail up -d` inside the worktree gets a stack that
matches its `.env`.

### 2. A failed seed left the database unrecoverable

`migrate_and_seed` now branches on the `.worktree-seeded` sentinel:

- sentinel present -> `artisan migrate --force`, as before, so a rebased worktree
  still picks up new migrations;
- sentinel absent -> `artisan migrate:fresh --seed --force`.

Rebuilding the schema is safe precisely *because* the sentinel is missing: no
seed has ever completed against those tables, so there is nothing to preserve,
and the partial rows a half-finished seed left behind can no longer collide with
the retry.

## How tested

TDD, red -> green, in `tests/Unit/WorktreeScriptTest.php` (which drives
`bin/worktree`'s functions directly via `WORKTREE_LIB=1`, with a `sail` stub that
records invocations):

- a new test parses the generated override as YAML with custom tags and asserts
  the `!override` `depends_on` is exactly `pgsql` + `redis`;
- the fresh-worktree seed test now asserts `artisan migrate:fresh --seed --force`;
- a new test asserts the unseeded path never issues the plain
  `migrate --force` + `db:seed --force` pair that caused the bug;
- the already-seeded test additionally asserts `migrate:fresh` is *not* issued,
  so a working worktree's data is never dropped.

Also verified against real Compose rather than only by reading YAML: running
`docker compose config` over the generated override resolves
`services["laravel.test"].depends_on` to exactly `["pgsql", "redis"]`.

Full backend gate green: Pint, PHPStan (0 errors), Rector (0 changed files),
2079 tests passing at **100.0 %** coverage. Local CodeRabbit pass returned 0
findings. No frontend files changed, so the JS gate is unaffected.

## Docs

- `dev-docs/concurrent-worktrees.md` — container topology is now 3 (+ reverb = 4),
  with the reason the bootstrap needs redis even though the gate does not, plus a
  note on the seed-recovery semantics under *Re-entry is idempotent*.
- `.agents/skills/implement-issue/SKILL.md` — step 0's description of the trimmed
  override.

No `.env`/config setting or operator-facing behaviour changed, so the published
`docs/` site needs no update. No i18n impact (no user-facing copy).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787313966&installation_model_id=428379&pr_number=728&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F728&signature=cf9f8ff3971e062bc49f0f67e650ba2e89d7a8faa29b2e976546e2beab2ac1c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->