### PR TITLE
feat: pause notifications manually or on a daily quiet-hours schedule

### DIFF
--- a/app/Actions/Users/BroadcastDndScheduleEdges.php
+++ b/app/Actions/Users/BroadcastDndScheduleEdges.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Users;
+
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+
+class BroadcastDndScheduleEdges
+{
+    /**
+     * Broadcast a profile update for every user whose quiet-hours window opens
+     * or closes this very minute, so teammates' open clients flip the DND badge
+     * without a reload.
+     *
+     * A recurring window changes nothing on the row when it starts or ends —
+     * unlike a lapsing manual pause there is no column to null — so nothing
+     * else would ever announce the flip. The match is the user's own wall
+     * clock against their stored `HH:MM` bounds: stateless on purpose, at the
+     * price that a minute the scheduler skips loses that minute's announcements
+     * (the next props reload still corrects every client).
+     *
+     * @return int the number of users whose edge was broadcast
+     */
+    public function handle(): int
+    {
+        $broadcast = 0;
+
+        User::query()
+            ->where('dnd_schedule_enabled', true)
+            ->whereNotNull('dnd_starts_at')
+            ->whereNotNull('dnd_ends_at')
+            ->cursor()
+            ->each(function (User $user) use (&$broadcast): void {
+                $wallClock = now($user->timezone ?? config('app.timezone'))->format('H:i');
+
+                if ($wallClock !== $user->dnd_starts_at && $wallClock !== $user->dnd_ends_at) {
+                    return;
+                }
+
+                event(new UserProfileUpdated($user));
+
+                $broadcast++;
+            });
+
+        return $broadcast;
+    }
+}

--- a/app/Actions/Users/ClearLapsedDndPauses.php
+++ b/app/Actions/Users/ClearLapsedDndPauses.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Users;
+
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+
+class ClearLapsedDndPauses
+{
+    /**
+     * Null out every manual do-not-disturb pause whose instant has passed, and
+     * broadcast each clear so teammates' open clients drop the DND badge
+     * without a reload.
+     *
+     * This is the eager half of expiry, mirroring {@see ClearExpiredUserStatuses}
+     * for the custom status. Reads already treat a lapsed pause as over (see
+     * {@see User::isDndActive()}), so this sweep is what makes the lapse
+     * *propagate*: nothing else would tell a teammate sitting on an idle page
+     * that the pause ended. Running it every minute keeps the wall-clock error
+     * under the smallest offered preset.
+     *
+     * The cursor can hand back a user who has since started a *fresh* pause, so
+     * each clear is conditional on the instant still being the lapsed one this
+     * pass read. A pause replaced in that window is left alone — and neither
+     * counted nor broadcast — rather than being wiped moments after the user
+     * started it.
+     *
+     * @return int the number of pauses cleared
+     */
+    public function handle(): int
+    {
+        $cleared = 0;
+
+        User::query()
+            ->whereNotNull('dnd_until')
+            ->where('dnd_until', '<=', now())
+            ->cursor()
+            ->each(function (User $user) use (&$cleared): void {
+                $updated = User::query()
+                    ->whereKey($user->getKey())
+                    ->where('dnd_until', $user->dnd_until)
+                    ->update(['dnd_until' => null]);
+
+                if ($updated === 0) {
+                    return;
+                }
+
+                event(new UserProfileUpdated($user->refresh()));
+
+                $cleared++;
+            });
+
+        return $cleared;
+    }
+}

--- a/app/Data/UserData.php
+++ b/app/Data/UserData.php
@@ -29,6 +29,11 @@ class UserData extends Data
         // freshly loaded client — which has no broadcast history — still paints
         // the right dot before any UserPresenceChanged event arrives.
         public PresenceState $presence = PresenceState::Active,
+        // Whether the author is in do-not-disturb right now, so the DND badge
+        // rides every presence-dot surface. A bare boolean on purpose: the
+        // pause instant and the quiet-hours schedule are the owner's business
+        // and never leave their own `auth.user` prop.
+        public bool $isDnd = false,
     ) {}
 
     /**
@@ -43,6 +48,7 @@ class UserData extends Data
             isBot: $user->isBot(),
             status: UserStatusData::forUser($user),
             presence: $user->effectivePresence(),
+            isDnd: $user->isDndActive(),
         );
     }
 }

--- a/app/Data/UserDndData.php
+++ b/app/Data/UserDndData.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\User;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+/**
+ * A user's own do-not-disturb configuration, as their own client reads it.
+ *
+ * Only ever serialised to its owner (the `auth.user` prop): teammates receive
+ * the single {@see UserData::$isDnd} boolean instead, so the pause instant and
+ * the quiet-hours schedule never leak. Carrying the full configuration lets the
+ * client evaluate "am I in DND right now" locally — the chime gate needs the
+ * answer at message-arrival time, not at page-load time.
+ */
+#[TypeScript]
+class UserDndData extends Data
+{
+    public function __construct(
+        /** ISO-8601 instant the manual pause lapses, or null when none is running. */
+        public ?string $until,
+        public bool $scheduleEnabled,
+        /** Daily window bounds as `HH:MM` wall-clock strings in the user's own timezone. */
+        public ?string $startsAt,
+        public ?string $endsAt,
+    ) {}
+
+    /**
+     * Build the DTO from a user's columns. A lapsed pause reads as absent
+     * immediately, without waiting for the scheduled sweep to null the column.
+     */
+    public static function forUser(User $user): self
+    {
+        return new self(
+            until: $user->dnd_until?->isFuture() ? $user->dnd_until->toIso8601String() : null,
+            // Null only on a freshly-made instance the column default has not
+            // been read back into yet, which is never scheduled.
+            scheduleEnabled: $user->dnd_schedule_enabled ?? false,
+            startsAt: $user->dnd_starts_at,
+            endsAt: $user->dnd_ends_at,
+        );
+    }
+}

--- a/app/Data/UserProfileData.php
+++ b/app/Data/UserProfileData.php
@@ -25,6 +25,10 @@ class UserProfileData extends Data
         public bool $isYou,
         /** The member's live custom status, shown in full on the card and page. */
         public ?UserStatusData $status = null,
+        // Whether the member is in do-not-disturb right now — the card names
+        // the state without exposing when it ends. Same curated boolean as
+        // UserData::$isDnd; the pause instant and schedule stay private.
+        public bool $isDnd = false,
     ) {}
 
     /**
@@ -49,6 +53,7 @@ class UserProfileData extends Data
             memberSince: $membership->created_at?->toIso8601String(),
             isYou: $member->is($viewer),
             status: UserStatusData::forUser($member),
+            isDnd: $member->isDndActive(),
         );
     }
 }

--- a/app/Http/Controllers/Settings/DndController.php
+++ b/app/Http/Controllers/Settings/DndController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Events\UserProfileUpdated;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateDndPauseRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class DndController extends Controller
+{
+    /**
+     * Pause the current user's notifications until an instant, replacing any
+     * pause already running.
+     *
+     * The pause lives on the row rather than in the client so it survives a
+     * reload, a new device, and a restart until it lapses. The broadcast tells
+     * teammates' open clients to paint the DND badge without a reload.
+     */
+    public function update(UpdateDndPauseRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        $user->forceFill(['dnd_until' => Carbon::parse((string) $request->validated('until'))])->save();
+
+        event(new UserProfileUpdated($user));
+
+        return back();
+    }
+
+    /**
+     * Resume notifications, ending a manual pause early.
+     *
+     * Only the pause is cleared: the recurring quiet-hours schedule is a
+     * standing preference and survives — resuming during quiet hours therefore
+     * leaves the user in DND until the window ends, which is what the schedule
+     * asked for.
+     */
+    public function destroy(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        $user->forceFill(['dnd_until' => null])->save();
+
+        event(new UserProfileUpdated($user));
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Settings/DndScheduleController.php
+++ b/app/Http/Controllers/Settings/DndScheduleController.php
@@ -27,7 +27,10 @@ class DndScheduleController extends Controller
 
         $changes = ['dnd_schedule_enabled' => (bool) $validated['enabled']];
 
-        if (isset($validated['starts_at'], $validated['ends_at'])) {
+        // Bounds are only ever rewritten on an enable: a disable flips the
+        // switch alone, so whatever it happens to carry can't clobber the
+        // stored window the next enable is meant to remember.
+        if ($changes['dnd_schedule_enabled'] && isset($validated['starts_at'], $validated['ends_at'])) {
             $changes['dnd_starts_at'] = $validated['starts_at'];
             $changes['dnd_ends_at'] = $validated['ends_at'];
         }

--- a/app/Http/Controllers/Settings/DndScheduleController.php
+++ b/app/Http/Controllers/Settings/DndScheduleController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Events\UserProfileUpdated;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateDndScheduleRequest;
+use Illuminate\Http\RedirectResponse;
+
+class DndScheduleController extends Controller
+{
+    /**
+     * Set the current user's recurring quiet-hours window.
+     *
+     * Enabling writes the window it was given; disabling flips the switch but
+     * keeps the stored bounds, so re-enabling later remembers them. Either way
+     * the broadcast lets teammates' open clients repaint the DND badge — a
+     * window that covers this very moment flips the flag right now.
+     */
+    public function update(UpdateDndScheduleRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $user = $request->user();
+
+        $changes = ['dnd_schedule_enabled' => (bool) $validated['enabled']];
+
+        if (isset($validated['starts_at'], $validated['ends_at'])) {
+            $changes['dnd_starts_at'] = $validated['starts_at'];
+            $changes['dnd_ends_at'] = $validated['ends_at'];
+        }
+
+        $user->forceFill($changes)->save();
+
+        event(new UserProfileUpdated($user));
+
+        return back();
+    }
+}

--- a/app/Http/Requests/Settings/UpdateDndPauseRequest.php
+++ b/app/Http/Requests/Settings/UpdateDndPauseRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateDndPauseRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            // The menu resolves its preset ("30 min", "until tomorrow", a custom
+            // pick) against the viewer's own zone and sends the instant, the way
+            // the status dialog sends `expires_at`. The server only insists it
+            // is still ahead, so a request left sitting until its moment passed
+            // is rejected rather than storing a pause that is born lapsed.
+            'until' => ['required', 'date', 'after:now'],
+        ];
+    }
+}

--- a/app/Http/Requests/Settings/UpdateDndScheduleRequest.php
+++ b/app/Http/Requests/Settings/UpdateDndScheduleRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateDndScheduleRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'enabled' => ['required', 'boolean'],
+            // Wall-clock `HH:MM` bounds in the user's own timezone. Only
+            // enabling insists on them: disabling leaves the stored window
+            // alone so re-enabling later remembers it. Identical bounds are
+            // rejected rather than stored as an empty window the evaluator
+            // would silently never match.
+            'starts_at' => ['required_if_accepted:enabled', 'nullable', 'date_format:H:i'],
+            'ends_at' => ['required_if_accepted:enabled', 'nullable', 'date_format:H:i', 'different:starts_at'],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Actions\Users\ClearExpiredUserStatuses;
 use App\Concerns\HasTeams;
 use App\Data\UserData;
+use App\Data\UserDndData;
 use App\Data\UserStatusData;
 use App\Enums\AppLocale;
 use App\Enums\ChimeSound;
@@ -70,6 +71,10 @@ use Laravel\Sanctum\HasApiTokens;
  * @property bool $share_read_receipts
  * @property SidebarPosition $sidebar_position
  * @property PresenceState $presence_state
+ * @property Carbon|null $dnd_until
+ * @property bool $dnd_schedule_enabled
+ * @property string|null $dnd_starts_at
+ * @property string|null $dnd_ends_at
  * @property Carbon|null $onboarding_completed_at
  * @property bool $is_tombstone
  * @property Carbon|null $deactivated_at
@@ -79,6 +84,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read string|null $avatar
  * @property-read UserStatusData|null $status
  * @property-read PresenceState $presence
+ * @property-read UserDndData $dnd
  * @property-read Team|null $currentTeam
  * @property-read Team|null $ownerTeam
  * @property-read Collection<int, Team> $ownedTeams
@@ -90,9 +96,9 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read Collection<int, Passkey> $passkeys
  * @property-read Collection<int, UserGroup> $userGroups
  */
-#[Appends(['avatar', 'status', 'presence'])]
+#[Appends(['avatar', 'status', 'presence', 'dnd'])]
 #[Fillable(['name', 'email', 'avatar_url', 'pronouns', 'title', 'phone', 'timezone', 'locale', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'sidebar_position', 'presence_state', 'onboarding_completed_at', 'collapsed_channel_sections', 'is_tombstone'])]
-#[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token', 'avatar_url', 'avatar_path', 'status_emoji', 'status_text', 'status_expires_at'])]
+#[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token', 'avatar_url', 'avatar_path', 'status_emoji', 'status_text', 'status_expires_at', 'dnd_until', 'dnd_schedule_enabled', 'dnd_starts_at', 'dnd_ends_at'])]
 #[ObservedBy(UserObserver::class)]
 class User extends Authenticatable implements HasLocalePreference, MustVerifyEmail, PasskeyUser
 {
@@ -153,6 +159,61 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
         }
 
         return $this->status_expires_at === null || $this->status_expires_at->isFuture();
+    }
+
+    /**
+     * Whether the user is in do-not-disturb right now.
+     *
+     * A manual pause whose `dnd_until` is still ahead reads as DND from the
+     * instant it is set, and lapses on read the instant it passes — the same
+     * lazy half of expiry as {@see hasLiveStatus()}, with the scheduled sweep
+     * as the eager half that propagates the lapse to teammates.
+     */
+    public function isDndActive(): bool
+    {
+        if ($this->dnd_until?->isFuture()) {
+            return true;
+        }
+
+        return $this->isInsideDndScheduleWindow();
+    }
+
+    /**
+     * Whether the recurring quiet-hours window covers this instant.
+     *
+     * The bounds are wall-clock `HH:MM` strings compared in the user's own
+     * timezone, so the window follows them when they travel. Start is
+     * inclusive and end exclusive, and a window whose end precedes its start
+     * wraps across midnight (22:00–07:00 covers the night, not an empty set).
+     */
+    private function isInsideDndScheduleWindow(): bool
+    {
+        if (! $this->dnd_schedule_enabled || $this->dnd_starts_at === null || $this->dnd_ends_at === null) {
+            return false;
+        }
+
+        $now = now($this->timezone ?? config('app.timezone'))->format('H:i');
+
+        if ($this->dnd_starts_at <= $this->dnd_ends_at) {
+            return $now >= $this->dnd_starts_at && $now < $this->dnd_ends_at;
+        }
+
+        return $now >= $this->dnd_starts_at || $now < $this->dnd_ends_at;
+    }
+
+    /**
+     * The user's own full do-not-disturb configuration.
+     *
+     * Appended to every serialisation of the model, which only ever reaches its
+     * owner (the `auth.user` prop) — teammates read the curated
+     * {@see UserData::$isDnd} boolean instead. The raw columns stay hidden so a
+     * lapsed pause can never leak through them.
+     *
+     * @return Attribute<covariant UserDndData, never>
+     */
+    protected function dnd(): Attribute
+    {
+        return Attribute::get(fn (): UserDndData => UserDndData::forUser($this));
     }
 
     /**
@@ -232,6 +293,8 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
             'share_read_receipts' => 'boolean',
             'sidebar_position' => SidebarPosition::class,
             'presence_state' => PresenceState::class,
+            'dnd_until' => 'datetime',
+            'dnd_schedule_enabled' => 'boolean',
             'onboarding_completed_at' => 'datetime',
             'status_expires_at' => 'datetime',
             'is_tombstone' => 'boolean',

--- a/database/migrations/2026_07_22_200746_add_do_not_disturb_to_users_table.php
+++ b/database/migrations/2026_07_22_200746_add_do_not_disturb_to_users_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            // The user's do-not-disturb state, gating only the in-app chime. A
+            // manual pause is an instant (`dnd_until` in the future = paused);
+            // the recurring quiet-hours window is a daily start/end pair kept as
+            // `HH:MM` strings evaluated in the user's own `timezone`, so the
+            // window follows them when they travel. The two are independent —
+            // either alone puts the user in DND.
+            $table->timestamp('dnd_until')->nullable()->after('presence_state');
+            $table->boolean('dnd_schedule_enabled')->default(false)->after('dnd_until');
+            $table->string('dnd_starts_at', 5)->nullable()->after('dnd_schedule_enabled');
+            $table->string('dnd_ends_at', 5)->nullable()->after('dnd_starts_at');
+
+            // The scheduled sweep scans for lapsed pauses every minute.
+            $table->index('dnd_until');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropIndex(['dnd_until']);
+            $table->dropColumn(['dnd_until', 'dnd_schedule_enabled', 'dnd_starts_at', 'dnd_ends_at']);
+        });
+    }
+};

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1213,5 +1213,21 @@
   ":active of :total active": ":active sur :total actifs",
   "Set yourself away": "Se marquer absent",
   "Set yourself active": "Se marquer actif",
-  "Could not change your presence.": "Impossible de modifier votre présence."
+  "Could not change your presence.": "Impossible de modifier votre présence.",
+  "Pause notifications": "Mettre les notifications en pause",
+  "Notifications paused": "Notifications en pause",
+  "Paused": "En pause",
+  "Resume": "Reprendre",
+  "Until tomorrow": "Jusqu'à demain",
+  "Quiet hours": "Heures calmes",
+  "quiet hours · until :time": "heures calmes · jusqu'à :time",
+  "Could not pause your notifications.": "Impossible de mettre vos notifications en pause.",
+  "Could not resume your notifications.": "Impossible de réactiver vos notifications.",
+  "Pick when the chime comes back. Teammates only see that notifications are paused.": "Choisissez quand le carillon revient. Vos collègues voient seulement que les notifications sont en pause.",
+  "Pause the chime on a daily schedule. Uses your timezone — :timezone.": "Met le carillon en pause selon un horaire quotidien. Utilise votre fuseau horaire — :timezone.",
+  "your device's": "celui de votre appareil",
+  "From": "De",
+  "to": "à",
+  "crosses midnight — ends tomorrow morning": "passe minuit — se termine demain matin",
+  "Could not update your quiet hours.": "Impossible de mettre à jour vos heures calmes."
 }

--- a/resources/js/components/AvatarStack.vue
+++ b/resources/js/components/AvatarStack.vue
@@ -30,6 +30,11 @@ const props = withDefaults(
          */
         presenceFor?: (userId: string) => RenderedPresence;
         /**
+         * Whether each stacked member is in do-not-disturb, driving the
+         * crescent badge on their dot. Only read when `presenceFor` is given.
+         */
+        dndFor?: (userId: string) => boolean;
+        /**
          * Background class matching the surface behind the stack, for the hollow
          * centre of an away dot. Pairs with `ringClass`.
          */
