### PR TITLE
fix: allow polls as reply and thread-root targets in send validation

### DIFF
--- a/app/Enums/MessageType.php
+++ b/app/Enums/MessageType.php
@@ -43,4 +43,20 @@ enum MessageType: string
     {
         return $this === self::MemberJoined || $this === self::MemberLeft;
     }
+
+    /**
+     * The backing values of every system-notice type — the deny-list for
+     * validation rules that reject a system notice as a reply or thread target.
+     * Derived from isSystem() so each type is classified in exactly one place
+     * and a future case joins (or stays off) the list automatically.
+     *
+     * @return list<string>
+     */
+    public static function systemValues(): array
+    {
+        return array_values(array_map(
+            static fn (self $type): string => $type->value,
+            array_filter(self::cases(), static fn (self $type): bool => $type->isSystem()),
+        ));
+    }
 }

--- a/app/Http/Requests/Api/V1/StoreMessageRequest.php
+++ b/app/Http/Requests/Api/V1/StoreMessageRequest.php
@@ -54,7 +54,7 @@ class StoreMessageRequest extends ApiRequest
                 'uuid',
                 Rule::exists('messages', 'id')
                     ->where('channel_id', $this->channel()->id)
-                    ->where('type', MessageType::Standard->value)
+                    ->whereNotIn('type', MessageType::systemValues())
                     ->whereNull('deleted_at'),
             ],
             // A thread reply must target a live root message in this same channel;
@@ -65,7 +65,7 @@ class StoreMessageRequest extends ApiRequest
                 'uuid',
                 Rule::exists('messages', 'id')
                     ->where('channel_id', $this->channel()->id)
-                    ->where('type', MessageType::Standard->value)
+                    ->whereNotIn('type', MessageType::systemValues())
                     ->whereNull('deleted_at')
                     ->whereNull('thread_root_id'),
             ],

--- a/app/Http/Requests/Channels/PostMessageRequest.php
+++ b/app/Http/Requests/Channels/PostMessageRequest.php
@@ -58,7 +58,7 @@ class PostMessageRequest extends FormRequest
                 'uuid',
                 Rule::exists('messages', 'id')
                     ->where('channel_id', $this->channel()->id)
-                    ->where('type', MessageType::Standard->value)
+                    ->whereNotIn('type', MessageType::systemValues())
                     ->whereNull('deleted_at'),
             ],
             // A thread reply must target a live root user message in this same
@@ -70,7 +70,7 @@ class PostMessageRequest extends FormRequest
                 'uuid',
                 Rule::exists('messages', 'id')
                     ->where('channel_id', $this->channel()->id)
-                    ->where('type', MessageType::Standard->value)
+                    ->whereNotIn('type', MessageType::systemValues())
                     ->whereNull('deleted_at')
                     ->whereNull('thread_root_id'),
             ],

--- a/app/Http/Requests/Channels/StorePollRequest.php
+++ b/app/Http/Requests/Channels/StorePollRequest.php
@@ -70,7 +70,7 @@ class StorePollRequest extends FormRequest
                 'uuid',
                 Rule::exists('messages', 'id')
                     ->where('channel_id', $this->channel()->id)
-                    ->where('type', MessageType::Standard->value)
+                    ->whereNotIn('type', MessageType::systemValues())
                     ->whereNull('deleted_at')
                     ->whereNull('thread_root_id'),
             ],

--- a/app/Http/Requests/Channels/StoreSlashCommandRequest.php
+++ b/app/Http/Requests/Channels/StoreSlashCommandRequest.php
@@ -59,7 +59,7 @@ class StoreSlashCommandRequest extends FormRequest
                 'uuid',
                 Rule::exists('messages', 'id')
                     ->where('channel_id', $this->channel()->id)
-                    ->where('type', MessageType::Standard->value)
+                    ->whereNotIn('type', MessageType::systemValues())
                     ->whereNull('deleted_at')
                     ->whereNull('thread_root_id'),
             ],

--- a/tests/Feature/Api/V1/MessageApiTest.php
+++ b/tests/Feature/Api/V1/MessageApiTest.php
@@ -55,6 +55,35 @@ it('is idempotent on a repeated client_uuid', function (): void {
     expect(Message::query()->where('channel_id', $this->channel->id)->count())->toBe(1);
 });
 
