### PR TITLE
fix: take the shell out of the tab order while an overlay hides it

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -9,6 +9,7 @@ import type { ReverbRuntimeConfig } from '@/lib/echo';
 import { initializeFlashToast } from '@/lib/flashToast';
 import { setMessages, translate } from '@/lib/i18n';
 import type { Messages } from '@/lib/i18n';
+import { initializeOverlayInert } from '@/lib/overlayInert';
 
 /**
  * Seeded from the server-shared props at boot (see `withApp`), so both Echo and
@@ -70,3 +71,5 @@ void createInertiaApp({
 initializeTheme();
 
 initializeFlashToast();
+
+initializeOverlayInert();

--- a/resources/js/lib/overlayInert.test.ts
+++ b/resources/js/lib/overlayInert.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { initializeOverlayInert } from '@/lib/overlayInert';
+
+/**
+ * Wait for the `MutationObserver` callback, which the platform delivers as a
+ * microtask once the current task settles.
+ */
+const flush = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve));
+
+let dispose: (() => void) | null = null;
+
+function start(): void {
+    dispose = initializeOverlayInert();
+}
+
+/** Stand in for what the `aria-hidden` package does when an overlay opens. */
+function hide(element: HTMLElement): void {
+    element.setAttribute('data-aria-hidden', 'true');
+    element.setAttribute('aria-hidden', 'true');
+}
+
+/** …and what it does when that overlay closes again. */
+function reveal(element: HTMLElement): void {
+    element.removeAttribute('data-aria-hidden');
+    element.removeAttribute('aria-hidden');
+}
+
+function shell(): HTMLElement {
+    const element = document.createElement('div');
+    element.innerHTML = '<a href="#main">Skip to content</a>';
+    document.body.append(element);
+
+    return element;
+}
+
+afterEach(() => {
+    dispose?.();
+    dispose = null;
+    document.body.innerHTML = '';
+});
+
+describe('initializeOverlayInert', () => {
+    it('makes the region an overlay hides inert', async () => {
+        const region = shell();
+        start();
+
+        hide(region);
+        await flush();
+
+        expect(region.hasAttribute('inert')).toBe(true);
+    });
+
+    it('hands the region back when the overlay closes', async () => {
+        const region = shell();
+        start();
+
+        hide(region);
+        await flush();
+        reveal(region);
+        await flush();
+
+        expect(region.hasAttribute('inert')).toBe(false);
+        expect(region.hasAttribute('data-overlay-inert')).toBe(false);
+    });
+
+    it('covers a region already hidden before it starts', async () => {
+        const region = shell();
+        hide(region);
+
+        start();
+
+        expect(region.hasAttribute('inert')).toBe(true);
+    });
+
+    it('covers every region an overlay hides, not just the first', async () => {
+        const first = shell();
+        const second = shell();
+        start();
+
+        hide(first);
+        hide(second);
+        await flush();
+
+        expect(first.hasAttribute('inert')).toBe(true);
+        expect(second.hasAttribute('inert')).toBe(true);
+    });
+
+    it('leaves an inert the app owns alone', async () => {
+        const region = shell();
+        region.setAttribute('inert', '');
+        start();
+
+        hide(region);
+        await flush();
+        reveal(region);
+        await flush();
+
+        // Never marked as ours, so the app's own inert survives the round trip.
+        expect(region.hasAttribute('data-overlay-inert')).toBe(false);
+        expect(region.hasAttribute('inert')).toBe(true);
+    });
+
+    it('stops mirroring once disposed', async () => {
+        const region = shell();
+        start();
+
+        dispose?.();
+        dispose = null;
+
+        hide(region);
+        await flush();
+
+        expect(region.hasAttribute('inert')).toBe(false);
+    });
+});