@@ -91,6 +96,7 @@ const DOT_SIZES = { sm: 'size-2', md: 'size-2.5' } as const;
                 v-if="presenceFor"
                 data-test="stack-presence-dot"
                 :presence="presenceFor(member.id)"
+                :is-dnd="dndFor?.(member.id) ?? false"
                 :surface-class="surfaceClass"
                 class="absolute -right-0.5 -bottom-0.5 ring-2"
                 :class="[DOT_SIZES[size], ringClass]"

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -58,6 +58,8 @@ const props = defineProps<{
     members: Mention[];
     /** How each team member reads on the presence roster, driving every dot here. */
     presenceFor: (userId: string) => RenderedPresence;
+    /** Whether each member is in do-not-disturb, driving the crescent badge. */
+    isDndFor?: (userId: string) => boolean;
     /**
      * The viewer-relative title (self-DM reads "You"); the page also feeds it to
      * `<Head>`, so it is resolved once there and passed down.
@@ -143,6 +145,13 @@ const dmPresence = computed<RenderedPresence>(() =>
     ),
 );
 
+/** Whether the 1:1 counterpart shows the crescent DND badge. */
+const dmDnd = computed(
+    () =>
+        props.channel.dmUserId != null &&
+        (props.isDndFor?.(props.channel.dmUserId) ?? false),
+);
+
 /**
  * How many of the channel's members are active right now.
  *
@@ -207,6 +216,7 @@ const groupParticipantCount = computed(
                     <PresenceDot
                         data-test="masthead-dm-presence"
                         :presence="dmPresence"
+                        :is-dnd="dmDnd"
                         surface-class="bg-card"
                         class="absolute -right-0.5 -bottom-0.5 size-2.5 ring-2 ring-card"
                     />
@@ -214,7 +224,9 @@ const groupParticipantCount = computed(
                          an aria-label on the role-less dot, which assistive tech
                          ignores on a bare <span>. -->
                     <span class="sr-only">{{
-                        $t(presenceLabelKey(dmPresence))
+                        dmDnd
+                            ? $t('Notifications paused')
+                            : $t(presenceLabelKey(dmPresence))
                     }}</span>
                 </span>
                 <span v-else class="text-brass italic">#</span>
@@ -355,6 +367,7 @@ const groupParticipantCount = computed(
                             v-if="!member.isBot"
                             data-test="masthead-member-presence"
                             :presence="props.presenceFor(member.id)"
+                            :is-dnd="props.isDndFor?.(member.id) ?? false"
                             surface-class="bg-card"
                             class="absolute -right-0.5 -bottom-0.5 size-2 ring-2 ring-card"
                         />

--- a/resources/js/components/DirectMessageListItem.vue
+++ b/resources/js/components/DirectMessageListItem.vue
@@ -30,6 +30,8 @@ const props = defineProps<{
     activeChannelSlug: string | null;
     /** How the DM's participant reads on the team presence roster. */
     presence: RenderedPresence;
+    /** Whether the DM's participant is in do-not-disturb, for the crescent badge. */
+    isDnd?: boolean;
     /** Whether this is the viewer's own self-DM (renders "You"). */
     isSelf: boolean;
 }>();
