### PR TITLE
feat: away and idle presence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -335,3 +335,9 @@ WEBHOOKS_DISABLE_AFTER=5
 # metadata targets — at registration and before each delivery. Set it false only
 # for a locked-down instance that deliberately targets internal endpoints.
 WEBHOOKS_BLOCK_PRIVATE_URLS=true
+
+# Presence: how many minutes a browser tab may go without pointer, keyboard,
+# scroll or focus activity before it reports itself idle. Teammates only see
+# someone as away once every device they are signed in on has gone idle. Floored
+# at 1 minute; idle detection cannot be turned off.
+PRESENCE_AWAY_AFTER_MINUTES=10

--- a/app/Data/UserData.php
+++ b/app/Data/UserData.php
@@ -2,6 +2,7 @@
 
 namespace App\Data;
 
+use App\Enums\PresenceState;
 use App\Models\User;
 use Spatie\LaravelData\Data;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
@@ -22,6 +23,12 @@ class UserData extends Data
         // can show the emoji inline beside their name. Null when they have set
         // none or theirs has lapsed, and the surface then renders nothing.
         public ?UserStatusData $status = null,
+        // How reachable the author is, composed with the Reverb roster on the
+        // client: the roster answers "connected at all", this refines a
+        // connected user into active or away. Carried in the initial props so a
+        // freshly loaded client — which has no broadcast history — still paints
+        // the right dot before any UserPresenceChanged event arrives.
+        public PresenceState $presence = PresenceState::Active,
     ) {}
 
     /**
@@ -35,6 +42,7 @@ class UserData extends Data
             avatar: $user->avatar,
             isBot: $user->isBot(),
             status: UserStatusData::forUser($user),
+            presence: $user->effectivePresence(),
         );
     }
 }

--- a/app/Enums/PresenceState.php
+++ b/app/Enums/PresenceState.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+/**
+ * How reachable a user is while they are connected.
+ *
+ * This is deliberately not a third "offline" case: whether someone is connected
+ * at all is answered by the Reverb presence roster, which is instant and needs
+ * no persistence. This enum only refines a *connected* user, and is composed
+ * with the roster on the client.
+ */
+#[TypeScript]
+enum PresenceState: string
+{
+    case Active = 'active';
+    case Away = 'away';
+}

--- a/app/Events/UserPresenceChanged.php
+++ b/app/Events/UserPresenceChanged.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Data\UserData;
+use App\Enums\PresenceState;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * A user flipped between active and away, on every team they belong to.
+ *
+ * Deliberately a separate, tiny event rather than a field on
+ * {@see UserProfileUpdated}, whose listener answers with a debounced reload of
+ * *every* Inertia prop. That is proportionate for an avatar or a custom status,
+ * which change a few times a day; auto-idle fires on every idle↔active
+ * transition, so reusing that path would mean hundreds of full-prop reloads per
+ * client over a lunch hour in a busy workspace. Clients patch a local map from
+ * this payload instead and re-render only the dots.
+ *
+ * The presence still rides `UserProfileUpdated` (via {@see UserData})
+ * so a client that reloads for any other reason lands on the right state.
+ */
+class UserPresenceChanged implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public User $user, public PresenceState $state) {}
+
+    /**
+     * The presence channel of each team the user belongs to — every teammate
+     * with that team open receives the flip.
+     *
+     * @return array<int, PresenceChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return $this->user->teams
+            ->map(fn (Team $team): PresenceChannel => new PresenceChannel('team.'.$team->id))
+            ->all();
+    }
+
+    /**
+     * @return array{id: string, state: string}
+     */
+    public function broadcastWith(): array
+    {
+        return ['id' => $this->user->id, 'state' => $this->state->value];
+    }
+}

--- a/app/Http/Controllers/PresenceConnectionController.php
+++ b/app/Http/Controllers/PresenceConnectionController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Events\UserPresenceChanged;
+use App\Http\Requests\ReleasePresenceRequest;
+use App\Http\Requests\ReportPresenceRequest;
+use App\Models\User;
+use App\Support\PresenceRegistry;
+use Illuminate\Http\Response;
+
+/**
+ * The client-side idle detector's two writes: a tab saying how active it is, and
+ * a tab saying goodbye.
+ *
+ * Both are deliberately quiet — nothing is broadcast unless the *aggregate* the
+ * user's teammates see actually moves. A second device going idle while the
+ * first is still in use changes nothing, and so costs nothing.
+ */
+class PresenceConnectionController extends Controller
+{
+    public function __construct(private readonly PresenceRegistry $registry) {}
+
+    /**
+     * Record how active one of the user's tabs is.
+     *
+     * Called on every idle↔active transition and, far more rarely, as a slow
+     * heartbeat so a crashed tab eventually ages out of the index.
+     */
+    public function store(ReportPresenceRequest $request): Response
+    {
+        $user = $request->user();
+
+        $this->broadcastIfChanged($user, function () use ($user, $request): void {
+            $this->registry->record($user->id, $request->connection(), $request->state());
+        });
+
+        return response()->noContent();
+    }
+
+    /**
+     * Drop a tab from the index as it closes.
+     *
+     * Without this, closing the one tab you were active in would leave its
+     * "active" entry standing until the TTL lapsed, so a second, idle tab would
+     * keep showing you as active — the case where being wrong matters most.
+     */
+    public function destroy(ReleasePresenceRequest $request): Response
+    {
+        $user = $request->user();
+
+        $this->broadcastIfChanged($user, function () use ($user, $request): void {
+            $this->registry->forget($user->id, $request->connection());
+        });
+
+        return response()->noContent();
+    }
+
+    /**
+     * Apply a change to the index, announcing it only if teammates would now see
+     * the user differently.
+     *
+     * A manual away pins the effective state, so a tab reporting under one is
+     * recorded (it still matters the moment the override is cleared) but never
+     * broadcast.
+     */
+    private function broadcastIfChanged(User $user, callable $apply): void
+    {
+        $before = $user->effectivePresence();
+
+        $apply();
+
+        $after = $user->effectivePresence();
+
+        if ($after !== $before) {
+            event(new UserPresenceChanged($user, $after));
+        }
+    }
+}

--- a/app/Http/Controllers/Settings/PresenceController.php
+++ b/app/Http/Controllers/Settings/PresenceController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Events\UserPresenceChanged;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdatePresenceRequest;
+use Illuminate\Http\RedirectResponse;
+
+class PresenceController extends Controller
+{
+    /**
+     * Set — or clear — the current user's manual away override.
+     *
+     * Away here is an override that outlives the browser: it is stored on the
+     * row, so it survives a reconnect, a new device, and a restart until the
+     * user unsets it. Clearing it hands the answer back to the live connections,
+     * which is why the broadcast carries the *effective* state rather than the
+     * one that was just written — a user who unsets away from a tab that has
+     * since gone idle stays away, and teammates are told so.
+     */
+    public function update(UpdatePresenceRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        $user->forceFill(['presence_state' => $request->state()])->save();
+
+        event(new UserPresenceChanged($user, $user->effectivePresence()));
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -142,6 +142,12 @@ class HandleInertiaRequests extends Middleware
             // is the single source of truth, shared the same way the settings page
             // sources its own options.
             'sidebarPositions' => SidebarPosition::options(),
+            // The auto-idle threshold rides every request because the detector
+            // that enforces it runs in the browser: a tab has to know how long
+            // "no activity" may last before it reports itself away.
+            'presence' => [
+                'awayAfterMinutes' => max((int) config('presence.away_after_minutes'), 1),
+            ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'currentTeam' => fn () => $user?->currentTeam ? $user->toUserTeam($user->currentTeam) : null,
             'teams' => fn () => $user?->toUserTeams(includeCurrent: true) ?? [],

--- a/app/Http/Requests/ReleasePresenceRequest.php
+++ b/app/Http/Requests/ReleasePresenceRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReleasePresenceRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'connection' => ['required', 'string', 'max:64'],
+        ];
+    }
+
+    /**
+     * The closing tab's key.
+     */
+    public function connection(): string
+    {
+        return (string) $this->validated('connection');
+    }
+}

--- a/app/Http/Requests/ReportPresenceRequest.php
+++ b/app/Http/Requests/ReportPresenceRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Enums\PresenceState;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class ReportPresenceRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // A per-tab key the browser mints once and keeps in sessionStorage.
+            // It is namespaced under the authenticated user, so however a client
+            // forges it, it can only ever describe one of its own connections.
+            'connection' => ['required', 'string', 'max:64'],
+            'state' => ['required', new Enum(PresenceState::class)],
+        ];
+    }
+
+    /**
+     * The reporting tab's key.
+     */
+    public function connection(): string
+    {
+        return (string) $this->validated('connection');
+    }
+
+    /**
+     * How active the reporting tab says it is.
+     */
+    public function state(): PresenceState
+    {
+        return PresenceState::from((string) $this->validated('state'));
+    }
+}

--- a/app/Http/Requests/Settings/UpdatePresenceRequest.php
+++ b/app/Http/Requests/Settings/UpdatePresenceRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use App\Enums\PresenceState;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class UpdatePresenceRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // The menu offers exactly one flip, so the target state is sent
+            // outright rather than toggled server-side — two tabs pressing it at
+            // once then agree instead of racing each other back and forth.
+            'state' => ['required', new Enum(PresenceState::class)],
+        ];
+    }
+
+    /**
+     * The manual override the user asked for.
+     */
+    public function state(): PresenceState
+    {
+        return PresenceState::from((string) $this->validated('state'));
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,12 +8,14 @@ use App\Data\UserData;
 use App\Data\UserStatusData;
 use App\Enums\AppLocale;
 use App\Enums\ChimeSound;
+use App\Enums\PresenceState;
 use App\Enums\SidebarPosition;
 use App\Enums\TeamRole;
 use App\Enums\UserType;
 use App\Observers\UserObserver;
 use App\Support\Gravatar;
 use App\Support\Images\ImageProxy;
+use App\Support\PresenceRegistry;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Translation\HasLocalePreference;
@@ -67,6 +69,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property ChimeSound $chime_sound
  * @property bool $share_read_receipts
  * @property SidebarPosition $sidebar_position
+ * @property PresenceState $presence_state
  * @property Carbon|null $onboarding_completed_at
  * @property bool $is_tombstone
  * @property Carbon|null $deactivated_at
@@ -75,6 +78,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property Carbon|null $updated_at
  * @property-read string|null $avatar
  * @property-read UserStatusData|null $status
+ * @property-read PresenceState $presence
  * @property-read Team|null $currentTeam
  * @property-read Team|null $ownerTeam
  * @property-read Collection<int, Team> $ownedTeams
@@ -86,8 +90,8 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read Collection<int, Passkey> $passkeys
  * @property-read Collection<int, UserGroup> $userGroups
  */
-#[Appends(['avatar', 'status'])]
-#[Fillable(['name', 'email', 'avatar_url', 'pronouns', 'title', 'phone', 'timezone', 'locale', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'sidebar_position', 'onboarding_completed_at', 'collapsed_channel_sections', 'is_tombstone'])]
+#[Appends(['avatar', 'status', 'presence'])]
+#[Fillable(['name', 'email', 'avatar_url', 'pronouns', 'title', 'phone', 'timezone', 'locale', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'sidebar_position', 'presence_state', 'onboarding_completed_at', 'collapsed_channel_sections', 'is_tombstone'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token', 'avatar_url', 'avatar_path', 'status_emoji', 'status_text', 'status_expires_at'])]
 #[ObservedBy(UserObserver::class)]
 class User extends Authenticatable implements HasLocalePreference, MustVerifyEmail, PasskeyUser
@@ -167,6 +171,37 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
     }
 
     /**
+     * How reachable the user is right now, as teammates should see them.
+     *
+     * A manual away is an override and wins outright — that is the whole point
+     * of setting it, and it survives reconnects because it lives on the row.
+     * Otherwise the answer is derived from the user's live browser connections,
+     * which is away only once every one of them has gone idle.
+     */
+    public function effectivePresence(): PresenceState
+    {
+        // Null only on a freshly-made instance the column default has not been
+        // read back into yet, which is never away.
+        if (($this->presence_state ?? PresenceState::Active) === PresenceState::Away) {
+            return PresenceState::Away;
+        }
+
+        return app(PresenceRegistry::class)->aggregate($this->id);
+    }
+
+    /**
+     * The user's effective presence, appended to every serialisation of the
+     * model so the viewer's own `auth.user` prop carries the same answer that
+     * {@see UserData::$presence} gives their teammates.
+     *
+     * @return Attribute<covariant PresenceState, never>
+     */
+    protected function presence(): Attribute
+    {
+        return Attribute::get(fn (): PresenceState => $this->effectivePresence());
+    }
+
+    /**
      * Get the recipient's preferred locale so mail and notifications render
      * in the language they chose in their settings.
      *
@@ -196,6 +231,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
             'chime_sound' => ChimeSound::class,
             'share_read_receipts' => 'boolean',
             'sidebar_position' => SidebarPosition::class,
+            'presence_state' => PresenceState::class,
             'onboarding_completed_at' => 'datetime',
             'status_expires_at' => 'datetime',
             'is_tombstone' => 'boolean',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Models\PersonalAccessToken;
 use App\Support\IpGeolocator;
+use App\Support\PresenceRegistry;
 use Carbon\CarbonImmutable;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
@@ -31,6 +32,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(IpGeolocator::class, fn (): IpGeolocator => new IpGeolocator(
             (string) config('geolocation.database_path'),
         ));
+
+        // One instance per request, so the presence aggregate a page needs for
+        // dozens of rendered users costs one cache read per distinct user.
+        $this->app->singleton(PresenceRegistry::class);
     }
 
     /**

--- a/app/Support/PresenceRegistry.php
+++ b/app/Support/PresenceRegistry.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Enums\PresenceState;
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+/**
+ * An owned, per-user index of live browser connections and how active each one is.
+ *
+ * Presence metadata on a Reverb roster is frozen at join and cannot be mutated
+ * without leaving and rejoining, so a mid-session active↔away flip has nowhere
+ * to live there. This index is that home: each of a user's tabs reports itself
+ * under its own key, and the aggregate is derived server-side so a client that
+ * has just loaded (and so has no event history) still gets the right answer in
+ * its initial props.
+ *
+ * It mirrors {@see SessionRegistry}'s cache-backed shape but is deliberately a
+ * separate class: sessions are the grain device management needs, and two tabs
+ * of one session can disagree about being idle.
+ *
+ * The feature fails open. A user with no entry at all — an evicted cache key, a
+ * client that has not reported yet, an unavailable Redis — reads as active,
+ * which is exactly the behaviour that predates this index.
+ *
+ * @phpstan-type ConnectionMeta array{state: string, last_seen: int}
+ */
+class PresenceRegistry
+{
+    /**
+     * Aggregates already resolved this request, keyed by user id.
+     *
+     * A single render asks for the same author's presence once per message row,
+     * so the cache round-trip is made once per user per request.
+     *
+     * @var array<string, PresenceState>
+     */
+    private array $resolved = [];
+
+    public function __construct(private readonly Cache $cache) {}
+
+    /**
+     * Record — or refresh — how active one of a user's connections is.
+     */
+    public function record(string $userId, string $connectionId, PresenceState $state): void
+    {
+        $connections = $this->load($userId);
+
+        $connections[$connectionId] = [
+            'state' => $state->value,
+            'last_seen' => now()->getTimestamp(),
+        ];
+
+        $this->save($userId, $connections);
+    }
+
+    /**
+     * Drop a connection, e.g. when its tab is closed.
+     */
+    public function forget(string $userId, string $connectionId): void
+    {
+        $connections = $this->load($userId);
+
+        if (! array_key_exists($connectionId, $connections)) {
+            return;
+        }
+
+        unset($connections[$connectionId]);
+
+        $this->save($userId, $connections);
+    }
+
+    /**
+     * The state teammates should see for a connected user.
+     *
+     * Away only once every reporting connection is idle: one active laptop
+     * keeps the user active however many phones have gone to sleep.
+     */
+    public function aggregate(string $userId): PresenceState
+    {
+        return $this->resolved[$userId] ??= $this->derive($userId);
+    }
+
+    /**
+     * Resolve a user's aggregate from their live connections.
+     */
+    private function derive(string $userId): PresenceState
+    {
+        $connections = $this->load($userId);
+
+        if ($connections === []) {
+            return PresenceState::Active;
+        }
+
+        foreach ($connections as $meta) {
+            if ($meta['state'] === PresenceState::Active->value) {
+                return PresenceState::Active;
+            }
+        }
+
+        return PresenceState::Away;
+    }
+
+    /**
+     * Read a user's connections, dropping any that stopped reporting.
+     *
+     * @return array<string, ConnectionMeta>
+     */
+    private function load(string $userId): array
+    {
+        /** @var array<string, ConnectionMeta> $connections */
+        $connections = $this->cache->get($this->key($userId), []);
+
+        $threshold = now()->subMinutes($this->ttlMinutes())->getTimestamp();
+
+        return array_filter($connections, fn (array $meta): bool => $meta['last_seen'] >= $threshold);
+    }
+
+    /**
+     * Persist a user's connections, or forget the key entirely when none remain.
+     *
+     * @param  array<string, ConnectionMeta>  $connections
+     */
+    private function save(string $userId, array $connections): void
+    {
+        unset($this->resolved[$userId]);
+
+        if ($connections === []) {
+            $this->cache->forget($this->key($userId));
+
+            return;
+        }
+
+        $this->cache->put($this->key($userId), $connections, now()->addMinutes($this->ttlMinutes()));
+    }
+
+    /**
+     * How long a connection survives without reporting.
+     *
+     * Derived from the one operator-facing knob rather than adding a second:
+     * clients heartbeat well inside this window, so the margin above the idle
+     * threshold only has to outlast a missed beat. A crashed tab is cleaned up
+     * once the margin lapses — the `pagehide` release handles every ordinary
+     * close instantly.
+     */
+    private function ttlMinutes(): int
+    {
+        return max((int) config('presence.away_after_minutes'), 1) + 5;
+    }
+
+    /**
+     * The cache key holding a user's connection index.
+     */
+    private function key(string $userId): string
+    {
+        return "presence-connections:{$userId}";
+    }
+}

