### PR TITLE
feat: sync read-state clearing across a user's own devices

### DIFF
--- a/app/Actions/Channels/MarkChannelRead.php
+++ b/app/Actions/Channels/MarkChannelRead.php
@@ -4,6 +4,7 @@ namespace App\Actions\Channels;
 
 use App\Data\UserData;
 use App\Events\MessageRead;
+use App\Events\ReadStateAdvanced;
 use App\Models\Channel;
 use App\Models\User;
 
@@ -17,10 +18,15 @@ class MarkChannelRead
      * mention badges. A channel with no messages leaves the pointer untouched,
      * and a non-member is a no-op because there is no pivot row to update.
      *
-     * When the pointer actually advances and the user shares read receipts, a
-     * {@see MessageRead} event is broadcast so peers can update their "Seen by"
-     * affordance. The advance guard also avoids re-broadcasting on the frequent
-     * no-op calls the client fires on every incoming message and window focus.
+     * A real advance broadcasts two independent signals. {@see ReadStateAdvanced}
+     * always goes to the reader's own other devices so their sidebar badge
+     * clears there too, skipping the device that just read (it already gets
+     * fresh counts in this request's response). {@see MessageRead} goes to peers
+     * so they can update their "Seen by" affordance, and only for a user who
+     * shares read receipts — that preference governs what peers see, never
+     * whether a user's own devices stay in step. The advance guard keeps both
+     * silent on the frequent no-op calls the client fires on every incoming
+     * message and window focus.
      */
     public function handle(Channel $channel, User $user): void
     {
@@ -37,6 +43,8 @@ class MarkChannelRead
         }
 
         $member->update(['last_read_message_id' => $latestMessageId]);
+
+        broadcast(new ReadStateAdvanced($user->id, $channel->id))->toOthers();
 
         if ($user->share_read_receipts) {
             event(new MessageRead($channel, UserData::fromUser($user), $latestMessageId));

--- a/app/Events/ReadStateAdvanced.php
+++ b/app/Events/ReadStateAdvanced.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fired when a user's read pointer advances, so their *other* devices can drop
+ * the channel's unread badge without waiting for a navigation.
+ *
+ * The increment direction already syncs across devices — every client watches
+ * each `channel.{id}` and reloads the authoritative counts on a new message —
+ * but clearing did not: reading on a phone left the desktop showing the channel
+ * unread. This rides the reader's own private `user.{id}` channel, so nothing
+ * about where they read leaks to peers, and it carries no counts: the client
+ * responds by reloading the server-computed `channels` prop, reusing the
+ * existing badge machinery rather than tracking counts of its own.
+ *
+ * Unlike {@see MessageRead}, this is dispatched regardless of the reader's
+ * `share_read_receipts` preference — that toggle governs revealing read state
+ * to *others*, not syncing a user's own devices.
+ */
+class ReadStateAdvanced implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public string $userId,
+        public string $channelId,
+    ) {}
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('user.'.$this->userId),
+        ];
+    }
+
+    /**
+     * Get the data to broadcast.
+     *
+     * @return array<string, string>
+     */
+    public function broadcastWith(): array
+    {
+        return ['channelId' => $this->channelId];
+    }
+}

