### PR TITLE
feat: render the app as one pane below the md breakpoint

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1240,5 +1240,7 @@
   "Auto (match language)": "Auto (suivre la langue)",
   "12-hour": "12 heures",
   "24-hour": "24 heures",
-  "Clock style updated.": "Format de l'heure mis à jour."
+  "Clock style updated.": "Format de l'heure mis à jour.",
+  "Show compose tools": "Afficher les outils de rédaction",
+  "Hide compose tools": "Masquer les outils de rédaction"
 }

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -86,7 +86,7 @@ function toggleStar(): void {
             as-child
             :is-active="channel.slug === activeChannelSlug"
             :data-muted="channel.muted"
-            class="h-8 gap-2 rounded-[9px] py-0 pr-2.5 pl-7 text-[13.5px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[active=true]:bg-sidebar-primary data-[active=true]:font-medium data-[active=true]:text-sidebar-primary-foreground data-[active=true]:shadow-[0_2px_6px_rgba(29,26,21,0.25)] data-[active=true]:hover:bg-sidebar-primary data-[active=true]:hover:text-sidebar-primary-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100"
+            class="h-11 gap-2 rounded-[10px] py-0 pr-2.5 pl-7 text-[15px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[active=true]:bg-sidebar-primary data-[active=true]:font-medium data-[active=true]:text-sidebar-primary-foreground data-[active=true]:shadow-[0_2px_6px_rgba(29,26,21,0.25)] data-[active=true]:hover:bg-sidebar-primary data-[active=true]:hover:text-sidebar-primary-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100 md:h-8 md:rounded-[9px] md:text-[13.5px]"
         >
             <Link
                 :href="

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -194,11 +194,15 @@ const hasActivityReadout = computed(
          stays pinned while the timeline scrolls beneath it, and translucency
          plus a blur keep the messages legible through it. The hairline shadow
          only appears once there is something scrolled underneath. -->
+    <!-- Its own container: what the masthead can fit is a question about the
+         width of the workspace pane, not the window. They part company on a
+         tablet, where the dock takes 300px of a 768px screen and leaves the
+         masthead the room of a large phone. -->
     <header
-        class="z-20 flex shrink-0 items-center gap-2.5 border-b border-border bg-card/80 px-4 pt-4 pb-3 backdrop-blur-md transition-shadow md:items-end md:gap-4 md:bg-transparent md:px-7 md:pt-5 md:pb-3.5 md:backdrop-blur-none"
+        class="@container z-20 flex shrink-0 items-center gap-2.5 border-b border-border bg-card/80 px-4 pt-4 pb-3 backdrop-blur-md transition-shadow @2xl:items-end @2xl:gap-4 @2xl:bg-transparent @2xl:px-7 @2xl:pt-5 @2xl:pb-3.5 @2xl:backdrop-blur-none"
         :class="
             props.scrolled
-                ? 'shadow-[0_2px_10px_rgba(60,55,40,0.07)] md:shadow-none'
+                ? 'shadow-[0_2px_10px_rgba(60,55,40,0.07)] @2xl:shadow-none'
                 : ''
         "
     >
@@ -208,7 +212,7 @@ const hasActivityReadout = computed(
 
         <div class="min-w-0 flex-1">
             <h1
-                class="flex items-center gap-2 truncate font-serif text-[22px] leading-none font-semibold tracking-[-0.02em] text-foreground md:text-[32px]"
+                class="flex items-center gap-2 truncate font-serif text-[22px] leading-none font-semibold tracking-[-0.02em] text-foreground @2xl:text-[32px]"
             >
                 <!-- A group DM shows an avatar stack of its participants; a 1:1
                      shows the other participant's avatar + presence dot; a
@@ -287,7 +291,7 @@ const hasActivityReadout = computed(
             <p
                 v-if="hasActivityReadout"
                 data-test="masthead-compact-activity"
-                class="mt-1 truncate text-[11.5px] text-muted-foreground md:hidden"
+                class="mt-1 truncate text-[11.5px] text-muted-foreground @2xl:hidden"
             >
                 {{
                     $t(':active of :total active', {
@@ -329,7 +333,7 @@ const hasActivityReadout = computed(
             </div>
         </div>
 
-        <div class="flex shrink-0 items-center gap-1 md:gap-3 md:pb-1">
+        <div class="flex shrink-0 items-center gap-1 @2xl:gap-3 @2xl:pb-1">
             <!-- Realtime connection cue: a quiet amber pill while reconnecting,
                  flipping to a brief green confirmation once the socket recovers.
                  The app stays fully usable throughout. -->
@@ -369,7 +373,7 @@ const hasActivityReadout = computed(
                     mastheadAvatars.visible.length > 0
                 "
                 data-test="masthead-members"
-                class="hidden items-center gap-2 md:flex"
+                class="hidden items-center gap-2 @2xl:flex"
             >
                 <span class="flex -space-x-1.5">
                     <!-- A bot in the roster squares its avatar (rounded-md vs a
@@ -466,7 +470,7 @@ const hasActivityReadout = computed(
                         type="button"
                         data-test="masthead-pins"
                         :aria-label="$t('Pinned messages')"
-                        class="h-9 gap-1 px-1.5 text-muted-foreground hover:bg-muted hover:text-foreground md:h-8"
+                        class="h-9 gap-1 px-1.5 text-muted-foreground hover:bg-muted hover:text-foreground @2xl:h-8"
                         @click="emit('openPins')"
                     >
                         <Pin
@@ -492,7 +496,7 @@ const hasActivityReadout = computed(
                 :href="searchMessages(props.teamSlug).url"
                 data-test="masthead-search"
                 :aria-label="$t('Search messages')"
-                class="flex size-9 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground md:size-auto md:p-1"
+                class="flex size-9 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground @2xl:size-auto @2xl:p-1"
             >
                 <Search class="size-4" />
             </Link>
@@ -510,7 +514,7 @@ const hasActivityReadout = computed(
                         size="icon"
                         :aria-label="$t('Channel options')"
                         data-test="channel-options"
-                        class="-mr-2 size-9 rounded text-muted-foreground hover:bg-muted hover:text-foreground md:mr-0 md:size-auto md:p-1"
+                        class="-mr-2 size-9 rounded text-muted-foreground hover:bg-muted hover:text-foreground @2xl:mr-0 @2xl:size-auto @2xl:p-1"
                     >
                         <EllipsisVertical class="size-4" />
                     </Button>

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -93,6 +93,12 @@ const props = defineProps<{
      * confirmation, or null when the socket is steadily connected.
      */
     connectionPill?: ConnectionPill;
+    /**
+     * Whether the conversation beneath has been scrolled away from its top.
+     * Drives the masthead's hairline shadow, which marks it as a layer over the
+     * timeline rather than part of it.
+     */
+    scrolled?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -170,19 +176,39 @@ const activeMemberCount = computed(
 const groupParticipantCount = computed(
     () => (props.channel.dmParticipants?.length ?? 0) + 1,
 );
+
+/**
+ * Whether the masthead has an activity readout to show.
+ *
+ * Below the breakpoint there is no room for the facepile, so its readout stands
+ * in for it on its own sub-line under the channel name — the same numbers the
+ * avatars carry on a wide viewport, in the space a phone actually has.
+ */
+const hasActivityReadout = computed(
+    () => !props.channel.isDirect && props.members.length > 0,
+);
 </script>
 
 <template>
+    <!-- Below the breakpoint the masthead is a layer over the conversation: it
+         stays pinned while the timeline scrolls beneath it, and translucency
+         plus a blur keep the messages legible through it. The hairline shadow
+         only appears once there is something scrolled underneath. -->
     <header
-        class="flex shrink-0 items-end gap-4 border-b border-border px-7 pt-5 pb-3.5"
+        class="z-20 flex shrink-0 items-center gap-2.5 border-b border-border bg-card/80 px-4 pt-4 pb-3 backdrop-blur-md transition-shadow md:items-end md:gap-4 md:bg-transparent md:px-7 md:pt-5 md:pb-3.5 md:backdrop-blur-none"
+        :class="
+            props.scrolled
+                ? 'shadow-[0_2px_10px_rgba(60,55,40,0.07)] md:shadow-none'
+                : ''
+        "
     >
         <SidebarTrigger
-            class="mb-1 -ml-1.5 size-8 shrink-0 text-muted-foreground md:hidden"
+            class="-my-1.5 -ml-2 size-9 shrink-0 text-muted-foreground md:hidden"
         />
 
         <div class="min-w-0 flex-1">
             <h1
-                class="flex items-center gap-2 truncate font-serif text-[32px] leading-none font-semibold tracking-[-0.02em] text-foreground"
+                class="flex items-center gap-2 truncate font-serif text-[22px] leading-none font-semibold tracking-[-0.02em] text-foreground md:text-[32px]"
             >
                 <!-- A group DM shows an avatar stack of its participants; a 1:1
                      shows the other participant's avatar + presence dot; a
@@ -256,6 +282,21 @@ const groupParticipantCount = computed(
                 </Tooltip>
             </h1>
 
+            <!-- The facepile's readout, standing in for the avatars below the
+                 breakpoint where they don't fit. Same numbers, one line down. -->
+            <p
+                v-if="hasActivityReadout"
+                data-test="masthead-compact-activity"
+                class="mt-1 truncate text-[11.5px] text-muted-foreground md:hidden"
+            >
+                {{
+                    $t(':active of :total active', {
+                        active: activeMemberCount,
+                        total: props.members.length,
+                    })
+                }}
+            </p>
+
             <!-- A group DM's subtitle names how many people are in the
                  conversation, the viewer included. -->
             <p
@@ -288,7 +329,7 @@ const groupParticipantCount = computed(
             </div>
         </div>
 
-        <div class="flex shrink-0 items-center gap-3 pb-1">
+        <div class="flex shrink-0 items-center gap-1 md:gap-3 md:pb-1">
             <!-- Realtime connection cue: a quiet amber pill while reconnecting,
                  flipping to a brief green confirmation once the socket recovers.
                  The app stays fully usable throughout. -->
@@ -328,7 +369,7 @@ const groupParticipantCount = computed(
                     mastheadAvatars.visible.length > 0
                 "
                 data-test="masthead-members"
-                class="flex items-center gap-2"
+                class="hidden items-center gap-2 md:flex"
             >
                 <span class="flex -space-x-1.5">
                     <!-- A bot in the roster squares its avatar (rounded-md vs a
@@ -425,7 +466,7 @@ const groupParticipantCount = computed(
                         type="button"
                         data-test="masthead-pins"
                         :aria-label="$t('Pinned messages')"
-                        class="gap-1 px-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                        class="h-9 gap-1 px-1.5 text-muted-foreground hover:bg-muted hover:text-foreground md:h-8"
                         @click="emit('openPins')"
                     >
                         <Pin
@@ -451,7 +492,7 @@ const groupParticipantCount = computed(
                 :href="searchMessages(props.teamSlug).url"
                 data-test="masthead-search"
                 :aria-label="$t('Search messages')"
-                class="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                class="flex size-9 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground md:size-auto md:p-1"
             >
                 <Search class="size-4" />
             </Link>
@@ -469,7 +510,7 @@ const groupParticipantCount = computed(
                         size="icon"
                         :aria-label="$t('Channel options')"
                         data-test="channel-options"
-                        class="size-auto rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                        class="-mr-2 size-9 rounded text-muted-foreground hover:bg-muted hover:text-foreground md:mr-0 md:size-auto md:p-1"
                     >
                         <EllipsisVertical class="size-4" />
                     </Button>

--- a/resources/js/components/ComposerSendButton.vue
+++ b/resources/js/components/ComposerSendButton.vue
@@ -111,15 +111,15 @@ function choosePreset(preset: QuickPreset): void {
             data-test="message-composer-send"
             :disabled="!canSubmit"
             :aria-label="$t('Send message')"
-            class="flex h-8.5 shrink-0 items-center gap-1.5 px-3 text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/5 disabled:opacity-40 md:pr-3 md:pl-4"
+            class="flex h-8.5 shrink-0 items-center gap-1.5 px-3 text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/5 disabled:opacity-40 @lg:pr-3 @lg:pl-4"
             @click="emit('send')"
         >
-            <!-- The label is dropped below the breakpoint: the pill has no room
-                 for it, and a locale whose word for "Send" runs longer than the
+            <!-- The label is dropped once the pill is narrow: it has no room for
+                 it, and a locale whose word for "Send" runs longer than the
                  English (fr "Envoyer") would otherwise squeeze the field until
                  its placeholder wrapped. The glyph and the aria-label carry the
                  meaning on their own. -->
-            <span class="hidden md:inline">{{ $t('Send') }}</span>
+            <span class="hidden @lg:inline">{{ $t('Send') }}</span>
             <Send class="size-3.25" />
         </Button>
 

--- a/resources/js/components/ComposerSendButton.vue
+++ b/resources/js/components/ComposerSendButton.vue
@@ -111,10 +111,15 @@ function choosePreset(preset: QuickPreset): void {
             data-test="message-composer-send"
             :disabled="!canSubmit"
             :aria-label="$t('Send message')"
-            class="flex h-8.5 shrink-0 items-center gap-1.5 pr-3 pl-4 text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/5 disabled:opacity-40"
+            class="flex h-8.5 shrink-0 items-center gap-1.5 px-3 text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary-foreground/5 disabled:opacity-40 md:pr-3 md:pl-4"
             @click="emit('send')"
         >
-            {{ $t('Send') }}
+            <!-- The label is dropped below the breakpoint: the pill has no room
+                 for it, and a locale whose word for "Send" runs longer than the
+                 English (fr "Envoyer") would otherwise squeeze the field until
+                 its placeholder wrapped. The glyph and the aria-label carry the
+                 meaning on their own. -->
+            <span class="hidden md:inline">{{ $t('Send') }}</span>
             <Send class="size-3.25" />
         </Button>
 

--- a/resources/js/components/DirectMessageListItem.vue
+++ b/resources/js/components/DirectMessageListItem.vue
@@ -120,7 +120,7 @@ function hide(): void {
             as-child
             :is-active="isActive"
             :data-muted="channel.muted"
-            class="h-8 gap-2 rounded-[9px] py-0 pr-2.5 pl-2.5 text-[13.5px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[active=true]:bg-sidebar-primary data-[active=true]:font-medium data-[active=true]:text-sidebar-primary-foreground data-[active=true]:shadow-[0_2px_6px_rgba(29,26,21,0.25)] data-[active=true]:hover:bg-sidebar-primary data-[active=true]:hover:text-sidebar-primary-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100"
+            class="h-11 gap-2 rounded-[10px] py-0 pr-2.5 pl-2.5 text-[15px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground data-[active=true]:bg-sidebar-primary data-[active=true]:font-medium data-[active=true]:text-sidebar-primary-foreground data-[active=true]:shadow-[0_2px_6px_rgba(29,26,21,0.25)] data-[active=true]:hover:bg-sidebar-primary data-[active=true]:hover:text-sidebar-primary-foreground data-[muted=true]:opacity-55 data-[muted=true]:hover:opacity-100 md:h-8 md:rounded-[9px] md:text-[13.5px]"
         >
             <Link
                 :href="show({ team: teamSlug, channel: channel.slug }).url"

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1300,7 +1300,7 @@ function onKeydown(event: KeyboardEvent): void {
          measured live off visualViewport (the layout viewport `svh` sizes
          against does not shrink when the keyboard opens). -->
     <div
-        class="mx-3 mb-2 shrink-0 md:mx-5 md:mb-4"
+        class="@container mx-3 mb-2 shrink-0 md:mx-5 md:mb-4"
         :style="{
             paddingBottom: `calc(env(safe-area-inset-bottom) + ${keyboardInsetPx}px)`,
         }"
@@ -1770,7 +1770,7 @@ function onKeydown(event: KeyboardEvent): void {
                      collapse it to zero width on a phone. -->
                 <div
                     v-else
-                    class="flex flex-wrap items-end gap-2.5 py-2 pr-2 pl-4.5 md:flex-nowrap"
+                    class="flex flex-wrap items-end gap-2.5 py-2 pr-2 pl-4.5 @lg:flex-nowrap"
                 >
                     <textarea
                         ref="textarea"
@@ -1855,8 +1855,8 @@ function onKeydown(event: KeyboardEvent): void {
                             class="shrink-0 items-end gap-2.5"
                             :class="
                                 toolsOpen
-                                    ? 'order-last flex w-full pt-1 md:order-none md:w-auto md:pt-0'
-                                    : 'hidden md:flex'
+                                    ? 'order-last flex w-full pt-1 @lg:order-none @lg:w-auto @lg:pt-0'
+                                    : 'hidden @lg:flex'
                             "
                             data-test="composer-tools"
                         >
@@ -1945,7 +1945,7 @@ function onKeydown(event: KeyboardEvent): void {
                             variant="ghost"
                             size="icon"
                             data-test="composer-tools-toggle"
-                            class="size-8.5 shrink-0 rounded-full text-muted-foreground md:hidden"
+                            class="size-8.5 shrink-0 rounded-full text-muted-foreground @lg:hidden"
                             :aria-expanded="toolsOpen"
                             :aria-label="
                                 toolsOpen

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -32,6 +32,7 @@ import {
 } from '@/components/ui/tooltip';
 import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
 import { useInitials } from '@/composables/useInitials';
+import { useKeyboardInset } from '@/composables/useKeyboardInset';
 import type {
     CommandCallbacks,
     SendCallbacks,
@@ -399,6 +400,19 @@ type MentionSuggestion =
 const suggestions = ref<MentionSuggestion[]>([]);
 const activeIndex = ref(0);
 const menuOpen = ref(false);
+
+/**
+ * Whether the compose tools are disclosed. Only consulted below the breakpoint,
+ * where they fold away behind a toggle so the field keeps the pill's width; from
+ * `md` up they are always in line and this is ignored.
+ */
+const toolsOpen = ref(false);
+
+/**
+ * How much of the screen the on-screen keyboard covers, so the pill can sit
+ * above it with its Send button reachable instead of behind it.
+ */
+const keyboardInsetPx = useKeyboardInset();
 
 const showMenu = computed(() => menuOpen.value && suggestions.value.length > 0);
 
@@ -1281,7 +1295,16 @@ function onKeydown(event: KeyboardEvent): void {
 </script>
 
 <template>
-    <div class="mx-5 mb-4 shrink-0">
+    <!-- The pill stays clear of both the device's home indicator and the
+         on-screen keyboard: the safe-area inset is static, the keyboard inset is
+         measured live off visualViewport (the layout viewport `svh` sizes
+         against does not shrink when the keyboard opens). -->
+    <div
+        class="mx-3 mb-2 shrink-0 md:mx-5 md:mb-4"
+        :style="{
+            paddingBottom: `calc(env(safe-area-inset-bottom) + ${keyboardInsetPx}px)`,
+        }"
+    >
         <div class="relative">
             <ul
                 v-if="showMenu"
@@ -1739,8 +1762,16 @@ function onKeydown(event: KeyboardEvent): void {
                     </Button>
                 </div>
 
-                <!-- Input row -->
-                <div v-else class="flex items-end gap-2.5 py-2 pr-2 pl-4.5">
+                <!-- Input row. Below the breakpoint this is the pill from the
+                     mobile design: just the field and Send, with the compose
+                     tools folded away behind the toggle beside them. Opening
+                     them wraps them onto a second line inside the same pill
+                     rather than squeezing the field, which is what used to
+                     collapse it to zero width on a phone. -->
+                <div
+                    v-else
+                    class="flex flex-wrap items-end gap-2.5 py-2 pr-2 pl-4.5 md:flex-nowrap"
+                >
                     <textarea
                         ref="textarea"
                         v-model="body"
@@ -1817,80 +1848,116 @@ function onKeydown(event: KeyboardEvent): void {
                             data-test="composer-file-input"
                             @change="onFilesPicked"
                         />
-                        <!-- Inline-format cluster: wraps the current selection in
+                        <!-- The compose tools. One instance, placed by CSS: in
+                             line with the field from `md` up, on their own row
+                             under it once disclosed on a phone. -->
+                        <div
+                            class="shrink-0 items-end gap-2.5"
+                            :class="
+                                toolsOpen
+                                    ? 'order-last flex w-full pt-1 md:order-none md:w-auto md:pt-0'
+                                    : 'hidden md:flex'
+                            "
+                            data-test="composer-tools"
+                        >
+                            <!-- Inline-format cluster: wraps the current selection in
                              Markdown markers, mirrored by the keyboard shortcuts.
                              mousedown is prevented so the textarea keeps focus and
                              its selection survives the click. -->
-                        <TooltipProvider
-                            :delay-duration="300"
-                            :skip-delay-duration="150"
-                        >
-                            <div
-                                class="flex shrink-0 items-center gap-0.5"
-                                data-test="composer-format-cluster"
+                            <TooltipProvider
+                                :delay-duration="300"
+                                :skip-delay-duration="150"
                             >
-                                <Tooltip
-                                    v-for="action in formatActions"
-                                    :key="action.marker"
+                                <div
+                                    class="flex shrink-0 items-center gap-0.5"
+                                    data-test="composer-format-cluster"
                                 >
-                                    <TooltipTrigger as-child>
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            :data-test="`message-composer-format-${action.marker}`"
-                                            class="size-7 shrink-0 rounded-full text-muted-foreground"
-                                            :aria-label="action.label"
-                                            @mousedown.prevent
-                                            @click="applyFormat(action.marker)"
-                                        >
-                                            <component
-                                                :is="action.icon"
-                                                class="size-3.5"
-                                            />
-                                        </Button>
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                        side="top"
-                                        :side-offset="6"
-                                        class="flex items-center gap-2"
+                                    <Tooltip
+                                        v-for="action in formatActions"
+                                        :key="action.marker"
                                     >
-                                        {{ action.label }}
-                                        <span
-                                            class="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
-                                            >{{ action.shortcut }}</span
+                                        <TooltipTrigger as-child>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                :data-test="`message-composer-format-${action.marker}`"
+                                                class="size-7 shrink-0 rounded-full text-muted-foreground"
+                                                :aria-label="action.label"
+                                                @mousedown.prevent
+                                                @click="
+                                                    applyFormat(action.marker)
+                                                "
+                                            >
+                                                <component
+                                                    :is="action.icon"
+                                                    class="size-3.5"
+                                                />
+                                            </Button>
+                                        </TooltipTrigger>
+                                        <TooltipContent
+                                            side="top"
+                                            :side-offset="6"
+                                            class="flex items-center gap-2"
                                         >
-                                    </TooltipContent>
-                                </Tooltip>
-                            </div>
-                        </TooltipProvider>
-                        <span
-                            class="mx-0.5 h-5 w-px shrink-0 self-center bg-border"
-                            aria-hidden="true"
-                        ></span>
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            :disabled="!attachmentsEnabled"
-                            data-test="message-composer-attach"
-                            class="size-7 shrink-0 rounded-full text-muted-foreground"
-                            :aria-label="$t('Add attachment')"
-                            @click="openFilePicker"
-                        >
-                            <Plus class="size-3.5" />
-                        </Button>
-                        <!-- The mic sits last before send, and only where the
+                                            {{ action.label }}
+                                            <span
+                                                class="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                                                >{{ action.shortcut }}</span
+                                            >
+                                        </TooltipContent>
+                                    </Tooltip>
+                                </div>
+                            </TooltipProvider>
+                            <span
+                                class="mx-0.5 h-5 w-px shrink-0 self-center bg-border"
+                                aria-hidden="true"
+                            ></span>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                :disabled="!attachmentsEnabled"
+                                data-test="message-composer-attach"
+                                class="size-7 shrink-0 rounded-full text-muted-foreground"
+                                :aria-label="$t('Add attachment')"
+                                @click="openFilePicker"
+                            >
+                                <Plus class="size-3.5" />
+                            </Button>
+                            <!-- The mic sits last before send, and only where the
                              browser can actually record (MediaRecorder +
                              getUserMedia in a secure context). -->
+                            <Button
+                                v-if="canRecord"
+                                variant="ghost"
+                                size="icon"
+                                data-test="message-composer-record"
+                                class="size-7 shrink-0 rounded-full text-muted-foreground"
+                                :aria-label="$t('Record a voice message')"
+                                @click="recorder.start"
+                            >
+                                <Mic class="size-3.5" />
+                            </Button>
+                        </div>
+                        <!-- Discloses the tools above on a phone, where they
+                             have no room beside the field. Hidden from `md` up,
+                             where they are always in line. -->
                         <Button
-                            v-if="canRecord"
                             variant="ghost"
                             size="icon"
-                            data-test="message-composer-record"
-                            class="size-7 shrink-0 rounded-full text-muted-foreground"
-                            :aria-label="$t('Record a voice message')"
-                            @click="recorder.start"
+                            data-test="composer-tools-toggle"
+                            class="size-8.5 shrink-0 rounded-full text-muted-foreground md:hidden"
+                            :aria-expanded="toolsOpen"
+                            :aria-label="
+                                toolsOpen
+                                    ? $t('Hide compose tools')
+                                    : $t('Show compose tools')
+                            "
+                            @click="toolsOpen = !toolsOpen"
                         >
-                            <Mic class="size-3.5" />
+                            <Plus
+                                class="size-4 transition-transform"
+                                :class="toolsOpen ? 'rotate-45' : ''"
+                            />
                         </Button>
                         <!-- Split send button: a primary Send plus a caret
                              opening the "Send later" menu (quick presets +

--- a/resources/js/components/ui/sidebar/SidebarProvider.vue
+++ b/resources/js/components/ui/sidebar/SidebarProvider.vue
@@ -5,6 +5,7 @@ import { TooltipProvider } from "reka-ui"
 import { computed, ref } from "vue"
 import { useEdgeSwipe } from "@/composables/useEdgeSwipe"
 import { useIsMobile } from "@/composables/useIsMobile"
+import { useSidebarPosition } from "@/composables/useSidebarPosition"
 import { writeClientCookie } from "@/lib/cookies"
 import { cn } from "@/lib/utils"
 import { provideSidebarContext, SIDEBAR_COOKIE_MAX_AGE, SIDEBAR_COOKIE_NAME, SIDEBAR_KEYBOARD_SHORTCUT, SIDEBAR_WIDTH, SIDEBAR_WIDTH_ICON } from "./utils"
@@ -46,10 +47,14 @@ function toggleSidebar() {
 }
 
 // Below the breakpoint the dock is a Sheet, so it also answers to the gesture
-// every phone app uses for one: swipe in from the left edge to open, back out
-// to dismiss.
+// every phone app uses for one: swipe in from its own edge to open, back out to
+// dismiss. The Sheet slides from whichever edge the user docked it to, so the
+// gesture follows that preference rather than assuming the left.
+const { sidebarPosition } = useSidebarPosition()
+
 useEdgeSwipe({
   enabled: isMobile,
+  edge: sidebarPosition,
   onOpen: () => setOpenMobile(true),
   onClose: () => setOpenMobile(false),
 })

--- a/resources/js/components/ui/sidebar/SidebarProvider.vue
+++ b/resources/js/components/ui/sidebar/SidebarProvider.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import type { HTMLAttributes, Ref } from "vue"
-import { defaultDocument, useEventListener, useMediaQuery, useVModel } from "@vueuse/core"
+import { defaultDocument, useEventListener, useVModel } from "@vueuse/core"
 import { TooltipProvider } from "reka-ui"
 import { computed, ref } from "vue"
+import { useEdgeSwipe } from "@/composables/useEdgeSwipe"
+import { useIsMobile } from "@/composables/useIsMobile"
 import { writeClientCookie } from "@/lib/cookies"
 import { cn } from "@/lib/utils"
 import { provideSidebarContext, SIDEBAR_COOKIE_MAX_AGE, SIDEBAR_COOKIE_NAME, SIDEBAR_KEYBOARD_SHORTCUT, SIDEBAR_WIDTH, SIDEBAR_WIDTH_ICON } from "./utils"
@@ -20,7 +22,7 @@ const emits = defineEmits<{
   "update:open": [open: boolean]
 }>()
 
-const isMobile = useMediaQuery("(max-width: 768px)")
+const isMobile = useIsMobile()
 const openMobile = ref(false)
 
 const open = useVModel(props, "open", emits, {
@@ -42,6 +44,15 @@ function setOpenMobile(value: boolean) {
 function toggleSidebar() {
   return isMobile.value ? setOpenMobile(!openMobile.value) : setOpen(!open.value)
 }
+
+// Below the breakpoint the dock is a Sheet, so it also answers to the gesture
+// every phone app uses for one: swipe in from the left edge to open, back out
+// to dismiss.
+useEdgeSwipe({
+  enabled: isMobile,
+  onOpen: () => setOpenMobile(true),
+  onClose: () => setOpenMobile(false),
+})
 
 useEventListener("keydown", (event: KeyboardEvent) => {
   if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {

--- a/resources/js/components/ui/sidebar/SidebarTrigger.vue
+++ b/resources/js/components/ui/sidebar/SidebarTrigger.vue
@@ -16,6 +16,7 @@ const { isMobile, state, toggleSidebar } = useSidebar()
   <Button
     data-sidebar="trigger"
     data-slot="sidebar-trigger"
+    data-test="sidebar-toggle"
     variant="ghost"
     size="icon"
     :class="cn('h-7 w-7', props.class)"

--- a/resources/js/components/ui/sidebar/utils.ts
+++ b/resources/js/components/ui/sidebar/utils.ts
@@ -4,7 +4,8 @@ import { createContext } from "reka-ui"
 export const SIDEBAR_COOKIE_NAME = "sidebar_state"
 export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 export const SIDEBAR_WIDTH = "16rem"
-export const SIDEBAR_WIDTH_MOBILE = "18rem"
+/** The dock's width as a left Sheet below the breakpoint (300px, per the mobile design). */
+export const SIDEBAR_WIDTH_MOBILE = "300px"
 export const SIDEBAR_WIDTH_ICON = "3rem"
 export const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 

--- a/resources/js/composables/useEdgeSwipe.ts
+++ b/resources/js/composables/useEdgeSwipe.ts
@@ -1,10 +1,13 @@
 import { onBeforeUnmount, onMounted } from 'vue';
 import type { Ref } from 'vue';
 import { swipeIntent } from '@/lib/edgeSwipe';
+import type { SwipeEdge } from '@/lib/edgeSwipe';
 
 type EdgeSwipeOptions = {
     /** Whether the gesture is live — it is a touch affordance, so mobile only. */
     enabled: Ref<boolean>;
+    /** The screen edge the panel lives on, and so the edge it is pulled from. */
+    edge: Ref<SwipeEdge>;
     /** Pull the panel out. */
     onOpen: () => void;
     /** Push it back. */
@@ -12,40 +15,58 @@ type EdgeSwipeOptions = {
 };
 
 /**
- * Open a left-edge panel by swiping in from the screen edge, and close it by
+ * Open an edge panel by swiping in from the screen edge, and close it by
  * swiping back out.
  *
- * Bound to touch and pen only: a mouse drag from the window's left edge is
- * someone selecting text, not reaching for the dock.
+ * Bound to touch and pen only: a mouse drag from the window's edge is someone
+ * selecting text, not reaching for the dock.
  */
 export function useEdgeSwipe({
     enabled,
+    edge,
     onOpen,
     onClose,
 }: EdgeSwipeOptions): void {
-    let start: { x: number; y: number } | null = null;
+    /**
+     * The in-flight gesture. Tagged with the pointer that began it so a second
+     * finger landing mid-drag cannot complete — or cancel — the first one's
+     * swipe.
+     */
+    let gesture: { pointerId: number; x: number; y: number } | null = null;
 
     function onPointerDown(event: PointerEvent): void {
-        start =
+        gesture =
             enabled.value && event.pointerType !== 'mouse'
-                ? { x: event.clientX, y: event.clientY }
+                ? {
+                      pointerId: event.pointerId,
+                      x: event.clientX,
+                      y: event.clientY,
+                  }
                 : null;
     }
 
     function onPointerUp(event: PointerEvent): void {
-        if (!start) {
+        if (!gesture || gesture.pointerId !== event.pointerId) {
+            return;
+        }
+
+        const { x, y } = gesture;
+        gesture = null;
+
+        // The viewport can cross the breakpoint mid-drag (a rotation, a resized
+        // window), and a gesture begun on a phone must not act on a desktop.
+        if (!enabled.value) {
             return;
         }
 
         const intent = swipeIntent({
-            startX: start.x,
-            startY: start.y,
+            startX: x,
+            startY: y,
             endX: event.clientX,
             endY: event.clientY,
             viewportWidth: window.innerWidth,
+            edge: edge.value,
         });
-
-        start = null;
 
         if (intent === 'open') {
             onOpen();
@@ -54,15 +75,30 @@ export function useEdgeSwipe({
         }
     }
 
+    /**
+     * The browser took the pointer over (a scroll or a system back-gesture won
+     * it): the drag never completes, so drop it rather than leave it to be
+     * matched against some later release.
+     */
+    function onPointerCancel(event: PointerEvent): void {
+        if (gesture?.pointerId === event.pointerId) {
+            gesture = null;
+        }
+    }
+
     onMounted(() => {
         document.addEventListener('pointerdown', onPointerDown, {
             passive: true,
         });
         document.addEventListener('pointerup', onPointerUp, { passive: true });
+        document.addEventListener('pointercancel', onPointerCancel, {
+            passive: true,
+        });
     });
 
     onBeforeUnmount(() => {
         document.removeEventListener('pointerdown', onPointerDown);
         document.removeEventListener('pointerup', onPointerUp);
+        document.removeEventListener('pointercancel', onPointerCancel);
     });
 }

--- a/resources/js/composables/useEdgeSwipe.ts
+++ b/resources/js/composables/useEdgeSwipe.ts
@@ -35,14 +35,18 @@ export function useEdgeSwipe({
     let gesture: { pointerId: number; x: number; y: number } | null = null;
 
     function onPointerDown(event: PointerEvent): void {
-        gesture =
-            enabled.value && event.pointerType !== 'mouse'
-                ? {
-                      pointerId: event.pointerId,
-                      x: event.clientX,
-                      y: event.clientY,
-                  }
-                : null;
+        // First finger down wins the gesture and keeps it until it lifts or is
+        // cancelled: a second one landing mid-drag — or a mouse, which never
+        // starts one — must not discard the swipe already in flight.
+        if (gesture || !enabled.value || event.pointerType === 'mouse') {
+            return;
+        }
+
+        gesture = {
+            pointerId: event.pointerId,
+            x: event.clientX,
+            y: event.clientY,
+        };
     }
 
     function onPointerUp(event: PointerEvent): void {

--- a/resources/js/composables/useEdgeSwipe.ts
+++ b/resources/js/composables/useEdgeSwipe.ts
@@ -1,0 +1,68 @@
+import { onBeforeUnmount, onMounted } from 'vue';
+import type { Ref } from 'vue';
+import { swipeIntent } from '@/lib/edgeSwipe';
+
+type EdgeSwipeOptions = {
+    /** Whether the gesture is live — it is a touch affordance, so mobile only. */
+    enabled: Ref<boolean>;
+    /** Pull the panel out. */
+    onOpen: () => void;
+    /** Push it back. */
+    onClose: () => void;
+};
+
+/**
+ * Open a left-edge panel by swiping in from the screen edge, and close it by
+ * swiping back out.
+ *
+ * Bound to touch and pen only: a mouse drag from the window's left edge is
+ * someone selecting text, not reaching for the dock.
+ */
+export function useEdgeSwipe({
+    enabled,
+    onOpen,
+    onClose,
+}: EdgeSwipeOptions): void {
+    let start: { x: number; y: number } | null = null;
+
+    function onPointerDown(event: PointerEvent): void {
+        start =
+            enabled.value && event.pointerType !== 'mouse'
+                ? { x: event.clientX, y: event.clientY }
+                : null;
+    }
+
+    function onPointerUp(event: PointerEvent): void {
+        if (!start) {
+            return;
+        }
+
+        const intent = swipeIntent({
+            startX: start.x,
+            startY: start.y,
+            endX: event.clientX,
+            endY: event.clientY,
+            viewportWidth: window.innerWidth,
+        });
+
+        start = null;
+
+        if (intent === 'open') {
+            onOpen();
+        } else if (intent === 'close') {
+            onClose();
+        }
+    }
+
+    onMounted(() => {
+        document.addEventListener('pointerdown', onPointerDown, {
+            passive: true,
+        });
+        document.addEventListener('pointerup', onPointerUp, { passive: true });
+    });
+
+    onBeforeUnmount(() => {
+        document.removeEventListener('pointerdown', onPointerDown);
+        document.removeEventListener('pointerup', onPointerUp);
+    });
+}

--- a/resources/js/composables/useIsMobile.test.ts
+++ b/resources/js/composables/useIsMobile.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    MOBILE_MEDIA_QUERY,
+    MOBILE_BREAKPOINT,
+} from '@/composables/useIsMobile';
+
+/**
+ * Stand in for the browser's media-query engine with one that actually
+ * evaluates `(max-width: …)` against a width, so the tests below assert the
+ * real boundary behaviour rather than a hand-fed boolean.
+ */
+function windowOfWidth(width: number): void {
+    const listeners = new Set<() => void>();
+
+    vi.stubGlobal('window', {
+        innerWidth: width,
+        matchMedia: (query: string) => {
+            const max = Number(/max-width:\s*([\d.]+)px/.exec(query)?.[1]);
+
+            return {
+                media: query,
+                matches: width <= max,
+                addEventListener: (_: string, listener: () => void) =>
+                    listeners.add(listener),
+                removeEventListener: (_: string, listener: () => void) =>
+                    listeners.delete(listener),
+            };
+        },
+    });
+}
+
+beforeEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('the mobile breakpoint', () => {
+    it('sits at the same 768px Tailwind opens `md:` at', () => {
+        expect(MOBILE_BREAKPOINT).toBe(768);
+    });
+
+    it('stops short of the breakpoint so `md:` never overlaps it', () => {
+        windowOfWidth(768);
+
+        expect(window.matchMedia(MOBILE_MEDIA_QUERY).matches).toBe(false);
+    });
+
+    it('covers the last width below the breakpoint', () => {
+        windowOfWidth(767);
+
+        expect(window.matchMedia(MOBILE_MEDIA_QUERY).matches).toBe(true);
+    });
+
+    it('covers a fractional width below the breakpoint', () => {
+        windowOfWidth(767.5);
+
+        expect(window.matchMedia(MOBILE_MEDIA_QUERY).matches).toBe(true);
+    });
+});

--- a/resources/js/composables/useIsMobile.ts
+++ b/resources/js/composables/useIsMobile.ts
@@ -1,0 +1,29 @@
+import { useMediaQuery } from '@vueuse/core';
+import type { Ref } from 'vue';
+
+/**
+ * The app's one breakpoint, in pixels: the width Tailwind opens `md:` at. Below
+ * it the shell renders a single pane; from it up, the dock and the workspace sit
+ * side by side.
+ */
+export const MOBILE_BREAKPOINT = 768;
+
+/**
+ * The media query for "below the breakpoint".
+ *
+ * It stops at 767.98px rather than 768px on purpose. `(max-width: 768px)` is
+ * true *at* 768 while Tailwind's `md:` applies *from* 768 up, so at exactly that
+ * width both sides claim the viewport: the dock renders as a Sheet (JS says
+ * mobile) while `md:hidden` hides the trigger that opens it (CSS says desktop),
+ * leaving no way to reach the dock at all.
+ */
+export const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 0.02}px)`;
+
+/**
+ * Whether the viewport is below the breakpoint. The single source of truth for
+ * that question — the shell, the dock, the masthead and the composer all read
+ * this rather than each testing their own query.
+ */
+export function useIsMobile(): Ref<boolean> {
+    return useMediaQuery(MOBILE_MEDIA_QUERY);
+}

--- a/resources/js/composables/useKeyboardInset.ts
+++ b/resources/js/composables/useKeyboardInset.ts
@@ -1,0 +1,39 @@
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import type { Ref } from 'vue';
+import { keyboardInset } from '@/lib/keyboardInset';
+
+/**
+ * How many pixels the on-screen keyboard currently covers, kept live off the
+ * visualViewport API.
+ *
+ * Zero on every device without a software keyboard, and during SSR — so a
+ * surface can pad by it unconditionally.
+ */
+export function useKeyboardInset(): Ref<number> {
+    const inset = ref(0);
+
+    function measure(): void {
+        const viewport = window.visualViewport;
+
+        inset.value = viewport
+            ? keyboardInset({
+                  innerHeight: window.innerHeight,
+                  height: viewport.height,
+                  offsetTop: viewport.offsetTop,
+              })
+            : 0;
+    }
+
+    onMounted(() => {
+        measure();
+        window.visualViewport?.addEventListener('resize', measure);
+        window.visualViewport?.addEventListener('scroll', measure);
+    });
+
+    onBeforeUnmount(() => {
+        window.visualViewport?.removeEventListener('resize', measure);
+        window.visualViewport?.removeEventListener('scroll', measure);
+    });
+
+    return inset;
+}

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -864,7 +864,7 @@ onMounted(() => {
                         <Button
                             variant="ghost"
                             data-test="quick-switcher-trigger"
-                            class="flex h-8 w-full items-center justify-start gap-2 rounded-[9px] bg-muted px-2.5 text-[13px] font-normal text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                            class="flex h-9.5 w-full items-center justify-start gap-2 rounded-[10px] bg-muted px-3 text-[13.5px] font-normal text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground md:h-8 md:rounded-[9px] md:px-2.5 md:text-[13px]"
                             @click="quickSwitcherOpen = true"
                         >
                             <Search class="size-3.25 shrink-0" />
@@ -1319,7 +1319,7 @@ onMounted(() => {
                                 <SidebarMenuItem>
                                     <SidebarMenuButton
                                         as-child
-                                        class="h-7.5 gap-2 rounded-[9px] px-2.5 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                        class="h-10.5 gap-2 rounded-[10px] px-2.5 text-[14px] text-muted-foreground hover:bg-sidebar-accent/60 md:h-7.5 md:rounded-[9px] md:text-[13px]"
                                     >
                                         <Link
                                             v-if="currentTeam"
@@ -1343,7 +1343,7 @@ onMounted(() => {
                                 <SidebarMenuItem>
                                     <SidebarMenuButton
                                         data-test="reminders-trigger"
-                                        class="h-7.5 gap-2 rounded-[9px] px-2.5 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                        class="h-10.5 gap-2 rounded-[10px] px-2.5 text-[14px] text-muted-foreground hover:bg-sidebar-accent/60 md:h-7.5 md:rounded-[9px] md:text-[13px]"
                                         @click="remindersDialogOpen = true"
                                     >
                                         <AlarmClock class="size-3.25" />
@@ -1359,7 +1359,7 @@ onMounted(() => {
                                 <SidebarMenuItem>
                                     <SidebarMenuButton
                                         as-child
-                                        class="h-7.5 gap-2 rounded-[9px] px-2.5 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                        class="h-10.5 gap-2 rounded-[10px] px-2.5 text-[14px] text-muted-foreground hover:bg-sidebar-accent/60 md:h-7.5 md:rounded-[9px] md:text-[13px]"
                                     >
                                         <Link
                                             v-if="currentTeam"
@@ -1381,7 +1381,7 @@ onMounted(() => {
                                 <SidebarMenuItem>
                                     <SidebarMenuButton
                                         as-child
-                                        class="h-7.5 gap-2 rounded-[9px] px-2.5 text-[13px] text-muted-foreground hover:bg-sidebar-accent/60"
+                                        class="h-10.5 gap-2 rounded-[10px] px-2.5 text-[14px] text-muted-foreground hover:bg-sidebar-accent/60 md:h-7.5 md:rounded-[9px] md:text-[13px]"
                                     >
                                         <Link
                                             v-if="currentTeam"
@@ -1407,22 +1407,23 @@ onMounted(() => {
             </SidebarFooter>
         </Sidebar>
 
-        <!-- Main card: fills the screen on mobile, floats on the warm canvas
-             (matching the dock) from md up. -->
+        <!-- Main card: below the breakpoint the card *is* the screen — one pane
+             on an 8px canvas gutter, no rail beside it. From md up it floats on
+             the warm canvas (matching the dock). -->
         <!-- Mirror the floating gap onto the correct edge: with the dock on the
              right, the inset reorders ahead of it and takes its outer margin on
              the left instead of the right. -->
         <SidebarInset
             id="main"
             tabindex="-1"
-            class="flex flex-col overflow-hidden focus-visible:outline-none md:my-3.5 md:rounded-[14px] md:border md:border-border md:bg-card md:shadow-sm"
+            class="mx-2 my-2 flex flex-col overflow-hidden rounded-[14px] border border-border bg-card shadow-sm focus-visible:outline-none md:my-3.5"
             :class="[
                 sidebarPosition === 'right'
-                    ? 'md:order-first md:ml-3.5'
-                    : 'md:mr-3.5',
+                    ? 'md:order-first md:mr-0 md:ml-3.5'
+                    : 'md:mr-3.5 md:ml-0',
                 demoMode
-                    ? 'h-[calc(100svh-var(--demo-banner-height))] md:h-[calc(100svh-1.75rem-var(--demo-banner-height))]'
-                    : 'h-svh md:h-[calc(100svh-1.75rem)]',
+                    ? 'h-[calc(100svh-1rem-var(--demo-banner-height))] md:h-[calc(100svh-1.75rem-var(--demo-banner-height))]'
+                    : 'h-[calc(100svh-1rem)] md:h-[calc(100svh-1.75rem)]',
             ]"
         >
             <slot />

--- a/resources/js/lib/edgeSwipe.test.ts
+++ b/resources/js/lib/edgeSwipe.test.ts
@@ -3,11 +3,18 @@ import { describe, expect, it } from 'vitest';
 import { swipeIntent } from '@/lib/edgeSwipe';
 
 /** A left-edge start, as a phone's back-swipe zone would report it. */
-const fromEdge = { startX: 6, startY: 300, viewportWidth: 390 };
+const fromLeftEdge = {
+    startX: 6,
+    startY: 300,
+    viewportWidth: 390,
+    edge: 'left' as const,
+};
 
-describe('swipeIntent', () => {
+describe('swipeIntent, for a dock on the left', () => {
     it('opens the dock on a rightward drag that began at the left edge', () => {
-        expect(swipeIntent({ ...fromEdge, endX: 90, endY: 306 })).toBe('open');
+        expect(swipeIntent({ ...fromLeftEdge, endX: 90, endY: 306 })).toBe(
+            'open',
+        );
     });
 
     it('ignores a rightward drag that began away from the edge', () => {
@@ -16,6 +23,7 @@ describe('swipeIntent', () => {
                 startX: 120,
                 startY: 300,
                 viewportWidth: 390,
+                edge: 'left',
                 endX: 220,
                 endY: 306,
             }),
@@ -23,13 +31,17 @@ describe('swipeIntent', () => {
     });
 
     it('ignores a drag too short to be deliberate', () => {
-        expect(swipeIntent({ ...fromEdge, endX: 40, endY: 300 })).toBe(null);
+        expect(swipeIntent({ ...fromLeftEdge, endX: 40, endY: 300 })).toBe(
+            null,
+        );
     });
 
     it('ignores a drag that is mostly vertical', () => {
         // Scrolling the timeline with a thumb near the edge must not open the
         // dock, however far the finger travels.
-        expect(swipeIntent({ ...fromEdge, endX: 90, endY: 500 })).toBe(null);
+        expect(swipeIntent({ ...fromLeftEdge, endX: 90, endY: 500 })).toBe(
+            null,
+        );
     });
 
     it('closes the dock on a leftward drag, wherever it began', () => {
@@ -38,6 +50,7 @@ describe('swipeIntent', () => {
                 startX: 250,
                 startY: 300,
                 viewportWidth: 390,
+                edge: 'left',
                 endX: 120,
                 endY: 306,
             }),
@@ -50,9 +63,52 @@ describe('swipeIntent', () => {
                 startX: 250,
                 startY: 300,
                 viewportWidth: 390,
+                edge: 'left',
                 endX: 220,
                 endY: 300,
             }),
         ).toBe(null);
+    });
+});
+
+/** The mirror image, for someone who has moved their dock to the right. */
+const fromRightEdge = {
+    startX: 384,
+    startY: 300,
+    viewportWidth: 390,
+    edge: 'right' as const,
+};
+
+describe('swipeIntent, for a dock on the right', () => {
+    it('opens the dock on a leftward drag that began at the right edge', () => {
+        expect(swipeIntent({ ...fromRightEdge, endX: 300, endY: 306 })).toBe(
+            'open',
+        );
+    });
+
+    it('ignores a leftward drag that began away from the edge', () => {
+        expect(
+            swipeIntent({
+                startX: 270,
+                startY: 300,
+                viewportWidth: 390,
+                edge: 'right',
+                endX: 170,
+                endY: 306,
+            }),
+        ).toBe(null);
+    });
+
+    it('closes the dock on a rightward drag, wherever it began', () => {
+        expect(
+            swipeIntent({
+                startX: 140,
+                startY: 300,
+                viewportWidth: 390,
+                edge: 'right',
+                endX: 280,
+                endY: 306,
+            }),
+        ).toBe('close');
     });
 });

--- a/resources/js/lib/edgeSwipe.test.ts
+++ b/resources/js/lib/edgeSwipe.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { swipeIntent } from '@/lib/edgeSwipe';
+
+/** A left-edge start, as a phone's back-swipe zone would report it. */
+const fromEdge = { startX: 6, startY: 300, viewportWidth: 390 };
+
+describe('swipeIntent', () => {
+    it('opens the dock on a rightward drag that began at the left edge', () => {
+        expect(swipeIntent({ ...fromEdge, endX: 90, endY: 306 })).toBe('open');
+    });
+
+    it('ignores a rightward drag that began away from the edge', () => {
+        expect(
+            swipeIntent({
+                startX: 120,
+                startY: 300,
+                viewportWidth: 390,
+                endX: 220,
+                endY: 306,
+            }),
+        ).toBe(null);
+    });
+
+    it('ignores a drag too short to be deliberate', () => {
+        expect(swipeIntent({ ...fromEdge, endX: 40, endY: 300 })).toBe(null);
+    });
+
+    it('ignores a drag that is mostly vertical', () => {
+        // Scrolling the timeline with a thumb near the edge must not open the
+        // dock, however far the finger travels.
+        expect(swipeIntent({ ...fromEdge, endX: 90, endY: 500 })).toBe(null);
+    });
+
+    it('closes the dock on a leftward drag, wherever it began', () => {
+        expect(
+            swipeIntent({
+                startX: 250,
+                startY: 300,
+                viewportWidth: 390,
+                endX: 120,
+                endY: 306,
+            }),
+        ).toBe('close');
+    });
+
+    it('ignores a leftward drag too short to be deliberate', () => {
+        expect(
+            swipeIntent({
+                startX: 250,
+                startY: 300,
+                viewportWidth: 390,
+                endX: 220,
+                endY: 300,
+            }),
+        ).toBe(null);
+    });
+});

--- a/resources/js/lib/edgeSwipe.ts
+++ b/resources/js/lib/edgeSwipe.ts
@@ -4,6 +4,9 @@ const EDGE_ZONE_PX = 24;
 /** How far a drag must travel horizontally before it reads as deliberate. */
 const MIN_TRAVEL_PX = 56;
 
+/** Which screen edge the panel is anchored to. */
+export type SwipeEdge = 'left' | 'right';
+
 /**
  * A completed drag, in viewport coordinates.
  */
@@ -13,18 +16,20 @@ export type Swipe = {
     endX: number;
     endY: number;
     viewportWidth: number;
+    /** The edge the panel lives on, which is the edge it is pulled from. */
+    edge: SwipeEdge;
 };
 
-/** What a completed drag asks of the dock, or null if it asks nothing. */
+/** What a completed drag asks of the panel, or null if it asks nothing. */
 export type SwipeIntent = 'open' | 'close' | null;
 
 /**
- * Read a completed drag as an instruction to the dock.
+ * Read a completed drag as an instruction to an edge panel.
  *
- * Opening is deliberately harder than closing: it only counts from the screen's
- * left edge, so a rightward drag in the middle of the conversation (swiping a
- * message, panning an image) never pulls the dock out. Closing counts anywhere,
- * because by then the dock is what the finger is on.
+ * Opening is deliberately harder than closing: it only counts from the panel's
+ * own screen edge, so a drag in the middle of the conversation (swiping a
+ * message, panning an image) never pulls the panel out. Closing counts
+ * anywhere, because by then the panel is what the finger is on.
  *
  * A drag that travels further vertically than horizontally is someone scrolling,
  * not swiping, however far it goes.
@@ -35,6 +40,7 @@ export function swipeIntent({
     endX,
     endY,
     viewportWidth,
+    edge,
 }: Swipe): SwipeIntent {
     const travelX = endX - startX;
 
@@ -46,9 +52,17 @@ export function swipeIntent({
         return null;
     }
 
-    if (travelX < 0) {
+    // Inward is rightward for a left-hand panel, leftward for a right-hand one.
+    const isInward = edge === 'left' ? travelX > 0 : travelX < 0;
+
+    if (!isInward) {
         return 'close';
     }
 
-    return startX <= EDGE_ZONE_PX && startX <= viewportWidth ? 'open' : null;
+    const startedAtEdge =
+        edge === 'left'
+            ? startX <= EDGE_ZONE_PX
+            : startX >= viewportWidth - EDGE_ZONE_PX;
+
+    return startedAtEdge ? 'open' : null;
 }

--- a/resources/js/lib/edgeSwipe.ts
+++ b/resources/js/lib/edgeSwipe.ts
@@ -1,0 +1,54 @@
+/** How close to the screen edge a drag must begin to count as an edge swipe. */
+const EDGE_ZONE_PX = 24;
+
+/** How far a drag must travel horizontally before it reads as deliberate. */
+const MIN_TRAVEL_PX = 56;
+
+/**
+ * A completed drag, in viewport coordinates.
+ */
+export type Swipe = {
+    startX: number;
+    startY: number;
+    endX: number;
+    endY: number;
+    viewportWidth: number;
+};
+
+/** What a completed drag asks of the dock, or null if it asks nothing. */
+export type SwipeIntent = 'open' | 'close' | null;
+
+/**
+ * Read a completed drag as an instruction to the dock.
+ *
+ * Opening is deliberately harder than closing: it only counts from the screen's
+ * left edge, so a rightward drag in the middle of the conversation (swiping a
+ * message, panning an image) never pulls the dock out. Closing counts anywhere,
+ * because by then the dock is what the finger is on.
+ *
+ * A drag that travels further vertically than horizontally is someone scrolling,
+ * not swiping, however far it goes.
+ */
+export function swipeIntent({
+    startX,
+    startY,
+    endX,
+    endY,
+    viewportWidth,
+}: Swipe): SwipeIntent {
+    const travelX = endX - startX;
+
+    if (Math.abs(travelX) < MIN_TRAVEL_PX) {
+        return null;
+    }
+
+    if (Math.abs(endY - startY) > Math.abs(travelX)) {
+        return null;
+    }
+
+    if (travelX < 0) {
+        return 'close';
+    }
+
+    return startX <= EDGE_ZONE_PX && startX <= viewportWidth ? 'open' : null;
+}

--- a/resources/js/lib/keyboardInset.test.ts
+++ b/resources/js/lib/keyboardInset.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { keyboardInset } from '@/lib/keyboardInset';
+
+describe('keyboardInset', () => {
+    it('is nothing while the on-screen keyboard is closed', () => {
+        expect(
+            keyboardInset({ innerHeight: 844, height: 844, offsetTop: 0 }),
+        ).toBe(0);
+    });
+
+    it('measures the slice of the layout viewport the keyboard covers', () => {
+        // An iPhone 14 with the keyboard open: 844 tall, 508 of it still visible.
+        expect(
+            keyboardInset({ innerHeight: 844, height: 508, offsetTop: 0 }),
+        ).toBe(336);
+    });
+
+    it('discounts the part of the shortfall the page is scrolled by', () => {
+        // Safari scrolls the layout viewport up as the keyboard opens: 60px of
+        // the 336px shortfall is offset, not covered.
+        expect(
+            keyboardInset({ innerHeight: 844, height: 508, offsetTop: 60 }),
+        ).toBe(276);
+    });
+
+    it('never reports a negative inset', () => {
+        // A pinch-zoomed visual viewport can report taller than the layout one.
+        expect(
+            keyboardInset({ innerHeight: 844, height: 900, offsetTop: 0 }),
+        ).toBe(0);
+    });
+
+    it('ignores a shortfall too small to be a keyboard', () => {
+        // Browser chrome (a collapsing URL bar) moves the visual viewport by a
+        // few dozen pixels; padding the composer by that would make it jitter.
+        expect(
+            keyboardInset({ innerHeight: 844, height: 800, offsetTop: 0 }),
+        ).toBe(0);
+    });
+});

--- a/resources/js/lib/keyboardInset.ts
+++ b/resources/js/lib/keyboardInset.ts
@@ -1,0 +1,37 @@
+/**
+ * The shortfall below which a visual-viewport change is browser chrome (a
+ * collapsing URL bar, a findbar) rather than an on-screen keyboard. Padding the
+ * composer by those few dozen pixels would make it jitter as the user scrolls.
+ */
+const KEYBOARD_THRESHOLD_PX = 120;
+
+/**
+ * The visual-viewport reading a keyboard inset is derived from.
+ */
+export type ViewportReading = {
+    /** The layout viewport's height — what `100svh` and `h-svh` resolve to. */
+    innerHeight: number;
+    /** The visual viewport's height: the part not covered by the keyboard. */
+    height: number;
+    /** How far the visual viewport is scrolled down the layout viewport. */
+    offsetTop: number;
+};
+
+/**
+ * How many pixels of the layout viewport the on-screen keyboard covers.
+ *
+ * The layout viewport (what `svh` sizes against) does not shrink when the
+ * keyboard opens, so a bottom-anchored composer ends up behind it. The visual
+ * viewport does shrink, and the difference — less whatever the browser scrolled
+ * the page by to compensate — is the padding that keeps the composer above the
+ * keyboard.
+ */
+export function keyboardInset({
+    innerHeight,
+    height,
+    offsetTop,
+}: ViewportReading): number {
+    const covered = innerHeight - height - offsetTop;
+
+    return covered >= KEYBOARD_THRESHOLD_PX ? covered : 0;
+}

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -787,6 +787,7 @@ watch(
     () => {
         mainStream.reset();
         resetScrollPin();
+        timelineScrolled.value = false;
         replyTarget.value = null;
         typing.reset();
         pinsPanelOpen.value = false;

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -370,6 +370,18 @@ const {
         messageListRef.value?.scrollToLatest(smooth ? 'smooth' : 'auto'),
 });
 
+/**
+ * Whether the timeline has conversation scrolled above its top edge. Below the
+ * breakpoint the masthead sits over the timeline rather than beside it, so it
+ * takes a hairline shadow exactly when there is something passing under it.
+ */
+const timelineScrolled = ref(false);
+
+function onTimelineScroll(): void {
+    onScroll();
+    timelineScrolled.value = (scrollContainer.value?.scrollTop ?? 0) > 0;
+}
+
 /** `Inertia::scroll` delivers messages newest-first; reverse for display. */
 const serverMessages = computed<Message[]>(() =>
     [...(props.messages?.data ?? [])].reverse(),
@@ -1184,6 +1196,7 @@ function archive(): void {
                 :notification-level="notificationLevel"
                 :notification-status="notificationStatus"
                 :connection-pill="connection.pill.value"
+                :scrolled="timelineScrolled"
                 @toggle-star="toggleStar"
                 @notification-level-change="onNotificationLevelChange"
                 @mute-change="onMuteChange"
@@ -1298,7 +1311,7 @@ function archive(): void {
                         :register-container="setScrollContainer"
                         :pinned-to-bottom="pinnedToBottom"
                         :new-message-count="newMessageCount"
-                        @scroll="onScroll"
+                        @scroll="onTimelineScroll"
                         @jump="jumpToPresent"
                     >
                         <Transition

--- a/tests/Browser/MobileShellTest.php
+++ b/tests/Browser/MobileShellTest.php
@@ -160,6 +160,7 @@ test('the dock opens as a 300px sheet whose every row clears a 44px touch target
         ->assertScript(<<<'JS'
         (() => [
             '[data-test="threads-inbox"]',
+            '[data-test="reminders-trigger"]',
             '[data-test="search-messages"]',
             '[data-test="browse-channels"]',
             '[data-test="quick-switcher-trigger"]',

--- a/tests/Browser/MobileShellTest.php
+++ b/tests/Browser/MobileShellTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AppLocale;
+
+/**
+ * The mobile breakpoint's shell: one pane below `md`, and no width at which the
+ * dock is unreachable.
+ *
+ * The boundary case is the one that regressed silently (#771). The dock's
+ * "is mobile" test used to be `(max-width: 768px)`, which is true *at* 768,
+ * while Tailwind's `md:` applies *from* 768 up. At exactly that width the dock
+ * rendered as a Sheet — so no rail existed — while `md:hidden` hid the trigger
+ * that opens the Sheet, leaving no route to the dock at all.
+ */
+
+/**
+ * Whether the always-mounted desktop rail is the dock's current treatment. The
+ * Sheet marks itself `data-mobile="true"`, so its absence distinguishes the two.
+ */
+function dockRailIsLive(): string
+{
+    return <<<'JS'
+    (() => document.querySelector('[data-slot="sidebar"]') !== null
+        && document.querySelector('[data-slot="sidebar"][data-mobile="true"]') === null)()
+    JS;
+}
+
+/**
+ * Whether the masthead's trigger — the only route to the dock once it is a
+ * Sheet — is actually on screen.
+ */
+function dockTriggerIsVisible(): string
+{
+    return <<<'JS'
+    (() => {
+        const trigger = document.querySelector('[data-test="sidebar-toggle"]');
+
+        return trigger !== null
+            && trigger.getBoundingClientRect().width > 0
+            && getComputedStyle(trigger).visibility !== 'hidden';
+    })()
+    JS;
+}
+
+test('exactly one dock treatment is live at every width across the breakpoint', function (int $width, bool $expectRail): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // Whichever side of the breakpoint this width falls on, the dock is
+    // reachable: the rail from `md` up, the Sheet trigger below it. Never both,
+    // and — the regression this guards — never neither.
+    signInThroughBrowser($alice)
+        ->resize($width, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertScript(dockRailIsLive(), $expectRail)
+        ->assertScript(dockTriggerIsVisible(), ! $expectRail);
+})->with([
+    'the tightest phone' => [360, false],
+    'the last mobile width' => [767, false],
+    'the breakpoint itself is desktop' => [768, true],
+    'just above the breakpoint' => [769, true],
+]);
+
+test('the channel screen never scrolls horizontally at a phone width', function (int $width, int $height): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize($width, $height)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertScript(
+            '(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)()',
+            true,
+        )
+        // Nothing the tests can name is clipped off the right edge either — a
+        // page can measure no wider than the viewport while still hiding a
+        // control past it under `overflow: hidden`.
+        ->assertScript(<<<'JS'
+        (() => [...document.querySelectorAll('[data-test]')]
+            .every(el => el.getBoundingClientRect().right <= window.innerWidth + 1))()
+        JS, true);
+})->with([
+    'small phone' => [360, 740],
+    'iPhone SE' => [375, 667],
+    'iPhone 14' => [390, 844],
+    'large phone' => [430, 932],
+    'landscape phone' => [740, 360],
+]);
+
+test('the channel name is readable however tight the viewport', function (int $width): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // The masthead's right-hand controls used to be unshrinkable, which left the
+    // <h1> measuring zero: the channel you were in had no name on a phone.
+    signInThroughBrowser($alice)
+        ->resize($width, 740)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertScript(<<<'JS'
+        (() => {
+            const heading = document.querySelector('main h1, header h1');
+
+            return heading !== null && heading.getBoundingClientRect().width > 80;
+        })()
+        JS, true);
+})->with([
+    'small phone' => [360],
+    'iPhone SE' => [375],
+    'iPhone 14' => [390],
+]);
+
+test('a long channel name truncates rather than pushing the search icon off screen', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $channel->update(['name' => 'quarterly-planning-and-roadmap-review-working-group']);
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate(browserChannelUrl($team, $channel))
+        // The search affordance stays wholly within the viewport...
+        ->assertScript(<<<'JS'
+        (() => {
+            const search = document.querySelector('[data-test="masthead-search"]');
+            const box = search.getBoundingClientRect();
+
+            return box.right <= window.innerWidth && box.left >= 0;
+        })()
+        JS, true)
+        // ...because the name gave way instead, ellipsised on one line.
+        ->assertScript(<<<'JS'
+        (() => {
+            const name = document.querySelector('header h1 span:last-child');
+
+            return name.scrollWidth > name.clientWidth;
+        })()
+        JS, true);
+});
+
+test('the dock opens as a 300px sheet whose every row clears a 44px touch target', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@sidebar-toggle')
+        ->assertPresent('@channels-nav')
+        ->assertScript(<<<'JS'
+        (() => Math.round(
+            document.querySelector('[data-slot="sidebar"][data-mobile="true"]')
+                .getBoundingClientRect().width
+        ) === 300)()
+        JS, true)
+        // Channel and direct-message rows are the ones a thumb hits most, and
+        // they carry the full 44px target.
+        ->assertScript(<<<'JS'
+        (() => [...document.querySelectorAll(
+            '[data-test="section-content-channels"] li a, [data-test="section-content-direct"] li a'
+        )].every(row => Math.round(row.getBoundingClientRect().height) >= 44))()
+        JS, true)
+        // The utility rows and the jump-to field clear the design's 38px floor.
+        ->assertScript(<<<'JS'
+        (() => [
+            '[data-test="threads-inbox"]',
+            '[data-test="search-messages"]',
+            '[data-test="browse-channels"]',
+            '[data-test="quick-switcher-trigger"]',
+        ].every(selector => {
+            const row = document.querySelector(selector);
+
+            return row !== null && Math.round(row.getBoundingClientRect().height) >= 38;
+        }))()
+        JS, true);
+});
+
+test('the dock dismisses without a reload', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@sidebar-toggle')
+        ->assertPresent('@channels-nav')
+        // Dismissed from the keyboard rather than the scrim: the scrim spans the
+        // whole viewport with the sheet on top of it, so a click driven at its
+        // centre lands on the sheet. Both routes run through the same
+        // `setOpenMobile(false)`, and the swipe-to-dismiss gesture is covered by
+        // its own unit tests over `swipeIntent`.
+        ->keys('@channels-nav', ['Escape'])
+        ->assertNotPresent('@channels-nav');
+});
+
+test('the composer stays a pill that keeps its field and Send button usable', function (int $width, int $height): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // The tool cluster used to squeeze the field to zero width, which wrapped
+    // its placeholder one character per line and inflated the composer to its
+    // 200px cap — most of a landscape phone's screen.
+    signInThroughBrowser($alice)
+        ->resize($width, $height)
+        ->navigate(browserChannelUrl($team, $channel))
+        // The field keeps a usable share of the pill, and — the actual tell of
+        // the collapse — stays a single line rather than growing to its 200px
+        // cap as a zero-width field's wrapped placeholder used to make it.
+        ->assertScript(<<<'JS'
+        (() => {
+            const field = document.querySelector('[data-test="message-composer-input"]').getBoundingClientRect();
+
+            return field.width >= 100 && field.height <= 60;
+        })()
+        JS, true)
+        // The whole composer stays a single pill rather than a block.
+        ->assertScript(<<<'JS'
+        (() => document.querySelector('[data-tour="composer"]')
+            .getBoundingClientRect().height < 100)()
+        JS, true)
+        // ...and the timeline, not the chrome, gets the majority of the screen.
+        ->assertScript(<<<'JS'
+        (() => {
+            const chrome = document.querySelector('header').getBoundingClientRect().height
+                + document.querySelector('[data-tour="composer"]').getBoundingClientRect().height;
+
+            return chrome < window.innerHeight / 2;
+        })()
+        JS, true);
+})->with([
+    'small phone' => [360, 740],
+    'iPhone SE' => [375, 667],
+    'iPhone 14' => [390, 844],
+    'landscape phone' => [740, 360],
+]);
+
+test('the composer pill survives a locale with longer words than the English', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+    $alice->update(['locale' => AppLocale::French]);
+
+    // French runs longer than English almost everywhere ("Envoyer" against
+    // "Send"), and a tight row is where that first shows (#765). The pill has to
+    // absorb it by dropping the label, not by narrowing the field until its
+    // placeholder wraps onto a second line.
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        // The catalog rides the initial response as a `once` prop, so signing in
+        // from the guest login page leaves the client on the English one until a
+        // document load re-inlines it (#764).
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertScript(<<<'JS'
+        (() => {
+            const field = document.querySelector('[data-test="message-composer-input"]');
+
+            // One line: a wrapped placeholder measures two line-heights.
+            return Math.round(field.getBoundingClientRect().height) <= 32;
+        })()
+        JS, true)
+        ->assertScript(<<<'JS'
+        (() => document.querySelector('[data-test="message-composer-input"]')
+            .getBoundingClientRect().width >= 150)()
+        JS, true);
+});
+
+test('every compose tool is still reachable once disclosed', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // Folding the tools away must not remove them: each one is still there,
+    // one tap further in.
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertScript(<<<'JS'
+        (() => document.querySelector('[data-test="composer-tools"]')
+            .getBoundingClientRect().height === 0)()
+        JS, true)
+        ->click('@composer-tools-toggle')
+        ->assertVisible('@message-composer-attach')
+        ->assertVisible('@composer-format-cluster')
+        // Disclosing them widens the pill onto a second row rather than
+        // narrowing the field.
+        // The field keeps a usable share of the pill, and — the actual tell of
+        // the collapse — stays a single line rather than growing to its 200px
+        // cap as a zero-width field's wrapped placeholder used to make it.
+        ->assertScript(<<<'JS'
+        (() => {
+            const field = document.querySelector('[data-test="message-composer-input"]').getBoundingClientRect();
+
+            return field.width >= 100 && field.height <= 60;
+        })()
+        JS, true);
+});

--- a/tests/Browser/MobileShellTest.php
+++ b/tests/Browser/MobileShellTest.php
@@ -106,6 +106,11 @@ test('the channel name is readable however tight the viewport', function (int $w
     'small phone' => [360],
     'iPhone SE' => [375],
     'iPhone 14' => [390],
+    // Tablet portrait is past the breakpoint, so the dock takes its 300px back
+    // and leaves the masthead the room of a large phone. What it can fit is a
+    // question about the pane, not the window, which is why the masthead sizes
+    // itself off its own container rather than the viewport.
+    'tablet portrait' => [768],
 ]);
 
 test('a long channel name truncates rather than pushing the search icon off screen', function (): void {
@@ -227,6 +232,9 @@ test('the composer stays a pill that keeps its field and Send button usable', fu
     'iPhone SE' => [375, 667],
     'iPhone 14' => [390, 844],
     'landscape phone' => [740, 360],
+    // Same reasoning as the masthead: the pill folds its tools away whenever the
+    // pane is narrow, which a tablet's is even though its window is not.
+    'tablet portrait' => [768, 1024],
 ]);
 
 test('the composer pill survives a locale with longer words than the English', function (): void {


### PR DESCRIPTION
Closes #771. First child of the mobile epic #770 — the breakpoint, the shell, the dock, the masthead and the composer that the rest of the epic builds on.

## The audit that drove this

Driven in a real browser at every viewport the epic mandates, against the seeded workspace:

| Defect | Evidence |
| --- | --- |
| **The dock was unreachable at exactly 768px** | `useMediaQuery("(max-width: 768px)")` is true *at* 768 while Tailwind's `md:` applies *from* 768 up. The dock rendered as a Sheet (so no rail existed) while `md:hidden` hid the trigger that opens it. No rail, no button. |
| **The channel name was invisible on a phone** | The masthead's right-hand controls were `shrink-0`, so the `<h1>` measured **width 0** at 360 and 390px. |
| **Controls clipped off the edge** | At 360px `channel-options` ran to x=370 and `message-composer-schedule` to x=380, past the 360px viewport. |
| **The composer ate the screen** | The tool cluster didn't fit, so flex squeezed the field to **zero width**; its placeholder then wrapped one character per line until the auto-resize hit its 200px cap. The composer stood **216px tall** — 26% of a 390x844 screen and **~60% of a landscape phone**, which left the timeline a ~40px sliver. |
| **No canvas gutter** | The card was flush edge-to-edge below `md` instead of the design's 8px gutter. |
| **Dock undersized** | 288px (`18rem`) against the design's 300px; rows measured ~32-36px against 44/42/38px. |

## What changed

- **One source of truth for the breakpoint.** `useIsMobile()` stops at 767.98px so `md:` and the Sheet can never both claim a width. The shell, dock, masthead and composer all read it.
- **The card is the screen** below `md`: one pane on an 8px gutter, rounded, no rail.
- **Masthead** keeps its name at every width — the facepile gives way and its readout stands in on a sub-line. Sticky, with a hairline shadow once the conversation is scrolled under it.
- **Dock** is a 300px left Sheet with 44px channel/DM rows, 42px utility rows and a 38px jump-to field, and answers to an edge swipe (in from its own edge to open, back out to dismiss).
- **Composer** is the design's pill: field plus Send, with the tools folded behind a disclosure that wraps them onto a second row rather than narrowing the field. It clears the on-screen keyboard via `env(safe-area-inset-bottom)` plus the visualViewport shortfall the layout viewport `svh` sizes against ignores.

The composer went **216px -> 52px**; the timeline's share of a landscape phone went **~11% -> 61%**.

## Two decisions, resolved in the issue rather than silently

1. **Masthead controls.** Screen `m1` draws only toggle + name + search, but dropping the pins button and the ⋮ menu would remove the only route to mute / notification level / archive / leave on a phone, against the epic's "preserve all current behaviour". Only the facepile gives way; its "N of M active" readout becomes the sub-line the design asks for, reusing the existing translated string rather than adding the mockup's literal "12 members · 3 online".
2. **Composer tools.** The drawn pill has no room for formatting, attach, record and schedule. They collapse behind a `+` disclosure that expands a second row inside the same pill — collapsed it matches `m1` exactly, expanded every control and `data-test` survives.

## Two deliberate divergences

- **The masthead is in flow, not overlaid.** The design positions it `absolute` with messages passing under it. Overlaying would move the virtualized timeline's geometry and the jump pills, the area #500 already makes delicate. It stays pinned (the acceptance criterion) and takes the translucency, blur and scroll shadow; the pills and the initial-pin tests are untouched.
- **The masthead and composer size off their own container, not the viewport.** Tablet portrait sits just past the breakpoint, so the dock takes its 300px back and leaves the pane the width of a large phone — where the viewport-based rules truncated the title to `# g…` and wrapped the composer's placeholder. Both now query their container, so they fold at the width that actually constrains them. Desktop is unchanged at 1280 (facepile, inline tools, "Send" label all verified).

## Testing

- **New:** `tests/Browser/MobileShellTest.php` — 22 cases over 360x740, 375x667, 390x844, 430x932, 768x1024 and landscape 740x360: exactly one dock treatment live across the breakpoint, no horizontal scroll, no `data-test` element clipped, the name readable, a long name truncating instead of pushing the search icon off-screen, the 300px sheet and its touch targets, the pill's field staying one line, and every tool still reachable once disclosed.
- **New unit tests** for `useIsMobile` (the 768 boundary), `keyboardInset` and `swipeIntent` (both dock edges, vertical drags, multi-touch).
- **Full suites:** 113 browser tests, 1057 Vitest, PHP at **100.0%** coverage with Pint, PHPStan and Rector clean.
- **i18n:** two new keys in `lang/fr.json`; French checked at 360px, where "Envoyer" was squeezing the field until the pill dropped the Send label (the field went 106px -> 166px, back to one line). Light and dark both checked.

## Screenshots

| | Before | After |
| --- | --- | --- |
| **390x844** | name invisible, 216px composer | name, sub-line, 52px pill |
| **768x1024** | dock unreachable | rail back, name readable, pill intact |
| **740x360** | timeline ~11% of screen | timeline 61% |

Local CodeRabbit ran clean (0 findings) through the container-query commit; the final pass hit the OSS tier rate limit, so the app review covers that last commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787400906&installation_model_id=428379&pr_number=781&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F781&signature=8af62a4e79db06e3321877f24256cb3593303c0182c6b92964e2b2cafa214c32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->