### PR TITLE
fix: sign in to a French UI without a reload

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -79,7 +79,14 @@ class HandleInertiaRequests extends Middleware
             // prop: it reaches the SSR render and first hydration (so the first
             // paint is already translated) but is excluded from every subsequent
             // SPA visit, keeping navigation payloads free of the catalog.
-            'translations' => Inertia::once(fn () => app(TranslationCatalog::class)->messages(app()->getLocale())),
+            //
+            // The once key carries the locale it holds, so "already loaded" means
+            // "already loaded *this* catalog". A visit that changes the effective
+            // locale without a document load — signing in as a French user from
+            // the English guest page — therefore ships the new catalog instead of
+            // leaving the client rendering the old one (#764).
+            'translations' => Inertia::once(fn () => app(TranslationCatalog::class)->messages(app()->getLocale()))
+                ->as('translations:'.app()->getLocale()),
             // A single deploy-time flag lets self-hosters lock down public
             // registration; when off, Fortify never registers the register
             // routes, so the frontend hides its "sign up" affordances to match.

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -10,6 +10,7 @@ import type { ReverbRuntimeConfig } from '@/lib/echo';
 import { initializeFlashToast } from '@/lib/flashToast';
 import { setMessages, translate } from '@/lib/i18n';
 import type { Messages } from '@/lib/i18n';
+import { initializeLocaleSync } from '@/lib/localeSync';
 import { initializeOverlayInert } from '@/lib/overlayInert';
 import type { TimeFormat } from '@/types';
 
@@ -26,7 +27,8 @@ void createInertiaApp({
     // Seed the translation catalog from the server-shared props before the first
     // render — on both the SSR pass and the client — so the initial paint is
     // already in the active locale (no flash of English on refresh). `translations`
-    // is a once prop, so it rides the initial document only, not every visit.
+    // is a once prop keyed by locale, so it rides the initial document and then
+    // only the visits that change language — `initializeLocaleSync` adopts those.
     // The clock-style preference is seeded the same way, so the first paint's
     // times of day are already on the viewer's chosen clock.
     // Also expose the translation helper as a global `$t` for templates.
@@ -76,6 +78,8 @@ void createInertiaApp({
 });
 
 initializeTheme();
+
+initializeLocaleSync();
 
 initializeFlashToast();
 

--- a/resources/js/lib/i18n.test.ts
+++ b/resources/js/lib/i18n.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 import { i18n, setMessages, translate } from './i18n';
 
@@ -56,5 +57,17 @@ describe('setMessages', () => {
 
         expect(i18n.locale).toBe('fr');
         expect(i18n.messages).toEqual({ Hello: 'Bonjour' });
+    });
+
+    it('restamps the document language, which no SPA swap reloads', () => {
+        setMessages('fr', {});
+
+        expect(document.documentElement.lang).toBe('fr');
+    });
+
+    it('writes the document language as a BCP 47 tag', () => {
+        setMessages('pt_BR', {});
+
+        expect(document.documentElement.lang).toBe('pt-BR');
     });
 });