--- a/resources/js/lib/overlayInert.ts
+++ b/resources/js/lib/overlayInert.ts
@@ -1,0 +1,69 @@
+/**
+ * Reka traps assistive tech inside an open overlay by marking every sibling of
+ * the overlay `aria-hidden="true"` — it delegates to the `aria-hidden` package,
+ * which stamps its own `data-aria-hidden` marker on each node it hid. It stops
+ * there: the hidden shell keeps its tab stops, so the skip link, the sidebar and
+ * the composer stay keyboard-focusable while being invisible to a screen reader.
+ * That is the WCAG 4.1.2 failure axe reports as `aria-hidden-focus` (#730), and
+ * it fires on every dropdown menu — a `Dialog` only escapes it because axe
+ * recognises an open `role="dialog"` and holds its checks back.
+ *
+ * A menu's focus trap makes the hidden region unreachable in practice, but only
+ * while the trap holds and only for Tab. Mirroring `inert` onto whatever reka
+ * hid removes the region from the tab order for real, so the two halves of
+ * "hidden" finally agree. Every reka overlay is covered at once, because they
+ * all hide the background through the same marker.
+ */
+
+/** The attribute the `aria-hidden` package stamps on each node it hides. */
+const HIDDEN_MARKER = 'data-aria-hidden';
+
+/**
+ * Our own marker, so `inert` is only ever removed from elements we made inert —
+ * an `inert` the app set itself is left untouched.
+ */
+const OWNED_MARKER = 'data-overlay-inert';
+
+/**
+ * Bring `inert` back in line with what is currently hidden behind an overlay.
+ * Idempotent, so it is safe to run on every mutation the overlay emits.
+ */
+function syncOverlayInert(): void {
+    for (const element of document.querySelectorAll<HTMLElement>(
+        `[${HIDDEN_MARKER}="true"]:not([${OWNED_MARKER}]):not([inert])`,
+    )) {
+        element.setAttribute('inert', '');
+        element.setAttribute(OWNED_MARKER, '');
+    }
+
+    for (const element of document.querySelectorAll<HTMLElement>(
+        `[${OWNED_MARKER}]:not([${HIDDEN_MARKER}="true"])`,
+    )) {
+        element.removeAttribute('inert');
+        element.removeAttribute(OWNED_MARKER);
+    }
+}
+
+/**
+ * Start mirroring `inert` onto the region reka hides behind an open overlay.
+ * Runs for the lifetime of the app; the returned disposer exists for tests.
+ */
+export function initializeOverlayInert(): () => void {
+    if (typeof window === 'undefined') {
+        return () => {};
+    }
+
+    const observer = new MutationObserver(syncOverlayInert);
+
+    // Only the marker matters: the package adds it as it hides a node and drops
+    // it as it restores one, so both directions arrive as attribute changes.
+    observer.observe(document.body, {
+        attributes: true,
+        attributeFilter: [HIDDEN_MARKER],
+        subtree: true,
+    });
+
+    syncOverlayInert();
+
+    return () => observer.disconnect();
+}

--- a/tests/Browser/A11yAuditTest.php
+++ b/tests/Browser/A11yAuditTest.php
@@ -52,6 +52,21 @@ test('the authenticated channel page has no serious accessibility violations in 
         ->assertNoAccessibilityIssues();
 });
 
+test('an open dropdown menu has no serious accessibility violations', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // Opening a reka dropdown marks the whole shell `aria-hidden` so assistive
+    // tech stays inside the menu. Everything it hides must leave the tab order
+    // with it, or the skip link, sidebar and composer stay keyboard-reachable
+    // from inside an ARIA-hidden region (`aria-hidden-focus`, #730).
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@settings-menu-item')
+        // Let the menu's entrance transition settle before axe reads the DOM.
+        ->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});
+
 test('the unread jump-to-unread pill has no serious accessibility violations in either theme', function (): void {
     ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
 

--- a/tests/Browser/A11yShellTest.php
+++ b/tests/Browser/A11yShellTest.php
@@ -58,6 +58,34 @@ test('the shell exposes a skip link targeting a focusable main region', function
         );
 });
 