+it('accepts a poll as the inline-reply and thread-root target', function (): void {
+    $poll = Message::factory()->poll()->for($this->channel)->for($this->bot, 'user')->create();
+
+    Sanctum::actingAs($this->bot, ['messages:write']);
+
+    $this->postJson("/api/v1/channels/{$this->channel->id}/messages", ['body' => 'Quoting the poll', 'reply_to_id' => $poll->id])
+        ->assertCreated();
+
+    $this->postJson("/api/v1/channels/{$this->channel->id}/messages", ['body' => 'Threading off the poll', 'thread_root_id' => $poll->id])
+        ->assertCreated();
+
+    $this->assertDatabaseHas('messages', ['body' => 'Quoting the poll', 'reply_to_id' => $poll->id]);
+    $this->assertDatabaseHas('messages', ['body' => 'Threading off the poll', 'thread_root_id' => $poll->id]);
+});
+
+it('rejects a system notice as the inline-reply or thread-root target', function (): void {
+    $notice = Message::factory()->for($this->channel)->for($this->bot, 'user')->memberJoined()->create();
+
+    Sanctum::actingAs($this->bot, ['messages:write']);
+
+    $this->postJson("/api/v1/channels/{$this->channel->id}/messages", ['body' => 'nope', 'reply_to_id' => $notice->id])
+        ->assertStatus(422)
+        ->assertJsonValidationErrorFor('reply_to_id');
+
+    $this->postJson("/api/v1/channels/{$this->channel->id}/messages", ['body' => 'nope', 'thread_root_id' => $notice->id])
+        ->assertStatus(422)
+        ->assertJsonValidationErrorFor('thread_root_id');
+});
+
 it('rejects an empty message body', function (): void {
     Sanctum::actingAs($this->bot, ['messages:write']);
 

--- a/tests/Feature/Channels/InlineReplyTest.php
+++ b/tests/Feature/Channels/InlineReplyTest.php
@@ -44,6 +44,26 @@ test('a message can reply to another message in the same channel', function (): 
     ]);
 });
 
+test('a message can reply to a poll inline', function (): void {
+    [$owner, $team, $general] = replyTeamWithGeneral();
+    $poll = Message::factory()->poll()->for($general)->for($owner)->create();
+    $clientUuid = (string) Str::uuid7();
+
+    $this->actingAs($owner)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => 'quoting the poll',
+            'client_uuid' => $clientUuid,
+            'reply_to_id' => $poll->id,
+        ])
+        ->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $this->assertDatabaseHas('messages', [
+        'client_uuid' => $clientUuid,
+        'body' => 'quoting the poll',
+        'reply_to_id' => $poll->id,
+    ]);
+});
+
 test('a message without a reply target persists a null reply reference', function (): void {
     [$owner, $team, $general] = replyTeamWithGeneral();
     $clientUuid = (string) Str::uuid7();

--- a/tests/Feature/Channels/SlashCommandTest.php
+++ b/tests/Feature/Channels/SlashCommandTest.php
@@ -204,6 +204,37 @@ test('a command run from a thread echoes into that thread', function (): void {
     ]);
 });
 
