### PR TITLE
fix: keep the presence menu's rows on one line in every locale

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1214,7 +1214,7 @@
   "Set yourself away": "Se marquer absent",
   "Set yourself active": "Se marquer actif",
   "Could not change your presence.": "Impossible de modifier votre présence.",
-  "Pause notifications": "Mettre les notifications en pause",
+  "Pause notifications": "Pause des notifications",
   "Notifications paused": "Notifications en pause",
   "Paused": "En pause",
   "Resume": "Reprendre",

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -443,7 +443,9 @@ const handleLogout = () => {
             <SmilePlus
                 class="size-3.75 text-muted-foreground group-focus/item:text-brass"
             />
-            <span class="min-w-0 flex-1 truncate">{{ $t('Set a status') }}</span>
+            <span class="min-w-0 flex-1 truncate">{{
+                $t('Set a status')
+            }}</span>
         </DropdownMenuItem>
         <div
             v-else
@@ -633,7 +635,9 @@ const handleLogout = () => {
                 <Settings
                     class="size-3.75 text-muted-foreground group-focus/item:text-brass"
                 />
-                <span class="min-w-0 flex-1 truncate">{{ $t('Settings') }}</span>
+                <span class="min-w-0 flex-1 truncate">{{
+                    $t('Settings')
+                }}</span>
             </Link>
         </DropdownMenuItem>
     </div>

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -443,7 +443,7 @@ const handleLogout = () => {
             <SmilePlus
                 class="size-3.75 text-muted-foreground group-focus/item:text-brass"
             />
-            {{ $t('Set a status') }}
+            <span class="min-w-0 flex-1 truncate">{{ $t('Set a status') }}</span>
         </DropdownMenuItem>
         <div
             v-else
@@ -514,16 +514,23 @@ const handleLogout = () => {
                     class="size-2.25"
                 />
             </span>
-            {{
+            <span class="min-w-0 flex-1 truncate">{{
                 togglesTo === 'away'
                     ? $t('Set yourself away')
                     : $t('Set yourself active')
-            }}
+            }}</span>
         </DropdownMenuItem>
         <!-- Pause notifications: the crescent row below the away toggle, its
              presets flowing out in a flyout. Choosing one applies in place;
              Custom… trades the menu for the dialog, and the trailing row links
-             to the recurring schedule in Settings. -->
+             to the recurring schedule in Settings.
+
+             Like its sibling rows, the label is a truncating flex child rather
+             than a bare text node: the menu is only as wide as the dock, and a
+             locale whose translation runs longer than the English (#760) would
+             otherwise wrap out of the fixed row height and shove the chevron
+             off-centre. Ellipsised text keeps the full string in the DOM, so the
+             accessible name stays complete. -->
         <DropdownMenuSub>
             <DropdownMenuSubTrigger
                 class="group/item mt-0.5 flex h-9 cursor-pointer items-center gap-2.5 rounded-[10px] px-2.5 py-0 text-[13.5px] font-normal text-foreground data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground data-[state=open]:bg-primary data-[state=open]:text-primary-foreground"
@@ -532,7 +539,9 @@ const handleLogout = () => {
                 <Moon
                     class="size-3.75 text-muted-foreground group-data-[highlighted]/item:text-brass group-data-[state=open]/item:text-brass"
                 />
-                {{ $t('Pause notifications') }}
+                <span class="min-w-0 flex-1 truncate">{{
+                    $t('Pause notifications')
+                }}</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent
                 class="min-w-47 rounded-[14px] p-1.25"
@@ -624,7 +633,7 @@ const handleLogout = () => {
                 <Settings
                     class="size-3.75 text-muted-foreground group-focus/item:text-brass"
                 />
-                {{ $t('Settings') }}
+                <span class="min-w-0 flex-1 truncate">{{ $t('Settings') }}</span>
             </Link>
         </DropdownMenuItem>
     </div>
@@ -643,7 +652,9 @@ const handleLogout = () => {
             <Keyboard
                 class="size-3.75 text-muted-foreground group-focus/item:text-brass"
             />
-            {{ $t('Keyboard shortcuts') }}
+            <span class="min-w-0 flex-1 truncate">{{
+                $t('Keyboard shortcuts')
+            }}</span>
             <DropdownMenuShortcut
                 class="ml-auto inline-flex h-4.5 min-w-4 items-center justify-center rounded-[5px] border border-border px-1 font-mono text-[10px] font-semibold tracking-normal text-muted-foreground group-focus/item:border-primary-foreground/30 group-focus/item:text-primary-foreground"
                 >?</DropdownMenuShortcut
@@ -657,7 +668,7 @@ const handleLogout = () => {
             <Compass
                 class="size-3.75 text-muted-foreground group-focus/item:text-brass"
             />
-            {{ $t('Replay tour') }}
+            <span class="min-w-0 flex-1 truncate">{{ $t('Replay tour') }}</span>
         </DropdownMenuItem>
     </div>
 

--- a/tests/Browser/UserMenuLongLabelTest.php
+++ b/tests/Browser/UserMenuLongLabelTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AppLocale;
+
+/**
+ * The user menu is only ever as wide as the dock it hangs off (its content
+ * tracks the trigger width and floors at min-w-64), so a locale whose
+ * translation runs longer than the English has nowhere to go. Every label row
+ * therefore renders its text as a truncating flex child rather than as a bare
+ * text node: without that, "Pause notifications" — twice the length in French —
+ * wrapped out of its fixed h-9 row and left the submenu chevron floating beside
+ * a two-line block (#760).
+ */
+
+/**
+ * A script asserting every fixed-height label row of the presence menu still
+ * measures exactly one 36px line (h-9) — the height a wrapped label overflows.
+ */
+function everyMenuRowIsOneLine(): string
+{
+    $rows = json_encode([
+        'set-status-menu-item',
+        'toggle-presence-menu-item',
+        'pause-notifications-menu-item',
+        'settings-menu-item',
+        'keyboard-shortcuts-menu-item',
+        'replay-tour-menu-item',
+    ], JSON_THROW_ON_ERROR);
+
+    return <<<JS
+    (() => {
+        const rows = {$rows}.map(name => document.querySelector('[data-test="' + name + '"]'));
+
+        return rows.every(row => row !== null && Math.round(row.getBoundingClientRect().height) === 36);
+    })()
+    JS;
+}
+
+test('the presence menu keeps its rows on one line in French', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+    $alice->update(['locale' => AppLocale::French]);
+
+    signInThroughBrowser($alice)
+        // The catalog rides the initial response as a `once` prop, so signing in
+        // from the guest login page leaves the client on the English one until a
+        // document load re-inlines it (#764). Drop this refresh when that lands.
+        ->refresh()
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@pause-notifications-menu-item')
+        // Let the dropdown settle past its open/pointer-grace window.
+        ->wait(0.5)
+        // The French catalog is the one the middleware inlined...
+        ->assertSee('Pause des notifications')
+        ->assertSee('Définir un statut')
+        ->assertSee('Se marquer absent')
+        // ...and no row has grown a second line under it.
+        ->assertScript(everyMenuRowIsOneLine(), true)
+        // The shipped French label fits the row outright, so the guard below
+        // never has to ellipsise it — no French user reads a clipped label.
+        ->assertScript(<<<'JS'
+        (() => {
+            const label = document.querySelector('[data-test="pause-notifications-menu-item"] span');
+
+            return label.scrollWidth <= label.clientWidth;
+        })()
+        JS, true)
+        // The submenu chevron still sits on the row's own centre line, rather
+        // than beside a taller block.
+        ->assertScript(<<<'JS'
+        (() => {
+            const row = document.querySelector('[data-test="pause-notifications-menu-item"]');
+            const chevron = [...row.querySelectorAll('svg')].at(-1);
+            const rowBox = row.getBoundingClientRect();
+            const chevronBox = chevron.getBoundingClientRect();
+
+            return Math.abs(
+                (chevronBox.top + chevronBox.height / 2) - (rowBox.top + rowBox.height / 2),
+            ) <= 1;
+        })()
+        JS, true)
+        // The pause presets and the quiet-hours footer row of the flyout hold
+        // their own heights in French too.
+        ->click('@pause-notifications-menu-item')
+        ->assertPresent('@pause-notifications-submenu')
+        ->assertScript(<<<'JS'
+        (() => {
+            const submenu = document.querySelector('[data-test="pause-notifications-submenu"]');
+            const rows = [...submenu.querySelectorAll('[data-test]')];
+
+            return rows.length > 0
+                && rows.every(row => Math.round(row.getBoundingClientRect().height) === 32)
+                && submenu.scrollWidth <= submenu.clientWidth;
+        })()
+        JS, true);
+});
+
+test('a menu label longer than the row ellipsises instead of wrapping', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // The guard has to hold for any locale, not just the French string that
+    // exposed it, so drive it with a label no translation would ever exceed.
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@pause-notifications-menu-item')
+        ->wait(0.5)
+        ->assertScript(<<<'JS'
+        (() => {
+            const label = document.querySelector('[data-test="pause-notifications-menu-item"] span');
+            label.textContent = 'Benachrichtigungen vorübergehend stummschalten und pausieren';
+
+            return true;
+        })()
+        JS, true)
+        ->assertScript(everyMenuRowIsOneLine(), true)
+        ->assertScript(<<<'JS'
+        (() => {
+            const label = document.querySelector('[data-test="pause-notifications-menu-item"] span');
+
+            // One rendered line, clipped rather than wrapped: the text overflows
+            // its own box (so the ellipsis shows) but the row does not.
+            return label.getClientRects().length === 1
+                && label.scrollWidth > label.clientWidth
+                && getComputedStyle(label).textOverflow === 'ellipsis';
+        })()
+        JS, true);
+});
+
+test('the presence menu renders at its narrowest supported width', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+    $alice->update(['locale' => AppLocale::French]);
+
+    // The rows above are measured at the narrow end of the menu, so pin that:
+    // the content tracks the trigger width but floors at min-w-64 (256px), and
+    // the dock is exactly that wide. The mobile sheet is wider (18rem), and the
+    // collapsed dock takes the trigger off-canvas with it, so there is no
+    // narrower state to check.
+    signInThroughBrowser($alice)
+        // See #764 — the French catalog only reaches the client on a document load.
+        ->refresh()
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@pause-notifications-menu-item')
+        ->wait(0.5)
+        ->assertScript(<<<'JS'
+        (() => {
+            const menu = document.querySelector('[data-test="pause-notifications-menu-item"]')
+                .closest('[data-slot="dropdown-menu-content"]');
+
+            return Math.round(menu.getBoundingClientRect().width) === 256;
+        })()
+        JS, true);
+});


### PR DESCRIPTION
Closes #760.

## What

In French the "Pause notifications" row of the user/presence menu wrapped onto two lines, spilling out of its fixed `h-9` row and leaving the submenu chevron floating beside a two-line block.

The root cause is that each row rendered its label as a **bare text node** inside a flex row. An anonymous flex item cannot be given `min-width: 0` or truncated, so a translation longer than the English had nowhere to go but a second line. Measured at the real menu width: the label needs 204px, the row offers 167px.

## How

- Every label row in the menu now renders its text as a `min-w-0 flex-1 truncate` span instead of a bare text node, so an over-long label stays on one line and ellipsises, with the trailing chevron/shortcut badge staying put. This is the locale-agnostic fix: it holds for any future locale, not just French. CSS truncation does not alter the DOM text, so the accessible name stays complete.
- Applied to all six rows of the menu (`Set a status`, the away toggle, `Pause notifications`, `Settings`, `Keyboard shortcuts`, `Replay tour`), not just the reported one, so the fix does not simply move the problem to the next long translation.
- Tightened the French label from "Mettre les notifications en pause" (204px) to "Pause des notifications" (145px), so French now fits the row outright and no French user reads a clipped label. The truncation guard above is the actual fix; this is on top of it, and is covered by its own assertion.

## Verification

Checked in a running app with the French locale active, at the narrow end of the menu (256px, its `min-w-64` floor, which is also the dock width):

- The pause row is a single 36px line and the chevron sits exactly on the row's centre line (delta 0px).
- The sibling rows the issue calls out hold their heights: "Définir un statut", "Se marquer absent", the pause presets flyout (`30 minutes` / `1 heure` / `Jusqu'à demain` / `Personnalisé…`) and its "Heures calmes / Paramètres" footer row, all unchanged and not overflowing.
- The collapsed-dock case in the issue turns out to be unreachable: the dock is `collapsible="offcanvas"`, so collapsing takes the menu trigger off-screen with it (measured at x=-275). The mobile sheet is wider (18rem). 256px is therefore the narrowest the menu ever renders, and that is what is covered.

## Tests

New `tests/Browser/UserMenuLongLabelTest.php` (3 tests, verified red before the fix):

1. French locale active: every row is one 36px line, the chevron is centred, the submenu rows hold their heights, and the shipped French label fits without ellipsising.
2. Locale-agnostic guard: a label longer than any real translation is injected and the row still renders one line, clipped with an ellipsis rather than wrapped. This is the test that fails without the fix.
3. The menu is measured at its 256px floor, pinning that the above ran at the narrow end.

Backend gate green: Pint, PHPStan, Rector, 2246 tests, **100.0%** coverage. Frontend gate green: lint, format, types, 1012 Vitest tests, build.

## Found while doing this (filed, not fixed here)

- #762 — the quiet-hours variant of the paused card squeezes its own label column to **0px** in French and overflows the card, so "En pause / heures calmes · jusqu'à 8:00" is erased entirely. Same class of defect, different mechanism (two competing siblings rather than a label vs. the row height), so it needs its own answer.
- #764 — a user whose locale is `fr` who signs in through the login form gets an **English** UI until a reload: the catalog is an `Inertia::once()` prop captured on the guest login page, while the sibling `locale` prop does flip. The new browser test carries a `->refresh()` workaround pointing at that issue.

## i18n / docs

`lang/fr.json` updated (one key). No new keys, no operator-facing config, so no `docs/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787367079&installation_model_id=428379&pr_number=765&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F765&signature=f2a8c81915768153ef75ff0373c9bf9a5168d759afca073d71735a97410a3393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->