### PR TITLE
feat: snooze the quiet-hours schedule for today from the paused card

### DIFF
--- a/app/Actions/Users/ClearLapsedDndScheduleSnoozes.php
+++ b/app/Actions/Users/ClearLapsedDndScheduleSnoozes.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Users;
+
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+
+class ClearLapsedDndScheduleSnoozes
+{
+    /**
+     * Null out every quiet-hours snooze whose instant has passed, and
+     * broadcast each clear so teammates' open clients repaint without a
+     * reload.
+     *
+     * This is the eager half of expiry, mirroring {@see ClearLapsedDndPauses}
+     * for the manual pause. Reads already treat a lapsed snooze as over (see
+     * {@see User::isDndActive()}); this sweep is what makes the lapse
+     * *propagate* — and keeps the column from holding a stale instant the next
+     * snooze would have to overwrite blind.
+     *
+     * The cursor can hand back a user who has since snoozed *afresh*, so each
+     * clear is conditional on the instant still being the lapsed one this pass
+     * read. A snooze replaced in that window is left alone — and neither
+     * counted nor broadcast — rather than being wiped moments after the user
+     * set it.
+     *
+     * @return int the number of snoozes cleared
+     */
+    public function handle(): int
+    {
+        $cleared = 0;
+
+        User::query()
+            ->whereNotNull('dnd_schedule_snoozed_until')
+            ->where('dnd_schedule_snoozed_until', '<=', now())
+            ->cursor()
+            ->each(function (User $user) use (&$cleared): void {
+                $updated = User::query()
+                    ->whereKey($user->getKey())
+                    ->where('dnd_schedule_snoozed_until', $user->dnd_schedule_snoozed_until)
+                    ->update(['dnd_schedule_snoozed_until' => null]);
+
+                if ($updated === 0) {
+                    return;
+                }
+
+                event(new UserProfileUpdated($user->refresh()));
+
+                $cleared++;
+            });
+
+        return $cleared;
+    }
+}

--- a/app/Data/UserDndData.php
+++ b/app/Data/UserDndData.php
@@ -25,11 +25,14 @@ class UserDndData extends Data
         /** Daily window bounds as `HH:MM` wall-clock strings in the user's own timezone. */
         public ?string $startsAt,
         public ?string $endsAt,
+        /** ISO-8601 instant a schedule snooze lapses, or null when none is running. */
+        public ?string $scheduleSnoozedUntil,
     ) {}
 
     /**
-     * Build the DTO from a user's columns. A lapsed pause reads as absent
-     * immediately, without waiting for the scheduled sweep to null the column.
+     * Build the DTO from a user's columns. A lapsed pause or snooze reads as
+     * absent immediately, without waiting for the scheduled sweep to null the
+     * column.
      */
     public static function forUser(User $user): self
     {
@@ -40,6 +43,7 @@ class UserDndData extends Data
             scheduleEnabled: $user->dnd_schedule_enabled ?? false,
             startsAt: $user->dnd_starts_at,
             endsAt: $user->dnd_ends_at,
+            scheduleSnoozedUntil: $user->dnd_schedule_snoozed_until?->isFuture() ? $user->dnd_schedule_snoozed_until->toIso8601String() : null,
         );
     }
 }