--- a/resources/js/composables/useSidebarBadges.test.ts
+++ b/resources/js/composables/useSidebarBadges.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRenderer, defineComponent } from 'vue';
+
+const reload = vi.fn();
+const page = {
+    props: {
+        auth: { user: { id: 'viewer-id' } },
+        channels: [],
+        channel: undefined as { id?: string } | undefined,
+    },
+};
+
+/** Listeners registered per Echo channel name, keyed by event name. */
+const listeners = new Map<string, Map<string, (payload: unknown) => void>>();
+const left: string[] = [];
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: {
+        reload: (...args: unknown[]) => reload(...args),
+    },
+    usePage: () => page,
+}));
+
+vi.mock('@laravel/echo-vue', () => ({
+    echo: () => ({
+        private(name: string) {
+            const channel = {
+                listen(event: string, handler: (payload: unknown) => void) {
+                    const events =
+                        listeners.get(name) ??
+                        new Map<string, (payload: unknown) => void>();
+                    events.set(event, handler);
+                    listeners.set(name, events);
+
+                    return channel;
+                },
+            };
+
+            return channel;
+        },
+        leave: (name: string) => left.push(name),
+    }),
+}));
+
+import { useSidebarBadges } from '@/composables/useSidebarBadges';
+
+/**
+ * A no-op custom renderer mounts a real component instance under Node (no DOM),
+ * which is what fires the composable's `onMounted` subscription and its
+ * `onBeforeUnmount` teardown. An effectScope alone never mounts either hook.
+ */
+const { createApp } = createRenderer<object, object>({
+    insert: () => {},
+    remove: () => {},
+    createElement: () => ({}),
+    createText: () => ({}),
+    createComment: () => ({}),
+    setText: () => {},
+    setElementText: () => {},
+    parentNode: () => null,
+    nextSibling: () => null,
+    patchProp: () => {},
+});
+
+/** Mount the composable, exposing its teardown. */
+function harness(): { unmount: () => void } {
+    const app = createApp(
+        defineComponent({
+            setup() {
+                useSidebarBadges();
+
+                return () => null;
+            },
+        }),
+    );
+    app.mount({});
+
+    return { unmount: () => app.unmount() };
+}
+
+/** Fire an event on a subscribed Echo channel, as Reverb would. */
+function emit(channel: string, event: string): void {
+    listeners.get(channel)?.get(event)?.({});
+}
+
+describe('useSidebarBadges cross-device read sync', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        reload.mockClear();
+        listeners.clear();
+        left.length = 0;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('reloads the badge props when another device advances the read pointer', () => {
+        harness();
+
+        emit('user.viewer-id', 'ReadStateAdvanced');
+
+        expect(reload).not.toHaveBeenCalled();
+
+        vi.runAllTimers();
+
+        expect(reload).toHaveBeenCalledTimes(1);
+        expect(reload).toHaveBeenCalledWith(
+            expect.objectContaining({ only: ['channels', 'hasUnreadThreads'] }),
+        );
+    });
+
+    it('collapses a burst of read signals into a single reload', () => {
+        harness();
+
+        emit('user.viewer-id', 'ReadStateAdvanced');
+        emit('user.viewer-id', 'ReadStateAdvanced');
+        emit('user.viewer-id', 'ReadStateAdvanced');
+
+        vi.runAllTimers();
+
+        expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the private channel on teardown', () => {
+        const { unmount } = harness();
+
+        unmount();
+
+        expect(left).toContain('user.viewer-id');
+    });
+});

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -1,5 +1,6 @@
 import { router, usePage } from '@inertiajs/vue3';
-import { computed } from 'vue';
+import { echo } from '@laravel/echo-vue';
+import { computed, onBeforeUnmount, onMounted } from 'vue';
 import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { backgroundVisit } from '@/lib/backgroundVisit';
@@ -20,6 +21,13 @@ const REFRESH_DEBOUNCE_MS = 500;
  * `channels` so the badge updates without a manual navigation. A single reload
  * recomputes every channel's count, so bursts across channels collapse to one
  * request.