@@ -155,6 +157,7 @@ function hide(): void {
                     <PresenceDot
                         data-test="dm-presence-dot"
                         :presence="presence"
+                        :is-dnd="isDnd ?? false"
                         :surface-class="
                             isActive ? 'bg-sidebar-primary' : 'bg-sidebar'
                         "
@@ -167,7 +170,9 @@ function hide(): void {
                          label rather than an aria-label on the role-less dot,
                          which assistive tech ignores on a bare <span>. -->
                     <span data-test="dm-presence-label" class="sr-only">{{
-                        $t(presenceLabelKey(presence))
+                        isDnd
+                            ? $t('Notifications paused')
+                            : $t(presenceLabelKey(presence))
                     }}</span>
                 </span>
                 <span

--- a/resources/js/components/DndPauseDialog.vue
+++ b/resources/js/components/DndPauseDialog.vue
@@ -1,0 +1,266 @@
+<script setup lang="ts">
+import { router, usePage } from '@inertiajs/vue3';
+import { CalendarDate, today } from '@internationalized/date';
+import { Clock } from '@lucide/vue';
+import type { DateValue } from 'reka-ui';
+import { computed, ref, watch } from 'vue';
+import { toast } from 'vue-sonner';
+import { update as updateDndPause } from '@/actions/App/Http/Controllers/Settings/DndController';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { useTranslations } from '@/composables/useTranslations';
+import {
+    to12Hour,
+    to24Hour,
+    wallTimeToInstant,
+    zonedWallTime,
+} from '@/lib/scheduleTime';
+
+const open = defineModel<boolean>('open', { default: false });
+
+const page = usePage();
+const { t } = useTranslations();
+
+const effectiveZone = computed(
+    () =>
+        page.props.auth.user.timezone ??
+        Intl.DateTimeFormat().resolvedOptions().timeZone,
+);
+
+// The day + time controls mirror the status dialog's "Custom…" expiry (and the
+// composer's schedule picker), so every until-picker reads the same in the app.
+const HOURS = Array.from({ length: 12 }, (_, index) => index + 1);
+const MINUTES = Array.from({ length: 12 }, (_, index) => index * 5);
+const PERIODS = ['AM', 'PM'] as const;
+
+const dateValue = ref<DateValue>();
+const minDate = ref<DateValue>();
+const hour = ref(9);
+const minute = ref(0);
+const period = ref<'AM' | 'PM'>('AM');
+const saving = ref(false);
+
+/** The grid the minute select offers, in milliseconds. */
+const MINUTE_STEP_MS = 5 * 60_000;
+
+/**
+ * Point the controls at an instant, expressed in the viewer's zone. Minutes
+ * snap down to the 5-minute grid the selects offer.
+ */
+function applyInstant(iso: string): void {
+    const wall = zonedWallTime(effectiveZone.value, new Date(iso));
+    dateValue.value = new CalendarDate(wall.year, wall.month, wall.day);
+    const clock = to12Hour(wall.hour);
+    hour.value = clock.hour;
+    period.value = clock.period;
+    minute.value = Math.floor(wall.minute / 5) * 5;
+}
+
+/**
+ * The instant a fresh dialog opens on: a whole step ahead of now, snapped up
+ * onto the grid, so it never opens already invalid. A pause already running
+ * seeds the controls with its own lapse instead, ready to be extended.
+ */
+function reset(): void {
+    minDate.value = today(effectiveZone.value);
+
+    const stepAhead = Date.now() + MINUTE_STEP_MS;
+
+    applyInstant(
+        page.props.auth.user.dnd?.until ??
+            new Date(
+                Math.ceil(stepAhead / MINUTE_STEP_MS) * MINUTE_STEP_MS,
+            ).toISOString(),
+    );
+}
+
+watch(open, (isOpen) => {
+    if (isOpen) {
+        reset();
+    }
+});
+
+// The instant the controls name, or null before a day is picked.
+const until = computed<string | null>(() => {
+    if (!dateValue.value) {
+        return null;
+    }
+
+    return wallTimeToInstant(
+        {
+            year: dateValue.value.year,
+            month: dateValue.value.month,
+            day: dateValue.value.day,
+            hour: to24Hour(hour.value, period.value),
+            minute: minute.value,
+        },
+        effectiveZone.value,
+    ).toISOString();
+});
+
+// A picked instant can sit in the past (an earlier time today); the server
+// rejects it, so guard the submit and say why rather than round-tripping.
+const isUntilInFuture = computed(
+    () => until.value !== null && new Date(until.value).getTime() > Date.now(),
+);
+
+const canSave = computed(() => isUntilInFuture.value && !saving.value);
+
+function save(): void {
+    if (!canSave.value || until.value === null) {
+        return;
+    }
+
+    saving.value = true;
+
+    router.put(
+        updateDndPause().url,
+        { until: until.value },
+        {
+            preserveScroll: true,
+            onSuccess: () => (open.value = false),
+            onError: () =>
+                toast.error(t('Could not pause your notifications.')),
+            onFinish: () => (saving.value = false),
+        },
+    );
+}
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent
+            data-test="dnd-pause-dialog"
+            class="max-h-[85dvh] gap-4 overflow-y-auto p-0 sm:max-w-md"
+        >
+            <DialogHeader class="gap-1 border-b border-border px-5 pt-5 pb-3.5">
+                <DialogTitle class="font-serif text-[20px] tracking-[-0.01em]">
+                    {{ $t('Pause notifications') }}
+                </DialogTitle>
+                <DialogDescription class="sr-only">
+                    {{
+                        $t(
+                            'Pick when the chime comes back. Teammates only see that notifications are paused.',
+                        )
+                    }}
+                </DialogDescription>
+            </DialogHeader>
+
+            <div class="flex flex-col gap-4 px-5">
+                <div class="rounded-xl border border-border bg-card">
+                    <Calendar
+                        v-model="dateValue"
+                        :min-value="minDate"
+                        weekday-format="short"
+                        class="p-2"
+                    />
+                    <div
+                        class="flex items-center gap-2 border-t border-border px-3 py-2.5"
+                    >
+                        <Clock
+                            class="size-3.5 shrink-0 text-muted-foreground"
+                            aria-hidden="true"
+                        />
+                        <Select v-model="hour">
+                            <SelectTrigger
+                                data-test="dnd-pause-hour"
+                                :aria-label="$t('Hour')"
+                                class="h-8 gap-1.5 rounded-lg px-3 text-[13px] font-semibold"
+                            >
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem
+                                    v-for="value in HOURS"
+                                    :key="value"
+                                    :value="value"
+                                >
+                                    {{ value }}
+                                </SelectItem>
+                            </SelectContent>
+                        </Select>
+                        <span aria-hidden="true" class="text-muted-foreground"
+                            >:</span
+                        >
+                        <Select v-model="minute">
+                            <SelectTrigger
+                                data-test="dnd-pause-minute"
+                                :aria-label="$t('Minute')"
+                                class="h-8 gap-1.5 rounded-lg px-3 text-[13px] font-semibold"
+                            >
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem
+                                    v-for="value in MINUTES"
+                                    :key="value"
+                                    :value="value"
+                                >
+                                    {{ String(value).padStart(2, '0') }}
+                                </SelectItem>
+                            </SelectContent>
+                        </Select>
+                        <div
+                            role="group"
+                            :aria-label="$t('AM or PM')"
+                            class="ml-auto flex items-center rounded-full bg-muted p-0.5"
+                        >
+                            <Button
+                                v-for="value in PERIODS"
+                                :key="value"
+                                variant="segmented"
+                                size="none"
+                                type="button"
+                                :aria-pressed="period === value"
+                                class="h-6.5 px-3 text-[12px] font-semibold"
+                                @click="period = value"
+                            >
+                                {{ value }}
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+                <p
+                    v-if="!isUntilInFuture && until !== null"
+                    data-test="dnd-pause-past"
+                    class="text-[12.5px] text-destructive-text"
+                >
+                    {{ $t('Pick a time in the future.') }}
+                </p>
+            </div>
+
+            <div class="flex items-center gap-2 px-5 pb-5">
+                <span class="flex-1" />
+                <Button
+                    variant="secondary"
+                    class="h-8.5 rounded-full text-[12.5px]"
+                    @click="open = false"
+                >
+                    {{ $t('Cancel') }}
+                </Button>
+                <Button
+                    data-test="dnd-pause-save"
+                    class="h-8.5 rounded-full text-[12.5px]"
+                    :disabled="!canSave"
+                    @click="save"
+                >
+                    {{ $t('Pause notifications') }}
+                </Button>
+            </div>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/DndPauseDialog.vue
+++ b/resources/js/components/DndPauseDialog.vue
@@ -72,19 +72,24 @@ function applyInstant(iso: string): void {
 
 /**
  * The instant a fresh dialog opens on: a whole step ahead of now, snapped up
- * onto the grid, so it never opens already invalid. A pause already running
- * seeds the controls with its own lapse instead, ready to be extended.
+ * onto the grid, so it never opens already invalid. A pause still running
+ * seeds the controls with its own lapse instead, ready to be extended — but a
+ * pause that lapsed after these props were built would seed a past instant
+ * with Save already disabled, so a stale one falls back to the default.
  */
 function reset(): void {
     minDate.value = today(effectiveZone.value);
 
     const stepAhead = Date.now() + MINUTE_STEP_MS;
+    const defaultUntil = new Date(
+        Math.ceil(stepAhead / MINUTE_STEP_MS) * MINUTE_STEP_MS,
+    ).toISOString();
+    const runningUntil = page.props.auth.user.dnd?.until;
 
     applyInstant(
-        page.props.auth.user.dnd?.until ??
-            new Date(
-                Math.ceil(stepAhead / MINUTE_STEP_MS) * MINUTE_STEP_MS,
-            ).toISOString(),
+        runningUntil && new Date(runningUntil).getTime() > Date.now()
+            ? runningUntil
+            : defaultUntil,
     );
 }
 

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -90,6 +90,11 @@ const props = defineProps<{
      * that render a timeline without one, where every author reads as offline.
      */
     presenceFor?: (userId: string) => RenderedPresence;
+    /**
+     * Whether each author is in do-not-disturb, driving the crescent badge on
+     * their dot. Absent on the same surfaces that carry no roster.
+     */
+    isDndFor?: (userId: string) => boolean;
     highlightMessageId?: string | null;
     /**
      * The message the "New messages" divider sits above — the first unread on
@@ -266,6 +271,13 @@ const viewerTimeZone = computed(
  */
 function presenceOf(authorId: string): RenderedPresence {
     return props.presenceFor?.(authorId) ?? 'offline';
+}
+
+/**
+ * Whether a message author shows the crescent DND badge on their dot.
+ */
+function dndOf(authorId: string): boolean {
+    return props.isDndFor?.(authorId) ?? false;
 }
 
 /**
@@ -820,6 +832,7 @@ function confirmDelete(): void {
                             :user-id="item.author.id"
                             :name="item.author.name"
                             :presence="presenceOf(item.author.id)"
+                            :is-dnd="dndOf(item.author.id)"
                             @mention="(member) => emit('mention', member)"
                         >
                             <div class="relative size-8.5 cursor-pointer">
@@ -866,6 +879,7 @@ function confirmDelete(): void {
                                     v-if="!item.author.isBot"
                                     data-test="presence-dot"
                                     :presence="presenceOf(item.author.id)"
+                                    :is-dnd="dndOf(item.author.id)"
                                     surface-class="bg-card"
                                     class="absolute right-0 bottom-0 size-2.5 ring-2 ring-card"
                                 />
@@ -889,6 +903,7 @@ function confirmDelete(): void {
                             :user-id="item.author.id"
                             :name="item.author.name"
                             :presence="presenceOf(item.author.id)"
+                            :is-dnd="dndOf(item.author.id)"
                             @mention="(member) => emit('mention', member)"
                         >
                             <span

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/sidebar';
 import UserMenuContent from '@/components/UserMenuContent.vue';
 import { useInitials } from '@/composables/useInitials';
+import { isDndActiveNow } from '@/lib/dnd';
 import type { RenderedPresence } from '@/lib/presence';
 import type { Team } from '@/types';
 
@@ -35,6 +36,18 @@ const hasAvatar = computed(() => !!user.avatar && user.avatar !== '');
  */
 const ownPresence = computed<RenderedPresence>(
     () => page.props.auth.user.presence ?? 'active',
+);
+
+/**
+ * The viewer's own do-not-disturb state, evaluated locally from the full
+ * configuration only their own prop carries — so the chip's crescent appears
+ * the moment a pause is set, without waiting for a broadcast round-trip.
+ */
+const ownDnd = computed(() =>
+    isDndActiveNow(
+        page.props.auth.user.dnd ?? null,
+        page.props.auth.user.timezone ?? null,
+    ),
 );
 </script>
 
@@ -70,6 +83,7 @@ const ownPresence = computed<RenderedPresence>(
                             <PresenceDot
                                 data-test="nav-user-presence"
                                 :presence="ownPresence"
+                                :is-dnd="ownDnd"
                                 surface-class="bg-popover group-hover/nav-user:bg-secondary group-data-[state=open]/nav-user:bg-sidebar-primary"
                                 class="absolute -right-0.5 -bottom-0.5 size-2.25 ring-2 ring-popover group-hover/nav-user:ring-secondary group-data-[state=open]/nav-user:ring-sidebar-primary"
                             />

--- a/resources/js/components/PresenceDot.test.ts
+++ b/resources/js/components/PresenceDot.test.ts
@@ -61,6 +61,41 @@ describe('PresenceDot', () => {
         expect(await render('away')).toContain('data-presence="away"');
     });
 
+    it('swaps the active dot for a filled crescent badge in dnd', async () => {
+        const html = await render('active', { isDnd: true });
+
+        expect(html).toContain('data-dnd="true"');
+        expect(html).toContain('M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9z');
+        expect(html).toContain('bg-muted-foreground');
+        expect(html).not.toContain('bg-emerald-500');
+    });
+
+    it('keeps the hollow away ring under the crescent in dnd', async () => {
+        const html = await render('away', {
+            isDnd: true,
+            surfaceClass: 'bg-sidebar',
+        });
+
+        expect(html).toContain('data-dnd="true"');
+        expect(html).toContain('border-muted-foreground');
+        expect(html).toContain('bg-sidebar');
+        expect(html).toContain('fill-muted-foreground');
+    });
+
+    it('never draws the crescent for someone offline', async () => {
+        const html = await render('offline', { isDnd: true });
+
+        expect(html).not.toContain('data-dnd');
+        expect(html).toContain('bg-muted-foreground/50');
+    });
+
+    it('draws the plain dot when dnd is off', async () => {
+        const html = await render('active', { isDnd: false });
+
+        expect(html).not.toContain('data-dnd');
+        expect(html).toContain('bg-emerald-500');
+    });
+
     it('is invisible to assistive tech, which reads the surface own label', async () => {
         expect(await render('active')).toContain('aria-hidden="true"');
     });

--- a/resources/js/components/PresenceDot.vue
+++ b/resources/js/components/PresenceDot.vue
@@ -14,8 +14,20 @@ const props = withDefaults(
          * would show through the hole. Ignored otherwise.
          */
         surfaceClass?: string;
+        /**
+         * The person is in do-not-disturb. A connected dot swaps for the
+         * crescent badge — filled stone when active, the hollow away ring with
+         * a stone crescent when away — so both signals survive in one badge.
+         * Ignored for someone offline, whose muted disc stays as it is.
+         */
+        isDnd?: boolean;
     }>(),
-    { surfaceClass: 'bg-background' },
+    { surfaceClass: 'bg-background', isDnd: false },
+);
+
+/** Whether the crescent badge replaces the plain dot. */
+const showsCrescent = computed(
+    () => props.isDnd && props.presence !== 'offline',
 );
 
 /**
@@ -23,23 +35,49 @@ const props = withDefaults(
  *
  * Away keeps the dot's footprint and hollows it — a ring in the neutral stone
  * over the surface behind — so a roster still reads at a glance without
- * introducing a second colour. Offline stays a muted disc.
+ * introducing a second colour. Offline stays a muted disc. In do-not-disturb
+ * the connected states keep their geometry but carry the crescent: active
+ * trades its green fill for the stone disc the glyph sits on, away keeps its
+ * hollow ring.
  */
 const stateClass = computed(() => {
     if (props.presence === 'active') {
-        return 'bg-emerald-500';
+        return showsCrescent.value
+            ? 'flex items-center justify-center bg-muted-foreground'
+            : 'bg-emerald-500';
     }
 
-    return props.presence === 'away'
-        ? ['border-2 border-muted-foreground', props.surfaceClass]
-        : 'bg-muted-foreground/50';
+    if (props.presence === 'away') {
+        return [
+            'border-2 border-muted-foreground',
+            props.surfaceClass,
+            showsCrescent.value ? 'flex items-center justify-center' : '',
+        ];
+    }
+
+    return 'bg-muted-foreground/50';
 });
+
+/** Crescent colour: light-on-stone when active, stone-on-surface when away. */
+const crescentClass = computed(() =>
+    props.presence === 'active' ? 'fill-background' : 'fill-muted-foreground',
+);
 </script>
 
 <template>
     <span
         :data-presence="presence"
+        :data-dnd="showsCrescent ? 'true' : undefined"
         aria-hidden="true"
         :class="cn('rounded-full', stateClass)"
-    />
+    >
+        <svg
+            v-if="showsCrescent"
+            viewBox="0 0 24 24"
+            class="size-full scale-[0.62]"
+            :class="crescentClass"
+        >
+            <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9z" />
+        </svg>
+    </span>
 </template>

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -35,6 +35,8 @@ const props = defineProps<{
     canPin?: boolean;
     /** How each author reads on the team presence roster, passed straight down. */
     presenceFor?: (userId: string) => RenderedPresence;
+    /** Whether each author is in do-not-disturb, threaded through to the list. */
+    isDndFor?: (userId: string) => boolean;
     loading?: boolean;
     readOnly?: boolean;
 }>();
@@ -324,6 +326,7 @@ watch(
                     :can-react="props.canReact"
                     :can-pin="props.canPin"
                     :presence-for="props.presenceFor"
+                    :is-dnd-for="props.isDndFor"
                     :editing-message-id="editingMessageId"
                     in-thread
                     @load-older="loadOlderReplies"

--- a/resources/js/components/UserHoverCard.vue
+++ b/resources/js/components/UserHoverCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
-import { AtSign, MessageSquare, UserRound } from '@lucide/vue';
+import { AtSign, MessageSquare, Moon, UserRound } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -30,6 +30,12 @@ const props = defineProps<{
      * that open a card without a roster to hand, which then show no dot at all.
      */
     presence?: RenderedPresence;
+    /**
+     * The roster's do-not-disturb answer, painting the crescent badge before
+     * the profile fetch lands. The fetched profile is the fresher claim once
+     * loaded.
+     */
+    isDnd?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -42,6 +48,14 @@ const { openDirectMessage } = useOpenDirectMessage(() => props.teamSlug);
 const profile = ref<UserProfile | null>(null);
 const loading = ref(false);
 const loaded = ref(false);
+
+/**
+ * Whether the card shows the member as in do-not-disturb: the fetched profile
+ * once it has landed, the roster's prop until then.
+ */
+const showsDnd = computed(() =>
+    profile.value ? profile.value.isDnd : (props.isDnd ?? false),
+);
 
 /**
  * Lazily load the profile the first time the card opens; the fetch is memoised
@@ -116,6 +130,7 @@ function onMessage(): void {
                             v-if="presence"
                             data-test="hover-card-presence"
                             :presence="presence"
+                            :is-dnd="showsDnd"
                             surface-class="bg-popover"
                             class="absolute right-0 bottom-0 size-3 ring-[2.5px] ring-popover"
                         />
@@ -167,6 +182,17 @@ function onMessage(): void {
                                     class="size-2"
                                 />
                                 {{ $t(presenceLabelKey(presence)) }}
+                            </span>
+                            <!-- The card names the DND state outright — the
+                                 one thing teammates learn; when it ends stays
+                                 the owner's business. -->
+                            <span
+                                v-if="showsDnd"
+                                data-test="hover-card-dnd"
+                                class="flex items-center gap-1.5 font-serif text-xs text-muted-foreground italic"
+                            >
+                                <Moon class="size-3" aria-hidden="true" />
+                                {{ $t('Notifications paused') }}
                             </span>
                             <span
                                 v-if="localTime()"

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
 import {
-    ChevronRight,
     Compass,
     Keyboard,
     LogOut,
@@ -501,7 +500,6 @@ const handleLogout = () => {
                     class="size-3.75 text-muted-foreground group-data-[highlighted]/item:text-brass group-data-[state=open]/item:text-brass"
                 />
                 {{ $t('Pause notifications') }}
-                <ChevronRight class="ml-auto size-3 text-muted-foreground" />
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent
                 class="min-w-47 rounded-[14px] p-1.25"

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
 import {
+    ChevronRight,
     Compass,
     Keyboard,
     LogOut,
@@ -16,6 +17,10 @@ import {
 import type { Component } from 'vue';
 import { computed } from 'vue';
 import { toast } from 'vue-sonner';
+import {
+    destroy as destroyDndPause,
+    update as updateDndPause,
+} from '@/actions/App/Http/Controllers/Settings/DndController';
 import { update as updatePresence } from '@/actions/App/Http/Controllers/Settings/PresenceController';
 import { destroy as destroyStatus } from '@/actions/App/Http/Controllers/Settings/StatusController';
 import MenuSegmentedControl from '@/components/MenuSegmentedControl.vue';
@@ -25,7 +30,11 @@ import { Button } from '@/components/ui/button';
 import {
     DropdownMenuItem,
     DropdownMenuLabel,
+    DropdownMenuSeparator,
     DropdownMenuShortcut,
+    DropdownMenuSub,
+    DropdownMenuSubContent,
+    DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu';
 import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
 import { useAppearance } from '@/composables/useAppearance';
@@ -33,13 +42,18 @@ import { useInitials } from '@/composables/useInitials';
 import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
 import { useOnboardingTour } from '@/composables/useOnboardingTour';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
+import { useDndPauseDialog } from '@/composables/useDndPauseDialog';
 import { useTranslations } from '@/composables/useTranslations';
 import { useUpdateStatus } from '@/composables/useUpdateStatus';
 import { useUserStatusDialog } from '@/composables/useUserStatusDialog';
 import { formatTimeOfDay } from '@/lib/datetime';
+import { isDndActiveNow, quietHoursEndsAt } from '@/lib/dnd';
+import { DND_PAUSE_KEYS, dndPauseLabel, resolveDndPause } from '@/lib/dndPause';
+import type { DndPauseKey } from '@/lib/dndPause';
 import { presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
 import { logout } from '@/routes';
+import { edit as appearanceEdit } from '@/routes/appearance';
 import { edit } from '@/routes/profile';
 import type { Appearance, SidebarPosition, Team, User } from '@/types';
 
@@ -110,6 +124,39 @@ const togglesTo = computed<RenderedPresence>(() =>
     ownPresence.value === 'away' ? 'active' : 'away',
 );
 
+/** The viewer's own full DND configuration, from the shared `auth.user` prop. */
+const ownDnd = computed(() => page.props.auth.user.dnd ?? null);
+
+const ownTimezone = computed(() => page.props.auth.user.timezone ?? null);
+
+/** Whether the viewer is in DND right now — a running pause or quiet hours. */
+const isDnd = computed(() =>
+    isDndActiveNow(ownDnd.value, ownTimezone.value),
+);
+
+/** The running manual pause's lapse, formatted, or null when none runs. */
+const pausedUntil = computed(() =>
+    ownDnd.value?.until
+        ? formatTimeOfDay(ownDnd.value.until, ownTimezone.value ?? undefined)
+        : null,
+);
+
+/**
+ * When the covering quiet-hours window closes, formatted. Only read when no
+ * manual pause runs — a pause is the more specific claim, so its lapse wins
+ * the card's subtitle.
+ */
+const quietHoursUntil = computed(() => {
+    const closes = quietHoursEndsAt(ownDnd.value, ownTimezone.value);
+
+    return closes
+        ? formatTimeOfDay(
+              closes.toISOString(),
+              ownTimezone.value ?? undefined,
+          )
+        : null;
+});
+
 // When the status clears, as a time of day in the viewer's own zone. Null for a
 // status that never clears, which then shows no second line at all.
 const clearsAt = computed(() =>
@@ -158,6 +205,54 @@ function togglePresence(event: Event): void {
     );
 }
 
+const { open: openDndPauseDialog } = useDndPauseDialog();
+
+/** The flyout's preset rows: everything but Custom…, which opens the dialog. */
+const pausePresets = DND_PAUSE_KEYS.filter((key) => key !== 'custom');
+
+/**
+ * Start a pause from a flyout preset.
+ *
+ * The default select behaviour closes the menu; prevented here so the STATUS
+ * section grows the paused card in place — immediate proof the pause took.
+ */
+function choosePause(event: Event, key: DndPauseKey): void {
+    event.preventDefault();
+
+    const until = resolveDndPause(
+        key,
+        ownTimezone.value ??
+            new Intl.DateTimeFormat().resolvedOptions().timeZone,
+    );
+
+    if (until === null) {
+        return;
+    }
+
+    router.put(
+        updateDndPause().url,
+        { until },
+        {
+            preserveScroll: true,
+            onError: () =>
+                toast.error(t('Could not pause your notifications.')),
+        },
+    );
+}
+
+/**
+ * End the manual pause early from the card's Resume pill. Kept in place (no
+ * menu dismissal) so the card collapses back to the plain rows.
+ */
+function resumeNotifications(event: Event): void {
+    event.preventDefault();
+
+    router.delete(destroyDndPause().url, {
+        preserveScroll: true,
+        onError: () => toast.error(t('Could not resume your notifications.')),
+    });
+}
+
 const handleLogout = () => {
     router.flushAll();
 };
@@ -185,6 +280,7 @@ const handleLogout = () => {
                     <PresenceDot
                         data-test="user-menu-presence"
                         :presence="ownPresence"
+                        :is-dnd="isDnd"
                         surface-class="bg-muted"
                         class="absolute right-0 bottom-0 size-2.75 ring-2 ring-muted"
                     />
@@ -211,15 +307,22 @@ const handleLogout = () => {
                     <div
                         class="mt-0.5 flex min-w-0 items-baseline gap-1.5 text-xs text-muted-foreground"
                     >
+                        <!-- In DND the readout names the pause instead of the
+                             presence — the state the viewer most needs to know
+                             they are in — in the same italic serif as away. -->
                         <span
                             data-test="user-menu-presence-label"
                             class="shrink-0 font-medium"
                             :class="
-                                ownPresence === 'away'
+                                isDnd || ownPresence === 'away'
                                     ? 'font-serif text-muted-foreground italic'
                                     : 'text-emerald-700 dark:text-emerald-400'
                             "
-                            >{{ $t(presenceLabelKey(ownPresence)) }}</span
+                            >{{
+                                isDnd
+                                    ? $t('Notifications paused')
+                                    : $t(presenceLabelKey(ownPresence))
+                            }}</span
                         >
                         <span aria-hidden="true" class="shrink-0"
                             >&middot;</span
@@ -251,6 +354,54 @@ const handleLogout = () => {
             class="px-2.5 pb-1.5 text-[10px] font-semibold tracking-[0.12em] text-muted-foreground uppercase"
             >{{ $t('Status') }}</DropdownMenuLabel
         >
+        <!-- While in DND the section leads with the paused card: crescent,
+             when it lifts in italic serif, and — for a manual pause — the
+             one-tap Resume pill. Quiet hours name their window instead; ending
+             those early is a schedule edit, not a tap (see the flyout link). -->
+        <div
+            v-if="isDnd"
+            data-test="dnd-paused-card"
+            class="mb-1 flex min-h-11 items-center gap-2.5 rounded-[10px] border border-border bg-muted px-2.5 py-1.5"
+        >
+            <Moon class="size-4 shrink-0 text-muted-foreground" />
+            <span class="flex min-w-0 flex-1 flex-col">
+                <span class="truncate text-[13px] font-semibold text-foreground">{{
+                    $t('Paused')
+                }}</span>
+                <span
+                    v-if="pausedUntil"
+                    data-test="dnd-paused-until"
+                    class="truncate font-serif text-[11px] text-muted-foreground italic"
+                    >{{ $t('until :time', { time: pausedUntil }) }}</span
+                >
+                <span
+                    v-else-if="quietHoursUntil"
+                    data-test="dnd-paused-until"
+                    class="truncate font-serif text-[11px] text-muted-foreground italic"
+                    >{{
+                        $t('quiet hours · until :time', {
+                            time: quietHoursUntil,
+                        })
+                    }}</span
+                >
+            </span>
+            <DropdownMenuItem
+                v-if="pausedUntil"
+                :as-child="true"
+                class="shrink-0 rounded-full p-0 focus:bg-transparent"
+                data-test="dnd-resume-menu-item"
+                @select="resumeNotifications"
+            >
+                <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    class="inline-flex h-6.5 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
+                >
+                    {{ $t('Resume') }}
+                </Button>
+            </DropdownMenuItem>
+        </div>
         <DropdownMenuItem
             v-if="!ownStatus"
             class="group/item flex h-9 cursor-pointer items-center gap-2.5 rounded-[10px] px-2.5 py-0 text-[13.5px] font-normal text-foreground focus:bg-primary focus:text-primary-foreground"
@@ -337,6 +488,56 @@ const handleLogout = () => {
                     : $t('Set yourself active')
             }}
         </DropdownMenuItem>
+        <!-- Pause notifications: the crescent row below the away toggle, its
+             presets flowing out in a flyout. Choosing one applies in place;
+             Custom… trades the menu for the dialog, and the trailing row links
+             to the recurring schedule in Settings. -->
+        <DropdownMenuSub>
+            <DropdownMenuSubTrigger
+                class="group/item mt-0.5 flex h-9 cursor-pointer items-center gap-2.5 rounded-[10px] px-2.5 py-0 text-[13.5px] font-normal text-foreground data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground data-[state=open]:bg-primary data-[state=open]:text-primary-foreground"
+                data-test="pause-notifications-menu-item"
+            >
+                <Moon
+                    class="size-3.75 text-muted-foreground group-data-[highlighted]/item:text-brass group-data-[state=open]/item:text-brass"
+                />
+                {{ $t('Pause notifications') }}
+                <ChevronRight class="ml-auto size-3 text-muted-foreground" />
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent
+                class="min-w-47 rounded-[14px] p-1.25"
+                data-test="pause-notifications-submenu"
+            >
+                <DropdownMenuItem
+                    v-for="preset in pausePresets"
+                    :key="preset"
+                    class="flex h-8 cursor-pointer items-center rounded-[9px] px-2.75 text-[13px] focus:bg-primary focus:text-primary-foreground"
+                    :data-test="`pause-preset-${preset}`"
+                    @select="(event: Event) => choosePause(event, preset)"
+                >
+                    {{ dndPauseLabel(preset) }}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                    class="flex h-8 cursor-pointer items-center rounded-[9px] px-2.75 text-[13px] focus:bg-primary focus:text-primary-foreground"
+                    data-test="pause-preset-custom"
+                    @select="openDndPauseDialog"
+                >
+                    {{ dndPauseLabel('custom') }}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator class="mx-1.5" />
+                <DropdownMenuItem
+                    :as-child="true"
+                    class="flex h-8 cursor-pointer items-center justify-between rounded-[9px] px-2.75 text-[12.5px] text-muted-foreground focus:bg-primary focus:text-primary-foreground"
+                    data-test="quiet-hours-menu-item"
+                >
+                    <Link :href="appearanceEdit()">
+                        {{ $t('Quiet hours') }}
+                        <span class="text-[11px] opacity-70">{{
+                            $t('Settings')
+                        }}</span>
+                    </Link>
+                </DropdownMenuItem>
+            </DropdownMenuSubContent>
+        </DropdownMenuSub>
     </div>
 
     <!-- Appearance: quick theme + sidebar switchers, grouped ahead of navigation.

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -37,11 +37,11 @@ import {
 } from '@/components/ui/dropdown-menu';
 import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
 import { useAppearance } from '@/composables/useAppearance';
+import { useDndPauseDialog } from '@/composables/useDndPauseDialog';
 import { useInitials } from '@/composables/useInitials';
 import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
 import { useOnboardingTour } from '@/composables/useOnboardingTour';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
-import { useDndPauseDialog } from '@/composables/useDndPauseDialog';
 import { useTranslations } from '@/composables/useTranslations';
 import { useUpdateStatus } from '@/composables/useUpdateStatus';
 import { useUserStatusDialog } from '@/composables/useUserStatusDialog';
@@ -129,9 +129,7 @@ const ownDnd = computed(() => page.props.auth.user.dnd ?? null);
 const ownTimezone = computed(() => page.props.auth.user.timezone ?? null);
 
 /** Whether the viewer is in DND right now — a running pause or quiet hours. */
-const isDnd = computed(() =>
-    isDndActiveNow(ownDnd.value, ownTimezone.value),
-);
+const isDnd = computed(() => isDndActiveNow(ownDnd.value, ownTimezone.value));
 
 /** The running manual pause's lapse, formatted, or null when none runs. */
 const pausedUntil = computed(() =>
@@ -149,10 +147,7 @@ const quietHoursUntil = computed(() => {
     const closes = quietHoursEndsAt(ownDnd.value, ownTimezone.value);
 
     return closes
-        ? formatTimeOfDay(
-              closes.toISOString(),
-              ownTimezone.value ?? undefined,
-          )
+        ? formatTimeOfDay(closes.toISOString(), ownTimezone.value ?? undefined)
         : null;
 });
 
@@ -364,9 +359,10 @@ const handleLogout = () => {
         >
             <Moon class="size-4 shrink-0 text-muted-foreground" />
             <span class="flex min-w-0 flex-1 flex-col">
-                <span class="truncate text-[13px] font-semibold text-foreground">{{
-                    $t('Paused')
-                }}</span>
+                <span
+                    class="truncate text-[13px] font-semibold text-foreground"
+                    >{{ $t('Paused') }}</span
+                >
                 <span
                     v-if="pausedUntil"
                     data-test="dnd-paused-until"

--- a/resources/js/composables/useChimeNotifications.ts
+++ b/resources/js/composables/useChimeNotifications.ts
@@ -2,6 +2,7 @@ import { usePage } from '@inertiajs/vue3';
 import { computed, onBeforeUnmount, onMounted } from 'vue';
 import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
 import { playChime, unlockChimeAudio } from '@/lib/chimeSounds';
+import { isDndActiveNow } from '@/lib/dnd';
 import { shouldChime } from '@/lib/shouldChime';
 import type { ChimeSound } from '@/types';
 
@@ -47,6 +48,12 @@ export function useChimeNotifications(): void {
                 : null,
             tabHasFocus: typeof document !== 'undefined' && document.hasFocus(),
             isActiveChannel: channelId === activeChannelId.value,
+            // Evaluated at arrival time, not page-load time, so a pause lapsing
+            // or a quiet-hours window opening takes effect without a visit.
+            dndActive: isDndActiveNow(
+                page.props.auth.user.dnd ?? null,
+                page.props.auth.user.timezone ?? null,
+            ),
         });
 
         if (decision) {

--- a/resources/js/composables/useDndPauseDialog.ts
+++ b/resources/js/composables/useDndPauseDialog.ts
@@ -1,0 +1,16 @@
+import { ref } from 'vue';
+
+/**
+ * Shared open-state for the custom "Pause notifications" dialog. The dialog is
+ * mounted once in the main layout, but it is opened from the presence menu's
+ * pause flyout — so the state lives here rather than being prop-drilled
+ * through the sidebar, mirroring the status dialog.
+ */
+const isOpen = ref(false);
+
+export function useDndPauseDialog() {
+    return {
+        isOpen,
+        open: () => (isOpen.value = true),
+    };
+}

--- a/resources/js/composables/useTeamPresence.test.ts
+++ b/resources/js/composables/useTeamPresence.test.ts
@@ -9,6 +9,7 @@ const page = {
             id: string;
             name: string;
             presence?: 'active' | 'away';
+            isDnd?: boolean;
         }[],
     },
 };
@@ -153,6 +154,21 @@ describe('useTeamPresence', () => {
 
         expect(api.presenceFor('maya')).toBe('away');
         expect(api.presenceFor('jonas')).toBe('active');
+
+        unmount();
+    });
+
+    it('reads a member dnd flag from the shared teamMembers prop', () => {
+        page.props.teamMembers = [
+            { id: 'maya', name: 'Maya', presence: 'active', isDnd: true },
+            { id: 'jonas', name: 'Jonas', presence: 'active' },
+        ];
+
+        const { api, unmount } = mount();
+
+        expect(api.isDndFor('maya')).toBe(true);
+        expect(api.isDndFor('jonas')).toBe(false);
+        expect(api.isDndFor('missing')).toBe(false);
 
         unmount();
     });

--- a/resources/js/composables/useTeamPresence.test.ts
+++ b/resources/js/composables/useTeamPresence.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createRenderer, defineComponent, nextTick } from 'vue';
+import { createRenderer, defineComponent, nextTick, reactive } from 'vue';
 
 const reload = vi.fn();
 
-const page = {
+// Reactive like the real usePage() page, so computeds inside the composable
+// re-read a prop the (simulated) profile reload has since replaced.
+const page = reactive({
     props: {
         teamMembers: [] as {
             id: string;
@@ -12,7 +14,7 @@ const page = {
             isDnd?: boolean;
         }[],
     },
-};
+});
 
 /** Roster handlers registered per presence channel, by hook name. */
 type Handlers = {
@@ -154,6 +156,37 @@ describe('useTeamPresence', () => {
 
         expect(api.presenceFor('maya')).toBe('away');
         expect(api.presenceFor('jonas')).toBe('active');
+
+        unmount();
+    });
+
+    it('reports no dnd at all when the teamMembers prop is absent', () => {
+        page.props.teamMembers =
+            undefined as unknown as typeof page.props.teamMembers;
+
+        const { api, unmount } = mount();
+
+        expect(api.isDndFor('maya')).toBe(false);
+
+        unmount();
+    });
+
+    it('re-reads the dnd flag when the profile reload refreshes the prop', () => {
+        page.props.teamMembers = [
+            { id: 'maya', name: 'Maya', presence: 'active', isDnd: false },
+        ];
+
+        const { api, unmount } = mount();
+
+        expect(api.isDndFor('maya')).toBe(false);
+
+        // Stand in for the debounced reload landing fresh props after a
+        // teammate's UserProfileUpdated broadcast.
+        page.props.teamMembers = [
+            { id: 'maya', name: 'Maya', presence: 'active', isDnd: true },
+        ];
+
+        expect(api.isDndFor('maya')).toBe(true);
 
         unmount();
     });

--- a/resources/js/composables/useTeamPresence.ts
+++ b/resources/js/composables/useTeamPresence.ts
@@ -97,6 +97,31 @@ export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
         return flips.value.get(userId) ?? seeded.value.get(userId) ?? 'active';
     }
 
+    /**
+     * The members currently flagged as in do-not-disturb, from the shared
+     * `teamMembers` prop. No live patching layer like the presence flips:
+     * every DND change broadcasts `UserProfileUpdated`, whose debounced reload
+     * below refreshes this very prop.
+     */
+    const dndIds = computed(() => {
+        const ids = new Set<string>();
+
+        for (const member of page.props.teamMembers ?? []) {
+            if (member.isDnd) {
+                ids.add(member.id);
+            }
+        }
+
+        return ids;
+    });
+
+    /**
+     * Whether the given member shows the crescent DND badge on their dot.
+     */
+    function isDndFor(userId: string): boolean {
+        return dndIds.value.has(userId);
+    }
+
     // A teammate changed their profile (avatar, custom status). Reload the
     // current page's props so every surface re-reads them, preserving scroll and
     // local state so the refresh is invisible. A teammate's timing is not the
@@ -192,5 +217,5 @@ export function useTeamPresence(teamId: MaybeRefOrGetter<string | undefined>) {
         }
     });
 
-    return { onlineIds, presenceFor };
+    return { onlineIds, presenceFor, isDndFor };
 }

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -76,12 +76,14 @@ import {
     SidebarMenuItem,
     SidebarProvider,
 } from '@/components/ui/sidebar';
+import DndPauseDialog from '@/components/DndPauseDialog.vue';
 import { Toaster } from '@/components/ui/sonner';
 import UpdateIndicator from '@/components/UpdateIndicator.vue';
 import UserStatusDialog from '@/components/UserStatusDialog.vue';
 import { adjacentSlug } from '@/composables/keyboardShortcuts';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useDemoMode } from '@/composables/useDemoMode';
+import { useDndPauseDialog } from '@/composables/useDndPauseDialog';
 import { useInitials } from '@/composables/useInitials';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
 import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
@@ -561,6 +563,7 @@ const quickSwitcherOpen = ref(false);
 const { isOpen: shortcutsOpen, toggle: toggleShortcuts } =
     useKeyboardShortcutsModal();
 const { isOpen: statusDialogOpen } = useUserStatusDialog();
+const { isOpen: dndPauseDialogOpen } = useDndPauseDialog();
 
 /**
  * The viewer's still-pending reminders in this team, feeding the "Reminders"
@@ -1458,6 +1461,8 @@ onMounted(() => {
         <KeyboardShortcutsModal v-model:open="shortcutsOpen" />
 
         <UserStatusDialog v-model:open="statusDialogOpen" />
+
+        <DndPauseDialog v-model:open="dndPauseDialogOpen" />
 
         <RemindersDialog
             v-model:open="remindersDialogOpen"

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -42,6 +42,7 @@ import CreateChannelModal from '@/components/CreateChannelModal.vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import DemoBanner from '@/components/DemoBanner.vue';
 import DirectMessageListItem from '@/components/DirectMessageListItem.vue';
+import DndPauseDialog from '@/components/DndPauseDialog.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import KeyboardShortcutsModal from '@/components/KeyboardShortcutsModal.vue';
 import NavUser from '@/components/NavUser.vue';
@@ -76,7 +77,6 @@ import {
     SidebarMenuItem,
     SidebarProvider,
 } from '@/components/ui/sidebar';
-import DndPauseDialog from '@/components/DndPauseDialog.vue';
 import { Toaster } from '@/components/ui/sonner';
 import UpdateIndicator from '@/components/UpdateIndicator.vue';
 import UserStatusDialog from '@/components/UserStatusDialog.vue';

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -151,7 +151,7 @@ const currentUserId = computed(() => String(page.props.auth.user.id));
 const teamMembers = computed(() => page.props.teamMembers ?? []);
 
 /** Live presence for the current team, driving the dot on each DM row. */
-const { presenceFor } = useTeamPresence(() => currentTeam.value?.id);
+const { presenceFor, isDndFor } = useTeamPresence(() => currentTeam.value?.id);
 
 // Report this tab's own idle state from the layout every authenticated surface
 // mounts, so someone reading a settings page still counts as here.
@@ -1261,6 +1261,10 @@ onMounted(() => {
                                             presenceFor,
                                             page.props.auth.user.presence,
                                         )
+                                    "
+                                    :is-dnd="
+                                        dm.dmUserId != null &&
+                                        isDndFor(dm.dmUserId)
                                     "
                                     :is-self="dm.dmUserId === currentUserId"
                                 />

--- a/resources/js/lib/dnd.test.ts
+++ b/resources/js/lib/dnd.test.ts
@@ -29,11 +29,7 @@ describe('isDndActiveNow', () => {
         const at = new Date('2026-07-22T12:00:00Z');
 
         expect(
-            isDndActiveNow(
-                dnd({ until: '2026-07-22T12:30:00Z' }),
-                'UTC',
-                at,
-            ),
+            isDndActiveNow(dnd({ until: '2026-07-22T12:30:00Z' }), 'UTC', at),
         ).toBe(true);
     });
 
@@ -129,9 +125,9 @@ describe('isDndActiveNow', () => {
                 'UTC',
             ),
         ).toBe(false);
-        expect(
-            isDndActiveNow(dnd({ scheduleEnabled: true }), 'UTC'),
-        ).toBe(false);
+        expect(isDndActiveNow(dnd({ scheduleEnabled: true }), 'UTC')).toBe(
+            false,
+        );
     });
 
     it('falls back to the local zone for a missing or invalid zone', () => {

--- a/resources/js/lib/dnd.test.ts
+++ b/resources/js/lib/dnd.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import { isDndActiveNow } from '@/lib/dnd';
+
+function dnd(
+    overrides: Partial<App.Data.UserDndData> = {},
+): App.Data.UserDndData {
+    return {
+        until: null,
+        scheduleEnabled: false,
+        startsAt: null,
+        endsAt: null,
+        ...overrides,
+    };
+}
+
+describe('isDndActiveNow', () => {
+    it('is inactive with no configuration at all', () => {
+        expect(isDndActiveNow(dnd(), 'UTC')).toBe(false);
+        expect(isDndActiveNow(null, 'UTC')).toBe(false);
+        expect(isDndActiveNow(undefined, 'UTC')).toBe(false);
+    });
+
+    it('is active while a manual pause is still ahead', () => {
+        const at = new Date('2026-07-22T12:00:00Z');
+
+        expect(
+            isDndActiveNow(
+                dnd({ until: '2026-07-22T12:30:00Z' }),
+                'UTC',
+                at,
+            ),
+        ).toBe(true);
+    });
+
+    it('lapses the instant the pause passes', () => {
+        const at = new Date('2026-07-22T12:30:00Z');
+
+        expect(
+            isDndActiveNow(dnd({ until: '2026-07-22T12:30:00Z' }), 'UTC', at),
+        ).toBe(false);
+    });
+
+    it('is active inside an enabled quiet-hours window', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+        });
+
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T12:00:00Z')),
+        ).toBe(true);
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T18:30:00Z')),
+        ).toBe(false);
+    });
+
+    it('starts the window inclusive and ends it exclusive', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+        });
+
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T09:00:00Z')),
+        ).toBe(true);
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T17:00:00Z')),
+        ).toBe(false);
+    });
+
+    it('wraps an overnight window across midnight', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '22:00',
+            endsAt: '07:00',
+        });
+
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T23:30:00Z')),
+        ).toBe(true);
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T06:30:00Z')),
+        ).toBe(true);
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T12:00:00Z')),
+        ).toBe(false);
+    });
+
+    it('evaluates the window on the wall clock of the given zone', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+        });
+
+        // 14:00 UTC is 10:00 in New York — inside the window. 12:00 UTC is
+        // 08:00 there — outside it, though a naive UTC read would say inside.
+        expect(
+            isDndActiveNow(
+                schedule,
+                'America/New_York',
+                new Date('2026-07-22T14:00:00Z'),
+            ),
+        ).toBe(true);
+        expect(
+            isDndActiveNow(
+                schedule,
+                'America/New_York',
+                new Date('2026-07-22T12:00:00Z'),
+            ),
+        ).toBe(false);
+    });
+
+    it('ignores a disabled or incomplete schedule', () => {
+        expect(
+            isDndActiveNow(
+                dnd({
+                    scheduleEnabled: false,
+                    startsAt: '00:00',
+                    endsAt: '23:59',
+                }),
+                'UTC',
+            ),
+        ).toBe(false);
+        expect(
+            isDndActiveNow(dnd({ scheduleEnabled: true }), 'UTC'),
+        ).toBe(false);
+    });
+
+    it('falls back to the local zone for a missing or invalid zone', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '00:00',
+            endsAt: '23:59',
+        });
+
+        // A window covering (almost) the whole day is active in any zone, so
+        // the fallback path is observable without pinning the runner's zone.
+        expect(isDndActiveNow(schedule, null)).toBe(true);
+        expect(isDndActiveNow(schedule, 'Not/AZone')).toBe(true);
+    });
+
+    it('either the pause or the schedule alone is enough', () => {
+        const at = new Date('2026-07-22T12:00:00Z');
+
+        expect(
+            isDndActiveNow(
+                dnd({
+                    until: '2026-07-22T13:00:00Z',
+                    scheduleEnabled: true,
+                    startsAt: '20:00',
+                    endsAt: '21:00',
+                }),
+                'UTC',
+                at,
+            ),
+        ).toBe(true);
+    });
+});

