### PR TITLE
ci: stop bot-appended PR-body footers from blocking release merges

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -19,6 +19,16 @@ export default {
                 'test',
             ],
         ],
+        // Every commit that reaches `develop` or `master` is a squash commit, so GitHub composes
+        // its body from the PR description — which review bots (Codesmith, CodeRabbit) and
+        // release-please edit, appending footers built from unwrappable `<a href>` and image URLs.
+        // Those bodies are unfixable by the time a promotion or backmerge PR lints them, so an
+        // error here blocks the release flow on markup nobody wrote (PR #741). commitlint 21 fixed
+        // this upstream by exempting lines with nothing to wrap on, but the action we pin still
+        // ships 19 — keep the limit as a warning until it catches up. The rules that guard
+        // release-please (type, subject case, header length) stay errors.
+        'body-max-line-length': [1, 'always', 100],
+        'footer-max-line-length': [1, 'always', 100],
     },
     // Dependabot generates verbose commit bodies whose lines exceed body-max-line-length.
     // Skip its bot commits (identified by their sign-off trailer); the PR title we squash-merge

--- a/tests/Unit/CommitlintLineLengthTest.php
+++ b/tests/Unit/CommitlintLineLengthTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Every commit that lands on `develop` or `master` is a squash commit, so GitHub builds its body
+ * from the PR description — which release-please writes and review bots edit, appending footers made
+ * of unwrappable `<a href>` and image URLs. `commitlint` then re-reads those commits on the backmerge
+ * and promotion PRs, where the message can no longer be changed, so an over-length body line becomes
+ * an unfixable merge blocker on the release flow (PR #741). These tests pin the two length rules to
+ * warnings, and pin the workflow to not promote warnings back into failures.
+ */
+function commitlintConfigSource(): string
+{
+    return (string) file_get_contents(dirname(__DIR__, 2).'/commitlint.config.mjs');
+}
+
+/**
+ * The `with:` inputs of the step running the commitlint action.
+ *
+ * @return array<string, mixed>
+ */
+function commitlintStepInputs(): array
+{
+    $workflow = Yaml::parse((string) file_get_contents(dirname(__DIR__, 2).'/.github/workflows/commitlint.yml'));
+
+    foreach ($workflow['jobs']['commitlint']['steps'] as $step) {
+        if (str_starts_with((string) ($step['uses'] ?? ''), 'wagoid/commitlint-github-action@')) {
+            return $step['with'] ?? [];
+        }
+    }
+
+    return [];
+}
+
+test('the body and footer length limits are warnings, not merge blockers', function (string $rule): void {
+    expect(commitlintConfigSource())->toMatch("/'{$rule}':\s*\[\s*1\s*,/");
+})->with(['body-max-line-length', 'footer-max-line-length']);
+
+test('the commitlint workflow does not fail on warnings', function (): void {
+    expect(commitlintStepInputs())->not->toHaveKey('failOnWarnings');
+});
+
+test('the commitlint workflow uses our config file', function (): void {
+    expect(commitlintStepInputs()['configFile'] ?? null)->toBe('commitlint.config.mjs');
+});


### PR DESCRIPTION
## Problem

The `commitlint` check on #741 (the automated `master` -> `develop` backmerge after 1.15.2) fails with:

```
✖ footer's lines must not be longer than 100 characters [footer-max-line-length]
```

`commitlint` is a required check in the "Protect develop" ruleset, so the backmerge is `BLOCKED` and its queued auto-merge cannot fire.

The offending commit is `440ab4c chore(master): release 1.15.2 (#738)`. Its subject is fine; its **body** is the problem. GitHub's squash merge copies the PR description into the commit message, and Codesmith now appends a footer to every PR body. Three of those lines are unwrappable `<a href>` and image URLs well past 100 characters.

This is not confined to release commits. Every recent squash commit on `develop` carries the same footer:

| commit | codesmith footer | lines > 100 | commitlint 19 |
| --- | --- | --- | --- |
| `811469d` feat: pause notifications... | yes | 3 | FAIL |
| `f926a93` feat: away and idle presence | yes | 3 | FAIL |
| `123da54` fix: start redis before... | yes | 3 | FAIL |
| `814d692` chore(master): release 1.15.1 | no | 0 | pass |

So the next `develop` -> `master` promotion PR, which lints every one of those commits, would have failed too. By the time a backmerge or promotion PR runs, the commit is already on the branch and the message cannot be edited, so the failure is unfixable in place.

## Fix

Demote `body-max-line-length` and `footer-max-line-length` from errors to warnings. This is what commitlint fixed upstream in v21 (it exempts lines with nothing to wrap on), but `wagoid/commitlint-github-action@v6.2.1` is the latest release and still ships commitlint 19. The workflow does not set `failOnWarnings`, so warnings are reported without blocking.

The rules release-please depends on stay errors.

## Verification

Reproduced and verified against `@commitlint/cli@19.8.1`, the version the pinned action runs.

Now pass, having failed before:

- all 12 commits in #741's range, including `chore(master): release 1.15.2`
- the last 10 commits on `develop`

Still blocked, confirming the guardrails are intact:

- sentence-case subject (`Add a thing`)
- trailing full stop (`feat: add a thing.`)
- non-conventional type (`wip: ...`)
- no type at all
- empty subject (`feat:`)
- header over 100 characters

`tests/Unit/CommitlintLineLengthTest.php` pins both rules to warning level and asserts the workflow never sets `failOnWarnings`, so a future edit cannot silently re-block the release flow.

`composer test` reports `Total: 100.0 %` with a clean Rector dry-run.

## Follow-up

Once merged, the failed `commitlint` job on #741 needs a re-run: the action reads the config from the PR's merge ref, which picks this up as soon as `develop` moves.

Separately, this makes the symptom harmless but Codesmith will keep injecting that footer into every commit body on `master`. Worth considering turning it off at the source in the Blacksmith app settings.

Refs #741

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787348921&installation_model_id=428379&pr_number=746&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F746&signature=51b3bf558d41f15d6f53435a0d716ff125ad124db4447c20c82954c77cd21031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->