### PR TITLE
fix: cut realtime broadcast latency from seconds to milliseconds

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -181,6 +181,12 @@ REDIS_HOST=redis
 REDIS_PASSWORD=null
 REDIS_PORT=6379
 
+# Seconds a queue worker waits on Redis for work before looking again. A job
+# arriving inside that window starts immediately, so this only sets how often a
+# worker rechecks its secondary queues. Leave it alone unless you have a reason;
+# anything below 1 is floored to 1, because Redis reads 0 as "wait forever".
+# REDIS_QUEUE_BLOCK_FOR=1
+
 # --- Mail (external SMTP, operator-provided) ---------------------------------
 MAIL_MAILER=smtp
 MAIL_SCHEME=null

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,9 +7,11 @@ use App\Support\IpGeolocator;
 use App\Support\PresenceRegistry;
 use Carbon\CarbonImmutable;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
@@ -47,6 +49,21 @@ class AppServiceProvider extends ServiceProvider
 
         $this->configureDefaults();
         $this->configureRateLimiting();
+        $this->configureQueueRouting();
+    }
+
+    /**
+     * Keep every broadcast off the shared `default` queue.
+     *
+     * Broadcasts are latency-critical and tiny; the jobs they would otherwise
+     * queue behind are neither — a link unfurl spends up to five seconds on
+     * outbound HTTP, and a webhook delivery or an export longer still. One
+     * registration covers every event, present and future, because queue routes
+     * match a queueable's interfaces as well as its class.
+     */
+    protected function configureQueueRouting(): void
+    {
+        Queue::route(ShouldBroadcast::class, queue: 'broadcasts');
     }
 
     /**

--- a/compose.yaml
+++ b/compose.yaml
@@ -49,7 +49,12 @@ services:
         image: 'sail-8.5/app'
         extra_hosts:
             - 'host.docker.internal:host-gateway'
-        command: ['php', 'artisan', 'queue:listen', '--tries=1', '--timeout=0']
+        # Broadcasts lead the queue list and the worker never sleeps between
+        # polls, matching the production topology's latency (see
+        # docker-compose.prod.yml). It stays a single `queue:listen` container:
+        # respawning per job is what picks up code edits without a restart, and
+        # its bootstrap is invisible next to the 3 seconds this replaces (#763).
+        command: ['php', 'artisan', 'queue:listen', '--queue=broadcasts,default', '--sleep=0', '--tries=1', '--timeout=0']
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1

--- a/config/queue.php
+++ b/config/queue.php
@@ -71,7 +71,18 @@ return [
             'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
             'queue' => env('REDIS_QUEUE', 'default'),
             'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),
-            'block_for' => null,
+            // Seconds a worker holds a blocking pop open before polling again.
+            // Without one, an idle worker naps for `--sleep` seconds before it
+            // notices a job — the realtime lag of issue #763. One second rather
+            // than longer because a worker blocks only on the FIRST queue in its
+            // list and polls the rest once per cycle, so this also caps how long
+            // a job on `default` waits behind an idle `broadcasts` queue.
+            //
+            // Floored at 1: the driver passes this straight to `BLPOP`, where 0
+            // means "wait forever" rather than "do not wait", so an operator
+            // reading it as "disable blocking" would silently strand every job
+            // on `default` until a broadcast happened to arrive.
+            'block_for' => max(1, (int) env('REDIS_QUEUE_BLOCK_FOR', 1)),
             'after_commit' => false,
         ],
 

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -72,7 +72,12 @@ services:
 
   queue:
     <<: *app
-    command: ['php', 'artisan', 'queue:work', '--tries=3']
+    command: ['php', 'artisan', 'queue:work', '--queue=broadcasts,default', '--sleep=0', '--tries=3']
+    depends_on: *worker-depends-on
+
+  queue-broadcasts:
+    <<: *app
+    command: ['php', 'artisan', 'queue:work', '--queue=broadcasts', '--sleep=0', '--tries=3']
     depends_on: *worker-depends-on
 
   scheduler:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,9 +45,10 @@
 # it being healthy before it starts.
 
 # The infrastructure every app-role service waits for. Split out of the *app
-# anchor so `queue`, `reverb`, and `scheduler` can add `app` to their own
-# `depends_on` without restating these three: a service that declares
-# `depends_on` replaces the anchor's value wholesale, it does not merge into it.
+# anchor so `queue`, `queue-broadcasts`, `reverb`, and `scheduler` can add `app`
+# to their own `depends_on` without restating these three: a service that
+# declares `depends_on` replaces the anchor's value wholesale, it does not merge
+# into it.
 x-infra-depends-on: &infra-depends-on
   pgsql:
     condition: service_healthy
@@ -56,11 +57,11 @@ x-infra-depends-on: &infra-depends-on
   meilisearch:
     condition: service_healthy
 
-# What the three worker services wait for: the infrastructure above, plus `app`.
+# What the four worker services wait for: the infrastructure above, plus `app`.
 #
-# The four app-role services share the `storage-app` named volume. On a fresh
+# The five app-role services share the `storage-app` named volume. On a fresh
 # volume (a first install, or any `up -d` after `down -v`) the daemon seeds it
-# from the image's /app/storage/app — `private/` and `public/`. Four containers
+# from the image's /app/storage/app — `private/` and `public/`. Containers
 # created at the same instant all trigger that copy-up, race inside dockerd, and
 # one dies with `mkdir /var/lib/docker/volumes/…/_data/private: file exists`
 # (#609). Waiting on `app` means exactly one container ever seeds the volume.
@@ -140,9 +141,31 @@ services:
   # healthcheck: the image sets HEALTHCHECK NONE and this service leaves it that
   # way, reporting a plain `Up` rather than a decorative or perpetually failing
   # probe. `restart: unless-stopped` (from the *app anchor) keeps it running.
+  #
+  # `--sleep=0` because a worker that finds nothing otherwise naps for whole
+  # seconds before looking again; the blocking pop (REDIS_QUEUE_BLOCK_FOR) is
+  # what makes it wait for work instead of spinning.
+  #
+  # It keeps `broadcasts` in its queue list deliberately, as an upgrade safety
+  # net: an operator running a customized compose file who never adds the
+  # `queue-broadcasts` service below still gets broadcasts delivered, just with
+  # the old head-of-line behaviour, instead of realtime silently dying. The
+  # order is not cosmetic — a Redis worker blocks only on the FIRST queue in the
+  # list and polls the rest once per cycle, so `broadcasts` has to lead.
   queue:
     <<: *app
-    command: ['php', 'artisan', 'queue:work', '--tries=3']
+    command: ['php', 'artisan', 'queue:work', '--queue=broadcasts,default', '--sleep=0', '--tries=3']
+    depends_on: *worker-depends-on
+
+  # Broadcasts (new messages, edits, reactions, typing, presence, read state)
+  # are latency-critical and tiny. Everything else on the queue is not: a link
+  # unfurl spends up to five seconds on outbound HTTP, and a webhook delivery or
+  # an audit export longer still. Priority ordering cannot rescue that — it
+  # picks the next job, it cannot preempt the unfurl already in flight — so
+  # broadcasts get their own process. Same no-healthcheck rationale as `queue`.
+  queue-broadcasts:
+    <<: *app
+    command: ['php', 'artisan', 'queue:work', '--queue=broadcasts', '--sleep=0', '--tries=3']
     depends_on: *worker-depends-on
 
   # Scheduler (delivers due scheduled messages, prunes expired invitations).

--- a/docs/src/content/docs/reference/architecture.md
+++ b/docs/src/content/docs/reference/architecture.md
@@ -8,10 +8,10 @@ driven by the same `.env`. Its values are injected into every app-role container
 and the file itself is also bind-mounted read-only at `/app/.env`, so artisan
 commands run against a container (maintenance, seeding the public demo) resolve
 configuration exactly like a standard on-disk install. The app image is served
-with [FrankenPHP](https://frankenphp.dev/). By default the four app-role services
-(`app`, `reverb`, `queue`, `scheduler`) share one **prebuilt image** pulled from
-the registry; the optional `docker-compose.build.yml` overlay replaces that pull
-with a local build from source (see
+with [FrankenPHP](https://frankenphp.dev/). By default the five app-role services
+(`app`, `reverb`, `queue`, `queue-broadcasts`, `scheduler`) share one **prebuilt
+image** pulled from the registry; the optional `docker-compose.build.yml` overlay
+replaces that pull with a local build from source (see
 [Installation](/self-hosting/installation/#build-from-source)).
 
 ## Services
@@ -21,40 +21,58 @@ with a local build from source (see
 | `app`         | FrankenPHP web server (serves HTTP; runs migrations on boot)|
 | `reverb`      | WebSocket server for real-time broadcasting                 |
 | `queue`       | Queue worker (`queue:work`) — sends mail, delivers jobs     |
+| `queue-broadcasts` | Queue worker dedicated to real-time broadcasts        |
 | `scheduler`   | Scheduled tasks (`schedule:work`) — due scheduled messages, invitation pruning |
 | `pgsql`       | PostgreSQL database (named volume `pgsql-data`)             |
 | `meilisearch` | Full-text search index (version-scoped named volume)       |
 | `redis`       | Cache, session, and queue backend (named volume `redis-data`)|
 
-Every app process (`app`, `reverb`, `queue`, `scheduler`) waits for `pgsql`,
-`redis`, and `meilisearch` to report healthy before it starts.
+Every app process (`app`, `reverb`, `queue`, `queue-broadcasts`, `scheduler`)
+waits for `pgsql`, `redis`, and `meilisearch` to report healthy before it starts.
+
+### Why broadcasts get their own worker
+
+Every real-time update — a new message, an edit, a reaction, a typing indicator,
+presence, read state — is a queued job. So is a link unfurl, which spends up to
+five seconds on outbound HTTP, and so are webhook deliveries, exports, and mail.
+On a single worker one unfurl holds every message behind it, and no amount of
+queue prioritisation helps: priority picks the *next* job, it cannot interrupt
+the one already running.
+
+So broadcasts are routed to their own `broadcasts` queue and drained by
+`queue-broadcasts`, which runs nothing else. The shared `queue` worker still
+lists `broadcasts` ahead of `default`, as a safety net: if you run a customised
+compose file and never add the new service, broadcasts are still delivered — they
+just queue behind slow jobs again, rather than stopping.
 
 ## Health checks
 
 The app image itself declares no health check, so `docker compose ps` reports
 each app-role service by what it actually serves:
 
-| Service     | Health in `docker compose ps` | Probe                       |
-| ----------- | ----------------------------- | --------------------------- |
-| `app`       | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080) |
-| `reverb`    | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080) |
-| `queue`     | `Up` (no health column)       | none (no HTTP surface)      |
-| `scheduler` | `Up` (no health column)       | none (no HTTP surface)      |
+| Service            | Health in `docker compose ps` | Probe                       |
+| ------------------ | ----------------------------- | --------------------------- |
+| `app`              | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080) |
+| `reverb`           | `healthy` / `unhealthy`       | `GET /up` (HTTP, port 8080) |
+| `queue`            | `Up` (no health column)       | none (no HTTP surface)      |
+| `queue-broadcasts` | `Up` (no health column)       | none (no HTTP surface)      |
+| `scheduler`        | `Up` (no health column)       | none (no HTTP surface)      |
 
-`queue` and `scheduler` run background workers (`queue:work` / `schedule:work`)
-with nothing to curl, so they carry no health check by design and show a plain
-`Up`. That confirms the container is running, not that jobs are being processed;
-check the worker logs (`docker compose logs queue`, `docker compose logs
+The workers (`queue:work` / `schedule:work`) have nothing to curl, so they carry
+no health check by design and show a plain `Up`. That confirms the container is
+running, not that jobs are being processed; check the worker logs (`docker
+compose logs queue`, `docker compose logs queue-broadcasts`, `docker compose logs
 scheduler`) to confirm throughput. `app` and `reverb` both answer `GET /up`, so
 a genuine outage flips them to `unhealthy`.
 
 ## Data flow
 
 - **HTTP** requests hit `app` (FrankenPHP) behind your reverse proxy.
-- **Real-time** updates are broadcast over WebSockets by `reverb`; the browser
+- **Real-time** updates are queued on `broadcasts`, picked up by
+  `queue-broadcasts`, and pushed over WebSockets by `reverb`; the browser
   connects to it through your TLS proxy.
-- **Background work** (email, scheduled message delivery) runs on `queue` and
-  `scheduler`.
+- **Background work** (email, link previews, webhook delivery, scheduled message
+  delivery) runs on `queue` and `scheduler`.
 - **Search** queries go to `meilisearch`; the index is derived from Postgres and
   rebuilt with `php artisan search:sync` when needed.
 
@@ -85,6 +103,11 @@ Cache, session, and the queue all use the **Redis** driver
 `REDIS_HOST=redis`). Broadcasting uses **Reverb**. Redis persists to a named
 volume with `appendonly` enabled, so queued jobs survive a restart.
 
+Workers wait on Redis for work rather than polling it on a timer
+([`REDIS_QUEUE_BLOCK_FOR`](/reference/environment-variables/#queue-workers)), so
+a job starts within milliseconds of being dispatched instead of after the next
+poll.
+
 The **Active sessions** panel (Security settings) — listing signed-in devices
 and revoking them — is backed by an owned per-user session index kept in the
 cache, so it works under the default Redis session driver with no need to switch
@@ -99,11 +122,12 @@ cache, so it works under the default Redis session driver with no need to switch
 | `redis-data`                  | Cache, session, queued jobs        |
 | `storage-app`                 | Uploaded files                     |
 
-`storage-app` is mounted by all four app-role services (`app`, `queue`,
-`reverb`, `scheduler`). On a fresh volume Docker seeds it from the image, so the
-three workers wait for `app` to start (`depends_on: app`) and exactly one
-container performs that seeding — starting them together makes the daemon race
-itself and one container fails with `mkdir …/_data/private: file exists`.
+`storage-app` is mounted by all five app-role services (`app`, `queue`,
+`queue-broadcasts`, `reverb`, `scheduler`). On a fresh volume Docker seeds it
+from the image, so the workers wait for `app` to start (`depends_on: app`) and
+exactly one container performs that seeding — starting them together makes the
+daemon race itself and one container fails with `mkdir …/_data/private: file
+exists`.
 
 These survive `docker compose down` / `up`. See
 [Upgrading](/self-hosting/upgrading/) for how the version-scoped Meilisearch

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -55,6 +55,17 @@ The stack **refuses to start** without these (no defaults):
 | `DB_USERNAME` | `laravel` | PostgreSQL user.                |
 | `DB_PASSWORD` | —         | Required secret (see above).    |
 
+## Queue workers
+
+Background work — real-time broadcasts, mail, link previews, webhook delivery,
+exports — runs through Redis on the `queue` and `queue-broadcasts` services (see
+[Architecture](/reference/architecture/#why-broadcasts-get-their-own-worker)).
+Neither needs configuring; the one tunable is how a worker waits for work.
+
+| Variable                 | Default | Notes                                                                                            |
+| ------------------------ | ------- | -------------------------------------------------------------------------------------------------- |
+| `REDIS_QUEUE_BLOCK_FOR`  | `1`     | Seconds a worker holds a blocking read on Redis open before it looks again. A job that arrives during that window starts immediately, so raising it does not slow anything down — it only decides how often a worker rechecks its *secondary* queues. Values below `1` are floored to `1`: the underlying Redis command reads `0` as "wait forever", which would strand everything but broadcasts. |
+
 ## Mail (SMTP)
 
 | Variable            | Notes                                        |

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -64,7 +64,7 @@ Neither needs configuring; the one tunable is how a worker waits for work.
 
 | Variable                 | Default | Notes                                                                                            |
 | ------------------------ | ------- | -------------------------------------------------------------------------------------------------- |
-| `REDIS_QUEUE_BLOCK_FOR`  | `1`     | Seconds a worker holds a blocking read on Redis open before it looks again. A job that arrives during that window starts immediately, so raising it does not slow anything down — it only decides how often a worker rechecks its *secondary* queues. Values below `1` are floored to `1`: the underlying Redis command reads `0` as "wait forever", which would strand everything but broadcasts. |
+| `REDIS_QUEUE_BLOCK_FOR`  | `1`     | Seconds a worker holds a blocking read on Redis open before it looks again. A job on the worker's **first** queue starts the instant it is dispatched however high this is, so raising it never slows real-time updates. What it does set is how long a job on a **secondary** queue can sit before the worker rechecks it — on the shared `queue` worker, that is `default`, so raising this to `10` can leave mail or a link preview waiting up to ten seconds to start. Values below `1` are floored to `1`: the underlying Redis command reads `0` as "wait forever", which would strand everything but broadcasts. |
 
 ## Mail (SMTP)
 

--- a/docs/src/content/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/self-hosting/upgrading.md
@@ -195,6 +195,12 @@ real-time updates so they never queue behind a slow job such as a link preview:
     depends_on: *worker-depends-on
 ```
 
+`*app` and `*worker-depends-on` are the YAML anchors the shipped file defines
+above its `services:` block — the image, `.env`, volumes, and what a worker waits
+for. If your file already has a `queue` service it has them too, so this pastes
+in as-is; if you renamed or dropped them, give the new service the same image,
+`env_file`, volumes, and `depends_on` as your existing `queue` worker.
+
 Missing it is not fatal. The shared `queue` worker also lists the `broadcasts`
 queue, so real-time updates still arrive — they simply wait behind whatever else
 that worker is busy with, which is how the stack behaved before the service

--- a/docs/src/content/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/self-hosting/upgrading.md
@@ -178,6 +178,28 @@ browser console open, and allow-list what it reports with the `CSP_EXTRA_*` keys
 before turning enforcement back on.
 :::
 
+### New services in a release
+
+A release can also add a **service** to the stack. If you run the shipped
+`docker-compose.prod.yml` (or `docker-compose.dokploy.yml`) unmodified, you get
+it automatically — pulling the new file is all it takes. If you maintain your own
+copy, compare it against the release's file and copy any new service across.
+
+The current example is `queue-broadcasts`, a second queue worker that carries
+real-time updates so they never queue behind a slow job such as a link preview:
+
+```yaml
+  queue-broadcasts:
+    <<: *app
+    command: ['php', 'artisan', 'queue:work', '--queue=broadcasts', '--sleep=0', '--tries=3']
+    depends_on: *worker-depends-on
+```
+
+Missing it is not fatal. The shared `queue` worker also lists the `broadcasts`
+queue, so real-time updates still arrive — they simply wait behind whatever else
+that worker is busy with, which is how the stack behaved before the service
+existed. Adding it is what makes them immediate.
+
 ### If it fails, it stops and hands you the backup
 
 The script **never rolls back on its own**, and that is deliberate.

--- a/tests/Feature/Events/BroadcastQueueTest.php
+++ b/tests/Feature/Events/BroadcastQueueTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\UserData;
+use App\Events\UserTyping;
+use App\Models\Channel;
+use App\Models\User;
+use Illuminate\Broadcasting\BroadcastEvent;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Queue;
+
+/**
+ * Every broadcast is a queued job, so it shares a worker with `UnfurlMessageLinks`
+ * (up to 5 seconds of outbound HTTP), webhook delivery, exports, and queued mail.
+ * One unfurl in flight stalls every message, reaction, and typing indicator
+ * behind it — the second half of the lag in issue #763. Routing broadcasts onto
+ * their own queue is what lets a dedicated worker drain them.
+ */
+test('a dispatched broadcast is queued away from the shared default queue', function (): void {
+    Queue::fake();
+
+    $channel = Channel::factory()->create();
+
+    event(new UserTyping($channel, UserData::fromUser(User::factory()->create())));
+
+    Queue::assertPushedOn('broadcasts', BroadcastEvent::class);
+});
+
+/**
+ * The route is registered against the `ShouldBroadcast` *interface*, which
+ * `QueueRoutes::getRoute` matches alongside the class itself — so it covers the
+ * fourteenth event as well as the thirteen that exist today, with no per-event
+ * edit to forget. This proves that for every event actually in the app.
+ */
+test('every broadcast event in the app routes to the broadcasts queue', function (): void {
+    $events = collect(File::files(app_path('Events')))
+        ->map(static fn (SplFileInfo $file): string => 'App\\Events\\'.$file->getBasename('.php'))
+        ->filter(static fn (string $event): bool => is_subclass_of($event, ShouldBroadcast::class));
+
+    expect($events)->not->toBeEmpty();
+
+    foreach ($events as $event) {
+        // Never constructed: the route matches on the class and its interfaces,
+        // so the event's own dependencies are irrelevant here.
+        $queue = Queue::resolveQueueFromQueueRoute(
+            (new ReflectionClass($event))->newInstanceWithoutConstructor(),
+        );
+
+        expect($queue)->toBe('broadcasts', $event.' would broadcast off the shared default queue');
+    }
+});
+
+/**
+ * A blocking pop returns the instant a job lands, so an idle worker stops
+ * polling-and-napping. The default is bounded at one second rather than five
+ * because the shared worker blocks only on `broadcasts` (the first queue in its
+ * list) and polls `default` once per block cycle — so this value is also how
+ * long a slow job can sit before it starts.
+ */
+test('the redis queue blocks for a job rather than polling and sleeping', function (): void {
+    expect(config('queue.connections.redis.block_for'))->toBe(1);
+});
+
+test('an operator can tune how long the worker blocks', function (): void {
+    $this->reloadWithEnv(['REDIS_QUEUE_BLOCK_FOR' => 5]);
+
+    expect(config('queue.connections.redis.block_for'))->toBe(5);
+});
+
+/**
+ * The driver hands this value to `BLPOP`, where a timeout of 0 means "wait
+ * forever" — the opposite of what an operator typing it would mean. Unfloored,
+ * the shared worker would block on `broadcasts` indefinitely and never poll
+ * `default`, so mail, unfurls, and webhooks would only ever start when a
+ * broadcast happened to arrive.
+ */
+test('a zero blocking window is floored rather than read as wait forever', function (int|string $value): void {
+    $this->reloadWithEnv(['REDIS_QUEUE_BLOCK_FOR' => $value]);
+
+    expect(config('queue.connections.redis.block_for'))->toBe(1);
+})->with([0, -1, 'nonsense']);