--- a/resources/js/lib/dnd.test.ts
+++ b/resources/js/lib/dnd.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { isDndActiveNow } from '@/lib/dnd';
+import {
+    isDndActiveNow,
+    quietHoursEndsAt,
+    quietHoursSegments,
+    quietHoursTicks,
+} from '@/lib/dnd';
 
 function dnd(
     overrides: Partial<App.Data.UserDndData> = {},
@@ -157,5 +162,136 @@ describe('isDndActiveNow', () => {
                 at,
             ),
         ).toBe(true);
+    });
+});
+
+describe('quietHoursEndsAt', () => {
+    it('is null outside the window, or with no usable schedule', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+        });
+
+        expect(
+            quietHoursEndsAt(schedule, 'UTC', new Date('2026-07-22T18:00:00Z')),
+        ).toBeNull();
+        expect(
+            quietHoursEndsAt(dnd(), 'UTC', new Date('2026-07-22T12:00:00Z')),
+        ).toBeNull();
+        expect(quietHoursEndsAt(null, 'UTC')).toBeNull();
+    });
+
+    it('ends a same-day window at its closing time today', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+        });
+
+        expect(
+            quietHoursEndsAt(
+                schedule,
+                'UTC',
+                new Date('2026-07-22T12:00:00Z'),
+            )?.toISOString(),
+        ).toBe('2026-07-22T17:00:00.000Z');
+    });
+
+    it('ends an overnight window tomorrow when entered before midnight', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '22:00',
+            endsAt: '07:00',
+        });
+
+        expect(
+            quietHoursEndsAt(
+                schedule,
+                'UTC',
+                new Date('2026-07-22T23:30:00Z'),
+            )?.toISOString(),
+        ).toBe('2026-07-23T07:00:00.000Z');
+    });
+
+    it('ends an overnight window today when inside its morning tail', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '22:00',
+            endsAt: '07:00',
+        });
+
+        expect(
+            quietHoursEndsAt(
+                schedule,
+                'UTC',
+                new Date('2026-07-22T06:00:00Z'),
+            )?.toISOString(),
+        ).toBe('2026-07-22T07:00:00.000Z');
+    });
+
+    it('resolves the closing instant in the given zone', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+        });
+
+        // 14:00 UTC is 10:00 in New York; their 17:00 close is 21:00 UTC.
+        expect(
+            quietHoursEndsAt(
+                schedule,
+                'America/New_York',
+                new Date('2026-07-22T14:00:00Z'),
+            )?.toISOString(),
+        ).toBe('2026-07-22T21:00:00.000Z');
+    });
+});
+
+describe('quietHoursSegments', () => {
+    it('draws awake–quiet–awake for a same-day window', () => {
+        expect(quietHoursSegments('09:00', '17:00')).toEqual([
+            { quiet: false, widthPct: 37.5 },
+            { quiet: true, widthPct: (8 / 24) * 100 },
+            { quiet: false, widthPct: (7 / 24) * 100 },
+        ]);
+    });
+
+    it('draws quiet–awake–quiet for an overnight window', () => {
+        expect(quietHoursSegments('18:00', '09:00')).toEqual([
+            { quiet: true, widthPct: 37.5 },
+            { quiet: false, widthPct: 37.5 },
+            { quiet: true, widthPct: 25 },
+        ]);
+    });
+
+    it('drops zero-width segments at the day edges', () => {
+        expect(quietHoursSegments('00:00', '17:00')).toEqual([
+            { quiet: true, widthPct: (17 / 24) * 100 },
+            { quiet: false, widthPct: (7 / 24) * 100 },
+        ]);
+    });
+});
+
+describe('quietHoursTicks', () => {
+    it('merges the window bounds into the base ticks, sorted', () => {
+        expect(quietHoursTicks('18:00', '09:00')).toEqual([
+            '00',
+            '06',
+            '09',
+            '12',
+            '18',
+            '24',
+        ]);
+    });
+
+    it('keeps the base ticks alone when the bounds already sit on them', () => {
+        expect(quietHoursTicks('18:00', '12:00')).toEqual([
+            '00',
+            '06',
+            '12',
+            '18',
+            '24',
+        ]);
     });
 });

