### PR TITLE
feat: choose a 12-hour or 24-hour clock in Language & region

### DIFF
--- a/app/Enums/TimeFormat.php
+++ b/app/Enums/TimeFormat.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum TimeFormat: string
+{
+    case Auto = 'auto';
+    case TwelveHour = '12h';
+    case TwentyFourHour = '24h';
+
+    /**
+     * Get the display label for the clock style.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Auto => __('Auto (match language)'),
+            self::TwelveHour => __('12-hour'),
+            self::TwentyFourHour => __('24-hour'),
+        };
+    }
+
+    /**
+     * Get the selectable clock styles as value/label pairs for the settings UI.
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    public static function options(): array
+    {
+        return array_map(
+            fn (self $format): array => ['value' => $format->value, 'label' => $format->label()],
+            self::cases(),
+        );
+    }
+}

--- a/app/Http/Controllers/Settings/LocaleController.php
+++ b/app/Http/Controllers/Settings/LocaleController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Settings;
 
 use App\Enums\AppLocale;
+use App\Enums\TimeFormat;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\LocalePreferencesRequest;
 use Illuminate\Http\RedirectResponse;
@@ -18,6 +19,7 @@ class LocaleController extends Controller
     {
         return Inertia::render('settings/Localization', [
             'locales' => AppLocale::options(),
+            'timeFormats' => TimeFormat::options(),
         ]);
     }
 

--- a/app/Http/Controllers/Settings/TimeFormatController.php
+++ b/app/Http/Controllers/Settings/TimeFormatController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\TimeFormatPreferencesRequest;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+class TimeFormatController extends Controller
+{
+    /**
+     * Choose whether times of day render on a 12- or 24-hour clock.
+     *
+     * Stored on the user so it follows them across devices; the redirect lets
+     * Inertia recompute the shared `auth.user` prop, which re-renders every
+     * clock in the interface with no full page reload.
+     */
+    public function update(TimeFormatPreferencesRequest $request): RedirectResponse
+    {
+        $request->user()->update($request->validated());
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Clock style updated.')]);
+
+        return to_route('locale.edit');
+    }
+}

--- a/app/Http/Requests/Settings/TimeFormatPreferencesRequest.php
+++ b/app/Http/Requests/Settings/TimeFormatPreferencesRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use App\Enums\TimeFormat;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TimeFormatPreferencesRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'time_format' => ['required', Rule::enum(TimeFormat::class)],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use App\Enums\ChimeSound;
 use App\Enums\PresenceState;
 use App\Enums\SidebarPosition;
 use App\Enums\TeamRole;
+use App\Enums\TimeFormat;
 use App\Enums\UserType;
 use App\Observers\UserObserver;
 use App\Support\Gravatar;
@@ -60,6 +61,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property Carbon|null $status_expires_at
  * @property string|null $timezone
  * @property AppLocale $locale
+ * @property TimeFormat $time_format
  * @property Carbon|null $email_verified_at
  * @property string $password
  * @property string|null $two_factor_secret
@@ -99,7 +101,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read Collection<int, UserGroup> $userGroups
  */
 #[Appends(['avatar', 'status', 'presence', 'dnd'])]
-#[Fillable(['name', 'email', 'avatar_url', 'pronouns', 'title', 'phone', 'timezone', 'locale', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'sidebar_position', 'presence_state', 'onboarding_completed_at', 'collapsed_channel_sections', 'is_tombstone'])]
+#[Fillable(['name', 'email', 'avatar_url', 'pronouns', 'title', 'phone', 'timezone', 'locale', 'time_format', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'sidebar_position', 'presence_state', 'onboarding_completed_at', 'collapsed_channel_sections', 'is_tombstone'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token', 'avatar_url', 'avatar_path', 'status_emoji', 'status_text', 'status_expires_at', 'dnd_until', 'dnd_schedule_enabled', 'dnd_starts_at', 'dnd_ends_at', 'dnd_schedule_snoozed_until'])]
 #[ObservedBy(UserObserver::class)]
 class User extends Authenticatable implements HasLocalePreference, MustVerifyEmail, PasskeyUser
@@ -328,6 +330,7 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
             'password' => 'hashed',
             'type' => UserType::class,
             'locale' => AppLocale::class,
+            'time_format' => TimeFormat::class,
             'chime_sound' => ChimeSound::class,
             'share_read_receipts' => 'boolean',
             'sidebar_position' => SidebarPosition::class,

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -7,6 +7,7 @@ use App\Enums\ChimeSound;
 use App\Enums\PresenceState;
 use App\Enums\SidebarPosition;
 use App\Enums\TeamRole;
+use App\Enums\TimeFormat;
 use App\Enums\UserType;
 use App\Models\Team;
 use App\Models\User;
@@ -42,6 +43,7 @@ class UserFactory extends Factory
             'two_factor_recovery_codes' => null,
             'two_factor_confirmed_at' => null,
             'locale' => AppLocale::English->value,
+            'time_format' => TimeFormat::Auto->value,
             'chime_sound' => ChimeSound::Ping->value,
             'share_read_receipts' => true,
             'sidebar_position' => SidebarPosition::Left->value,

--- a/database/migrations/2026_07_23_020538_add_time_format_to_users_table.php
+++ b/database/migrations/2026_07_23_020538_add_time_format_to_users_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\TimeFormat;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            // Whether times of day render on a 12- or 24-hour clock. `auto` keeps
+            // today's behaviour — the clock style follows the display language —
+            // so the column is a no-op for every existing account until they
+            // choose otherwise (see App\Enums\TimeFormat).
+            $table->string('time_format')->default(TimeFormat::Auto->value)->after('locale');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('time_format');
+        });
+    }
+};

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -248,7 +248,7 @@
   "Data & privacy": "Données et confidentialité",
   "Data export downloaded": "Export de données téléchargé",
   "Data export requested": "Export de données demandé",
-  "Dates, times, and numbers are formatted to match your selected language.": "Les dates, heures et nombres sont formatés selon la langue que vous avez sélectionnée.",
+  "Dates and numbers are formatted to match your selected language.": "Les dates et les nombres sont formatés selon la langue que vous avez sélectionnée.",
   "Decline": "Refuser",
   "Delete": "Supprimer",
   "Delete account": "Supprimer le compte",
@@ -1231,5 +1231,14 @@
   "crosses midnight — ends tomorrow morning": "passe minuit — se termine demain matin",
   "Could not update your quiet hours.": "Impossible de mettre à jour vos heures calmes.",
   "Snooze schedule today": "Suspendre l'horaire aujourd'hui",
