### PR TITLE
ci: point dependabot at develop instead of master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    # `develop` is the line every ordinary change goes through; `master` only
+    # takes promotions from it. Without this, dependabot opens against the
+    # repository's default branch — `master` — and the bump ships without ever
+    # being exercised on a release candidate. Note that dependabot reads this
+    # file from the default branch only, so the setting takes effect once this
+    # change has been promoted to `master`, and *security* updates ignore it.
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     # `deps` is our changelog type for dependency bumps: release-please folds it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,32 @@ while `master` does. A back-merge can never satisfy that requirement on `develop
 the only way to bring `master` up to date with `develop` is to merge `develop` into
 `master` — an unsanctioned promotion. Requiring it there deadlocks the back-merge.
 
+### Dependabot follows the same rule, with two exceptions
+
+`.github/dependabot.yml` sets `target-branch: "develop"` on every ecosystem, so a
+routine version bump arrives on the candidate line like any other change and is
+exercised on an rc before it ships. `tests/Unit/ReleaseFlowTest.php` asserts that
+over every entry, so a second ecosystem cannot be added without the redirect —
+along with the `deps` commit prefix, which is what makes Dependabot's subjects
+parse as Conventional Commits for commitlint and the `pr-title` check.
+
+Two things that setting does *not* do, both worth knowing before you go looking
+for a bug that is not there:
+
+- **Dependabot reads `.github/dependabot.yml` from the default branch only** —
+  `master`. Editing it on `develop` changes nothing until that change has been
+  promoted; until then Dependabot keeps behaving exactly as it did, with nothing
+  to signal that the setting is inert. If Dependabot PRs are still arriving on
+  `master`, check whether the config has actually reached `master` before
+  changing it again.
+- **Security updates ignore `target-branch` entirely** and always open against
+  the default branch. Alert-driven PRs will keep arriving on `master`, which is
+  arguably where a security fix belongs anyway — but that leaves `master` ahead
+  of `develop`, so one has to be merged back the same way a hotfix is (see
+  [Hotfixes](#hotfixes-releasing-when-develop-is-not-releasable), step 4). Only
+  a stable release opens that back-merge for you; a security PR merged on its
+  own does not, so raise it by hand.
+
 ### Why the two lines cannot contaminate each other
 
 release-please reads its config *and* its version manifest from the branch it

--- a/tests/Unit/ReleaseFlowTest.php
+++ b/tests/Unit/ReleaseFlowTest.php
@@ -1344,3 +1344,49 @@ test('the guard talks to GitHub with the release token', function (): void {
 
     expect($steps[0]['env']['GH_TOKEN'])->toBe('${{ secrets.RELEASE_PLEASE_TOKEN }}');
 });
+
+/**
+ * The per-ecosystem `updates` entries of the Dependabot configuration.
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function dependabotUpdates(): array
+{
+    /** @var array<string, mixed> $config */
+    $config = Yaml::parseFile(repositoryPath('.github/dependabot.yml'));
+
+    expect($config)->toHaveKey('updates');
+
+    /** @var array<int, array<string, mixed>> $updates */
+    $updates = $config['updates'];
+
+    expect($updates)->not->toBeEmpty();
+
+    return $updates;
+}
+
+/*
+ * Dependabot opens against the repository's default branch unless an entry says
+ * otherwise, and that default is `master` — the stable line. A bump landing
+ * there is never exercised on a candidate, and leaves `develop` behind until the
+ * next back-merge carries it across: the same "PR against master bypasses the
+ * candidate line, and nothing errors to tell you" failure every other change is
+ * routed away from. Asserted over *every* entry rather than the one that exists
+ * today, so a second ecosystem cannot be added without the redirect.
+ */
+test('every dependabot ecosystem targets the candidate line', function (): void {
+    expect(collect(dependabotUpdates())->pluck('target-branch')->all())
+        ->each->toBe('develop');
+});
+
+/*
+ * `target-branch` moves where the PR lands, not what it is called, and the
+ * subject still has to satisfy commitlint and the `pr-title` check on develop.
+ * Dependabot's own default subjects are not Conventional Commits, so the prefix
+ * is what makes them parse — and `deps` is the type release-please folds into
+ * the Dependencies section without bumping a version on its own.
+ */
+test('every dependabot ecosystem commits under the deps type', function (): void {
+    expect(collect(dependabotUpdates())->pluck('commit-message.prefix')->all())
+        ->each->toBe('deps');
+});


### PR DESCRIPTION
Closes #737.

## What

`.github/dependabot.yml` now sets `target-branch: "develop"` on its `github-actions` entry, so routine version bumps arrive on the candidate line instead of the repository's default branch.

## Why

Dependabot opens against the default branch (`master`) unless an entry says otherwise. `master` is the stable line, so a bump merged there is exactly the "PR opened against master bypasses the candidate line, and nothing errors to tell you" failure mode `CONTRIBUTING.md` routes every other change away from: the bump never gets exercised on an RC, and `develop` sits behind `master` until the next back-merge.

## How tested

`tests/Unit/ReleaseFlowTest.php` gains two guards, asserted over **every** `updates` entry rather than the one that exists today, so a future ecosystem cannot be added without the redirect:

- every entry carries `target-branch: develop`
- every entry keeps `commit-message.prefix: deps`, which is what makes Dependabot's subjects parse as Conventional Commits for commitlint and the `pr-title` check

Full gate green: `composer test` (Pint + PHPStan + Rector + suite at `Total: 100.0 %`) and `npm run lint:check` (0 errors). No frontend files are touched, so `format:check` / `types:check` / `build` are unaffected. A local CodeRabbit pass against `develop` returned 0 findings.

## Docs

`CONTRIBUTING.md` → *Releases* gains a subsection recording the two caveats, so the next person does not "fix" a misrouted Dependabot PR by editing the config on `develop` and wondering why nothing changes:

- Dependabot reads `.github/dependabot.yml` from the **default branch only**, so this setting is inert until the change is promoted to `master`.
- Dependabot **security** updates ignore `target-branch` and always open against the default branch. Those still land on `master` and need a back-merge, the same as a hotfix.

No i18n changes (no user-facing copy) and no `docs/` changes (contributor-facing, not operator-facing).

## Note on acceptance criterion 2

The issue's second criterion — "the change is present on `master`" — is deliberately **not** met by this PR. Per your call, this takes the normal line: it lands on `develop` and becomes live at the next `develop` -> `master` promotion. Until then Dependabot keeps opening against `master`, which is expected rather than a regression, and is exactly what the new `CONTRIBUTING.md` note describes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787348223&installation_model_id=428379&pr_number=742&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F742&signature=e7ebf1e1c87727e782b277cb19fe7243cf5e4537dc7f4542a048b9915607402d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->