### PR TITLE
feat: ship a dokploy compose template and a self-hosting guide for it

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -31,7 +31,19 @@ COMPOSE_FILE=docker-compose.prod.yml
 
 APP_VERSION=1.15.2 # x-release-please-version
 
-APP_NAME="The Desk"
+# --- A note on quotes and references -----------------------------------------
+# Every value below is deliberately unquoted and self-contained:
+#
+#   - A PaaS environment editor (Dokploy, Coolify, …) writes its textarea to
+#     .env but normalises quotes away, so a quoted value with a space lands as
+#     `APP_NAME=The Desk` and phpdotenv aborts the boot with `Encountered
+#     unexpected whitespace`, behind a container restart loop that hides it.
+#   - `${OTHER_VALUE}` is never expanded: these values reach the containers
+#     through compose's `env_file:`, which passes them through literally.
+#
+# Editing .env directly on your own host? Then quoting works normally, and a
+# display name with spaces (`APP_NAME="Acme Chat"`) is fine.
+APP_NAME=TheDesk
 APP_ENV=production
 # Required. Generate with: docker run --rm ghcr.io/deskhq/the-desk:latest php artisan key:generate --show
 APP_KEY=
@@ -52,7 +64,7 @@ LOG_LEVEL=warning
 REGISTRATION_ENABLED=true
 EMAIL_VERIFICATION_ENABLED=false
 GRAVATAR_ENABLED=true
-# GRAVATAR_URL="https://www.gravatar.com/avatar"
+# GRAVATAR_URL=https://www.gravatar.com/avatar
 # GRAVATAR_SIZE=200
 # GRAVATAR_DEFAULT=404
 UPDATE_CHECK_ENABLED=true
@@ -111,8 +123,11 @@ CSP_ENABLED=true
 # SSO_OIDC_ISSUER=https://your-idp.example.com
 # SSO_OIDC_CLIENT_ID=
 # SSO_OIDC_CLIENT_SECRET=
-# SSO_OIDC_REDIRECT_URI="${APP_URL}/auth/oidc/callback"
+# SSO_OIDC_REDIRECT_URI=https://chat.example.com/auth/oidc/callback
 # SSO_OIDC_DISCOVERY_URL=
+# The one setting here that cannot be written without quotes: it is split on
+# spaces. Leave it commented out unless your provider needs different scopes,
+# especially on a PaaS whose environment editor strips the quotes.
 # SSO_OIDC_SCOPES="openid profile email"
 # SSO_OIDC_VALIDATE_ID_TOKEN=true
 # SSO_DEFAULT_TEAM_ID=
@@ -120,8 +135,8 @@ CSP_ENABLED=true
 # --- Single sign-on (LDAP / Active Directory) --------------------------------
 # LDAP_HOST=ldap.example.com
 # LDAP_PORT=389
-# LDAP_BASE_DN="dc=example,dc=com"
-# LDAP_USERNAME="cn=readonly,dc=example,dc=com"
+# LDAP_BASE_DN=dc=example,dc=com
+# LDAP_USERNAME=cn=readonly,dc=example,dc=com
 # LDAP_PASSWORD=
 # LDAP_TLS=false
 # LDAP_STARTTLS=false
@@ -173,8 +188,8 @@ MAIL_HOST=smtp.example.com
 MAIL_PORT=587
 MAIL_USERNAME=
 MAIL_PASSWORD=