-  "Could not snooze your quiet hours.": "Impossible de suspendre vos heures calmes."
+  "Could not snooze your quiet hours.": "Impossible de suspendre vos heures calmes.",
+  "Clock": "Horloge",
+  "Clock style": "Format de l'heure",
+  "Choose whether times of day are shown on a 12-hour or a 24-hour clock.": "Choisissez si les heures sont affichées sur une horloge de 12 ou de 24 heures.",
+  "Auto follows your display language. Your choice applies everywhere a time of day appears, including your quiet hours.": "Auto suit votre langue d'affichage. Votre choix s'applique partout où une heure est affichée, y compris vos heures calmes.",
+  "Select a clock style": "Sélectionnez un format d'heure",
+  "Auto (match language)": "Auto (suivre la langue)",
+  "12-hour": "12 heures",
+  "24-hour": "24 heures",
+  "Clock style updated.": "Format de l'heure mis à jour."
 }

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -4,12 +4,14 @@ import { initializeTheme } from '@/composables/useAppearance';
 import AuthLayout from '@/layouts/AuthLayout.vue';
 import MainLayout from '@/layouts/MainLayout.vue';
 import SettingsLayout from '@/layouts/settings/Layout.vue';
+import { setTimeFormat } from '@/lib/clock';
 import { reverbEchoConfig } from '@/lib/echo';
 import type { ReverbRuntimeConfig } from '@/lib/echo';
 import { initializeFlashToast } from '@/lib/flashToast';
 import { setMessages, translate } from '@/lib/i18n';
 import type { Messages } from '@/lib/i18n';
 import { initializeOverlayInert } from '@/lib/overlayInert';
+import type { TimeFormat } from '@/types';
 
 /**
  * Seeded from the server-shared props at boot (see `withApp`), so both Echo and
@@ -25,6 +27,8 @@ void createInertiaApp({
     // render — on both the SSR pass and the client — so the initial paint is
     // already in the active locale (no flash of English on refresh). `translations`
     // is a once prop, so it rides the initial document only, not every visit.
+    // The clock-style preference is seeded the same way, so the first paint's
+    // times of day are already on the viewer's chosen clock.
     // Also expose the translation helper as a global `$t` for templates.
     withApp(app, { page }) {
         const props = page.props as {
@@ -32,6 +36,7 @@ void createInertiaApp({
             reverb?: ReverbRuntimeConfig;
             locale?: string;
             translations?: Messages;
+            auth?: { user?: { time_format?: TimeFormat } | null };
         };
 
         appName = props.name ?? 'Laravel';
@@ -44,6 +49,8 @@ void createInertiaApp({
         }
 
         setMessages(props.locale ?? 'en', props.translations ?? {});
+
+        setTimeFormat(props.auth?.user?.time_format ?? 'auto');
 
         app.config.globalProperties.$t = translate;
     },

--- a/resources/js/composables/useTimeFormat.test.ts
+++ b/resources/js/composables/useTimeFormat.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+
+const page = reactive({
+    props: { auth: { user: { time_format: 'auto' } } },
+});
+
+const patch = vi.fn();
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: {
+        patch: (...args: unknown[]) => patch(...args),
+    },
+    usePage: () => page,
+}));
+
+import { useTimeFormat } from '@/composables/useTimeFormat';
+import { setTimeFormat, timeFormat } from '@/lib/clock';
+
+beforeEach(() => {
+    patch.mockReset();
+    page.props.auth.user.time_format = 'auto';
+    setTimeFormat('auto');
+});
+
+afterEach(() => {
+    setTimeFormat('auto');
+});
+
+describe('useTimeFormat', () => {
+    it('reads the preference off the shared auth prop', () => {
+        page.props.auth.user.time_format = '24h';
+
+        expect(useTimeFormat().timeFormat.value).toBe('24h');
+    });
+
+    it('applies the new style before the write lands', () => {
+        useTimeFormat().updateTimeFormat('24h');
+
+        expect(timeFormat()).toBe('24h');
+        expect(patch).toHaveBeenCalledWith(
+            expect.any(String),
+            { time_format: '24h' },
+            expect.objectContaining({ preserveScroll: true }),
+        );
+    });
+
+    /**
+     * The swapped style is the only thing driving the formatters, so a rejected
+     * write has to put the previous one back — otherwise the whole interface
+     * keeps rendering a clock the account never stored.
+     */
+    it('puts the previous style back when the write fails', () => {
+        useTimeFormat().updateTimeFormat('24h');
+
+        expect(timeFormat()).toBe('24h');
+
+        const [, , options] = patch.mock.calls[0] as [
+            string,
+            unknown,
+            { onError: () => void },
+        ];
+        options.onError();
+
+        expect(timeFormat()).toBe('auto');
+    });
+});