--- a/app/Http/Controllers/Settings/DndScheduleSnoozeController.php
+++ b/app/Http/Controllers/Settings/DndScheduleSnoozeController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Events\UserProfileUpdated;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class DndScheduleSnoozeController extends Controller
+{
+    /**
+     * Snooze the quiet-hours schedule until the running window next closes.
+     *
+     * The lapse instant is the server's own computation from the stored bounds
+     * — the client sends nothing — so the snooze can never outlive tonight's
+     * window: once it passes the schedule resumes on its own, with no
+     * re-enable step. Outside the window there is nothing to suppress, so the
+     * request changes nothing and announces nothing. The broadcast tells
+     * teammates' open clients to drop the DND badge without a reload.
+     */
+    public function update(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        $closesAt = $user->dndScheduleClosesAt();
+
+        if ($closesAt === null) {
+            return back();
+        }
+
+        $user->forceFill(['dnd_schedule_snoozed_until' => $closesAt])->save();
+
+        event(new UserProfileUpdated($user));
+
+        return back();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,6 +17,7 @@ use App\Observers\UserObserver;
 use App\Support\Gravatar;
 use App\Support\Images\ImageProxy;
 use App\Support\PresenceRegistry;
+use Carbon\CarbonInterface;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Translation\HasLocalePreference;
@@ -75,6 +76,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property bool $dnd_schedule_enabled
  * @property string|null $dnd_starts_at
  * @property string|null $dnd_ends_at
+ * @property Carbon|null $dnd_schedule_snoozed_until
  * @property Carbon|null $onboarding_completed_at
  * @property bool $is_tombstone
  * @property Carbon|null $deactivated_at
@@ -98,7 +100,7 @@ use Laravel\Sanctum\HasApiTokens;
  */
 #[Appends(['avatar', 'status', 'presence', 'dnd'])]
 #[Fillable(['name', 'email', 'avatar_url', 'pronouns', 'title', 'phone', 'timezone', 'locale', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'sidebar_position', 'presence_state', 'onboarding_completed_at', 'collapsed_channel_sections', 'is_tombstone'])]
-#[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token', 'avatar_url', 'avatar_path', 'status_emoji', 'status_text', 'status_expires_at', 'dnd_until', 'dnd_schedule_enabled', 'dnd_starts_at', 'dnd_ends_at'])]
+#[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token', 'avatar_url', 'avatar_path', 'status_emoji', 'status_text', 'status_expires_at', 'dnd_until', 'dnd_schedule_enabled', 'dnd_starts_at', 'dnd_ends_at', 'dnd_schedule_snoozed_until'])]
 #[ObservedBy(UserObserver::class)]
 class User extends Authenticatable implements HasLocalePreference, MustVerifyEmail, PasskeyUser
 {
@@ -185,10 +187,17 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
      * timezone, so the window follows them when they travel. Start is
      * inclusive and end exclusive, and a window whose end precedes its start
      * wraps across midnight (22:00–07:00 covers the night, not an empty set).
+     * A snooze still ahead of its lapse suppresses the window outright — it is
+     * set to the instant the running window next closes, so the schedule
+     * resumes on its own without a re-enable step.
      */
     private function isInsideDndScheduleWindow(): bool
     {
         if (! $this->dnd_schedule_enabled || $this->dnd_starts_at === null || $this->dnd_ends_at === null) {
+            return false;
+        }
+
+        if ($this->dnd_schedule_snoozed_until?->isFuture()) {
             return false;
         }
 
@@ -199,6 +208,36 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
         }
 
         return $now >= $this->dnd_starts_at || $now < $this->dnd_ends_at;
+    }
+
+    /**
+     * The instant the quiet-hours window covering this moment next closes, or
+     * null when no window covers it.
+     *
+     * This is what a snooze suppresses the schedule until: an overnight window
+     * entered before midnight closes tomorrow morning, its morning tail closes
+     * today. Null outside the window (or while already snoozed) so a stale
+     * request can never suppress a window that has not opened. Computed on the
+     * user's own wall clock but returned in the app timezone, because Eloquent
+     * persists a datetime's wall-clock reading without converting it first.
+     */
+    public function dndScheduleClosesAt(): ?CarbonInterface
+    {
+        if (! $this->isInsideDndScheduleWindow()) {
+            return null;
+        }
+
+        $now = now($this->timezone ?? config('app.timezone'));
+
+        $closes = $now->setTimeFromTimeString((string) $this->dnd_ends_at);
+
+        // Inside the window the end is always ahead on the wall clock; an end
+        // reading behind now means tonight's window closes tomorrow morning.
+        if ($closes->lessThanOrEqualTo($now)) {
+            $closes = $closes->addDay();
+        }
+
+        return $closes->setTimezone(config('app.timezone'));
     }
 
     /**
@@ -295,6 +334,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
             'presence_state' => PresenceState::class,
             'dnd_until' => 'datetime',
             'dnd_schedule_enabled' => 'boolean',
+            'dnd_schedule_snoozed_until' => 'datetime',
             'onboarding_completed_at' => 'datetime',
             'status_expires_at' => 'datetime',
             'is_tombstone' => 'boolean',

--- a/database/migrations/2026_07_22_221425_add_dnd_schedule_snooze_to_users_table.php
+++ b/database/migrations/2026_07_22_221425_add_dnd_schedule_snooze_to_users_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            // A one-day snooze of the quiet-hours schedule: while this instant
+            // is ahead the evaluator ignores the recurring window, then the
+            // schedule resumes on its own. Set to the instant the running
+            // window next closes, so it can never outlive tonight's window.
+            $table->timestamp('dnd_schedule_snoozed_until')->nullable()->after('dnd_ends_at');
+
+            // The scheduled sweep scans for lapsed snoozes every minute.
+            $table->index('dnd_schedule_snoozed_until');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropIndex(['dnd_schedule_snoozed_until']);
+            $table->dropColumn('dnd_schedule_snoozed_until');
+        });
+    }
+};

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1229,5 +1229,7 @@
   "From": "De",
   "to": "à",
   "crosses midnight — ends tomorrow morning": "passe minuit — se termine demain matin",
-  "Could not update your quiet hours.": "Impossible de mettre à jour vos heures calmes."
+  "Could not update your quiet hours.": "Impossible de mettre à jour vos heures calmes.",
+  "Snooze schedule today": "Suspendre l'horaire aujourd'hui",
+  "Could not snooze your quiet hours.": "Impossible de suspendre vos heures calmes."
 }

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -20,6 +20,7 @@ import {
     destroy as destroyDndPause,
     update as updateDndPause,
 } from '@/actions/App/Http/Controllers/Settings/DndController';
+import { update as snoozeDndSchedule } from '@/actions/App/Http/Controllers/Settings/DndScheduleSnoozeController';
 import { update as updatePresence } from '@/actions/App/Http/Controllers/Settings/PresenceController';
 import { destroy as destroyStatus } from '@/actions/App/Http/Controllers/Settings/StatusController';
 import MenuSegmentedControl from '@/components/MenuSegmentedControl.vue';
@@ -247,6 +248,25 @@ function resumeNotifications(event: Event): void {
     });
 }
 
+/**
+ * Lift tonight's quiet-hours window from the card's snooze pill, without
+ * disabling the standing schedule — the server suppresses the window until it
+ * next closes, then the schedule resumes on its own. Kept in place (no menu
+ * dismissal) so the card collapses back to the plain rows.
+ */
+function snoozeSchedule(event: Event): void {
+    event.preventDefault();
+
+    router.put(
+        snoozeDndSchedule().url,
+        {},
+        {
+            preserveScroll: true,
+            onError: () => toast.error(t('Could not snooze your quiet hours.')),
+        },
+    );
+}
+
 const handleLogout = () => {
     router.flushAll();
 };
@@ -350,9 +370,9 @@ const handleLogout = () => {
             >{{ $t('Status') }}</DropdownMenuLabel
         >
         <!-- While in DND the section leads with the paused card: crescent,
-             when it lifts in italic serif, and — for a manual pause — the
-             one-tap Resume pill. Quiet hours name their window instead; ending
-             those early is a schedule edit, not a tap (see the flyout link). -->
+             when it lifts in italic serif, and a one-tap pill — Resume for a
+             manual pause, Snooze for quiet hours (lifts tonight's window and
+             lets the standing schedule resume on its own). -->
         <div
             v-if="isDnd"
             data-test="dnd-paused-card"
@@ -395,6 +415,22 @@ const handleLogout = () => {
                     class="inline-flex h-6.5 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
                 >
                     {{ $t('Resume') }}
+                </Button>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+                v-else-if="quietHoursUntil"
+                :as-child="true"
+                class="shrink-0 rounded-full p-0 focus:bg-transparent"
+                data-test="dnd-snooze-menu-item"
+                @select="snoozeSchedule"
+            >
+                <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    class="inline-flex h-6.5 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
+                >
+                    {{ $t('Snooze schedule today') }}
                 </Button>
             </DropdownMenuItem>
         </div>

--- a/resources/js/lib/dnd.test.ts
+++ b/resources/js/lib/dnd.test.ts
@@ -14,6 +14,7 @@ function dnd(
         scheduleEnabled: false,
         startsAt: null,
         endsAt: null,
+        scheduleSnoozedUntil: null,
         ...overrides,
     };
 }
@@ -54,6 +55,46 @@ describe('isDndActiveNow', () => {
         expect(
             isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T18:30:00Z')),
         ).toBe(false);
+    });
+
+    it('is inactive inside a window while a snooze is still ahead', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+            scheduleSnoozedUntil: '2026-07-22T17:00:00Z',
+        });
+
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-22T12:00:00Z')),
+        ).toBe(false);
+    });
+
+    it('honours the window again once the snooze lapses', () => {
+        const schedule = dnd({
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+            scheduleSnoozedUntil: '2026-07-22T17:00:00Z',
+        });
+
+        expect(
+            isDndActiveNow(schedule, 'UTC', new Date('2026-07-23T12:00:00Z')),
+        ).toBe(true);
+    });
+
+    it('never mutes a manual pause with a snooze', () => {
+        const paused = dnd({
+            until: '2026-07-22T14:00:00Z',
+            scheduleEnabled: true,
+            startsAt: '09:00',
+            endsAt: '17:00',
+            scheduleSnoozedUntil: '2026-07-22T17:00:00Z',
+        });
+
+        expect(
+            isDndActiveNow(paused, 'UTC', new Date('2026-07-22T12:00:00Z')),
+        ).toBe(true);
     });
 
     it('starts the window inclusive and ends it exclusive', () => {

--- a/resources/js/lib/dnd.ts
+++ b/resources/js/lib/dnd.ts
@@ -10,8 +10,8 @@ import type { WallTime } from './scheduleTime';
  * time — a pause that lapsed two minutes ago, or a quiet-hours window that
  * opened one minute ago, must take effect without waiting for a server
  * round-trip. Keep the semantics in lockstep with the server: start inclusive,
- * end exclusive, and a window whose end precedes its start wraps across
- * midnight.
+ * end exclusive, a window whose end precedes its start wraps across midnight,
+ * and a snooze still ahead of its lapse suppresses the window outright.
  */
 export function isDndActiveNow(
     dnd: App.Data.UserDndData | null | undefined,
@@ -27,6 +27,13 @@ export function isDndActiveNow(
     }
 
     if (!dnd.scheduleEnabled || dnd.startsAt === null || dnd.endsAt === null) {
+        return false;
+    }
+
+    if (
+        dnd.scheduleSnoozedUntil !== null &&
+        new Date(dnd.scheduleSnoozedUntil) > at
+    ) {
         return false;
     }
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,6 +10,7 @@ use App\Actions\Teams\PurgeExpiredAuditExports;
 use App\Actions\Users\BroadcastDndScheduleEdges;
 use App\Actions\Users\ClearExpiredUserStatuses;
 use App\Actions\Users\ClearLapsedDndPauses;
+use App\Actions\Users\ClearLapsedDndScheduleSnoozes;
 use App\Models\TeamInvitation;
 use Illuminate\Support\Facades\Schedule;
 
@@ -43,6 +44,12 @@ Schedule::call(fn (ClearLapsedDndPauses $clear): int => $clear->handle())
     ->everyMinute()
     ->withoutOverlapping()
     ->description('Clear lapsed do-not-disturb pauses');
+
+Schedule::call(fn (ClearLapsedDndScheduleSnoozes $clear): int => $clear->handle())
+    ->name('clear-lapsed-dnd-schedule-snoozes')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->description('Clear lapsed quiet-hours snoozes');
 
 Schedule::call(fn (BroadcastDndScheduleEdges $broadcast): int => $broadcast->handle())
     ->name('broadcast-dnd-schedule-edges')

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Settings\AvatarController;
 use App\Http\Controllers\Settings\DataExportController;
 use App\Http\Controllers\Settings\DndController;
 use App\Http\Controllers\Settings\DndScheduleController;
+use App\Http\Controllers\Settings\DndScheduleSnoozeController;
 use App\Http\Controllers\Settings\LocaleController;
 use App\Http\Controllers\Settings\NotificationController;
 use App\Http\Controllers\Settings\PersonalAccessTokenController;
@@ -62,6 +63,7 @@ Route::middleware(['auth'])->group(function (): void {
     Route::put('settings/dnd', [DndController::class, 'update'])->name('dnd.update');
     Route::delete('settings/dnd', [DndController::class, 'destroy'])->name('dnd.destroy');
     Route::put('settings/dnd-schedule', [DndScheduleController::class, 'update'])->name('dnd-schedule.update');
+    Route::put('settings/dnd-schedule/snooze', [DndScheduleSnoozeController::class, 'update'])->name('dnd-schedule.snooze');
 
     Route::patch('settings/timezone', [TimezoneController::class, 'update'])->name('timezone.update');
 

--- a/tests/Browser/DoNotDisturbTest.php
+++ b/tests/Browser/DoNotDisturbTest.php
@@ -35,13 +35,16 @@ test('a user pauses notifications from the presence menu and resumes in place', 
 test('a user snoozes the quiet-hours schedule for today from the paused card', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 
-    // A window covering the whole day, so the card is showing whenever the
-    // suite happens to run.
+    // A window straddling this very minute, so the card is showing whenever
+    // the suite happens to run — near midnight the bounds wrap, which the
+    // evaluator treats as an overnight window.
+    $now = now('UTC');
+
     $alice->forceFill([
         'timezone' => 'UTC',
         'dnd_schedule_enabled' => true,
-        'dnd_starts_at' => '00:00',
-        'dnd_ends_at' => '23:59',
+        'dnd_starts_at' => $now->subMinutes(10)->format('H:i'),
+        'dnd_ends_at' => $now->addMinutes(10)->format('H:i'),
     ])->save();
 
     $page = signInThroughBrowser($alice)

--- a/tests/Browser/DoNotDisturbTest.php
+++ b/tests/Browser/DoNotDisturbTest.php
@@ -32,6 +32,37 @@ test('a user pauses notifications from the presence menu and resumes in place', 
         ->and($alice->isDndActive())->toBeFalse();
 });
 
+test('a user snoozes the quiet-hours schedule for today from the paused card', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // A window covering the whole day, so the card is showing whenever the
+    // suite happens to run.
+    $alice->forceFill([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '00:00',
+        'dnd_ends_at' => '23:59',
+    ])->save();
+
+    $page = signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@dnd-paused-card')
+        ->assertSee('quiet hours')
+        // No manual pause runs, so the card offers the snooze pill in place of
+        // Resume: one tap lifts tonight's window without touching the schedule.
+        ->assertNotPresent('@dnd-resume-menu-item')
+        ->click('@dnd-snooze-menu-item')
+        ->wait(0.5)
+        ->assertNotPresent('@dnd-paused-card')
+        ->assertPresent('@pause-notifications-menu-item');
+
+    $alice->refresh();
+
+    expect($alice->dnd_schedule_snoozed_until)->not->toBeNull()
+        ->and($alice->isDndActive())->toBeFalse()
+        ->and($alice->dnd_schedule_enabled)->toBeTrue();
+});
+
 test('the custom pause dialog stores the picked instant', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 

--- a/tests/Feature/Console/ClearLapsedDndScheduleSnoozesTest.php
+++ b/tests/Feature/Console/ClearLapsedDndScheduleSnoozesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Actions\Users\ClearLapsedDndScheduleSnoozes;
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Event;
+
+test('a lapsed snooze is cleared and the clear is broadcast', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $user = User::factory()->create(['dnd_schedule_snoozed_until' => now()->subMinute()]);
+
+    expect(app(ClearLapsedDndScheduleSnoozes::class)->handle())->toBe(1);
+
+    expect($user->refresh()->dnd_schedule_snoozed_until)->toBeNull();
+
+    Event::assertDispatched(
+        UserProfileUpdated::class,
+        fn (UserProfileUpdated $event): bool => $event->user->is($user),
+    );
+});
+
+test('a snooze still ahead of its lapse is left alone', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $user = User::factory()->create(['dnd_schedule_snoozed_until' => now()->addMinutes(30)]);
+
+    expect(app(ClearLapsedDndScheduleSnoozes::class)->handle())->toBe(0);
+    expect($user->refresh()->dnd_schedule_snoozed_until)->not->toBeNull();
+
+    Event::assertNotDispatched(UserProfileUpdated::class);
+});
+
+test('a user with no snooze is never touched', function (): void {
+    User::factory()->create();
+
+    expect(app(ClearLapsedDndScheduleSnoozes::class)->handle())->toBe(0);
+});
+
+test('the sweep clears every lapsed snooze in one pass', function (): void {
+    User::factory()->count(3)->create(['dnd_schedule_snoozed_until' => now()->subHour()]);
+
+    expect(app(ClearLapsedDndScheduleSnoozes::class)->handle())->toBe(3);
+    expect(User::query()->whereNotNull('dnd_schedule_snoozed_until')->count())->toBe(0);
+});
+
+test('a snooze replaced mid-sweep is left alone', function (): void {
+    User::factory()->count(2)->create(['dnd_schedule_snoozed_until' => now()->subMinute()]);
+
+    // Stand in for someone snoozing afresh in the window between the sweep's
+    // query and its write. The first clear the sweep performs is the trigger,
+    // so whichever user it reaches second is mutated behind it — while the
+    // model it already hydrated still carries the lapsed instant.
+    Event::listen(UserProfileUpdated::class, function () use (&$replaced): void {
+        if ($replaced ?? false) {
+            return;
+        }
+
+        $replaced = true;
+
+        User::query()
+            ->whereNotNull('dnd_schedule_snoozed_until')
+            ->update(['dnd_schedule_snoozed_until' => now()->addHour()]);
+    });
+
+    // Only the first user is cleared; the replaced one is skipped, because its
+    // clear is conditional on the instant the sweep actually read.
+    expect(app(ClearLapsedDndScheduleSnoozes::class)->handle())->toBe(1);
+
+    expect(User::query()->whereNotNull('dnd_schedule_snoozed_until')->sole()->dnd_schedule_snoozed_until->isFuture())->toBeTrue();
+});
+
+test('the sweep is scheduled every minute', function (): void {
+    $events = collect(app(Schedule::class)->events())
+        ->filter(fn ($event): bool => $event->description === 'Clear lapsed quiet-hours snoozes');
+
+    expect($events)->toHaveCount(1)
+        ->and($events->first()->expression)->toBe('* * * * *');
+});

--- a/tests/Feature/Dnd/DndEvaluationTest.php
+++ b/tests/Feature/Dnd/DndEvaluationTest.php
@@ -108,6 +108,49 @@ test('the window is evaluated in the user timezone, not the server one', functio
     });
 });
 
+test('a snoozed quiet-hours window reads as no dnd', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+        'dnd_schedule_snoozed_until' => Carbon::parse('2026-07-22 17:00:00', 'UTC'),
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 12:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeFalse();
+    });
+});
+
+test('a lapsed snooze lets the window read as dnd again', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+        'dnd_schedule_snoozed_until' => Carbon::parse('2026-07-22 17:00:00', 'UTC'),
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-23 12:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeTrue();
+    });
+});
+
+test('a snooze never mutes a manual pause', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_until' => Carbon::parse('2026-07-22 14:00:00', 'UTC'),
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+        'dnd_schedule_snoozed_until' => Carbon::parse('2026-07-22 17:00:00', 'UTC'),
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 12:00:00', 'UTC'), function () use ($user): void {
+        expect($user->isDndActive())->toBeTrue();
+    });
+});
+
 test('a disabled schedule never reads as dnd', function (): void {
     $user = User::factory()->create([
         'timezone' => 'UTC',

--- a/tests/Feature/Dnd/DndScheduleSnoozeTest.php
+++ b/tests/Feature/Dnd/DndScheduleSnoozeTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use App\Events\UserProfileUpdated;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+
+test('snoozing inside a same-day window suppresses it until it closes today', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 12:00:00', 'UTC'), function () use ($user): void {
+        $this->actingAs($user)
+            ->put(route('dnd-schedule.snooze'))
+            ->assertRedirect();
+
+        expect($user->refresh()->dnd_schedule_snoozed_until->equalTo(Carbon::parse('2026-07-22 17:00:00', 'UTC')))->toBeTrue()
+            ->and($user->isDndActive())->toBeFalse();
+    });
+
+    Event::assertDispatched(
+        UserProfileUpdated::class,
+        fn (UserProfileUpdated $event): bool => $event->user->is($user),
+    );
+});
+
+test('snoozing an overnight window before midnight suppresses it until tomorrow morning', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 23:30:00', 'UTC'), function () use ($user): void {
+        $this->actingAs($user)
+            ->put(route('dnd-schedule.snooze'))
+            ->assertRedirect();
+
+        expect($user->refresh()->dnd_schedule_snoozed_until->equalTo(Carbon::parse('2026-07-23 07:00:00', 'UTC')))->toBeTrue();
+    });
+});
+
+test('snoozing an overnight window in its morning tail suppresses it until it closes today', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '22:00',
+        'dnd_ends_at' => '07:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 06:30:00', 'UTC'), function () use ($user): void {
+        $this->actingAs($user)
+            ->put(route('dnd-schedule.snooze'))
+            ->assertRedirect();
+
+        expect($user->refresh()->dnd_schedule_snoozed_until->equalTo(Carbon::parse('2026-07-22 07:00:00', 'UTC')))->toBeTrue();
+    });
+});
+
+test('the snooze lapse is computed in the user timezone, not the server one', function (): void {
+    $user = User::factory()->create([
+        'timezone' => 'America/New_York',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+    ]);
+
+    // 16:00 UTC is 12:00 in New York, inside the window; 17:00 New York wall
+    // clock is 21:00 UTC in July (EDT).
+    $this->travelTo(Carbon::parse('2026-07-22 16:00:00', 'UTC'), function () use ($user): void {
+        $this->actingAs($user)
+            ->put(route('dnd-schedule.snooze'))
+            ->assertRedirect();
+
+        expect($user->refresh()->dnd_schedule_snoozed_until->equalTo(Carbon::parse('2026-07-22 21:00:00', 'UTC')))->toBeTrue();
+    });
+});
+
+test('snoozing outside the window changes nothing and announces nothing', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 18:30:00', 'UTC'), function () use ($user): void {
+        $this->actingAs($user)
+            ->put(route('dnd-schedule.snooze'))
+            ->assertRedirect();
+
+        expect($user->refresh()->dnd_schedule_snoozed_until)->toBeNull();
+    });
+
+    Event::assertNotDispatched(UserProfileUpdated::class);
+});
+
+test('snoozing with the schedule disabled changes nothing', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => false,
+        'dnd_starts_at' => '00:00',
+        'dnd_ends_at' => '23:59',
+    ]);
+
+    $this->actingAs($user)
+        ->put(route('dnd-schedule.snooze'))
+        ->assertRedirect();
+
+    expect($user->refresh()->dnd_schedule_snoozed_until)->toBeNull();
+
+    Event::assertNotDispatched(UserProfileUpdated::class);
+});
+
+test('snoozing leaves the manual pause and the schedule untouched', function (): void {
+    $until = Carbon::parse('2026-07-22 14:00:00', 'UTC');
+
+    $user = User::factory()->create([
+        'timezone' => 'UTC',
+        'dnd_until' => $until,
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '09:00',
+        'dnd_ends_at' => '17:00',
+    ]);
+
+    $this->travelTo(Carbon::parse('2026-07-22 12:00:00', 'UTC'), function () use ($user, $until): void {
+        $this->actingAs($user)->put(route('dnd-schedule.snooze'))->assertRedirect();
+
+        $user->refresh();
+
+        expect($user->dnd_until->equalTo($until))->toBeTrue()
+            ->and($user->dnd_schedule_enabled)->toBeTrue()
+            ->and($user->dnd_starts_at)->toBe('09:00')
+            ->and($user->dnd_ends_at)->toBe('17:00')
+            ->and($user->isDndActive())->toBeTrue();
+    });
+});
+
+test('a guest cannot snooze the schedule', function (): void {
+    $this->put(route('dnd-schedule.snooze'))
+        ->assertRedirect(route('login'));
+});