--- a/tests/Unit/ProductionComposeStorageVolumeTest.php
+++ b/tests/Unit/ProductionComposeStorageVolumeTest.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * `app`, `queue`, `reverb`, and `scheduler` all mount the same named volume
- * (`storage-app`). On a fresh volume the daemon seeds it from the image
- * (copy-up); four containers created at the same instant race inside dockerd and
- * one dies with `mkdir /var/lib/docker/volumes/..._data/private: file exists`.
- * Making the three workers wait for `app` means exactly one container triggers
- * the copy-up. See issue #609.
+ * `app`, `queue`, `queue-broadcasts`, `reverb`, and `scheduler` all mount the
+ * same named volume (`storage-app`). On a fresh volume the daemon seeds it from
+ * the image (copy-up); containers created at the same instant race inside
+ * dockerd and one dies with `mkdir /var/lib/docker/volumes/..._data/private:
+ * file exists`. Making the workers wait for `app` means exactly one container
+ * triggers the copy-up. See issue #609.
  */
 $compose = fn (): array => Yaml::parseFile(dirname(__DIR__, 2).'/docker-compose.prod.yml');
 
-$sharedVolumeWorkers = ['queue', 'reverb', 'scheduler'];
+$sharedVolumeWorkers = ['queue', 'queue-broadcasts', 'reverb', 'scheduler'];
 