-MAIL_FROM_ADDRESS="hello@example.com"
-MAIL_FROM_NAME="${APP_NAME}"
+MAIL_FROM_ADDRESS=hello@example.com
+MAIL_FROM_NAME=TheDesk
 
 # --- Search (meilisearch service) --------------------------------------------
 SCOUT_DRIVER=meilisearch

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -1,7 +1,9 @@
-# Production stack for a container-network PaaS: Dokploy, and anything else
-# that fronts compose services with an injected Traefik network. Point Dokploy's
-# Compose Path at this file and never edit YAML; the walkthrough is at
-# https://docs.thedeskhq.app/self-hosting/dokploy/.
+# Production stack for Dokploy, which fronts compose services with its own
+# injected Traefik network. Point Dokploy's Compose Path at this file and never
+# edit YAML; the walkthrough is at
+# https://docs.thedeskhq.app/self-hosting/dokploy/. Another PaaS of the same
+# shape (Coolify, say) needs this file with its own network name in place of
+# dokploy-network.
 #
 # It is docker-compose.prod.yml (read that file for the rationale behind every
 # setting) with exactly two differences, which

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -1,0 +1,136 @@
+# Production stack for a container-network PaaS: Dokploy, and anything else
+# that fronts compose services with an injected Traefik network. Point Dokploy's
+# Compose Path at this file and never edit YAML; the walkthrough is at
+# https://docs.thedeskhq.app/self-hosting/dokploy/.
+#
+# It is docker-compose.prod.yml (read that file for the rationale behind every
+# setting) with exactly two differences, which
+# tests/Unit/DokployComposeTemplateTest.php holds it to:
+#
+#   1. No `ports:`. Traefik reaches the containers over dokploy-network, and
+#      reverb's 127.0.0.1:8080 would collide with Dokploy's Traefik dashboard.
+#   2. `app` and `reverb` join the external dokploy-network, alongside the
+#      stack's implicit `default` network.
+#
+# On a bare VPS with your own reverse proxy, use docker-compose.prod.yml instead.
+
+x-infra-depends-on: &infra-depends-on
+  pgsql:
+    condition: service_healthy
+  redis:
+    condition: service_healthy
+  meilisearch:
+    condition: service_healthy
+
+x-worker-depends-on: &worker-depends-on
+  <<: *infra-depends-on
+  app:
+    condition: service_started
+
+x-app: &app
+  image: ${APP_IMAGE:-ghcr.io/deskhq/the-desk:${APP_VERSION:?APP_VERSION is required — set it in .env (see .env.prod.example) or override APP_IMAGE}}
+  env_file:
+    - .env
+  restart: unless-stopped
+  volumes:
+    - ./.env:/app/.env:ro
+    - storage-app:/app/storage/app
+  depends_on: *infra-depends-on
+
+# `default` keeps the proxied services on the stack network, so they still
+# resolve pgsql, redis, and each other by name once Dokploy attaches a domain.
+x-proxied-networks: &proxied-networks
+  - default
+  - dokploy-network
+
+services:
+  app:
+    <<: *app
+    environment:
+      AUTORUN_MIGRATIONS: 'true'
+    networks: *proxied-networks
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:8080/up']
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+  reverb:
+    <<: *app
+    command: ['php', 'artisan', 'reverb:start', '--host=0.0.0.0', '--port=8080']
+    depends_on: *worker-depends-on
+    networks: *proxied-networks
+    healthcheck:
+      test: ['CMD', 'curl', '-fsS', 'http://localhost:8080/up']
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  queue:
+    <<: *app
+    command: ['php', 'artisan', 'queue:work', '--tries=3']
+    depends_on: *worker-depends-on
+
+  scheduler:
+    <<: *app
+    command: ['php', 'artisan', 'schedule:work']
+    depends_on: *worker-depends-on
+
+  pgsql:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_DB: ${DB_DATABASE:-laravel}
+      POSTGRES_USER: ${DB_USERNAME:-laravel}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+    volumes:
+      - pgsql-data:/var/lib/postgresql
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-q', '-d', '${DB_DATABASE:-laravel}', '-U', '${DB_USERNAME:-laravel}']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  meilisearch:
+    image: getmeili/meilisearch:${MEILISEARCH_VERSION:-v1.49}
+    environment:
+      MEILI_MASTER_KEY: ${MEILISEARCH_KEY:?MEILISEARCH_KEY is required}
+      MEILI_ENV: production
+      MEILI_NO_ANALYTICS: ${MEILISEARCH_NO_ANALYTICS:-true}
+    volumes:
+      - meili-data:/meili_data
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--spider', 'http://127.0.0.1:7700/health']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:alpine
+    command: ['redis-server', '--appendonly', 'yes']
+    volumes:
+      - redis-data:/data
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+# Created by Dokploy and shared by every application it deploys; Traefik is
+# attached to it. Declared explicitly rather than left to Dokploy's injection so
+# `reverb` reaches it too: injection only rewrites the services a domain is
+# attached to.
+networks:
+  dokploy-network:
+    external: true
+
+volumes:
+  pgsql-data:
+  meili-data:
+    name: the-desk-meili-${MEILISEARCH_VERSION:-v1.49}
+  redis-data:
+  storage-app:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,6 +32,13 @@
 #     directly and needs no host publishing at all.
 # Set APP_BIND=0.0.0.0 only to deliberately expose the raw HTTP app off-box.
 #
+# Every service sits on the implicit `default` network, deliberately, with no
+# custom network declared. A PaaS that fronts compose services with an injected
+# proxy network (Dokploy, Coolify, CapRover) rewrites `networks:` on whichever
+# service a domain is attached to, so a custom network would leave that service
+# unable to resolve `pgsql` while the rest of the stack stayed behind. See
+# docker-compose.dokploy.yml for the Dokploy-shaped variant of this file.
+#
 # Redis backs cache, session, and queue (SESSION_DRIVER/CACHE_STORE=redis,
 # QUEUE_CONNECTION=redis in .env, with REDIS_HOST=redis). Broadcasting uses
 # Reverb. The `redis` service below is always-on; every app process depends on
@@ -97,8 +104,6 @@ x-app: &app
     - ./.env:/app/.env:ro
     - storage-app:/app/storage/app
   depends_on: *infra-depends-on
-  networks:
-    - app
 
 services:
   # Web app (FrankenPHP). Runs migrations on start and serves HTTP on 8080.
@@ -159,8 +164,6 @@ services:
       # path); mounting the old path makes the container refuse to start.
       - pgsql-data:/var/lib/postgresql
     restart: unless-stopped
-    networks:
-      - app
     healthcheck:
       test: ['CMD', 'pg_isready', '-q', '-d', '${DB_DATABASE:-laravel}', '-U', '${DB_USERNAME:-laravel}']
       interval: 10s