--- a/resources/js/lib/dnd.ts
+++ b/resources/js/lib/dnd.ts
@@ -52,11 +52,7 @@ export function quietHoursEndsAt(
     timeZone: string | null | undefined,
     at: Date = new Date(),
 ): Date | null {
-    if (
-        !dnd?.scheduleEnabled ||
-        dnd.startsAt === null ||
-        dnd.endsAt === null
-    ) {
+    if (!dnd?.scheduleEnabled || dnd.startsAt === null || dnd.endsAt === null) {
         return null;
     }
 

--- a/resources/js/lib/dnd.ts
+++ b/resources/js/lib/dnd.ts
@@ -1,0 +1,60 @@
+/**
+ * Client-side twin of `User::isDndActive()` on the server: whether the viewer
+ * is in do-not-disturb at a given instant, from the full configuration their
+ * own `auth.user` prop carries.
+ *
+ * The chime gate needs this answer at message-arrival time, not at page-load
+ * time — a pause that lapsed two minutes ago, or a quiet-hours window that
+ * opened one minute ago, must take effect without waiting for a server
+ * round-trip. Keep the semantics in lockstep with the server: start inclusive,
+ * end exclusive, and a window whose end precedes its start wraps across
+ * midnight.
+ */
+export function isDndActiveNow(
+    dnd: App.Data.UserDndData | null | undefined,
+    timeZone: string | null | undefined,
+    at: Date = new Date(),
+): boolean {
+    if (!dnd) {
+        return false;
+    }
+
+    if (dnd.until !== null && new Date(dnd.until) > at) {
+        return true;
+    }
+
+    if (!dnd.scheduleEnabled || dnd.startsAt === null || dnd.endsAt === null) {
+        return false;
+    }
+
+    const wallClock = wallClockIn(timeZone, at);
+
+    if (dnd.startsAt <= dnd.endsAt) {
+        return wallClock >= dnd.startsAt && wallClock < dnd.endsAt;
+    }
+
+    return wallClock >= dnd.startsAt || wallClock < dnd.endsAt;
+}
+
+/**
+ * The `HH:MM` wall-clock reading of an instant in a zone, falling back to the
+ * device's own zone when the given one is missing or not a valid IANA
+ * identifier. The locale is pinned because this string is compared against the
+ * stored schedule bounds, never shown to anyone.
+ */
+function wallClockIn(timeZone: string | null | undefined, at: Date): string {
+    const options: Intl.DateTimeFormatOptions = {
+        hour: '2-digit',
+        minute: '2-digit',
+        hourCycle: 'h23',
+    };
+
+    try {
+        return at.toLocaleTimeString('en-GB', {
+            ...options,
+            timeZone: timeZone ?? undefined,
+        });
+    } catch {
+        return at.toLocaleTimeString('en-GB', options);
+    }
+}

--- a/resources/js/lib/dnd.ts
+++ b/resources/js/lib/dnd.ts
@@ -1,3 +1,6 @@
+import { wallTimeToInstant, zonedWallTime } from './scheduleTime';
+import type { WallTime } from './scheduleTime';
+
 /**
  * Client-side twin of `User::isDndActive()` on the server: whether the viewer
  * is in do-not-disturb at a given instant, from the full configuration their
@@ -34,6 +37,125 @@ export function isDndActiveNow(
     }
 
     return wallClock >= dnd.startsAt || wallClock < dnd.endsAt;
+}
+
+/**
+ * The instant the currently-running quiet-hours window closes, or null when
+ * the schedule is off, incomplete, or not covering this instant.
+ *
+ * Feeds the paused card's "quiet hours · until 9:00 AM" line: an overnight
+ * window entered before midnight closes tomorrow, its morning tail closes
+ * today.
+ */
+export function quietHoursEndsAt(
+    dnd: App.Data.UserDndData | null | undefined,
+    timeZone: string | null | undefined,
+    at: Date = new Date(),
+): Date | null {
+    if (
+        !dnd?.scheduleEnabled ||
+        dnd.startsAt === null ||
+        dnd.endsAt === null
+    ) {
+        return null;
+    }
+
+    const wallClock = wallClockIn(timeZone, at);
+    const zone = timeZone ?? deviceZone();
+    const wall = zonedWallTime(zone, at);
+    const [hour, minute] = dnd.endsAt.split(':').map(Number);
+    const closing = { ...wall, hour, minute };
+
+    if (dnd.startsAt <= dnd.endsAt) {
+        if (wallClock < dnd.startsAt || wallClock >= dnd.endsAt) {
+            return null;
+        }
+
+        return wallTimeToInstant(closing, zone);
+    }
+
+    if (wallClock < dnd.endsAt) {
+        return wallTimeToInstant(closing, zone);
+    }
+
+    if (wallClock >= dnd.startsAt) {
+        return wallTimeToInstant(nextCivilDay(closing), zone);
+    }
+
+    return null;
+}
+
+/**
+ * The awake/quiet segments a daily window paints across a 24h strip, left to
+ * right from midnight, each as a percentage of the day. Zero-width segments
+ * are dropped so a bound sitting on midnight doesn't render an empty sliver.
+ */
+export function quietHoursSegments(
+    startsAt: string,
+    endsAt: string,
+): { quiet: boolean; widthPct: number }[] {
+    const start = minutesOfDay(startsAt);
+    const end = minutesOfDay(endsAt);
+
+    const segments =
+        start <= end
+            ? [
+                  { quiet: false, widthPct: pctOfDay(start) },
+                  { quiet: true, widthPct: pctOfDay(end - start) },
+                  { quiet: false, widthPct: pctOfDay(MINUTES_PER_DAY - end) },
+              ]
+            : [
+                  { quiet: true, widthPct: pctOfDay(end) },
+                  { quiet: false, widthPct: pctOfDay(start - end) },
+                  { quiet: true, widthPct: pctOfDay(MINUTES_PER_DAY - start) },
+              ];
+
+    return segments.filter((segment) => segment.widthPct > 0);
+}
+
+/**
+ * The hour labels under the 24h strip: the fixed 00/06/12/18/24 frame with
+ * the window's own bound hours merged in, so the quiet edges are always named.
+ */
+export function quietHoursTicks(startsAt: string, endsAt: string): string[] {
+    const hours = new Set([0, 6, 12, 18, 24]);
+
+    hours.add(Number(startsAt.slice(0, 2)));
+    hours.add(Number(endsAt.slice(0, 2)));
+
+    return [...hours]
+        .sort((a, b) => a - b)
+        .map((hour) => String(hour).padStart(2, '0'));
+}
+
+const MINUTES_PER_DAY = 24 * 60;
+
+function minutesOfDay(bound: string): number {
+    const [hour, minute] = bound.split(':').map(Number);
+
+    return hour * 60 + minute;
+}
+
+function pctOfDay(minutes: number): number {
+    return (minutes / MINUTES_PER_DAY) * 100;
+}
+
+/** Shift a wall-clock reading to the same time on the following civil day. */
+function nextCivilDay(wall: WallTime): WallTime {
+    const shifted = new Date(Date.UTC(wall.year, wall.month - 1, wall.day));
+    shifted.setUTCDate(shifted.getUTCDate() + 1);
+
+    return {
+        ...wall,
+        year: shifted.getUTCFullYear(),
+        month: shifted.getUTCMonth() + 1,
+        day: shifted.getUTCDate(),
+    };
+}
+
+/** The device's own IANA zone, the fallback when the account has none set. */
+function deviceZone(): string {
+    return new Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
 /**

--- a/resources/js/lib/dndPause.test.ts
+++ b/resources/js/lib/dndPause.test.ts
@@ -28,9 +28,9 @@ describe('resolveDndPause', () => {
         );
 
         // 9:00 in New York on the 23rd is 13:00 UTC.
-        expect(
-            resolveDndPause('until-tomorrow', 'America/New_York', now),
-        ).toBe('2026-07-23T13:00:00.000Z');
+        expect(resolveDndPause('until-tomorrow', 'America/New_York', now)).toBe(
+            '2026-07-23T13:00:00.000Z',
+        );
     });
 
     it('rolls "until tomorrow" across a month boundary', () => {

--- a/resources/js/lib/dndPause.test.ts
+++ b/resources/js/lib/dndPause.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { DND_PAUSE_KEYS, dndPauseLabel, resolveDndPause } from '@/lib/dndPause';
+
+describe('resolveDndPause', () => {
+    const now = new Date('2026-07-22T12:00:00Z');
+
+    it('offers the four presets in menu order', () => {
+        expect(DND_PAUSE_KEYS).toEqual([
+            'thirty-minutes',
+            'one-hour',
+            'until-tomorrow',
+            'custom',
+        ]);
+    });
+
+    it('resolves the fixed durations from now', () => {
+        expect(resolveDndPause('thirty-minutes', 'UTC', now)).toBe(
+            '2026-07-22T12:30:00.000Z',
+        );
+        expect(resolveDndPause('one-hour', 'UTC', now)).toBe(
+            '2026-07-22T13:00:00.000Z',
+        );
+    });
+
+    it('resolves "until tomorrow" to 9:00 the next morning in the given zone', () => {
+        expect(resolveDndPause('until-tomorrow', 'UTC', now)).toBe(
+            '2026-07-23T09:00:00.000Z',
+        );
+
+        // 9:00 in New York on the 23rd is 13:00 UTC.
+        expect(
+            resolveDndPause('until-tomorrow', 'America/New_York', now),
+        ).toBe('2026-07-23T13:00:00.000Z');
+    });
+
+    it('rolls "until tomorrow" across a month boundary', () => {
+        expect(
+            resolveDndPause(
+                'until-tomorrow',
+                'UTC',
+                new Date('2026-07-31T22:00:00Z'),
+            ),
+        ).toBe('2026-08-01T09:00:00.000Z');
+    });
+
+    it('names no instant for the custom choice, whose picker supplies it', () => {
+        expect(resolveDndPause('custom', 'UTC', now)).toBeNull();
+    });
+
+    it('labels every choice', () => {
+        expect(dndPauseLabel('thirty-minutes')).toBe('30 minutes');
+        expect(dndPauseLabel('one-hour')).toBe('1 hour');
+        expect(dndPauseLabel('until-tomorrow')).toBe('Until tomorrow');
+        expect(dndPauseLabel('custom')).toBe('Custom…');
+    });
+});

--- a/resources/js/lib/dndPause.ts
+++ b/resources/js/lib/dndPause.ts
@@ -1,0 +1,82 @@
+/**
+ * The "Pause notifications" choices offered by the presence menu, and the time
+ * math that turns one into the instant the pause lapses.
+ *
+ * Mirrors `statusExpiry` for the custom status: every choice is resolved
+ * against the viewer's *own* zone and handed to the server as a UTC instant.
+ * Kept free of Vue and DOM so it can be unit-tested in isolation; `now` is
+ * always injectable so tests are deterministic.
+ */
+
+import { translate } from './i18n';
+import { wallTimeToInstant, zonedWallTime } from './scheduleTime';
+
+/** The pause choices, in the order the flyout lists them. */
+export const DND_PAUSE_KEYS = [
+    'thirty-minutes',
+    'one-hour',
+    'until-tomorrow',
+    'custom',
+] as const;
+
+export type DndPauseKey = (typeof DND_PAUSE_KEYS)[number];
+
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * The hour "Until tomorrow" runs to: 9:00 the next morning in the viewer's
+ * zone, so the pause covers the night and lapses at working hours rather than
+ * at a midnight the user sleeps through.
+ */
+const TOMORROW_MORNING_HOUR = 9;
+
+/**
+ * The instant a choice resolves to, as a UTC ISO 8601 string, or null for
+ * `custom` (the date-and-time picker supplies the instant instead).
+ */
+export function resolveDndPause(
+    key: DndPauseKey,
+    timeZone: string,
+    now: Date = new Date(),
+): string | null {
+    if (key === 'custom') {
+        return null;
+    }
+
+    if (key === 'thirty-minutes') {
+        return new Date(now.getTime() + 30 * MS_PER_MINUTE).toISOString();
+    }
+
+    if (key === 'one-hour') {
+        return new Date(now.getTime() + 60 * MS_PER_MINUTE).toISOString();
+    }
+
+    const wall = zonedWallTime(timeZone, now);
+    const tomorrow = new Date(Date.UTC(wall.year, wall.month - 1, wall.day));
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+
+    return wallTimeToInstant(
+        {
+            year: tomorrow.getUTCFullYear(),
+            month: tomorrow.getUTCMonth() + 1,
+            day: tomorrow.getUTCDate(),
+            hour: TOMORROW_MORNING_HOUR,
+            minute: 0,
+        },
+        timeZone,
+    ).toISOString();
+}
+
+/**
+ * The translated label for a choice, as the flyout shows it.
+ */
+export function dndPauseLabel(key: DndPauseKey): string {
+    const labels: Record<DndPauseKey, string> = {
+        'thirty-minutes': translate('30 minutes'),
+        'one-hour': translate('1 hour'),
+        'until-tomorrow': translate('Until tomorrow'),
+        custom: translate('Custom…'),
+    };
+
+    return labels[key];
+}

--- a/resources/js/lib/groupDm.test.ts
+++ b/resources/js/lib/groupDm.test.ts
@@ -17,6 +17,7 @@ function participant(id: string, name: string): DmParticipant {
         isBot: false,
         status: null,
         presence: 'active',
+        isDnd: false,
     };
 }
 

--- a/resources/js/lib/shouldChime.test.ts
+++ b/resources/js/lib/shouldChime.test.ts
@@ -17,6 +17,7 @@ function input(
         channel: { muted: false, notificationLevel: 'all' },
         tabHasFocus: false,
         isActiveChannel: false,
+        dndActive: false,
         ...overrides,
     };
 }
@@ -28,6 +29,16 @@ describe('shouldChime', () => {
 
     it('never chimes when chimes are disabled', () => {
         expect(shouldChime(input({ chimeEnabled: false }))).toBe(false);
+    });
+
+    it('never chimes while the user is in do-not-disturb', () => {
+        expect(shouldChime(input({ dndActive: true }))).toBe(false);
+    });
+
+    it('suppresses even a direct mention while in do-not-disturb', () => {
+        expect(
+            shouldChime(input({ dndActive: true, mentionsCurrentUser: true })),
+        ).toBe(false);
     });
 
     it("never chimes for the user's own message", () => {

--- a/resources/js/lib/shouldChime.ts
+++ b/resources/js/lib/shouldChime.ts
@@ -28,6 +28,13 @@ export type ChimeDecisionInput = {
     tabHasFocus: boolean;
     /** The message landed in the channel the user is actively viewing on screen. */
     isActiveChannel: boolean;
+    /**
+     * The user is in do-not-disturb at this instant — a manual pause still
+     * running, or their quiet-hours window covering right now (see
+     * `isDndActiveNow`). Suppresses everything, mentions included: DND is the
+     * stronger, time-boxed claim on top of the standing per-channel levels.
+     */
+    dndActive: boolean;
 };
 
 /**
@@ -37,11 +44,15 @@ export type ChimeDecisionInput = {
  * mention badge stay consistent: a direct @mention alerts unless the channel is
  * muted or set to "nothing"; ordinary traffic alerts only at the "all" level. On
  * top of that a chime is suppressed for the user's own messages, when chimes are
- * disabled, and when the user is already actively looking at the message (its
- * channel is open and the tab has focus).
+ * disabled, while the user is in do-not-disturb, and when the user is already
+ * actively looking at the message (its channel is open and the tab has focus).
  */
 export function shouldChime(input: ChimeDecisionInput): boolean {
     if (!input.chimeEnabled) {
+        return false;
+    }
+
+    if (input.dndActive) {
         return false;
     }
 

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -197,7 +197,7 @@ const typingNames = typing.typingNames;
  * Live presence for the team, driving the dots on message avatars, the masthead
  * and the facepile. Follows the team across channel switches.
  */
-const { presenceFor } = useTeamPresence(() => props.team.id);
+const { presenceFor, isDndFor } = useTeamPresence(() => props.team.id);
 
 /**
  * Read positions of the channel's other members who share read receipts, keyed
@@ -1171,6 +1171,7 @@ function archive(): void {
                 :team-slug="props.team.slug"
                 :members="props.members"
                 :presence-for="presenceFor"
+                :is-dnd-for="isDndFor"
                 :title="mastheadTitle"
                 :can-manage-preferences="props.canManagePreferences"
                 :can-archive="props.canArchive"
@@ -1349,6 +1350,7 @@ function archive(): void {
                                 :can-react="props.canReact"
                                 :can-pin="props.canReact"
                                 :presence-for="presenceFor"
+                                :is-dnd-for="isDndFor"
                                 :readers="channelReadersList"
                                 :highlight-message-id="highlightedMessageId"
                                 :unread-divider-id="unreadDividerId"
@@ -1526,6 +1528,7 @@ function archive(): void {
                 :can-react="props.canReact"
                 :can-pin="props.canReact"
                 :presence-for="presenceFor"
+                :is-dnd-for="isDndFor"
                 :loading="threadLoading"
                 :read-only="props.channel.isArchived"
                 @close="closeThread"

--- a/resources/js/pages/settings/Appearance.vue
+++ b/resources/js/pages/settings/Appearance.vue
@@ -1,15 +1,26 @@
 <script setup lang="ts">
-import { Head } from '@inertiajs/vue3';
-import { Play } from '@lucide/vue';
-import { ref, watch } from 'vue';
+import { Head, router, usePage } from '@inertiajs/vue3';
+import { Moon, Play } from '@lucide/vue';
+import { computed, ref, watch } from 'vue';
+import { toast } from 'vue-sonner';
+import { update as updateDndSchedule } from '@/actions/App/Http/Controllers/Settings/DndScheduleController';
 import AppearanceTabs from '@/components/AppearanceTabs.vue';
 import SettingsPane from '@/components/SettingsPane.vue';
 import SettingsPaneSection from '@/components/SettingsPaneSection.vue';
 import SidebarPositionTabs from '@/components/SidebarPositionTabs.vue';
 import { Button } from '@/components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { useChimes } from '@/composables/useChimes';
 import { useReadReceipts } from '@/composables/useReadReceipts';
+import { useTranslations } from '@/composables/useTranslations';
+import { quietHoursSegments, quietHoursTicks } from '@/lib/dnd';
 import { translate } from '@/lib/i18n';
 import { edit } from '@/routes/appearance';
 import type {
@@ -49,6 +60,76 @@ function choose(value: ChimeSound): void {
 }
 
 const { shareReadReceipts, updateShareReadReceipts } = useReadReceipts();
+
+const page = usePage();
+const { t } = useTranslations();
+
+/**
+ * The stored quiet-hours schedule, from the viewer's own `auth.user` prop. The
+ * window a fresh account opens on mirrors the design's example evening.
+ */
+const storedDnd = computed(() => page.props.auth.user.dnd ?? null);
+
+const scheduleEnabled = ref(storedDnd.value?.scheduleEnabled ?? false);
+const startsAt = ref(storedDnd.value?.startsAt ?? '18:00');
+const endsAt = ref(storedDnd.value?.endsAt ?? '09:00');
+
+// Local mirrors so the controls answer on click, before the persisted
+// preference round-trips back through the shared prop.
+watch(storedDnd, (value) => {
+    scheduleEnabled.value = value?.scheduleEnabled ?? false;
+    startsAt.value = value?.startsAt ?? startsAt.value;
+    endsAt.value = value?.endsAt ?? endsAt.value;
+});
+
+/** The half-hour grid both bound selects offer. */
+const QUIET_HOUR_OPTIONS = Array.from({ length: 48 }, (_, index) => {
+    const hour = String(Math.floor(index / 2)).padStart(2, '0');
+
+    return `${hour}:${index % 2 === 0 ? '00' : '30'}`;
+});
+
+const crossesMidnight = computed(() => startsAt.value > endsAt.value);
+
+const stripSegments = computed(() =>
+    quietHoursSegments(startsAt.value, endsAt.value),
+);
+const stripTicks = computed(() => quietHoursTicks(startsAt.value, endsAt.value));
+
+function persistSchedule(): void {
+    router.put(
+        updateDndSchedule().url,
+        {
+            enabled: scheduleEnabled.value,
+            starts_at: startsAt.value,
+            ends_at: endsAt.value,
+        },
+        {
+            preserveScroll: true,
+            onError: () =>
+                toast.error(t('Could not update your quiet hours.')),
+        },
+    );
+}
+
+function toggleSchedule(enabled: boolean): void {
+    scheduleEnabled.value = enabled;
+    persistSchedule();
+}
+
+function chooseBound(bound: 'startsAt' | 'endsAt', value: unknown): void {
+    if (typeof value !== 'string') {
+        return;
+    }
+
+    if (bound === 'startsAt') {
+        startsAt.value = value;
+    } else {
+        endsAt.value = value;
+    }
+
+    persistSchedule();
+}
 </script>
 
 <template>
@@ -114,6 +195,135 @@ const { shareReadReceipts, updateShareReadReceipts } = useReadReceipts();
                     <Play class="size-3 fill-current" />
                     {{ $t('Preview') }}
                 </Button>
+            </div>
+        </SettingsPaneSection>
+
+        <SettingsPaneSection
+            :title="$t('Quiet hours')"
+            :description="
+                $t(
+                    'Pause the chime on a daily schedule. Uses your timezone — :timezone.',
+                    {
+                        timezone:
+                            page.props.auth.user.timezone ??
+                            $t('your device\'s'),
+                    },
+                )
+            "
+        >
+            <template #action>
+                <Switch
+                    id="quiet-hours-enabled"
+                    data-test="quiet-hours-enabled"
+                    :model-value="scheduleEnabled"
+                    :aria-label="$t('Quiet hours')"
+                    @update:model-value="toggleSchedule"
+                />
+            </template>
+
+            <div v-if="scheduleEnabled" class="flex flex-col gap-4">
+                <div class="flex flex-wrap items-center gap-x-3.5 gap-y-2">
+                    <div class="flex items-center gap-2.5">
+                        <span
+                            id="quiet-hours-from-label"
+                            class="text-[12.5px] font-semibold text-muted-foreground"
+                            >{{ $t('From') }}</span
+                        >
+                        <Select
+                            :model-value="startsAt"
+                            @update:model-value="
+                                (value) => chooseBound('startsAt', value)
+                            "
+                        >
+                            <SelectTrigger
+                                data-test="quiet-hours-starts-at"
+                                aria-labelledby="quiet-hours-from-label"
+                                class="h-9 rounded-[10px] font-mono text-[13.5px]"
+                            >
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent class="max-h-64">
+                                <SelectItem
+                                    v-for="option in QUIET_HOUR_OPTIONS"
+                                    :key="`from-${option}`"
+                                    :value="option"
+                                    class="font-mono text-[13px]"
+                                >
+                                    {{ option }}
+                                </SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div class="flex items-center gap-2.5">
+                        <span
+                            id="quiet-hours-to-label"
+                            class="text-[12.5px] font-semibold text-muted-foreground"
+                            >{{ $t('to') }}</span
+                        >
+                        <Select
+                            :model-value="endsAt"
+                            @update:model-value="
+                                (value) => chooseBound('endsAt', value)
+                            "
+                        >
+                            <SelectTrigger
+                                data-test="quiet-hours-ends-at"
+                                aria-labelledby="quiet-hours-to-label"
+                                class="h-9 rounded-[10px] font-mono text-[13.5px]"
+                            >
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent class="max-h-64">
+                                <SelectItem
+                                    v-for="option in QUIET_HOUR_OPTIONS"
+                                    :key="`to-${option}`"
+                                    :value="option"
+                                    class="font-mono text-[13px]"
+                                >
+                                    {{ option }}
+                                </SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <span
+                        v-if="crossesMidnight"
+                        data-test="quiet-hours-overnight"
+                        class="inline-flex items-center gap-1.5 font-serif text-xs text-muted-foreground italic"
+                    >
+                        <Moon class="size-3" aria-hidden="true" />
+                        {{ $t('crosses midnight — ends tomorrow morning') }}
+                    </span>
+                </div>
+
+                <!-- The 24h strip: dark segments are quiet. Decorative — the
+                     selects above carry the same facts accessibly. -->
+                <div
+                    class="flex max-w-130 flex-col gap-1.5"
+                    aria-hidden="true"
+                    data-test="quiet-hours-strip"
+                >
+                    <div
+                        class="flex h-2.5 overflow-hidden rounded-[5px] border border-border"
+                    >
+                        <div
+                            v-for="(segment, index) in stripSegments"
+                            :key="index"
+                            :class="
+                                segment.quiet
+                                    ? 'bg-muted-foreground'
+                                    : 'bg-muted'
+                            "
+                            :style="{ width: `${segment.widthPct}%` }"
+                        />
+                    </div>
+                    <div
+                        class="flex justify-between font-mono text-[10px] text-muted-foreground"
+                    >
+                        <span v-for="tick in stripTicks" :key="tick">{{
+                            tick
+                        }}</span>
+                    </div>
+                </div>
             </div>
         </SettingsPaneSection>
 

--- a/resources/js/pages/settings/Appearance.vue
+++ b/resources/js/pages/settings/Appearance.vue
@@ -94,7 +94,9 @@ const crossesMidnight = computed(() => startsAt.value > endsAt.value);
 const stripSegments = computed(() =>
     quietHoursSegments(startsAt.value, endsAt.value),
 );
-const stripTicks = computed(() => quietHoursTicks(startsAt.value, endsAt.value));
+const stripTicks = computed(() =>
+    quietHoursTicks(startsAt.value, endsAt.value),
+);
 
 function persistSchedule(): void {
     router.put(
@@ -106,8 +108,7 @@ function persistSchedule(): void {
         },
         {
             preserveScroll: true,
-            onError: () =>
-                toast.error(t('Could not update your quiet hours.')),
+            onError: () => toast.error(t('Could not update your quiet hours.')),
         },
     );
 }

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -17,6 +17,11 @@ export type User = {
      * live connections say when they have set none.
      */
     presence: App.Enums.PresenceState;
+    /**
+     * The viewer's own full do-not-disturb configuration. Only ever serialised
+     * to its owner; teammates receive the bare `isDnd` boolean instead.
+     */
+    dnd: App.Data.UserDndData;
     locale: AppLocale;
     avatar?: string;
     email_verified_at: string | null;

--- a/resources/js/types/people.ts
+++ b/resources/js/types/people.ts
@@ -11,6 +11,11 @@ export type PersonRef = {
      * refs some pickers assemble, which then read as active.
      */
     presence?: App.Enums.PresenceState;
+    /**
+     * Whether the member is in do-not-disturb, driving the crescent badge on
+     * the dot surfaces. Absent on hand-built refs, which then show no badge.
+     */
+    isDnd?: boolean;
 };
 
 /**

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -42,6 +42,8 @@ export type UserProfile = {
     memberSince: string | null;
     isYou: boolean;
     status: App.Data.UserStatusData | null;
+    /** Whether the member is in do-not-disturb right now; never says when it ends. */
+    isDnd: boolean;
 };
 
 export type TeamInvitation = {

--- a/routes/console.php
+++ b/routes/console.php
@@ -7,7 +7,9 @@ use App\Actions\Channels\DispatchDueScheduledMessages;
 use App\Actions\Channels\PurgeExpiredAttachments;
 use App\Actions\Images\PurgeCachedProxyImages;
 use App\Actions\Teams\PurgeExpiredAuditExports;
+use App\Actions\Users\BroadcastDndScheduleEdges;
 use App\Actions\Users\ClearExpiredUserStatuses;
+use App\Actions\Users\ClearLapsedDndPauses;
 use App\Models\TeamInvitation;
 use Illuminate\Support\Facades\Schedule;
 
@@ -35,6 +37,18 @@ Schedule::call(fn (ClearExpiredUserStatuses $clear): int => $clear->handle())
     ->everyMinute()
     ->withoutOverlapping()
     ->description('Clear lapsed custom statuses');
+
+Schedule::call(fn (ClearLapsedDndPauses $clear): int => $clear->handle())
+    ->name('clear-lapsed-dnd-pauses')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->description('Clear lapsed do-not-disturb pauses');
+
+Schedule::call(fn (BroadcastDndScheduleEdges $broadcast): int => $broadcast->handle())
+    ->name('broadcast-dnd-schedule-edges')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->description('Broadcast quiet-hours windows opening or closing');
 
 Schedule::call(fn (PurgeExpiredAttachments $purge): int => $purge->handle())
     ->name('purge-expired-pending-attachments')

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Settings\AboutController;
 use App\Http\Controllers\Settings\AppearanceController;
 use App\Http\Controllers\Settings\AvatarController;
 use App\Http\Controllers\Settings\DataExportController;
+use App\Http\Controllers\Settings\DndController;
+use App\Http\Controllers\Settings\DndScheduleController;
 use App\Http\Controllers\Settings\LocaleController;
 use App\Http\Controllers\Settings\NotificationController;
 use App\Http\Controllers\Settings\PersonalAccessTokenController;
@@ -54,6 +56,12 @@ Route::middleware(['auth'])->group(function (): void {
     // The manual away toggle sits beside the status in the same presence menu,
     // and is reachable from every workspace surface for the same reason.
     Route::put('settings/presence', [PresenceController::class, 'update'])->name('presence.update');
+
+    // Do-not-disturb rides the same presence menu: the pause is set and ended
+    // from it, and the recurring quiet-hours schedule from its dialog.
+    Route::put('settings/dnd', [DndController::class, 'update'])->name('dnd.update');
+    Route::delete('settings/dnd', [DndController::class, 'destroy'])->name('dnd.destroy');
+    Route::put('settings/dnd-schedule', [DndScheduleController::class, 'update'])->name('dnd-schedule.update');
 
     Route::patch('settings/timezone', [TimezoneController::class, 'update'])->name('timezone.update');
 

--- a/tests/Browser/DoNotDisturbTest.php
+++ b/tests/Browser/DoNotDisturbTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+test('a user pauses notifications from the presence menu and resumes in place', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@pause-notifications-menu-item')
+        // The flyout offers the presets; choosing one applies in place.
+        ->click('@pause-notifications-menu-item')
+        ->assertPresent('@pause-notifications-submenu')
+        ->click('@pause-preset-thirty-minutes')
+        ->wait(0.5);
+
+    expect($alice->refresh()->dnd_until)->not->toBeNull()
+        ->and($alice->isDndActive())->toBeTrue();
+
+    // The STATUS section now leads with the paused card — crescent, lapse in
+    // italic serif, Resume pill — and the masthead names the state.
+    $page->assertPresent('@dnd-paused-card')
+        ->assertPresent('@dnd-paused-until')
+        ->assertSee('Notifications paused')
+        // Resuming from the pill collapses the card without closing the menu.
+        ->click('@dnd-resume-menu-item')
+        ->wait(0.5)
+        ->assertNotPresent('@dnd-paused-card');
+
+    expect($alice->refresh()->dnd_until)->toBeNull()
+        ->and($alice->isDndActive())->toBeFalse();
+});
+
+test('the custom pause dialog stores the picked instant', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->click('@pause-notifications-menu-item')
+        ->assertPresent('@pause-notifications-submenu')
+        ->click('@pause-preset-custom')
+        ->assertPresent('@dnd-pause-dialog')
+        // The controls open seeded on the next 5-minute step, already valid.
+        ->click('@dnd-pause-save')
+        ->wait(0.5)
+        ->assertNotPresent('@dnd-pause-dialog');
+
+    expect($alice->refresh()->dnd_until)->not->toBeNull()
+        ->and($alice->dnd_until->isFuture())->toBeTrue();
+});
+
+test('the paused shell with its crescent badge has no serious accessibility violations in either theme', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $alice->forceFill(['dnd_until' => now()->addMinutes(30)])->save();
+
+    // Audited with the menu closed: an *open* reka dropdown marks the page
+    // behind it aria-hidden while the skip link stays focusable, a pre-existing
+    // shell-wide finding tracked in #730 that would drown this slice's surfaces.
+    // The crescent badge on the sidebar chip is what this run guards.
+    $page = signInThroughBrowser($alice)
+        ->assertPresent(
+            '[data-test="nav-user-presence"][data-dnd="true"]',
+        )
+        ->assertNoAccessibilityIssues();
+
+    // Re-audit against the dark palette, persisting the choice so the
+    // appearance controller doesn't revert it mid-audit.
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});
+
+test('the quiet hours settings section has no serious accessibility violations', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $alice->forceFill([
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '18:00',
+        'dnd_ends_at' => '09:00',
+    ])->save();
+
+    signInThroughBrowser($alice)
+        ->navigate('/settings/appearance')
+        ->assertPresent('@quiet-hours-enabled')
+        ->assertPresent('@quiet-hours-starts-at')
+        ->assertSee('crosses midnight')
+        ->assertNoAccessibilityIssues();
+});

--- a/tests/Browser/DoNotDisturbTest.php
+++ b/tests/Browser/DoNotDisturbTest.php
@@ -25,7 +25,8 @@ test('a user pauses notifications from the presence menu and resumes in place', 
         // Resuming from the pill collapses the card without closing the menu.
         ->click('@dnd-resume-menu-item')
         ->wait(0.5)
-        ->assertNotPresent('@dnd-paused-card');
+        ->assertNotPresent('@dnd-paused-card')
+        ->assertPresent('@pause-notifications-menu-item');
 
     expect($alice->refresh()->dnd_until)->toBeNull()
         ->and($alice->isDndActive())->toBeFalse();

--- a/tests/Feature/Channels/ReadReceiptsTest.php
+++ b/tests/Feature/Channels/ReadReceiptsTest.php
@@ -141,7 +141,7 @@ test('MessageRead broadcasts on the channel private channel with the reader and 
 
     expect($event->broadcastOn())->toEqual([new PrivateChannel('channel.'.$general->id)]);
     expect($event->broadcastWith())->toEqual([
-        'reader' => ['id' => $owner->id, 'name' => $owner->name, 'avatar' => $owner->avatar, 'isBot' => false, 'status' => null, 'presence' => 'active'],
+        'reader' => ['id' => $owner->id, 'name' => $owner->name, 'avatar' => $owner->avatar, 'isBot' => false, 'status' => null, 'presence' => 'active', 'isDnd' => false],
         'lastReadMessageId' => $message->id,
     ]);
 });

--- a/tests/Feature/Console/BroadcastDndScheduleEdgesTest.php
+++ b/tests/Feature/Console/BroadcastDndScheduleEdgesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Actions\Users\BroadcastDndScheduleEdges;
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+
+test('a window opening this minute is broadcast', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 22:00:10', 'UTC'), function () use ($user): void {
+        expect(app(BroadcastDndScheduleEdges::class)->handle())->toBe(1);
+
+        Event::assertDispatched(
+            UserProfileUpdated::class,
+            fn (UserProfileUpdated $event): bool => $event->user->is($user),
+        );
+    });
+});
+
+test('a window closing this minute is broadcast', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 07:00:45', 'UTC'), function (): void {
+        expect(app(BroadcastDndScheduleEdges::class)->handle())->toBe(1);
+
+        Event::assertDispatched(UserProfileUpdated::class);
+    });
+});
+
+test('a minute inside or outside the window broadcasts nothing', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 23:30:00', 'UTC'), function (): void {
+        expect(app(BroadcastDndScheduleEdges::class)->handle())->toBe(0);
+    });
+
+    Event::assertNotDispatched(UserProfileUpdated::class);
+});
+
+test('a disabled schedule is never broadcast', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => false,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 22:00:10', 'UTC'), function (): void {
+        expect(app(BroadcastDndScheduleEdges::class)->handle())->toBe(0);
+    });
+
+    Event::assertNotDispatched(UserProfileUpdated::class);
+});
+
+test('the edge is matched in the user timezone, not the server one', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    User::factory()->create([
+        'timezone' => 'America/New_York',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    // 02:00 UTC is 22:00 in New York — their window opens now.
+    $this->travelTo(Carbon::parse('2026-07-23 02:00:30', 'UTC'), function (): void {
+        expect(app(BroadcastDndScheduleEdges::class)->handle())->toBe(1);
+    });
+
+    // 22:00 UTC is 18:00 in New York — no edge for them.
+    $this->travelTo(Carbon::parse('2026-07-22 22:00:30', 'UTC'), function (): void {
+        expect(app(BroadcastDndScheduleEdges::class)->handle())->toBe(0);
+    });
+});
+
+test('the edge broadcast is scheduled every minute', function (): void {
+    $events = collect(app(Schedule::class)->events())
+        ->filter(fn ($event): bool => $event->description === 'Broadcast quiet-hours windows opening or closing');
+
+    expect($events)->toHaveCount(1)
+        ->and($events->first()->expression)->toBe('* * * * *');
+});

--- a/tests/Feature/Console/BroadcastDndScheduleEdgesTest.php
+++ b/tests/Feature/Console/BroadcastDndScheduleEdgesTest.php
@@ -58,6 +58,10 @@ test('a minute inside or outside the window broadcasts nothing', function (): vo
         expect(app(BroadcastDndScheduleEdges::class)->handle())->toBe(0);
     });
 