-test('every app-role service mounts the shared storage-app volume', function () use ($compose): void {
+test('every app-role service mounts the shared storage-app volume', function () use ($compose, $sharedVolumeWorkers): void {
     $services = $compose()['services'];
 
-    foreach (['app', 'queue', 'reverb', 'scheduler'] as $service) {
+    foreach (['app', ...$sharedVolumeWorkers] as $service) {
         expect($services[$service]['volumes'])->toContain('storage-app:/app/storage/app');
     }
 });

--- a/tests/Unit/QueueTopologyTest.php
+++ b/tests/Unit/QueueTopologyTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Realtime latency lives in the compose files, which no other test executes.
+ *
+ * Two settings there decide how fast a broadcast reaches Reverb: `--sleep=0`,
+ * without which an idle worker naps for whole seconds between polls even with a
+ * blocking pop configured, and a dedicated `queue-broadcasts` worker, without
+ * which a 5-second link unfurl on the shared queue holds every message,
+ * reaction, and typing indicator behind it. Both read as harmless the moment
+ * someone tidies a command line, so they need a guard or they rot back to the
+ * 3-second lag of issue #763.
+ */
+$composePath = fn (string $file): string => dirname(__DIR__, 2).'/'.$file;
+
+/** The two stacks an operator runs in production; they must not drift apart. */
+$productionFiles = ['docker-compose.prod.yml', 'docker-compose.dokploy.yml'];
+
+/** Every stack that runs a worker, production and the Sail dev stack. */
+$allFiles = [...$productionFiles, 'compose.yaml'];
+
+/**
+ * The services in a compose file that consume the queue, as name => command.
+ *
+ * @return array<string, list<string>>
+ */
+function queueWorkerCommands(string $file): array
+{
+    /** @var array<string, array<string, mixed>> $services */
+    $services = Yaml::parseFile(dirname(__DIR__, 2).'/'.$file)['services'];
+
+    return array_map(
+        static fn (array $service): array => (array) $service['command'],
+        array_filter(
+            $services,
+            static fn (array $service): bool => array_intersect(
+                ['queue:work', 'queue:listen'],
+                (array) ($service['command'] ?? []),
+            ) !== [],
+        ),
+    );
+}
+
+/**
+ * The comma-separated value of a worker command's `--queue=` option, or null
+ * when it takes whatever the connection's default queue is.
+ *
+ * @param  list<string>  $command
+ */
+function workerQueueOption(array $command): ?string
+{
+    foreach ($command as $token) {
+        if (str_starts_with($token, '--queue=')) {
+            return substr($token, strlen('--queue='));
+        }
+    }
+
+    return null;
+}
+
+test('the worker services are found, so the assertions below match something', function (string $file, array $expected) use ($composePath): void {
+    expect($composePath($file))->toBeReadableFile()
+        ->and(array_keys(queueWorkerCommands($file)))->toBe($expected);
+})->with([
+    ['docker-compose.prod.yml', ['queue', 'queue-broadcasts']],
+    ['docker-compose.dokploy.yml', ['queue', 'queue-broadcasts']],
+    // The dev stack gets no second container: `queue:listen` respawns per job so
+    // it picks up code edits without a restart, and its few hundred milliseconds
+    // of bootstrap are invisible next to the 3 seconds this replaces.
+    ['compose.yaml', ['queue']],
+]);
+
+/**
+ * `block_for` makes an *occupied* queue return instantly, but `Worker::daemon`
+ * still sleeps whenever a poll comes back empty — so without `--sleep=0` an
+ * event dispatched during that nap waits the sleep out. That is exactly the
+ * intermittent 1-to-3-second lag reported in #763.
+ */
+test('no worker sleeps between polls', function (string $file): void {
+    $napping = array_keys(array_filter(
+        queueWorkerCommands($file),
+        static fn (array $command): bool => ! in_array('--sleep=0', $command, true),
+    ));
+
+    expect($napping)->toBe([]);
+})->with($allFiles);
+
+/**
+ * Priority ordering alone cannot fix head-of-line blocking: it chooses the next
+ * job, it cannot preempt the 5-second unfurl already in flight. Only a second
+ * process can.
+ */
+test('each production stack runs a worker dedicated to broadcasts', function (string $file): void {
+    $command = queueWorkerCommands($file)['queue-broadcasts'];
+
+    expect(workerQueueOption($command))->toBe('broadcasts')
+        ->and($command)->toContain('queue:work');
+})->with($productionFiles);
+
+/**
+ * The shared worker keeps `broadcasts` in its list as an upgrade safety net: an
+ * operator running a customized compose file who never adds the new service
+ * still gets broadcasts delivered, just with the old head-of-line behaviour,
+ * rather than realtime silently dying.
+ *
+ * The order is not cosmetic. `RedisQueue::pop` blocks only on the first queue in
+ * the list, so `broadcasts` has to come first or the fix is quietly undone.
+ */
+test('the shared worker drains broadcasts first and default second', function (string $file): void {
+    expect(workerQueueOption(queueWorkerCommands($file)['queue']))->toBe('broadcasts,default');
+})->with($allFiles);
+
+test('the two production stacks agree on how their workers run', function () use ($productionFiles): void {
+    [$prod, $dokploy] = array_map(queueWorkerCommands(...), $productionFiles);
+
+    expect($dokploy)->toBe($prod);
+});


### PR DESCRIPTION
Closes #763.

## What

Realtime updates arrived up to 3 seconds late, intermittently. Every event in `app/Events/` is `ShouldBroadcast`, so each broadcast is a queued job — and two independent faults made those jobs wait.

**1. The worker idled.** `config/queue.php` set `'block_for' => null`, disabling the blocking pop, so an idle worker polled, found nothing, and slept out its full `--sleep` (default 3) before looking again. No worker command overrode that default. Both halves had to change: a blocking pop alone still leaves `Worker::daemon` sleeping after every empty poll.

**2. One queue, one worker, shared with slow jobs.** Broadcasts sat behind `UnfurlMessageLinks` (up to 5s of outbound HTTP per link), `DeliverWebhook`, `GenerateAuditExport`, `ExportUserData`, and queued mail. Queue priority cannot rescue that — it picks the *next* job, it cannot preempt the unfurl already running.

## How

- **`config/queue.php`** — `block_for` becomes `max(1, (int) env('REDIS_QUEUE_BLOCK_FOR', 1))`. The floor is deliberate: the driver hands this straight to `BLPOP`, where `0` means *wait forever*, not *do not wait*, so an operator setting `REDIS_QUEUE_BLOCK_FOR=0` would otherwise strand every job on `default` until a broadcast happened to arrive. (Found while measuring — see below.)
- **`AppServiceProvider`** — `Queue::route(ShouldBroadcast::class, queue: 'broadcasts')`. One registration covers all 13 events and every future one, because queue routes match a queueable's interfaces as well as its class. No per-event edits, no drift.
- **Compose (all three stacks)** — `--sleep=0` on every worker; a new `queue-broadcasts` service in both production files; the shared `queue` worker becomes `--queue=broadcasts,default`. Order matters and is asserted: a Redis worker blocks only on the *first* queue and polls the rest once per cycle, so `broadcasts` has to lead. Keeping `broadcasts` on the shared worker is the upgrade safety net — an operator running a customised compose file who never adds the new service still gets broadcasts, just with the old head-of-line behaviour instead of realtime silently dying.
- The dev stack gets no second container: `queue:listen` respawns per job (which is what picks up code edits without a restart) and its bootstrap is invisible next to the 3 seconds it replaces.

## Measured

Dispatch-to-pickup, on the dev stack, after 10+ seconds of idle:

| | before | after |
| --- | --- | --- |
| idle worker | 0.6s – 2.3s | 2ms – 49ms |
| behind an in-flight 5s job | 3.5s | 2ms – 13ms |

The degraded path was checked too: with only the shared worker (no `queue-broadcasts`), broadcasts still arrive — at the old 3.5s behind a slow job, which is the documented fallback, not a regression.

## Testing

- `tests/Unit/QueueTopologyTest.php` — parses all three compose files: every worker carries `--sleep=0`, both production stacks define the broadcasts worker, the shared worker lists `broadcasts` first, and the two production stacks agree with each other. Modelled on `DocsBuildGateTest`, since this fix otherwise lives entirely in files no test executes.
- `tests/Feature/Events/BroadcastQueueTest.php` — a real dispatched event lands on `broadcasts`; *every* `ShouldBroadcast` event in `app/Events/` resolves to that queue (so event #14 is covered automatically); the `REDIS_QUEUE_BLOCK_FOR` default, an operator override, and the floor at `1`.
- `tests/Unit/ProductionComposeStorageVolumeTest.php` — the new worker joins the shared-volume `depends_on: app` guard from #609.

`sail composer test` green at **100.0%** coverage (2268 tests); frontend gate green; `docs` site builds.

## Docs

- `reference/architecture.md` — services and health-check tables, the five app-role services, data flow, and a new *Why broadcasts get their own worker* section.
- `reference/environment-variables.md` — a *Queue workers* section documenting `REDIS_QUEUE_BLOCK_FOR`, including what raising it costs on secondary queues.
- `self-hosting/upgrading.md` — a *New services in a release* section for operators running a customised compose file: guidance, not a breaking-change warning, since the fallback queue list keeps them working.
- `.env.prod.example` — the tunable, commented out at its default.

No user-facing copy changed, so no i18n catalog updates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787367904&installation_model_id=428379&pr_number=768&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F768&signature=1db5a642387af30dc7d3b0b322e440ba02adb92dc94801c94a75b2653e130dbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->