--- a/app/Support/PresenceRegistry.php
+++ b/app/Support/PresenceRegistry.php
@@ -6,6 +6,7 @@ namespace App\Support;
 
 use App\Enums\PresenceState;
 use Illuminate\Contracts\Cache\Repository as Cache;
+use Throwable;
 
 /**
  * An owned, per-user index of live browser connections and how active each one is.
@@ -110,8 +111,17 @@ class PresenceRegistry
      */
     private function load(string $userId): array
     {
-        /** @var array<string, ConnectionMeta> $connections */
-        $connections = $this->cache->get($this->key($userId), []);
+        try {
+            /** @var array<string, ConnectionMeta> $connections */
+            $connections = $this->cache->get($this->key($userId), []);
+        } catch (Throwable $exception) {
+            // Failing open is the whole contract: a dot is not worth 500ing a
+            // page render over, and an unreachable cache reads as "no idle
+            // connections", which is exactly the pre-feature behaviour.
+            report($exception);
+
+            return [];
+        }
 
         $threshold = now()->subMinutes($this->ttlMinutes())->getTimestamp();
 
@@ -127,13 +137,19 @@ class PresenceRegistry
     {
         unset($this->resolved[$userId]);
 
-        if ($connections === []) {
-            $this->cache->forget($this->key($userId));
+        try {
+            if ($connections === []) {
+                $this->cache->forget($this->key($userId));
 
-            return;
+                return;
+            }
+
+            $this->cache->put($this->key($userId), $connections, now()->addMinutes($this->ttlMinutes()));
+        } catch (Throwable $exception) {
+            // A dropped write is recoverable on its own: every connection
+            // re-states itself on its next heartbeat.
+            report($exception);
         }
-
-        $this->cache->put($this->key($userId), $connections, now()->addMinutes($this->ttlMinutes()));
     }
 
     /**

--- a/config/presence.php
+++ b/config/presence.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*

--- a/config/presence.php
+++ b/config/presence.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-idle threshold
+    |--------------------------------------------------------------------------
+    |
+    | How many minutes a browser tab may go without pointer, keyboard, scroll or
+    | focus activity before it reports itself idle. Once every one of a user's
+    | connections is idle, teammates see them as away; any activity anywhere
+    | flips them straight back to active.
+    |
+    | The value reaches the browser as a shared Inertia prop, since the idle
+    | detector runs client-side.
+    |
+    */
+
+    'away_after_minutes' => (int) env('PRESENCE_AWAY_AFTER_MINUTES', 10),
+
+];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Enums\AppLocale;
 use App\Enums\ChimeSound;
+use App\Enums\PresenceState;
 use App\Enums\SidebarPosition;
 use App\Enums\TeamRole;
 use App\Enums\UserType;
@@ -44,6 +45,7 @@ class UserFactory extends Factory
             'chime_sound' => ChimeSound::Ping->value,
             'share_read_receipts' => true,
             'sidebar_position' => SidebarPosition::Left->value,
+            'presence_state' => PresenceState::Active->value,
             // Factory users are onboarded by default so the first-run tour never
             // auto-fires in unrelated feature/browser tests; opt into the pre-tour
             // state with the notOnboarded() helper below.

--- a/database/migrations/2026_07_22_142717_add_presence_state_to_users_table.php
+++ b/database/migrations/2026_07_22_142717_add_presence_state_to_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Enums\PresenceState;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            // The user's *manual* away override, and only that: auto-idle is
+            // derived per connection in the cache-backed PresenceRegistry, since
+            // two tabs of one account can disagree about being idle. Away here
+            // wins over every connection, and survives reconnects until unset.
+            $table->string('presence_state', 16)
+                ->default(PresenceState::Active->value)
+                ->after('status_expires_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('presence_state');
+        });
+    }
+};

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -337,3 +337,29 @@ To enable it, download a free **GeoLite2 City** database from
 required) and mount the `.mmdb` file at `GEOIP_DATABASE_PATH`. The database is not
 bundled: MaxMind's licence does not allow redistribution, and it is refreshed
 regularly, so you keep it up to date yourself.
+
+## Presence
+
+Every member sees a small dot beside their teammates' avatars: **filled** when
+someone is active, a **hollow ring** when they are away, and none at all when
+they are not connected. Away has two sources — a member can set it by hand from
+the user menu (which persists until they unset it), and each browser tab reports
+itself idle after a stretch with no pointer, keyboard, scroll, or focus activity.
+Someone counts as away only once **every** device they are signed in on has gone
+idle, so a laptop in use keeps them active however long a phone has been asleep.
+
+| Variable                      | Default | Notes                                                                                                 |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `PRESENCE_AWAY_AFTER_MINUTES` | `10`    | Minutes a tab may go without activity before it reports itself idle. Floored at `1`; there is no "never". |
+
+Idle detection runs in the browser, so the threshold is served to each client
+with the page rather than baked into the build — changing it takes effect on
+every client's next page load, with no rebuild.
+
+:::note[Presence needs no extra service]
+Who is *connected* comes from the Reverb presence channel the app already uses;
+active-versus-away is tracked in the cache (Redis in the bundled production
+stack). Nothing is written to the database except a member's own manual away
+setting, and if the cache is unavailable everyone simply reads as active — the
+same as before the feature existed.
+:::

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1208,5 +1208,10 @@
   "Could not save your status.": "Impossible d’enregistrer votre statut.",
   "Could not clear your status.": "Impossible d’effacer votre statut.",
   "Status updated.": "Statut mis à jour.",
-  "Status cleared.": "Statut effacé."
+  "Status cleared.": "Statut effacé.",
+  "Away": "Absent",
+  ":active of :total active": ":active sur :total actifs",
+  "Set yourself away": "Se marquer absent",
+  "Set yourself active": "Se marquer actif",
+  "Could not change your presence.": "Impossible de modifier votre présence."
 }

--- a/resources/js/components/AvatarStack.vue
+++ b/resources/js/components/AvatarStack.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { getInitials } from '@/composables/useInitials';
 import { memberAvatarStack } from '@/lib/memberAvatars';
 import type { StackMember } from '@/lib/memberAvatars';
+import type { RenderedPresence } from '@/lib/presence';
 
 const props = withDefaults(
     defineProps<{
@@ -21,8 +23,19 @@ const props = withDefaults(
          * `ring-sidebar`, `ring-sidebar-primary`).
          */
         ringClass?: string;
+        /**
+         * How each stacked member reads on the presence roster. Omitted on the
+         * stacks where presence is meaningless (a poll's voters, a group DM's
+         * fixed participant list), which then render no dots at all.
+         */
+        presenceFor?: (userId: string) => RenderedPresence;
+        /**
+         * Background class matching the surface behind the stack, for the hollow
+         * centre of an away dot. Pairs with `ringClass`.
+         */
+        surfaceClass?: string;
     }>(),
-    { max: 3, size: 'md', ringClass: 'ring-card' },
+    { max: 3, size: 'md', ringClass: 'ring-card', surfaceClass: 'bg-card' },
 );
 
 const stack = computed(() => memberAvatarStack(props.members, props.max));
@@ -44,28 +57,45 @@ const SIZES = {
 } as const;
 
 const dims = computed(() => SIZES[props.size]);
+
+// Per-size dot geometry, matching the ring the avatars already carry so the dot
+// reads as part of the same stack rather than floating over it.
+const DOT_SIZES = { sm: 'size-2', md: 'size-2.5' } as const;
 </script>
 
 <template>
     <span class="flex shrink-0" aria-hidden="true">
-        <Avatar
+        <!-- A member with presence gets a positioned wrapper so their dot can sit
+             on the avatar's corner; without one the avatar stacks directly, as
+             it always has. -->
+        <span
             v-for="member in stack.visible"
             :key="member.id"
-            class="ring-2 select-none"
-            :class="[dims.box, ringClass]"
+            class="relative"
+            :class="dims.box"
         >
-            <AvatarImage
-                v-if="member.avatar"
-                :src="member.avatar"
-                :alt="member.name"
+            <Avatar class="size-full ring-2 select-none" :class="ringClass">
+                <AvatarImage
+                    v-if="member.avatar"
+                    :src="member.avatar"
+                    :alt="member.name"
+                />
+                <AvatarFallback
+                    class="font-semibold text-primary"
+                    :class="dims.text"
+                >
+                    {{ getInitials(member.name) }}
+                </AvatarFallback>
+            </Avatar>
+            <PresenceDot
+                v-if="presenceFor"
+                data-test="stack-presence-dot"
+                :presence="presenceFor(member.id)"
+                :surface-class="surfaceClass"
+                class="absolute -right-0.5 -bottom-0.5 ring-2"
+                :class="[DOT_SIZES[size], ringClass]"
             />
-            <AvatarFallback
-                class="font-semibold text-primary"
-                :class="dims.text"
-            >
-                {{ getInitials(member.name) }}
-            </AvatarFallback>
-        </Avatar>
+        </span>
         <span
             v-if="stack.overflow > 0"
             class="flex items-center justify-center rounded-full bg-muted font-semibold text-muted-foreground ring-2 select-none"

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -39,7 +39,7 @@ import type { ConnectionPill } from '@/composables/useConnectionState';
 import { getInitials } from '@/composables/useInitials';
 import { memberAvatarStack } from '@/lib/memberAvatars';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