--- a/resources/js/composables/useTimeFormat.ts
+++ b/resources/js/composables/useTimeFormat.ts
@@ -1,0 +1,35 @@
+import { router, usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import { setTimeFormat } from '@/lib/clock';
+import { update } from '@/routes/time-format';
+import type { TimeFormat } from '@/types';
+
+/**
+ * Read and mutate the current user's clock-style preference. The value is the
+ * shared `auth.user.time_format` prop, so every consumer stays in sync.
+ */
+export function useTimeFormat() {
+    const page = usePage();
+
+    const timeFormat = computed<TimeFormat>(
+        () => page.props.auth.user?.time_format ?? 'auto',
+    );
+
+    /**
+     * Switch clock style: swap the active style first so every rendered time of
+     * day re-renders immediately without a full reload, then persist the choice.
+     * The shared prop refreshes from the redirect, so no optimistic state is
+     * needed.
+     */
+    function updateTimeFormat(next: TimeFormat): void {
+        setTimeFormat(next);
+
+        router.patch(
+            update().url,
+            { time_format: next },
+            { preserveScroll: true, preserveState: true },
+        );
+    }
+
+    return { timeFormat, updateTimeFormat };
+}

--- a/resources/js/composables/useTimeFormat.ts
+++ b/resources/js/composables/useTimeFormat.ts
@@ -18,16 +18,25 @@ export function useTimeFormat() {
     /**
      * Switch clock style: swap the active style first so every rendered time of
      * day re-renders immediately without a full reload, then persist the choice.
-     * The shared prop refreshes from the redirect, so no optimistic state is
-     * needed.
+     *
+     * The swap is the only thing driving the formatters, so a failed write has
+     * to put the previous style back — otherwise the whole interface keeps
+     * rendering a clock the account never actually stored, until the next full
+     * reload reseeds it from the shared prop.
      */
     function updateTimeFormat(next: TimeFormat): void {
+        const previous = timeFormat.value;
+
         setTimeFormat(next);
 
         router.patch(
             update().url,
             { time_format: next },
-            { preserveScroll: true, preserveState: true },
+            {
+                preserveScroll: true,
+                preserveState: true,
+                onError: () => setTimeFormat(previous),
+            },
         );
     }
 

--- a/resources/js/lib/clock.test.ts
+++ b/resources/js/lib/clock.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    hourCycleFor,
+    prefersTwelveHour,
+    setTimeFormat,
+    timeFormat,
+} from './clock';
+
+afterEach(() => {
+    setTimeFormat('auto');
+});
+
+describe('timeFormat', () => {
+    it('starts on auto, so the language decides the clock style', () => {
+        expect(timeFormat()).toBe('auto');
+    });
+
+    it('reads back the preference it was set to', () => {
+        setTimeFormat('24h');
+
+        expect(timeFormat()).toBe('24h');
+    });
+});
+
+describe('hourCycleFor', () => {
+    it('leaves the hour cycle to the locale under auto', () => {
+        expect(hourCycleFor('auto')).toBeUndefined();
+    });
+
+    it('pins a 12-hour cycle that renders midnight as 12, not 0', () => {
+        expect(hourCycleFor('12h')).toBe('h12');
+    });
+
+    it('pins a 24-hour cycle that renders midnight as 00, not 24', () => {
+        expect(hourCycleFor('24h')).toBe('h23');
+    });
+
+    it('falls back to the stored preference', () => {
+        setTimeFormat('12h');
+
+        expect(hourCycleFor()).toBe('h12');
+    });
+});
+
+describe('prefersTwelveHour', () => {
+    it('resolves auto against the locale', () => {
+        expect(prefersTwelveHour('en', 'auto')).toBe(true);
+        expect(prefersTwelveHour('fr', 'auto')).toBe(false);
+    });
+
+    it('overrides the locale when a style is chosen', () => {
+        expect(prefersTwelveHour('fr', '12h')).toBe(true);
+        expect(prefersTwelveHour('en', '24h')).toBe(false);
+    });
+
+    it('falls back to the stored preference', () => {
+        setTimeFormat('12h');
+
+        expect(prefersTwelveHour('fr')).toBe(true);
+    });
+});

--- a/resources/js/lib/clock.ts
+++ b/resources/js/lib/clock.ts
@@ -1,0 +1,64 @@
+import { reactive } from 'vue';
+import type { TimeFormat } from '@/types';
+
+/**
+ * The viewer's clock-style preference, seeded from their `auth.user` prop at
+ * boot (see `app.ts`) and swapped live when they pick another style.
+ *
+ * It is reactive and read inside the formatting helpers, so every rendered time
+ * of day re-renders the instant the preference changes — no reload, and no
+ * threading the preference through every call site.
+ */
+const clock = reactive<{ format: TimeFormat }>({ format: 'auto' });
+
+/** The active clock-style preference. */
+export function timeFormat(): TimeFormat {
+    return clock.format;
+}
+
+/** Replace the active clock-style preference, e.g. after the user picks one. */
+export function setTimeFormat(format: TimeFormat): void {
+    clock.format = format;
+}
+
+/**
+ * The Intl hour cycle a preference asks for, or `undefined` under `auto` — where
+ * omitting the option is what lets the locale keep deciding, reproducing the
+ * behaviour the app had before the preference existed.
+ *
+ * The chosen cycles are the sane halves of each pair: `h12` renders midnight as
+ * "12 AM" (not `h11`'s "0 AM") and `h23` renders it as "00" (not `h24`'s "24").
+ */
+export function hourCycleFor(
+    format: TimeFormat = clock.format,
+): Intl.DateTimeFormatOptions['hourCycle'] {
+    switch (format) {
+        case '12h':
+            return 'h12';
+        case '24h':
+            return 'h23';
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Whether times land on a 12-hour clock once the preference is resolved against
+ * the locale — asking Intl what `auto` means for that language rather than
+ * hardcoding a list. Callers that hand-build clock labels (the quiet-hours
+ * strip) need this answer; callers that format through Intl want
+ * `hourCycleFor` instead.
+ */
+export function prefersTwelveHour(
+    locale: string,
+    format: TimeFormat = clock.format,
+): boolean {
+    if (format !== 'auto') {
+        return format === '12h';
+    }
+
+    return (
+        new Intl.DateTimeFormat(locale, { hour: 'numeric' }).resolvedOptions()
+            .hour12 === true
+    );
+}

--- a/resources/js/lib/datetime.test.ts
+++ b/resources/js/lib/datetime.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setTimeFormat } from './clock';
 import {
     formatCalendarDate,
     formatDateTime,
@@ -6,6 +7,7 @@ import {
     formatLocalTime,
     formatRelativeTime,
     formatTimeOfDay,
+    formatWallTime,
 } from './datetime';
 import { formatNumber } from './numbers';
 
@@ -183,5 +185,99 @@ describe('formatRelativeTime', () => {
         // French renders -3 days as "il y a 3 jours" (‑2 would collapse to the
         // word "avant-hier"), so a mid-range value exercises the translation.
         expect(formatRelativeTime(ago(3 * 86400), 'fr', now)).toContain('jour');
+    });
+});
+
+describe('the clock-style preference', () => {
+    afterEach(() => {
+        setTimeFormat('auto');
+    });
+
+    /**
+     * Auto is the migration's default, so it has to reproduce the app's
+     * pre-preference behaviour byte for byte in both shipped locales: the clock
+     * style keeps following the display language.
+     */
+    describe('auto', () => {
+        it('leaves each locale on its own clock style', () => {
+            expect(formatTimeOfDay(INSTANT, 'UTC', 'en')).toBe('3:30 PM');
+            expect(formatTimeOfDay(INSTANT, 'UTC', 'fr')).toBe('15:30');
+        });
+
+        it('leaves quiet-hours bounds on the locale clock too', () => {
+            expect(formatWallTime('18:00', 'en')).toBe('6:00 PM');
+            expect(formatWallTime('18:00', 'fr')).toBe('18:00');
+        });
+    });
+
+    describe('12-hour', () => {
+        it('renders an English time on a 12-hour clock', () => {
+            setTimeFormat('12h');
+
+            expect(formatTimeOfDay(INSTANT, 'UTC', 'en')).toBe('3:30 PM');
+        });
+
+        it('overrides a 24-hour locale', () => {
+            setTimeFormat('12h');
+
+            expect(formatTimeOfDay(INSTANT, 'UTC', 'fr')).toBe('3:30 PM');
+            expect(formatDateTime(INSTANT, 'UTC', 'fr')).toContain('3:30 PM');
+            expect(formatLocalTime('UTC', new Date(INSTANT), 'fr')).toBe(
+                '3:30 PM',
+            );
+            expect(formatWallTime('18:00', 'fr')).toBe('6:00 PM');
+        });
+
+        it('renders midnight as 12 AM rather than 0 AM', () => {
+            setTimeFormat('12h');
+
+            expect(formatWallTime('00:30', 'en')).toBe('12:30 AM');
+        });
+    });
+
+    describe('24-hour', () => {
+        it('overrides a 12-hour locale', () => {
+            setTimeFormat('24h');
+
+            expect(formatTimeOfDay(INSTANT, 'UTC', 'en')).toBe('15:30');
+            expect(formatDateTime(INSTANT, 'UTC', 'en')).toBe('Jul 10, 15:30');
+            expect(formatLocalTime('UTC', new Date(INSTANT), 'en')).toBe(
+                '15:30',
+            );
+            expect(formatWallTime('18:00', 'en')).toBe('18:00');
+        });
+
+        it('renders midnight as 00 rather than 24', () => {
+            setTimeFormat('24h');
+
+            expect(formatWallTime('00:30', 'en')).toBe('00:30');
+        });
+
+        it('leaves a 24-hour locale untouched', () => {
+            setTimeFormat('24h');
+
+            expect(formatTimeOfDay(INSTANT, 'UTC', 'fr')).toBe('15:30');
+        });
+    });
+
+    it('takes an explicit style over the stored preference', () => {
+        setTimeFormat('24h');
+
+        expect(formatTimeOfDay(INSTANT, 'UTC', 'en', '12h')).toBe('3:30 PM');
+        expect(formatWallTime('18:00', 'en', '12h')).toBe('6:00 PM');
+    });
+
+    /**
+     * Date-only and relative helpers are explicitly out of scope: they carry no
+     * time of day, so the preference must not reach them.
+     */
+    it('leaves date-only and relative helpers alone', () => {
+        setTimeFormat('24h');
+
+        expect(formatIsoDay('2026-07-10', 'en')).toBe('Jul 10, 2026');
+        expect(formatCalendarDate('2026-07-10', 'en')).toBe('Jul 10');
+        expect(
+            formatRelativeTime('2026-07-08T15:30:00Z', 'en', new Date(INSTANT)),
+        ).toBe('2 days ago');
     });
 });

--- a/resources/js/lib/datetime.ts
+++ b/resources/js/lib/datetime.ts
@@ -2,10 +2,18 @@
  * Timestamp formatting helpers. All rendering happens client-side in a target
  * IANA time zone — the viewer's stored zone where known, otherwise the runtime's
  * local zone (passing `timeZone: undefined` to the Intl APIs falls back to it) —
- * and in the active locale, so month names, ordering, and clock style follow the
- * user's language.
+ * and in the active locale, so month names and ordering follow the user's
+ * language.
+ *
+ * The clock style follows the language too, unless the viewer has pinned one:
+ * every time of day here resolves its hour cycle through the clock-style
+ * preference, which defaults to `auto` (the locale decides). Date-only,
+ * relative, and calendar helpers carry no time of day, so the preference does
+ * not reach them.
  */
 
+import type { TimeFormat } from '@/types';
+import { hourCycleFor, prefersTwelveHour } from './clock';
 import { i18n, translate } from './i18n';
 
 /**
@@ -15,10 +23,12 @@ export function formatTimeOfDay(
     iso: string,
     timeZone?: string,
     locale: string = i18n.locale,
+    format?: TimeFormat,
 ): string {
     return new Date(iso).toLocaleTimeString(locale, {
         hour: 'numeric',
         minute: '2-digit',
+        hourCycle: hourCycleFor(format),
         timeZone,
     });
 }
@@ -30,13 +40,59 @@ export function formatDateTime(
     iso: string,
     timeZone?: string,
     locale: string = i18n.locale,
+    format?: TimeFormat,
 ): string {
     return new Date(iso).toLocaleString(locale, {
         month: 'short',
         day: 'numeric',
         hour: 'numeric',
         minute: '2-digit',
+        hourCycle: hourCycleFor(format),
         timeZone,
+    });
+}
+
+/**
+ * Format an `HH:mm` wall-clock reading (e.g. a stored quiet-hours bound) as a
+ * time of day. The reading carries no date or zone — it is a time on the clock
+ * face, not an instant — so it is anchored to an arbitrary day and rendered in
+ * the runtime's own zone, leaving only the hour and minute visible.
+ */
+export function formatWallTime(
+    wallTime: string,
+    locale: string = i18n.locale,
+    format?: TimeFormat,
+): string {
+    const [hour, minute] = wallTime.split(':').map(Number);
+
+    return new Date(2000, 0, 1, hour, minute).toLocaleTimeString(locale, {
+        hour: 'numeric',
+        minute: '2-digit',
+        hourCycle: hourCycleFor(format),
+    });
+}
+
+/**
+ * A compact label for a whole hour of the clock face (e.g. "6 PM", "18"), for
+ * the tick marks under the quiet-hours strip.
+ *
+ * On a 24-hour clock the label is the bare zero-padded hour, so the strip keeps
+ * its fixed 00 / 06 / 12 / 18 / 24 frame — including the end-of-day 24, which
+ * Intl would fold back to 00 (and French would render as "18 h", too wide for a
+ * tick). Only the 12-hour clock needs Intl, for its AM/PM markers.
+ */
+export function formatWallHour(
+    hour: number,
+    locale: string = i18n.locale,
+    format?: TimeFormat,
+): string {
+    if (!prefersTwelveHour(locale, format)) {
+        return String(hour).padStart(2, '0');
+    }
+
+    return new Date(2000, 0, 1, hour % 24).toLocaleTimeString(locale, {
+        hour: 'numeric',
+        hourCycle: 'h12',
     });
 }
 
@@ -193,6 +249,7 @@ export function formatLocalTime(
     timeZone: string | null,
     at: Date,
     locale: string = i18n.locale,
+    format?: TimeFormat,
 ): string | null {
     if (!timeZone) {
         return null;
@@ -202,6 +259,7 @@ export function formatLocalTime(
         return at.toLocaleTimeString(locale, {
             hour: 'numeric',
             minute: '2-digit',
+            hourCycle: hourCycleFor(format),
             timeZone,
         });
     } catch {

--- a/resources/js/lib/dnd.test.ts
+++ b/resources/js/lib/dnd.test.ts
@@ -312,7 +312,7 @@ describe('quietHoursSegments', () => {
 
 describe('quietHoursTicks', () => {
     it('merges the window bounds into the base ticks, sorted', () => {
-        expect(quietHoursTicks('18:00', '09:00')).toEqual([
+        expect(quietHoursTicks('18:00', '09:00', 'fr')).toEqual([
             '00',
             '06',
             '09',
@@ -323,12 +323,47 @@ describe('quietHoursTicks', () => {
     });
 
     it('keeps the base ticks alone when the bounds already sit on them', () => {
-        expect(quietHoursTicks('18:00', '12:00')).toEqual([
+        expect(quietHoursTicks('18:00', '12:00', 'fr')).toEqual([
             '00',
             '06',
             '12',
             '18',
             '24',
+        ]);
+    });
+
+    /**
+     * The strip used to be hardcoded to a 24-hour frame while the paused card two
+     * screens away spoke 12-hour, so an English viewer configured quiet hours in
+     * one convention and was told about them in the other. Both now follow the
+     * clock-style preference.
+     */
+    it('labels the frame on a 12-hour clock when the viewer reads one', () => {
+        expect(quietHoursTicks('18:00', '09:00', 'en')).toEqual([
+            '12 AM',
+            '6 AM',
+            '9 AM',
+            '12 PM',
+            '6 PM',
+            '12 AM',
+        ]);
+    });
+
+    it('honours an explicit clock style over the locale', () => {
+        expect(quietHoursTicks('18:00', '12:00', 'en', '24h')).toEqual([
+            '00',
+            '06',
+            '12',
+            '18',
+            '24',
+        ]);
+
+        expect(quietHoursTicks('18:00', '12:00', 'fr', '12h')).toEqual([
+            '12 AM',
+            '6 AM',
+            '12 PM',
+            '6 PM',
+            '12 AM',
         ]);
     });
 });

--- a/resources/js/lib/dnd.ts
+++ b/resources/js/lib/dnd.ts
@@ -1,3 +1,6 @@
+import type { TimeFormat } from '@/types';
+import { formatWallHour } from './datetime';
+import { i18n } from './i18n';
 import { wallTimeToInstant, zonedWallTime } from './scheduleTime';
 import type { WallTime } from './scheduleTime';
 
@@ -119,8 +122,17 @@ export function quietHoursSegments(
 /**
  * The hour labels under the 24h strip: the fixed 00/06/12/18/24 frame with
  * the window's own bound hours merged in, so the quiet edges are always named.
+ *
+ * The labels follow the viewer's clock style, so the strip and the bound selects
+ * above it speak the same convention as the paused card that reports the window
+ * back to them.
  */
-export function quietHoursTicks(startsAt: string, endsAt: string): string[] {
+export function quietHoursTicks(
+    startsAt: string,
+    endsAt: string,
+    locale: string = i18n.locale,
+    format?: TimeFormat,
+): string[] {
     const hours = new Set([0, 6, 12, 18, 24]);
 
     hours.add(Number(startsAt.slice(0, 2)));
@@ -128,7 +140,7 @@ export function quietHoursTicks(startsAt: string, endsAt: string): string[] {
 
     return [...hours]
         .sort((a, b) => a - b)
-        .map((hour) => String(hour).padStart(2, '0'));
+        .map((hour) => formatWallHour(hour, locale, format));
 }
 
 const MINUTES_PER_DAY = 24 * 60;

--- a/resources/js/lib/reminderTime.test.ts
+++ b/resources/js/lib/reminderTime.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setTimeFormat } from '@/lib/clock';
 import { isReminderToday, reminderPresets } from '@/lib/reminderTime';
 
 /** A fixed reference instant: Tuesday 14 Jul 2026, 15:30 UTC. */
@@ -80,5 +81,23 @@ describe('isReminderToday', () => {
                 NOW,
             ),
         ).toBe(true);
+    });
+});
+
+describe('the clock-style preference', () => {
+    afterEach(() => {
+        setTimeFormat('auto');
+    });
+
+    it('renders the preset details on the chosen clock', () => {
+        setTimeFormat('24h');
+
+        const presets = reminderPresets('UTC', NOW);
+        const byKey = Object.fromEntries(
+            presets.map((preset) => [preset.key, preset.detail]),
+        );
+
+        expect(byKey.tomorrow).toBe('09:00');
+        expect(byKey['next-week']).toBe('Mon, 09:00');
     });
 });

--- a/resources/js/lib/reminderTime.ts
+++ b/resources/js/lib/reminderTime.ts
@@ -6,6 +6,7 @@
  * can be unit-tested in isolation; `now` is always injectable for determinism.
  */
 
+import { hourCycleFor } from './clock';
 import { i18n } from './i18n';
 import { wallTimeToInstant, zonedWallTime } from './scheduleTime';
 import type { WallTime } from './scheduleTime';
@@ -56,6 +57,7 @@ function timeDetail(iso: string, timeZone: string): string {
     return new Date(iso).toLocaleTimeString(i18n.locale, {
         hour: 'numeric',
         minute: '2-digit',
+        hourCycle: hourCycleFor(),
         timeZone,
     });
 }

--- a/resources/js/lib/scheduleTime.test.ts
+++ b/resources/js/lib/scheduleTime.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setTimeFormat } from '@/lib/clock';
 import {
     formatPresetPreview,
     formatScheduledFor,
@@ -172,5 +173,30 @@ describe('formatScheduledFor', () => {
         expect(label).toMatch(/Jul 20/);
         expect(label).not.toMatch(/^Today/);
         expect(label).not.toMatch(/^Tomorrow/);
+    });
+});
+
+describe('the clock-style preference', () => {
+    afterEach(() => {
+        setTimeFormat('auto');
+    });
+
+    it('renders the send-later preview on the chosen clock', () => {
+        setTimeFormat('24h');
+
+        expect(
+            formatPresetPreview('2026-07-14T16:30:00.000Z', 'UTC', NOW),
+        ).toBe('16:30');
+        expect(
+            formatPresetPreview('2026-07-15T09:00:00.000Z', 'UTC', NOW),
+        ).toBe('Wed 09:00');
+    });
+
+    it('renders the scheduled-for summary on the chosen clock', () => {
+        setTimeFormat('24h');
+
+        expect(formatScheduledFor('2026-07-14T18:00:00.000Z', 'UTC', NOW)).toBe(
+            'Today at 18:00',
+        );
     });
 });

--- a/resources/js/lib/scheduleTime.ts
+++ b/resources/js/lib/scheduleTime.ts
@@ -8,6 +8,7 @@
  * `now` is always injectable so tests are deterministic.
  */
 
+import { hourCycleFor } from './clock';
 import { i18n, translate } from './i18n';
 
 /** Wall-clock components, as read off a clock on the wall in some zone. */
@@ -208,6 +209,7 @@ export function formatPresetPreview(
     const time = target.toLocaleTimeString(i18n.locale, {
         hour: 'numeric',
         minute: '2-digit',
+        hourCycle: hourCycleFor(),
         timeZone,
     });
 
@@ -290,6 +292,7 @@ export function formatScheduledFor(
     const time = target.toLocaleTimeString(i18n.locale, {
         hour: 'numeric',
         minute: '2-digit',
+        hourCycle: hourCycleFor(),
         timeZone,
     });
 

--- a/resources/js/pages/settings/Appearance.vue
+++ b/resources/js/pages/settings/Appearance.vue
@@ -20,6 +20,7 @@ import { Switch } from '@/components/ui/switch';
 import { useChimes } from '@/composables/useChimes';
 import { useReadReceipts } from '@/composables/useReadReceipts';
 import { useTranslations } from '@/composables/useTranslations';
+import { formatWallTime } from '@/lib/datetime';
 import { quietHoursSegments, quietHoursTicks } from '@/lib/dnd';
 import { translate } from '@/lib/i18n';
 import { edit } from '@/routes/appearance';
@@ -82,12 +83,21 @@ watch(storedDnd, (value) => {
     endsAt.value = value?.endsAt ?? endsAt.value;
 });
 
-/** The half-hour grid both bound selects offer. */
-const QUIET_HOUR_OPTIONS = Array.from({ length: 48 }, (_, index) => {
+/**
+ * The half-hour grid both bound selects offer. The stored value stays a 24-hour
+ * `HH:mm` string — the server compares it against wall-clock readings — while
+ * the label follows the viewer's clock style, so the bounds read in the same
+ * convention as the paused card that reports the window back to them.
+ */
+const QUIET_HOUR_BOUNDS = Array.from({ length: 48 }, (_, index) => {
     const hour = String(Math.floor(index / 2)).padStart(2, '0');
 
     return `${hour}:${index % 2 === 0 ? '00' : '30'}`;
 });
+
+const quietHourOptions = computed(() =>
+    QUIET_HOUR_BOUNDS.map((value) => ({ value, label: formatWallTime(value) })),
+);
 
 const crossesMidnight = computed(() => startsAt.value > endsAt.value);
 
@@ -245,12 +255,12 @@ function chooseBound(bound: 'startsAt' | 'endsAt', value: unknown): void {
                             </SelectTrigger>
                             <SelectContent class="max-h-64">
                                 <SelectItem
-                                    v-for="option in QUIET_HOUR_OPTIONS"
-                                    :key="`from-${option}`"
-                                    :value="option"
+                                    v-for="option in quietHourOptions"
+                                    :key="`from-${option.value}`"
+                                    :value="option.value"
                                     class="font-mono text-[13px]"
                                 >
-                                    {{ option }}
+                                    {{ option.label }}
                                 </SelectItem>
                             </SelectContent>
                         </Select>
@@ -276,12 +286,12 @@ function chooseBound(bound: 'startsAt' | 'endsAt', value: unknown): void {
                             </SelectTrigger>
                             <SelectContent class="max-h-64">
                                 <SelectItem
-                                    v-for="option in QUIET_HOUR_OPTIONS"
-                                    :key="`to-${option}`"
-                                    :value="option"
+                                    v-for="option in quietHourOptions"
+                                    :key="`to-${option.value}`"
+                                    :value="option.value"
                                     class="font-mono text-[13px]"
                                 >
-                                    {{ option }}
+                                    {{ option.label }}
                                 </SelectItem>
                             </SelectContent>
                         </Select>

--- a/resources/js/pages/settings/Localization.vue
+++ b/resources/js/pages/settings/Localization.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import FormField from '@/components/FormField.vue';
 import SettingsSection from '@/components/SettingsSection.vue';
 import {
@@ -11,12 +11,19 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { useLocale } from '@/composables/useLocale';
+import { useTimeFormat } from '@/composables/useTimeFormat';
 import { translate } from '@/lib/i18n';
 import { edit } from '@/routes/locale';
-import type { AppLocale, LocaleOption } from '@/types';
+import type {
+    AppLocale,
+    LocaleOption,
+    TimeFormat,
+    TimeFormatOption,
+} from '@/types';
 
 defineProps<{
     locales: LocaleOption[];
+    timeFormats: TimeFormatOption[];
 }>();
 
 defineOptions({
@@ -42,6 +49,25 @@ function onSelect(value: unknown): void {
     selected.value = value as AppLocale;
     void updateLocale(selected.value);
 }
+
+const { timeFormat, updateTimeFormat } = useTimeFormat();
+
+// Local mirror so the select answers on click, before the persisted preference
+// round-trips back through the shared prop.
+const selectedTimeFormat = ref<TimeFormat>(timeFormat.value);
+
+watch(timeFormat, (value) => {
+    selectedTimeFormat.value = value;
+});
+
+function onSelectTimeFormat(value: unknown): void {
+    if (typeof value !== 'string') {
+        return;
+    }
+
+    selectedTimeFormat.value = value as TimeFormat;
+    updateTimeFormat(selectedTimeFormat.value);
+}
 </script>
 
 <template>
@@ -60,7 +86,7 @@ function onSelect(value: unknown): void {
             :label="$t('Display language')"
             :hint="
                 $t(
-                    'Dates, times, and numbers are formatted to match your selected language.',
+                    'Dates and numbers are formatted to match your selected language.',
                 )
             "
             v-slot="{ id }"
@@ -72,6 +98,44 @@ function onSelect(value: unknown): void {
                 <SelectContent>
                     <SelectItem
                         v-for="option in locales"
+                        :key="option.value"
+                        :value="option.value"
+                    >
+                        {{ option.label }}
+                    </SelectItem>
+                </SelectContent>
+            </Select>
+        </FormField>
+    </SettingsSection>
+
+    <SettingsSection
+        :title="$t('Clock')"
+        :description="
+            $t(
+                'Choose whether times of day are shown on a 12-hour or a 24-hour clock.',
+            )
+        "
+    >
+        <FormField
+            id="time-format"
+            :label="$t('Clock style')"
+            :hint="
+                $t(
+                    'Auto follows your display language. Your choice applies everywhere a time of day appears, including your quiet hours.',
+                )
+            "
+            v-slot="{ id }"
+        >
+            <Select
+                :model-value="selectedTimeFormat"
+                @update:model-value="onSelectTimeFormat"
+            >
+                <SelectTrigger :id="id" data-test="time-format" class="w-full">
+                    <SelectValue :placeholder="$t('Select a clock style')" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem
+                        v-for="option in timeFormats"
                         :key="option.value"
                         :value="option.value"
                     >

--- a/resources/js/pages/settings/Localization.vue
+++ b/resources/js/pages/settings/Localization.vue
@@ -138,6 +138,7 @@ function onSelectTimeFormat(value: unknown): void {
                         v-for="option in timeFormats"
                         :key="option.value"
                         :value="option.value"
+                        :data-test="`time-format-${option.value}`"
                     >
                         {{ option.label }}
                     </SelectItem>

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -1,6 +1,7 @@
 import type { ChimeSound } from './chimes';
 import type { AppLocale } from './locale';
 import type { SidebarPosition } from './sidebar';
+import type { TimeFormat } from './timeFormat';
 
 export type User = {
     id: number;
@@ -23,6 +24,8 @@ export type User = {
      */
     dnd: App.Data.UserDndData;
     locale: AppLocale;
+    /** Whether times of day render on a 12- or 24-hour clock, or follow the language. */
+    time_format: TimeFormat;
     avatar?: string;
     email_verified_at: string | null;
     created_at: string;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -10,4 +10,5 @@ export * from './security';
 export * from './sessions';
 export * from './sidebar';
 export * from './teams';
+export * from './timeFormat';
 export * from './ui';

--- a/resources/js/types/timeFormat.ts
+++ b/resources/js/types/timeFormat.ts
@@ -1,0 +1,6 @@
+export type TimeFormat = App.Enums.TimeFormat;
+
+export type TimeFormatOption = {
+    value: TimeFormat;
+    label: string;
+};

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Settings\SecurityController;
 use App\Http\Controllers\Settings\SessionController;
 use App\Http\Controllers\Settings\SidebarPositionController;
 use App\Http\Controllers\Settings\StatusController;
+use App\Http\Controllers\Settings\TimeFormatController;
 use App\Http\Controllers\Settings\TimezoneController;
 use App\Http\Controllers\Teams\AnalyticsController;
 use App\Http\Controllers\Teams\AuditController;
@@ -101,6 +102,7 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
 
     Route::get('settings/language', [LocaleController::class, 'edit'])->name('locale.edit');
     Route::patch('settings/language', [LocaleController::class, 'update'])->name('locale.update');
+    Route::patch('settings/time-format', [TimeFormatController::class, 'update'])->name('time-format.update');
 
     // Human personal access tokens for the public REST API. JSON endpoints only
     // (the settings UI ships in a follow-up); the whole surface 404s when the

--- a/tests/Browser/ClockStyleTest.php
+++ b/tests/Browser/ClockStyleTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TimeFormat;
+
+/**
+ * The clock-style preference re-renders every time of day live. Reaching the
+ * settings pages through the nav keeps the visits client-side (a hard navigate
+ * would drop the browser session), matching SidebarPositionTest.
+ *
+ * The quiet-hours bounds are the sharpest witness: they used to be hardcoded to
+ * a 24-hour frame while the paused card two screens away spoke 12-hour, so an
+ * English viewer configured the window in one convention and was told about it
+ * in the other.
+ */
+test('a user pins a 24-hour clock and the quiet-hours bounds follow it', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $alice->forceFill([
+        'time_format' => TimeFormat::Auto->value,
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => '18:00',
+        'dnd_ends_at' => '09:00',
+    ])->save();
+
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@settings-menu-item')
+        // Let the dropdown settle past its open/pointer-grace window.
+        ->wait(0.5)
+        ->click('@settings-menu-item')
+        ->assertPathContains('/settings')
+        ->click('@settings-nav-appearance')
+        ->assertPathContains('/settings/appearance')
+        // English on Auto reads a 12-hour clock, as it always has.
+        ->assertSeeIn('@quiet-hours-starts-at', '6:00 PM')
+        ->click('@settings-nav-language')
+        ->assertPathContains('/settings/language')
+        // The clock-style select is a second labelled control on the page; axe
+        // guards its label/role wiring the way the language select above it is.
+        ->assertNoAccessibilityIssues()
+        ->click('@time-format')
+        ->assertPresent('@time-format-24h')
+        ->click('@time-format-24h')
+        ->click('@settings-nav-appearance')
+        ->assertPathContains('/settings/appearance')
+        // The stored bound is unchanged — only the label it renders under.
+        ->assertSeeIn('@quiet-hours-starts-at', '18:00');
+
+    expect($alice->refresh()->time_format)->toBe(TimeFormat::TwentyFourHour);
+    expect($alice->dnd_starts_at)->toBe('18:00');
+});

--- a/tests/Feature/Settings/TimeFormatSettingsTest.php
+++ b/tests/Feature/Settings/TimeFormatSettingsTest.php
@@ -2,6 +2,8 @@
 
 use App\Enums\TimeFormat;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
 
 test('the localization page offers the selectable clock styles', function (): void {
@@ -17,8 +19,19 @@ test('the localization page offers the selectable clock styles', function (): vo
         );
 });
 
-test('a new account defaults to the automatic clock style', function (): void {
-    expect(User::factory()->create()->time_format)->toBe(TimeFormat::Auto);
+/**
+ * The column default is what carries every account that existed before the
+ * preference did, so it is asserted against a row inserted without the column
+ * rather than through the factory (which sets it explicitly).
+ */
+test('an account stored without a clock style reads as automatic', function (): void {
+    $attributes = User::factory()->raw();
+    unset($attributes['time_format']);
+
+    $id = (string) Str::uuid7();
+    DB::table('users')->insert([...$attributes, 'id' => $id]);
+
+    expect(User::query()->findOrFail($id)->time_format)->toBe(TimeFormat::Auto);
 });
 
 test('the clock style can be set to 24-hour', function (): void {

--- a/tests/Feature/Settings/TimeFormatSettingsTest.php
+++ b/tests/Feature/Settings/TimeFormatSettingsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Enums\TimeFormat;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('the localization page offers the selectable clock styles', function (): void {
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->get(route('locale.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->has('timeFormats', count(TimeFormat::cases()))
+            ->where('timeFormats.0', ['value' => TimeFormat::Auto->value, 'label' => 'Auto (match language)'])
+        );
+});
+
+test('a new account defaults to the automatic clock style', function (): void {
+    expect(User::factory()->create()->time_format)->toBe(TimeFormat::Auto);
+});
+
+test('the clock style can be set to 24-hour', function (): void {
+    $user = User::factory()->create(['time_format' => TimeFormat::Auto->value]);
+
+    $this
+        ->actingAs($user)
+        ->patch(route('time-format.update'), ['time_format' => TimeFormat::TwentyFourHour->value])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect(route('locale.edit'));
+
+    expect($user->refresh()->time_format)->toBe(TimeFormat::TwentyFourHour);
+});
+
+test('the clock style can be set back to automatic', function (): void {
+    $user = User::factory()->create(['time_format' => TimeFormat::TwelveHour->value]);
+
+    $this
+        ->actingAs($user)
+        ->patch(route('time-format.update'), ['time_format' => TimeFormat::Auto->value])
+        ->assertSessionHasNoErrors();
+
+    expect($user->refresh()->time_format)->toBe(TimeFormat::Auto);
+});
+
+test('the clock style rides the shared auth user prop', function (): void {
+    $user = User::factory()->create(['time_format' => TimeFormat::TwelveHour->value]);
+
+    $this
+        ->actingAs($user)
+        ->get(route('locale.edit'))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('auth.user.time_format', TimeFormat::TwelveHour->value)
+        );
+});
+
+test('an unknown clock style is rejected', function (): void {
+    $user = User::factory()->create(['time_format' => TimeFormat::Auto->value]);
+
+    $this
+        ->actingAs($user)
+        ->from(route('locale.edit'))
+        ->patch(route('time-format.update'), ['time_format' => 'sundial'])
+        ->assertSessionHasErrors('time_format');
+
+    expect($user->refresh()->time_format)->toBe(TimeFormat::Auto);
+});
+
+test('a clock style is required', function (): void {
+    $user = User::factory()->create();
+
+    $this
+        ->actingAs($user)
+        ->from(route('locale.edit'))
+        ->patch(route('time-format.update'), [])
+        ->assertSessionHasErrors('time_format');
+});
+
+test('guests cannot update the clock style', function (): void {
+    $this->patch(route('time-format.update'), ['time_format' => TimeFormat::TwentyFourHour->value])
+        ->assertRedirect(route('login'));
+});
+
+test('every clock style has a label', function (): void {
+    foreach (TimeFormat::cases() as $format) {
+        expect($format->label())->not->toBe('');
+    }
+});


### PR DESCRIPTION
Closes #759.

## What

Adds an explicit clock-style preference so a user's 12- or 24-hour clock is no longer an implicit side effect of their display language.

- **Three options, defaulting to Auto** — `App\Enums\TimeFormat` (`auto` / `12h` / `24h`) on a `users.time_format` column. `auto` is today's behaviour exactly (the locale decides), so the migration is a no-op for every existing account and nobody's clock silently flips.
- **Lives on Language & region**, under the display-language select, persisted through `TimeFormatController` and shared on the `auth.user` prop like `chime_sound` and `sidebar_position`.
- **Every time of day follows it.** `lib/clock.ts` holds the preference as a reactive module singleton (mirroring `lib/i18n`), seeded in `app.ts` from the shared prop; the formatters resolve their Intl `hourCycle` through it. That covers `formatTimeOfDay`, `formatDateTime` and `formatLocalTime` — so the timeline and its hover cards, the DND paused card and pause dialog, sessions and security activity, audit and export screens, search results, pins, the lightbox and the quick switcher — plus the scheduled-message previews (`scheduleTime.ts`) and reminder details (`reminderTime.ts`), which render times of day too.
- **Quiet hours included.** The bound selects and the 24h strip ticks in Appearance & notifications now render through the preference (new `formatWallTime` / `formatWallHour`), which removes the contradiction the issue describes: an English user configured the window in 24-hour time and was then told about it in 12-hour time. The persisted `starts_at` / `ends_at` values stay `HH:mm`.
- `h12` / `h23` are chosen deliberately over `h11` / `h24`, so midnight reads "12 AM" and "00", never "0 AM" or "24:00".

Out of scope, unchanged: date ordering, seconds, week-start, relative phrasing, and the two server-side `format('H:i')` wall-clock comparisons (`User`, `BroadcastDndScheduleEdges`).

## Notes

The composer's "Send later" / reminder pickers still take input through an hour + AM/PM control (`to12Hour` / `to24Hour`). Their *output* labels now follow the preference; converting the picker itself to a 24-hour input is a control redesign the issue doesn't ask for, so it is left alone.

The language hint changed from "Dates, times, and numbers…" to "Dates and numbers…", since times are no longer strictly language-driven.

## Testing

- `tests/Feature/Settings/TimeFormatSettingsTest.php` — page props, persistence, validation, guest guard, and the column default asserted against a row inserted without it (the path that carries pre-existing accounts).
- Vitest — `lib/clock.ts`, the datetime helpers under all three settings in both locales (including that Auto reproduces current behaviour byte for byte), the quiet-hours tick labels, the schedule/reminder labels, and `useTimeFormat`'s rollback when the write fails.
- `tests/Browser/ClockStyleTest.php` — pins 24-hour on Language & region and asserts the quiet-hours bound flips from "6:00 PM" to "18:00" on a client-side navigation with no reload, the stored bound unchanged; includes an axe pass on the page.
- Full gate green: `composer test` at `Total: 100.0 %` with clean Pint/PHPStan/Rector, plus `lint:check`, `format:check`, `types:check`, `test:js` (1039 tests) and `build`.

## i18n

New keys translated in `lang/fr.json`; the enum labels ("Auto (match language)", "12-hour", "24-hour") are translated server-side and ride the page props.

No operator-facing config or env changes, so `docs/` is untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787367499&installation_model_id=428379&pr_number=767&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F767&signature=0ecc56dfdfcad211f267cf12636eb4b61d201fd56aea527f02293aadcad6f114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->