--- a/resources/js/lib/i18n.ts
+++ b/resources/js/lib/i18n.ts
@@ -69,10 +69,19 @@ export function translate(
 
 /**
  * Replace the active locale and catalog, e.g. after the user switches language.
+ *
+ * The single choke point for a locale change on the client, so it also restamps
+ * `<html lang>`: the Blade shell only writes that on a document load, and an SPA
+ * locale change (a language switch, or signing in as a French user) never has
+ * one. Guarded for the SSR pass, where there is no document to stamp.
  */
 export function setMessages(locale: string, messages: Messages): void {
     i18n.locale = locale;
     i18n.messages = messages;
+
+    if (typeof document !== 'undefined') {
+        document.documentElement.lang = locale.replaceAll('_', '-');
+    }
 }
 
 /**

--- a/resources/js/lib/localeSync.test.ts
+++ b/resources/js/lib/localeSync.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { on, listeners } = vi.hoisted(() => {
+    const listeners = new Map<string, (event: unknown) => void>();
+
+    return {
+        listeners,
+        on: vi.fn((event: string, callback: (event: unknown) => void) => {
+            listeners.set(event, callback);
+        }),
+    };
+});
+
+vi.mock('@inertiajs/vue3', () => ({ router: { on } }));
+
+import { i18n, setMessages } from '@/lib/i18n';
+import { initializeLocaleSync } from '@/lib/localeSync';
+
+/** Deliver a page to one of the registered router listeners. */
+function emit(event: string, props: Record<string, unknown>): void {
+    listeners.get(event)?.({ detail: { page: { props } } });
+}
+
+describe('initializeLocaleSync', () => {
+    beforeEach(() => {
+        on.mockClear();
+        listeners.clear();
+        setMessages('en', { Channels: 'Channels' });
+        initializeLocaleSync();
+    });
+
+    it('adopts the catalog of a visit that changes the locale', () => {
+        emit('beforeUpdate', {
+            locale: 'fr',
+            translations: { Channels: 'Canaux' },
+        });
+
+        expect(i18n.locale).toBe('fr');
+        expect(i18n.messages).toEqual({ Channels: 'Canaux' });
+        expect(document.documentElement.lang).toBe('fr');
+    });
+
+    it('also adopts it on a history restore, which skips the update event', () => {
+        emit('navigate', {
+            locale: 'fr',
+            translations: { Channels: 'Canaux' },
+        });
+
+        expect(i18n.locale).toBe('fr');
+    });
+
+    it('leaves the catalog alone when the locale is unchanged', () => {
+        emit('beforeUpdate', { locale: 'en', translations: {} });
+
+        expect(i18n.messages).toEqual({ Channels: 'Channels' });
+    });
+
+    it('leaves the catalog alone when the visit carries none', () => {
+        emit('beforeUpdate', { locale: 'fr' });
+
+        expect(i18n.locale).toBe('en');
+        expect(i18n.messages).toEqual({ Channels: 'Channels' });
+    });
+
+    it('ignores a page with no shared locale at all', () => {
+        emit('beforeUpdate', {});
+
+        expect(i18n.locale).toBe('en');
+    });
+});

--- a/resources/js/lib/localeSync.ts
+++ b/resources/js/lib/localeSync.ts
@@ -1,0 +1,44 @@
+import { router } from '@inertiajs/vue3';
+import { i18n, setMessages } from '@/lib/i18n';
+import type { Messages } from '@/lib/i18n';
+
+/** The shared props a page carries about the language it was rendered in. */
+type LocalePageProps = {
+    locale?: string;
+    translations?: Messages;
+};
+
+/**
+ * Adopt a page's shared locale and catalog when they name a language the client
+ * is not rendering in yet.
+ *
+ * The server keys the catalog's once prop by locale, so a visit that changes the
+ * effective locale carries the matching catalog while every other visit leaves
+ * it out — hence the "no catalog" and "same locale" cases are both no-ops rather
+ * than a reason to blank the messages.
+ */
+function adoptPageLocale(event: unknown): void {
+    const page = (event as CustomEvent<{ page?: { props?: LocalePageProps } }>)
+        .detail?.page;
+    const locale = page?.props?.locale;
+    const messages = page?.props?.translations;
+
+    if (!locale || !messages || locale === i18n.locale) {
+        return;
+    }
+
+    setMessages(locale, messages);
+}
+
+/**
+ * Keep the rendered language in step with the shared `locale` prop for the whole
+ * SPA lifetime, not just the document load that booted it (#764).
+ */
+export function initializeLocaleSync(): void {
+    // `beforeUpdate` lands before the page swap, so a visit that changes the
+    // locale is already painted in the new language — no flash of the old one.
+    // A history restore swaps the page without firing it, so `navigate` covers
+    // that; adopting is idempotent, so the pair never fights itself.
+    router.on('beforeUpdate', adoptPageLocale);
+    router.on('navigate', adoptPageLocale);
+}

--- a/tests/Browser/LocaleAfterSignInTest.php
+++ b/tests/Browser/LocaleAfterSignInTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AppLocale;
+
+/**
+ * The message catalog rides the initial document as a once prop, so the guest
+ * login page hands the client the English one. Signing in is an Inertia visit
+ * rather than a document load, so nothing re-inlined the catalog the signed-in
+ * user's locale asks for: the sibling `locale` prop flipped to `fr` while the
+ * client kept rendering from the guest page's English catalog, and the French
+ * UI only appeared after a reload (#764).
+ */
+test('a French user who signs in gets a French UI with no reload', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+    $alice->update(['locale' => AppLocale::French]);
+
+    signInThroughBrowser($alice)
+        // The sidebar the redirect lands on reads from the French catalog...
+        ->assertSee('Canaux')
+        ->assertSee('Fils de discussion')
+        ->assertSee('Rappels')
+        // ...and the document agrees about the language it is written in, which
+        // only the Blade shell used to stamp.
+        ->assertScript('document.documentElement.lang', 'fr');
+});

