### PR TITLE
fix: give browser retry attempts the remaining budget instead of 1s

### DIFF
--- a/tests/Browser/Support/Execution.php
+++ b/tests/Browser/Support/Execution.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Browser;
+
+use Amp\ByteStream\ReadableResourceStream;
+use Pest\Browser\Playwright\Playwright;
+use Pest\Support\Container;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestStatus\TestStatus;
+use ReflectionClass;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function Amp\async;
+use function Amp\delay;
+
+/**
+ * Shadow of `pest-plugin-browser` v4.3.1's `Pest\Browser\Execution`, loaded
+ * from `tests/Pest.php` before the vendor autoloader can load the original.
+ *
+ * The vendor class runs every retry attempt of `waitForExpectation()` under a
+ * hardcoded 1000ms protocol budget (`Playwright::usingTimeout(1_000, ...)`).
+ * On CPU-starved runners those 1s attempts expire routinely, which (a) leaves
+ * stale `Timeout 1000ms exceeded` error responses queued on the singleton
+ * websocket — `Client::execute()` later throws them from unrelated calls
+ * without matching response ids — and (b) re-drives non-idempotent clicks
+ * whose first attempt already landed, so the overlay they opened blocks every
+ * subsequent attempt. Both flake signatures are documented in issue #786.
+ *
+ * The single behavioural change is in `waitForExpectation()`: each attempt
+ * gets the *remaining* outer budget instead of 1s, so an attempt only expires
+ * when the expectation genuinely fails. Everything else is a verbatim copy.
+ * Remove this shadow (and its `require` in `tests/Pest.php`) once the plugin
+ * fixes the protocol layer upstream; `tests/Unit/BrowserRetryBudgetTest.php`
+ * pins the shadow until then.
+ *
+ * @internal
+ */
+final class Execution
+{
+    /**
+     * Either the current context
+     */
+    private bool $waiting = false;
+
+    /**
+     * The current context instance, or null if not set.
+     */
+    private static ?Execution $instance = null;
+
+    /**
+     * Creates a new context instance.
+     */
+    public static function instance(): self
+    {
+        if (! self::$instance instanceof self) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Debugs the test execution by waiting for a key press.
+     */
+    public function debug(TestStatus $status): void
+    {
+        $this->waiting = true;
+
+        // @phpstan-ignore-next-line
+        $testName = str_replace('__pest_evaluable_', '', test()->name());
+        $message = $status->message();
+
+        // @phpstan-ignore-next-line
+        Container::getInstance()->get(OutputInterface::class)->writeln(
+            "\n  <info>Test [{$testName}] failed with the message:</info> {$message}\n"
+        );
+
+        // @phpstan-ignore-next-line
+        Container::getInstance()->get(OutputInterface::class)->writeln(
+            '  <info>Press any key to continue...</info>'
+        );
+
+        $stdin = new ReadableResourceStream(STDIN);
+
+        async(function () use ($stdin): void {
+            while ($stdin->read() !== null) {
+                $stdin->close();
+
+                delay(0.1);
+
+                break;
+            }
+        })->await();
+    }
+
+    /**
+     * Pauses the execution.
+     */
+    public function wait(int|float $seconds = 1): void
+    {
+        async(function () use ($seconds): void {
+            $this->waiting = true;
+
+            delay($seconds);
+
+            $this->waiting = false;
+        })->await();
+    }
+
+    /**
+     * Checks if the execution is paused.
+     */
+    public function isWaiting(): bool
+    {
+        return $this->waiting;
+    }
+
+    /**
+     * Ticks the execution.
+     */
+    public function tick(): void
+    {
+        delay(0);
+    }
+
+    /**
+     * Waits for a key press.
+     */
+    public function waitForKey(): void
+    {
+        $this->waiting = true;
+
+        // @phpstan-ignore-next-line
+        Container::getInstance()->get(OutputInterface::class)->writeln(
+            '  <info>Press any key to continue...</info>'
+        );
+
+        $stdin = new ReadableResourceStream(STDIN);
+
+        async(function () use ($stdin): void {
+            while ($stdin->read() !== null) {
+                $stdin->close();
+
+                delay(0.1);
+
+                break;
+            }
+        })->await();
+    }
+
+    /**
+     * Awaits for a condition to be met, retrying until the timeout is reached.
+     *
+     * Patched for #786: each attempt runs under the remaining outer budget
+     * instead of the vendor's hardcoded 1000ms, so attempts never expire on a
+     * slow runner while the expectation still has time to hold.
+     */
+    public function waitForExpectation(callable $callback): mixed
+    {
+        $timeout = Playwright::timeout();
+
+        $originalCount = Assert::getCount();
+
+        $start = microtime(true);
+        $end = $start + ($timeout / 1_000);
+
+        while (microtime(true) < $end) {
+            $remainingBudget = max(1, (int) ceil(($end - microtime(true)) * 1_000));
+
+            try {
+                return Playwright::usingTimeout($remainingBudget, $callback);
+            } catch (ExpectationFailedException) {
+                //
+            }
+
+            $this->resetAssertions($originalCount);
+
+            self::instance()->tick();
+        }
+
+        return $callback();
+    }
+
+    /**
+     * Resets the assertion count to the original value.
+     */
+    private function resetAssertions(int $originalCount): void
+    {
+        if (Assert::getCount() === $originalCount) {
+            return;
+        }
+
+        $reflector = new ReflectionClass(Assert::class);
+        $property = $reflector->getProperty('count');
+
+        // @phpstan-ignore-next-line
+        $property->setValue(Assert::class, $originalCount);
+    }
+}

--- a/tests/Browser/Support/Execution.php
+++ b/tests/Browser/Support/Execution.php
@@ -56,7 +56,7 @@ final class Execution
     public static function instance(): self
     {
         if (! self::$instance instanceof self) {
-            self::$instance = new self();
+            self::$instance = new self;
         }
 
         return self::$instance;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,6 +7,23 @@ use Tests\TestCase;
 
 /*
 |--------------------------------------------------------------------------
+| Browser Plugin Shadow (#786)
+|--------------------------------------------------------------------------
+|
+| pest-plugin-browser v4.3.1 runs each retry attempt of an awaitable browser
+| call under a hardcoded 1000ms protocol budget. On CPU-starved CI runners
+| those attempts expire routinely, poisoning the Playwright websocket with
+| stale error responses and re-driving non-idempotent clicks (issue #786).
+| This patched copy of the plugin's Execution class gives each attempt the
+| remaining outer budget instead. It must be declared before the autoloader
+| can load the vendor class, hence the require at the very top of this file.
+|
+*/
+
+require_once __DIR__.'/Browser/Support/Execution.php';
+
+/*
+|--------------------------------------------------------------------------
 | Test Case
 |--------------------------------------------------------------------------
 |

--- a/tests/Unit/BrowserRetryBudgetTest.php
+++ b/tests/Unit/BrowserRetryBudgetTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Pest\Browser\Execution;
+use Pest\Browser\Playwright\Client;
+use Pest\Browser\Playwright\Playwright;
+use PHPUnit\Framework\ExpectationFailedException;
+
+/**
+ * pest-plugin-browser v4.3.1 runs every retry attempt of
+ * `Execution::waitForExpectation()` under a hardcoded 1000ms protocol budget.
+ * On CPU-starved runners (GitHub-hosted `ubuntu-latest`) those 1s attempts
+ * expire routinely, queueing stale error responses on the singleton websocket
+ * and re-driving non-idempotent clicks — the two flake signatures of issue
+ * #786. `tests/Browser/Support/Execution.php` shadows the vendor class (it is
+ * required from `tests/Pest.php` before the autoloader can load the original)
+ * and gives each attempt the remaining outer budget instead. These tests pin
+ * the shadow so a dependency bump or a moved `require` cannot silently bring
+ * the 1s budget back.
+ */
+it('loads the patched Execution shadow instead of the vendor class', function (): void {
+    $file = new ReflectionClass(Execution::class)->getFileName();
+
+    expect($file)->toBe(dirname(__DIR__).'/Browser/Support/Execution.php');
+});
+
+it('gives a retry attempt the remaining outer budget instead of 1000ms', function (): void {
+    $previousTimeout = Playwright::timeout();
+    Playwright::setTimeout(15_000);
+
+    try {
+        $attemptBudget = Execution::instance()->waitForExpectation(
+            fn (): int => Client::instance()->timeout(),
+        );
+    } finally {
+        Playwright::setTimeout($previousTimeout);
+    }
+
+    expect($attemptBudget)->toBeGreaterThan(1_000);
+});
+
+it('still retries a failing expectation until the outer clock expires', function (): void {
+    $previousTimeout = Playwright::timeout();
+    Playwright::setTimeout(100);
+
+    $attempts = 0;
+
+    try {
+        Execution::instance()->waitForExpectation(function () use (&$attempts): void {
+            $attempts++;
+
+            throw new ExpectationFailedException('never holds');
+        });
+
+        $this->fail('The expectation should not have been met.');
+    } catch (ExpectationFailedException) {
+        // The final bare attempt rethrows once the outer clock has expired.
+    } finally {
+        Playwright::setTimeout($previousTimeout);
+    }
+
+    expect($attempts)->toBeGreaterThanOrEqual(2);
+});

--- a/tests/Unit/BrowserRetryBudgetTest.php
+++ b/tests/Unit/BrowserRetryBudgetTest.php
@@ -25,19 +25,30 @@ it('loads the patched Execution shadow instead of the vendor class', function ()
     expect($file)->toBe(dirname(__DIR__).'/Browser/Support/Execution.php');
 });
 
-it('gives a retry attempt the remaining outer budget instead of 1000ms', function (): void {
+it('gives every retry attempt the remaining outer budget instead of 1000ms', function (): void {
     $previousTimeout = Playwright::timeout();
     Playwright::setTimeout(15_000);
 
+    /** @var list<int> $attemptBudgets */
+    $attemptBudgets = [];
+
     try {
-        $attemptBudget = Execution::instance()->waitForExpectation(
-            fn (): int => Client::instance()->timeout(),
-        );
+        Execution::instance()->waitForExpectation(function () use (&$attemptBudgets): int {
+            $attemptBudgets[] = Client::instance()->timeout();
+
+            if (count($attemptBudgets) === 1) {
+                throw new ExpectationFailedException('force a retry');
+            }
+
+            return Client::instance()->timeout();
+        });
     } finally {
         Playwright::setTimeout($previousTimeout);
     }
 
-    expect($attemptBudget)->toBeGreaterThan(1_000);
+    expect($attemptBudgets)->toHaveCount(2)
+        ->and($attemptBudgets[0])->toBeGreaterThan(1_000)->toBeLessThanOrEqual(15_000)
+        ->and($attemptBudgets[1])->toBeGreaterThan(1_000)->toBeLessThanOrEqual($attemptBudgets[0]);
 });
 
 it('still retries a failing expectation until the outer clock expires', function (): void {
@@ -45,6 +56,7 @@ it('still retries a failing expectation until the outer clock expires', function
     Playwright::setTimeout(100);
 
     $attempts = 0;
+    $startedAt = hrtime(true);
 
     try {
         Execution::instance()->waitForExpectation(function () use (&$attempts): void {
@@ -60,5 +72,8 @@ it('still retries a failing expectation until the outer clock expires', function
         Playwright::setTimeout($previousTimeout);
     }
 
-    expect($attempts)->toBeGreaterThanOrEqual(2);
+    $elapsedMilliseconds = (hrtime(true) - $startedAt) / 1_000_000;
+
+    expect($attempts)->toBeGreaterThanOrEqual(2)
+        ->and($elapsedMilliseconds)->toBeGreaterThanOrEqual(100);
 });

--- a/tests/Unit/BrowserRetryBudgetTest.php
+++ b/tests/Unit/BrowserRetryBudgetTest.php
@@ -36,9 +36,7 @@ it('gives every retry attempt the remaining outer budget instead of 1000ms', fun
         Execution::instance()->waitForExpectation(function () use (&$attemptBudgets): int {
             $attemptBudgets[] = Client::instance()->timeout();
 
-            if (count($attemptBudgets) === 1) {
-                throw new ExpectationFailedException('force a retry');
-            }
+            throw_if(count($attemptBudgets) === 1, ExpectationFailedException::class, 'force a retry');
 
             return Client::instance()->timeout();
         });


### PR DESCRIPTION
Closes #786.

## What

Shadows `pest-plugin-browser` v4.3.1's `Pest\Browser\Execution` with a patched copy (`tests/Browser/Support/Execution.php`, required from the top of `tests/Pest.php` before the vendor autoloader can load the original). The single behavioural change: each retry attempt of `waitForExpectation()` runs under the **remaining outer budget** instead of the vendor's hardcoded `Playwright::usingTimeout(1_000, ...)`.

## Why

On CPU-starved GitHub-hosted runners the 1s attempts expire routinely, which arms both flake signatures from #786:

- expired `navigate()` attempts queue stale `Timeout 1000ms exceeded` error responses on the singleton Playwright websocket, and `Client::execute()` later throws them from unrelated calls without matching response ids (the bare 1000ms timeout with no screenshot, in a test that actually passed);
- non-idempotent clicks whose early attempt landed get re-driven, and the overlay they opened blocks every subsequent attempt (`Timeout 15000ms exceeded` at ~33s).

With the remaining-budget patch an attempt only expires when the expectation genuinely fails, so neither trap can arm. Genuine failures keep the same worst-case wall clock, and fast DOM-assertion retries keep their cadence (the budget only bounds protocol calls that wait). The runner stays on `ubuntu-latest` (the `CI_RUNNER` parking is deliberate, see #786/#782).

The shadow is deliberately a verbatim copy apart from that one method, and its header documents the removal condition: adopt the upstream fix once `pestphp/pest-plugin-browser` matches error responses to request ids / stops re-driving non-idempotent actions.

## How tested

- `tests/Unit/BrowserRetryBudgetTest.php` pins the shadow (a dependency bump or moved `require` fails the suite): asserts the shadow wins the autoload race, that every retry attempt gets the remaining budget (>1000ms, shrinking), and that a failing expectation still retries until the outer clock expires.
- Full browser suite with the shadow in place: 114/114 passed.
- Full backend gate green (Pint, PHPStan, Rector, 100.0% coverage) and all five frontend checks pass.

Local CodeRabbit pass applied two test-strengthening findings; the i18n finding on the shadow's debug console strings was declined (developer-facing test-runner output in a verbatim vendor copy, not user-facing app copy).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787413283&installation_model_id=428379&pr_number=787&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F787&signature=d6ca469aa2edd685b773c45b4f60b50fbddd256be6e7b8256ab139e5c376738a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->