### PR TITLE
test: stop REVERB_*_PUBLIC leaking from .env into the test run

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -86,5 +86,22 @@
              the single-process app server the page is talking to. Tests that
              exercise Gravatar itself opt back in with config()->set(). -->
         <env name="GRAVATAR_ENABLED" value="false"/>
+        <!--
+            Keep the browser-facing Reverb connection derived from the
+            server-facing one, as it is out of the box. App\Support\ReverbConfig
+            prefers these overrides over `options.*`, so any value in the host's
+            .env — which bin/worktree copies verbatim into every worktree —
+            shadows the config() overrides the reverb tests make, and they fail
+            on a machine-specific port ("Failed asserting that 20012 is
+            identical to 443", issue #732). Pinning them empty restores the
+            fallback; tests that exercise a real override opt back in with
+            config()->set(), and the browser suite sets all three explicitly.
+            `force` re-applies the pin even when the name is already defined at
+            the process level, so it also survives a `putenv` from an earlier
+            bootstrap.
+        -->
+        <env name="REVERB_HOST_PUBLIC" value="" force="true"/>
+        <env name="REVERB_PORT_PUBLIC" value="" force="true"/>
+        <env name="REVERB_SCHEME_PUBLIC" value="" force="true"/>
     </php>
 </phpunit>

--- a/tests/Unit/Support/ReverbConfigTest.php
+++ b/tests/Unit/Support/ReverbConfigTest.php
@@ -45,6 +45,21 @@ test('the websocket origin honours the browser-facing overrides', function (): v
     expect(ReverbConfig::websocketOrigin())->toBe('wss://ws.example.test:443');
 });
 
+/*
+ * Regression guard for #732. The browser-facing overrides come from
+ * REVERB_HOST_PUBLIC / REVERB_PORT_PUBLIC / REVERB_SCHEME_PUBLIC, and
+ * ReverbConfig prefers them over the server-facing connection — so any value in
+ * the host's .env (which bin/worktree copies verbatim into every worktree)
+ * shadows the config() overrides the tests above make, and the suite fails on a
+ * machine-specific port. phpunit.xml pins all three empty; this asserts the pin
+ * is in place, because without it the failure surfaces far from its cause.
+ */
+test('the browser-facing overrides are unset in the test environment', function (): void {
+    expect(config('broadcasting.connections.reverb.public_host'))->toBeEmpty()
+        ->and(config('broadcasting.connections.reverb.public_port'))->toBeEmpty()
+        ->and(config('broadcasting.connections.reverb.public_scheme'))->toBeEmpty();
+});
+
 test('the websocket origin is null when no browser-facing host can be resolved', function (): void {
     config([
         'app.url' => '',


### PR DESCRIPTION
Closes #732.

## What

`ReverbConfigSharingTest` failed with `Failed asserting that 20012 is identical to 443` on any checkout whose `.env` sets the browser-facing Reverb overrides. Pins `REVERB_HOST_PUBLIC` / `REVERB_PORT_PUBLIC` / `REVERB_SCHEME_PUBLIC` empty in `phpunit.xml` so the suite always derives the browser-facing connection from the server-facing one, as it does out of the box.

## Root cause (a correction to the issue)

The issue attributes the leak to `bin/worktree` seeding `REVERB_PORT_PUBLIC=20012`. It does not — `git log -S REVERB_PORT_PUBLIC -- bin/` is empty across all history, and the generated `.env` leaves all three commented out. The actual path is `bin/worktree` copying the **main checkout's** `.env` verbatim: whatever the host has set travels into every worktree. `App\Support\ReverbConfig` prefers `public_port` over `options.port`, so the value shadows the `config()` override the test makes.

The symptom and the fix are exactly as the acceptance criteria describe; only the origin of the value differs, and pinning covers it regardless of which `.env` supplied it.

## Changes

- `phpunit.xml`: pin the three `REVERB_*_PUBLIC` names empty with `force="true"`, alongside the existing `DEMO_MODE` / SSO / Gravatar pins.
- `tests/Unit/Support/ReverbConfigTest.php`: a regression guard asserting the overrides are unset in the test environment, so a re-introduced leak fails at its cause rather than as a stray port three files away. It asserts semantics (`toBeEmpty()`), not the exact `''` PHPUnit normalizes the pin to.

Tests that exercise a real override are unaffected — they set the config explicitly, and the browser suite sets all three in `useReverbForBrowserTests()`.

## Testing

- Reproduced the issue's exact failure by setting all three in the worktree `.env`; red before, green after.
- Full gate green **with the leak still in `.env`** (the acceptance criterion): Pint, PHPStan, Rector, `--min=100` coverage at `Total: 100.0 %`.
- Frontend gate green: `lint:check`, `format:check`, `types:check`, `test:js` (1006 tests).
- No i18n or docs impact (test-harness only).

## Discovered along the way

Filed #756: `phpunit.xml` documents `force="true"` as beating an exported process-level value, which it does not — PHPUnit writes the pin to `putenv`/`$_ENV` but never `$_SERVER`, where an exported value lives and where Laravel's `env()` still finds it. That affects the existing `DEMO_MODE` pin as much as these new ones; the `.env` arrival path this PR fixes is unaffected, so it is left to the issue.

## CodeRabbit

One minor finding, consciously declined: swap `toBeEmpty()` for `toBe('')`. `toBeEmpty()` is deliberate — it expresses "no browser-facing override is configured", which is true for both the pinned `''` and the `null` an unset `env()` returns. `toBe('')` would couple the guard to PHPUnit's normalization and fail spuriously if the value ever arrived as `null`. Same reasoning as the note in PR #578 ("the regression test asserts semantics, not exact strings").

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787354854&installation_model_id=428379&pr_number=757&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F757&signature=024c8fc3db96efa8bd472e9cc96459db58e73627089b2ad82570015d1fa0fc96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->