### PR TITLE
fix: message composer hidden below the fold on mobile browsers

### DIFF
--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1297,7 +1297,7 @@ function onKeydown(event: KeyboardEvent): void {
 <template>
     <!-- The pill stays clear of both the device's home indicator and the
          on-screen keyboard: the safe-area inset is static, the keyboard inset is
-         measured live off visualViewport (the layout viewport `svh` sizes
+         measured live off visualViewport (the layout viewport `dvh` sizes
          against does not shrink when the keyboard opens). -->
     <div
         class="@container mx-3 mb-2 shrink-0 md:mx-5 md:mb-4"

--- a/resources/js/layouts/MainLayout.test.ts
+++ b/resources/js/layouts/MainLayout.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const mainLayout = readFileSync(
+    `${repoRoot}/resources/js/layouts/MainLayout.vue`,
+    'utf8',
+);
+const threadPanel = readFileSync(
+    `${repoRoot}/resources/js/components/ThreadPanel.vue`,
+    'utf8',
+);
+
+/**
+ * The mobile shell must size against the *dynamic* viewport (`dvh`), not the
+ * small viewport (`svh`).
+ *
+ * On iOS WebKit browsers whose chrome sits at the bottom (Arc, in-app webviews),
+ * an `svh`-tall shell extends behind that bar, pushing the composer — the shell's
+ * bottom row — off-screen (#790). `dvh` tracks the live visible viewport, so the
+ * shell's bottom always clears the bar. Chromium resolves `svh` and `dvh`
+ * identically, so a browser test cannot catch a regression here; this pins the
+ * CSS mechanism at the source instead.
+ */
+describe('mobile shell viewport sizing', () => {
+    it('sizes the main pane against the dynamic viewport', () => {
+        expect(mainLayout).toContain('h-[calc(100dvh-1rem)]');
+        expect(mainLayout).toContain('md:h-[calc(100dvh-1.75rem)]');
+    });
+
+    it('keeps the demo-banner offset on the dynamic viewport too', () => {
+        expect(mainLayout).toContain(
+            'h-[calc(100dvh-1rem-var(--demo-banner-height))]',
+        );
+        expect(mainLayout).toContain(
+            'md:h-[calc(100dvh-1.75rem-var(--demo-banner-height))]',
+        );
+    });
+
+    it('never sizes a full-height surface against the small viewport', () => {
+        // `svh` is the regression unit: it excludes retractable chrome but not a
+        // persistent bottom bar, so the composer hides behind it on iOS.
+        expect(mainLayout).not.toContain('100svh');
+    });
+
+    it('lets the mobile thread push inherit the shell height rather than re-deriving it', () => {
+        // The thread panel fills the (dynamic-viewport) shell via `inset-0`, so it
+        // must not pin its own viewport-unit height and drift from the shell.
+        expect(threadPanel).toContain('max-md:absolute');
+        expect(threadPanel).toContain('max-md:inset-0');
+        expect(threadPanel).not.toContain('100svh');
+        expect(threadPanel).not.toContain('100vh');
+    });
+});

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -741,7 +741,7 @@ onMounted(() => {
             :class="[
                 'p-3.5',
                 {
-                    'md:top-(--demo-banner-height) md:h-[calc(100svh-var(--demo-banner-height))]':
+                    'md:top-(--demo-banner-height) md:h-[calc(100dvh-var(--demo-banner-height))]':
                         demoMode,
                 },
             ]"
@@ -1422,8 +1422,8 @@ onMounted(() => {
                     ? 'md:order-first md:mr-0 md:ml-3.5'
                     : 'md:mr-3.5 md:ml-0',
                 demoMode
-                    ? 'h-[calc(100svh-1rem-var(--demo-banner-height))] md:h-[calc(100svh-1.75rem-var(--demo-banner-height))]'
-                    : 'h-[calc(100svh-1rem)] md:h-[calc(100svh-1.75rem)]',
+                    ? 'h-[calc(100dvh-1rem-var(--demo-banner-height))] md:h-[calc(100dvh-1.75rem-var(--demo-banner-height))]'
+                    : 'h-[calc(100dvh-1rem)] md:h-[calc(100dvh-1.75rem)]',
             ]"
         >
             <slot />

--- a/resources/js/lib/keyboardInset.ts
+++ b/resources/js/lib/keyboardInset.ts
@@ -9,7 +9,7 @@ const KEYBOARD_THRESHOLD_PX = 120;
  * The visual-viewport reading a keyboard inset is derived from.
  */
 export type ViewportReading = {
-    /** The layout viewport's height — what `100svh` and `h-svh` resolve to. */
+    /** The layout viewport's height — what `100dvh` and `h-dvh` resolve to. */
     innerHeight: number;
     /** The visual viewport's height: the part not covered by the keyboard. */
     height: number;
@@ -20,7 +20,7 @@ export type ViewportReading = {
 /**
  * How many pixels of the layout viewport the on-screen keyboard covers.
  *
- * The layout viewport (what `svh` sizes against) does not shrink when the
+ * The layout viewport (what `dvh` sizes against) does not shrink when the
  * keyboard opens, so a bottom-anchored composer ends up behind it. The visual
  * viewport does shrink, and the difference — less whatever the browser scrolled
  * the page by to compensate — is the padding that keeps the composer above the


### PR DESCRIPTION
Closes #790.

## What

The one-pane mobile shell (#781) sized its main card with `100svh`. On iOS WebKit browsers whose chrome sits at the **bottom** (Arc, in-app webviews), an `svh`-tall shell extends *behind* that bar, pushing the composer — the shell's bottom row — off-screen, so a message can't be sent. Android Chrome and iOS Chrome (top URL bar) are unaffected, which matches the field reports.

## Why `dvh`

`svh` = the *small* viewport: it discounts retractable chrome but not a persistent bottom bar. `dvh` = the *dynamic* viewport: it tracks the live visible area, so the shell's bottom always clears the bar **and** there's no gap when the chrome retracts on scroll.

## How

- `MainLayout` main card: `100svh` → `100dvh` (mobile + `md:`, incl. the demo-banner offset).
- The mobile thread push (#789) fills the shell via `inset-0`, so it inherits the dynamic-viewport height for free; the bottom sheets (#785) already use `dvh`.
- `keyboardInset` reads `window.innerHeight` (the layout viewport, unchanged by `svh`/`dvh`), so the on-screen-keyboard handling is untouched — only its doc comments were corrected.

## Testing

- **New** `resources/js/layouts/MainLayout.test.ts` — pins the shell to `dvh` and forbids `svh` on the full-height surfaces. Chromium resolves `svh`/`dvh` identically, so a browser test can't catch this regression (per the issue's acceptance criteria); the source test pins the mechanism instead.
- Full frontend gate green: `lint:check`, `format:check`, `types:check`, `test:js` (1092 passing), `build`.
- ⚠️ Real-device Arc verification pending on staging — Chromium/Playwright can't reproduce iOS WebKit's bottom-bar behaviour.

## i18n / docs

None — CSS-unit change only, no user-facing copy, no operator-facing config.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787427851&installation_model_id=428379&pr_number=791&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F791&signature=09daf0aedddc16dcbd4704fb4daaca1c650a122aa7e604be17e2662d27a55ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->