+ *
+ * The same reload also answers {@see \App\Events\ReadStateAdvanced} on the
+ * viewer's own private `user.{id}` channel, which is how *clearing* a badge
+ * reaches their other devices: reading on a phone would otherwise leave the
+ * desktop showing the channel unread until its next navigation. Sharing one
+ * debounced reload with the arrival side means a read and an arrival landing
+ * together still cost a single request.
  */
 export function useSidebarBadges(): void {
     const page = usePage();
@@ -32,9 +40,10 @@ export function useSidebarBadges(): void {
     // reload defaults to preserving scroll and page state; it re-evaluates the
     // shared `channels` prop to recompute every badge count, plus the aggregate
     // `hasUnreadThreads` flag behind the sidebar's Threads dot. A teammate's
-    // message decides when it fires, so it runs as a background visit
-    // ({@see backgroundVisit}) — otherwise an arrival landing mid-navigation
-    // cancels the visit the user actually asked for.
+    // message — or another of the viewer's own devices — decides when it fires,
+    // so it runs as a background visit ({@see backgroundVisit}); otherwise an
+    // arrival landing mid-navigation cancels the visit the user actually asked
+    // for.
     const refresh = useDebouncedPost(
         () =>
             router.reload({
@@ -59,5 +68,24 @@ export function useSidebarBadges(): void {
         if (decision) {
             refresh.schedule();
         }
+    });
+
+    function ownChannelName(): string {
+        return `user.${currentUserId.value}`;
+    }
+
+    // Echo opens a websocket, so touch it only in the browser (never on the SSR
+    // pass). The authenticated user is stable for the session, so a single
+    // subscribe/teardown pair is enough.
+    onMounted(() => {
+        echo()
+            .private(ownChannelName())
+            .listen('ReadStateAdvanced', () => {
+                refresh.schedule();
+            });
+    });
+
+    onBeforeUnmount(() => {
+        echo().leave(ownChannelName());
     });
 }

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -624,9 +624,16 @@ const stickyDayLabel = computed<string | null>(() => {
  * Debounced and gated on tab focus: a channel is only "read" while the user is
  * actually looking at it, and a burst of arriving messages collapses to one
  * request. The redirect refreshes just the shared `channels` prop.
+ *
+ * The Echo socket id rides along so the resulting `ReadStateAdvanced` broadcast
+ * skips this tab: the response above already brings it fresh counts, and its
+ * own signal would only buy a second, redundant sidebar reload. The reader's
+ * *other* devices still receive it, which is the point of the broadcast.
  */
 const readPost = useDebouncedPost(
     () => {
+        const socketId = echo().socketId();
+
         router.post(
             markChannelRead({
                 team: props.team.slug,
@@ -641,6 +648,7 @@ const readPost = useDebouncedPost(
                 preserveScroll: true,
                 preserveState: true,
                 only: ['channels'],
+                headers: socketId ? { 'X-Socket-ID': socketId } : {},
             },
         );
     },

--- a/tests/Feature/Channels/CrossDeviceReadSyncTest.php
+++ b/tests/Feature/Channels/CrossDeviceReadSyncTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use App\Actions\Channels\MarkChannelRead;
+use App\Actions\Channels\OpenDirectMessage;
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Events\MessageRead;
+use App\Events\ReadStateAdvanced;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Create a team with its owner already a member of #general.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function readSyncTeamWithGeneral(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = Channel::where('team_id', $team->id)->where('slug', 'general')->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * Add a user to the team and the given channel, returning them.
+ */
+function readSyncMember(Team $team, Channel $channel, User $user): User
+{
+    $team->memberships()->create(['user_id' => $user->id, 'role' => TeamRole::Member]);
+    $channel->channelMembers()->firstOrCreate(['user_id' => $user->id]);
+
+    return $user;
+}
+
+test('advancing the read pointer signals the reader other devices', function (): void {
+    Event::fake([ReadStateAdvanced::class]);
+
+    [$owner, $team, $general] = readSyncTeamWithGeneral();
+    $member = readSyncMember($team, $general, User::factory()->create());
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    Event::assertDispatched(ReadStateAdvanced::class, fn (ReadStateAdvanced $event): bool => $event->userId === $member->id
+        && $event->channelId === $general->id);
+});
+
+test('a reader who hides read receipts still syncs their own devices', function (): void {
+    Event::fake([ReadStateAdvanced::class, MessageRead::class]);
+
+    [$owner, $team, $general] = readSyncTeamWithGeneral();
+    $member = readSyncMember($team, $general, User::factory()->withoutReadReceipts()->create());
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    // Their own devices still learn the channel is read...
+    Event::assertDispatched(ReadStateAdvanced::class);
+    // ...while peers learn nothing, exactly as the preference promises.
+    Event::assertNotDispatched(MessageRead::class);
+});
+
+test('a read that advances nothing signals nothing', function (): void {
+    Event::fake([ReadStateAdvanced::class]);
+
+    [$owner, $team, $general] = readSyncTeamWithGeneral();
+    $member = readSyncMember($team, $general, User::factory()->create());
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    // The client re-marks the open channel read on every arrival and every
+    // window focus, so the no-op path is the common one; it must stay silent
+    // or every focus would storm the reader's other devices with reloads.
+    app(MarkChannelRead::class)->handle($general, $member);
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    Event::assertDispatchedTimes(ReadStateAdvanced::class, 1);
+});
+
+test('a read with nothing to point at signals nothing', function (): void {
+    Event::fake([ReadStateAdvanced::class]);
+
+    [$owner, $team, $general] = readSyncTeamWithGeneral();
+    $member = readSyncMember($team, $general, User::factory()->create());
+    $outsider = User::factory()->create();
+    $team->memberships()->create(['user_id' => $outsider->id, 'role' => TeamRole::Member]);
+    $general->channelMembers()->where('user_id', $outsider->id)->delete();
+
+    // An empty channel leaves the pointer untouched.
+    app(MarkChannelRead::class)->handle($general, $member);
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    // A non-member has no pivot row to advance.
+    app(MarkChannelRead::class)->handle($general, $outsider);
+
+    Event::assertNotDispatched(ReadStateAdvanced::class);
+});
+
+test('the read endpoint signals the reader other devices for a channel', function (): void {
+    Event::fake([ReadStateAdvanced::class]);
+
+    [$owner, $team, $general] = readSyncTeamWithGeneral();
+    $member = readSyncMember($team, $general, User::factory()->create());
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    $this->actingAs($member)
+        ->post(route('channels.read', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertRedirect();
+
+    Event::assertDispatched(ReadStateAdvanced::class, fn (ReadStateAdvanced $event): bool => $event->userId === $member->id
+        && $event->channelId === $general->id);
+});
+
+test('the read endpoint signals the reader other devices for a direct message', function (): void {
+    Event::fake([ReadStateAdvanced::class]);
+
+    [$owner, $team, $general] = readSyncTeamWithGeneral();
+    $member = readSyncMember($team, $general, User::factory()->create());
+
+    $dm = app(OpenDirectMessage::class)->handle($team, $owner, $member);
+    Message::factory()->for($dm)->for($owner)->create();
+
+    $this->actingAs($member)
+        ->post(route('channels.read', ['team' => $team->slug, 'channel' => $dm->slug]))
+        ->assertRedirect();
+
+    Event::assertDispatched(ReadStateAdvanced::class, fn (ReadStateAdvanced $event): bool => $event->userId === $member->id
+        && $event->channelId === $dm->id);
+});
+
+test('the signal skips the very device that did the reading', function (): void {
+    Event::fake([ReadStateAdvanced::class]);
+
+    [$owner, $team, $general] = readSyncTeamWithGeneral();
+    $member = readSyncMember($team, $general, User::factory()->create());
+
+    Message::factory()->for($general)->for($owner)->create();
+
+    // The reading tab sends its Echo socket id, and that connection already
+    // gets fresh counts in this request's own response — echoing the signal
+    // back to it would only buy a second, redundant sidebar reload.
+    $this->actingAs($member)
+        ->withHeader('X-Socket-ID', 'reading-device-socket')
+        ->post(route('channels.read', ['team' => $team->slug, 'channel' => $general->slug]))
+        ->assertRedirect();
+
+    Event::assertDispatched(
+        ReadStateAdvanced::class,
+        fn (ReadStateAdvanced $event): bool => $event->socket === 'reading-device-socket',
+    );
+});
+
+test('ReadStateAdvanced broadcasts the channel id on the reader own private channel', function (): void {
+    $event = new ReadStateAdvanced('user-id', 'channel-id');
+
+    expect($event->broadcastOn())->toEqual([new PrivateChannel('user.user-id')]);
+    expect($event->broadcastWith())->toEqual(['channelId' => 'channel-id']);
+});


### PR DESCRIPTION
Closes #376.

## What

Read a channel or DM on one device and its sidebar unread badge now clears on your **other** devices in real time. This was the one direction of unread state that did not already sync.

## Why

The *increment* direction already syncs cross-device: every client subscribes to each `channel.{id}` and runs a debounced authoritative reload on `MessageSent`, so new unreads appear live everywhere. *Read-clearing* did not propagate — advancing `channel_members.last_read_message_id` only broadcast `MessageRead` (and only when `share_read_receipts` was on), which the sidebar-badge machinery never listened to. Reading on a phone left the desktop showing the channel unread until it happened to navigate.

## How

**Backend**

- New `App\Events\ReadStateAdvanced`, broadcast on the reader's own `PrivateChannel('user.{id}')`. It carries only `channelId` — no counts — so nothing about where someone read leaks to peers and the client keeps using the existing server-computed badge machinery rather than a new client-side counting model.
- `MarkChannelRead` emits it after a real pointer advance, **outside** the `share_read_receipts` branch: that preference governs revealing read state to *others*, never whether a user's own devices stay in step. It reuses the existing no-op guard, so the frequent re-marks the client fires on every arrival and window focus stay silent.
- The broadcast goes out with `->toOthers()`.

**Frontend**

- `useSidebarBadges` subscribes to `user.{id}` and, on `ReadStateAdvanced`, schedules the *same* debounced reload the arrival side already uses — so a read and an incoming message landing together still cost a single request.
- The mark-read POST in `channels/Show.vue` now sends `X-Socket-ID`, which is what lets `toOthers()` skip the tab that just read: that tab already gets fresh `channels` in the request's own response, so echoing the signal back would only buy a second, redundant reload. Same mechanism `UserTyping` already uses; if Echo is not connected the header is absent and it degrades to that harmless extra reload.

## Testing

`tests/Feature/Channels/CrossDeviceReadSyncTest.php` (8 tests) covers every acceptance criterion:

- reading a channel signals the reader's other devices, and the same for a DM, both through the action and the `channels.read` endpoint
- it still fires with `share_read_receipts = false`, while `MessageRead` correctly does not
- nothing is signalled when the pointer does not advance, on an empty channel, or for a non-member
- the signal skips the socket that did the reading
- the broadcast channel name and payload contract

`resources/js/composables/useSidebarBadges.test.ts` (3 tests) covers the new subscription, burst collapsing into one reload, and channel teardown.

Adjacent suites (`ReadReceiptsTest`, `UnreadBadgeTest`, `ThreadReadTest`) still pass, so the "Seen by" affordance and the increment-side liveness are unregressed.

Gate: `composer test` at **Total: 100.0 %** with Pint/PHPStan/Rector clean, plus `lint:check`, `format:check`, `types:check`, `test:js` (910 passed) and `build`.

## i18n and docs

None needed — the change ships no user-facing copy and no operator-facing config or `.env` setting.

## Out of scope

Thread read-state cross-device sync and optimistic/offline-resilient badge counts, both deferred by the issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787317088&installation_model_id=428379&pr_number=729&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F729&signature=ac5e4e6bfb69b64f04c4b966f58bbf354064df47facce2366dc5f2eaebea756e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->