-import { presenceLabelKey } from '@/lib/presence';
+import { dmParticipantPresence, presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
 import type {
     Channel,
@@ -135,10 +135,12 @@ const dmAvatar = computed(() =>
  * the team roster. A DM is a fixed set, so the "who's in the channel" facepile is
  * meaningless and hidden.
  */
-const dmParticipantPresence = computed<RenderedPresence>(() =>
-    props.channel.dmUserId != null
-        ? props.presenceFor(props.channel.dmUserId)
-        : 'offline',
+const dmPresence = computed<RenderedPresence>(() =>
+    dmParticipantPresence(
+        props.channel.dmUserId,
+        props.presenceFor,
+        page.props.auth.user.presence,
+    ),
 );
 
 /**
@@ -204,7 +206,7 @@ const groupParticipantCount = computed(
                     </Avatar>
                     <PresenceDot
                         data-test="masthead-dm-presence"
-                        :presence="dmParticipantPresence"
+                        :presence="dmPresence"
                         surface-class="bg-card"
                         class="absolute -right-0.5 -bottom-0.5 size-2.5 ring-2 ring-card"
                     />
@@ -212,7 +214,7 @@ const groupParticipantCount = computed(
                          an aria-label on the role-less dot, which assistive tech
                          ignores on a bare <span>. -->
                     <span class="sr-only">{{
-                        $t(presenceLabelKey(dmParticipantPresence))
+                        $t(presenceLabelKey(dmPresence))
                     }}</span>
                 </span>
                 <span v-else class="text-brass italic">#</span>

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -15,6 +15,7 @@ import type { AcceptableValue } from 'reka-ui';
 import { computed } from 'vue';
 import { index as searchMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
 import AvatarStack from '@/components/AvatarStack.vue';
+import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import {
@@ -38,6 +39,8 @@ import type { ConnectionPill } from '@/composables/useConnectionState';
 import { getInitials } from '@/composables/useInitials';
 import { memberAvatarStack } from '@/lib/memberAvatars';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
+import { presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
 import type {
     Channel,
     Mention,
@@ -53,8 +56,8 @@ const props = defineProps<{
      * overlapping member facepile.
      */
     members: Mention[];
-    /** Ids of team members currently online, driving the DM presence dot. */
-    onlineIds: Set<string>;
+    /** How each team member reads on the presence roster, driving every dot here. */
+    presenceFor: (userId: string) => RenderedPresence;
     /**
      * The viewer-relative title (self-DM reads "You"); the page also feeds it to
      * `<Head>`, so it is resolved once there and passed down.
@@ -132,10 +135,24 @@ const dmAvatar = computed(() =>
  * the team roster. A DM is a fixed set, so the "who's in the channel" facepile is
  * meaningless and hidden.
  */
-const dmParticipantOnline = computed(
+const dmParticipantPresence = computed<RenderedPresence>(() =>
+    props.channel.dmUserId != null
+        ? props.presenceFor(props.channel.dmUserId)
+        : 'offline',
+);
+
+/**
+ * How many of the channel's members are active right now.
+ *
+ * Away counts as present but not active, which is the whole point of the third
+ * state: the readout answers "who could answer me now", not "who has the tab
+ * open".
+ */
+const activeMemberCount = computed(
     () =>
-        props.channel.dmUserId != null &&
-        props.onlineIds.has(props.channel.dmUserId),
+        props.members.filter(
+            (member) => props.presenceFor(member.id) === 'active',
+        ).length,
 );
 
 /** The group's participant count, including the viewer, for the subtitle. */
@@ -185,18 +202,18 @@ const groupParticipantCount = computed(
                             {{ getInitials(props.channel.name) }}
                         </AvatarFallback>
                     </Avatar>
-                    <span
-                        :data-online="dmParticipantOnline"
-                        :aria-label="
-                            dmParticipantOnline ? $t('Online') : $t('Offline')
-                        "
-                        class="absolute -right-0.5 -bottom-0.5 size-2.5 rounded-full ring-2 ring-card"
-                        :class="
-                            dmParticipantOnline
-                                ? 'bg-emerald-500'
-                                : 'bg-muted-foreground/50'
-                        "
+                    <PresenceDot
+                        data-test="masthead-dm-presence"
+                        :presence="dmParticipantPresence"
+                        surface-class="bg-card"
+                        class="absolute -right-0.5 -bottom-0.5 size-2.5 ring-2 ring-card"
                     />
+                    <!-- Announced through a screen-reader-only label rather than
+                         an aria-label on the role-less dot, which assistive tech
+                         ignores on a bare <span>. -->
+                    <span class="sr-only">{{
+                        $t(presenceLabelKey(dmParticipantPresence))
+                    }}</span>
                 </span>
                 <span v-else class="text-brass italic">#</span>
                 <span class="truncate">{{ props.title }}</span>
@@ -296,54 +313,71 @@ const groupParticipantCount = computed(
                     mastheadAvatars.visible.length > 0
                 "
                 data-test="masthead-members"
-                class="flex -space-x-1.5"
+                class="flex items-center gap-2"
             >
-                <span class="sr-only">
-                    {{
-                        props.members.length === 1
-                            ? $t(':count member', {
-                                  count: props.members.length,
-                              })
-                            : $t(':count members', {
-                                  count: props.members.length,
-                              })
-                    }}
-                </span>
-                <!-- A bot in the roster squares its avatar (rounded-md vs a
-                     human's circle) and shows a glyph, so it reads as non-human
-                     even at this size — matching its message-row treatment. -->
-                <Avatar
-                    v-for="member in mastheadAvatars.visible"
-                    :key="member.id"
-                    class="size-6 text-[9px] ring-2 ring-card"
-                    :class="member.isBot ? 'rounded-md' : ''"
-                    :title="member.name"
-                    aria-hidden="true"
-                >
-                    <AvatarImage
-                        v-if="member.avatar && !member.isBot"
-                        :src="member.avatar"
-                        :alt="member.name"
-                    />
-                    <AvatarFallback
-                        :class="
-                            member.isBot
-                                ? 'rounded-md bg-muted-foreground text-background'
-                                : 'bg-primary/10 font-semibold text-primary'
-                        "
+                <span class="flex -space-x-1.5">
+                    <!-- A bot in the roster squares its avatar (rounded-md vs a
+                         human's circle) and shows a glyph, so it reads as
+                         non-human even at this size — matching its message-row
+                         treatment. A bot has no presence, so it shows no dot. -->
+                    <span
+                        v-for="member in mastheadAvatars.visible"
+                        :key="member.id"
+                        class="relative size-6"
+                        :title="member.name"
+                        aria-hidden="true"
                     >
-                        <Bot v-if="member.isBot" class="size-3" />
-                        <template v-else>{{
-                            getInitials(member.name)
-                        }}</template>
-                    </AvatarFallback>
-                </Avatar>
+                        <Avatar
+                            class="size-6 text-[9px] ring-2 ring-card"
+                            :class="member.isBot ? 'rounded-md' : ''"
+                        >
+                            <AvatarImage
+                                v-if="member.avatar && !member.isBot"
+                                :src="member.avatar"
+                                :alt="member.name"
+                            />
+                            <AvatarFallback
+                                :class="
+                                    member.isBot
+                                        ? 'rounded-md bg-muted-foreground text-background'
+                                        : 'bg-primary/10 font-semibold text-primary'
+                                "
+                            >
+                                <Bot v-if="member.isBot" class="size-3" />
+                                <template v-else>{{
+                                    getInitials(member.name)
+                                }}</template>
+                            </AvatarFallback>
+                        </Avatar>
+                        <PresenceDot
+                            v-if="!member.isBot"
+                            data-test="masthead-member-presence"
+                            :presence="props.presenceFor(member.id)"
+                            surface-class="bg-card"
+                            class="absolute -right-0.5 -bottom-0.5 size-2 ring-2 ring-card"
+                        />
+                    </span>
+                    <span
+                        v-if="mastheadAvatars.overflow > 0"
+                        class="flex size-6 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-card select-none"
+                        aria-hidden="true"
+                    >
+                        +{{ mastheadAvatars.overflow }}
+                    </span>
+                </span>
+                <!-- The one readout of the facepile, and the only place the
+                     member count is spelled out — away counts as present but not
+                     active, so the two numbers can differ. -->
                 <span
-                    v-if="mastheadAvatars.overflow > 0"
-                    class="flex size-6 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-card select-none"
-                    aria-hidden="true"
+                    data-test="masthead-active-count"
+                    class="text-[11.5px] text-muted-foreground"
                 >
-                    +{{ mastheadAvatars.overflow }}
+                    {{
+                        $t(':active of :total active', {
+                            active: activeMemberCount,
+                            total: props.members.length,
+                        })
+                    }}
                 </span>
             </span>
 

--- a/resources/js/components/DirectMessageListItem.test.ts
+++ b/resources/js/components/DirectMessageListItem.test.ts
@@ -91,7 +91,7 @@ async function render(overrides: Partial<Channel> = {}): Promise<string> {
                 channel: channel(overrides),
                 teamSlug: 'acme',
                 activeChannelSlug: null,
-                online: true,
+                presence: 'active',
                 isSelf: false,
             }),
     });

--- a/resources/js/components/DirectMessageListItem.vue
+++ b/resources/js/components/DirectMessageListItem.vue
@@ -6,6 +6,7 @@ import { toast } from 'vue-sonner';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { store as hideDirectMessage } from '@/actions/App/Http/Controllers/Channels/HideDirectMessageController';
 import AvatarStack from '@/components/AvatarStack.vue';
+import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
@@ -19,14 +20,16 @@ import { useInitials } from '@/composables/useInitials';
 import { useTranslations } from '@/composables/useTranslations';
 import { groupDmSidebarName } from '@/lib/groupDm';
 import { notificationIndicator } from '@/lib/notificationIndicator';
+import { presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
 import type { Channel } from '@/types/channels';
 
 const props = defineProps<{
     channel: Channel;
     teamSlug: string;
     activeChannelSlug: string | null;
-    /** Whether the DM's participant is currently on the team presence roster. */
-    online: boolean;
+    /** How the DM's participant reads on the team presence roster. */
+    presence: RenderedPresence;
     /** Whether this is the viewer's own self-DM (renders "You"). */
     isSelf: boolean;
 }>();
@@ -149,23 +152,22 @@ function hide(): void {
                             {{ getInitials(channel.name) }}
                         </AvatarFallback>
                     </Avatar>
-                    <span
+                    <PresenceDot
                         data-test="dm-presence-dot"
-                        :data-online="online"
-                        aria-hidden="true"
-                        class="absolute -right-0.5 -bottom-0.5 size-2 rounded-full ring-2"
-                        :class="[
-                            online
-                                ? 'bg-emerald-500'
-                                : 'bg-muted-foreground/50',
-                            isActive ? 'ring-sidebar-primary' : 'ring-sidebar',
-                        ]"
+                        :presence="presence"
+                        :surface-class="
+                            isActive ? 'bg-sidebar-primary' : 'bg-sidebar'
+                        "
+                        class="absolute -right-0.5 -bottom-0.5 size-2 ring-2"
+                        :class="
+                            isActive ? 'ring-sidebar-primary' : 'ring-sidebar'
+                        "
                     />
                     <!-- The presence is announced through a screen-reader-only
                          label rather than an aria-label on the role-less dot,
                          which assistive tech ignores on a bare <span>. -->
                     <span data-test="dm-presence-label" class="sr-only">{{
-                        online ? $t('Online') : $t('Offline')
+                        $t(presenceLabelKey(presence))
                     }}</span>
                 </span>
                 <span

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -10,6 +10,7 @@ import MessageForward from '@/components/MessageForward.vue';
 import MessagePoll from '@/components/MessagePoll.vue';
 import MessageQuote from '@/components/MessageQuote.vue';
 import MessageReactions from '@/components/MessageReactions.vue';
+import PresenceDot from '@/components/PresenceDot.vue';
 import SafeHtml from '@/components/SafeHtml.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -40,6 +41,8 @@ import { canReactToMessage, showsThreadSummary } from '@/lib/messageActions';
 import type { MessageActionContext } from '@/lib/messageActions';
 import { tokenizeMessageBody } from '@/lib/messageBody';
 import type { MessageBodySegment } from '@/lib/messageBody';
+import { presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
 import { readersForMessage } from '@/lib/readReceipts';
 import { buildTimelineItems, messageAccessibleName } from '@/lib/timeline';
 import type { TimelineGroup, TimelineItem } from '@/lib/timeline';
@@ -82,7 +85,11 @@ const props = defineProps<{
      * channel); the "Pinned by" indicator still renders read-only when false.
      */
     canPin?: boolean;
-    onlineIds?: Set<string>;
+    /**
+     * How each author reads on the team presence roster. Absent on the surfaces
+     * that render a timeline without one, where every author reads as offline.
+     */
+    presenceFor?: (userId: string) => RenderedPresence;
     highlightMessageId?: string | null;
     /**
      * The message the "New messages" divider sits above — the first unread on
@@ -255,10 +262,10 @@ const viewerTimeZone = computed(
 );
 
 /**
- * Whether a message author is currently present on the team presence roster.
+ * How a message author reads on the team presence roster.
  */
-function isOnline(authorId: string): boolean {
-    return props.onlineIds?.has(authorId) ?? false;
+function presenceOf(authorId: string): RenderedPresence {
+    return props.presenceFor?.(authorId) ?? 'offline';
 }
 
 /**
@@ -812,7 +819,7 @@ function confirmDelete(): void {
                             :team-slug="props.teamSlug"
                             :user-id="item.author.id"
                             :name="item.author.name"
-                            :online="isOnline(item.author.id)"
+                            :presence="presenceOf(item.author.id)"
                             @mention="(member) => emit('mention', member)"
                         >
                             <div class="relative size-8.5 cursor-pointer">
@@ -855,17 +862,12 @@ function confirmDelete(): void {
                                      via the sr-only text beside the name below,
                                      so this repeated dot is decorative to AT. A bot
                                      has no presence, so it shows no dot. -->
-                                <span
+                                <PresenceDot
                                     v-if="!item.author.isBot"
                                     data-test="presence-dot"
-                                    :data-online="isOnline(item.author.id)"
-                                    aria-hidden="true"
-                                    class="absolute right-0 bottom-0 size-2.5 rounded-full ring-2 ring-card"
-                                    :class="
-                                        isOnline(item.author.id)
-                                            ? 'bg-emerald-500'
-                                            : 'bg-muted-foreground/60'
-                                    "
+                                    :presence="presenceOf(item.author.id)"
+                                    surface-class="bg-card"
+                                    class="absolute right-0 bottom-0 size-2.5 ring-2 ring-card"
                                 />
                             </div>
                         </UserHoverCard>
@@ -886,7 +888,7 @@ function confirmDelete(): void {
                             :team-slug="props.teamSlug"
                             :user-id="item.author.id"
                             :name="item.author.name"
-                            :online="isOnline(item.author.id)"
+                            :presence="presenceOf(item.author.id)"
                             @mention="(member) => emit('mention', member)"
                         >
                             <span
@@ -912,9 +914,7 @@ function confirmDelete(): void {
                             >{{ $t('Bot') }}</span
                         >
                         <span v-else class="sr-only">{{
-                            isOnline(item.author.id)
-                                ? $t('Online')
-                                : $t('Offline')
+                            $t(presenceLabelKey(presenceOf(item.author.id)))
                         }}</span>
                         <div role="list">
                             <div

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -2,6 +2,7 @@
 import { usePage } from '@inertiajs/vue3';
 import { ChevronsUpDown } from '@lucide/vue';
 import { computed } from 'vue';
+import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
     DropdownMenu,
@@ -16,6 +17,7 @@ import {
 } from '@/components/ui/sidebar';
 import UserMenuContent from '@/components/UserMenuContent.vue';
 import { useInitials } from '@/composables/useInitials';
+import type { RenderedPresence } from '@/lib/presence';
 import type { Team } from '@/types';
 
 const page = usePage();
@@ -25,6 +27,15 @@ const { getInitials } = useInitials();
 
 const currentTeam = computed(() => page.props.currentTeam as Team | null);
 const hasAvatar = computed(() => !!user.avatar && user.avatar !== '');
+
+/**
+ * The viewer's own effective presence, read from the shared `auth.user` prop so
+ * the trigger's dot mirrors the menu's readout and the flip lands here without
+ * the chip remounting. Never "offline" — you are, by definition, looking at it.
+ */
+const ownPresence = computed<RenderedPresence>(
+    () => page.props.auth.user.presence ?? 'active',
+);
 </script>
 
 <template>
@@ -52,9 +63,15 @@ const hasAvatar = computed(() => !!user.avatar && user.avatar !== '');
                                     {{ getInitials(user.name) }}
                                 </AvatarFallback>
                             </Avatar>
-                            <span
-                                aria-hidden="true"
-                                class="absolute -right-0.5 -bottom-0.5 size-2.25 rounded-full border-2 border-popover bg-emerald-600 group-hover/nav-user:border-secondary group-data-[state=open]/nav-user:border-sidebar-primary"
+                            <!-- The halo tracks the chip's own surface, which
+                                 changes on hover and while the menu is open, so
+                                 an away dot's hollow centre keeps matching what
+                                 is actually behind it. -->
+                            <PresenceDot
+                                data-test="nav-user-presence"
+                                :presence="ownPresence"
+                                surface-class="bg-popover group-hover/nav-user:bg-secondary group-data-[state=open]/nav-user:bg-sidebar-primary"
+                                class="absolute -right-0.5 -bottom-0.5 size-2.25 ring-2 ring-popover group-hover/nav-user:ring-secondary group-data-[state=open]/nav-user:ring-sidebar-primary"
                             />
                         </span>
                         <span

--- a/resources/js/components/PresenceDot.test.ts
+++ b/resources/js/components/PresenceDot.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { createSSRApp, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import PresenceDot from './PresenceDot.vue';
+import type { RenderedPresence } from '@/lib/presence';
+
+function render(
+    presence: RenderedPresence,
+    props: Record<string, unknown> = {},
+): Promise<string> {
+    return renderToString(
+        createSSRApp({
+            render: () => h(PresenceDot, { presence, ...props }),
+        }),
+    );
+}
+
+describe('PresenceDot', () => {
+    it('fills the dot for someone active', async () => {
+        const html = await render('active');
+
+        expect(html).toContain('bg-emerald-500');
+        expect(html).not.toContain('border-muted-foreground');
+    });
+
+    it('hollows the dot for someone away, keeping its footprint', async () => {
+        const html = await render('away');
+
+        expect(html).toContain('border-muted-foreground');
+        expect(html).not.toContain('bg-emerald-500');
+    });
+
+    it('fills an away dot with the surface behind it so the avatar cannot show through', async () => {
+        const html = await render('away', { surfaceClass: 'bg-sidebar' });
+
+        expect(html).toContain('bg-sidebar');
+    });
+
+    it('ignores the surface fill for any state that is not away', async () => {
+        const html = await render('active', { surfaceClass: 'bg-sidebar' });
+
+        expect(html).not.toContain('bg-sidebar');
+    });
+
+    it('mutes the dot for someone offline', async () => {
+        const html = await render('offline');
+
+        expect(html).toContain('bg-muted-foreground/50');
+    });
+
+    it('carries the caller geometry so each surface keeps its own size and ring', async () => {
+        const html = await render('active', {
+            class: 'absolute size-2.5 ring-2 ring-card',
+        });
+
+        expect(html).toContain('size-2.5');
+        expect(html).toContain('ring-card');
+    });
+
+    it('records the state for tests and styling hooks', async () => {
+        expect(await render('away')).toContain('data-presence="away"');
+    });
+
+    it('is invisible to assistive tech, which reads the surface own label', async () => {
+        expect(await render('active')).toContain('aria-hidden="true"');
+    });
+});

--- a/resources/js/components/PresenceDot.test.ts
+++ b/resources/js/components/PresenceDot.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { createSSRApp, h } from 'vue';
 import { renderToString } from 'vue/server-renderer';
-import PresenceDot from './PresenceDot.vue';
 import type { RenderedPresence } from '@/lib/presence';
+import PresenceDot from './PresenceDot.vue';
 
 function render(
     presence: RenderedPresence,

--- a/resources/js/components/PresenceDot.vue
+++ b/resources/js/components/PresenceDot.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { cn } from '@/lib/utils';
+import type { RenderedPresence } from '@/lib/presence';
+
+const props = withDefaults(
+    defineProps<{
+        /** How the person renders: connected and active, connected but idle, or gone. */
+        presence: RenderedPresence;
+        /**
+         * Background class matching the surface the dot sits on (`bg-card`,
+         * `bg-sidebar`, …). Only used by the away state, whose centre is the
+         * surface showing through the ring — without it the avatar underneath
+         * would show through the hole. Ignored otherwise.
+         */
+        surfaceClass?: string;
+    }>(),
+    { surfaceClass: 'bg-background' },
+);
+
+/**
+ * The three-state vocabulary, at every size the dot is drawn.
+ *
+ * Away keeps the dot's footprint and hollows it — a ring in the neutral stone
+ * over the surface behind — so a roster still reads at a glance without
+ * introducing a second colour. Offline stays a muted disc.
+ */
+const stateClass = computed(() => {
+    if (props.presence === 'active') {
+        return 'bg-emerald-500';
+    }
+
+    return props.presence === 'away'
+        ? ['border-2 border-muted-foreground', props.surfaceClass]
+        : 'bg-muted-foreground/50';
+});
+</script>
+
+<template>
+    <span
+        :data-presence="presence"
+        aria-hidden="true"
+        :class="cn('rounded-full', stateClass)"
+    />
+</template>

--- a/resources/js/components/PresenceDot.vue
+++ b/resources/js/components/PresenceDot.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { cn } from '@/lib/utils';
 import type { RenderedPresence } from '@/lib/presence';
+import { cn } from '@/lib/utils';
 
 const props = withDefaults(
     defineProps<{

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -8,6 +8,7 @@ import ScrollableMessageList from '@/components/ScrollableMessageList.vue';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useScrollPin } from '@/composables/useScrollPin';
+import type { RenderedPresence } from '@/lib/presence';
 import type { Mention, Message } from '@/types';
 
 const props = defineProps<{
@@ -32,7 +33,8 @@ const props = defineProps<{
     canModerate?: boolean;
     canReact?: boolean;
     canPin?: boolean;
-    onlineIds?: Set<string>;
+    /** How each author reads on the team presence roster, passed straight down. */
+    presenceFor?: (userId: string) => RenderedPresence;
     loading?: boolean;
     readOnly?: boolean;
 }>();
@@ -321,7 +323,7 @@ watch(
                     :can-moderate="props.canModerate"
                     :can-react="props.canReact"
                     :can-pin="props.canPin"
-                    :online-ids="props.onlineIds"
+                    :presence-for="props.presenceFor"
                     :editing-message-id="editingMessageId"
                     in-thread
                     @load-older="loadOlderReplies"

--- a/resources/js/components/UserHoverCard.vue
+++ b/resources/js/components/UserHoverCard.vue
@@ -2,6 +2,7 @@
 import { Link } from '@inertiajs/vue3';
 import { AtSign, MessageSquare, UserRound } from '@lucide/vue';
 import { computed, ref } from 'vue';
+import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -15,6 +16,8 @@ import { useInitials } from '@/composables/useInitials';
 import { useOpenDirectMessage } from '@/composables/useOpenDirectMessage';
 import { fetchUserProfile } from '@/composables/useUserProfileCard';
 import { formatLocalTime, formatTimeOfDay } from '@/lib/datetime';
+import { presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
 import { show } from '@/routes/teams/members';
 import type { UserProfile } from '@/types';
 
@@ -22,7 +25,11 @@ const props = defineProps<{
     teamSlug: string;
     userId: string;
     name: string;
-    online?: boolean;
+    /**
+     * How the member reads on the team presence roster. Absent on the surfaces
+     * that open a card without a roster to hand, which then show no dot at all.
+     */
+    presence?: RenderedPresence;
 }>();
 
 const emit = defineEmits<{
@@ -105,16 +112,12 @@ function onMessage(): void {
                                 getInitials(profile?.name ?? name)
                             }}</AvatarFallback>
                         </Avatar>
-                        <span
+                        <PresenceDot
+                            v-if="presence"
                             data-test="hover-card-presence"
-                            :data-online="online === true"
-                            :aria-label="online ? $t('Online') : $t('Offline')"
-                            class="absolute right-0 bottom-0 size-3 rounded-full ring-[2.5px] ring-popover"
-                            :class="
-                                online
-                                    ? 'bg-emerald-500'
-                                    : 'bg-muted-foreground/60'
-                            "
+                            :presence="presence"
+                            surface-class="bg-popover"
+                            class="absolute right-0 bottom-0 size-3 ring-[2.5px] ring-popover"
                         />
                     </div>
                     <div class="min-w-0 flex-1">
@@ -145,6 +148,26 @@ function onMessage(): void {
                             >
                                 {{ profile.roleLabel }}
                             </Badge>
+                            <!-- The card is the one surface with room to spell
+                                 the presence out, so away gets the word beside
+                                 its ring rather than only the dot's shape. -->
+                            <span
+                                v-if="presence"
+                                data-test="hover-card-presence-label"
+                                class="flex items-center gap-1.5 text-xs"
+                                :class="
+                                    presence === 'away'
+                                        ? 'font-serif text-muted-foreground italic'
+                                        : 'text-muted-foreground'
+                                "
+                            >
+                                <PresenceDot
+                                    :presence="presence"
+                                    surface-class="bg-popover"
+                                    class="size-2"
+                                />
+                                {{ $t(presenceLabelKey(presence)) }}
+                            </span>
                             <span
                                 v-if="localTime()"
                                 class="text-xs text-muted-foreground"

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -16,8 +16,10 @@ import {
 import type { Component } from 'vue';
 import { computed } from 'vue';
 import { toast } from 'vue-sonner';
+import { update as updatePresence } from '@/actions/App/Http/Controllers/Settings/PresenceController';
 import { destroy as destroyStatus } from '@/actions/App/Http/Controllers/Settings/StatusController';
 import MenuSegmentedControl from '@/components/MenuSegmentedControl.vue';
+import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import {
@@ -35,6 +37,8 @@ import { useTranslations } from '@/composables/useTranslations';
 import { useUpdateStatus } from '@/composables/useUpdateStatus';
 import { useUserStatusDialog } from '@/composables/useUserStatusDialog';
 import { formatTimeOfDay } from '@/lib/datetime';
+import { presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
 import { logout } from '@/routes';
 import { edit } from '@/routes/profile';
 import type { Appearance, SidebarPosition, Team, User } from '@/types';
@@ -93,6 +97,19 @@ const hasAvatar = computed(
 // than the `user` prop so it tracks a set/clear without the menu remounting.
 const ownStatus = computed(() => page.props.auth.user.status ?? null);
 
+/**
+ * The viewer's own effective presence, from the same shared prop for the same
+ * reason. Never "offline" — the menu is open, so they are plainly here.
+ */
+const ownPresence = computed<RenderedPresence>(
+    () => page.props.auth.user.presence ?? 'active',
+);
+
+/** The state the toggle would switch to, which is also the glyph it previews. */
+const togglesTo = computed<RenderedPresence>(() =>
+    ownPresence.value === 'away' ? 'active' : 'away',
+);
+
 // When the status clears, as a time of day in the viewer's own zone. Null for a
 // status that never clears, which then shows no second line at all.
 const clearsAt = computed(() =>
@@ -121,6 +138,26 @@ function clearStatus(event: Event): void {
     });
 }
 
+/**
+ * Flip the manual away override.
+ *
+ * The default select behaviour closes the menu; prevented here so the row and
+ * the masthead readout above it flip in place, the way the theme and sidebar
+ * switchers apply without dismissing the menu.
+ */
+function togglePresence(event: Event): void {
+    event.preventDefault();
+
+    router.put(
+        updatePresence().url,
+        { state: togglesTo.value },
+        {
+            preserveScroll: true,
+            onError: () => toast.error(t('Could not change your presence.')),
+        },
+    );
+}
+
 const handleLogout = () => {
     router.flushAll();
 };
@@ -145,9 +182,11 @@ const handleLogout = () => {
                             {{ getInitials(user.name) }}
                         </AvatarFallback>
                     </Avatar>
-                    <span
-                        aria-hidden="true"
-                        class="absolute right-0 bottom-0 size-2.75 rounded-full border-2 border-muted bg-emerald-600"
+                    <PresenceDot
+                        data-test="user-menu-presence"
+                        :presence="ownPresence"
+                        surface-class="bg-muted"
+                        class="absolute right-0 bottom-0 size-2.75 ring-2 ring-muted"
                     />
                 </span>
                 <div class="min-w-0 flex-1">
@@ -166,8 +205,26 @@ const handleLogout = () => {
                             decorative
                         />
                     </div>
-                    <div class="mt-0.5 truncate text-xs text-muted-foreground">
-                        {{ user.email }}
+                    <!-- The subtitle doubles as the current-state readout: a
+                         green "Active" or an italic serif "Away", ahead of the
+                         address the viewer is signed in as. -->
+                    <div
+                        class="mt-0.5 flex min-w-0 items-baseline gap-1.5 text-xs text-muted-foreground"
+                    >
+                        <span
+                            data-test="user-menu-presence-label"
+                            class="shrink-0 font-medium"
+                            :class="
+                                ownPresence === 'away'
+                                    ? 'font-serif text-muted-foreground italic'
+                                    : 'text-emerald-700 dark:text-emerald-400'
+                            "
+                            >{{ $t(presenceLabelKey(ownPresence)) }}</span
+                        >
+                        <span aria-hidden="true" class="shrink-0"
+                            >&middot;</span
+                        >
+                        <span class="truncate">{{ user.email }}</span>
                     </div>
                 </div>
             </div>
@@ -259,6 +316,27 @@ const handleLogout = () => {
                 </Button>
             </DropdownMenuItem>
         </div>
+        <!-- The manual away toggle. Its leading glyph previews the state it
+             would switch *to*, so the row reads as an action rather than as a
+             second copy of the readout above. -->
+        <DropdownMenuItem
+            class="group/item mt-0.5 flex h-9 cursor-pointer items-center gap-2.5 rounded-[10px] px-2.5 py-0 text-[13.5px] font-normal text-foreground focus:bg-primary focus:text-primary-foreground"
+            data-test="toggle-presence-menu-item"
+            @select="togglePresence"
+        >
+            <span class="flex w-3.75 justify-center">
+                <PresenceDot
+                    :presence="togglesTo"
+                    surface-class="bg-popover group-focus/item:bg-primary"
+                    class="size-2.25"
+                />
+            </span>
+            {{
+                togglesTo === 'away'
+                    ? $t('Set yourself away')
+                    : $t('Set yourself active')
+            }}
+        </DropdownMenuItem>
     </div>
 
     <!-- Appearance: quick theme + sidebar switchers, grouped ahead of navigation.

--- a/resources/js/composables/usePresenceReporter.test.ts
+++ b/resources/js/composables/usePresenceReporter.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRenderer, defineComponent } from 'vue';
+
+const page = {
+    props: {
+        presence: { awayAfterMinutes: 10 },
+    },
+};
+
+vi.mock('@inertiajs/vue3', () => ({ usePage: () => page }));
+
+vi.mock('@/routes/presence', () => ({
+    report: () => ({ url: '/presence/connection' }),
+    release: () => ({ url: '/presence/connection/release' }),
+}));
+
+import {
+    PRESENCE_CONNECTION_STORAGE_KEY,
+    PRESENCE_HEARTBEAT_MS,
+    usePresenceReporter,
+} from '@/composables/usePresenceReporter';
+
+const { createApp } = createRenderer<object, object>({
+    insert: () => {},
+    remove: () => {},
+    createElement: () => ({}),
+    createText: () => ({}),
+    createComment: () => ({}),
+    setText: () => {},
+    setElementText: () => {},
+    parentNode: () => null,
+    nextSibling: () => null,
+});
+
+/** Handlers registered on document/window, by event name. */
+const handlers = new Map<string, (event?: unknown) => void>();
+
+const store = new Map<string, string>();
+const fetchMock = vi.fn(() => Promise.resolve());
+
+/** The bodies posted so far, newest last, as `[url, payload]` pairs. */
+function posts(): [string, Record<string, unknown>][] {
+    return fetchMock.mock.calls.map((call) => {
+        const [url, init] = call as unknown as [string, { body: string }];
+
+        return [url, JSON.parse(init.body) as Record<string, unknown>];
+    });
+}
+
+function mount() {
+    const app = createApp(
+        defineComponent({
+            setup: () => {
+                usePresenceReporter();
+
+                return () => null;
+            },
+        }),
+    );
+
+    app.mount({});
+
+    return { unmount: () => app.unmount() };
+}
+
+/** Fire an activity event the way the browser would. */
+function activity(event = 'keydown'): void {
+    handlers.get(event)?.();
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    handlers.clear();
+    store.clear();
+    fetchMock.mockClear();
+
+    const listenerTarget = {
+        addEventListener: (name: string, handler: (event?: unknown) => void) =>
+            handlers.set(name, handler),
+        removeEventListener: (name: string) => handlers.delete(name),
+    };
+
+    vi.stubGlobal('document', { ...listenerTarget, cookie: '' });
+    vi.stubGlobal('window', listenerTarget);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('sessionStorage', {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => store.set(key, value),
+    });
+    vi.stubGlobal('crypto', { randomUUID: () => 'tab-uuid' });
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
+
+describe('usePresenceReporter', () => {
+    it('registers the tab as active as soon as it opens', () => {
+        const { unmount } = mount();
+
+        expect(posts()).toEqual([
+            [
+                '/presence/connection',
+                { connection: 'tab-uuid', state: 'active' },
+            ],
+        ]);
+
+        unmount();
+    });
+
+    it('reuses the key already minted for this tab', () => {
+        store.set(PRESENCE_CONNECTION_STORAGE_KEY, 'existing-tab');
+
+        const { unmount } = mount();
+
+        expect(posts()[0][1].connection).toBe('existing-tab');
+
+        unmount();
+    });
+
+    it('keeps the tab key across remounts so a page visit is not a new device', () => {
+        mount().unmount();
+        fetchMock.mockClear();
+
+        const { unmount } = mount();
+
+        expect(posts()[0][1].connection).toBe('tab-uuid');
+
+        unmount();
+    });
+
+    it('reports away once the configured threshold passes with no activity', () => {
+        const { unmount } = mount();
+        fetchMock.mockClear();
+
+        vi.advanceTimersByTime(10 * 60 * 1000 - 1);
+
+        expect(posts().some(([, body]) => body.state === 'away')).toBe(false);
+
+        vi.advanceTimersByTime(1);
+
+        expect(posts()).toContainEqual([
+            '/presence/connection',
+            { connection: 'tab-uuid', state: 'away' },
+        ]);
+
+        unmount();
+    });
+
+    it('honours an operator-configured threshold', () => {
+        page.props.presence.awayAfterMinutes = 2;
+
+        const { unmount } = mount();
+        fetchMock.mockClear();
+
+        vi.advanceTimersByTime(2 * 60 * 1000);
+
+        expect(posts()).toHaveLength(1);
+        expect(posts()[0][1].state).toBe('away');
+
+        unmount();
+        page.props.presence.awayAfterMinutes = 10;
+    });
+
+    it('stays active while the person keeps working', () => {
+        const { unmount } = mount();
+        fetchMock.mockClear();
+
+        for (let minute = 0; minute < 30; minute++) {
+            vi.advanceTimersByTime(60 * 1000);
+            activity();
+        }
+
+        expect(posts().filter(([, body]) => body.state === 'away')).toEqual([]);
+
+        unmount();
+    });
+
+    it('comes back on the first input after going away', () => {
+        const { unmount } = mount();
+
+        vi.advanceTimersByTime(10 * 60 * 1000);
+        fetchMock.mockClear();
+
+        activity('pointerdown');
+
+        expect(posts()).toEqual([
+            [
+                '/presence/connection',
+                { connection: 'tab-uuid', state: 'active' },
+            ],
+        ]);
+
+        unmount();
+    });
+
+    it('treats regaining window focus as activity', () => {
+        const { unmount } = mount();
+
+        vi.advanceTimersByTime(10 * 60 * 1000);
+        fetchMock.mockClear();
+
+        activity('focus');
+
+        expect(posts()[0][1].state).toBe('active');
+
+        unmount();
+    });
+
+    it('does not re-post on every keystroke while already active', () => {
+        const { unmount } = mount();
+        fetchMock.mockClear();
+
+        activity();
+        activity();
+        activity();
+
+        expect(posts()).toEqual([]);
+
+        unmount();
+    });
+
+    it('heartbeats so a crashed tab eventually ages out', () => {
+        const { unmount } = mount();
+        fetchMock.mockClear();
+
+        vi.advanceTimersByTime(PRESENCE_HEARTBEAT_MS);
+
+        expect(posts()).toContainEqual([
+            '/presence/connection',
+            { connection: 'tab-uuid', state: 'active' },
+        ]);
+
+        unmount();
+    });
+
+    it('releases the tab as the page goes away', () => {
+        const { unmount } = mount();
+        fetchMock.mockClear();
+
+        activity('pagehide');
+
+        expect(posts()).toEqual([
+            [
+                '/presence/connection/release',
+                { connection: 'tab-uuid' },
+            ],
+        ]);
+
+        unmount();
+    });
+
+    it('sends the release with keepalive so it survives the unload', () => {
+        const { unmount } = mount();
+        fetchMock.mockClear();
+
+        activity('pagehide');
+
+        const [, init] = fetchMock.mock.calls[0] as unknown as [
+            string,
+            { keepalive?: boolean },
+        ];
+
+        expect(init.keepalive).toBe(true);
+
+        unmount();
+    });
+
+    it('stops reporting once the app is torn down', () => {
+        const { unmount } = mount();
+
+        unmount();
+        fetchMock.mockClear();
+
+        vi.advanceTimersByTime(60 * 60 * 1000);
+
+        expect(posts()).toEqual([]);
+    });
+});

--- a/resources/js/composables/usePresenceReporter.test.ts
+++ b/resources/js/composables/usePresenceReporter.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/routes/presence', () => ({
 import {
     PRESENCE_CONNECTION_STORAGE_KEY,
     PRESENCE_HEARTBEAT_MS,
+    PRESENCE_REGISTER_DELAY_MS,
     usePresenceReporter,
 } from '@/composables/usePresenceReporter';
 
@@ -97,8 +98,12 @@ afterEach(() => {
 });
 
 describe('usePresenceReporter', () => {
-    it('registers the tab as active as soon as it opens', () => {
+    it('registers the tab as active shortly after it opens, off the load path', () => {
         const { unmount } = mount();
+
+        expect(posts()).toEqual([]);
+
+        vi.advanceTimersByTime(PRESENCE_REGISTER_DELAY_MS);
 
         expect(posts()).toEqual([
             [
@@ -114,6 +119,7 @@ describe('usePresenceReporter', () => {
         store.set(PRESENCE_CONNECTION_STORAGE_KEY, 'existing-tab');
 
         const { unmount } = mount();
+        vi.advanceTimersByTime(PRESENCE_REGISTER_DELAY_MS);
 
         expect(posts()[0][1].connection).toBe('existing-tab');
 
@@ -125,6 +131,7 @@ describe('usePresenceReporter', () => {
         fetchMock.mockClear();
 
         const { unmount } = mount();
+        vi.advanceTimersByTime(PRESENCE_REGISTER_DELAY_MS);
 
         expect(posts()[0][1].connection).toBe('tab-uuid');
 
@@ -153,9 +160,10 @@ describe('usePresenceReporter', () => {
         page.props.presence.awayAfterMinutes = 2;
 
         const { unmount } = mount();
+        vi.advanceTimersByTime(PRESENCE_REGISTER_DELAY_MS);
         fetchMock.mockClear();
 
-        vi.advanceTimersByTime(2 * 60 * 1000);
+        vi.advanceTimersByTime(2 * 60 * 1000 - PRESENCE_REGISTER_DELAY_MS);
 
         expect(posts()).toHaveLength(1);
         expect(posts()[0][1].state).toBe('away');

--- a/resources/js/composables/usePresenceReporter.test.ts
+++ b/resources/js/composables/usePresenceReporter.test.ts
@@ -30,6 +30,7 @@ const { createApp } = createRenderer<object, object>({
     setElementText: () => {},
     parentNode: () => null,
     nextSibling: () => null,
+    patchProp: () => {},
 });
 
 /** Handlers registered on document/window, by event name. */
@@ -242,10 +243,7 @@ describe('usePresenceReporter', () => {
         activity('pagehide');
 
         expect(posts()).toEqual([
-            [
-                '/presence/connection/release',
-                { connection: 'tab-uuid' },
-            ],
+            ['/presence/connection/release', { connection: 'tab-uuid' }],
         ]);
 
         unmount();

--- a/resources/js/composables/usePresenceReporter.ts
+++ b/resources/js/composables/usePresenceReporter.ts
@@ -1,0 +1,177 @@
+import { usePage } from '@inertiajs/vue3';
+import { onBeforeUnmount, onMounted } from 'vue';
+import { parseXsrfToken } from '@/lib/uploadAttachment';
+import { release, report } from '@/routes/presence';
+
+/**
+ * Where this tab's connection key lives.
+ *
+ * `sessionStorage` is per tab and survives navigations within it, which is
+ * exactly the grain presence needs. The session would be too coarse — two tabs
+ * share one, and since a tab only writes on a transition, a backgrounded tab's
+ * "away" would land last and overrule the foreground tab being typed in.
+ */
+export const PRESENCE_CONNECTION_STORAGE_KEY = 'desk:presence-connection';
+
+/**
+ * How often a tab re-asserts its state.
+ *
+ * Only a backstop: `pagehide` releases the connection on every ordinary close,
+ * so this exists purely so a crashed or killed tab eventually ages out of the
+ * server-side index. That makes minutes the right order of magnitude, and it
+ * stays comfortably inside the registry's own time-to-live.
+ */
+export const PRESENCE_HEARTBEAT_MS = 5 * 60 * 1000;
+
+/**
+ * Ignore further activity for this long after handling some.
+ *
+ * A scroll or a burst of typing fires hundreds of events; all that is needed is
+ * to know activity happened at all.
+ */
+const ACTIVITY_THROTTLE_MS = 1000;
+
+/**
+ * Input that counts as "still here". Deliberately real interaction rather than
+ * `document.hasFocus()`, which is the house convention for gating a mark-read:
+ * publishing "away" to thirty colleagues is a much stronger claim than deciding
+ * whether to advance a read pointer, and clicking into a terminal beside the
+ * window should not make it. A hidden tab needs no special case — it cannot
+ * receive any of these, so it ages into away on its own.
+ */
+const ACTIVITY_EVENTS = [
+    'pointerdown',
+    'keydown',
+    'scroll',
+    'touchstart',
+] as const;
+
+/**
+ * Reports this tab's idle state, so teammates see the viewer as away once every
+ * device they are signed in on has gone quiet.
+ *
+ * Only transitions are sent, so an ordinary working session costs one request
+ * when the tab opens and one on each idle↔active flip — the server decides
+ * whether that even changes what teammates see.
+ */
+export function usePresenceReporter(): void {
+    const page = usePage();
+
+    let connectionId = '';
+    let idle = false;
+    let lastActivityAt = 0;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let heartbeat: ReturnType<typeof setInterval> | undefined;
+
+    function thresholdMs(): number {
+        return Math.max(page.props.presence?.awayAfterMinutes ?? 10, 1) * 60_000;
+    }
+
+    /**
+     * A fire-and-forget POST.
+     *
+     * `keepalive` is what lets the release outlive the page that sent it. It is
+     * `sendBeacon`'s mechanism, reached through `fetch` so the CSRF token can
+     * ride a header — `sendBeacon` cannot set one, and exempting the endpoint
+     * would let any page silently mark someone offline.
+     */
+    function post(url: string, body: Record<string, string>): void {
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        };
+
+        const token = parseXsrfToken(document.cookie);
+
+        if (token) {
+            headers['X-XSRF-TOKEN'] = token;
+        }
+
+        void fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+            keepalive: true,
+        })?.catch?.(() => {
+            // A dropped report self-heals: the next transition or heartbeat
+            // re-states this tab, and an entry that never arrives reads as
+            // active, which is the state that predates this feature.
+        });
+    }
+
+    function reportState(state: App.Enums.PresenceState): void {
+        post(report().url, { connection: connectionId, state });
+    }
+
+    function goIdle(): void {
+        idle = true;
+        reportState('away');
+    }
+
+    /**
+     * Restart the countdown, and announce the return if this tab had lapsed.
+     */
+    function onActivity(): void {
+        const now = Date.now();
+
+        if (!idle && now - lastActivityAt < ACTIVITY_THROTTLE_MS) {
+            return;
+        }
+
+        lastActivityAt = now;
+
+        if (idle) {
+            idle = false;
+            reportState('active');
+        }
+
+        clearTimeout(idleTimer);
+        idleTimer = setTimeout(goIdle, thresholdMs());
+    }
+
+    function onPageHide(): void {
+        post(release().url, { connection: connectionId });
+    }
+
+    // Every browser API below (sessionStorage, listeners, timers) is absent on
+    // the SSR pass, so none of this may run during setup.
+    onMounted(() => {
+        connectionId =
+            sessionStorage.getItem(PRESENCE_CONNECTION_STORAGE_KEY) ??
+            crypto.randomUUID();
+        sessionStorage.setItem(PRESENCE_CONNECTION_STORAGE_KEY, connectionId);
+
+        // Register before the first transition: a freshly opened tab that never
+        // reports would leave an older, idle tab of the same account deciding.
+        reportState('active');
+
+        lastActivityAt = Date.now();
+        idleTimer = setTimeout(goIdle, thresholdMs());
+        heartbeat = setInterval(
+            () => reportState(idle ? 'away' : 'active'),
+            PRESENCE_HEARTBEAT_MS,
+        );
+
+        for (const event of ACTIVITY_EVENTS) {
+            document.addEventListener(event, onActivity, { passive: true });
+        }
+
+        // Coming back to the window counts as being here; losing it does not
+        // count as leaving — it simply stops refreshing the countdown, so the
+        // full threshold still has to pass.
+        window.addEventListener('focus', onActivity);
+        window.addEventListener('pagehide', onPageHide);
+    });
+
+    onBeforeUnmount(() => {
+        clearTimeout(idleTimer);
+        clearInterval(heartbeat);
+
+        for (const event of ACTIVITY_EVENTS) {
+            document.removeEventListener(event, onActivity);
+        }
+
+        window.removeEventListener('focus', onActivity);
+        window.removeEventListener('pagehide', onPageHide);
+    });
+}

--- a/resources/js/composables/usePresenceReporter.ts
+++ b/resources/js/composables/usePresenceReporter.ts
@@ -1,6 +1,7 @@
 import { usePage } from '@inertiajs/vue3';
 import { onBeforeUnmount, onMounted } from 'vue';
 import { parseXsrfToken } from '@/lib/uploadAttachment';
+import { generateUuid } from '@/lib/uuid';
 import { release, report } from '@/routes/presence';
 
 /**
@@ -140,7 +141,7 @@ export function usePresenceReporter(): void {
     onMounted(() => {
         connectionId =
             sessionStorage.getItem(PRESENCE_CONNECTION_STORAGE_KEY) ??
-            crypto.randomUUID();
+            generateUuid();
         sessionStorage.setItem(PRESENCE_CONNECTION_STORAGE_KEY, connectionId);
 
         // Register before the first transition: a freshly opened tab that never

--- a/resources/js/composables/usePresenceReporter.ts
+++ b/resources/js/composables/usePresenceReporter.ts
@@ -64,7 +64,9 @@ export function usePresenceReporter(): void {
     let heartbeat: ReturnType<typeof setInterval> | undefined;
 
     function thresholdMs(): number {
-        return Math.max(page.props.presence?.awayAfterMinutes ?? 10, 1) * 60_000;
+        return (
+            Math.max(page.props.presence?.awayAfterMinutes ?? 10, 1) * 60_000
+        );
     }
 
     /**

--- a/resources/js/composables/usePresenceReporter.ts
+++ b/resources/js/composables/usePresenceReporter.ts
@@ -25,6 +25,17 @@ export const PRESENCE_CONNECTION_STORAGE_KEY = 'desk:presence-connection';
 export const PRESENCE_HEARTBEAT_MS = 5 * 60 * 1000;
 
 /**
+ * How long after mount the tab announces itself.
+ *
+ * Deliberately off the page-load critical path: the register races nothing —
+ * an unregistered tab already reads as active (the fail-open default), so the
+ * only thing this delay postpones is a fresh active tab overriding an older
+ * idle one by a few seconds. Firing it at mount would instead contend with the
+ * Inertia visit and the websocket authorization requests of a loading page.
+ */
+export const PRESENCE_REGISTER_DELAY_MS = 3000;
+
+/**
  * Ignore further activity for this long after handling some.
  *
  * A scroll or a burst of typing fires hundreds of events; all that is needed is
@@ -61,6 +72,7 @@ export function usePresenceReporter(): void {
     let connectionId = '';
     let idle = false;
     let lastActivityAt = 0;
+    let registerTimer: ReturnType<typeof setTimeout> | undefined;
     let idleTimer: ReturnType<typeof setTimeout> | undefined;
     let heartbeat: ReturnType<typeof setInterval> | undefined;
 
@@ -146,7 +158,11 @@ export function usePresenceReporter(): void {
 
         // Register before the first transition: a freshly opened tab that never
         // reports would leave an older, idle tab of the same account deciding.
-        reportState('active');
+        // Deferred so the request never contends with the page's own loading.
+        registerTimer = setTimeout(
+            () => reportState('active'),
+            PRESENCE_REGISTER_DELAY_MS,
+        );
 
         lastActivityAt = Date.now();
         idleTimer = setTimeout(goIdle, thresholdMs());
@@ -167,6 +183,7 @@ export function usePresenceReporter(): void {
     });
 
     onBeforeUnmount(() => {
+        clearTimeout(registerTimer);
         clearTimeout(idleTimer);
         clearInterval(heartbeat);
 

--- a/resources/js/composables/useTeamPresence.test.ts
+++ b/resources/js/composables/useTeamPresence.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRenderer, defineComponent, nextTick } from 'vue';
+
+const reload = vi.fn();
+
+const page = {
+    props: {
+        teamMembers: [] as {
+            id: string;
+            name: string;
+            presence?: 'active' | 'away';
+        }[],
+    },
+};
+
+/** Roster handlers registered per presence channel, by hook name. */
+type Handlers = {
+    here?: (members: { id: string; name: string }[]) => void;
+    joining?: (member: { id: string; name: string }) => void;
+    leaving?: (member: { id: string; name: string }) => void;
+    listeners: Map<string, (payload: never) => void>;
+};
+
+const channels = new Map<string, Handlers>();
+const left: string[] = [];
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { reload: (...args: unknown[]) => reload(...args) },
+    usePage: () => page,
+}));
+
+vi.mock('@laravel/echo-vue', () => ({
+    echo: () => ({
+        join(name: string) {
+            const handlers: Handlers = channels.get(name) ?? {
+                listeners: new Map(),
+            };
+            channels.set(name, handlers);
+
+            const chain = {
+                here(callback: Handlers['here']) {
+                    handlers.here = callback;
+
+                    return chain;
+                },
+                joining(callback: Handlers['joining']) {
+                    handlers.joining = callback;
+
+                    return chain;
+                },
+                leaving(callback: Handlers['leaving']) {
+                    handlers.leaving = callback;
+
+                    return chain;
+                },
+                listen(event: string, callback: (payload: never) => void) {
+                    handlers.listeners.set(event, callback);
+
+                    return chain;
+                },
+            };
+
+            return chain;
+        },
+        leave: (name: string) => left.push(name),
+    }),
+}));
+
+import { useTeamPresence } from '@/composables/useTeamPresence';
+
+/**
+ * A no-op renderer mounts a real component instance under Node (no DOM), which
+ * is what fires the composable's `onMounted` subscription.
+ */
+const { createApp } = createRenderer<object, object>({
+    insert: () => {},
+    remove: () => {},
+    createElement: () => ({}),
+    createText: () => ({}),
+    createComment: () => ({}),
+    setText: () => {},
+    setElementText: () => {},
+    parentNode: () => null,
+    nextSibling: () => null,
+    setScopeId: () => {},
+});
+
+function mount() {
+    let api!: ReturnType<typeof useTeamPresence>;
+
+    const app = createApp(
+        defineComponent({
+            setup() {
+                api = useTeamPresence(() => 'team-1');
+
+                return () => null;
+            },
+        }),
+    );
+
+    app.mount({});
+
+    return { api, unmount: () => app.unmount() };
+}
+
+const roster = () => channels.get('team.team-1')!;
+
+beforeEach(() => {
+    channels.clear();
+    left.length = 0;
+    reload.mockClear();
+    page.props.teamMembers = [];
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('useTeamPresence', () => {
+    it('reports a member absent from the roster as offline', () => {
+        const { api, unmount } = mount();
+
+        roster().here!([]);
+
+        expect(api.presenceFor('maya')).toBe('offline');
+
+        unmount();
+    });
+
+    it('reports a roster member with no reported state as active', () => {
+        const { api, unmount } = mount();
+
+        roster().here!([{ id: 'maya', name: 'Maya' }]);
+
+        expect(api.presenceFor('maya')).toBe('active');
+
+        unmount();
+    });
+
+    it('seeds a joining client from the presence carried in the initial props', () => {
+        page.props.teamMembers = [
+            { id: 'maya', name: 'Maya', presence: 'away' },
+            { id: 'jonas', name: 'Jonas', presence: 'active' },
+        ];
+
+        const { api, unmount } = mount();
+
+        roster().here!([
+            { id: 'maya', name: 'Maya' },
+            { id: 'jonas', name: 'Jonas' },
+        ]);
+
+        expect(api.presenceFor('maya')).toBe('away');
+        expect(api.presenceFor('jonas')).toBe('active');
+
+        unmount();
+    });
+
+    it('patches a member live when they go away, with no reload', () => {
+        const { api, unmount } = mount();
+
+        roster().here!([{ id: 'maya', name: 'Maya' }]);
+        roster().listeners.get('UserPresenceChanged')!({
+            id: 'maya',
+            state: 'away',
+        } as never);
+
+        expect(api.presenceFor('maya')).toBe('away');
+        expect(reload).not.toHaveBeenCalled();
+
+        unmount();
+    });
+
+    it('patches them back to active on their next activity', () => {
+        const { api, unmount } = mount();
+
+        roster().here!([{ id: 'maya', name: 'Maya' }]);
+        roster().listeners.get('UserPresenceChanged')!({
+            id: 'maya',
+            state: 'away',
+        } as never);
+        roster().listeners.get('UserPresenceChanged')!({
+            id: 'maya',
+            state: 'active',
+        } as never);
+
+        expect(api.presenceFor('maya')).toBe('active');
+
+        unmount();
+    });
+
+    it('prefers a live flip over the state the props were seeded with', () => {
+        page.props.teamMembers = [{ id: 'maya', name: 'Maya', presence: 'away' }];
+
+        const { api, unmount } = mount();
+
+        roster().here!([{ id: 'maya', name: 'Maya' }]);
+        roster().listeners.get('UserPresenceChanged')!({
+            id: 'maya',
+            state: 'active',
+        } as never);
+
+        expect(api.presenceFor('maya')).toBe('active');
+
+        unmount();
+    });
+
+    it('renders a member who leaves as offline, whatever they last reported', () => {
+        const { api, unmount } = mount();
+
+        roster().here!([{ id: 'maya', name: 'Maya' }]);
+        roster().listeners.get('UserPresenceChanged')!({
+            id: 'maya',
+            state: 'away',
+        } as never);
+        roster().leaving!({ id: 'maya', name: 'Maya' });
+
+        expect(api.presenceFor('maya')).toBe('offline');
+
+        unmount();
+    });
+
+    it('forgets a stale flip so a returning member re-reads the fresh props', () => {
+        page.props.teamMembers = [
+            { id: 'maya', name: 'Maya', presence: 'active' },
+        ];
+
+        const { api, unmount } = mount();
+
+        roster().here!([{ id: 'maya', name: 'Maya' }]);
+        roster().listeners.get('UserPresenceChanged')!({
+            id: 'maya',
+            state: 'away',
+        } as never);
+        roster().leaving!({ id: 'maya', name: 'Maya' });
+        roster().joining!({ id: 'maya', name: 'Maya' });
+
+        expect(api.presenceFor('maya')).toBe('active');
+
+        unmount();
+    });
+
+    it('still reloads every prop when a teammate changes their profile', async () => {
+        vi.useFakeTimers();
+
+        const { unmount } = mount();
+
+        roster().listeners.get('UserProfileUpdated')!(undefined as never);
+
+        await vi.advanceTimersByTimeAsync(500);
+        await nextTick();
+
+        expect(reload).toHaveBeenCalledTimes(1);
+
+        unmount();
+    });
+
+    it('leaves the channel on unmount', () => {
+        const { unmount } = mount();
+
+        unmount();
+
+        expect(left).toContain('team.team-1');
+    });
+});

--- a/resources/js/composables/useTeamPresence.test.ts
+++ b/resources/js/composables/useTeamPresence.test.ts
@@ -82,6 +82,7 @@ const { createApp } = createRenderer<object, object>({
     setElementText: () => {},
     parentNode: () => null,
     nextSibling: () => null,
+    patchProp: () => {},
     setScopeId: () => {},
 });
 
@@ -190,7 +191,9 @@ describe('useTeamPresence', () => {
     });
 
     it('prefers a live flip over the state the props were seeded with', () => {
-        page.props.teamMembers = [{ id: 'maya', name: 'Maya', presence: 'away' }];
+        page.props.teamMembers = [
+            { id: 'maya', name: 'Maya', presence: 'away' },
+        ];
 
         const { api, unmount } = mount();
 

--- a/resources/js/composables/useTeamPresence.ts
+++ b/resources/js/composables/useTeamPresence.ts
@@ -1,8 +1,9 @@
-import { router } from '@inertiajs/vue3';
+import { router, usePage } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
-import { onBeforeUnmount, onMounted, ref, toValue, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, toValue, watch } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import type { RenderedPresence } from '@/lib/presence';
 
 /**
  * How long to coalesce a burst of profile updates before reloading, so many
@@ -20,29 +21,88 @@ export type PresenceMember = {
 };
 
 /**
- * Tracks which members of a team are currently online via the `team.{id}`
- * Reverb presence channel. `here` seeds the roster on join, while `joining`
- * and `leaving` keep it live as members open and close the workspace.
+ * A teammate flipping between active and away mid-session, as carried by the
+ * server-broadcast `UserPresenceChanged` event.
+ */
+export type PresenceFlip = {
+    id: string;
+    state: App.Enums.PresenceState;
+};
+
+/**
+ * Tracks which members of a team are reachable via the `team.{id}` Reverb
+ * presence channel, and how reachable each of them is.
+ *
+ * Two sources are composed, because neither answers alone. The roster (`here` /
+ * `joining` / `leaving`) is authoritative for *connected at all* and is instant,
+ * but its `user_info` is frozen at join, so a mid-session flip cannot live
+ * there. The active/away refinement therefore arrives separately: seeded from
+ * the presence the server put in the initial props (a client that has just
+ * loaded has no event history) and then patched by `UserPresenceChanged`.
+ *
+ * Callers get a single `presenceFor` rather than the two sources, so none of the
+ * dot surfaces can compose them differently.
  *
  * The subscription follows the given team id: switching teams leaves the old
  * presence channel and joins the new one, and the channel is left on unmount.
  */
 export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
+    const page = usePage();
+
     // Ids of the members currently present, driving the online dots.
     const onlineIds = ref<Set<string>>(new Set());
 
+    // Live active/away flips received since this client loaded, by user id.
+    // Authoritative over the props seed, which can only be as fresh as the last
+    // Inertia visit.
+    const flips = ref<Map<string, App.Enums.PresenceState>>(new Map());
+
     // A pending debounced profile-update reload, if any.
     let profileReloadTimer: ReturnType<typeof setTimeout> | undefined;
+
+    /**
+     * The presence the server resolved for each teammate when these props were
+     * built — the cold-start answer for anyone who has not flipped since.
+     */
+    const seeded = computed(() => {
+        const states = new Map<string, App.Enums.PresenceState>();
+
+        for (const member of page.props.teamMembers ?? []) {
+            if (member.presence) {
+                states.set(member.id, member.presence);
+            }
+        }
+
+        return states;
+    });
 
     function channelName(id: string): string {
         return `team.${id}`;
     }
 
-    // A teammate changed their profile (today: their avatar). Reload the current
-    // page's props so every avatar surface re-reads the new image, preserving
-    // scroll and local state so the refresh is invisible. A teammate's timing is
-    // not the viewer's, and this one reloads *every* prop, so interrupting a
-    // visit with it is especially costly; see {@see backgroundVisit}.
+    /**
+     * How the given member should render: offline unless they hold a connection,
+     * and then whatever they last reported.
+     *
+     * Anyone connected but unaccounted for reads as active — a teammate on older
+     * JS, one whose registry entry was evicted, an unreachable cache. Each of
+     * those degrades to exactly the behaviour that predates away rather than to a
+     * wrong "away".
+     */
+    function presenceFor(userId: string): RenderedPresence {
+        if (!onlineIds.value.has(userId)) {
+            return 'offline';
+        }
+
+        return flips.value.get(userId) ?? seeded.value.get(userId) ?? 'active';
+    }
+
+    // A teammate changed their profile (avatar, custom status). Reload the
+    // current page's props so every surface re-reads them, preserving scroll and
+    // local state so the refresh is invisible. A teammate's timing is not the
+    // viewer's, and this one reloads *every* prop, so interrupting a visit with
+    // it is especially costly; see {@see backgroundVisit}. Presence deliberately
+    // does not come through here — it flips far too often to pay this price.
     function scheduleProfileReload(): void {
         clearTimeout(profileReloadTimer);
         profileReloadTimer = setTimeout(() => {
@@ -54,6 +114,16 @@ export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
         onlineIds.value = new Set(ids);
     }
 
+    function forgetFlip(id: string): void {
+        if (!flips.value.has(id)) {
+            return;
+        }
+
+        const next = new Map(flips.value);
+        next.delete(id);
+        flips.value = next;
+    }
+
     function join(id: string): void {
         echo()
             .join(channelName(id))
@@ -61,14 +131,23 @@ export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
                 replace(members.map((member) => member.id));
             })
             .joining((member: PresenceMember) => {
+                // Their last flip predates this connection and may describe a
+                // session that has since ended, so the props seed is the fresher
+                // claim until they report again.
+                forgetFlip(member.id);
                 onlineIds.value = new Set(onlineIds.value).add(member.id);
             })
             .leaving((member: PresenceMember) => {
+                forgetFlip(member.id);
+
                 const next = new Set(onlineIds.value);
                 next.delete(member.id);
                 onlineIds.value = next;
             })
-            .listen('UserProfileUpdated', scheduleProfileReload);
+            .listen('UserProfileUpdated', scheduleProfileReload)
+            .listen('UserPresenceChanged', (flip: PresenceFlip) => {
+                flips.value = new Map(flips.value).set(flip.id, flip.state);
+            });
     }
 
     function leave(id: string): void {
@@ -95,6 +174,7 @@ export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
             }
 
             replace([]);
+            flips.value = new Map();
 
             if (newId) {
                 join(newId);
@@ -112,5 +192,5 @@ export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
         }
     });
 
-    return { onlineIds };
+    return { onlineIds, presenceFor };
 }

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -105,6 +105,7 @@ import {
     toggleCollapsedSection,
 } from '@/lib/channelSections';
 import type { SidebarSectionKey } from '@/lib/channelSections';
+import { dmParticipantPresence } from '@/lib/presence';
 import type { Channel, ChannelSection } from '@/types/channels';
 import type { MessageReminder } from '@/types/messages';
 import type { RoleOption } from '@/types/teams';
@@ -1255,9 +1256,11 @@ onMounted(() => {
                                     :team-slug="currentTeam?.slug ?? ''"
                                     :active-channel-slug="activeChannelSlug"
                                     :presence="
-                                        dm.dmUserId != null
-                                            ? presenceFor(dm.dmUserId)
-                                            : 'offline'
+                                        dmParticipantPresence(
+                                            dm.dmUserId,
+                                            presenceFor,
+                                            page.props.auth.user.presence,
+                                        )
                                     "
                                     :is-self="dm.dmUserId === currentUserId"
                                 />

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -91,6 +91,7 @@ import {
     shouldAutoStartTour,
     useOnboardingTour,
 } from '@/composables/useOnboardingTour';
+import { usePresenceReporter } from '@/composables/usePresenceReporter';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
 import { useTeamPresence } from '@/composables/useTeamPresence';
@@ -148,8 +149,12 @@ const currentUserId = computed(() => String(page.props.auth.user.id));
 /** The current team's members, feeding the DM entry points (people picker + ⌘K). */
 const teamMembers = computed(() => page.props.teamMembers ?? []);
 
-/** Online roster for the current team, driving the presence dot on each DM row. */
-const { onlineIds } = useTeamPresence(() => currentTeam.value?.id);
+/** Live presence for the current team, driving the dot on each DM row. */
+const { presenceFor } = useTeamPresence(() => currentTeam.value?.id);
+
+// Report this tab's own idle state from the layout every authenticated surface
+// mounts, so someone reading a settings page still counts as here.
+usePresenceReporter();
 
 /** The "New message" people picker opened from the "Direct messages" header. */
 const newDmOpen = ref(false);
@@ -1249,9 +1254,10 @@ onMounted(() => {
                                     :channel="dm"
                                     :team-slug="currentTeam?.slug ?? ''"
                                     :active-channel-slug="activeChannelSlug"
-                                    :online="
-                                        dm.dmUserId != null &&
-                                        onlineIds.has(dm.dmUserId)
+                                    :presence="
+                                        dm.dmUserId != null
+                                            ? presenceFor(dm.dmUserId)
+                                            : 'offline'
                                     "
                                     :is-self="dm.dmUserId === currentUserId"
                                 />

--- a/resources/js/lib/groupDm.test.ts
+++ b/resources/js/lib/groupDm.test.ts
@@ -10,7 +10,14 @@ import {
 import type { Channel, DmParticipant } from '@/types/channels';
 
 function participant(id: string, name: string): DmParticipant {
-    return { id, name, avatar: null, isBot: false, status: null };
+    return {
+        id,
+        name,
+        avatar: null,
+        isBot: false,
+        status: null,
+        presence: 'active',
+    };
 }
 
 function dmChannel(id: string, participants: DmParticipant[]): Channel {

--- a/resources/js/lib/presence.test.ts
+++ b/resources/js/lib/presence.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { dmParticipantPresence, presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
+
+const roster: Record<string, RenderedPresence> = {
+    maya: 'away',
+    jonas: 'active',
+};
+
+const presenceFor = (id: string): RenderedPresence => roster[id] ?? 'offline';
+
+describe('dmParticipantPresence', () => {
+    it('reads the other participant off the roster', () => {
+        expect(dmParticipantPresence('maya', presenceFor, 'active')).toBe(
+            'away',
+        );
+    });
+
+    it('falls back to the viewer in a self-DM, which has no other participant', () => {
+        expect(dmParticipantPresence(null, presenceFor, 'away')).toBe('away');
+        expect(dmParticipantPresence(undefined, presenceFor, 'active')).toBe(
+            'active',
+        );
+    });
+
+    it('still reports a participant who has left the roster as offline', () => {
+        expect(dmParticipantPresence('gone', presenceFor, 'active')).toBe(
+            'offline',
+        );
+    });
+});
+
+describe('presenceLabelKey', () => {
+    it('names each state in English, for the caller to translate', () => {
+        expect(presenceLabelKey('active')).toBe('Active');
+        expect(presenceLabelKey('away')).toBe('Away');
+        expect(presenceLabelKey('offline')).toBe('Offline');
+    });
+});

--- a/resources/js/lib/presence.test.ts
+++ b/resources/js/lib/presence.test.ts
@@ -16,7 +16,7 @@ describe('dmParticipantPresence', () => {
         );
     });
 
-    it('falls back to the viewer in a self-DM, which has no other participant', () => {
+    it('falls back to the viewer when there is no counterpart id to look up', () => {
         expect(dmParticipantPresence(null, presenceFor, 'away')).toBe('away');
         expect(dmParticipantPresence(undefined, presenceFor, 'active')).toBe(
             'active',

--- a/resources/js/lib/presence.ts
+++ b/resources/js/lib/presence.ts
@@ -8,6 +8,20 @@
 export type RenderedPresence = App.Enums.PresenceState | 'offline';
 
 /**
+ * How the other side of a 1:1 DM renders.
+ */
+export function dmParticipantPresence(
+    dmUserId: string | null | undefined,
+    presenceFor: (userId: string) => RenderedPresence,
+    ownPresence: RenderedPresence,
+): RenderedPresence {
+    // A self-DM has no other participant, so it renders viewer-relative all the
+    // way down: the same fallback the avatar beside the dot already makes. The
+    // person reading the page is never offline to themselves.
+    return dmUserId != null ? presenceFor(dmUserId) : ownPresence;
+}
+
+/**
  * The message key announcing a presence to assistive tech.
  *
  * Returned untranslated so the caller resolves it through `$t` and the label

--- a/resources/js/lib/presence.ts
+++ b/resources/js/lib/presence.ts
@@ -1,0 +1,22 @@
+/**
+ * How a person renders on every dot surface.
+ *
+ * The server's `App.Enums.PresenceState` only describes someone who holds a
+ * connection; whether they hold one at all is the Reverb roster's answer. This
+ * union is the two composed, and is what the dot components take.
+ */
+export type RenderedPresence = App.Enums.PresenceState | 'offline';
+
+/**
+ * The message key announcing a presence to assistive tech.
+ *
+ * Returned untranslated so the caller resolves it through `$t` and the label
+ * follows a live locale switch, the way every other surface's copy does.
+ */
+export function presenceLabelKey(presence: RenderedPresence): string {
+    if (presence === 'active') {
+        return 'Active';
+    }
+
+    return presence === 'away' ? 'Away' : 'Offline';
+}

--- a/resources/js/lib/presence.ts
+++ b/resources/js/lib/presence.ts
@@ -15,9 +15,10 @@ export function dmParticipantPresence(
     presenceFor: (userId: string) => RenderedPresence,
     ownPresence: RenderedPresence,
 ): RenderedPresence {
-    // A self-DM has no other participant, so it renders viewer-relative all the
-    // way down: the same fallback the avatar beside the dot already makes. The
-    // person reading the page is never offline to themselves.
+    // Every 1:1 carries a counterpart id — a self-DM resolves it to the viewer
+    // themselves — so a missing id means a group conversation, whose surfaces
+    // render a facepile rather than this dot. Falling back to the viewer's own
+    // presence keeps a defensive render from ever being a wrong "offline".
     return dmUserId != null ? presenceFor(dmUserId) : ownPresence;
 }
 

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -194,10 +194,10 @@ const typing = useTypingIndicator(() => {
 const typingNames = typing.typingNames;
 
 /**
- * Live roster of team members currently online, driving the presence dots on
- * message avatars. Follows the team across channel switches.
+ * Live presence for the team, driving the dots on message avatars, the masthead
+ * and the facepile. Follows the team across channel switches.
  */
-const { onlineIds } = useTeamPresence(() => props.team.id);
+const { presenceFor } = useTeamPresence(() => props.team.id);
 
 /**
  * Read positions of the channel's other members who share read receipts, keyed
@@ -1170,7 +1170,7 @@ function archive(): void {
                 :channel="props.channel"
                 :team-slug="props.team.slug"
                 :members="props.members"
-                :online-ids="onlineIds"
+                :presence-for="presenceFor"
                 :title="mastheadTitle"
                 :can-manage-preferences="props.canManagePreferences"
                 :can-archive="props.canArchive"
@@ -1348,7 +1348,7 @@ function archive(): void {
                                 :can-moderate="canModerate"
                                 :can-react="props.canReact"
                                 :can-pin="props.canReact"
-                                :online-ids="onlineIds"
+                                :presence-for="presenceFor"
                                 :readers="channelReadersList"
                                 :highlight-message-id="highlightedMessageId"
                                 :unread-divider-id="unreadDividerId"
@@ -1525,7 +1525,7 @@ function archive(): void {
                 :can-moderate="canModerate"
                 :can-react="props.canReact"
                 :can-pin="props.canReact"
-                :online-ids="onlineIds"
+                :presence-for="presenceFor"
                 :loading="threadLoading"
                 :read-only="props.channel.isArchived"
                 @close="closeThread"

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -12,6 +12,11 @@ export type User = {
     timezone: string | null;
     /** The viewer's own live custom status; null when unset or already lapsed. */
     status: App.Data.UserStatusData | null;
+    /**
+     * The viewer's own effective presence — their manual override, or what their
+     * live connections say when they have set none.
+     */
+    presence: App.Enums.PresenceState;
     locale: AppLocale;
     avatar?: string;
     email_verified_at: string | null;

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -32,6 +32,7 @@ declare module '@inertiajs/core' {
             gifPickerEnabled: boolean;
             pollsEnabled: boolean;
             sidebarPositions: SidebarPositionOption[];
+            presence: { awayAfterMinutes: number };
             sidebarOpen: boolean;
             currentTeam: Team | null;
             teams: Team[];

--- a/resources/js/types/people.ts
+++ b/resources/js/types/people.ts
@@ -5,6 +5,12 @@
 export type PersonRef = {
     id: string;
     name: string;
+    /**
+     * The server's resolved active/away answer for this member, seeding the dot
+     * surfaces for a client that has only just loaded. Absent on the hand-built
+     * refs some pickers assemble, which then read as active.
+     */
+    presence?: App.Enums.PresenceState;
 };
 
 /**

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Settings\DataExportController;
 use App\Http\Controllers\Settings\LocaleController;
 use App\Http\Controllers\Settings\NotificationController;
 use App\Http\Controllers\Settings\PersonalAccessTokenController;
+use App\Http\Controllers\Settings\PresenceController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\ReadReceiptsController;
 use App\Http\Controllers\Settings\SecurityController;
@@ -49,6 +50,10 @@ Route::middleware(['auth'])->group(function (): void {
     // the plain `auth` group rather than behind the verified-email gate.
     Route::put('settings/status', [StatusController::class, 'update'])->name('status.update');
     Route::delete('settings/status', [StatusController::class, 'destroy'])->name('status.destroy');
+
+    // The manual away toggle sits beside the status in the same presence menu,
+    // and is reachable from every workspace surface for the same reason.
+    Route::put('settings/presence', [PresenceController::class, 'update'])->name('presence.update');
 
     Route::patch('settings/timezone', [TimezoneController::class, 'update'])->name('timezone.update');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\Channels\ThreadsController;
 use App\Http\Controllers\ImageProxyController;
 use App\Http\Controllers\LocaleCatalogController;
 use App\Http\Controllers\OnboardingController;
+use App\Http\Controllers\PresenceConnectionController;
 use App\Http\Controllers\SidebarSectionController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Controllers\Webhooks\IncomingWebhookController;
@@ -210,6 +211,11 @@ Route::middleware(['auth'])->group(function (): void {
         ->name('images.proxy');
 
     Route::patch('sidebar/sections', [SidebarSectionController::class, 'update'])->name('sidebar.sections.update');
+
+    // The idle detector's two writes. Not settings — the browser reports these
+    // on its own, and they describe one tab rather than a stored preference.
+    Route::post('presence/connection', [PresenceConnectionController::class, 'store'])->name('presence.report');
+    Route::post('presence/connection/release', [PresenceConnectionController::class, 'destroy'])->name('presence.release');
 
     Route::patch('onboarding', [OnboardingController::class, 'update'])->name('onboarding.update');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -214,8 +214,15 @@ Route::middleware(['auth'])->group(function (): void {
 
     // The idle detector's two writes. Not settings — the browser reports these
     // on its own, and they describe one tab rather than a stored preference.
-    Route::post('presence/connection', [PresenceConnectionController::class, 'store'])->name('presence.report');
-    Route::post('presence/connection/release', [PresenceConnectionController::class, 'destroy'])->name('presence.release');
+    // Throttled like the typing signal: an honest client posts a handful of
+    // times an hour, so a cap this generous is invisible to it while bounding
+    // how fast one account can grow its own connection index.
+    Route::post('presence/connection', [PresenceConnectionController::class, 'store'])
+        ->middleware('throttle:60,1')
+        ->name('presence.report');
+    Route::post('presence/connection/release', [PresenceConnectionController::class, 'destroy'])
+        ->middleware('throttle:60,1')
+        ->name('presence.release');
 
     Route::patch('onboarding', [OnboardingController::class, 'update'])->name('onboarding.update');
 

--- a/tests/Browser/RealtimeTypingTest.php
+++ b/tests/Browser/RealtimeTypingTest.php
@@ -10,9 +10,11 @@ test('a member sees the typing indicator while another composes', function (): v
 
     $bobPage->assertPresent('@message-composer-input');
 
-    // The first keystroke whispers immediately (leading-edge throttle), so Bob's
-    // roster picks Alice up over Reverb without her ever sending a message.
-    $alicePage->type('@message-composer-input', 'Drafting a thought…');
+    // Keystroke by keystroke rather than a single fill: the first input signals
+    // immediately (leading-edge throttle) and typing past the 2.5s throttle
+    // window re-signals, so Bob still catches a beat even if his channel
+    // subscription was still authorizing when the first one broadcast.
+    $alicePage->typeSlowly('@message-composer-input', 'Drafting a thought…', 150);
 
     $bobPage->assertSeeIn('@typing-indicator', $alice->name);
 });

--- a/tests/Feature/Channels/ReadReceiptsTest.php
+++ b/tests/Feature/Channels/ReadReceiptsTest.php
@@ -141,7 +141,7 @@ test('MessageRead broadcasts on the channel private channel with the reader and 
 
     expect($event->broadcastOn())->toEqual([new PrivateChannel('channel.'.$general->id)]);
     expect($event->broadcastWith())->toEqual([
-        'reader' => ['id' => $owner->id, 'name' => $owner->name, 'avatar' => $owner->avatar, 'isBot' => false, 'status' => null],
+        'reader' => ['id' => $owner->id, 'name' => $owner->name, 'avatar' => $owner->avatar, 'isBot' => false, 'status' => null, 'presence' => 'active'],
         'lastReadMessageId' => $message->id,
     ]);
 });

--- a/tests/Feature/Presence/EffectivePresenceTest.php
+++ b/tests/Feature/Presence/EffectivePresenceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Data\UserData;
+use App\Enums\PresenceState;
+use App\Models\User;
+use App\Support\PresenceRegistry;
+
+test('a new user is active by default', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->presence_state)->toBe(PresenceState::Active)
+        ->and($user->effectivePresence())->toBe(PresenceState::Active);
+});
+
+test('a manual away wins over an active connection', function (): void {
+    $user = User::factory()->create(['presence_state' => PresenceState::Away]);
+
+    app(PresenceRegistry::class)->record($user->id, 'laptop', PresenceState::Active);
+
+    expect($user->effectivePresence())->toBe(PresenceState::Away);
+});
+
+test('an unset manual state defers to the connection aggregate', function (): void {
+    $user = User::factory()->create(['presence_state' => PresenceState::Active]);
+
+    app(PresenceRegistry::class)->record($user->id, 'laptop', PresenceState::Away);
+
+    expect($user->effectivePresence())->toBe(PresenceState::Away);
+});
+
+test('the presence rides the user DTO every surface renders from', function (): void {
+    $user = User::factory()->create(['presence_state' => PresenceState::Away]);
+
+    expect(UserData::fromUser($user)->presence)->toBe(PresenceState::Away);
+});

--- a/tests/Feature/Presence/ManualPresenceTest.php
+++ b/tests/Feature/Presence/ManualPresenceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Enums\PresenceState;
+use App\Events\UserPresenceChanged;
+use App\Models\User;
+use App\Support\PresenceRegistry;
+use Illuminate\Support\Facades\Event;
+
+test('a user can set themselves away', function (): void {
+    Event::fake([UserPresenceChanged::class]);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->from('/')
+        ->put(route('presence.update'), ['state' => 'away'])
+        ->assertRedirect('/');
+
+    expect($user->fresh()->presence_state)->toBe(PresenceState::Away);
+
+    Event::assertDispatched(
+        UserPresenceChanged::class,
+        fn (UserPresenceChanged $event): bool => $event->user->is($user) && $event->state === PresenceState::Away,
+    );
+});
+
+test('a user can set themselves active again', function (): void {
+    Event::fake([UserPresenceChanged::class]);
+
+    $user = User::factory()->create(['presence_state' => PresenceState::Away]);
+
+    $this->actingAs($user)
+        ->from('/')
+        ->put(route('presence.update'), ['state' => 'active'])
+        ->assertRedirect('/');
+
+    expect($user->fresh()->presence_state)->toBe(PresenceState::Active);
+
+    Event::assertDispatched(
+        UserPresenceChanged::class,
+        fn (UserPresenceChanged $event): bool => $event->state === PresenceState::Active,
+    );
+});
+
+test('clearing a manual away reports the state the connections say', function (): void {
+    Event::fake([UserPresenceChanged::class]);
+
+    $user = User::factory()->create(['presence_state' => PresenceState::Away]);
+    app(PresenceRegistry::class)->record($user->id, 'laptop', PresenceState::Away);
+
+    $this->actingAs($user)->put(route('presence.update'), ['state' => 'active']);
+
+    Event::assertDispatched(
+        UserPresenceChanged::class,
+        fn (UserPresenceChanged $event): bool => $event->state === PresenceState::Away,
+    );
+});
+
+test('an unknown state is rejected', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->put(route('presence.update'), ['state' => 'lurking'])
+        ->assertSessionHasErrors('state');
+});
+
+test('a guest cannot set a presence', function (): void {
+    $this->put(route('presence.update'), ['state' => 'away'])->assertRedirect(route('login'));
+});

--- a/tests/Feature/Presence/PresenceBroadcastTest.php
+++ b/tests/Feature/Presence/PresenceBroadcastTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\PresenceState;
+use App\Events\UserPresenceChanged;
+use App\Models\User;
+use Illuminate\Broadcasting\PresenceChannel;
+
+test('it broadcasts on the presence channel of every team the user belongs to', function (): void {
+    $user = User::factory()->create();
+    $teamA = app(CreateTeam::class)->handle($user, 'Acme');
+    $teamB = app(CreateTeam::class)->handle($user, 'Globex');
+
+    $names = collect((new UserPresenceChanged($user->fresh(), PresenceState::Away))->broadcastOn())
+        ->map(fn (PresenceChannel $channel): string => $channel->name);
+
+    expect($names)->toContain('presence-team.'.$teamA->id)
+        ->and($names)->toContain('presence-team.'.$teamB->id);
+});
+
+test('its payload is just the user id and their new state', function (): void {
+    $user = User::factory()->create();
+
+    $payload = (new UserPresenceChanged($user, PresenceState::Away))->broadcastWith();
+
+    expect($payload)->toBe(['id' => $user->id, 'state' => 'away']);
+});

--- a/tests/Feature/Presence/PresenceConnectionTest.php
+++ b/tests/Feature/Presence/PresenceConnectionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use App\Enums\PresenceState;
+use App\Events\UserPresenceChanged;
+use App\Models\User;
+use App\Support\PresenceRegistry;
+use Illuminate\Support\Facades\Event;
+
+test('a tab reporting itself idle turns the user away for teammates', function (): void {
+    Event::fake([UserPresenceChanged::class]);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('presence.report'), ['connection' => 'tab-a', 'state' => 'away'])
+        ->assertNoContent();
+
+    expect(app(PresenceRegistry::class)->aggregate($user->id))->toBe(PresenceState::Away);
+
+    Event::assertDispatched(
+        UserPresenceChanged::class,
+        fn (UserPresenceChanged $event): bool => $event->state === PresenceState::Away,
+    );
+});
+
+test('a second tab going idle broadcasts nothing because the aggregate is unchanged', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'tab-a', 'state' => 'away']);
+
+    Event::fake([UserPresenceChanged::class]);
+
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'tab-b', 'state' => 'away']);
+
+    Event::assertNotDispatched(UserPresenceChanged::class);
+});
+
+test('a tab going idle while another stays active broadcasts nothing', function (): void {
+    Event::fake([UserPresenceChanged::class]);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'laptop', 'state' => 'active']);
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'phone', 'state' => 'away']);
+
+    expect(app(PresenceRegistry::class)->aggregate($user->id))->toBe(PresenceState::Active);
+
+    Event::assertNotDispatched(UserPresenceChanged::class);
+});
+
+test('activity on any tab brings the user back', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'tab-a', 'state' => 'away']);
+
+    Event::fake([UserPresenceChanged::class]);
+
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'tab-a', 'state' => 'active']);
+
+    Event::assertDispatched(
+        UserPresenceChanged::class,
+        fn (UserPresenceChanged $event): bool => $event->state === PresenceState::Active,
+    );
+});
+
+test('a manual away is not undone by a tab reporting activity', function (): void {
+    Event::fake([UserPresenceChanged::class]);
+
+    $user = User::factory()->create(['presence_state' => PresenceState::Away]);
+
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'tab-a', 'state' => 'active']);
+
+    expect($user->fresh()->effectivePresence())->toBe(PresenceState::Away);
+
+    Event::assertNotDispatched(UserPresenceChanged::class);
+});
+
+test('closing the last idle tab returns the user to active', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'tab-a', 'state' => 'away']);
+
+    Event::fake([UserPresenceChanged::class]);
+
+    $this->actingAs($user)
+        ->postJson(route('presence.release'), ['connection' => 'tab-a'])
+        ->assertNoContent();
+
+    Event::assertDispatched(
+        UserPresenceChanged::class,
+        fn (UserPresenceChanged $event): bool => $event->state === PresenceState::Active,
+    );
+});
+
+test('closing an active tab while an idle one remains turns the user away', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'laptop', 'state' => 'active']);
+    $this->actingAs($user)->postJson(route('presence.report'), ['connection' => 'phone', 'state' => 'away']);
+
+    Event::fake([UserPresenceChanged::class]);
+
+    $this->actingAs($user)->postJson(route('presence.release'), ['connection' => 'laptop']);
+
+    Event::assertDispatched(
+        UserPresenceChanged::class,
+        fn (UserPresenceChanged $event): bool => $event->state === PresenceState::Away,
+    );
+});
+
+test('a report needs a connection key and a known state', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('presence.report'), ['state' => 'away'])
+        ->assertJsonValidationErrors('connection');
+
+    $this->actingAs($user)
+        ->postJson(route('presence.report'), ['connection' => 'tab-a', 'state' => 'lurking'])
+        ->assertJsonValidationErrors('state');
+});
+
+test('a guest cannot report a connection', function (): void {
+    $this->postJson(route('presence.report'), ['connection' => 'tab-a', 'state' => 'away'])
+        ->assertUnauthorized();
+});

--- a/tests/Feature/Presence/PresencePropsTest.php
+++ b/tests/Feature/Presence/PresencePropsTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Enums\PresenceState;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('the idle threshold reaches the browser', function (): void {
+    config()->set('presence.away_after_minutes', 7);
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('profile.edit'))
+        ->assertInertia(fn (Assert $page) => $page->where('presence.awayAfterMinutes', 7));
+});
+
+test('a nonsensical threshold is floored at a minute rather than disabling idle detection', function (): void {
+    config()->set('presence.away_after_minutes', 0);
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('profile.edit'))
+        ->assertInertia(fn (Assert $page) => $page->where('presence.awayAfterMinutes', 1));
+});
+
+test('the viewer reads their own presence off the shared auth prop', function (): void {
+    $user = User::factory()->create(['presence_state' => PresenceState::Away]);
+
+    $this->actingAs($user)
+        ->get(route('profile.edit'))
+        ->assertInertia(fn (Assert $page) => $page->where('auth.user.presence', 'away'));
+});

--- a/tests/Feature/Presence/PresencePropsTest.php
+++ b/tests/Feature/Presence/PresencePropsTest.php
@@ -9,7 +9,7 @@ test('the idle threshold reaches the browser', function (): void {
 
     $this->actingAs(User::factory()->create())
         ->get(route('profile.edit'))
-        ->assertInertia(fn (Assert $page) => $page->where('presence.awayAfterMinutes', 7));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('presence.awayAfterMinutes', 7));
 });
 
 test('a nonsensical threshold is floored at a minute rather than disabling idle detection', function (): void {
@@ -17,7 +17,7 @@ test('a nonsensical threshold is floored at a minute rather than disabling idle 
 
     $this->actingAs(User::factory()->create())
         ->get(route('profile.edit'))
-        ->assertInertia(fn (Assert $page) => $page->where('presence.awayAfterMinutes', 1));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('presence.awayAfterMinutes', 1));
 });
 
 test('the viewer reads their own presence off the shared auth prop', function (): void {
@@ -25,5 +25,5 @@ test('the viewer reads their own presence off the shared auth prop', function ()
 
     $this->actingAs($user)
         ->get(route('profile.edit'))
-        ->assertInertia(fn (Assert $page) => $page->where('auth.user.presence', 'away'));
+        ->assertInertia(fn (Assert $page): Assert => $page->where('auth.user.presence', 'away'));
 });

--- a/tests/Feature/Presence/PresenceRegistryTest.php
+++ b/tests/Feature/Presence/PresenceRegistryTest.php
@@ -39,7 +39,7 @@ test('releasing the last idle connection returns the user to active', function (
     expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Active);
 });
 
-test('releasing an idle tab leaves the other tabs deciding', function (): void {
+test('releasing the active tab leaves the idle tab deciding', function (): void {
     $this->registry->record('user-1', 'laptop', PresenceState::Active);
     $this->registry->record('user-1', 'phone', PresenceState::Away);
 

--- a/tests/Feature/Presence/PresenceRegistryTest.php
+++ b/tests/Feature/Presence/PresenceRegistryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Enums\PresenceState;
+use App\Support\PresenceRegistry;
+
+beforeEach(function (): void {
+    $this->registry = app(PresenceRegistry::class);
+});
+
+test('a user with no reported connection reads as active', function (): void {
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Active);
+});
+
+test('a single idle connection makes the user away', function (): void {
+    $this->registry->record('user-1', 'tab-a', PresenceState::Away);
+
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Away);
+});
+
+test('one active connection keeps the user active while another is idle', function (): void {
+    $this->registry->record('user-1', 'laptop', PresenceState::Active);
+    $this->registry->record('user-1', 'phone', PresenceState::Away);
+
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Active);
+});
+
+test('a connection reporting again replaces its previous state', function (): void {
+    $this->registry->record('user-1', 'laptop', PresenceState::Active);
+    $this->registry->record('user-1', 'laptop', PresenceState::Away);
+
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Away);
+});
+
+test('releasing the last idle connection returns the user to active', function (): void {
+    $this->registry->record('user-1', 'laptop', PresenceState::Away);
+    $this->registry->forget('user-1', 'laptop');
+
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Active);
+});
+
+test('releasing an idle tab leaves the other tabs deciding', function (): void {
+    $this->registry->record('user-1', 'laptop', PresenceState::Active);
+    $this->registry->record('user-1', 'phone', PresenceState::Away);
+
+    $this->registry->forget('user-1', 'laptop');
+
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Away);
+});
+
+test('connections are scoped per user', function (): void {
+    $this->registry->record('user-1', 'tab-a', PresenceState::Away);
+
+    expect($this->registry->aggregate('user-2'))->toBe(PresenceState::Active);
+});
+
+test('a connection that stopped reporting ages out and stops holding the user away', function (): void {
+    config()->set('presence.away_after_minutes', 10);
+
+    $this->registry->record('user-1', 'crashed-tab', PresenceState::Away);
+
+    $this->travel(16)->minutes();
+
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Active);
+});
+
+test('a connection still reporting within the window keeps its state', function (): void {
+    config()->set('presence.away_after_minutes', 10);
+
+    $this->registry->record('user-1', 'tab-a', PresenceState::Away);
+
+    $this->travel(14)->minutes();
+
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Away);
+});
+
+test('forgetting an unknown connection is a no-op', function (): void {
+    $this->registry->record('user-1', 'laptop', PresenceState::Away);
+
+    $this->registry->forget('user-1', 'never-seen');
+
+    expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Away);
+});

--- a/tests/Feature/Presence/PresenceRegistryTest.php
+++ b/tests/Feature/Presence/PresenceRegistryTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\PresenceState;
 use App\Support\PresenceRegistry;
+use Illuminate\Contracts\Cache\Repository;
 
 beforeEach(function (): void {
     $this->registry = app(PresenceRegistry::class);
@@ -80,3 +81,32 @@ test('forgetting an unknown connection is a no-op', function (): void {
 
     expect($this->registry->aggregate('user-1'))->toBe(PresenceState::Away);
 });
+
+test('an unreachable cache reads as active rather than failing the page', function (): void {
+    $cache = Mockery::mock(Repository::class);
+    $cache->shouldReceive('get')->andThrow(new RuntimeException('redis is down'));
+
+    expect((new PresenceRegistry($cache))->aggregate('user-1'))->toBe(PresenceState::Active);
+});
+
+test('an unreachable cache swallows a write, which the next heartbeat re-states', function (): void {
+    $cache = Mockery::mock(Repository::class);
+    $cache->shouldReceive('get')->andReturn([]);
+    $cache->shouldReceive('put')->andThrow(new RuntimeException('redis is down'));
+
+    $registry = new PresenceRegistry($cache);
+
+    $registry->record('user-1', 'tab-a', PresenceState::Away);
+
+    expect($registry->aggregate('user-1'))->toBe(PresenceState::Active);
+});
+
+test('an unreachable cache swallows a release too', function (): void {
+    $cache = Mockery::mock(Repository::class);
+    $cache->shouldReceive('get')->andReturn(['tab-a' => ['state' => 'away', 'last_seen' => now()->getTimestamp()]]);
+    $cache->shouldReceive('forget')->andThrow(new RuntimeException('redis is down'));
+
+    $registry = new PresenceRegistry($cache);
+
+    $registry->forget('user-1', 'tab-a');
+})->throwsNoExceptions();


### PR DESCRIPTION
Closes #378. Part of the presence & identity epic (#374).

## What

Adds an "away" presence state beyond binary online/offline, per the locked decisions on the issue:

- **Manual away** — a toggle in the presence menu (`PUT settings/presence`), persisted on a new `users.presence_state` enum column so it survives reconnects until unset.
- **Auto-idle** — a client-side detector (`usePresenceReporter`): throttled `pointerdown`/`keydown`/`scroll`/`touchstart` + `window.focus` refresh one timer; crossing the configured threshold flips the tab to away, activity flips it back. Losing focus does not flip you away on its own.
- **Server-derived aggregation** — a cache-backed `PresenceRegistry` (user → per-tab connection → `{state, last_seen}`). You read active to teammates if *any* of your connections is active; away only when all are idle. A roster member with no registry entry renders active — the feature fails open (including on an unreachable cache, which is caught, reported, and read as "no idle connections").
- **Transport** — a lightweight `UserPresenceChanged` event on the existing `team.{id}` presence channel carrying `{id, state}`; nothing broadcasts unless the aggregate teammates see actually moves. The presence field also rides `UserProfileUpdated` so a joining client starts correct, without touching the hot path.
- **Connection identity** — a per-tab UUID in `sessionStorage` (not the session: two tabs share it; not the socket id: it regenerates each reconnect and strands ghost "active" entries). Liveness via `pagehide` + `sendBeacon` release, with a slow TTL heartbeat as crash backstop. Both report routes are throttled.
- **Rendering** — a shared `PresenceDot` component (green active / hollow away) across every dot surface: sidebar DM rows, `MessageList`, `ChannelMasthead`, `AvatarStack`, `UserHoverCard`, `ThreadPanel`, `NavUser`, and the user menu. All surfaces compose roster + state through a single `presenceFor()` from `useTeamPresence`, with 1:1 rows going through `dmParticipantPresence()`.

## Config & docs

- `PRESENCE_AWAY_AFTER_MINUTES` (new `config/presence.php`), shared to the browser as an Inertia prop; documented in the Starlight env-vars reference.
- New UI copy translated in `lang/fr.json`.

## Testing

- TDD throughout; backend gate green (`Pint` + `PHPStan` + `Rector` + Pest at **100.0 %** coverage), frontend gate green (`lint:check`, `format:check`, `types:check`, `test:js` — 955 tests, `build`).
- New feature suites under `tests/Feature/Presence/` (registry aggregation + fail-open, connection reporting/release + broadcast-on-change, manual toggle, shared props, effective presence) and Vitest suites for `usePresenceReporter`, `useTeamPresence`, `PresenceDot`, and the presence lib.
- While running the gate in the worktree, found a pre-existing env leak that fails `ReverbConfigSharingTest` in `bin/worktree` checkouts — filed as #732, not fixed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787333291&installation_model_id=428379&pr_number=733&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F733&signature=db6dc90cf881f126d960f235d6b08f531f7b52e2e4cd1cf0ee681ca9931c2e29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->