### PR TITLE
test: make phpunit.xml's force-pinned env vars beat an exported value

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
 >
     <testsuites>
@@ -40,8 +40,11 @@
             stays green. Pinning also keeps DEMO_MODE defined at the process
             level, so the immutable env repository never "adopts" the .env value
             as its own and re-writes it on later application refreshes. `force`
-            makes the pin win even over an exported/process-level DEMO_MODE, so
-            the suite is deterministic no matter how the flag arrives.
+            re-applies the pin even when DEMO_MODE is already defined at the
+            process level — but PHPUnit writes it to putenv() and $_ENV only, so
+            an exported value would still win from $_SERVER; tests/bootstrap.php
+            clears that copy (#756). Between them the suite is deterministic no
+            matter how the flag arrives.
         -->
         <env name="DEMO_MODE" value="false" force="true"/>
         <!--
@@ -98,7 +101,8 @@
             config()->set(), and the browser suite sets all three explicitly.
             `force` re-applies the pin even when the name is already defined at
             the process level, so it also survives a `putenv` from an earlier
-            bootstrap.
+            bootstrap; an exported value additionally needs the $_SERVER copy
+            tests/bootstrap.php clears (#756).
         -->
         <env name="REVERB_HOST_PUBLIC" value="" force="true"/>
         <env name="REVERB_PORT_PUBLIC" value="" force="true"/>

--- a/tests/Fixtures/env-pins/configuration.xml
+++ b/tests/Fixtures/env-pins/configuration.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../../vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <php>
+        <env name="PIN_WITHOUT_FORCE" value="a"/>
+        <env name="PIN_FORCED_EMPTY" value="" force="true"/>
+        <env name="PIN_FORCED_VALUE" value="b" force="true"/>
+        <env name="PIN_FORCE_DISABLED" value="c" force="false"/>
+        <server name="SERVER_PIN_FORCED" value="d" force="true"/>
+    </php>
+</phpunit>

--- a/tests/Support/ForcedEnvPins.php
+++ b/tests/Support/ForcedEnvPins.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use RuntimeException;
+use SimpleXMLElement;
+
+/**
+ * Makes phpunit.xml's `force="true"` env pins beat an exported value.
+ *
+ * PHPUnit's PhpHandler writes a forced pin to putenv() and $_ENV, but never to
+ * $_SERVER. An exported variable (`export`, `docker run -e`, `sail exec -e`)
+ * lands in $_SERVER too, and Laravel's env repository reads that adapter first,
+ * so the export would still win over the pin. Clearing the $_SERVER copy of
+ * every forced name lets the pin resolve, whichever way the value arrived.
+ */
+final class ForcedEnvPins
+{
+    /**
+     * Drop the $_SERVER copy of every force-pinned name, so the pin resolves.
+     *
+     * Call this from the bootstrap script: PHPUnit applies the `<php>` pins
+     * before it loads the bootstrap, so the pinned values are already sitting
+     * in putenv()/$_ENV by the time the stale $_SERVER entries go away.
+     */
+    public static function clearServerCopies(string $configurationPath): void
+    {
+        foreach (self::names($configurationPath) as $name) {
+            unset($_SERVER[$name]);
+        }
+    }
+
+    /**
+     * The names of the `force="true"` env pins declared in a PHPUnit configuration.
+     *
+     * @return list<string>
+     */
+    public static function names(string $configurationPath): array
+    {
+        $configuration = @simplexml_load_file($configurationPath);
+
+        throw_unless($configuration instanceof SimpleXMLElement, RuntimeException::class, "Unable to read the PHPUnit configuration at [{$configurationPath}].");
+
+        $names = [];
+
+        foreach ($configuration->xpath('//php/env') ?: [] as $pin) {
+            if (((string) ($pin['force'] ?? '')) === 'true') {
+                $names[] = (string) $pin['name'];
+            }
+        }
+
+        return $names;
+    }
+}

--- a/tests/Unit/EnvPinArrivalTest.php
+++ b/tests/Unit/EnvPinArrivalTest.php
@@ -7,6 +7,9 @@ declare(strict_types=1);
  * DEMO_MODE and the REVERB_*_PUBLIC trio exported, so the force-pinned values
  * are checked against every arrival mode (#756). They hold in an ordinary run
  * too, where this file simply guards that the pins are what the suite resolves.
+ *
+ * DEMO_MODE reads as an empty string rather than "false": PHPUnit normalizes a
+ * boolean-looking value="false" away before it writes the pin.
  */
 
 test('the force-pinned env variables resolve to their phpunit.xml values', function (): void {
@@ -14,7 +17,7 @@ test('the force-pinned env variables resolve to their phpunit.xml values', funct
         ->and($_SERVER)->not->toHaveKey('REVERB_HOST_PUBLIC')
         ->and($_SERVER)->not->toHaveKey('REVERB_PORT_PUBLIC')
         ->and($_SERVER)->not->toHaveKey('REVERB_SCHEME_PUBLIC')
-        ->and(env('DEMO_MODE'))->toBeFalsy()
+        ->and(env('DEMO_MODE'))->toBe('')
         ->and(env('REVERB_HOST_PUBLIC'))->toBe('')
         ->and(env('REVERB_PORT_PUBLIC'))->toBe('')
         ->and(env('REVERB_SCHEME_PUBLIC'))->toBe('');

--- a/tests/Unit/EnvPinArrivalTest.php
+++ b/tests/Unit/EnvPinArrivalTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The assertions EnvPinExportedArrivalTest re-runs in a child process that has
+ * DEMO_MODE and the REVERB_*_PUBLIC trio exported, so the force-pinned values
+ * are checked against every arrival mode (#756). They hold in an ordinary run
+ * too, where this file simply guards that the pins are what the suite resolves.
+ */
+
+test('the force-pinned env variables resolve to their phpunit.xml values', function (): void {
+    expect($_SERVER)->not->toHaveKey('DEMO_MODE')
+        ->and($_SERVER)->not->toHaveKey('REVERB_HOST_PUBLIC')
+        ->and($_SERVER)->not->toHaveKey('REVERB_PORT_PUBLIC')
+        ->and($_SERVER)->not->toHaveKey('REVERB_SCHEME_PUBLIC')
+        ->and(env('DEMO_MODE'))->toBeFalsy()
+        ->and(env('REVERB_HOST_PUBLIC'))->toBe('')
+        ->and(env('REVERB_PORT_PUBLIC'))->toBe('')
+        ->and(env('REVERB_SCHEME_PUBLIC'))->toBe('');
+});

--- a/tests/Unit/EnvPinExportedArrivalTest.php
+++ b/tests/Unit/EnvPinExportedArrivalTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\Process;
+
+/*
+ * The arrival mode the pins used to lose to (#756): a genuinely exported
+ * variable. PHPUnit writes a `force="true"` pin to putenv() and $_ENV only, so
+ * the export's $_SERVER entry — which Laravel's env repository reads first —
+ * survived and won. It cannot be reproduced in-process (the export has to
+ * predate the run), so this re-runs EnvPinArrivalTest in a child process with
+ * the values exported into it, exactly as `sail exec -e` or `docker run -e`
+ * would deliver them.
+ */
+
+test('a force-pinned env variable exported into the process still resolves to its pin', function (): void {
+    $process = new Process(
+        [PHP_BINARY, 'vendor/bin/pest', '--colors=never', 'tests/Unit/EnvPinArrivalTest.php'],
+        dirname(__DIR__, 2),
+        [
+            'DEMO_MODE' => 'true',
+            'REVERB_HOST_PUBLIC' => 'exported.example',
+            'REVERB_PORT_PUBLIC' => '20012',
+            'REVERB_SCHEME_PUBLIC' => 'http',
+        ],
+    );
+
+    $process->setTimeout(120)->run();
+
+    $this->assertSame(
+        0,
+        $process->getExitCode(),
+        'The exported values leaked past the pins:'.PHP_EOL.$process->getOutput().$process->getErrorOutput(),
+    );
+});

--- a/tests/Unit/Support/ForcedEnvPinsTest.php
+++ b/tests/Unit/Support/ForcedEnvPinsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Support\ForcedEnvPins;
+
+/*
+ * ForcedEnvPins is what makes phpunit.xml's `force="true"` pins live up to
+ * their name (#756). PHPUnit writes a forced pin to putenv() and $_ENV only,
+ * so an exported variable — which also lands in $_SERVER — still wins, because
+ * Laravel's env repository reads $_SERVER first. tests/bootstrap.php runs this
+ * helper right after PHPUnit applies the pins to clear those stale copies.
+ */
+
+$fixture = dirname(__DIR__, 2).'/Fixtures/env-pins/configuration.xml';
+
+afterEach(function (): void {
+    unset($_SERVER['PIN_FORCED_EMPTY'], $_SERVER['PIN_FORCED_VALUE'], $_SERVER['PIN_WITHOUT_FORCE']);
+});
+
+test('it reads the names of the force-pinned env variables', function () use ($fixture): void {
+    expect(ForcedEnvPins::names($fixture))->toBe(['PIN_FORCED_EMPTY', 'PIN_FORCED_VALUE']);
+});
+
+test('it clears the exported copy of every force-pinned name', function () use ($fixture): void {
+    $_SERVER['PIN_FORCED_EMPTY'] = 'exported';
+    $_SERVER['PIN_FORCED_VALUE'] = 'exported';
+    $_SERVER['PIN_WITHOUT_FORCE'] = 'exported';
+
+    ForcedEnvPins::clearServerCopies($fixture);
+
+    expect($_SERVER)->not->toHaveKey('PIN_FORCED_EMPTY')
+        ->and($_SERVER)->not->toHaveKey('PIN_FORCED_VALUE')
+        ->and($_SERVER)->toHaveKey('PIN_WITHOUT_FORCE', 'exported');
+});

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Support\ForcedEnvPins;
+
+require __DIR__.'/../vendor/autoload.php';
+
+/*
+ * PHPUnit has already applied the `<php>` pins from phpunit.xml by the time it
+ * loads this script, but a `force="true"` pin only reaches putenv() and $_ENV.
+ * Drop the $_SERVER copy an exported variable would leave behind, so the pin —
+ * not the export — is what the suite resolves. See Tests\Support\ForcedEnvPins.
+ */
+ForcedEnvPins::clearServerCopies(__DIR__.'/../phpunit.xml');


### PR DESCRIPTION
Closes #756.

## What

`phpunit.xml` documented `force="true"` as making a pin win "even over an exported/process-level" value. It did not: PHPUnit's `PhpHandler::handleEnvVariables()` writes a forced pin to `putenv()` and `$_ENV` only, never `$_SERVER`. An exported variable (`export`, `docker run -e`, `sail exec -e`) lands in `$_SERVER` too, and Laravel's env repository reads that adapter first — so the export still won, for `DEMO_MODE` and for the `REVERB_*_PUBLIC` pins added in #732.

This takes the stronger of the two options in the issue: the pins are now genuinely process-env-proof, rather than the claim being downgraded.

## How

- `phpunit.xml` bootstraps `tests/bootstrap.php` instead of `vendor/autoload.php`. PHPUnit applies the `<php>` pins (`Application.php:129`) *before* it loads the bootstrap (`:132`), so by then the pinned values are already in `putenv()`/`$_ENV` and only the stale `$_SERVER` copies remain.
- `Tests\Support\ForcedEnvPins` reads the `force="true"` `<env>` names straight out of the configuration and unsets their `$_SERVER` entries — so a pin added later is covered with no second list to maintain. Non-forced pins are untouched, keeping their "an existing process value wins" semantics.
- The two misleading comments in `phpunit.xml` now describe the actual mechanism (`force` + the `$_SERVER` strip) instead of overselling `force` alone.

## How tested

- `tests/Unit/Support/ForcedEnvPinsTest.php` covers the helper against a fixture configuration: only `force="true"` `<env>` entries are reported (not `force="false"`, not unforced, not `<server>`), and only those get cleared.
- `tests/Unit/EnvPinExportedArrivalTest.php` covers the arrival mode nothing reached before. It cannot be reproduced in-process — the export has to predate the run — so it re-runs `tests/Unit/EnvPinArrivalTest.php` in a child process with `DEMO_MODE=true` and the `REVERB_*_PUBLIC` trio exported into it, and asserts the pins still win. That child run failed before the bootstrap was wired in, exactly as the issue describes.
- The issue's original reproduction now passes too: `sail exec -e REVERB_PORT_PUBLIC=20012 -e REVERB_HOST_PUBLIC=exported.example -e DEMO_MODE=true laravel.test php artisan test tests/Unit/Support/ReverbConfigTest.php tests/Feature/ReverbConfigSharingTest.php tests/Feature/Demo` — 32 passed.
- Full gate green: Pint, PHPStan, Rector, 2246 tests, `Total: 100.0 %`.

No user-facing copy and no operator-facing setting changed, so no i18n or `docs/` updates apply. Typed `test:` because it hardens the suite's own isolation and ships nothing to users (same as #757, the sibling fix for #732).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787364301&installation_model_id=428379&pr_number=761&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F761&signature=bf3a3137a32d612e1a5eb666182264180c59c75dddca33799b8bb3d17c8ed9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->