+    $this->travelTo(Carbon::parse('2026-07-22 12:00:00', 'UTC'), function (): void {
+        expect(app(BroadcastDndScheduleEdges::class)->handle())->toBe(0);
+    });
+
     Event::assertNotDispatched(UserProfileUpdated::class);
 });
 

--- a/tests/Feature/Console/ClearLapsedDndPausesTest.php
+++ b/tests/Feature/Console/ClearLapsedDndPausesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Actions\Users\ClearLapsedDndPauses;
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Event;
+
+test('a lapsed pause is cleared and the clear is broadcast', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $user = User::factory()->create(['dnd_until' => now()->subMinute()]);
+
+    expect(app(ClearLapsedDndPauses::class)->handle())->toBe(1);
+
+    expect($user->refresh()->dnd_until)->toBeNull();
+
+    Event::assertDispatched(
+        UserProfileUpdated::class,
+        fn (UserProfileUpdated $event): bool => $event->user->is($user),
+    );
+});
+
+test('a pause still ahead of its lapse is left alone', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $user = User::factory()->create(['dnd_until' => now()->addMinutes(30)]);
+
+    expect(app(ClearLapsedDndPauses::class)->handle())->toBe(0);
+    expect($user->refresh()->dnd_until)->not->toBeNull();
+
+    Event::assertNotDispatched(UserProfileUpdated::class);
+});
+
+test('a user with no pause is never touched', function (): void {
+    User::factory()->create();
+
+    expect(app(ClearLapsedDndPauses::class)->handle())->toBe(0);
+});
+
+test('the sweep clears every lapsed pause in one pass', function (): void {
+    User::factory()->count(3)->create(['dnd_until' => now()->subHour()]);
+
+    expect(app(ClearLapsedDndPauses::class)->handle())->toBe(3);
+    expect(User::query()->whereNotNull('dnd_until')->count())->toBe(0);
+});
+
+test('a pause replaced mid-sweep is left alone', function (): void {
+    User::factory()->count(2)->create(['dnd_until' => now()->subMinute()]);
+
+    // Stand in for someone starting a fresh pause in the window between the
+    // sweep's query and its write. The first clear the sweep performs is the
+    // trigger, so whichever user it reaches second is mutated behind it — while
+    // the model it already hydrated still carries the lapsed instant.
+    Event::listen(UserProfileUpdated::class, function () use (&$replaced): void {
+        if ($replaced ?? false) {
+            return;
+        }
+
+        $replaced = true;
+
+        User::query()
+            ->whereNotNull('dnd_until')
+            ->update(['dnd_until' => now()->addHour()]);
+    });
+
+    // Only the first user is cleared; the replaced one is skipped, because its
+    // clear is conditional on the instant the sweep actually read.
+    expect(app(ClearLapsedDndPauses::class)->handle())->toBe(1);
+
+    expect(User::query()->whereNotNull('dnd_until')->sole()->dnd_until->isFuture())->toBeTrue();
+});
+
+test('the sweep is scheduled every minute', function (): void {
+    $events = collect(app(Schedule::class)->events())
+        ->filter(fn ($event): bool => $event->description === 'Clear lapsed do-not-disturb pauses');
+
+    expect($events)->toHaveCount(1)
+        ->and($events->first()->expression)->toBe('* * * * *');
+});