+test('a command run from a thread whose root is a poll echoes into that thread', function (): void {
+    [$owner, $team, $general] = commandTeam();
+    $root = Message::factory()->poll()->for($general)->for($owner)->create();
+
+    $this->actingAs($owner)
+        ->post(route('channels.commands.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => '/shrug in the poll thread',
+            'client_uuid' => (string) Str::uuid7(),
+            'thread_root_id' => $root->id,
+        ]);
+
+    $this->assertDatabaseHas('messages', [
+        'channel_id' => $general->id,
+        'thread_root_id' => $root->id,
+        'body' => 'in the poll thread ¯\_(ツ)_/¯',
+    ]);
+});
+
+test('a command rejects a thread root that is a system notice', function (): void {
+    [$owner, $team, $general] = commandTeam();
+    $notice = Message::factory()->for($general)->for($owner)->memberJoined()->create();
+
+    $this->actingAs($owner)
+        ->post(route('channels.commands.store', ['team' => $team->slug, 'channel' => $general->slug]), [
+            'body' => '/shrug',
+            'client_uuid' => (string) Str::uuid7(),
+            'thread_root_id' => $notice->id,
+        ])
+        ->assertInvalid(['thread_root_id']);
+});
+
 test('a command rejects a thread root from another channel', function (): void {
     [$owner, $team, $general] = commandTeam();
     $other = Channel::factory()->for($team)->create();

--- a/tests/Feature/Channels/SystemMessageTest.php
+++ b/tests/Feature/Channels/SystemMessageTest.php
@@ -152,6 +152,11 @@ test('joining a team posts no join notice in the onboarding #general channel', f
 
 test('isSystem reflects the message type', function (): void {
     expect(MessageType::Standard->isSystem())->toBeFalse()
+        ->and(MessageType::Poll->isSystem())->toBeFalse()
         ->and(MessageType::MemberJoined->isSystem())->toBeTrue()
         ->and(MessageType::MemberLeft->isSystem())->toBeTrue();
+});
+
+test('systemValues lists exactly the system-notice type values', function (): void {
+    expect(MessageType::systemValues())->toBe(['member_joined', 'member_left']);
 });

--- a/tests/Feature/Channels/ThreadTest.php
+++ b/tests/Feature/Channels/ThreadTest.php
@@ -112,6 +112,36 @@ test('a reply cannot start on a deleted root', function (): void {
         ->assertInvalid(['thread_root_id']);
 });
 
+test('a reply persists in a thread whose root is a poll', function (): void {
+    Event::fake([MessageSent::class]);
+
+    [$owner, $team, $general] = threadTeamWithGeneral();
+    $root = Message::factory()->poll()->for($general)->for($owner)->create();
+    $clientUuid = (string) Str::uuid7();
+
+    postThreadReply($team, $general, $owner, $root, [
+        'body' => 'poll thread reply',
+        'client_uuid' => $clientUuid,
+        'sent_to_channel' => true,
+    ])->assertRedirect(route('channels.show', ['team' => $team->slug, 'channel' => $general->slug]));
+
+    $this->assertDatabaseHas('messages', [
+        'client_uuid' => $clientUuid,
+        'body' => 'poll thread reply',
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => true,
+    ]);
+
+    expect($root->refresh()->reply_count)->toBe(1);
+
+    Event::assertDispatched(MessageSent::class, function (MessageSent $event) use ($root, $clientUuid): bool {
+        $payload = $event->message->toArray();
+
+        return $payload['clientUuid'] === $clientUuid
+            && $payload['threadRootId'] === $root->id;
+    });
+});
+
 test('a non-uuid thread root is rejected', function (): void {
     [$owner, $team, $general] = threadTeamWithGeneral();
     $root = Message::factory()->for($general)->for($owner)->create();

--- a/tests/Feature/Polls/PollTest.php
+++ b/tests/Feature/Polls/PollTest.php
@@ -360,3 +360,22 @@ test('a poll can be posted into a thread', function (): void {
     expect($poll->thread_root_id)->toBe($root->id)
         ->and($poll->sent_to_channel)->toBeTrue();
 });
+
+test('a poll can be posted into a thread whose root is a poll', function (): void {
+    [$owner, $team, $general] = pollTeam();
+    $root = Message::factory()->poll()->for($general)->for($owner)->create();
+
+    postPoll($owner, $team, $general, ['thread_root_id' => $root->id])->assertRedirect();
+
+    $threaded = Message::where('type', MessageType::Poll)->whereNotNull('thread_root_id')->firstOrFail();
+
+    expect($threaded->thread_root_id)->toBe($root->id);
+});
+
+test('a poll cannot be posted into a thread rooted on a system notice', function (): void {
+    [$owner, $team, $general] = pollTeam();
+    $notice = Message::factory()->for($general)->for($owner)->memberJoined()->create();
+
+    postPoll($owner, $team, $general, ['thread_root_id' => $notice->id])
+        ->assertInvalid(['thread_root_id']);
+});


### PR DESCRIPTION
Closes #736.

## What

Every send path validated `thread_root_id` / `reply_to_id` with `where('type', MessageType::Standard)`, so a poll (`MessageType::Poll`) could never be a reply or thread-root target: replying in a poll's thread, quoting a poll inline, posting a poll into a poll-rooted thread, running a slash command there, and the API v1 send endpoint all failed validation and (on the web path) rolled back the optimistic reply with the error toast.

The rule's intent was "not a system notice". This adds `MessageType::systemValues()` — a deny-list derived from `isSystem()` so each type is classified in one place — and switches all five request classes to `whereNotIn('type', MessageType::systemValues())`:

- `app/Http/Requests/Channels/PostMessageRequest.php` (`reply_to_id`, `thread_root_id`)
- `app/Http/Requests/Channels/StorePollRequest.php` (`thread_root_id`)
- `app/Http/Requests/Channels/StoreSlashCommandRequest.php` (`thread_root_id`)
- `app/Http/Requests/Api/V1/StoreMessageRequest.php` (`reply_to_id`, `thread_root_id`)

The rest of each rule (same channel, not deleted, root not itself a reply) is unchanged. `member_joined` / `member_left` targets stay rejected on every path.

## Testing

TDD, red → green per path:

- `ThreadTest`: a reply persists in a poll-rooted thread, lands in the main timeline with `sent_to_channel`, bumps the root aggregates, and goes out over `MessageSent`.
- `InlineReplyTest`: an inline reply quoting a poll persists.
- `PollTest`: a poll posts into a poll-rooted thread; a system-notice root is rejected.
- `SlashCommandTest`: a command echoes into a poll-rooted thread; a system-notice root is rejected.
- `MessageApiTest`: the API accepts a poll as `reply_to_id` / `thread_root_id` and rejects a system notice as either.
- `SystemMessageTest`: `systemValues()` spec + existing system-notice rejection guards stay green.

`./vendor/bin/sail composer test` green at `Total: 100.0 %`; frontend gate (`lint:check`, `format:check`, `types:check`, `test:js`, `build`) green. Local CodeRabbit pass: 0 findings.

## Related

The unread-badge half of the same `standard` vs "not system" conflation (`HandleInertiaRequests`, `ChannelTimelineWindow`) is deliberately not touched here — split out to #752.

No user-facing copy changed, so no i18n catalog updates; nothing operator-facing, so no docs changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787353041&installation_model_id=428379&pr_number=753&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F753&signature=e69a675f5365a464597352cf39f883f1f3fec5a5c4418cc8c62cc48235e84cc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->