### PR TITLE
fix: count polls toward the unread badge and the new-messages boundary

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -509,8 +509,9 @@ class HandleInertiaRequests extends Middleware
             ->where('messages.user_id', '!=', $user->id)
             // System notices (member joined / left) are ambient: they never
             // advance the unread badge or raise a mention, so they are excluded
-            // from both the unread and mention counts.
-            ->where('messages.type', MessageType::Standard->value)
+            // from both the unread and mention counts. Every other type counts —
+            // a poll is user-authored and badges the channel like a message.
+            ->whereNotIn('messages.type', MessageType::systemValues())
             ->where(fn (Builder $query) => $query
                 ->whereNull('channel_members.last_read_message_id')
                 ->orWhereColumn('messages.id', '>', 'channel_members.last_read_message_id'));

--- a/app/Support/ChannelTimelineWindow.php
+++ b/app/Support/ChannelTimelineWindow.php
@@ -223,9 +223,9 @@ class ChannelTimelineWindow
 
         $firstUnreadId = $this->mainTimeline()
             ->where('id', '>', $this->lastReadMessageId)
-            // The "New messages" boundary sits at the first unread user message;
-            // ambient system notices never open the boundary.
-            ->where('type', MessageType::Standard->value)
+            // The "New messages" boundary sits at the first unread user message —
+            // a poll included; only the ambient system notices never open it.
+            ->whereNotIn('type', MessageType::systemValues())
             ->orderBy('id')
             ->value('id');
 

--- a/tests/Feature/Channels/ChannelTimelineWindowTest.php
+++ b/tests/Feature/Channels/ChannelTimelineWindowTest.php
@@ -73,6 +73,24 @@ it('renders system notices in the timeline but never as the unread boundary', fu
         ->and($window->messages()->items()[0]->id)->toBe($notice->id);
 });
 
+it('anchors the unread boundary on a first-unread poll', function (): void {
+    ['user' => $user, 'general' => $general] = windowFixture();
+    $read = windowMessages($general, $user, 30);
+    Message::factory()->for($general)->for($user)->poll()->create();
+    $unread = windowMessages($general, $user, 70);
+
+    $window = new ChannelTimelineWindow(
+        channel: $general,
+        viewer: $user,
+        lastReadMessageId: $read[29]->id,
+    );
+
+    // The poll is the first unread message, so it opens the boundary and the
+    // window caps 39 rows past it — one row earlier than it would had the
+    // boundary skipped the poll and landed on the message after it.
+    expect($window->ceilingId())->toBe($unread[39]->id);
+});
+
 it('opens at newest with no ceiling on a never-read channel', function (): void {
     ['user' => $user, 'general' => $general] = windowFixture();
     windowMessages($general, $user, 60);

--- a/tests/Feature/Channels/UnreadBadgeTest.php
+++ b/tests/Feature/Channels/UnreadBadgeTest.php
@@ -137,6 +137,33 @@ test('system notices are ambient and never advance the unread or mention badge',
         ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
 });
 
+test('a poll badges the channel like any other user-authored message', function (): void {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general, 'Ada Lovelace');
+
+    $read = unreadPost($general, $owner);
+    markReadUpTo($member, $general, $read);
+
+    // A poll is user-authored and interactive, so it advances the badge; only the
+    // ambient join/leave notices posted alongside it stay out of the count.
+    Message::factory()->for($general)->for($owner)->poll()->create();
+    Message::factory()->for($general)->for($owner)->memberJoined()->create();
+
+    expect(sidebarChannel($member, $team, $general))
+        ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 0]);
+});
+
+test('a poll that mentions the user raises the mention badge', function (): void {
+    [$owner, $team, $general] = unreadTeamWithGeneral();
+    $member = unreadChannelMember($team, $general, 'Grace Hopper');
+
+    $poll = Message::factory()->for($general)->for($owner)->poll()->create();
+    $poll->mentionedUsers()->attach($member->id);
+
+    expect(sidebarChannel($member, $team, $general))
+        ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 1]);
+});
+
 test('the mention count only counts unread messages that mention the user', function (): void {
     [$owner, $team, $general] = unreadTeamWithGeneral();
     $member = unreadChannelMember($team, $general, 'Grace Hopper');


### PR DESCRIPTION
Closes #752.

## What

Two query sites filtered by `type = standard` where the intent was "not a system notice", so a poll (`MessageType::Poll`) was silently excluded:

- `app/Http/Middleware/HandleInertiaRequests.php` — a poll posted to a channel raised no unread badge (and no mention badge when it mentioned you).
- `app/Support/ChannelTimelineWindow.php` — a poll as the first unread message never opened the "New messages" boundary.

Both now use the same "not system" constraint the send-validation rules use: `whereNotIn('type', MessageType::systemValues())`. `MessageType::isSystem()` already documents a poll as user-authored and interactive, so this is the deny-list the two sites always meant.

## Why

Split out of #736 (its "Related, not covered here" note), confirmed while fixing the reply-validation half. Builds on `MessageType::systemValues()`, added in #753.

## How tested

Written test-first; all three new cases failed for the right reason before the fix.

- `tests/Feature/Channels/UnreadBadgeTest.php` — a poll badges the channel while a join notice posted alongside it does not; a poll that mentions the user raises the mention badge.
- `tests/Feature/Channels/ChannelTimelineWindowTest.php` — the window anchors 39 rows past a first-unread poll (an exact-id assertion, so it fails if the boundary skips the poll and lands on the message after it).
- The existing "system notices are ambient and never advance the unread or mention badge" and "renders system notices in the timeline but never as the unread boundary" tests still pass, keeping system notices out of both surfaces.

`./vendor/bin/sail composer test` green at `Total: 100.0 %`; frontend lint/format/types/vitest green.

## i18n / docs

None — no user-facing copy and no operator-facing setting changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787353909&installation_model_id=428379&pr_number=754&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F754&signature=5bd10c93db92ca8c872a6f84a07e7f17474aca3c5f23bf5c505d791179d80aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->