### PR TITLE
ci: resolve every runner from a CI_RUNNER repository variable

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -13,9 +13,13 @@ inputs:
   # Not read from `vars` here: a composite action is handed its context by the
   # call site, and taking the label from the job means the build path can never
   # disagree with the runner it is executing on.
+  # An expression written out in full here would be evaluated as one rather than
+  # read as prose — the manifest is templated, descriptions included — and `vars`
+  # is not a context an action manifest can resolve, so it fails to load. Name
+  # the variable, never the expression.
   runner:
     description: >-
-      The runner label the calling job resolved, i.e. `${{ vars.CI_RUNNER }}`.
+      The runner label the calling job resolved from the CI_RUNNER variable.
       The Blacksmith path is taken for any label starting with `blacksmith` —
       the sized ones like `blacksmith-4vcpu-ubuntu-2404` and the bare
       `blacksmith` default alike. Anything else, an unset variable included,

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -1,0 +1,97 @@
+name: Build the production image
+description: >-
+  Builds (and optionally pushes) the production image on whichever runner the
+  fleet is currently on, with the layer cache that provider offers.
+
+# Every job takes its runner from the `CI_RUNNER` repository variable, so moving
+# the fleet between providers is a settings change rather than a code change
+# (see CONTRIBUTING.md → CI runners). `uses:` is the one field that cannot be
+# templated with an expression, so the two Blacksmith-only Docker actions cannot
+# follow that variable directly — this action holds both call pairs and picks
+# between them from the label the calling job resolved.
+inputs:
+  # Not read from `vars` here: a composite action is handed its context by the
+  # call site, and taking the label from the job means the build path can never
+  # disagree with the runner it is executing on.
+  runner:
+    description: >-
+      The runner label the calling job resolved, i.e. `${{ vars.CI_RUNNER }}`.
+      The Blacksmith path is taken only for a `blacksmith-*` label; anything
+      else — including an unset variable — builds on the GitHub-hosted path.
+    required: false
+    default: ''
+  context:
+    description: The build context.
+    required: false
+    default: .
+  file:
+    description: The Dockerfile to build.
+    required: false
+    default: Dockerfile
+  platforms:
+    description: Target platforms. arm64 emulation is deferred (see #205).
+    required: false
+    default: linux/amd64
+  push:
+    description: Whether to push the built image to its registry.
+    required: false
+    default: 'false'
+  load:
+    description: Whether to load the built image into the local daemon.
+    required: false
+    default: 'false'
+  tags:
+    description: Newline- or comma-separated tags for the image.
+    required: false
+    default: ''
+  labels:
+    description: Newline-separated OCI labels for the image.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+
+  steps:
+    # ---- Blacksmith ----
+    # The builder mounts a layer cache on a sticky disk, so the caching the
+    # GitHub path asks for explicitly below comes for free here.
+    - name: Set up the Blacksmith builder
+      if: startsWith(inputs.runner, 'blacksmith')
+      uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1.11.0
+
+    - name: Build with the Blacksmith builder
+      if: startsWith(inputs.runner, 'blacksmith')
+      uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        platforms: ${{ inputs.platforms }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        tags: ${{ inputs.tags }}
+        labels: ${{ inputs.labels }}
+
+    # ---- GitHub-hosted ----
+    - name: Set up buildx
+      if: ${{ ! startsWith(inputs.runner, 'blacksmith') }}
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+    # The `type=gha` cache is not optional. The extension layer fetches `redis`
+    # from pecl.php.net, so an uncached rebuild on every run turned each PECL
+    # outage into a red build on a commit that changed nothing (#626). This is
+    # the GitHub-hosted equivalent of the sticky-disk cache above; without it
+    # this path would reintroduce that failure the moment the fleet moved.
+    - name: Build with buildx
+      if: ${{ ! startsWith(inputs.runner, 'blacksmith') }}
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        platforms: ${{ inputs.platforms }}
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
+        tags: ${{ inputs.tags }}
+        labels: ${{ inputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -16,8 +16,10 @@ inputs:
   runner:
     description: >-
       The runner label the calling job resolved, i.e. `${{ vars.CI_RUNNER }}`.
-      The Blacksmith path is taken only for a `blacksmith-*` label; anything
-      else — including an unset variable — builds on the GitHub-hosted path.
+      The Blacksmith path is taken for any label starting with `blacksmith` —
+      the sized ones like `blacksmith-4vcpu-ubuntu-2404` and the bare
+      `blacksmith` default alike. Anything else, an unset variable included,
+      builds on the GitHub-hosted path.
     required: false
     default: ''
   context:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    # `/` covers `.github/workflows`. Actions pinned anywhere else are invisible
+    # to dependabot unless their directory is listed too, and the Docker build
+    # actions live in a composite action because `uses:` cannot be templated
+    # with the runner variable (see CONTRIBUTING.md → CI runners).
+    directories:
+      - "/"
+      - "/.github/actions/docker-build"
     # `develop` is the line every ordinary change goes through; `master` only
     # takes promotions from it. Without this, dependabot opens against the
     # repository's default branch — `master` — and the bump ships without ever

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    # `/` covers `.github/workflows`. Actions pinned anywhere else are invisible
-    # to dependabot unless their directory is listed too, and the Docker build
-    # actions live in a composite action because `uses:` cannot be templated
-    # with the runner variable (see CONTRIBUTING.md → CI runners).
+    # `/` covers `.github/workflows` plus an `action.yml` at the repository
+    # root — and nothing else, so a composite action in a subdirectory is
+    # invisible to dependabot until its own directory is listed. These two do
+    # not overlap for that reason. The Docker build actions live in such a
+    # composite action because `uses:` cannot be templated with the runner
+    # variable (see CONTRIBUTING.md → CI runners).
     directories:
       - "/"
       - "/.github/actions/docker-build"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     permissions:
       # Required to upload results to the code-scanning (Security) tab.
       security-events: write

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   commitlint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -38,7 +38,7 @@ jobs:
   # build if they drift.
   pr-title:
     name: Validate PR title
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Validate the PR title as a Conventional Commit
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
       # Allows the action to post its summary comment on the PR when it fails.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     # Whether this ref is a release candidate, decided once (see the classify
     # step) so the image tags and the release notes cannot disagree about it.
@@ -63,20 +63,17 @@ jobs:
       # ---- Build-only validation (pull requests, non-publishing branches) ----
       # Validates that the production image builds. Nothing is pushed.
       #
-      # A Blacksmith builder with the same layer cache the publish step uses,
-      # rather than a plain `docker build`: the extension layer fetches `redis`
-      # from pecl.php.net, so an uncached rebuild on every run turned each PECL
-      # outage into a red build on a commit that changed nothing (#626). Cached,
-      # that layer is only rebuilt when the Dockerfile lines above it actually
-      # change.
-      - name: Set up the Blacksmith builder (build-only)
-        if: env.PUBLISH != 'true'
-        uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1.11.0
-
+      # Through the composite action — which sets up a caching builder for the
+      # provider in play — rather than a plain `docker build`: the extension
+      # layer fetches `redis` from pecl.php.net, so an uncached rebuild on every
+      # run turned each PECL outage into a red build on a commit that changed
+      # nothing (#626). Cached, that layer is only rebuilt when the Dockerfile
+      # lines above it actually change.
       - name: Build production image
         if: env.PUBLISH != 'true'
-        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
+        uses: ./.github/actions/docker-build
         with:
+          runner: ${{ vars.CI_RUNNER }}
           context: .
           file: Dockerfile
           platforms: linux/amd64
@@ -104,10 +101,6 @@ jobs:
           fi
 
       # ---- Publish to GitHub Container Registry (master + v* tags) ----
-      - name: Set up the Blacksmith builder
-        if: env.PUBLISH == 'true'
-        uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1.11.0
-
       - name: Log in to GHCR
         if: env.PUBLISH == 'true'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -145,8 +138,9 @@ jobs:
       # the SPA at runtime, so this single image works for any operator's host.
       - name: Build and push image
         if: env.PUBLISH == 'true'
-        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
+        uses: ./.github/actions/docker-build
         with:
+          runner: ${{ vars.CI_RUNNER }}
           context: .
           file: Dockerfile
           platforms: linux/amd64
@@ -163,7 +157,7 @@ jobs:
   link-release-image:
     name: Link GHCR image on the release
     needs: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     # Only for a published `v*` release tag: that is the only ref that has a
     # release-please release to annotate. master `edge` pushes and PR build-only
     # runs are skipped entirely, so this never touches a non-release publish.
@@ -231,7 +225,7 @@ jobs:
   # shell, so the app's `--min=100` PHP coverage gate cannot see them (see #473).
   backup-restore:
     name: Backup & restore round trip
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout code
@@ -239,16 +233,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up the Blacksmith builder
-        uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1.11.0
-
       # `load` puts the image in the local daemon as the-desk:ci, which the .env
       # below points APP_IMAGE at, so the stack runs this build rather than
-      # pulling a published release. The Blacksmith builder reuses the layers the
-      # publish job wrote on the last master build.
+      # pulling a published release. The builder reuses the layers the publish
+      # job wrote on the last master build.
       - name: Build production image
-        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
+        uses: ./.github/actions/docker-build
         with:
+          runner: ${{ vars.CI_RUNNER }}
           context: .
           file: Dockerfile
           platforms: linux/amd64
@@ -363,7 +355,7 @@ jobs:
   # prod-only job, so without this it would only ever be claimed, not proven.
   upgrade-build-from-source:
     name: Upgrade script (build from source)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout code
@@ -422,7 +414,7 @@ jobs:
   # (see #475).
   upgrade:
     name: Upgrade script
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout code
@@ -430,12 +422,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up the Blacksmith builder
-        uses: useblacksmith/setup-docker-builder@6ff44f8e5255f9d8aa31ef22f7e57a2d926b7da0 # v1.11.0
-
       - name: Build production image
-        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
+        uses: ./.github/actions/docker-build
         with:
+          runner: ${{ vars.CI_RUNNER }}
           context: .
           file: Dockerfile
           platforms: linux/amd64

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
   # which is how #614 broke the deploy, surfacing only in the Cloudflare build
   # log after merge. This job reproduces that environment before merge (#622).
   build:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     steps:
       # A full checkout, not a sparse `docs/` one: the content config reads the

--- a/.github/workflows/extension-pins.yml
+++ b/.github/workflows/extension-pins.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   check-pins:
     name: Check the pinned PHP extension sources
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     permissions:
       contents: read

--- a/.github/workflows/integration-merge.yml
+++ b/.github/workflows/integration-merge.yml
@@ -43,7 +43,7 @@ jobs:
         (github.base_ref == 'master' && github.head_ref == 'develop')
         || (github.base_ref == 'develop' && github.head_ref == 'master')
       )
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       # The PAT, not GITHUB_TOKEN: GitHub suppresses `on: push` for refs written
       # by the built-in token, so a promotion merged under it would land on

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   quality:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
   release-please:
     name: Release from master
     if: github.ref == 'refs/heads/master'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       version: ${{ steps.release.outputs.version }}
@@ -58,7 +58,7 @@ jobs:
   prerelease:
     name: Cut a release candidate from develop
     if: github.ref == 'refs/heads/develop'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       # The candidate line reads its own config *and* its own manifest, both of
       # which release-please resolves from `target-branch`. That separation is
@@ -91,7 +91,7 @@ jobs:
     name: Refuse a candidate below the baseline
     needs: prerelease
     if: github.ref == 'refs/heads/develop'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Refuse a candidate that does not move the baseline forwards
         env:
@@ -232,7 +232,7 @@ jobs:
     name: Move the candidate baseline to the released version
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       # A stable release must not be reported as failed just because there is no
       # candidate line to update — `develop` is created separately from this
@@ -406,7 +406,7 @@ jobs:
     name: Merge the released master back into develop
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       # No checkout: the PR is opened from `master` itself, so GitHub keeps it in
       # step with the branch as it moves and there is no working copy to manage.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   ci:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     strategy:
       matrix:
         # We develop and ship on 8.5, so CI exercises 8.5 only to keep Actions
@@ -137,7 +137,7 @@ jobs:
   # never folds into the 100% coverage gate above — the `browser` group is
   # excluded from phpunit's default suites and only runs via `pest tests/Browser`.
   browser:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     services:
       postgres:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,12 @@ under **Settings → Secrets and variables → Actions → Variables**:
 | `blacksmith-4vcpu-ubuntu-2404` | [Blacksmith](https://blacksmith.sh) 4-vCPU runners |
 | unset (or deleted)             | GitHub-hosted `ubuntu-latest`                      |
 
-GitHub-hosted is deliberately the fallback rather than the other way round: an
-unset — or unavailable — variable has to degrade to a runner that exists, so the
-repository is never stranded if the Blacksmith installation is removed.
+GitHub-hosted is deliberately the fallback rather than the other way round: with
+nothing set, a fresh fork still runs CI on a runner that exists. The fallback
+fires on an **unset** variable, though, not on an unreachable runner — a
+`CI_RUNNER` left naming a Blacksmith label after the installation is removed
+leaves every job queued against a label nothing answers to. Clear the variable
+first, then uninstall.
 
 `uses:` is the one workflow field that cannot take an expression, so the two
 Blacksmith-only Docker actions cannot follow the variable directly. They sit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,37 @@ below the PHP coverage gate. It needs no database and runs in seconds.
 
 Auto-fix with `./vendor/bin/sail npm run lint` and `./vendor/bin/sail npm run format`.
 
+### CI runners
+
+Where those gates run is a repository setting, not a code change. No workflow
+names a runner: every job resolves one from the `CI_RUNNER` repository variable,
+
+```yaml
+runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+```
+
+so moving the whole fleet is a matter of setting or clearing that one variable
+under **Settings → Secrets and variables → Actions → Variables**:
+
+| `CI_RUNNER`                    | Where CI runs                                      |
+| ------------------------------ | -------------------------------------------------- |
+| `blacksmith-4vcpu-ubuntu-2404` | [Blacksmith](https://blacksmith.sh) 4-vCPU runners |
+| unset (or deleted)             | GitHub-hosted `ubuntu-latest`                      |
+
+GitHub-hosted is deliberately the fallback rather than the other way round: an
+unset — or unavailable — variable has to degrade to a runner that exists, so the
+repository is never stranded if the Blacksmith installation is removed.
+
+`uses:` is the one workflow field that cannot take an expression, so the two
+Blacksmith-only Docker actions cannot follow the variable directly. They sit
+behind `.github/actions/docker-build`, a composite action that is handed the
+same label (`runner: ${{ vars.CI_RUNNER }}`) and picks between the Blacksmith
+builder and `docker/setup-buildx-action` + `docker/build-push-action` with the
+`type=gha` layer cache. Both paths cache layers, which is what stops the PECL
+`redis` fetch being re-run on every build (#626). Add new Docker builds through
+that action, not by calling a provider's action directly —
+`tests/Unit/RunnerLabelTest.php` fails the build if either rule is broken.
+
 ## Coding conventions
 
 - **Test-driven.** Every change must be programmatically tested — write or update

--- a/tests/Unit/DockerfileExtensionRetryTest.php
+++ b/tests/Unit/DockerfileExtensionRetryTest.php
@@ -73,36 +73,44 @@ test('the retry loop advances, backs off, and gives up with a legible message', 
 
 /**
  * What matters is that the layers are reused, not which cache backend does it.
- * On Blacksmith the builder mounts a persistent layer cache, so the build step
- * only has to run through `useblacksmith/setup-docker-builder`; on a GitHub
- * runner the same reuse needs an explicit `type=gha` cache on the step. Accept
- * either shape, and fail a plain `docker build` (or a build-push step with
- * neither cache in place), which is what refetches PECL every run.
+ * The build-only validation goes through `.github/actions/docker-build`, which
+ * holds one path per runner provider (#782) — so the guarantee only holds if
+ * *both* of its paths cache. On Blacksmith the builder mounts a persistent layer
+ * cache, so the build step only has to run behind `setup-docker-builder`; on a
+ * GitHub runner the same reuse needs an explicit `type=gha` cache on the step.
+ * Accept either shape, and fail a plain `docker build` (or a build-push step
+ * with neither cache in place), which is what refetches PECL every run.
  */
 test('the build-only validation caches its layers so PECL is not refetched every run', function (): void {
-    $steps = Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/docker.yml')['jobs']['build']['steps'];
-
-    $build = collect($steps)->firstWhere('name', 'Build production image');
+    $build = collect(Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/docker.yml')['jobs']['build']['steps'])
+        ->firstWhere('name', 'Build production image');
 
     expect($build)->not->toBeNull()
-        ->and($build['uses'] ?? '')->toMatch('#^(docker|useblacksmith)/build-push-action@#')
+        ->and($build['uses'] ?? '')->toBe('./.github/actions/docker-build')
         ->and($build['with']['push'] ?? null)->toBeFalse();
 
-    if (str_starts_with((string) $build['uses'], 'useblacksmith/')) {
-        // The builder has to be set up on the same condition as the build, or
-        // the build-only run falls back to an uncached default builder.
-        $builderIsSetUpFirst = collect($steps)
-            ->take((int) collect($steps)->search($build))
-            ->contains(fn (array $step): bool => str_starts_with($step['uses'] ?? '', 'useblacksmith/setup-docker-builder@')
-                && ($step['if'] ?? null) === ($build['if'] ?? null));
+    $steps = collect(Yaml::parseFile(dirname(__DIR__, 2).'/.github/actions/docker-build/action.yml')['runs']['steps']);
+    $builds = $steps->filter(static fn (array $step): bool => str_contains((string) ($step['uses'] ?? ''), '/build-push-action@'));
 
-        expect($builderIsSetUpFirst)->toBeTrue('the Blacksmith layer cache only exists behind its own builder');
+    expect($builds)->toHaveCount(2, 'one build per provider, or one of them is a silently uncached path');
 
-        return;
+    foreach ($builds as $build) {
+        if (str_starts_with((string) $build['uses'], 'useblacksmith/')) {
+            // The builder has to be set up on the same condition as the build,
+            // or the run falls back to an uncached default builder.
+            $builderIsSetUpFirst = $steps
+                ->take((int) $steps->search($build))
+                ->contains(fn (array $step): bool => str_starts_with($step['uses'] ?? '', 'useblacksmith/setup-docker-builder@')
+                    && ($step['if'] ?? null) === ($build['if'] ?? null));
+
+            expect($builderIsSetUpFirst)->toBeTrue('the Blacksmith layer cache only exists behind its own builder');
+
+            continue;
+        }
+
+        expect($build['with']['cache-from'] ?? null)->toBe('type=gha')
+            ->and($build['with']['cache-to'] ?? '')->toStartWith('type=gha,mode=max');
     }
-
-    expect($build['with']['cache-from'] ?? null)->toBe('type=gha')
-        ->and($build['with']['cache-to'] ?? '')->toStartWith('type=gha,mode=max');
 });
 
 test('the bundled extension list is unchanged', function (): void {

--- a/tests/Unit/DocsBuildGateTest.php
+++ b/tests/Unit/DocsBuildGateTest.php
@@ -43,11 +43,13 @@ test('the docs job installs from the lockfile and builds the site', function (st
 /**
  * Only the operating system matters here, not who hosts the runner: the guard
  * exists so a lockfile resolved on macOS is proven against the Linux Cloudflare
- * builder. GitHub's own `ubuntu-*` labels and Blacksmith's `blacksmith-*-ubuntu-*`
- * ones both satisfy that, so match the family rather than one exact label.
+ * builder. The job takes its runner from `vars.CI_RUNNER` like every other one
+ * (see RunnerLabelTest), and both sides of that switch are Ubuntu — so what this
+ * asserts is that the docs job stays on the shared expression rather than being
+ * pinned to a runner of its own, which is the only way it could drift off Linux.
  */
 test('the docs job builds on linux so it reproduces the cloudflare builder', function () use ($docsJob): void {
-    expect($docsJob()['runs-on'])->toMatch('/(^|-)ubuntu-/');
+    expect($docsJob()['runs-on'])->toMatch('/^\$\{\{\s*vars\.CI_RUNNER\s*\|\|\s*\'ubuntu-[^\']+\'\s*\}\}$/');
 });
 
 test('the docs guard runs on pull requests touching the docs project', function () use ($docsWorkflow): void {

--- a/tests/Unit/RunnerLabelTest.php
+++ b/tests/Unit/RunnerLabelTest.php
@@ -99,6 +99,31 @@ test('the composite action is what actually holds the two provider paths', funct
         ->toEqualCanonicalizing(['runner', 'context', 'file', 'platforms', 'push', 'load', 'tags', 'labels']);
 });
 
+/**
+ * An action manifest is templated in full — input descriptions included — and
+ * `vars` is not a context it can resolve. So a `${{ vars.CI_RUNNER }}` written
+ * as *prose* in a description is still evaluated, and the whole action fails to
+ * load with "Unrecognized named-value: 'vars'". That is why the action is handed
+ * the label as an input; naming the variable in prose is fine, writing the
+ * expression is not.
+ */
+test('the composite action manifest resolves no context an action cannot see', function (): void {
+    $manifest = implode("\n", array_filter(
+        explode("\n", (string) file_get_contents(dockerBuildActionPath())),
+        static fn (string $line): bool => ! str_starts_with(ltrim($line), '#'),
+    ));
+
+    preg_match_all('/\$\{\{(?<expression>[^}]*)\}\}/', $manifest, $matches);
+
+    expect($matches['expression'])->not->toBeEmpty('the manifest passes its inputs through expressions, so this must find some');
+
+    foreach ($matches['expression'] as $expression) {
+        expect($expression)
+            ->not->toContain('vars.')
+            ->not->toContain('secrets.');
+    }
+});
+
 test('the composite action selects its path from the runner label it is handed', function (): void {
     $steps = collect(dockerBuildAction()['runs']['steps']);
 

--- a/tests/Unit/RunnerLabelTest.php
+++ b/tests/Unit/RunnerLabelTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Where CI runs is a repository setting, not a code change. Every job resolves
+ * its runner from the `CI_RUNNER` repository variable, so setting it to a
+ * Blacksmith label moves the whole fleet there and clearing it drops everything
+ * back onto GitHub-hosted runners — with no workflow edit and no PR either way
+ * (issue #782).
+ *
+ * `uses:` cannot be templated with an expression, so the two Blacksmith-only
+ * Docker actions cannot follow the same variable directly. They live behind
+ * `.github/actions/docker-build` instead, which branches on the label it is
+ * handed. These tests keep both halves honest: a job that re-pins a literal
+ * label, or a Blacksmith action that leaks back into a workflow, strands the
+ * switch without failing anything else.
+ */
+function workflowFiles(): array
+{
+    return glob(dirname(__DIR__, 2).'/.github/workflows/*.yml') ?: [];
+}
+
+function workflowJobs(string $file): array
+{
+    return Yaml::parseFile($file)['jobs'] ?? [];
+}
+
+function dockerBuildActionPath(): string
+{
+    return dirname(__DIR__, 2).'/.github/actions/docker-build/action.yml';
+}
+
+function dockerBuildAction(): array
+{
+    return Yaml::parseFile(dockerBuildActionPath());
+}
+
+/**
+ * The one shape a job's `runs-on` may take. The fallback is captured rather
+ * than matched literally so the assertion can say *why* it has to be a
+ * GitHub-hosted label: an unset variable must degrade to a runner that exists,
+ * not to an empty `runs-on` that fails the job.
+ */
+function runnerExpressionFallback(string $runsOn): ?string
+{
+    $matched = preg_match(
+        '/^\$\{\{\s*vars\.CI_RUNNER\s*\|\|\s*\'(?<fallback>[^\']+)\'\s*\}\}$/',
+        $runsOn,
+        $matches,
+    );
+
+    return $matched === 1 ? $matches['fallback'] : null;
+}
+
+test('every job resolves its runner from the CI_RUNNER variable', function (string $file): void {
+    $jobs = workflowJobs($file);
+
+    expect($jobs)->not->toBeEmpty(basename($file).' parsed to no jobs, so this test would scan nothing');
+
+    foreach ($jobs as $id => $job) {
+        $where = basename($file).' → '.$id;
+
+        expect($job['runs-on'] ?? null)->not->toBeNull($where.' must declare where it runs');
+        expect(runnerExpressionFallback((string) $job['runs-on']))
+            ->not->toBeNull($where.' pins a literal runner label; it must read `vars.CI_RUNNER` so the fleet can be moved without a code change');
+    }
+})->with(fn (): array => workflowFiles());
+
+test('an unset CI_RUNNER falls back to a github-hosted linux runner', function (string $file): void {
+    foreach (workflowJobs($file) as $id => $job) {
+        expect(runnerExpressionFallback((string) $job['runs-on']))
+            ->toBe('ubuntu-latest', basename($file).' → '.$id.' must fall back to a GitHub-hosted label, so clearing the variable is always safe');
+    }
+})->with(fn (): array => workflowFiles());
+
+test('no workflow pins a provider-specific runner label', function (string $file): void {
+    $lines = collect(explode("\n", (string) file_get_contents($file)))
+        ->filter(static fn (string $line): bool => (bool) preg_match('/^\s*(-\s*)?runs-on:/', $line))
+        ->filter(static fn (string $line): bool => ! str_contains($line, 'vars.CI_RUNNER'));
+
+    expect($lines->all())->toBeEmpty(basename($file).' declares a runner outside the variable');
+})->with(fn (): array => workflowFiles());
+
+test('blacksmith actions live only behind the docker-build composite action', function (string $file): void {
+    expect((string) file_get_contents($file))
+        ->not->toContain('useblacksmith/', basename($file).' calls a Blacksmith-only action directly; `uses:` cannot be templated, so it belongs in .github/actions/docker-build');
+})->with(fn (): array => workflowFiles());
+
+test('the composite action is what actually holds the two provider paths', function (): void {
+    expect(dockerBuildActionPath())->toBeFile();
+
+    $action = dockerBuildAction();
+
+    expect($action['runs']['using'] ?? null)->toBe('composite')
+        ->and(array_keys($action['inputs'] ?? []))
+        ->toEqualCanonicalizing(['runner', 'context', 'file', 'platforms', 'push', 'load', 'tags', 'labels']);
+});
+
+test('the composite action selects its path from the runner label it is handed', function (): void {
+    $steps = collect(dockerBuildAction()['runs']['steps']);
+
+    $blacksmith = $steps->filter(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), 'useblacksmith/'));
+    $github = $steps->filter(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), 'docker/'));
+
+    expect($blacksmith)->toHaveCount(2, 'the Blacksmith path is a builder plus a build')
+        ->and($github)->toHaveCount(2, 'the GitHub-hosted path is a buildx builder plus a build');
+
+    foreach ($blacksmith as $step) {
+        expect($step['if'] ?? '')->toContain("startsWith(inputs.runner, 'blacksmith')");
+    }
+
+    // The complement, not a second positive condition: two overlapping
+    // conditions would run both builders on the same runner.
+    foreach ($github as $step) {
+        expect($step['if'] ?? '')->toContain("! startsWith(inputs.runner, 'blacksmith')");
+    }
+});
+
+/**
+ * The layer cache is not a nicety on this path. The extension layer fetches
+ * `redis` from pecl.php.net, so an uncached rebuild on every run turned each
+ * PECL outage into a red build on a commit that changed nothing (#626). The
+ * Blacksmith builder mounts a persistent cache of its own; the GitHub-hosted
+ * builder only reuses layers if the step asks for the Actions cache.
+ */
+test('the github-hosted build path caches its layers through the actions cache', function (): void {
+    $build = collect(dockerBuildAction()['runs']['steps'])
+        ->first(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), 'docker/build-push-action@'));
+
+    expect($build)->not->toBeNull()
+        ->and($build['with']['cache-from'] ?? null)->toBe('type=gha')
+        ->and($build['with']['cache-to'] ?? '')->toStartWith('type=gha,mode=max');
+});
+
+test('both provider paths build the same image from the same inputs', function (string $input): void {
+    $builds = collect(dockerBuildAction()['runs']['steps'])
+        ->filter(static fn (array $step): bool => str_contains((string) ($step['uses'] ?? ''), '/build-push-action@'));
+
+    expect($builds)->toHaveCount(2);
+
+    foreach ($builds as $build) {
+        expect($build['with'][$input] ?? null)
+            ->toBe('${{ inputs.'.$input.' }}', $build['uses'].' drops the '.$input.' input, so the two paths would build different images');
+    }
+})->with(['context', 'file', 'platforms', 'push', 'load', 'tags', 'labels']);
+
+test('every docker build in the workflow goes through the composite action', function (): void {
+    $steps = collect(workflowJobs(dirname(__DIR__, 2).'/.github/workflows/docker.yml'))
+        ->flatMap(static fn (array $job): array => $job['steps'] ?? []);
+
+    $builds = $steps->filter(static fn (array $step): bool => ($step['uses'] ?? null) === './.github/actions/docker-build');
+
+    expect($builds)->not->toBeEmpty('the production image must still be built somewhere');
+
+    foreach ($builds as $build) {
+        expect($build['with']['runner'] ?? null)
+            ->toBe('${{ vars.CI_RUNNER }}', 'the composite action cannot read the variable itself; the call site has to hand it the label the job resolved');
+    }
+
+    $direct = $steps->filter(static fn (array $step): bool => (bool) preg_match('#/(build-push|setup-docker-builder|setup-buildx)-?action@#', (string) ($step['uses'] ?? '')));
+
+    expect($direct->all())->toBeEmpty('a build outside the composite action only works on one provider');
+});
+
+test('dependabot keeps the composite action pins up to date', function (): void {
+    $updates = Yaml::parseFile(dirname(__DIR__, 2).'/.github/dependabot.yml')['updates'];
+
+    $directories = collect($updates)
+        ->filter(static fn (array $update): bool => $update['package-ecosystem'] === 'github-actions')
+        ->flatMap(static fn (array $update): array => $update['directories'] ?? [$update['directory']]);
+
+    // Actions pinned outside `.github/workflows` are invisible to dependabot
+    // unless their directory is listed, so moving them into a composite action
+    // would silently drop them out of the weekly bump.
+    expect($directories->all())->toContain('/.github/actions/docker-build');
+});
+
+test('contributing documents how to move the fleet between providers', function (): void {
+    $contributing = (string) file_get_contents(dirname(__DIR__, 2).'/CONTRIBUTING.md');
+
+    expect($contributing)
+        ->toContain('CI_RUNNER')
+        ->toContain('blacksmith-4vcpu-ubuntu-2404')
+        ->toContain('ubuntu-latest');
+});


### PR DESCRIPTION
Closes #782.

## What

Where CI runs becomes a repository setting instead of a code change. Every job
resolves its runner from a single variable:

```yaml
runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
```

| `CI_RUNNER` | Where CI runs |
| --- | --- |
| `blacksmith-4vcpu-ubuntu-2404` | Blacksmith 4-vCPU runners |
| unset | GitHub-hosted `ubuntu-latest` |

All 20 `runs-on` sites across the 10 workflows go through it. (The issue
estimated 16; the actual count is 20.)

`uses:` is the one field that takes no expression, so the two Blacksmith-only
Docker actions could not follow the variable. The four setup + build pairs in
`docker.yml` collapse into one local composite action,
`.github/actions/docker-build`, handed the same label and branching on it:

- **Blacksmith** — `useblacksmith/setup-docker-builder` + `useblacksmith/build-push-action`, layer cache on sticky disk (today's behaviour, unchanged).
- **GitHub-hosted** — `docker/setup-buildx-action` + `docker/build-push-action` with `cache-from: type=gha` and `cache-to: type=gha,mode=max`.

## Why the cache on the fallback path is not optional

The extension layer fetches `redis` from pecl.php.net, so an uncached rebuild on
every run turned each PECL outage into a red build on a commit that changed
nothing (#626). The Blacksmith builder mounts a persistent cache; on a GitHub
runner the same reuse only happens if the step asks for the Actions cache. A
plain `docker build` on the fallback path would reintroduce that failure the
moment the fleet moved.

## Two decisions worth flagging

- **No second `CI_RUNNER_LARGE` variable.** The issue left it open pending
  evidence of a real wall-clock hit from 4 vCPU to 2 on the Paratest suite. That
  can only be measured from a GitHub-hosted run, so one variable ships now and
  this PR's own CI provides the number to decide on.
- **The prefix match is `blacksmith`, not `blacksmith-`.** Blacksmith's bare
  `blacksmith` label is also valid, and matching only the sized form would
  quietly put a Blacksmith runner on the buildx path.

## Testing

- `tests/Unit/RunnerLabelTest.php` (new) fails the build if a workflow re-pins a
  literal runner label, drops the `ubuntu-latest` fallback, calls a Blacksmith
  action outside the composite, or builds an image without going through it.
- `tests/Unit/DocsBuildGateTest.php` and `tests/Unit/DockerfileExtensionRetryTest.php`
  updated to follow the runner expression and the composite action rather than
  the literals they asserted before. The #626 layer-cache guarantee is now
  asserted on *both* provider paths.
- Backend gate green at `Total: 100.0 %` with a clean Pint/PHPStan/Rector run;
  frontend gate (lint, format, types, `test:js`, build) green.
- `actionlint` reports no new issues on the rewritten workflows.
- A local CodeRabbit pass is clean.

## Notes

- `.github/dependabot.yml` gains the composite action's directory. `directory: "/"`
  covers `.github/workflows` plus an `action.yml` at the repository *root* only,
  so without this the two Blacksmith pins would silently drop out of the weekly
  bump. The two entries do not overlap for the same reason.
- No i18n impact (no user-facing copy). No `docs/` impact — this is contributor
  tooling, not operator-facing, so it is documented in `CONTRIBUTING.md`.
- **Set `CI_RUNNER` before merging**, or the first `develop` run afterwards lands
  on `ubuntu-latest`. Harmless, just slower.
- Acceptance criteria 2 and 3 ("a full run is green on each provider") can only
  be verified by this PR's own CI; the config is proven statically here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787403063&installation_model_id=428379&pr_number=783&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F783&signature=3077d91d3069ae6024da9b5a12d75b4d724a3ba20bc6790a612ce84df581e2ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->