### PR TITLE
feat: render dialogs as bottom sheets below the md breakpoint

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -50,6 +50,7 @@
     --color-border: var(--border);
     --color-input: var(--input);
     --color-ring: var(--ring);
+    --color-scrim: var(--scrim);
 
     --color-chart-1: var(--chart-1);
     --color-chart-2: var(--chart-2);
@@ -145,6 +146,10 @@
     --destructive-text: hsl(0 72% 40%);
     --border: #e3dfd5;
     --input: #e0dbcd;
+    /* Scrim behind a bottom sheet — ink at 50%, per the mobile design (#772).
+       Lighter than the desktop dialog's, because a sheet leaves the screen you
+       came from visible above it and that is the point of the treatment. */
+    --scrim: rgba(29, 26, 21, 0.5);
     /* Focus indicator — decoupled from --brass and darkened to a bronze so the
        ring itself clears the 3:1 non-text threshold (WCAG 2.4.7/1.4.11) on the
        sand background; --brass keeps its lighter accent value (#269). */
@@ -213,6 +218,9 @@
     --destructive-text: hsl(0 72% 64%);
     --border: #2e2a21;
     --input: #2a271f;
+    /* Deeper than the light theme's: the sheet is a light-on-dark card here, so
+       the wash has to darken a surface that is already dark to separate them. */
+    --scrim: rgba(0, 0, 0, 0.6);
     --ring: #c9a35c;
     --brass: #c9a35c;
     /* Light brass so badge/pill text stays legible on the dark brass fill; the

--- a/resources/js/components/MessageLightbox.vue
+++ b/resources/js/components/MessageLightbox.vue
@@ -108,6 +108,7 @@ function onKeydown(event: KeyboardEvent): void {
             />
             <DialogContent
                 data-test="attachment-lightbox"
+                mobile="dialog"
                 class="fixed inset-0 z-50 flex items-center justify-center p-6 focus:outline-none"
                 @keydown="onKeydown"
             >

--- a/resources/js/components/RemindersDialog.vue
+++ b/resources/js/components/RemindersDialog.vue
@@ -79,7 +79,7 @@ function openReminder(reminder: MessageReminder): void {
 
 <template>
     <Dialog v-model:open="open">
-        <DialogContent class="gap-4 sm:max-w-lg">
+        <DialogContent mobile="detail" class="gap-4 sm:max-w-lg">
             <DialogHeader>
                 <!-- Right padding leaves room for the dialog's own close button
                      so the "Clear all" action never sits under it. -->

--- a/resources/js/components/ScheduledMessagesDialog.vue
+++ b/resources/js/components/ScheduledMessagesDialog.vue
@@ -103,7 +103,7 @@ function bodyPreview(body: string): string {
 
 <template>
     <Dialog v-model:open="open">
-        <DialogContent class="gap-0 p-0 sm:max-w-lg">
+        <DialogContent mobile="detail" class="gap-0 p-0 sm:max-w-lg">
             <DialogHeader class="gap-1 px-6 pt-6 pb-4">
                 <div class="flex items-center gap-2 pr-7">
                     <DialogTitle class="text-[20px]">{{

--- a/resources/js/components/ui/dialog/DialogContent.test.ts
+++ b/resources/js/components/ui/dialog/DialogContent.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+
+/**
+ * Renders a real `<Dialog>`/`<DialogContent>` pair under jsdom at a chosen
+ * viewport, so the presentation the primitive picks — a bottom sheet on a phone,
+ * a centred dialog from `md` up — is what the tests read, rather than a
+ * hand-copied class string.
+ */
+let app: App | null = null;
+
+/**
+ * jsdom has no `matchMedia`. Answering the app's one breakpoint query from a
+ * width lets a test stand at any viewport it likes.
+ */
+function standAt(width: number): void {
+    window.matchMedia = ((query: string) => {
+        const limit = Number(/max-width:\s*([\d.]+)px/.exec(query)?.[1] ?? NaN);
+
+        return {
+            matches: Number.isNaN(limit) ? false : width <= limit,
+            media: query,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            addListener: () => {},
+            removeListener: () => {},
+            onchange: null,
+            dispatchEvent: () => false,
+        };
+    }) as typeof window.matchMedia;
+}
+
+async function open(mobile?: 'sheet' | 'detail' | 'dialog'): Promise<HTMLElement> {
+    app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(Dialog, { defaultOpen: true }, () => [
+                    h(DialogContent, { mobile, class: 'sm:max-w-md' }, () => [
+                        h(DialogTitle, () => 'Create a channel'),
+                    ]),
+                ]),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(document.createElement('div'));
+
+    await nextTick();
+    await nextTick();
+
+    const content = document.querySelector<HTMLElement>(
+        '[data-slot="dialog-content"]',
+    );
+
+    expect(content).not.toBeNull();
+
+    return content as HTMLElement;
+}
+
+beforeEach(() => standAt(390));
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('below the md breakpoint', () => {
+    it('presents as a bottom sheet with the design’s chrome', async () => {
+        const content = await open();
+
+        expect(content.className).toContain('bottom-0');
+        expect(content.className).toContain('rounded-t-[20px]');
+        expect(content.className).toContain('border-t');
+        // The sheet grows with its content up to the cap rather than being pinned.
+        expect(content.style.maxHeight).toBe('calc(85dvh - 0px)');
+        expect(content.style.height).toBe('');
+    });
+
+    it('beats whatever width the call site set for its desktop dialog', async () => {
+        // `sm:` opens at 640px, below the breakpoint: a sheet that respected it
+        // would stop short of the screen edge on a landscape phone.
+        expect((await open()).style.maxWidth).toBe('none');
+    });
+
+    it('offers a grab handle to drag it away by', async () => {
+        const content = await open();
+
+        expect(
+            content.querySelector('[data-test="sheet-grab-handle"]'),
+        ).not.toBeNull();
+    });
+
+    it('pins a detail sheet to 85% of the screen', async () => {
+        // The stand-in for a desktop right-hand pane: a fixed height, so a list
+        // does not resize under the thumb as it is worked through.
+        expect((await open('detail')).style.height).toBe('calc(85dvh - 0px)');
+    });
+
+    it('leaves an opted-out dialog centred, with no handle', async () => {
+        const content = await open('dialog');
+
+        expect(content.className).toContain('translate-x-[-50%]');
+        expect(content.style.maxWidth).toBe('');
+        expect(
+            content.querySelector('[data-test="sheet-grab-handle"]'),
+        ).toBeNull();
+    });
+});
+
+describe('from the md breakpoint up', () => {
+    beforeEach(() => standAt(1280));
+
+    it('keeps the centred dialog untouched', async () => {
+        const content = await open();
+
+        expect(content.className).toContain('translate-x-[-50%]');
+        expect(content.className).toContain('sm:max-w-md');
+        expect(content.className).not.toContain('rounded-t-[20px]');
+        // No sizing is imposed inline, so the call site's own classes still decide.
+        expect(content.style.maxWidth).toBe('');
+        expect(content.style.maxHeight).toBe('');
+        expect(content.style.height).toBe('');
+        expect(
+            content.querySelector('[data-test="sheet-grab-handle"]'),
+        ).toBeNull();
+    });
+});