--- a/tests/Browser/UserMenuLongLabelTest.php
+++ b/tests/Browser/UserMenuLongLabelTest.php
@@ -43,10 +43,6 @@ test('the presence menu keeps its rows on one line in French', function (): void
     $alice->update(['locale' => AppLocale::French]);
 
     signInThroughBrowser($alice)
-        // The catalog rides the initial response as a `once` prop, so signing in
-        // from the guest login page leaves the client on the English one until a
-        // document load re-inlines it (#764). Drop this refresh when that lands.
-        ->refresh()
         ->click('@sidebar-menu-button')
         ->assertPresent('@pause-notifications-menu-item')
         // Let the dropdown settle past its open/pointer-grace window.

--- a/tests/Feature/LocaleSharingTest.php
+++ b/tests/Feature/LocaleSharingTest.php
@@ -1,8 +1,24 @@
 <?php
 
 use App\Enums\AppLocale;
+use App\Http\Middleware\HandleInertiaRequests;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * The headers an SPA visit carries, declaring which once props the client
+ * already holds — the shape the post-login redirect arrives in.
+ *
+ * @return array<string, string>
+ */
+function inertiaHeaders(string $loadedOnceProps): array
+{
+    return [
+        'X-Inertia' => 'true',
+        'X-Inertia-Version' => (string) app(HandleInertiaRequests::class)->version(request()),
+        'X-Inertia-Except-Once-Props' => $loadedOnceProps,
+    ];
+}
 
 test('the active locale is shared to inertia from the user preference', function (): void {
     $user = User::factory()->create(['locale' => AppLocale::French->value]);
@@ -31,4 +47,43 @@ test('the active catalog rides the initial response as a once prop', function ()
             ->where('locale', 'fr')
             ->has('translations')
         );
+});
+
+test('the catalog once prop is keyed by the locale it holds', function (): void {
+    $user = User::factory()->create(['locale' => AppLocale::French->value]);
+
+    $page = $this
+        ->actingAs($user)
+        ->get(route('locale.edit'))
+        ->viewData('page');
+
+    expect($page['onceProps'])->toHaveKey('translations:fr');
+});
+
+test('the catalog is re-sent when the client only holds another locale', function (): void {
+    $user = User::factory()->create(['locale' => AppLocale::French->value]);
+
+    $response = $this
+        ->actingAs($user)
+        ->withHeaders(inertiaHeaders(loadedOnceProps: 'translations:en'))
+        ->get(route('locale.edit'));
+
+    $response->assertOk();
+
+    expect($response->json('props.locale'))->toBe('fr')
+        ->and($response->json('props.translations.Channels'))->toBe('Canaux');
+});
+
+test('the catalog stays out of visits once the client holds the matching locale', function (): void {
+    $user = User::factory()->create(['locale' => AppLocale::French->value]);
+
+    $response = $this
+        ->actingAs($user)
+        ->withHeaders(inertiaHeaders(loadedOnceProps: 'translations:fr'))
+        ->get(route('locale.edit'));
+
+    $response->assertOk();
+
+    expect($response->json('props.locale'))->toBe('fr')
+        ->and($response->json('props'))->not->toHaveKey('translations');
 });


### PR DESCRIPTION
Closes #764.

## What was wrong

The shared `translations` catalog rode the initial document as an Inertia **once** prop, keyed by its prop path. `/login` renders for a guest, so the catalog the client received was the English one. Signing in is an Inertia visit rather than a document load, so the once prop was never re-sent: the sibling `locale` prop flipped to `fr` while the client kept rendering from the guest page's English catalog, and `<html lang>` stayed `en`. A French user only saw French after a full reload.

## What changed

**Server.** The once prop now carries the locale in its key (`translations:fr`), so "already loaded" means "already loaded *this* catalog". The client reports what it holds via `X-Inertia-Except-Once-Props`, so a visit that changes the effective locale ships the new catalog while every other visit still leaves the 87 KB payload out. `locale` and `translations` can no longer disagree.

**Client.** A new `initializeLocaleSync()` (`resources/js/lib/localeSync.ts`, wired in `app.ts` alongside the other initializers) adopts a page's shared locale + catalog whenever they name a language the client is not rendering in yet. It listens on `beforeUpdate`, which lands *before* the page swap so the new language is painted on the first frame with no flash of the old one, plus `navigate` to cover history back/forward restores. Adopting is idempotent, so the pair never fights itself, and an in-app language switch (which swaps optimistically) is left alone.

`setMessages()` now also restamps `document.documentElement.lang`. It is the single choke point for a client-side locale change, and the Blade shell only writes that attribute on a document load, so this fixes `<html lang>` for the sign-in case and for the in-app language switch alike. Guarded for the SSR pass, where there is no document.

## How it was tested

- `tests/Feature/LocaleSharingTest.php`: the once key carries the locale; the catalog is re-sent when the client only holds another locale; it stays out of visits once the client holds the matching one.
- `resources/js/lib/localeSync.test.ts`: adoption on `beforeUpdate` and on `navigate`, and the three no-op cases (same locale, no catalog, no shared locale).
- `resources/js/lib/i18n.test.ts`: `setMessages` restamps `<html lang>`, as a BCP 47 tag.
- `tests/Browser/LocaleAfterSignInTest.php`: a French user signs in through the real form and reads "Canaux / Fils de discussion / Rappels" with `<html lang="fr">`, no intervening reload.
- The `->refresh()` workaround in `tests/Browser/UserMenuLongLabelTest.php` is removed, and that test still passes.

Backend gate green at 100% coverage; frontend lint/format/types/vitest/build green; full browser suite green (91 tests).

No new user-facing copy, so no i18n catalog additions. Nothing operator-facing, so no docs change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787396056&installation_model_id=428379&pr_number=779&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F779&signature=da6c8815de8ea252d0b62f0378d6f42365cf5f92c134e6dbed92576354d5125a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->