@@ -182,8 +185,6 @@ services:
     volumes:
       - meili-data:/meili_data
     restart: unless-stopped
-    networks:
-      - app
     healthcheck:
       test: ['CMD', 'wget', '--no-verbose', '--spider', 'http://127.0.0.1:7700/health']
       interval: 10s
@@ -199,17 +200,11 @@ services:
     volumes:
       - redis-data:/data
     restart: unless-stopped
-    networks:
-      - app
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 10s
       timeout: 5s
       retries: 5
-
-networks:
-  app:
-    driver: bridge
 
 volumes:
   pgsql-data:

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -110,6 +110,7 @@ export default defineConfig({
 						{ label: 'Installation', slug: 'self-hosting/installation' },
 						{ label: 'Configuration', slug: 'self-hosting/configuration' },
 						{ label: 'Reverse proxy & TLS', slug: 'self-hosting/reverse-proxy' },
+						{ label: 'Deploying on Dokploy', slug: 'self-hosting/dokploy' },
 						{ label: 'First user & workspace', slug: 'self-hosting/first-user' },
 						{ label: 'Running a public demo', slug: 'self-hosting/demo' },
 						{ label: 'Upgrading', slug: 'self-hosting/upgrading' },

--- a/docs/src/content/docs/self-hosting/dokploy.md
+++ b/docs/src/content/docs/self-hosting/dokploy.md
@@ -8,7 +8,9 @@ Compose stacks behind its own Traefik. The repository ships
 `docker-compose.dokploy.yml` for it, so a deploy is four screens of settings and
 no YAML editing.
 
-That file is [`docker-compose.prod.yml`](/self-hosting/installation/) with two
+That file is
+[`docker-compose.prod.yml`](https://github.com/deskhq/the-desk/blob/master/docker-compose.prod.yml),
+the stack described in [Installation](/self-hosting/installation/), with two
 differences:
 
 1. **No `ports:`.** Traefik reaches the containers over Dokploy's own
@@ -18,10 +20,13 @@ differences:
 2. **`app` and `reverb` join `dokploy-network`** explicitly, next to the stack's
    own `default` network.
 
-:::note
-The same shape applies to Coolify, CapRover, and anything else that fronts
-compose services with an injected proxy network. The file works there too; only
-the names of the screens differ.
+:::note[Another PaaS?]
+This file is written for Dokploy, and the external network it declares is
+Dokploy's own. Any other platform that runs a compose stack behind an injected
+proxy network (Coolify, for instance) needs the same two changes with **its**
+network name in place of `dokploy-network`, so copy the file and rename that one
+reference. Platforms that do not run plain Compose at all, such as CapRover with
+its Swarm and NGINX layout, are not covered here.
 :::
 
 ## Before you start

--- a/docs/src/content/docs/self-hosting/dokploy.md
+++ b/docs/src/content/docs/self-hosting/dokploy.md
@@ -1,0 +1,271 @@
+---
+title: Deploying on Dokploy
+description: Deploy The Desk on Dokploy with the shipped docker-compose.dokploy.yml. Compose settings, the environment tab, domains for the app and Reverb, and the four failures a PaaS deploy hits.
+---
+
+[Dokploy](https://dokploy.com) is a self-hosted PaaS that runs your Docker
+Compose stacks behind its own Traefik. The repository ships
+`docker-compose.dokploy.yml` for it, so a deploy is four screens of settings and
+no YAML editing.
+
+That file is [`docker-compose.prod.yml`](/self-hosting/installation/) with two
+differences:
+
+1. **No `ports:`.** Traefik reaches the containers over Dokploy's own
+   `dokploy-network`, so publishing on the host does nothing. It also removes a
+   collision: Reverb's default host port is `8080`, which is Dokploy's Traefik
+   dashboard.
+2. **`app` and `reverb` join `dokploy-network`** explicitly, next to the stack's
+   own `default` network.
+
+:::note
+The same shape applies to Coolify, CapRover, and anything else that fronts
+compose services with an injected proxy network. The file works there too; only
+the names of the screens differ.
+:::
+
+## Before you start
+
+- **An amd64 host.** The published image is built for `linux/amd64` only
+  ([#205](https://github.com/deskhq/the-desk/issues/205)), so it will not boot on
+  an ARM server.
+- **A DNS A record** for your host (this page uses `chat.example.com`) pointing
+  at the Dokploy server.
+- **SMTP credentials**, as with any install. See
+  [Requirements](/self-hosting/requirements/).
+
+## Create the Compose application
+
+In your Dokploy project, create a **Compose** service (not an Application) and
+set:
+
+| Field            | Value                            |
+| ---------------- | -------------------------------- |
+| Provider         | GitHub → `deskhq/the-desk`       |
+| Branch           | `master`                         |
+| Compose Path     | `./docker-compose.dokploy.yml`   |
+| Compose Type     | Docker Compose                   |
+
+:::caution[Use `master`, not `develop`]
+`develop` is the release-candidate line: it is where `vX.Y.Z-rc.N` candidates are
+cut from. `master` carries the stable releases. Deploying from `develop` is not
+what you want unless you are deliberately testing a candidate.
+:::
+
+The branch only decides which **compose file** Dokploy reads. The application
+image itself comes from the GitHub Container Registry and is selected by
+`APP_VERSION` in the environment, so the two move independently. See
+[Pinning and upgrading](#pinning-and-upgrading) below.
+
+## The Environment tab
+
+Dokploy writes the contents of this tab to a `.env` file next to the compose
+file. That one file satisfies both halves of how the stack reads configuration:
+compose's `env_file:` injects the values into every container, and the
+`./.env:/app/.env:ro` bind mount puts the physical file inside the app so
+`php artisan` resolves exactly the same configuration.
+
+Start from
+[`.env.prod.example`](https://github.com/deskhq/the-desk/blob/master/.env.prod.example)
+and paste it in, then fill in your values. Three rules are specific to this tab:
+
+1. **No quotes.** The editor normalises them away, so `APP_NAME="The Desk"` is
+   written as `APP_NAME=The Desk` and phpdotenv aborts the boot with
+   `Encountered unexpected whitespace`. Keep every value free of spaces. The
+   shipped template already is.
+2. **No `${OTHER_VALUE}` references.** Values reach the containers through
+   `env_file:`, which passes them through literally, so a reference arrives as
+   the characters you typed. Write the value out.
+3. **No `COMPOSE_FILE` line.** It names `docker-compose.prod.yml`, which is the
+   wrong file here. Dokploy passes its own Compose Path explicitly.
+
+The values you must set by hand are the same everywhere: `APP_URL`, the
+[required secrets](/self-hosting/installation/#required-secrets) (`APP_KEY`,
+`DB_PASSWORD`, `MEILISEARCH_KEY`, and the `REVERB_APP_*` trio), your `MAIL_*`
+credentials, and the Reverb values from the next section. `docker/gen-secrets.sh`
+is the bare-VPS path and has nothing to write into here, so generate the secrets
+locally and paste them:
+
+```bash
+docker run --rm ghcr.io/deskhq/the-desk:latest php artisan key:generate --show
+docker run --rm ghcr.io/deskhq/the-desk:latest php artisan reverb:secret
+openssl rand -hex 32   # DB_PASSWORD, and again for MEILISEARCH_KEY
+```
+
+## The Domains tab
+
+Add **two** domain rows, one per service.
+
+| Service  | Host               | Path   | Strip Path | Container Port | HTTPS |
+| -------- | ------------------ | ------ | ---------- | -------------- | ----- |
+| `app`    | `chat.example.com` | `/`    | off        | `8080`         | on    |
+| `reverb` | `chat.example.com` | `/app` | **off**    | `8080`         | on    |
+
+:::caution[Container Port is `8080`, not `8000`]
+This field is the port **inside** the container, which is `8080` for both
+services. `APP_PORT` (default `8000`) is the host-side publish port that
+[Reverse proxy & TLS](/self-hosting/reverse-proxy/) talks about, and the Dokploy
+template publishes no host ports at all. The field's placeholder is `3000`, which
+is right for nothing here.
+:::
+
+Turn HTTPS on and let Dokploy issue a Let's Encrypt certificate. The app trusts
+Traefik's `X-Forwarded-*` headers out of the box, so it generates `https://`
+links with nothing further to configure.
+
+### Reverb on the same domain (recommended)
+
+The second row above routes `/app` to `reverb`, which is the path Echo opens its
+WebSocket against (`wss://chat.example.com/app/{key}`). **Strip Path must be
+off**: Reverb needs the prefix. This costs one DNS record and one certificate,
+and the app has no route under `/app` to collide with.
+
+Then, in the Environment tab:
+
+```dotenv
+REVERB_PORT_PUBLIC=443
+REVERB_SCHEME_PUBLIC=https
+REVERB_ALLOWED_ORIGINS=chat.example.com
+```
+
+Leave `REVERB_HOST_PUBLIC` unset. The browser-facing host then defaults to the
+host of `APP_URL`, which is exactly what you want when both share a domain.
+
+### Reverb on its own subdomain
+
+The alternative is a `ws-` style subdomain, which needs its own public DNS record
+and its own certificate. Point the `reverb` domain row at `ws.example.com` with
+Path `/`, then set:
+
+```dotenv
+REVERB_HOST_PUBLIC=ws.example.com
+REVERB_PORT_PUBLIC=443
+REVERB_SCHEME_PUBLIC=https
+REVERB_ALLOWED_ORIGINS=chat.example.com
+```
+
+`REVERB_ALLOWED_ORIGINS` stays the **app's** host in both layouts. It is checked
+against the browser's `Origin` header, which is the page the socket was opened
+from, not the host the socket connects to. Leaving it at the template's
+`chat.example.com` when your host is something else rejects every handshake
+silently, and all you see is a
+[stuck "Reconnecting…" banner](#a-stuck-reconnecting-banner).
+
+## Deploy
+
+Hit **Deploy**. The `app` container runs `php artisan migrate --force` on boot,
+so the database is ready by the time it reports healthy. Then
+[create the first user and workspace](/self-hosting/first-user/).
+
+## Running artisan commands
+
+There is no `docker compose exec` here, because the compose project belongs to
+Dokploy. Go through the container directly:
+
+```bash
+docker ps --filter name=app --format '{{.Names}}'
+docker exec -it <project>-app-1 php artisan about
+```
+
+The image already sets the working directory to `/app` and runs as the `www`
+user, so neither `-w` nor `-u` is needed.
+
+## Pinning and upgrading
+
+`APP_VERSION` selects the image tag, and upgrading is an edit in the Environment
+tab followed by **Redeploy** (Dokploy pulls the new tag):
+
+```dotenv
+APP_VERSION=1.15.2 # x-release-please-version
+```
+
+To track stable releases instead of pinning one, set `APP_IMAGE`, which overrides
+the version entirely:
+
+```dotenv
+APP_IMAGE=ghcr.io/deskhq/the-desk:latest
+```
+
+`latest` is only ever applied to a stable release. A release candidate is
+published as `X.Y.Z-rc.N` plus the moving `rc` tag, so a candidate can never land
+on `latest` and this cannot drift onto the `develop` line by accident.
+
+:::caution[Auto-deploy on tags fires for candidates too]
+Trigger Type **On Tag** fires for every `v*` tag in the repository, and that
+includes the `vX.Y.Z-rc.N` candidates cut from `develop`. If you only want stable
+releases, pin `APP_VERSION` and redeploy by hand, or trigger on pushes to
+`master`.
+:::
+
+See [Upgrading](/self-hosting/upgrading/) for what an upgrade does to your data
+and the search index.
+
+## Troubleshooting
+
+### A bare `404 page not found` from Traefik
+
+**Symptom.** The domain resolves and serves TLS, but every request returns a
+plain `404 page not found` with no styling. That page is Traefik's, not the
+app's.
+
+**Cause.** Traefik drops the router for a container that is not running, so a
+crash-looping `app` container looks like a missing route. The wrong **Container
+Port** produces the same page.
+
+**Fix.** Read the container logs, which name the real failure:
+
+```bash
+docker logs <project>-app-1 --tail=100
+```
+
+Then confirm Container Port is `8080` on both domain rows.
+
+### `could not translate host name "pgsql" to address`
+
+**Symptom.** The `app` container restarts in a loop with
+`SQLSTATE[08006] could not translate host name "pgsql" to address`, while
+`pgsql` itself is up and healthy.
+
+**Cause.** The stack is split across two networks. Dokploy rewrites `networks:`
+on whichever service a domain is attached to, replacing a custom network with
+`default` plus `dokploy-network`. Every other service stays on the custom one, so
+the web container can no longer resolve its own database.
+
+**Fix.** Use `docker-compose.dokploy.yml`, which declares no custom network.
+If you pasted a compose file of your own, remove any `networks:` block that is
+not `dokploy-network`.
+
+### `Failed to parse dotenv file. Encountered unexpected whitespace`
+
+**Symptom.** Containers restart in a loop. The error names neither the file nor
+the key, and the deployment log usually scrolls past it.
+
+**Cause.** A value in the Environment tab contains a space. The editor stripped
+the quotes that made it parse.
+
+**Fix.** Find the value with a space in it and remove the space, for example
+`APP_NAME=TheDesk`. `SSO_OIDC_SCOPES` is the one setting that cannot be written
+without spaces, so leave it commented out unless your identity provider needs
+non-default scopes.
+
+### A stuck "Reconnecting…" banner
+
+**Symptom.** The app loads and you can sign in, but a **"Reconnecting…"** banner
+sits at the top and no real-time updates arrive.
+
+**Cause.** On this platform it is almost always one of two things: the `reverb`
+domain row with Path `/app` is missing (or has Strip Path on), or
+`REVERB_ALLOWED_ORIGINS` is still the template's `chat.example.com` while your
+host is something else, in which case Reverb rejects every handshake without
+saying so.
+
+**Fix.** Re-check the [Domains table](#the-domains-tab) and the
+`REVERB_ALLOWED_ORIGINS` value for your layout, then redeploy. The full
+symptom-first walkthrough is in
+[Troubleshooting](/self-hosting/troubleshooting/#reconnecting-after-login--websocket-wont-connect).
+
+:::caution
+`.env` changes need the containers **recreated**, not just restarted, because the
+config cache is built at boot. Dokploy's **Redeploy** does that. See
+[Changed `.env` but nothing changed](/self-hosting/troubleshooting/#changed-env-but-nothing-changed).
+:::

--- a/docs/src/content/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/self-hosting/installation.md
@@ -22,6 +22,13 @@ Make sure you meet the [requirements](/self-hosting/requirements/) first — Doc
 24+, a domain, a TLS reverse proxy, and working SMTP.
 :::
 
+:::tip[Deploying on a PaaS instead?]
+Dokploy, Coolify, and CapRover front your containers with their own Traefik, which
+needs a slightly different compose file. `docker-compose.dokploy.yml` is shipped
+for that: see [Deploying on Dokploy](/self-hosting/dokploy/) and skip this page's
+host-port setup.
+:::
+
 ## Pull the published image
 
 The image comes from the GitHub Container Registry (`ghcr.io/deskhq/the-desk`;

--- a/docs/src/content/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/self-hosting/installation.md
@@ -23,9 +23,9 @@ Make sure you meet the [requirements](/self-hosting/requirements/) first — Doc
 :::
 
 :::tip[Deploying on a PaaS instead?]
-Dokploy, Coolify, and CapRover front your containers with their own Traefik, which
-needs a slightly different compose file. `docker-compose.dokploy.yml` is shipped
-for that: see [Deploying on Dokploy](/self-hosting/dokploy/) and skip this page's
+Dokploy and Coolify front your containers with their own Traefik, which needs a
+slightly different compose file. `docker-compose.dokploy.yml` is shipped for
+that: see [Deploying on Dokploy](/self-hosting/dokploy/) and skip this page's
 host-port setup.
 :::
 

--- a/docs/src/content/docs/self-hosting/reverse-proxy.md
+++ b/docs/src/content/docs/self-hosting/reverse-proxy.md
@@ -121,9 +121,9 @@ host to the `reverb` service. Traefik forwards WebSocket upgrades automatically
 once the service is reachable.
 
 :::tip[Running a PaaS?]
-Dokploy, Coolify, and CapRover already run Traefik and attach your containers to
-it, so you configure domains in their UI rather than writing labels. The
-repository ships a compose template for that shape, and
+Dokploy and Coolify run their own Traefik and attach your containers to it, so
+you configure domains in their UI rather than writing labels. The repository
+ships `docker-compose.dokploy.yml` for that shape, and
 [Deploying on Dokploy](/self-hosting/dokploy/) walks through the domain rows,
 including the one that routes `/app` to Reverb on a single hostname.
 :::

--- a/docs/src/content/docs/self-hosting/reverse-proxy.md
+++ b/docs/src/content/docs/self-hosting/reverse-proxy.md
@@ -120,6 +120,14 @@ config) that route `chat.example.com` to the `app` service and your WebSocket
 host to the `reverb` service. Traefik forwards WebSocket upgrades automatically
 once the service is reachable.
 
+:::tip[Running a PaaS?]
+Dokploy, Coolify, and CapRover already run Traefik and attach your containers to
+it, so you configure domains in their UI rather than writing labels. The
+repository ships a compose template for that shape, and
+[Deploying on Dokploy](/self-hosting/dokploy/) walks through the domain rows,
+including the one that routes `/app` to Reverb on a single hostname.
+:::
+
 ## Upload body size
 
 Message attachments are capped by [`ATTACHMENT_MAX_SIZE_MB`](/reference/environment-variables/#attachments)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
         { "type": "generic", "path": ".env.prod.example" },
         { "type": "generic", "path": "docker/install.sh" },
         { "type": "generic", "path": "docs/src/content/docs/comparison.md" },
+        { "type": "generic", "path": "docs/src/content/docs/self-hosting/dokploy.md" },
         { "type": "generic", "path": "docs/src/content/docs/self-hosting/installation.md" },
         { "type": "generic", "path": "docs/src/content/docs/self-hosting/upgrading.md" }
       ]

--- a/tests/Unit/DokployComposeTemplateTest.php
+++ b/tests/Unit/DokployComposeTemplateTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * A PaaS that fronts compose services with an injected proxy network (Dokploy,
+ * Coolify, CapRover) rewrites `networks:` on whichever service a domain is
+ * attached to. A custom bridge network therefore splits the stack in half: the
+ * proxied service moves to the injected network while the rest stay behind, and
+ * the web container crash-loops on `could not translate host name "pgsql"`.
+ * The implicit `default` network is where the injection lands anyway, so the
+ * custom one buys nothing. See issue #751.
+ */
+$prod = fn (): array => Yaml::parseFile(dirname(__DIR__, 2).'/docker-compose.prod.yml');
+
+$dokploy = fn (): array => Yaml::parseFile(dirname(__DIR__, 2).'/docker-compose.dokploy.yml');
+
+/** The services Traefik routes to, and the only two that publish host ports. */
+$proxied = ['app', 'reverb'];
+
+test('the production stack declares no custom network', function () use ($prod): void {
+    expect($prod())->not->toHaveKey('networks');
+});
+
+test('no production service pins itself to a network', function () use ($prod): void {
+    $pinned = array_keys(array_filter($prod()['services'], static fn (array $service): bool => isset($service['networks'])));
+
+    expect($pinned)->toBe([]);
+});
+
+test('the dokploy template covers exactly the production services', function () use ($prod, $dokploy): void {
+    expect(array_keys($dokploy()['services']))->toBe(array_keys($prod()['services']));
+});
+
+/**
+ * The template is a standalone file because Dokploy points at a single compose
+ * path, so it can only stay correct by being a mechanical mirror: the production
+ * stack minus host publishing, plus the proxy network. Anything else that
+ * diverges is drift, and this is what catches it.
+ */
+test('the dokploy template is the production stack minus host publishing', function (string $name) use ($prod, $dokploy, $proxied): void {
+    $expected = $prod()['services'][$name];
+    unset($expected['ports']);
+
+    if (in_array($name, $proxied, true)) {
+        $expected['networks'] = ['default', 'dokploy-network'];
+    }
+
+    expect($dokploy()['services'][$name])->toEqual($expected);
+})->with(fn (): array => array_keys(Yaml::parseFile(dirname(__DIR__, 2).'/docker-compose.prod.yml')['services']));
+
+test('the dokploy template joins the proxy network explicitly', function () use ($dokploy): void {
+    expect($dokploy()['networks'])->toBe(['dokploy-network' => ['external' => true]]);
+});
+
+test('the dokploy template keeps the production volumes', function () use ($prod, $dokploy): void {
+    expect($dokploy()['volumes'])->toEqual($prod()['volumes']);
+});

--- a/tests/Unit/ProductionEnvTemplateTest.php
+++ b/tests/Unit/ProductionEnvTemplateTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * A PaaS environment editor (Dokploy, Coolify, …) writes its textarea to `.env`
+ * verbatim but normalises quotes, so `APP_NAME="The Desk"` lands as
+ * `APP_NAME=The Desk` and phpdotenv aborts the boot with `Failed to parse dotenv
+ * file. Encountered unexpected whitespace at [The Desk]` — an error that names
+ * neither the file nor the key, hidden behind a container restart loop.
+ *
+ * The same values also reach the container through compose's `env_file:`, which
+ * passes them through literally, so a `${VAR}` reference is never expanded: it
+ * arrives as the characters an operator typed. See issue #751.
+ *
+ * Commented-out settings are checked too — they are the lines an operator
+ * uncomments, so a hazard parked behind a `#` is a hazard shipped.
+ *
+ * @return list<array{key: string, value: string, line: int}>
+ */
+$settings = function (): array {
+    $template = (string) file_get_contents(dirname(__DIR__, 2).'/.env.prod.example');
+    $settings = [];
+
+    foreach (explode("\n", $template) as $index => $line) {
+        if (preg_match('/^#?\s*([A-Z][A-Z0-9_]*)=(.*)$/', trim($line), $matches) !== 1) {
+            continue;
+        }
+
+        $settings[] = [
+            'key' => $matches[1],
+            // Drop the trailing inline comment dotenv itself strips, so an
+            // annotation such as `# x-release-please-version` is not read as
+            // whitespace inside the value.
+            'value' => (string) preg_replace('/\s+#.*$/', '', $matches[2]),
+            'line' => $index + 1,
+        ];
+    }
+
+    return $settings;
+};
+
+/**
+ * The one setting whose value cannot be expressed without spaces: Socialite is
+ * handed `explode(' ', …)` of it. It ships commented out, and the Dokploy guide
+ * tells PaaS operators to leave it that way.
+ *
+ * @var list<string>
+ */
+$quotedByNecessity = ['SSO_OIDC_SCOPES'];
+
+test('the template is parsed, not silently matched to nothing', function () use ($settings): void {
+    expect(count($settings()))->toBeGreaterThan(50);
+});
+
+test('no setting breaks when a PaaS strips its quotes', function () use ($settings, $quotedByNecessity): void {
+    $fragile = array_values(array_map(
+        static fn (array $setting): string => $setting['key'].' (line '.$setting['line'].')',
+        array_filter(
+            $settings(),
+            static fn (array $setting): bool => ! in_array($setting['key'], $quotedByNecessity, true)
+                && preg_match('/\s/', $setting['value']) === 1,
+        ),
+    ));
+
+    expect($fragile)->toBe([]);
+});
+
+test('no setting references another one, which env_file would not expand', function () use ($settings): void {
+    $referencing = array_values(array_map(
+        static fn (array $setting): string => $setting['key'].' (line '.$setting['line'].')',
+        array_filter($settings(), static fn (array $setting): bool => str_contains($setting['value'], '${')),
+    ));
+
+    expect($referencing)->toBe([]);
+});

--- a/tests/Unit/ProductionEnvTemplateTest.php
+++ b/tests/Unit/ProductionEnvTemplateTest.php
@@ -16,23 +16,24 @@ declare(strict_types=1);
  * Commented-out settings are checked too — they are the lines an operator
  * uncomments, so a hazard parked behind a `#` is a hazard shipped.
  *
- * @return list<array{key: string, value: string, line: int}>
+ * @return list<array{key: string, value: string, line: int, commented: bool}>
  */
 $settings = function (): array {
     $template = (string) file_get_contents(dirname(__DIR__, 2).'/.env.prod.example');
     $settings = [];
 
     foreach (explode("\n", $template) as $index => $line) {
-        if (preg_match('/^#?\s*([A-Z][A-Z0-9_]*)=(.*)$/', trim($line), $matches) !== 1) {
+        if (preg_match('/^(#?)\s*([A-Z][A-Z0-9_]*)=(.*)$/', trim($line), $matches) !== 1) {
             continue;
         }
 
         $settings[] = [
-            'key' => $matches[1],
+            'commented' => $matches[1] === '#',
+            'key' => $matches[2],
             // Drop the trailing inline comment dotenv itself strips, so an
             // annotation such as `# x-release-please-version` is not read as
             // whitespace inside the value.
-            'value' => (string) preg_replace('/\s+#.*$/', '', $matches[2]),
+            'value' => (string) preg_replace('/\s+#.*$/', '', $matches[3]),
             'line' => $index + 1,
         ];
     }
@@ -42,8 +43,9 @@ $settings = function (): array {
 
 /**
  * The one setting whose value cannot be expressed without spaces: Socialite is
- * handed `explode(' ', …)` of it. It ships commented out, and the Dokploy guide
- * tells PaaS operators to leave it that way.
+ * handed `explode(' ', …)` of it. The exemption is deliberately narrowed to the
+ * commented-out example it ships as, so activating it in the template would have
+ * to be a conscious decision rather than an inherited licence.
  *
  * @var list<string>
  */
@@ -58,7 +60,7 @@ test('no setting breaks when a PaaS strips its quotes', function () use ($settin
         static fn (array $setting): string => $setting['key'].' (line '.$setting['line'].')',
         array_filter(
             $settings(),
-            static fn (array $setting): bool => ! in_array($setting['key'], $quotedByNecessity, true)
+            static fn (array $setting): bool => (! $setting['commented'] || ! in_array($setting['key'], $quotedByNecessity, true))
                 && preg_match('/\s/', $setting['value']) === 1,
         ),
     ));


### PR DESCRIPTION
Closes #751.

Deploying the demo instance on Dokploy surfaced four things the production stack did not account for. This makes the stack portable to a container-network PaaS and documents the path.

## What changed

**`docker-compose.prod.yml` is portable.** The custom `app` bridge network is gone (from the `x-app` anchor, from `pgsql`/`meilisearch`/`redis`, and the top-level block). A PaaS rewrites `networks:` on whichever service a domain is attached to, so a custom network split the stack in half and the web container crash-looped on `could not translate host name "pgsql"`. Everything now sits on the implicit `default` network, which is where the injection lands anyway. Pure simplification, no behaviour change.

**New `docker-compose.dokploy.yml`.** The production stack with the two `ports:` blocks removed (Traefik routes over the network, and Reverb's `127.0.0.1:8080` collides with Dokploy's Traefik dashboard) and `dokploy-network` declared as an external network on `app` and `reverb`. Operators point Dokploy's Compose Path at it and never edit YAML.

`dokploy-network` is declared **explicitly** rather than left to Dokploy's injection: injection only rewrites the services a domain is attached to, so an explicit declaration is what guarantees `reverb` reaches Traefik, and the file documents what it depends on.

**`.env.prod.example` survives a PaaS env editor.** `APP_NAME`, `MAIL_FROM_NAME`, and `MAIL_FROM_ADDRESS` are unquoted. Dokploy normalises quotes away, so `APP_NAME="The Desk"` landed as `APP_NAME=The Desk` and phpdotenv aborted the boot with an error naming neither the file nor the key.

While there: `MAIL_FROM_NAME="${APP_NAME}"` and the commented `SSO_OIDC_REDIRECT_URI="${APP_URL}/…"` were already broken on this stack. Values reach the containers through compose's `env_file:`, which does not interpolate, so the reference arrived literally. Both are now written out. `SSO_OIDC_SCOPES` keeps its quotes (Socialite is handed `explode(' ', …)` of it) and carries a comment saying so.

**New docs page** `self-hosting/dokploy.md`, in the sidebar and linked from `installation.md` and `reverse-proxy.md`. Covers the compose app settings (branch `master`, not the `develop` candidate line), the Environment tab and why it satisfies both `env_file:` and the `./.env:/app/.env:ro` mount, Container Port `8080` (not `APP_PORT`), both Reverb layouts with their `REVERB_HOST_PUBLIC` / `REVERB_ALLOWED_ORIGINS` values, pinning and upgrading, the amd64-only image (#205), running artisan, and a symptom-first troubleshooting section for the four failures above.

## How it was tested

- Two new unit tests. `DokployComposeTemplateTest` holds the template to being a mechanical mirror of the production stack (same services, same content, minus `ports`, plus the proxy network), which is what keeps a standalone second compose file from drifting. `ProductionEnvTemplateTest` fails on any template value that needs its quotes or references another one.
- `./vendor/bin/sail composer test` green at 100%, plus the frontend gate (`lint:check`, `format:check`, `types:check`, `test:js`, `build`).
- `docker compose config` on both files, then a real `docker compose up -d` of the production stack from a clean directory: all seven services healthy, `app` and `reverb` both answering 200 on `/up`.
- `cd docs && npm run build` passes; the new page is in `docs/dist` and every anchor it links to resolves.
- `php artisan release:check-version-refs` passes: the page's `APP_VERSION` example carries the `x-release-please-version` annotation and the page is registered under `extra-files`.

## Notes

The docs are operator-facing only, so there are no i18n keys in this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787355222&installation_model_id=428379&pr_number=758&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F758&signature=e23a8cc8737a8c3f499ba5069f22ad5ef5930251817f1374b9ba01877be81c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->