--- a/tests/Feature/Dnd/DndSerializationTest.php
+++ b/tests/Feature/Dnd/DndSerializationTest.php
@@ -20,24 +20,27 @@ test('the author payload never leaks the pause instant or the schedule', functio
         'dnd_schedule_enabled' => true,
         'dnd_starts_at' => '22:00',
         'dnd_ends_at' => '07:00',
+        'dnd_schedule_snoozed_until' => now()->addHours(2),
     ]);
 
     // Scan the whole serialized tree, not just the top-level keys, so a
     // private field can't hide inside a nested structure.
     $json = (string) json_encode(UserData::fromUser($user)->toArray());
 
-    expect($json)->not->toContain('dndUntil', 'dndScheduleEnabled', 'dndStartsAt', 'dndEndsAt', 'scheduleEnabled', 'startsAt', 'endsAt')
+    expect($json)->not->toContain('dndUntil', 'dndScheduleEnabled', 'dndStartsAt', 'dndEndsAt', 'scheduleEnabled', 'startsAt', 'endsAt', 'snoozed', 'Snoozed')
         ->and($json)->not->toContain('22:00', '07:00');
 });
 
 test('a user reads their own full dnd configuration, raw columns hidden', function (): void {
     $until = now()->addHour()->startOfSecond();
+    $snoozedUntil = now()->addHours(2)->startOfSecond();
 
     $user = User::factory()->create([
         'dnd_until' => $until,
         'dnd_schedule_enabled' => true,
         'dnd_starts_at' => '22:00',
         'dnd_ends_at' => '07:00',
+        'dnd_schedule_snoozed_until' => $snoozedUntil,
     ]);
 
     $serialized = $user->toArray();
@@ -46,13 +49,20 @@ test('a user reads their own full dnd configuration, raw columns hidden', functi
         ->and($serialized['dnd']['scheduleEnabled'])->toBeTrue()
         ->and($serialized['dnd']['startsAt'])->toBe('22:00')
         ->and($serialized['dnd']['endsAt'])->toBe('07:00')
-        ->and($serialized)->not->toHaveKeys(['dnd_until', 'dnd_schedule_enabled', 'dnd_starts_at', 'dnd_ends_at']);
+        ->and($serialized['dnd']['scheduleSnoozedUntil'])->toBe($snoozedUntil->toIso8601String())
+        ->and($serialized)->not->toHaveKeys(['dnd_until', 'dnd_schedule_enabled', 'dnd_starts_at', 'dnd_ends_at', 'dnd_schedule_snoozed_until']);
 });
 
 test('a lapsed pause reads as absent from the own dnd configuration', function (): void {
     $user = User::factory()->create(['dnd_until' => now()->subMinute()]);
 
     expect($user->toArray()['dnd']['until'])->toBeNull();
+});
+
+test('a lapsed snooze reads as absent from the own dnd configuration', function (): void {
+    $user = User::factory()->create(['dnd_schedule_snoozed_until' => now()->subMinute()]);
+
+    expect($user->toArray()['dnd']['scheduleSnoozedUntil'])->toBeNull();
 });
 
 test('the hover card names dnd without exposing when it ends', function (): void {


### PR DESCRIPTION
Closes #739.

## What

While DND comes from the quiet-hours window alone (no manual pause), the presence menu's paused card now offers **"Snooze schedule today"** in place of the Resume pill — one tap lifts tonight's window without disabling the standing schedule, exactly as the #379 design frame (§1c) specifies.

## How

- New `dnd_schedule_snoozed_until` timestamp on `users`. `PUT settings/dnd-schedule/snooze` computes the instant the running window next closes **server-side** (`User::dndScheduleClosesAt()`, evaluated on the user's own wall clock — an overnight window entered before midnight closes tomorrow morning) and stores it; outside the window the request is a no-op, so a stale tap can never suppress a window that hasn't opened.
- `User::isDndActive()` and the client evaluator (`resources/js/lib/dnd.ts`) stay in lockstep: a snooze still ahead suppresses the schedule branch only — a manual pause is never muted. Once the instant passes the schedule resumes on its own, no re-enable step.
- `UserProfileUpdated` broadcasts when the snooze is set, and a new every-minute sweep (`ClearLapsedDndScheduleSnoozes`, mirroring `ClearLapsedDndPauses`) nulls lapsed snoozes and broadcasts the clear, so teammates' DND badges follow both edges.
- The snooze instant rides the owner-only `UserDndData` DTO; teammates still receive only the `isDnd` boolean.

## Testing

- Feature: endpoint semantics (same-day, overnight both halves, user-timezone computation, outside-window no-op, guest), evaluator snooze semantics, serialization (owner DTO carries it, lapsed reads null, never leaks to teammates), sweep behaviour + scheduling.
- Vitest: `isDndActiveNow` snooze cases (suppresses window, lapses, never mutes a pause).
- Browser: snoozing from the paused card collapses it in place and persists the snooze.
- Full gate green: `composer test` at 100.0% coverage, `lint:check` / `format:check` / `types:check` / `test:js` / `build`.

## i18n

New keys translated in `lang/fr.json` («Suspendre l'horaire aujourd'hui», error toast).

## CodeRabbit (local CLI pass)

Applied: pinned the browser test's window to the running minute (the 00:00–23:59 window left one uncovered minute per day). Skipped: a claim `setTimeFromTimeString` mutates `$now` (the app pins `CarbonImmutable`), an ordering suggestion already implemented, and hardening the sweep's `refresh()` against a user deleted mid-pass (kept identical to the sibling `ClearLapsedDndPauses`; hardening both belongs in its own change). Re-run came back clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787351665&installation_model_id=428379&pr_number=750&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F750&signature=b2d9bcc9dcade80fcb71d2eb3baf9d305809910c0dd32c2bbc5e52b775f6f29b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->