+test('an open dropdown menu takes the shell out of the tab order and hands it back on close', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@settings-menu-item')
+        ->wait(0.5)
+        // The menu hides the shell from assistive tech, so the skip link has to
+        // leave the tab order with it rather than stay focusable inside an
+        // `aria-hidden` region (#730).
+        ->assertScript(
+            'document.querySelector(\'a[data-test="skip-to-content"]\').closest("[inert]") !== null',
+        );
+
+    $page->keys('[data-test="settings-menu-item"]', 'Escape')
+        ->wait(0.5)
+        ->assertNotPresent('@settings-menu-item')
+        // Closing restores both halves: the skip link is reachable again, and
+        // focus lands back on the trigger it left from.
+        ->assertScript(
+            'document.querySelector(\'a[data-test="skip-to-content"]\').closest("[inert]") === null',
+        )
+        ->assertScript(
+            'document.activeElement?.getAttribute("data-test")',
+            'sidebar-menu-button',
+        );
+});
+
 test('the sidebar wraps channel navigation in a landmark with an accessible name', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 

--- a/tests/Browser/CustomStatusTest.php
+++ b/tests/Browser/CustomStatusTest.php
@@ -165,7 +165,7 @@ test('the status dialog passes the axe audit in either theme', function (): void
     $page->wait(0.5)->assertNoAccessibilityIssues();
 });
 
-test('the status card exposes menu semantics and a named clear control', function (): void {
+test('the status card passes the axe audit and exposes menu semantics', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 
     $alice->forceFill([
@@ -174,12 +174,13 @@ test('the status card exposes menu semantics and a named clear control', functio
         'status_expires_at' => now()->addHour(),
     ])->save();
 
-    // A whole-page axe audit cannot run with a dropdown menu open: reka marks
-    // the rest of the shell aria-hidden, which traps the focusable skip link and
-    // trips `aria-hidden-focus` on untouched code (#730). Until that is fixed,
-    // pin the card's own semantics directly instead.
     signInThroughBrowser($alice)
         ->click('@sidebar-menu-button')
+        ->assertPresent('@edit-status-menu-item')
+        // Let the menu's entrance transition settle before axe reads the DOM,
+        // so a mid-animation opacity never manufactures a contrast failure.
+        ->wait(0.5)
+        ->assertNoAccessibilityIssues()
         // Both rows are real menu items, so arrow-key navigation reaches them and
         // Enter/Space activates them.
         ->assertAttribute('[data-test="edit-status-menu-item"]', 'role', 'menuitem')


### PR DESCRIPTION
Closes #730.

## What

Opening any reka `DropdownMenu` made axe report a **serious** `aria-hidden-focus` violation: the skip link, sidebar, masthead and composer stayed keyboard-focusable inside an ARIA-hidden region.

Reka hands the "hide the background" job to the `aria-hidden` package, which marks every sibling of the open overlay `aria-hidden="true"` and stamps its own `data-aria-hidden` marker on each node it hid. It never touches their tab stops, so the two halves of "hidden" disagreed. A `Dialog` escaped the same fate only because axe's `isModalOpen` heuristic recognises an open `role="dialog"` and holds its checks back — `role="menu"` gets no such pass.

## How

`resources/js/lib/overlayInert.ts` starts an app-lifetime `MutationObserver` (from `app.ts`, alongside `initializeTheme` / `initializeFlashToast`) that mirrors `inert` onto whatever carries `data-aria-hidden="true"`, and lifts it when the marker goes.

- It keys on the marker rather than on any one component, so every reka overlay is covered at once.
- It records its own work with a `data-overlay-inert` attribute, so an `inert` the app owns is never cleared.
- Focus restore is unaffected: reka's `FocusScope` restores focus in a `setTimeout`, which lands after the observer's microtask has already lifted `inert`.

## Testing

- `A11yAuditTest` — whole-page audit with the user menu open. This is the red test: it failed on `aria-hidden-focus` before the fix.
- `A11yShellTest` — an open menu takes the skip link out of the tab order, and Escape hands it back *and* returns focus to the trigger.
- `CustomStatusTest` — the targeted-assertion fallback is replaced by a real audit of the status card, keeping the two assertions axe cannot make (the icon-only clear button's name, the decorative emoji).
- `resources/js/lib/overlayInert.test.ts` — 6 cases, including the app-owned-`inert` and disposal paths.

Gates: `composer test` at `Total: 100.0 %` with clean Pint/PHPStan/Rector; lint, format, types, `test:js` (1012) and build all pass; full `tests/Browser` suite 86/86. Local CodeRabbit against `develop`: 0 findings.

No user-facing copy and no operator-facing surface, so no `lang/fr.json` or `docs/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787354687&installation_model_id=428379&pr_number=755&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F755&signature=f0d17732e30e75f57415a1652c5decb3c78f7b7a1e9bf1c2057411f70163a6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->