--- a/tests/Feature/Dnd/DndEvaluationTest.php
+++ b/tests/Feature/Dnd/DndEvaluationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+test('a user with no dnd configuration is not in dnd', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->isDndActive())->toBeFalse();
+});
+
+test('a manual pause still ahead of its lapse reads as dnd', function (): void {
+    $user = User::factory()->create([
+        'dnd_until' => now()->addMinutes(30),
+    ]);
+
+    expect($user->isDndActive())->toBeTrue();
+});
+
+test('a manual pause lapses on read once its instant passes', function (): void {
+    $user = User::factory()->create([
+        'dnd_until' => now()->subMinute(),
+    ]);
+
+    expect($user->isDndActive())->toBeFalse();
+});
+
+test('an enabled quiet-hours schedule reads as dnd inside its window', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 12:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeTrue();
+    });
+});
+
+test('an enabled quiet-hours schedule reads as no dnd outside its window', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 18:30:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeFalse();
+    });
+});
+
+test('the window starts inclusive and ends exclusive', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 09:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeTrue();
+    });
+
+    $this->travelTo(Carbon::parse('2026-07-22 17:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeFalse();
+    });
+});
+
+test('an overnight window wraps across midnight', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 23:30:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeTrue();
+    });
+
+    $this->travelTo(Carbon::parse('2026-07-22 06:30:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeTrue();
+    });
+
+    $this->travelTo(Carbon::parse('2026-07-22 12:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeFalse();
+    });
+});
+
+test('the window is evaluated in the user timezone, not the server one', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'America/New_York',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+    ]);
+
+    // 14:00 UTC is 10:00 in New York — inside the window. 12:00 UTC is 08:00
+    // there — outside it, though a naive UTC read would say inside.
+    $this->travelTo(Carbon::parse('2026-07-22 14:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeTrue();
+    });
+
+    $this->travelTo(Carbon::parse('2026-07-22 12:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeFalse();
+    });
+});
+
+test('a disabled schedule never reads as dnd', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => false,
+        'dnd_starts_at' => '00:00',
+        'dnd_ends_at' => '23:59',
+    ]);
+
+    expect($user->isDndActive())->toBeFalse();
+});
+
+test('an enabled schedule missing either bound never reads as dnd', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => null,
+        'dnd_ends_at' => null,
+    ]);
+
+    expect($user->isDndActive())->toBeFalse();
+});