--- a/resources/js/components/ui/dialog/DialogContent.test.ts
+++ b/resources/js/components/ui/dialog/DialogContent.test.ts
@@ -60,12 +60,16 @@ async function open(mobile?: 'sheet' | 'detail' | 'dialog'): Promise<HTMLElement
     return content as HTMLElement;
 }
 
+/** jsdom ships no `matchMedia`, so this is `undefined` — put back either way. */
+const realMatchMedia = window.matchMedia;
+
 beforeEach(() => standAt(390));
 
 afterEach(() => {
     app?.unmount();
     app = null;
     document.body.innerHTML = '';
+    window.matchMedia = realMatchMedia;
 });
 
 describe('below the md breakpoint', () => {

--- a/resources/js/components/ui/dialog/DialogContent.vue
+++ b/resources/js/components/ui/dialog/DialogContent.vue
@@ -1,29 +1,116 @@
 <script setup lang="ts">
 import type { DialogContentEmits, DialogContentProps } from "reka-ui"
-import type { HTMLAttributes } from "vue"
+import type { CSSProperties, HTMLAttributes } from "vue"
 import { X } from "@lucide/vue"
 import { reactiveOmit } from "@vueuse/core"
 import {
   DialogClose,
   DialogContent,
   DialogPortal,
+  injectDialogRootContext,
   useForwardPropsEmits,
 } from "reka-ui"
+import { computed } from "vue"
+import { useIsMobile } from "@/composables/useIsMobile"
+import { useKeyboardInset } from "@/composables/useKeyboardInset"
+import { useSheetDrag } from "@/composables/useSheetDrag"
 import { cn } from "@/lib/utils"
 import DialogOverlay from "./DialogOverlay.vue"
+
+/**
+ * How a dialog presents below the `md` breakpoint.
+ *
+ * - `sheet` — a bottom sheet that grows with its content, capped so it never
+ *   fills the screen. The default: a centred desktop dialog does not fit a
+ *   phone, and making that every call site's problem is how they drifted apart.
+ * - `detail` — a bottom sheet pinned to 85% of the screen, the mobile stand-in
+ *   for a desktop right-hand pane (the epic's rules table).
+ * - `dialog` — stay a centred dialog. For a surface that is already full-bleed,
+ *   such as the image lightbox.
+ */
+type MobilePresentation = "sheet" | "detail" | "dialog"
+
+/**
+ * The height a sheet is allowed: tall enough to be worth opening, short enough
+ * that the scrim above it still reads as the screen you came from.
+ */
+const SHEET_HEIGHT = "85dvh"
+
+/**
+ * The room kept under a sheet's last row — uniform whatever padding the call
+ * site asked for, so a primary action never sits flush against the screen edge,
+ * and clear of the home indicator on a device that has one.
+ */
+const SHEET_BOTTOM_PADDING = "1.5rem"
 
 defineOptions({
   inheritAttrs: false,
 })
 
-const props = withDefaults(defineProps<DialogContentProps & { class?: HTMLAttributes["class"], showCloseButton?: boolean }>(), {
+const props = withDefaults(defineProps<DialogContentProps & {
+  class?: HTMLAttributes["class"]
+  showCloseButton?: boolean
+  mobile?: MobilePresentation
+}>(), {
   showCloseButton: true,
+  mobile: "sheet",
 })
 const emits = defineEmits<DialogContentEmits>()
 
-const delegatedProps = reactiveOmit(props, "class")
+const delegatedProps = reactiveOmit(props, "class", "mobile")
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
+
+const isMobile = useIsMobile()
+const keyboardInset = useKeyboardInset()
+const rootContext = injectDialogRootContext()
+
+/** Whether this dialog is presenting as a bottom sheet at the current width. */
+const asSheet = computed(() => isMobile.value && props.mobile !== "dialog")
+
+const drag = useSheetDrag({
+  enabled: asSheet,
+  onDismiss: () => rootContext.onOpenChange(false),
+})
+
+const contentClass = computed(() => asSheet.value
+  ? cn(
+      "bg-sidebar data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom fixed inset-x-0 bottom-0 z-50 flex w-full flex-col gap-4 overflow-y-auto rounded-t-[20px] border-t p-6 shadow-[0_-10px_32px_rgba(29,26,21,0.22)] transition-transform duration-200",
+      props.class,
+      // The handle takes the top of the sheet whatever padding the call site
+      // set, so this trails those classes rather than leading them.
+      "pt-1.5",
+    )
+  : cn(
+      "bg-sidebar data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-[0_16px_40px_rgba(29,26,21,0.14)] duration-200 sm:max-w-lg",
+      props.class,
+    ))
+
+/**
+ * What classes cannot say: a sheet has to beat whatever width the call site set
+ * for its desktop dialog, and it sizes against the on-screen keyboard, which
+ * only the visual viewport knows the height of.
+ */
+const contentStyle = computed<CSSProperties | undefined>(() => {
+  if (!asSheet.value) {
+    return undefined
+  }
+
+  const room = `calc(${SHEET_HEIGHT} - ${keyboardInset.value}px)`
+
+  return {
+    maxWidth: "none",
+    maxHeight: room,
+    height: props.mobile === "detail" ? room : undefined,
+    // `position: fixed` anchors to the layout viewport, which the keyboard does
+    // not shrink — without this the sheet would open behind it.
+    bottom: `${keyboardInset.value}px`,
+    paddingBottom: `calc(${SHEET_BOTTOM_PADDING} + env(safe-area-inset-bottom))`,
+    transform: drag.offset.value === 0 ? undefined : `translateY(${drag.offset.value}px)`,
+    // The sheet follows the finger untweened; the tween is for the way back.
+    transition: drag.dragging.value ? "none" : undefined,
+  }
+})
 </script>
 
 <template>
@@ -32,12 +119,26 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
     <DialogContent
       data-slot="dialog-content"
       v-bind="{ ...$attrs, ...forwarded }"
-      :class="
-        cn(
-          'bg-sidebar data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-[0_16px_40px_rgba(29,26,21,0.14)] duration-200 sm:max-w-lg',
-          props.class,
-        )"
+      :class="contentClass"
+      :style="contentStyle"
     >
+      <!-- The grab handle: a touch affordance for a gesture that Escape, the
+           scrim and the close button each offer another way to, so it is
+           decorative to a screen reader. -->
+      <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- a pointer-only drag target, not a control -->
+      <div
+        v-if="asSheet"
+        aria-hidden="true"
+        data-test="sheet-grab-handle"
+        class="bg-inherit sticky top-0 z-10 flex shrink-0 cursor-grab touch-none justify-center py-1.5"
+        @pointerdown="drag.start"
+        @pointermove="drag.move"
+        @pointerup="drag.end"
+        @pointercancel="drag.cancel"
+      >
+        <span class="bg-muted-foreground/30 h-1 w-11 rounded-full" />
+      </div>
+
       <slot />
 
       <DialogClose

--- a/resources/js/components/ui/dialog/DialogHeader.vue
+++ b/resources/js/components/ui/dialog/DialogHeader.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 <template>
   <div
     data-slot="dialog-header"
-    :class="cn('flex flex-col gap-2 text-center sm:text-left', props.class)"
+    :class="cn('flex flex-col gap-2 text-left', props.class)"
   >
     <slot />
   </div>

--- a/resources/js/components/ui/dialog/DialogOverlay.vue
+++ b/resources/js/components/ui/dialog/DialogOverlay.vue
@@ -14,7 +14,7 @@ const delegatedProps = reactiveOmit(props, "class")
   <DialogOverlay
     data-slot="dialog-overlay"
     v-bind="delegatedProps"
-    :class="cn('data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80', props.class)"
+    :class="cn('data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 max-md:bg-scrim', props.class)"
   >
     <slot />
   </DialogOverlay>

--- a/resources/js/composables/useSheetDrag.test.ts
+++ b/resources/js/composables/useSheetDrag.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+
+import { useSheetDrag } from '@/composables/useSheetDrag';
+
+/**
+ * A grab handle inside a sheet of a known height, with pointer capture stubbed:
+ * jsdom implements neither, and the composable only uses capture to keep
+ * receiving moves — which a dispatched drag delivers regardless.
+ */
+let handle: HTMLElement;
+let captured: number | null;
+
+function mountHandle(sheetHeight: number): void {
+    document.body.innerHTML = '';
+    captured = null;
+
+    const sheet = document.createElement('div');
+    sheet.dataset.slot = 'dialog-content';
+    sheet.getBoundingClientRect = () => ({ height: sheetHeight }) as DOMRect;
+
+    handle = document.createElement('div');
+    handle.setPointerCapture = (pointerId: number) => {
+        captured = pointerId;
+    };
+    handle.releasePointerCapture = (pointerId: number) => {
+        if (captured === pointerId) {
+            captured = null;
+        }
+    };
+    handle.hasPointerCapture = (pointerId: number) => captured === pointerId;
+
+    sheet.append(handle);
+    document.body.append(sheet);
+}
+
+/** A pointer event as the handle would receive it, `touch` unless told otherwise. */
+function pointer(
+    type: string,
+    { y, at = 0, id = 1, pointerType = 'touch' } = {} as {
+        y: number;
+        at?: number;
+        id?: number;
+        pointerType?: string;
+    },
+): PointerEvent {
+    const event = new Event(type);
+
+    // `timeStamp` and `currentTarget` are getters on Event, and `currentTarget`
+    // is only set while an event is being dispatched — these handlers are called
+    // directly, so both have to be planted.
+    Object.defineProperties(event, {
+        clientY: { value: y },
+        pointerId: { value: id },
+        pointerType: { value: pointerType },
+        timeStamp: { value: at },
+        currentTarget: { value: handle },
+    });
+
+    return event as PointerEvent;
+}
+
+beforeEach(() => mountHandle(600));
+
+describe('useSheetDrag', () => {
+    it('follows the finger and puts the sheet back when the drag stops short', () => {
+        const onDismiss = vi.fn();
+        const drag = useSheetDrag({ enabled: ref(true), onDismiss });
+
+        drag.start(pointer('pointerdown', { y: 100, at: 0 }));
+        drag.move(pointer('pointermove', { y: 160, at: 300 }));
+
+        expect(drag.dragging.value).toBe(true);
+        expect(drag.offset.value).toBe(60);
+
+        drag.end(pointer('pointerup', { y: 160, at: 400 }));
+
+        // 60px of a 600px sheet, released at a standstill: not thrown away.
+        expect(onDismiss).not.toHaveBeenCalled();
+        expect(drag.offset.value).toBe(0);
+        expect(drag.dragging.value).toBe(false);
+        expect(captured).toBeNull();
+    });
+
+    it('dismisses a drag that travelled most of the way down', () => {
+        const onDismiss = vi.fn();
+        const drag = useSheetDrag({ enabled: ref(true), onDismiss });
+
+        drag.start(pointer('pointerdown', { y: 100, at: 0 }));
+        drag.move(pointer('pointermove', { y: 400, at: 500 }));
+        drag.end(pointer('pointerup', { y: 400, at: 600 }));
+
+        expect(onDismiss).toHaveBeenCalledOnce();
+    });
+
+    it('reads the travel the release itself reports', () => {
+        const onDismiss = vi.fn();
+        const drag = useSheetDrag({ enabled: ref(true), onDismiss });
+
+        // The finger carried on past the last move it reported before lifting:
+        // the distance it ended at is the one the decision has to be made on.
+        drag.start(pointer('pointerdown', { y: 100, at: 0 }));
+        drag.move(pointer('pointermove', { y: 150, at: 400 }));
+        drag.end(pointer('pointerup', { y: 420, at: 460 }));
+
+        expect(onDismiss).toHaveBeenCalledOnce();
+    });
+
+    it('ignores a mouse, which has the close button instead', () => {
+        const onDismiss = vi.fn();
+        const drag = useSheetDrag({ enabled: ref(true), onDismiss });
+
+        drag.start(
+            pointer('pointerdown', { y: 100, at: 0, pointerType: 'mouse' }),
+        );
+        drag.move(pointer('pointermove', { y: 500, at: 100 }));
+        drag.end(pointer('pointerup', { y: 500, at: 200 }));
+
+        expect(drag.dragging.value).toBe(false);
+        expect(drag.offset.value).toBe(0);
+        expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it('ignores the gesture entirely while the surface is a desktop dialog', () => {
+        const onDismiss = vi.fn();
+        const drag = useSheetDrag({ enabled: ref(false), onDismiss });
+
+        drag.start(pointer('pointerdown', { y: 100, at: 0 }));
+        drag.move(pointer('pointermove', { y: 500, at: 100 }));
+        drag.end(pointer('pointerup', { y: 500, at: 200 }));
+
+        expect(drag.offset.value).toBe(0);
+        expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it('keeps the drag for the finger that began it', () => {
+        const onDismiss = vi.fn();
+        const drag = useSheetDrag({ enabled: ref(true), onDismiss });
+
+        drag.start(pointer('pointerdown', { y: 100, at: 0 }));
+        // A second finger lands mid-drag: it can neither move the sheet...
+        drag.move(pointer('pointermove', { y: 500, at: 100, id: 2 }));
+
+        expect(drag.offset.value).toBe(0);
+
+        // ...nor complete the first finger's gesture.
+        drag.end(pointer('pointerup', { y: 500, at: 200, id: 2 }));
+
+        expect(onDismiss).not.toHaveBeenCalled();
+        expect(drag.dragging.value).toBe(true);
+    });
+
+    it('drops a drag the browser took the pointer away from', () => {
+        const onDismiss = vi.fn();
+        const drag = useSheetDrag({ enabled: ref(true), onDismiss });
+
+        drag.start(pointer('pointerdown', { y: 100, at: 0 }));
+        drag.move(pointer('pointermove', { y: 500, at: 100 }));
+        drag.cancel(pointer('pointercancel', { y: 500, at: 200 }));
+
+        // Far enough to have been a dismissal, but a cancelled drag never
+        // completes: the sheet goes back and stays open.
+        expect(onDismiss).not.toHaveBeenCalled();
+        expect(drag.offset.value).toBe(0);
+        expect(drag.dragging.value).toBe(false);
+        expect(captured).toBeNull();
+    });
+
+    it('resists a drag upward instead of lifting the sheet off its edge', () => {
+        const drag = useSheetDrag({ enabled: ref(true), onDismiss: vi.fn() });
+
+        drag.start(pointer('pointerdown', { y: 300, at: 0 }));
+        drag.move(pointer('pointermove', { y: 100, at: 100 }));
+
+        expect(drag.offset.value).toBeGreaterThan(-48);
+        expect(drag.offset.value).toBeLessThan(0);
+    });
+});

--- a/resources/js/composables/useSheetDrag.ts
+++ b/resources/js/composables/useSheetDrag.ts
@@ -119,6 +119,14 @@ export function useSheetDrag({
             return;
         }
 
+        // The release carries a position of its own, and a finger can travel a
+        // good way between the last move it reported and lifting off. Folding it
+        // in as a final move is what makes a flick read as one — but only when it
+        // moved, or an unmoved release would zero out the speed it left at.
+        if (event.clientY !== gesture.lastY) {
+            move(event);
+        }
+
         const { height, previousY, previousAt, lastY, lastAt } = gesture;
         const travelled = offset.value;
 

--- a/resources/js/composables/useSheetDrag.ts
+++ b/resources/js/composables/useSheetDrag.ts
@@ -1,0 +1,151 @@
+import { ref } from 'vue';
+import type { Ref } from 'vue';
+import { sheetOffset, shouldDismissSheet } from '@/lib/sheetDrag';
+
+type SheetDragOptions = {
+    /** Whether the surface is currently a sheet — the gesture is mobile only. */
+    enabled: Ref<boolean>;
+    /** Close the sheet, once a drag has asked for it. */
+    onDismiss: () => void;
+};
+
+type SheetDrag = {
+    /** How far down the sheet currently sits, in pixels. */
+    offset: Ref<number>;
+    /** Whether a drag is in flight, so the sheet can follow the finger untweened. */
+    dragging: Ref<boolean>;
+    /** Begin a drag. Bound to the grab handle's `pointerdown`. */
+    start: (event: PointerEvent) => void;
+    /** Carry it. Bound to `pointermove`. */
+    move: (event: PointerEvent) => void;
+    /** Finish it, dismissing the sheet if it travelled far or fast enough. */
+    end: (event: PointerEvent) => void;
+    /** Drop it — the browser took the pointer over. */
+    cancel: (event: PointerEvent) => void;
+};
+
+/** The in-flight drag, tagged with the pointer that owns it. */
+type Gesture = {
+    pointerId: number;
+    /** Where the finger went down, which every offset is measured from. */
+    startY: number;
+    /** The sheet's height when the drag began: how far "far enough" is. */
+    height: number;
+    /** The move before the current one, for the parting speed of a flick. */
+    previousY: number;
+    previousAt: number;
+    /** The latest move, which the release reads its speed from. */
+    lastY: number;
+    lastAt: number;
+};
+
+/**
+ * Drag a bottom sheet down to dismiss it.
+ *
+ * The gesture belongs to the grab handle rather than to the whole sheet: the
+ * sheet body scrolls its own content, and a drag that had to guess between
+ * "scroll this list" and "throw the sheet away" would get one of them wrong.
+ * Escape, the scrim and the close button dismiss the sheet too, so nothing is
+ * reachable only through the gesture.
+ */
+export function useSheetDrag({
+    enabled,
+    onDismiss,
+}: SheetDragOptions): SheetDrag {
+    const offset = ref(0);
+    const dragging = ref(false);
+
+    let gesture: Gesture | null = null;
+
+    /** Whether this event belongs to the drag in flight. */
+    function owns(event: PointerEvent): boolean {
+        return gesture !== null && gesture.pointerId === event.pointerId;
+    }
+
+    /** Let go of the pointer and put the sheet back where it started. */
+    function settle(event: PointerEvent): void {
+        const handle = event.currentTarget as HTMLElement;
+
+        if (handle.hasPointerCapture(event.pointerId)) {
+            handle.releasePointerCapture(event.pointerId);
+        }
+
+        gesture = null;
+        dragging.value = false;
+        offset.value = 0;
+    }
+
+    function start(event: PointerEvent): void {
+        // A mouse press on the handle is not a drag-to-dismiss: capturing the
+        // pointer would swallow the click, and a desktop has the close button.
+        if (gesture || !enabled.value || event.pointerType === 'mouse') {
+            return;
+        }
+
+        const handle = event.currentTarget as HTMLElement;
+        const sheet = handle.closest<HTMLElement>(
+            '[data-slot="dialog-content"]',
+        );
+
+        gesture = {
+            pointerId: event.pointerId,
+            startY: event.clientY,
+            height: sheet?.getBoundingClientRect().height ?? 0,
+            previousY: event.clientY,
+            previousAt: event.timeStamp,
+            lastY: event.clientY,
+            lastAt: event.timeStamp,
+        };
+
+        dragging.value = true;
+        handle.setPointerCapture(event.pointerId);
+    }
+
+    function move(event: PointerEvent): void {
+        if (!gesture || !owns(event)) {
+            return;
+        }
+
+        offset.value = sheetOffset(event.clientY - gesture.startY);
+
+        gesture.previousY = gesture.lastY;
+        gesture.previousAt = gesture.lastAt;
+        gesture.lastY = event.clientY;
+        gesture.lastAt = event.timeStamp;
+    }
+
+    function end(event: PointerEvent): void {
+        if (!gesture || !owns(event)) {
+            return;
+        }
+
+        const { height, previousY, previousAt, lastY, lastAt } = gesture;
+        const travelled = offset.value;
+
+        settle(event);
+
+        // Guard the divisor: two moves can share a timestamp, and a release
+        // with no move before it has none at all.
+        const elapsed = Math.max(lastAt - previousAt, 1);
+
+        if (
+            shouldDismissSheet({
+                offset: travelled,
+                height,
+                velocity: (lastY - previousY) / elapsed,
+            })
+        ) {
+            onDismiss();
+        }
+    }
+
+    function cancel(event: PointerEvent): void {
+        if (!gesture || !owns(event)) {
+            return;
+        }
+
+        settle(event);
+    }
+
+    return { offset, dragging, start, move, end, cancel };
+}

--- a/resources/js/lib/sheetDrag.test.ts
+++ b/resources/js/lib/sheetDrag.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { sheetOffset, shouldDismissSheet } from '@/lib/sheetDrag';
+
+describe('sheetOffset', () => {
+    it('follows a downward drag one-for-one', () => {
+        expect(sheetOffset(120)).toBe(120);
+    });
+
+    it('stays put at the start of a drag', () => {
+        expect(sheetOffset(0)).toBe(0);
+    });
+
+    it('resists an upward drag rather than lifting off its edge', () => {
+        // The sheet is anchored to the bottom of the screen. Dragging up has
+        // nowhere to go, so it gives a little and stops — pulling it into the
+        // middle of the viewport would leave a gap under it.
+        expect(sheetOffset(-100)).toBeGreaterThan(-100);
+        expect(sheetOffset(-100)).toBeLessThan(0);
+    });
+
+    it('never lets an upward drag exceed the rubber band', () => {
+        expect(sheetOffset(-10_000)).toBeGreaterThanOrEqual(-48);
+    });
+});
+
+describe('shouldDismissSheet', () => {
+    it('dismisses a drag past a third of the sheet', () => {
+        expect(
+            shouldDismissSheet({ offset: 200, height: 500, velocity: 0 }),
+        ).toBe(true);
+    });
+
+    it('keeps a drag that stopped short of it', () => {
+        expect(
+            shouldDismissSheet({ offset: 80, height: 500, velocity: 0 }),
+        ).toBe(false);
+    });
+
+    it('dismisses a short flick, because speed reads as intent', () => {
+        // A quick flick downward is how a sheet is thrown away on a phone: the
+        // finger barely travels, so distance alone would keep it open.
+        expect(
+            shouldDismissSheet({ offset: 60, height: 500, velocity: 1.2 }),
+        ).toBe(true);
+    });
+
+    it('keeps a slow drag however fast the finger came back up', () => {
+        // Velocity only counts downward: flicking back up is someone changing
+        // their mind, not throwing the sheet away.
+        expect(
+            shouldDismissSheet({ offset: 20, height: 500, velocity: -3 }),
+        ).toBe(false);
+    });
+
+    it('keeps an upward drag whatever the sheet measures', () => {
+        expect(
+            shouldDismissSheet({ offset: -40, height: 500, velocity: 0 }),
+        ).toBe(false);
+    });
+
+    it('falls back to an absolute travel when the sheet has no measured height', () => {
+        // A sheet mid-animation can measure zero; a fraction of zero would then
+        // dismiss on the first pixel of a drag.
+        expect(shouldDismissSheet({ offset: 4, height: 0, velocity: 0 })).toBe(
+            false,
+        );
+        expect(shouldDismissSheet({ offset: 200, height: 0, velocity: 0 })).toBe(
+            true,
+        );
+    });
+});

--- a/resources/js/lib/sheetDrag.test.ts
+++ b/resources/js/lib/sheetDrag.test.ts
@@ -65,8 +65,8 @@ describe('shouldDismissSheet', () => {
         expect(shouldDismissSheet({ offset: 4, height: 0, velocity: 0 })).toBe(
             false,
         );
-        expect(shouldDismissSheet({ offset: 200, height: 0, velocity: 0 })).toBe(
-            true,
-        );
+        expect(
+            shouldDismissSheet({ offset: 200, height: 0, velocity: 0 }),
+        ).toBe(true);
     });
 });

--- a/resources/js/lib/sheetDrag.ts
+++ b/resources/js/lib/sheetDrag.ts
@@ -1,0 +1,74 @@
+/**
+ * How far an upward drag may pull the sheet past its bottom edge. It gives a
+ * little so the gesture feels alive, then holds: a sheet lifted into the middle
+ * of the screen would leave a gap under it that belongs to nothing.
+ */
+const RUBBER_BAND_PX = 48;
+
+/** The share of its own height a sheet must travel before it counts as thrown away. */
+const DISMISS_FRACTION = 1 / 3;
+
+/**
+ * The travel that dismisses a sheet whose height is unknown. A sheet caught
+ * mid-animation can measure zero, and a fraction of zero would dismiss it on
+ * the first pixel of a drag.
+ */
+const DISMISS_FALLBACK_PX = 160;
+
+/** Downward pixels per millisecond past which a drag reads as a flick. */
+const FLICK_VELOCITY = 0.5;
+
+/** The travel a flick must still cover, so a stray twitch cannot dismiss. */
+const FLICK_MIN_TRAVEL_PX = 32;
+
+/**
+ * How far down the sheet sits while a drag is in flight, given how far the
+ * pointer has moved from where it went down.
+ */
+export function sheetOffset(deltaY: number): number {
+    if (deltaY >= 0) {
+        return deltaY;
+    }
+
+    // Asymptotic resistance: the further up the finger goes, the less the sheet
+    // follows, and it never passes the band.
+    return -RUBBER_BAND_PX * (1 - RUBBER_BAND_PX / (RUBBER_BAND_PX - deltaY));
+}
+
+/**
+ * A finished drag, as the sheet saw it.
+ */
+export type SheetDrag = {
+    /** How far down the sheet ended up, in pixels. */
+    offset: number;
+    /** The sheet's own height, which sets how far "far enough" is. */
+    height: number;
+    /** The drag's parting speed in pixels per millisecond; positive is downward. */
+    velocity: number;
+};
+
+/**
+ * Whether a finished drag asked for the sheet to be dismissed.
+ *
+ * Two ways to ask: drag it most of the way down, or flick it. The flick is what
+ * a thumb actually does — the finger barely travels, so distance alone would
+ * always put the sheet back.
+ */
+export function shouldDismissSheet({
+    offset,
+    height,
+    velocity,
+}: SheetDrag): boolean {
+    if (offset <= 0) {
+        return false;
+    }
+
+    const threshold =
+        height > 0 ? height * DISMISS_FRACTION : DISMISS_FALLBACK_PX;
+
+    if (offset >= threshold) {
+        return true;
+    }
+
+    return velocity >= FLICK_VELOCITY && offset >= FLICK_MIN_TRAVEL_PX;
+}

--- a/tests/Browser/MobileSheetsTest.php
+++ b/tests/Browser/MobileSheetsTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AppLocale;
+use Pest\Browser\Api\AwaitableWebpage;
+
+/**
+ * Dialogs below the `md` breakpoint (#772).
+ *
+ * Every dialog presents as a bottom sheet on a phone and stays a centred dialog
+ * from `md` up. The defect this replaces was structural rather than cosmetic: a
+ * dialog centred with `translate(-50%, -50%)` and no height cap overflows both
+ * ends of a short viewport, so on a landscape phone its title and its primary
+ * action were *both* off screen, with no way to scroll to either.
+ */
+
+/**
+ * Whether the open dialog presents as a bottom sheet: pinned to the bottom edge,
+ * spanning the full width, and no taller than the screen.
+ */
+function openSurfaceIsASheet(): string
+{
+    return <<<'JS'
+    (() => {
+        const sheet = document.querySelector('[data-slot="dialog-content"]');
+
+        if (sheet === null) {
+            return false;
+        }
+
+        const box = sheet.getBoundingClientRect();
+
+        return Math.round(box.bottom) === window.innerHeight
+            && Math.round(box.width) === window.innerWidth
+            && box.top >= 0
+            && box.height <= window.innerHeight;
+    })()
+    JS;
+}
+
+/**
+ * Whether the open dialog presents as a centred desktop dialog, floating clear
+ * of every edge.
+ */
+function openSurfaceIsACentredDialog(): string
+{
+    return <<<'JS'
+    (() => {
+        const dialog = document.querySelector('[data-slot="dialog-content"]');
+
+        if (dialog === null) {
+            return false;
+        }
+
+        const box = dialog.getBoundingClientRect();
+
+        return box.bottom < window.innerHeight
+            && box.top > 0
+            && box.width < window.innerWidth;
+    })()
+    JS;
+}
+
+/**
+ * Open the create-channel dialog from the dock. It is the plainest of the form
+ * dialogs — a header, three fields and a pair of actions — so it stands in for
+ * the whole set that shares the primitive.
+ */
+function openCreateChannelDialog(AwaitableWebpage $page, int $width, int $height, string $url): AwaitableWebpage
+{
+    $page = $page->resize($width, $height)->navigate($url);
+
+    // Below the breakpoint the dock is a Sheet, so its rows only exist once it
+    // is opened; from `md` up the rail is always mounted.
+    if ($width < 768) {
+        $page = $page->click('@sidebar-toggle');
+    }
+
+    return $page->click('@create-channel-trigger')->assertPresent('@create-channel-submit');
+}
+
+test('a dialog is a bottom sheet on a phone and a centred dialog from md up', function (int $width, int $height, bool $expectSheet): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        $width,
+        $height,
+        browserChannelUrl($team, $channel),
+    )
+        ->assertScript(openSurfaceIsASheet(), $expectSheet)
+        ->assertScript(openSurfaceIsACentredDialog(), ! $expectSheet);
+})->with([
+    'small phone' => [360, 740, true],
+    'iPhone SE' => [375, 667, true],
+    'iPhone 14' => [390, 844, true],
+    'large phone' => [430, 932, true],
+    // A short viewport is its own failure mode, and where the old centred dialog
+    // ran off both ends of the screen at once.
+    'landscape phone' => [740, 360, true],
+    // The breakpoint itself is desktop, matching `useIsMobile` and Tailwind's
+    // `md:` — the boundary the dock got wrong in #771.
+    'tablet portrait' => [768, 1024, false],
+    'desktop' => [1280, 800, false],
+]);
+
+test('a sheet taller than the screen scrolls inside itself and leaves the page behind locked', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // A landscape phone is 360px tall; the create-channel form is not.
+    openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        740,
+        360,
+        browserChannelUrl($team, $channel),
+    )
+        ->assertScript(<<<'JS'
+        (() => {
+            const sheet = document.querySelector('[data-slot="dialog-content"]');
+
+            return sheet.scrollHeight > sheet.clientHeight
+                && getComputedStyle(sheet).overflowY === 'auto';
+        })()
+        JS, true)
+        // ...and the conversation behind it does not scroll instead, which is
+        // what makes an overflowing sheet feel like a broken page.
+        ->assertScript(<<<'JS'
+        (() => document.documentElement.scrollHeight <= document.documentElement.clientHeight)()
+        JS, true);
+});
+
+test('a sheet keeps every control it draws inside the viewport', function (int $width, int $height): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        $width,
+        $height,
+        browserChannelUrl($team, $channel),
+    )
+        ->assertScript(<<<'JS'
+        (() => {
+            const sheet = document.querySelector('[data-slot="dialog-content"]');
+
+            return [...sheet.querySelectorAll('button, input, select')]
+                // A Select ships a visually-hidden native `<select>` parked off
+                // the left edge to carry its value; it is not a drawn control.
+                .filter(control => control.closest('[aria-hidden="true"]') === null)
+                .every(control => {
+                    const box = control.getBoundingClientRect();
+
+                    return box.left >= -1 && box.right <= window.innerWidth + 1;
+                });
+        })()
+        JS, true);
+})->with([
+    'small phone' => [360, 740],
+    'iPhone SE' => [375, 667],
+    'iPhone 14' => [390, 844],
+    'large phone' => [430, 932],
+]);
+
+test('a sheet traps focus, and Escape closes it', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $page = openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        390,
+        844,
+        browserChannelUrl($team, $channel),
+    )
+        // Focus lands inside the sheet when it opens...
+        ->assertScript(<<<'JS'
+        (() => document.querySelector('[data-slot="dialog-content"]').contains(document.activeElement))()
+        JS, true);
+
+    // ...and cannot be tabbed out of it: past the last control it wraps back to
+    // the first rather than walking into the conversation behind the scrim.
+    foreach (range(1, 12) as $ignored) {
+        $page = $page->keys('[data-slot="dialog-content"]', ['Tab']);
+    }
+
+    $page->assertScript(<<<'JS'
+    (() => document.querySelector('[data-slot="dialog-content"]').contains(document.activeElement))()
+    JS, true)
+        ->keys('@create-channel-name', ['Escape'])
+        ->assertNotPresent('@create-channel-submit');
+});
+
+test('tapping the scrim dismisses a sheet', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // A sheet leaves the top of the screen showing, so — unlike the dock, whose
+    // scrim the sheet covers entirely — there is somewhere to tap that really is
+    // the scrim.
+    $page = openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        390,
+        844,
+        browserChannelUrl($team, $channel),
+    );
+
+    $page->script(<<<'JS'
+    (() => {
+        const scrim = document.querySelector('[data-slot="dialog-overlay"]');
+        const sheet = document.querySelector('[data-slot="dialog-content"]').getBoundingClientRect();
+        const point = {
+            bubbles: true,
+            cancelable: true,
+            clientX: Math.round(window.innerWidth / 2),
+            clientY: Math.round(sheet.top / 2),
+        };
+
+        for (const type of ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']) {
+            scrim.dispatchEvent(new MouseEvent(type, point));
+        }
+    })()
+    JS);
+
+    $page->assertNotPresent('@create-channel-submit');
+});
+
+test('dragging the grab handle down throws the sheet away', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $page = openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        390,
+        844,
+        browserChannelUrl($team, $channel),
+    )->assertPresent('@sheet-grab-handle');
+
+    // Synthesised as touch on purpose: the gesture is bound to touch and pen, so
+    // a mouse press on the handle never starts a drag on a desktop.
+    $page->script(<<<'JS'
+    (() => {
+        const handle = document.querySelector('[data-test="sheet-grab-handle"]');
+        const box = handle.getBoundingClientRect();
+        const at = (type, clientY) => new PointerEvent(type, {
+            pointerId: 1,
+            pointerType: 'touch',
+            isPrimary: true,
+            bubbles: true,
+            cancelable: true,
+            clientX: Math.round(box.x + box.width / 2),
+            clientY,
+        });
+
+        // Pointer capture needs a trusted event. The handlers only use it to keep
+        // receiving moves, which a synthesised drag delivers to them anyway.
+        handle.setPointerCapture = () => {};
+        handle.hasPointerCapture = () => false;
+
+        handle.dispatchEvent(at('pointerdown', box.y));
+        handle.dispatchEvent(at('pointermove', box.y + 300));
+        handle.dispatchEvent(at('pointerup', box.y + 300));
+    })()
+    JS);
+
+    $page->assertNotPresent('@create-channel-submit');
+});
+
+test('a detail sheet stands at 85% of the screen whatever it holds', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // Reminders is a list that shortens as it is worked through; pinning it to
+    // the epic's 85% keeps it from resizing under the thumb between taps.
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@sidebar-toggle')
+        ->click('@reminders-trigger')
+        ->assertScript(openSurfaceIsASheet(), true)
+        ->assertScript(<<<'JS'
+        (() => {
+            const height = document.querySelector('[data-slot="dialog-content"]')
+                .getBoundingClientRect().height;
+
+            return Math.abs(height - window.innerHeight * 0.85) <= 1;
+        })()
+        JS, true);
+});
+
+test('a sheet survives a locale whose words run longer than the English', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+    $alice->update(['locale' => AppLocale::French]);
+
+    // French is where a tight row first breaks (#765), and 360px is the tightest
+    // width the epic covers.
+    openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        360,
+        740,
+        browserChannelUrl($team, $channel),
+    )
+        ->assertScript(openSurfaceIsASheet(), true)
+        ->assertScript(<<<'JS'
+        (() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)()
+        JS, true);
+});