--- a/tests/Feature/Dnd/DndPauseTest.php
+++ b/tests/Feature/Dnd/DndPauseTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+
+test('a user can pause notifications until an instant', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+    $user = User::factory()->create();
+    // The column stores whole seconds, so compare against a whole-second instant.
+    $until = now()->addMinutes(30)->startOfSecond();
+
+    $this->actingAs($user)
+        ->put(route('dnd.update'), ['until' => $until->toIso8601String()])
+        ->assertRedirect();
+
+    expect($user->refresh()->dnd_until->equalTo($until))->toBeTrue();
+
+    Event::assertDispatched(UserProfileUpdated::class);
+});
+
+test('pausing again replaces the running pause', function (): void {
+    $user = User::factory()->create(['dnd_until' => now()->addMinutes(30)]);
+    $until = now()->addHour()->startOfSecond();
+
+    $this->actingAs($user)
+        ->put(route('dnd.update'), ['until' => $until->toIso8601String()])
+        ->assertRedirect();
+
+    expect($user->refresh()->dnd_until->equalTo($until))->toBeTrue();
+});
+
+test('a pause instant is required and must be ahead', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->put(route('dnd.update'), [])
+        ->assertSessionHasErrors('until');
+
+    $this->actingAs($user)
+        ->put(route('dnd.update'), ['until' => now()->subMinute()->toIso8601String()])
+        ->assertSessionHasErrors('until');
+});
+
+test('a user can resume notifications, ending the pause early', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+    $user = User::factory()->create(['dnd_until' => now()->addHour()]);
+
+    $this->actingAs($user)
+        ->delete(route('dnd.destroy'))
+        ->assertRedirect();
+
+    expect($user->refresh()->dnd_until)->toBeNull();
+
+    Event::assertDispatched(UserProfileUpdated::class);
+});
+
+test('resuming leaves the quiet-hours schedule untouched', function (): void {
+    $user = User::factory()->create([
+        'dnd_until' => now()->addHour(),
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->actingAs($user)->delete(route('dnd.destroy'))->assertRedirect();
+
+    $user->refresh();
+
+    expect($user->dnd_schedule_enabled)->toBeTrue()
+        ->and($user->dnd_starts_at)->toBe('22:00')
+        ->and($user->dnd_ends_at)->toBe('07:00');
+});
+
+test('a guest cannot pause notifications', function (): void {
+    $this->put(route('dnd.update'), ['until' => now()->addHour()->toIso8601String()])
+        ->assertRedirect(route('login'));
+});

--- a/tests/Feature/Dnd/DndScheduleTest.php
+++ b/tests/Feature/Dnd/DndScheduleTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+
+test('a user can enable a daily quiet-hours window', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->put(route('dnd-schedule.update'), [
+            'enabled' => true,
+            'starts_at' => '22:00',
+            'ends_at' => '07:00',
+        ])
+        ->assertRedirect();
+
+    $user->refresh();
+
+    expect($user->dnd_schedule_enabled)->toBeTrue()
+        ->and($user->dnd_starts_at)->toBe('22:00')
+        ->and($user->dnd_ends_at)->toBe('07:00');
+
+    Event::assertDispatched(UserProfileUpdated::class);
+});
+
+test('disabling the schedule keeps the stored window for re-enabling', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+    $user = User::factory()->create([
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('dnd-schedule.update'), ['enabled' => false])
+        ->assertRedirect();
+
+    $user->refresh();
+
+    expect($user->dnd_schedule_enabled)->toBeFalse()
+        ->and($user->dnd_starts_at)->toBe('22:00')
+        ->and($user->dnd_ends_at)->toBe('07:00');
+
+    Event::assertDispatched(UserProfileUpdated::class);
+});
+
+test('enabling requires both window bounds', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->put(route('dnd-schedule.update'), ['enabled' => true])
+        ->assertSessionHasErrors(['starts_at', 'ends_at']);
+});
+
+test('the window bounds must be wall-clock times', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->put(route('dnd-schedule.update'), [
+            'enabled' => true,
+            'starts_at' => '25:99',
+            'ends_at' => 'noon',
+        ])
+        ->assertSessionHasErrors(['starts_at', 'ends_at']);
+});
+
+test('an empty window is rejected', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->put(route('dnd-schedule.update'), [
+            'enabled' => true,
+            'starts_at' => '09:00',
+            'ends_at' => '09:00',
+        ])
+        ->assertSessionHasErrors('ends_at');
+});
+
+test('a guest cannot change the schedule', function (): void {
+    $this->put(route('dnd-schedule.update'), ['enabled' => true])
+        ->assertRedirect(route('login'));
+});

--- a/tests/Feature/Dnd/DndScheduleTest.php
+++ b/tests/Feature/Dnd/DndScheduleTest.php
@@ -46,6 +46,28 @@ test('disabling the schedule keeps the stored window for re-enabling', function 
     Event::assertDispatched(UserProfileUpdated::class);
 });
 
+test('a disable carrying bounds cannot clobber the stored window', function (): void {
+    $user = User::factory()->create([
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('dnd-schedule.update'), [
+            'enabled' => false,
+            'starts_at' => '10:00',
+            'ends_at' => '11:00',
+        ])
+        ->assertRedirect();
+
+    $user->refresh();
+
+    expect($user->dnd_schedule_enabled)->toBeFalse()
+        ->and($user->dnd_starts_at)->toBe('22:00')
+        ->and($user->dnd_ends_at)->toBe('07:00');
+});
+
 test('enabling requires both window bounds', function (): void {
     $user = User::factory()->create();
 

--- a/tests/Feature/Dnd/DndSerializationTest.php
+++ b/tests/Feature/Dnd/DndSerializationTest.php
@@ -22,10 +22,12 @@ test('the author payload never leaks the pause instant or the schedule', functio
         'dnd_ends_at' => '07:00',
     ]);
 
-    $payload = UserData::fromUser($user)->toArray();
+    // Scan the whole serialized tree, not just the top-level keys, so a
+    // private field can't hide inside a nested structure.
+    $json = (string) json_encode(UserData::fromUser($user)->toArray());
 
-    expect(array_keys($payload))->not->toContain('dndUntil', 'dndScheduleEnabled', 'dndStartsAt', 'dndEndsAt')
-        ->and(json_encode($payload))->not->toContain('22:00', '07:00');
+    expect($json)->not->toContain('dndUntil', 'dndScheduleEnabled', 'dndStartsAt', 'dndEndsAt', 'scheduleEnabled', 'startsAt', 'endsAt')
+        ->and($json)->not->toContain('22:00', '07:00');
 });
 
 test('a user reads their own full dnd configuration, raw columns hidden', function (): void {

--- a/tests/Feature/Dnd/DndSerializationTest.php
+++ b/tests/Feature/Dnd/DndSerializationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Data\UserData;
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+
+test('the serialized author payload carries the dnd flag', function (): void {
+    $paused = User::factory()->create(['dnd_until' => now()->addHour()]);
+    $free = User::factory()->create();
+
+    expect(UserData::fromUser($paused)->isDnd)->toBeTrue()
+        ->and(UserData::fromUser($free)->isDnd)->toBeFalse();
+});
+
+test('the author payload never leaks the pause instant or the schedule', function (): void {
+    $user = User::factory()->create([
+        'dnd_until' => now()->addHour(),
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $payload = UserData::fromUser($user)->toArray();
+
+    expect(array_keys($payload))->not->toContain('dndUntil', 'dndScheduleEnabled', 'dndStartsAt', 'dndEndsAt')
+        ->and(json_encode($payload))->not->toContain('22:00', '07:00');
+});
+
+test('a user reads their own full dnd configuration, raw columns hidden', function (): void {
+    $until = now()->addHour()->startOfSecond();
+
+    $user = User::factory()->create([
+        'dnd_until' => $until,
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $serialized = $user->toArray();
+
+    expect($serialized['dnd']['until'])->toBe($until->toIso8601String())
+        ->and($serialized['dnd']['scheduleEnabled'])->toBeTrue()
+        ->and($serialized['dnd']['startsAt'])->toBe('22:00')
+        ->and($serialized['dnd']['endsAt'])->toBe('07:00')
+        ->and($serialized)->not->toHaveKeys(['dnd_until', 'dnd_schedule_enabled', 'dnd_starts_at', 'dnd_ends_at']);
+});
+
+test('a lapsed pause reads as absent from the own dnd configuration', function (): void {
+    $user = User::factory()->create(['dnd_until' => now()->subMinute()]);
+
+    expect($user->toArray()['dnd']['until'])->toBeNull();
+});
+
+test('the profile broadcast carries the dnd flag to teammates', function (): void {
+    $user = User::factory()->create(['dnd_until' => now()->addHour()]);
+
+    $payload = (new UserProfileUpdated($user))->broadcastWith();
+
+    expect($payload['user']['isDnd'])->toBeTrue();
+});

--- a/tests/Feature/Dnd/DndSerializationTest.php
+++ b/tests/Feature/Dnd/DndSerializationTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Data\UserData;
+use App\Enums\TeamRole;
 use App\Events\UserProfileUpdated;
+use App\Models\Team;
 use App\Models\User;
 
 test('the serialized author payload carries the dnd flag', function (): void {
@@ -49,6 +51,28 @@ test('a lapsed pause reads as absent from the own dnd configuration', function (
     $user = User::factory()->create(['dnd_until' => now()->subMinute()]);
 
     expect($user->toArray()['dnd']['until'])->toBeNull();
+});
+
+test('the hover card names dnd without exposing when it ends', function (): void {
+    $viewer = User::factory()->create();
+    $member = User::factory()->create([
+        'dnd_until' => now()->addHour(),
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+    $team = Team::factory()->create();
+
+    $team->members()->attach($viewer, ['role' => TeamRole::Member->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $response = $this->actingAs($viewer)
+        ->getJson(route('teams.members.card', [$team, $member]))
+        ->assertOk()
+        ->assertJsonPath('isDnd', true);
+
+    expect($response->json())->not->toHaveKeys(['dndUntil', 'dnd'])
+        ->and($response->content())->not->toContain('22:00', '07:00');
 });
 
 test('the profile broadcast carries the dnd flag to teammates', function (): void {


### PR DESCRIPTION
Closes #379.

## What

Do Not Disturb — child 4b of the Presence & identity epic (#374), built to the `Do Not Disturb.dc.html` design frame:

- **Manual pause** from the presence menu's new "Pause notifications" flyout (30 minutes / 1 hour / Until tomorrow / Custom…). "Until tomorrow" resolves to 9:00 the next morning in the user's timezone; Custom… opens a calendar + time dialog mirroring the status dialog's picker. While paused, the STATUS section leads with a paused card (crescent, "until HH:MM" in italic serif, one-tap Resume pill) and the masthead reads "Notifications paused".
- **Recurring quiet hours** in Settings → Appearance & notifications: toggle + From/to half-hour selects, a crosses-midnight hint, and a 24h strip visualising the quiet segments. Evaluated in the user's own timezone; overnight windows wrap.
- **Chime gate**: `shouldChime` gains a `dndActive` input (suppresses mentions too), evaluated at message-arrival time by a client-side twin (`lib/dnd.ts`) of `User::isDndActive()`.
- **DND indicator**: a crescent badge replaces the presence dot on every dot surface (sidebar chip, DM rows, timeline, masthead, facepiles, hover card) — filled stone over active, hollow ring kept for away, untouched for offline. The hover card names the state ("Notifications paused") without exposing when it ends.
- **Privacy**: teammates only ever receive the `isDnd` boolean (on `UserData`, `UserProfileData`, and the shared `UserProfileUpdated` broadcast); the pause instant and schedule stay on the owner's own `auth.user` prop.
- **Propagation**: two every-minute sweeps — `ClearLapsedDndPauses` (nulls lapsed pauses and broadcasts, mirroring the status sweep) and `BroadcastDndScheduleEdges` (announces a quiet-hours window opening/closing so badges flip live).

## Scope decisions

- "Snooze schedule today" (a design caption for the quiet-hours paused card) is deferred to #739 — it needs a schema addition beyond this issue's locked data model. The quiet-hours card names its window and carries no action.
- The axe `aria-hidden-focus` finding on any *open* dropdown menu is pre-existing shell behaviour, tracked in #730; the new a11y audits run against settled surfaces.

## Testing

- 34 new backend tests (evaluation incl. timezone/overnight/boundary semantics, HTTP pause/resume/schedule, serialization + leak guards, both sweeps) — full gate green at 100% coverage with Pint/PHPStan/Rector clean.
- 25 new Vitest cases (`lib/dnd`, `lib/dndPause`, `shouldChime`, `PresenceDot`, `useTeamPresence`) — 990 passing.
- 4 new browser tests: pause + in-place resume, custom dialog persistence, axe audits of the paused shell (light + dark) and the quiet-hours settings section.
- Verified live against the design frame: flyout, paused card, resume, custom dialog, quiet-hours section incl. the 18:00–09:00 overnight example.

## i18n

All new copy through `$t`/`__()`; French translations added to `lang/fr.json`.

Local CodeRabbit review ran clean (0 findings) after applying its fixes (schedule-disable can no longer clobber stored bounds; custom-pause dialog re-seeds a lapsed instant; deeper serialization leak scans; broader sweep/composable test coverage).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787347994&installation_model_id=428379&pr_number=740&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F740&signature=05dd4a500c18918ef5c1bf59afcd3c692a3873486d7eef56263a344c461d7937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->