--- a/tests/Browser/MobileSheetsTest.php
+++ b/tests/Browser/MobileSheetsTest.php
@@ -330,12 +330,19 @@ test('an open sheet has no serious accessibility violations in either theme', fu
     // scrim token — and the automated gate does not audit a11y. axe-core reads
     // the real rendered DOM, so a clean run covers both the handle's semantics
     // (decorative, and unreachable by keyboard) and the scrim's contrast.
+    // Settle first: the sheet slides and fades in over 200ms, and
+    // `assertNoAccessibilityIssues` is one of the two assertions that does not
+    // retry. Sampled mid-fade, axe reads the half-transparent title composited
+    // against everything behind it and reports a contrast of 2.38 that no one
+    // ever sees — which is exactly how this failed on CI while passing locally.
     $page = openCreateChannelDialog(
         signInThroughBrowser($alice),
         390,
         844,
         browserChannelUrl($team, $channel),
-    )->assertNoAccessibilityIssues();
+    )
+        ->wait(0.5)
+        ->assertNoAccessibilityIssues();
 
     $page->script(<<<'JS'
     () => {

--- a/tests/Browser/MobileSheetsTest.php
+++ b/tests/Browser/MobileSheetsTest.php
@@ -115,12 +115,24 @@ test('a sheet taller than the screen scrolls inside itself and leaves the page b
         360,
         browserChannelUrl($team, $channel),
     )
+        // The form is taller than the sheet, and scrolling the sheet — not the
+        // page — is what brings its primary action within reach.
         ->assertScript(<<<'JS'
         (() => {
             const sheet = document.querySelector('[data-slot="dialog-content"]');
 
-            return sheet.scrollHeight > sheet.clientHeight
-                && getComputedStyle(sheet).overflowY === 'auto';
+            return sheet.scrollHeight > sheet.clientHeight;
+        })()
+        JS, true)
+        ->assertScript(<<<'JS'
+        (() => {
+            const sheet = document.querySelector('[data-slot="dialog-content"]');
+            sheet.scrollTop = sheet.scrollHeight;
+
+            const submit = document.querySelector('[data-test="create-channel-submit"]')
+                .getBoundingClientRect();
+
+            return submit.top >= 0 && submit.bottom <= window.innerHeight;
         })()
         JS, true)
         // ...and the conversation behind it does not scroll instead, which is
@@ -177,14 +189,17 @@ test('a sheet traps focus, and Escape closes it', function (): void {
 
     // ...and cannot be tabbed out of it: past the last control it wraps back to
     // the first rather than walking into the conversation behind the scrim.
+    // Checked after every press, so a failure names the tab that escaped rather
+    // than only reporting that one of twelve did.
     foreach (range(1, 12) as $ignored) {
-        $page = $page->keys('[data-slot="dialog-content"]', ['Tab']);
+        $page = $page
+            ->keys('[data-slot="dialog-content"]', ['Tab'])
+            ->assertScript(<<<'JS'
+            (() => document.querySelector('[data-slot="dialog-content"]').contains(document.activeElement))()
+            JS, true);
     }
 
-    $page->assertScript(<<<'JS'
-    (() => document.querySelector('[data-slot="dialog-content"]').contains(document.activeElement))()
-    JS, true)
-        ->keys('@create-channel-name', ['Escape'])
+    $page->keys('@create-channel-name', ['Escape'])
         ->assertNotPresent('@create-channel-submit');
 });
 
@@ -201,9 +216,13 @@ test('tapping the scrim dismisses a sheet', function (): void {
         browserChannelUrl($team, $channel),
     );
 
+    // Dispatched at whatever a hit test says is under that point, not at the
+    // overlay element: while a dialog is open the whole page is
+    // `pointer-events: none`, so a tap above the sheet resolves to the document
+    // and is answered by a document-level listener. Aiming straight at the
+    // overlay would pass without proving a finger ever reaches it.
     $page->script(<<<'JS'
     (() => {
-        const scrim = document.querySelector('[data-slot="dialog-overlay"]');
         const sheet = document.querySelector('[data-slot="dialog-content"]').getBoundingClientRect();
         const point = {
             bubbles: true,
@@ -211,10 +230,11 @@ test('tapping the scrim dismisses a sheet', function (): void {
             clientX: Math.round(window.innerWidth / 2),
             clientY: Math.round(sheet.top / 2),
         };
+        const target = document.elementFromPoint(point.clientX, point.clientY);
 
-        for (const type of ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']) {
-            scrim.dispatchEvent(new MouseEvent(type, point));
-        }
+        target.dispatchEvent(new PointerEvent('pointerdown', { ...point, pointerId: 1, pointerType: 'mouse', isPrimary: true, button: 0 }));
+        target.dispatchEvent(new PointerEvent('pointerup', { ...point, pointerId: 1, pointerType: 'mouse', isPrimary: true, button: 0 }));
+        target.dispatchEvent(new MouseEvent('click', { ...point, button: 0 }));
     })()
     JS);
 
@@ -294,6 +314,9 @@ test('a sheet survives a locale whose words run longer than the English', functi
         740,
         browserChannelUrl($team, $channel),
     )
+        // The catalog has actually taken: without this the sheet would be proven
+        // against the English copy while claiming to prove it against French.
+        ->assertSee('Créer un canal')
         ->assertScript(openSurfaceIsASheet(), true)
         ->assertScript(<<<'JS'
         (() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)()

--- a/tests/Browser/MobileSheetsTest.php
+++ b/tests/Browser/MobileSheetsTest.php
@@ -299,3 +299,28 @@ test('a sheet survives a locale whose words run longer than the English', functi
         (() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)()
         JS, true);
 });
+
+test('an open sheet has no serious accessibility violations in either theme', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // The sheet adds chrome the centred dialog never had — a grab handle, a new
+    // scrim token — and the automated gate does not audit a11y. axe-core reads
+    // the real rendered DOM, so a clean run covers both the handle's semantics
+    // (decorative, and unreachable by keyboard) and the scrim's contrast.
+    $page = openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        390,
+        844,
+        browserChannelUrl($team, $channel),
+    )->assertNoAccessibilityIssues();
+
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)->assertNoAccessibilityIssues();
+});


### PR DESCRIPTION
Closes #772. Second child of the mobile epic #770, on top of the breakpoint foundation from #771.

## The defect

Below `md` every dialog was still a desktop dialog: centred with `translate(-50%, -50%)`, no height cap. Driven at the epic's viewports against the seeded workspace:

| Viewport | What the create-channel dialog did |
| --- | --- |
| 740x360 (landscape phone) | **Overflowed both ends at once.** The card's top edge sat above the viewport and its primary action below it, with nothing to scroll — the title and the "Create channel" button were both unreachable. |
| 375x667 · 390x844 | Fitted, but as a floating card on a phone: centred title, `sm:max-w-*` gutters, nothing that reads as a mobile surface. |

## What changed

**One primitive, no call-site branching.** `ui/dialog`'s `DialogContent` now resolves its own presentation from `useIsMobile()` (the 767.98px query #771 established, so `md:` and the sheet can never both claim a width). Below `md` it is a bottom sheet with the chrome from `m4`/`m8`: full width, `20px 20px 0 0`, a 44x4 grab handle, top shadow, ink-at-50% scrim, and bottom room that clears `env(safe-area-inset-bottom)`. From `md` up the class string is byte-for-byte what it was.

- **Internal scroll.** The sheet caps at `85dvh` and scrolls its own content; reka already locks the page behind it.
- **Keyboard-safe.** `position: fixed` anchors to the layout viewport, which the on-screen keyboard does not shrink, so the sheet lifts by the visualViewport shortfall (`useKeyboardInset`, from #771) and its cap shrinks by the same amount.
- **Drag-to-dismiss.** New `lib/sheetDrag` (pure: rubber-banded offset, distance-or-flick dismissal) behind `useSheetDrag`. Bound to the handle rather than the whole sheet — a drag that had to guess between "scroll this list" and "throw the sheet away" gets one of them wrong — and to touch and pen only. Escape, the scrim and the close button are unchanged and still do the same job.
- **A detail variant** pinned to 85% height, the stand-in for a desktop right-hand pane, on the two list surfaces that shorten as they are worked through (`RemindersDialog`, `ScheduledMessagesDialog`) so they do not resize under the thumb between taps.
- **A `--scrim` token** (ink at 50% light, deeper in dark) applied below `md` only; the desktop dialog keeps `bg-black/80`.
- `DialogHeader` is left-aligned at every width — it was already `sm:text-left`, so only the sheet's own range changes.

Everything else came along for free: `ConfirmDialog`, `ForwardMessageDialog`, `ScheduleMessageDialog`, `UserStatusDialog`, `DndPauseDialog`, `KeyboardShortcutsModal`, `AddDirectMessagePeopleModal`, `NewDirectMessageModal`, `CreateChannelModal`, `InviteMemberModal`, `LeaveChannelModal`, `PendingInvitationsModal`, `ManageSessions`, `CommandDialog`, the integrations dialogs and the team pages. No call site branches on viewport.

## The two judgement calls the issue asked for

**`KeyboardShortcutsModal` stays reachable, and renders as a sheet.** The design drops its row from the user menu, not the modal itself, and that row is `UserMenuContent`'s — #777's file, where hiding it here would collide. It is also still reachable by `?` on a tablet with a hardware keyboard, which is exactly the audience it has. So: sheet now, entry-point decision to #777.

**Nested dialogs stack as sheets.** Verified with the real pair — Scheduled messages → Reschedule, both open at 390x844: two full-width sheets pinned to the bottom edge, the later one on top, each with its own handle and scrim. The reschedule sheet starts at y=209 over the list sheet at y=127.

**Not adopted deliberately:** `MessageLightbox` opts out with `mobile="dialog"`. It is already the whole screen, and a bottom sheet would crop the image it exists to show.

## Verified in the browser

Driven with the Playwright MCP against the seeded workspace, then re-shot after. 36 before + 36 after (create-channel, reminders, new-DM, invite-member, user-status, keyboard-shortcuts x 360x740, 375x667, 390x844, 430x932, 768x1024, 740x360). GitHub's CLI cannot upload images; the set is on disk under `shots772/{before,after}/` if you want to drag any in.

| Check | Evidence |
| --- | --- |
| 740x360 no longer overflows | sheet spans y 54→360 in a 360px viewport, `scrollHeight` 402 > `clientHeight` 305, `document` not scrollable |
| Width beats the call site's `sm:max-w-lg` | 740px-wide sheet at a 740px viewport |
| **Nothing changes at `md`+** | 5 of the 6 dialogs' 768x1024 screenshots are **byte-identical** before and after; the sixth (reminders) differs only in a live count and is visually identical |
| Light and dark | both shot at 390x844; the scrim token carries its own dark value |
| Select inside a sheet | the Visibility popover opens and picks correctly at 360x740 |

## Tests

- `tests/Browser/MobileSheetsTest.php` — 18 tests: sheet-vs-dialog at all seven widths across the breakpoint, internal scroll with the primary action reachable after scrolling, no control off the edge, focus trapped through 12 tabs, scrim tap, drag-to-dismiss, the 85% detail height, French at 360px, and an axe audit of an open sheet in both themes.
- `resources/js/lib/sheetDrag.test.ts` (10) and `resources/js/composables/useSheetDrag.test.ts` (8) — the gesture's arithmetic and its guards: disabled state, pointer ownership, cancellation, capture release, and reading the travel the release itself reports.
- `resources/js/components/ui/dialog/DialogContent.test.ts` (6) — which presentation the primitive picks at each width, including the `dialog` opt-out.
- Whole browser suite re-run: 131 passed.

## i18n and docs

No new user-facing copy — the grab handle is `aria-hidden` and every string already went through `$t`. Every `data-test` selector is preserved. Nothing operator-facing, so no `docs/` change.

## Found while doing this

#784 — closing any dialog drops focus to `<body>` instead of restoring it to the opener. Pre-existing and identical at every viewport; root cause (reka's `triggerElement` is null because we drive `v-model:open` rather than `DialogTrigger`) is in the issue. Left alone here; the focus test asserts the trap, which does hold.

## Review

Local CodeRabbit ran clean through the last completed pass — four findings applied (release-position travel in the drag, composable guard tests, a real hit-tested scrim tap, per-tab focus assertions, jsdom `matchMedia` restore). Further passes hit the OSS tier rate limit, so the app review covers the final commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787409402&installation_model_id=428379&pr_number=785&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F785&signature=564f949239b7dfeb0a113aa0282f818281b693d9c4fb906d0bb2e9172a6c806e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->