### PR TITLE
feat: render the quick switcher as a full-screen overlay below md

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -566,6 +566,7 @@
   "Read receipts and typing hints you can share — or switch off.": "Des accusés de lecture et des indicateurs de saisie que vous pouvez partager — ou désactiver.",
   "Ready to download": "Prêt à télécharger",
   "Recent activity": "Activité récente",
+  "Recent shows before you type · results ranked by activity": "Les récents s'affichent avant la saisie · résultats classés par activité",
   "Reconnected — 1 queued message sent, you're caught up.": "Reconnecté — 1 message en attente envoyé, vous êtes à jour.",
   "Reconnected — :count queued messages sent, you're caught up.": "Reconnecté — :count messages en attente envoyés, vous êtes à jour.",
   "Reconnecting": "Reconnexion",

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -37,6 +37,8 @@ import {
 } from '@/components/ui/tooltip';
 import type { ConnectionPill } from '@/composables/useConnectionState';
 import { getInitials } from '@/composables/useInitials';
+import { useIsMobile } from '@/composables/useIsMobile';
+import { useQuickSwitcher } from '@/composables/useQuickSwitcher';
 import { memberAvatarStack } from '@/lib/memberAvatars';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
 import { dmParticipantPresence, presenceLabelKey } from '@/lib/presence';
@@ -123,6 +125,14 @@ const mastheadAvatars = computed(() =>
 );
 
 const page = usePage();
+
+/**
+ * Below the breakpoint the search icon is the jump-to overlay's entry point
+ * (m5): a phone has no ⌘K, and the overlay leads on to the search page via its
+ * message results. From `md` up it stays a plain link to the search page.
+ */
+const isMobile = useIsMobile();
+const { open: openQuickSwitcher } = useQuickSwitcher();
 
 /** The other participant of a 1:1 DM, whose avatar the masthead shows. */
 const dmParticipant = computed(() => props.channel.dmParticipants?.[0] ?? null);
@@ -492,7 +502,20 @@ const hasActivityReadout = computed(
                 <TooltipContent>{{ $t('Pinned messages') }}</TooltipContent>
             </Tooltip>
 
+            <Button
+                v-if="isMobile"
+                variant="ghost"
+                size="icon"
+                type="button"
+                data-test="masthead-search"
+                :aria-label="$t('Search messages')"
+                class="size-9 rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                @click="openQuickSwitcher"
+            >
+                <Search class="size-4" />
+            </Button>
             <Link
+                v-else
                 :href="searchMessages(props.teamSlug).url"
                 data-test="masthead-search"
                 :aria-label="$t('Search messages')"

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -294,6 +294,7 @@ function openReminders(): void {
                     />
                 </div>
                 <CommandList
+                    :aria-label="$t('Quick switcher')"
                     class="max-md:max-h-none max-md:flex-1 max-md:p-1.5"
                 >
                     <CommandGroup
@@ -303,7 +304,7 @@ function openReminders(): void {
                         <CommandItem
                             value="action:reminders"
                             data-test="quick-switcher-reminders"
-                            class="group h-9.5 gap-2 rounded-lg px-2.5 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 max-md:text-[15px]"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 max-md:text-[15px] md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground"
                             @select="openReminders"
                         >
                             <AlarmClock
@@ -327,7 +328,7 @@ function openReminders(): void {
                             :key="channel.id"
                             :value="`channel:${channel.id}`"
                             data-test="quick-switcher-channel"
-                            class="group h-9.5 gap-2 rounded-lg px-2.5 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground"
                             @select="selectChannel(channel)"
                         >
                             <span
@@ -373,7 +374,7 @@ function openReminders(): void {
                             :key="person.id"
                             :value="`person:${person.id}`"
                             data-test="quick-switcher-person"
-                            class="group h-9.5 gap-2 rounded-lg px-2.5 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground"
                             @select="selectPerson(person.id)"
                         >
                             <span

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -303,7 +303,7 @@ function openReminders(): void {
                         <CommandItem
                             value="action:reminders"
                             data-test="quick-switcher-reminders"
-                            class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 max-md:text-[15px]"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 max-md:text-[15px]"
                             @select="openReminders"
                         >
                             <AlarmClock
@@ -327,7 +327,7 @@ function openReminders(): void {
                             :key="channel.id"
                             :value="`channel:${channel.id}`"
                             data-test="quick-switcher-channel"
-                            class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3"
                             @select="selectChannel(channel)"
                         >
                             <span
@@ -373,7 +373,7 @@ function openReminders(): void {
                             :key="person.id"
                             :value="`person:${person.id}`"
                             data-test="quick-switcher-person"
-                            class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3"
                             @select="selectPerson(person.id)"
                         >
                             <span
@@ -395,7 +395,7 @@ function openReminders(): void {
                             </span>
                             <span
                                 v-else
-                                class="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none group-data-[highlighted]:bg-primary-foreground/20 group-data-[highlighted]:text-primary-foreground"
+                                class="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none md:group-data-[highlighted]:bg-primary-foreground/20 md:group-data-[highlighted]:text-primary-foreground"
                                 aria-hidden="true"
                                 >{{ getInitials(person.name) }}</span
                             >

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -8,16 +8,30 @@ import {
     index as searchPage,
     suggest as suggestMessages,
 } from '@/actions/App/Http/Controllers/Channels/SearchController';
+import PresenceDot from '@/components/PresenceDot.vue';
 import SafeHtml from '@/components/SafeHtml.vue';
+import { Button } from '@/components/ui/button';
 import {
-    CommandDialog,
+    Command,
     CommandGroup,
     CommandItem,
     CommandList,
 } from '@/components/ui/command';
-import { rankChannels } from '@/composables/quickSwitcher';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    matchRange,
+    rankChannels,
+    rankChannelsByActivity,
+} from '@/composables/quickSwitcher';
 import { useCustomEmojis } from '@/composables/useCustomEmojis';
 import { getInitials } from '@/composables/useInitials';
+import { useIsMobile } from '@/composables/useIsMobile';
 import { useMessageSearch } from '@/composables/useMessageSearch';
 import { useOpenDirectMessage } from '@/composables/useOpenDirectMessage';
 import { useTranslations } from '@/composables/useTranslations';
@@ -25,6 +39,8 @@ import { useUserGroups } from '@/composables/useUserGroups';
 import { formatDateTime } from '@/lib/datetime';
 import { renderMessageBody } from '@/lib/messageBody';
 import { rankPeople } from '@/lib/peopleDirectory';
+import { presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
 import { filtersToParams, parseSearchQuery } from '@/lib/searchTokens';
 import type { SearchParams } from '@/lib/searchTokens';
 import type { MessageSearchResult } from '@/types';
@@ -36,6 +52,13 @@ const props = defineProps<{
     members: PersonRef[];
     currentUserId: string;
     teamSlug: string;
+    /**
+     * How each team member reads on the presence roster, driving the mobile
+     * overlay's avatar dots and presence words.
+     */
+    presenceFor: (userId: string) => RenderedPresence;
+    /** Whether each member is in do-not-disturb, driving the crescent badge. */
+    isDndFor?: (userId: string) => boolean;
 }>();
 
 const open = defineModel<boolean>('open', { default: false });
@@ -70,9 +93,43 @@ const parsedFilters = computed(() =>
 
 const searchText = computed(() => parsedFilters.value.text);
 
+/**
+ * Below the breakpoint the overlay is entered without a keyboard and often
+ * without a destination in mind, so recency does the ranking work: an empty
+ * query reads as "recents" and score ties fall to the busiest channel. The
+ * desktop palette keeps its alphabetical ordering untouched.
+ */
+const isMobile = useIsMobile();
+
 const channelResults = computed(() =>
-    rankChannels(props.channels, query.value),
+    isMobile.value
+        ? rankChannelsByActivity(props.channels, query.value)
+        : rankChannels(props.channels, query.value),
 );
+
+/** A run of a result's name, marked when it is the part the query matched. */
+type NameSegment = { text: string; highlighted: boolean };
+
+/**
+ * Split a name around the typed query's contiguous match so the mobile rows
+ * can brighten it; a single unhighlighted run when nothing contiguous matches.
+ */
+function nameSegments(name: string): NameSegment[] {
+    const range = matchRange(name, query.value);
+
+    if (range === null) {
+        return [{ text: name, highlighted: false }];
+    }
+
+    return [
+        { text: name.slice(0, range.start), highlighted: false },
+        {
+            text: name.slice(range.start, range.start + range.length),
+            highlighted: true,
+        },
+        { text: name.slice(range.start + range.length), highlighted: false },
+    ].filter((segment) => segment.text !== '');
+}
 
 // Team members ranked next to channels; choosing one opens/creates their DM.
 const { t } = useTranslations();
@@ -175,178 +232,326 @@ function openReminders(): void {
 </script>
 
 <template>
-    <CommandDialog
-        v-model:open="open"
-        :title="$t('Quick switcher')"
-        :description="$t('Jump to a channel or search messages')"
-    >
-        <div class="flex h-12 items-center gap-2.5 border-b px-4">
-            <Search class="size-4 shrink-0 text-muted-foreground/70" />
-            <ListboxFilter
-                v-model="query"
-                auto-focus
-                :placeholder="$t('Jump to a channel or search messages…')"
-                data-test="quick-switcher-input"
-                class="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-            />
-        </div>
-        <CommandList>
-            <CommandGroup v-if="trimmedQuery === ''" :heading="$t('Actions')">
-                <CommandItem
-                    value="action:reminders"
-                    data-test="quick-switcher-reminders"
-                    class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground"
-                    @select="openReminders"
-                >
-                    <AlarmClock
-                        class="size-4 shrink-0 text-muted-foreground/70 group-data-[highlighted]:text-brass"
-                    />
-                    <span class="truncate">{{ $t('Reminders') }}</span>
-                    <span
-                        class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100"
-                        aria-hidden="true"
-                        >↵</span
-                    >
-                </CommandItem>
-            </CommandGroup>
-
-            <CommandGroup
-                v-if="channelResults.length > 0"
-                :heading="$t('Channels')"
-            >
-                <CommandItem
-                    v-for="channel in channelResults"
-                    :key="channel.id"
-                    :value="`channel:${channel.id}`"
-                    data-test="quick-switcher-channel"
-                    class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground"
-                    @select="selectChannel(channel)"
-                >
-                    <span
-                        class="shrink-0 font-semibold text-muted-foreground group-data-[highlighted]:text-brass"
-                        aria-hidden="true"
-                        >#</span
-                    >
-                    <span class="truncate">{{ channel.name }}</span>
-                    <span
-                        class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100"
-                        aria-hidden="true"
-                        >↵</span
-                    >
-                </CommandItem>
-            </CommandGroup>
-
-            <CommandGroup
-                v-if="peopleResults.length > 0"
-                :heading="$t('People')"
-            >
-                <CommandItem
-                    v-for="person in peopleResults"
-                    :key="person.id"
-                    :value="`person:${person.id}`"
-                    data-test="quick-switcher-person"
-                    class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground"
-                    @select="selectPerson(person.id)"
-                >
-                    <span
-                        class="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none group-data-[highlighted]:bg-primary-foreground/20 group-data-[highlighted]:text-primary-foreground"
-                        aria-hidden="true"
-                        >{{ getInitials(person.name) }}</span
-                    >
-                    <span class="truncate">{{
-                        person.isSelf ? t('You') : person.name
-                    }}</span>
-                    <span
-                        class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100"
-                        aria-hidden="true"
-                        >↵</span
-                    >
-                </CommandItem>
-            </CommandGroup>
-
-            <CommandGroup v-if="searchText !== ''" :heading="$t('Messages')">
-                <p
-                    v-if="isSearchingMessages && messageResults.length === 0"
-                    class="px-2 py-2 text-xs text-muted-foreground"
-                >
-                    {{ $t('Searching…') }}
-                </p>
-                <p
-                    v-else-if="messageResults.length === 0"
-                    data-test="quick-switcher-no-messages"
-                    class="px-2 py-2 text-xs text-muted-foreground"
-                >
-                    {{
-                        $t('No messages match “:query”.', {
-                            query: searchText,
-                        })
-                    }}
-                </p>
-
-                <CommandItem
-                    v-for="result in messageResults"
-                    :key="result.message.id"
-                    :value="`message:${result.message.id}`"
-                    data-test="quick-switcher-message"
-                    class="items-start gap-2.5"
-                    @select="selectMessage(result)"
+    <Dialog v-model:open="open">
+        <DialogContent
+            class="overflow-hidden p-0"
+            mobile="fullscreen"
+            :show-close-button="!isMobile"
+        >
+            <DialogHeader class="sr-only">
+                <DialogTitle>{{ $t('Quick switcher') }}</DialogTitle>
+                <DialogDescription>{{
+                    $t('Jump to a channel or search messages')
+                }}</DialogDescription>
+            </DialogHeader>
+            <Command>
+                <!-- Below the breakpoint the input is a pill with a Cancel
+                     affordance beside it (m5); the desktop palette keeps its
+                     plain underlined row. -->
+                <div
+                    v-if="isMobile"
+                    class="flex shrink-0 items-center gap-2.5 border-b px-3.5 pt-3.5 pb-3"
                 >
                     <div
-                        class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-semibold text-primary select-none"
-                        aria-hidden="true"
+                        class="flex h-10.5 min-w-0 flex-1 items-center gap-2 rounded-full border border-input bg-card px-3.5"
                     >
-                        {{ getInitials(result.message.user.name) }}
+                        <Search
+                            class="size-3.5 shrink-0 text-muted-foreground/70"
+                        />
+                        <ListboxFilter
+                            v-model="query"
+                            auto-focus
+                            :placeholder="
+                                $t('Jump to a channel or search messages…')
+                            "
+                            data-test="quick-switcher-input"
+                            class="h-full w-full min-w-0 bg-transparent text-[15px] outline-hidden placeholder:text-muted-foreground"
+                        />
                     </div>
-                    <div class="min-w-0 flex-1">
-                        <div class="flex items-baseline gap-1.5 text-xs">
-                            <span class="font-semibold text-foreground">{{
-                                result.message.user.name
-                            }}</span>
-                            <span class="text-muted-foreground"
-                                ><span class="text-muted-foreground">#</span
-                                >{{ result.channelName }}</span
-                            >
+                    <Button
+                        variant="ghost"
+                        type="button"
+                        data-test="quick-switcher-cancel"
+                        class="h-10.5 shrink-0 px-1.5 text-sm font-semibold text-muted-foreground"
+                        @click="open = false"
+                    >
+                        {{ $t('Cancel') }}
+                    </Button>
+                </div>
+                <div
+                    v-else
+                    class="flex h-12 items-center gap-2.5 border-b px-4"
+                >
+                    <Search class="size-4 shrink-0 text-muted-foreground/70" />
+                    <ListboxFilter
+                        v-model="query"
+                        auto-focus
+                        :placeholder="
+                            $t('Jump to a channel or search messages…')
+                        "
+                        data-test="quick-switcher-input"
+                        class="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                </div>
+                <CommandList
+                    class="max-md:max-h-none max-md:flex-1 max-md:p-1.5"
+                >
+                    <CommandGroup
+                        v-if="trimmedQuery === ''"
+                        :heading="$t('Actions')"
+                    >
+                        <CommandItem
+                            value="action:reminders"
+                            data-test="quick-switcher-reminders"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 max-md:text-[15px]"
+                            @select="openReminders"
+                        >
+                            <AlarmClock
+                                class="size-4 shrink-0 text-muted-foreground/70 group-data-[highlighted]:text-brass"
+                            />
+                            <span class="truncate">{{ $t('Reminders') }}</span>
                             <span
-                                class="ml-auto shrink-0 text-[10px] text-muted-foreground"
+                                class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100 max-md:hidden"
+                                aria-hidden="true"
+                                >↵</span
+                            >
+                        </CommandItem>
+                    </CommandGroup>
+
+                    <CommandGroup
+                        v-if="channelResults.length > 0"
+                        :heading="$t('Channels')"
+                    >
+                        <CommandItem
+                            v-for="channel in channelResults"
+                            :key="channel.id"
+                            :value="`channel:${channel.id}`"
+                            data-test="quick-switcher-channel"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3"
+                            @select="selectChannel(channel)"
+                        >
+                            <span
+                                class="shrink-0 font-semibold text-muted-foreground group-data-[highlighted]:text-brass max-md:font-serif max-md:text-[17px] max-md:italic"
+                                aria-hidden="true"
+                                >#</span
+                            >
+                            <span class="truncate max-md:text-[15px]">
+                                <template v-if="isMobile">
+                                    <template
+                                        v-for="(segment, index) in nameSegments(
+                                            channel.name,
+                                        )"
+                                        :key="index"
+                                    >
+                                        <span
+                                            v-if="segment.highlighted"
+                                            data-test="quick-switcher-match"
+                                            class="rounded-[3px] bg-brass/25"
+                                            >{{ segment.text }}</span
+                                        >
+                                        <template v-else>{{
+                                            segment.text
+                                        }}</template>
+                                    </template>
+                                </template>
+                                <template v-else>{{ channel.name }}</template>
+                            </span>
+                            <span
+                                class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100 max-md:hidden"
+                                aria-hidden="true"
+                                >↵</span
+                            >
+                        </CommandItem>
+                    </CommandGroup>
+
+                    <CommandGroup
+                        v-if="peopleResults.length > 0"
+                        :heading="$t('People')"
+                    >
+                        <CommandItem
+                            v-for="person in peopleResults"
+                            :key="person.id"
+                            :value="`person:${person.id}`"
+                            data-test="quick-switcher-person"
+                            class="group h-9.5 gap-2 rounded-lg px-2.5 data-[highlighted]:bg-primary data-[highlighted]:text-primary-foreground max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3"
+                            @select="selectPerson(person.id)"
+                        >
+                            <span
+                                v-if="isMobile"
+                                class="relative size-7 shrink-0"
+                                aria-hidden="true"
+                            >
+                                <span
+                                    class="flex size-7 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none"
+                                    >{{ getInitials(person.name) }}</span
+                                >
+                                <PresenceDot
+                                    :presence="presenceFor(person.id)"
+                                    :is-dnd="isDndFor?.(person.id) ?? false"
+                                    surface-class="bg-sidebar"
+                                    size="28"
+                                    class="ring-sidebar"
+                                />
+                            </span>
+                            <span
+                                v-else
+                                class="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none group-data-[highlighted]:bg-primary-foreground/20 group-data-[highlighted]:text-primary-foreground"
+                                aria-hidden="true"
+                                >{{ getInitials(person.name) }}</span
+                            >
+                            <span class="truncate max-md:text-[15px]">
+                                <template v-if="isMobile">
+                                    <template
+                                        v-for="(segment, index) in nameSegments(
+                                            person.isSelf
+                                                ? t('You')
+                                                : person.name,
+                                        )"
+                                        :key="index"
+                                    >
+                                        <span
+                                            v-if="segment.highlighted"
+                                            data-test="quick-switcher-match"
+                                            class="rounded-[3px] bg-brass/25"
+                                            >{{ segment.text }}</span
+                                        >
+                                        <template v-else>{{
+                                            segment.text
+                                        }}</template>
+                                    </template>
+                                </template>
+                                <template v-else>{{
+                                    person.isSelf ? t('You') : person.name
+                                }}</template>
+                            </span>
+                            <span
+                                v-if="isMobile"
+                                class="ml-auto shrink-0 text-[11.5px] text-muted-foreground"
                                 >{{
-                                    formatTimestamp(result.message.createdAt)
+                                    $t(presenceLabelKey(presenceFor(person.id)))
                                 }}</span
                             >
-                        </div>
-                        <p
-                            class="mt-0.5 line-clamp-1 text-[13px] text-foreground/80"
-                        >
-                            <SafeHtml
-                                :html="
-                                    renderMessageBody(
-                                        result.message.body,
-                                        result.message.mentions,
-                                        customEmojis,
-                                        userGroups,
-                                    )
-                                "
-                                variant="messageBody"
-                            />
-                        </p>
-                    </div>
-                </CommandItem>
+                            <span
+                                v-else
+                                class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100"
+                                aria-hidden="true"
+                                >↵</span
+                            >
+                        </CommandItem>
+                    </CommandGroup>
 
-                <CommandItem
-                    value="see-all-results"
-                    data-test="quick-switcher-see-all"
-                    class="mt-1 gap-2 rounded-lg border-t border-border px-2.5 font-serif text-[13px] text-muted-foreground italic data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
-                    @select="seeAllResults"
-                >
-                    <span class="truncate">{{
-                        $t('See all results for “:query”', {
-                            query: searchText,
-                        })
-                    }}</span>
-                    <span class="ml-auto shrink-0 not-italic" aria-hidden="true"
-                        >&rarr;</span
+                    <CommandGroup
+                        v-if="searchText !== ''"
+                        :heading="$t('Messages')"
                     >
-                </CommandItem>
-            </CommandGroup>
-        </CommandList>
-    </CommandDialog>
+                        <p
+                            v-if="
+                                isSearchingMessages &&
+                                messageResults.length === 0
+                            "
+                            class="px-2 py-2 text-xs text-muted-foreground"
+                        >
+                            {{ $t('Searching…') }}
+                        </p>
+                        <p
+                            v-else-if="messageResults.length === 0"
+                            data-test="quick-switcher-no-messages"
+                            class="px-2 py-2 text-xs text-muted-foreground"
+                        >
+                            {{
+                                $t('No messages match “:query”.', {
+                                    query: searchText,
+                                })
+                            }}
+                        </p>
+
+                        <CommandItem
+                            v-for="result in messageResults"
+                            :key="result.message.id"
+                            :value="`message:${result.message.id}`"
+                            data-test="quick-switcher-message"
+                            class="items-start gap-2.5 max-md:min-h-11.5 max-md:rounded-[11px] max-md:px-3"
+                            @select="selectMessage(result)"
+                        >
+                            <div
+                                class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-semibold text-primary select-none"
+                                aria-hidden="true"
+                            >
+                                {{ getInitials(result.message.user.name) }}
+                            </div>
+                            <div class="min-w-0 flex-1">
+                                <div
+                                    class="flex items-baseline gap-1.5 text-xs"
+                                >
+                                    <span
+                                        class="font-semibold text-foreground"
+                                        >{{ result.message.user.name }}</span
+                                    >
+                                    <span class="text-muted-foreground"
+                                        ><span class="text-muted-foreground"
+                                            >#</span
+                                        >{{ result.channelName }}</span
+                                    >
+                                    <span
+                                        class="ml-auto shrink-0 text-[10px] text-muted-foreground"
+                                        >{{
+                                            formatTimestamp(
+                                                result.message.createdAt,
+                                            )
+                                        }}</span
+                                    >
+                                </div>
+                                <p
+                                    class="mt-0.5 line-clamp-1 text-[13px] text-foreground/80"
+                                >
+                                    <SafeHtml
+                                        :html="
+                                            renderMessageBody(
+                                                result.message.body,
+                                                result.message.mentions,
+                                                customEmojis,
+                                                userGroups,
+                                            )
+                                        "
+                                        variant="messageBody"
+                                    />
+                                </p>
+                            </div>
+                        </CommandItem>
+
+                        <CommandItem
+                            value="see-all-results"
+                            data-test="quick-switcher-see-all"
+                            class="mt-1 gap-2 rounded-lg border-t border-border px-2.5 font-serif text-[13px] text-muted-foreground italic data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground max-md:min-h-11.5 max-md:rounded-[11px] max-md:px-3"
+                            @select="seeAllResults"
+                        >
+                            <span class="truncate">{{
+                                $t('See all results for “:query”', {
+                                    query: searchText,
+                                })
+                            }}</span>
+                            <span
+                                class="ml-auto shrink-0 not-italic"
+                                aria-hidden="true"
+                                >&rarr;</span
+                            >
+                        </CommandItem>
+                    </CommandGroup>
+                </CommandList>
+                <!-- The design's standing explanation of the empty-query list:
+                     it doubles as the overlay's ranking hint, so it stays put
+                     rather than living inside the scrolling results. -->
+                <p
+                    v-if="isMobile"
+                    class="shrink-0 px-4 pt-2.5 pb-3 text-center text-[11.5px] text-muted-foreground"
+                >
+                    {{
+                        $t(
+                            'Recent shows before you type · results ranked by activity',
+                        )
+                    }}
+                </p>
+            </Command>
+        </DialogContent>
+    </Dialog>
 </template>

--- a/resources/js/components/ui/dialog/DialogContent.test.ts
+++ b/resources/js/components/ui/dialog/DialogContent.test.ts
@@ -34,7 +34,9 @@ function standAt(width: number): void {
     }) as typeof window.matchMedia;
 }
 
-async function open(mobile?: 'sheet' | 'detail' | 'dialog'): Promise<HTMLElement> {
+async function open(
+    mobile?: 'sheet' | 'detail' | 'dialog' | 'fullscreen',
+): Promise<HTMLElement> {
     app = createApp(
         defineComponent({
             setup: () => () =>
@@ -104,6 +106,21 @@ describe('below the md breakpoint', () => {
         expect((await open('detail')).style.height).toBe('calc(85dvh - 0px)');
     });
 
+    it('fills the screen edge-to-edge for a fullscreen overlay', async () => {
+        const content = await open('fullscreen');
+
+        expect(content.className).toContain('inset-0');
+        // No sheet chrome: an overlay that is the screen has nothing to round
+        // off or drag away by.
+        expect(content.className).not.toContain('rounded-t-[20px]');
+        expect(
+            content.querySelector('[data-test="sheet-grab-handle"]'),
+        ).toBeNull();
+        // The bottom tracks the on-screen keyboard so the list's end stays
+        // reachable while typing (0 with no keyboard up).
+        expect(content.style.bottom).toBe('0px');
+    });
+
     it('leaves an opted-out dialog centred, with no handle', async () => {
         const content = await open('dialog');
 
@@ -131,5 +148,12 @@ describe('from the md breakpoint up', () => {
         expect(
             content.querySelector('[data-test="sheet-grab-handle"]'),
         ).toBeNull();
+    });
+
+    it('keeps a fullscreen-below-md dialog centred from md up', async () => {
+        const content = await open('fullscreen');
+
+        expect(content.className).toContain('translate-x-[-50%]');
+        expect(content.className).not.toContain('inset-0');
     });
 });

--- a/resources/js/components/ui/dialog/DialogContent.test.ts
+++ b/resources/js/components/ui/dialog/DialogContent.test.ts
@@ -119,6 +119,10 @@ describe('below the md breakpoint', () => {
         // The bottom tracks the on-screen keyboard so the list's end stays
         // reachable while typing (0 with no keyboard up).
         expect(content.style.bottom).toBe('0px');
+        // Beats a call-site width like the harness's `sm:max-w-md`, which
+        // opens at 640px — below the breakpoint, where it would otherwise
+        // shrink the overlay on a landscape phone.
+        expect(content.style.maxWidth).toBe('none');
     });
 
     it('leaves an opted-out dialog centred, with no handle', async () => {

--- a/resources/js/components/ui/dialog/DialogContent.vue
+++ b/resources/js/components/ui/dialog/DialogContent.vue
@@ -27,8 +27,10 @@ import DialogOverlay from "./DialogOverlay.vue"
  *   for a desktop right-hand pane (the epic's rules table).
  * - `dialog` — stay a centred dialog. For a surface that is already full-bleed,
  *   such as the image lightbox.
+ * - `fullscreen` — the overlay is the screen: edge to edge, no sheet chrome.
+ *   For the jump-to switcher, whose list deserves the whole viewport.
  */
-type MobilePresentation = "sheet" | "detail" | "dialog"
+type MobilePresentation = "sheet" | "detail" | "dialog" | "fullscreen"
 
 /**
  * The height a sheet is allowed: tall enough to be worth opening, short enough
@@ -66,14 +68,26 @@ const keyboardInset = useKeyboardInset()
 const rootContext = injectDialogRootContext()
 
 /** Whether this dialog is presenting as a bottom sheet at the current width. */
-const asSheet = computed(() => isMobile.value && props.mobile !== "dialog")
+const asSheet = computed(() =>
+  isMobile.value && props.mobile !== "dialog" && props.mobile !== "fullscreen")
+
+/** Whether this dialog is presenting as a full-screen overlay at the current width. */
+const asFullscreen = computed(() => isMobile.value && props.mobile === "fullscreen")
 
 const drag = useSheetDrag({
   enabled: asSheet,
   onDismiss: () => rootContext.onOpenChange(false),
 })
 
-const contentClass = computed(() => asSheet.value
+const contentClass = computed(() => {
+  if (asFullscreen.value) {
+    return cn(
+      "bg-sidebar data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 flex w-full max-w-none flex-col overflow-hidden rounded-none border-0 p-0 duration-200",
+      props.class,
+    )
+  }
+
+  return asSheet.value
   ? cn(
       "bg-sidebar data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom fixed inset-x-0 bottom-0 z-50 flex w-full flex-col gap-4 overflow-y-auto rounded-t-[20px] border-t p-6 shadow-[0_-10px_32px_rgba(29,26,21,0.22)] transition-transform duration-200",
       props.class,
@@ -84,7 +98,8 @@ const contentClass = computed(() => asSheet.value
   : cn(
       "bg-sidebar data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border p-6 shadow-[0_16px_40px_rgba(29,26,21,0.14)] duration-200 sm:max-w-lg",
       props.class,
-    ))
+    )
+})
 
 /**
  * What classes cannot say: a sheet has to beat whatever width the call site set
@@ -92,6 +107,12 @@ const contentClass = computed(() => asSheet.value
  * only the visual viewport knows the height of.
  */
 const contentStyle = computed<CSSProperties | undefined>(() => {
+  if (asFullscreen.value) {
+    // `inset-0` anchors to the layout viewport, which the on-screen keyboard
+    // does not shrink — tracking it keeps the list's end reachable while typing.
+    return { bottom: `${keyboardInset.value}px` }
+  }
+
   if (!asSheet.value) {
     return undefined
   }

--- a/resources/js/components/ui/dialog/DialogContent.vue
+++ b/resources/js/components/ui/dialog/DialogContent.vue
@@ -110,7 +110,9 @@ const contentStyle = computed<CSSProperties | undefined>(() => {
   if (asFullscreen.value) {
     // `inset-0` anchors to the layout viewport, which the on-screen keyboard
     // does not shrink — tracking it keeps the list's end reachable while typing.
-    return { bottom: `${keyboardInset.value}px` }
+    // Like the sheet, fullscreen has to beat any width the call site set for
+    // its desktop dialog (`sm:` opens at 640px, below the breakpoint).
+    return { bottom: `${keyboardInset.value}px`, maxWidth: "none" }
   }
 
   if (!asSheet.value) {

--- a/resources/js/composables/quickSwitcher.test.ts
+++ b/resources/js/composables/quickSwitcher.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { rankChannels, scoreChannelName } from '@/composables/quickSwitcher';
+import {
+    matchRange,
+    rankChannels,
+    rankChannelsByActivity,
+    scoreChannelName,
+} from '@/composables/quickSwitcher';
 
 describe('scoreChannelName', () => {
     it('scores an empty query as a neutral match for every name', () => {
@@ -120,5 +125,113 @@ describe('rankChannels', () => {
         );
 
         expect(result.map((c) => c.name)).toEqual(['general']);
+    });
+});
+
+describe('rankChannelsByActivity', () => {
+    const channel = (name: string, lastActivityAt: string | null) => ({
+        name,
+        lastActivityAt,
+    });
+
+    it('returns every channel most-recently-active first for an empty query', () => {
+        const result = rankChannelsByActivity(
+            [
+                channel('announce', '2026-07-20T10:00:00Z'),
+                channel('random', '2026-07-22T10:00:00Z'),
+                channel('general', '2026-07-21T10:00:00Z'),
+            ],
+            '',
+        );
+
+        expect(result.map((c) => c.name)).toEqual([
+            'random',
+            'general',
+            'announce',
+        ]);
+    });
+
+    it('sorts channels without any activity after dated ones, alphabetically', () => {
+        const result = rankChannelsByActivity(
+            [
+                channel('zebra', null),
+                channel('apple', null),
+                channel('general', '2026-07-01T10:00:00Z'),
+            ],
+            '',
+        );
+
+        expect(result.map((c) => c.name)).toEqual([
+            'general',
+            'apple',
+            'zebra',
+        ]);
+    });
+
+    it('ranks a better name match above a more recently active one', () => {
+        const result = rankChannelsByActivity(
+            [
+                channel('regeneration', '2026-07-22T10:00:00Z'),
+                channel('general', '2026-07-01T10:00:00Z'),
+            ],
+            'gen',
+        );
+
+        expect(result.map((c) => c.name)).toEqual(['general', 'regeneration']);
+    });
+
+    it('breaks score ties by recency instead of alphabetically', () => {
+        const result = rankChannelsByActivity(
+            [
+                channel('general-chat', '2026-07-01T10:00:00Z'),
+                channel('general-docs', '2026-07-22T10:00:00Z'),
+            ],
+            'general-',
+        );
+
+        expect(result.map((c) => c.name)).toEqual([
+            'general-docs',
+            'general-chat',
+        ]);
+    });
+
+    it('filters out non-matches', () => {
+        const result = rankChannelsByActivity(
+            [
+                channel('general', null),
+                channel('marketing', '2026-07-22T10:00:00Z'),
+            ],
+            'gen',
+        );
+
+        expect(result.map((c) => c.name)).toEqual(['general']);
+    });
+});
+
+describe('matchRange', () => {
+    it('finds the first case-insensitive occurrence of the query', () => {
+        expect(matchRange('Priya Desai', 'des')).toEqual({
+            start: 6,
+            length: 3,
+        });
+    });
+
+    it('matches at the start of the name', () => {
+        expect(matchRange('design', 'des')).toEqual({ start: 0, length: 3 });
+    });
+
+    it('returns null for an empty query', () => {
+        expect(matchRange('design', '')).toBeNull();
+    });
+
+    it('returns null when the query is only a subsequence, not a substring', () => {
+        expect(matchRange('gardening', 'gen')).toBeNull();
+    });
+
+    it('ignores a leading # and surrounding whitespace, like the ranking does', () => {
+        expect(matchRange('design', ' #des ')).toEqual({
+            start: 0,
+            length: 3,
+        });
     });
 });

--- a/resources/js/composables/quickSwitcher.ts
+++ b/resources/js/composables/quickSwitcher.ts
@@ -7,6 +7,12 @@ import type { Channel } from '@/types/channels';
  */
 export type RankableChannel = Pick<Channel, 'name'>;
 
+/**
+ * What the activity-aware ranking needs on top of the name: the recency signal
+ * the mobile overlay orders its "recents" and breaks score ties with.
+ */
+export type ActivityRankableChannel = Pick<Channel, 'name' | 'lastActivityAt'>;
+
 const WORD_BOUNDARY = /[^a-z0-9]+/;
 
 /**
@@ -106,4 +112,60 @@ export function rankChannels<T extends RankableChannel>(
                 a.channel.name.localeCompare(b.channel.name),
         )
         .map((scored) => scored.channel);
+}
+
+/**
+ * Rank channels for the mobile overlay: same match scoring as
+ * {@link rankChannels}, but ties fall to the most recent activity instead of
+ * the alphabet — so an empty query reads as "recents", and typed results keep
+ * the busiest channel first among equal matches. Channels that never had any
+ * activity sort last, alphabetically.
+ */
+export function rankChannelsByActivity<T extends ActivityRankableChannel>(
+    channels: readonly T[],
+    query: string,
+): T[] {
+    const normalizedQuery = query.trim().replace(/^#+/, '');
+
+    const activityOf = (channel: T): number =>
+        channel.lastActivityAt === null
+            ? Number.NEGATIVE_INFINITY
+            : Date.parse(channel.lastActivityAt);
+
+    return channels
+        .map((channel) => ({
+            channel,
+            score: scoreChannelName(channel.name, normalizedQuery),
+        }))
+        .filter(
+            (scored): scored is { channel: T; score: number } =>
+                scored.score !== null,
+        )
+        .sort(
+            (a, b) =>
+                b.score - a.score ||
+                activityOf(b.channel) - activityOf(a.channel) ||
+                a.channel.name.localeCompare(b.channel.name),
+        )
+        .map((scored) => scored.channel);
+}
+
+/**
+ * Where a query reads as a contiguous, case-insensitive substring of a name —
+ * the range the mobile overlay highlights. Null when the query is empty or
+ * only matches as a scattered subsequence: no highlight beats a wrong one.
+ */
+export function matchRange(
+    name: string,
+    query: string,
+): { start: number; length: number } | null {
+    const needle = query.trim().replace(/^#+/, '').toLowerCase();
+
+    if (needle === '') {
+        return null;
+    }
+
+    const start = name.toLowerCase().indexOf(needle);
+
+    return start === -1 ? null : { start, length: needle.length };
 }

--- a/resources/js/composables/useQuickSwitcher.ts
+++ b/resources/js/composables/useQuickSwitcher.ts
@@ -1,0 +1,21 @@
+import { ref } from 'vue';
+
+/**
+ * Shared open-state for the quick switcher. The palette is mounted once in the
+ * main layout, but below the breakpoint it is entered from the channel
+ * masthead's search icon — a different subtree — so the state lives here
+ * rather than being prop-drilled (the keyboard-shortcuts modal's pattern).
+ */
+const isOpen = ref(false);
+
+export function useQuickSwitcher() {
+    return {
+        isOpen,
+        open: (): void => {
+            isOpen.value = true;
+        },
+        toggle: (): void => {
+            isOpen.value = !isOpen.value;
+        },
+    };
+}

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -94,6 +94,7 @@ import {
     useOnboardingTour,
 } from '@/composables/useOnboardingTour';
 import { usePresenceReporter } from '@/composables/usePresenceReporter';
+import { useQuickSwitcher } from '@/composables/useQuickSwitcher';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
 import { useTeamPresence } from '@/composables/useTeamPresence';
@@ -559,7 +560,8 @@ const { getInitials } = useInitials();
 const { switchTeam } = useTeamSwitch();
 const { start: startOnboardingTour } = useOnboardingTour();
 
-const quickSwitcherOpen = ref(false);
+const { isOpen: quickSwitcherOpen, toggle: toggleQuickSwitcher } =
+    useQuickSwitcher();
 const { isOpen: shortcutsOpen, toggle: toggleShortcuts } =
     useKeyboardShortcutsModal();
 const { isOpen: statusDialogOpen } = useUserStatusDialog();
@@ -679,8 +681,7 @@ function moveChannel(delta: number): void {
 }
 
 useKeyboardShortcuts({
-    'quick-switcher': () =>
-        (quickSwitcherOpen.value = !quickSwitcherOpen.value),
+    'quick-switcher': () => toggleQuickSwitcher(),
     'previous-channel': () => moveChannel(-1),
     'next-channel': () => moveChannel(1),
     'show-shortcuts': () => toggleShortcuts(),
@@ -1448,6 +1449,8 @@ onMounted(() => {
             :members="teamMembers"
             :current-user-id="currentUserId"
             :team-slug="currentTeam.slug"
+            :presence-for="presenceFor"
+            :is-dnd-for="isDndFor"
             @open-reminders="remindersDialogOpen = true"
         />
 

--- a/tests/Browser/MobileQuickSwitcherTest.php
+++ b/tests/Browser/MobileQuickSwitcherTest.php
@@ -150,6 +150,33 @@ test('selecting a channel row navigates to it, as it does today', function (): v
         ->assertPathContains('/c/boardroom');
 });
 
+test('the overlay has no serious accessibility violations, light or dark', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // The settle lets the overlay's 200ms fade finish: axe blends the
+    // mid-animation opacity into its contrast arithmetic otherwise.
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@masthead-search')
+        ->assertVisible('@quick-switcher-input')
+        ->wait(0.5)
+        ->assertNoAccessibilityIssues();
+
+    // Re-audit against the dark palette; persisting to localStorage first keeps
+    // the appearance controller from re-resolving 'system' back to light.
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});
+
 test('from md up the search icon still links to the search page and the palette stays a centred dialog', function (): void {
     ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
 

--- a/tests/Browser/MobileQuickSwitcherTest.php
+++ b/tests/Browser/MobileQuickSwitcherTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The mobile quick switcher (#775): below `md` the ⌘K palette becomes a
+ * full-screen overlay entered from the masthead search icon, listing recent
+ * channels before anything is typed (screen `m5` of the mobile design).
+ */
+test('the masthead search icon opens the switcher as a full-screen overlay below md', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@masthead-search')
+        // The tap opens the overlay in place — it must not navigate to the
+        // search page the way the desktop icon does.
+        ->assertPathContains("/c/{$channel->slug}")
+        ->assertVisible('@quick-switcher-input')
+        // The overlay is the screen: its panel spans the whole viewport.
+        ->assertScript(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-slot="dialog-content"]');
+            const box = panel.getBoundingClientRect();
+
+            return Math.round(box.width) >= window.innerWidth
+                && Math.round(box.height) >= window.innerHeight - 1
+                && Math.round(box.top) === 0;
+        })()
+        JS, true);
+});
+
+test('Cancel and Escape both dismiss the overlay', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@masthead-search')
+        ->assertVisible('@quick-switcher-cancel')
+        ->click('@quick-switcher-cancel')
+        ->assertNotPresent('@quick-switcher-input')
+        ->click('@masthead-search')
+        ->assertVisible('@quick-switcher-input')
+        ->keys('@quick-switcher-input', ['Escape'])
+        ->assertNotPresent('@quick-switcher-input');
+});

--- a/tests/Browser/MobileQuickSwitcherTest.php
+++ b/tests/Browser/MobileQuickSwitcherTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use App\Actions\Channels\JoinChannel;
+use App\Models\Channel;
+use App\Models\Message;
+
 /**
  * The mobile quick switcher (#775): below `md` the ⌘K palette becomes a
  * full-screen overlay entered from the masthead search icon, listing recent
@@ -45,4 +49,128 @@ test('Cancel and Escape both dismiss the overlay', function (): void {
         ->assertVisible('@quick-switcher-input')
         ->keys('@quick-switcher-input', ['Escape'])
         ->assertNotPresent('@quick-switcher-input');
+});
+
+test('an empty query lists channels most recently active first', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    $planning = Channel::factory()->for($team)->create([
+        'name' => 'planning',
+        'slug' => 'planning',
+    ]);
+    $design = Channel::factory()->for($team)->create([
+        'name' => 'design',
+        'slug' => 'design',
+    ]);
+    app(JoinChannel::class)->handle($planning, $alice);
+    app(JoinChannel::class)->handle($design, $alice);
+
+    // Joining just posted "member joined" notices stamped now in every channel,
+    // which would drown the activity times this test is about — push them all
+    // into last week so the deliberate messages below are each channel's latest.
+    Message::query()->update(['created_at' => now()->subWeek()]);
+
+    // Activity order: design spoke just now, #general yesterday, planning two
+    // days ago.
+    Message::factory()->for($planning)->for($alice, 'user')->create(['created_at' => now()->subDays(2)]);
+    Message::factory()->for($general)->for($alice, 'user')->create(['created_at' => now()->subDay()]);
+    Message::factory()->for($design)->for($alice, 'user')->create(['created_at' => now()]);
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $general))
+        ->click('@masthead-search')
+        ->assertScript(<<<'JS'
+        (() => {
+            const names = [...document.querySelectorAll('[data-test="quick-switcher-channel"]')]
+                .map(row => row.textContent);
+
+            return names.length === 3
+                && names[0].includes('design')
+                && names[1].includes('general')
+                && names[2].includes('planning');
+        })()
+        JS, true);
+});
+
+test('typing filters into the channel and people groups with the match highlighted', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    // "bo" reaches both groups: the boardroom channel and Bob Member.
+    $boardroom = Channel::factory()->for($team)->create([
+        'name' => 'boardroom',
+        'slug' => 'boardroom',
+    ]);
+    app(JoinChannel::class)->handle($boardroom, $alice);
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $general))
+        ->click('@masthead-search')
+        ->type('@quick-switcher-input', 'bo')
+        ->assertScript(<<<'JS'
+        (() => {
+            const channels = [...document.querySelectorAll('[data-test="quick-switcher-channel"]')];
+            const people = [...document.querySelectorAll('[data-test="quick-switcher-person"]')];
+
+            return channels.length === 1
+                && channels[0].textContent.includes('boardroom')
+                && people.length === 1
+                && people[0].textContent.includes('Bob Member');
+        })()
+        JS, true)
+        // Each surviving row brightens the run of its name the query matched.
+        ->assertScript(<<<'JS'
+        (() => [...document.querySelectorAll('[data-test="quick-switcher-channel"], [data-test="quick-switcher-person"]')]
+            .every(row => row.querySelector('[data-test="quick-switcher-match"]')?.textContent.toLowerCase() === 'bo'))()
+        JS, true)
+        // Every row carries the design's 46px height — comfortably past the
+        // 44px touch floor.
+        ->assertScript(<<<'JS'
+        (() => [...document.querySelectorAll('[data-test="quick-switcher-channel"], [data-test="quick-switcher-person"]')]
+            .every(row => Math.round(row.getBoundingClientRect().height) >= 44))()
+        JS, true);
+});
+
+test('selecting a channel row navigates to it, as it does today', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    $boardroom = Channel::factory()->for($team)->create([
+        'name' => 'boardroom',
+        'slug' => 'boardroom',
+    ]);
+    app(JoinChannel::class)->handle($boardroom, $alice);
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $general))
+        ->click('@masthead-search')
+        ->type('@quick-switcher-input', 'boardroom')
+        ->click('@quick-switcher-channel')
+        ->assertPathContains('/c/boardroom');
+});
+
+test('from md up the search icon still links to the search page and the palette stays a centred dialog', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 800)
+        ->navigate(browserChannelUrl($team, $channel))
+        // The sidebar's Jump-to entry opens the palette exactly as before: a
+        // centred dialog, no mobile Cancel affordance.
+        ->click('@quick-switcher-trigger')
+        ->assertVisible('@quick-switcher-input')
+        ->assertNotPresent('@quick-switcher-cancel')
+        ->assertScript(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-slot="dialog-content"]').getBoundingClientRect();
+
+            return panel.width < window.innerWidth && panel.top > 0;
+        })()
+        JS, true)
+        ->keys('@quick-switcher-input', ['Escape'])
+        ->assertNotPresent('@quick-switcher-input')
+        // The masthead icon keeps its desktop meaning: a link to the search page.
+        ->click('@masthead-search')
+        ->assertPathContains('/search');
 });


### PR DESCRIPTION
Closes #775. Fifth child of the mobile epic #770, implementing design screen `m5`.

## What

Below `md`, the ⌘K palette becomes a **full-screen overlay** entered from the masthead search icon, with recent channels listed before anything is typed:

- **Entry point**: the masthead search icon opens the overlay below `md` (new shared `useQuickSwitcher` open-state composable, same pattern as the shortcuts modal, so the masthead — a different subtree from the layout-mounted palette — can open it without prop-drilling). From `md` up the icon stays a plain link to the search page, and ⌘K keeps working everywhere.
- **Presentation**: a new `mobile="fullscreen"` presentation on the shared `DialogContent` primitive — edge to edge, no sheet chrome, bottom tracking `useKeyboardInset` so the input stays above the on-screen keyboard and the list's end stays reachable while typing. Inline `maxWidth: none` beats any call-site width class, same as the sheet branch.
- **m5 chrome**: 42px pill search field with a Cancel affordance, uppercase `CHANNELS` / `PEOPLE` section labels, 46px rows (≥44px touch targets), the brass italic serif hash, the matched substring highlighted (new pure `matchRange` helper), 28px initials avatars with live `PresenceDot` + presence word (driven by the layout's `presenceFor`/`isDndFor` roster), and the centred footer hint. All colours through the existing theme tokens, no mockup hex.
- **Recents & ranking**: new `rankChannelsByActivity` — the same match scoring as the desktop palette, but ties fall to `lastActivityAt` instead of the alphabet, so an empty query reads as "recents" and typed results keep the busiest channel first. Mobile only; the desktop palette's ordering is untouched.
- **Behaviour preserved**: the Reminders action, live message results, and "See all results" all remain on mobile; selecting any row navigates exactly as before; every existing `data-test` selector is preserved.

**Design gap (deliberate):** the mockup draws a right-aligned member count on channel rows, but `ChannelData` ships no member count — per the design-fidelity rule the trailing meta is omitted rather than faked. Can be added later if the DTO grows the field.

## i18n

All new copy through `$t()`; `lang/fr.json` gains the footer hint ("Les récents s'affichent avant la saisie · résultats classés par activité"); "Cancel"/"Annuler" already existed. French verified at 360px.

## a11y

The overlay is audited with axe in light **and** dark (new browser test) — that audit surfaced the shared `CommandList` listbox having no accessible name, fixed here at the switcher's call site with `aria-label`. The same latent gap in `NewDirectMessageModal` is filed as #798.

## How tested

- **Vitest**: `rankChannelsByActivity` (recency ordering, null-activity channels, score-beats-activity, recency tie-breaks), `matchRange`, and `DialogContent`'s fullscreen presentation (edge-to-edge, no sheet chrome, keyboard-tracked bottom, call-site width beaten, centred from `md` up) — 1104 tests green.
- **Pest browser** (`tests/Browser/MobileQuickSwitcherTest.php`, 7 tests): opens full-screen from the masthead icon without navigating, Cancel + Escape dismissal, empty-query recents ordering, typed filtering with highlighted matches in both groups, ≥44px rows, row selection navigating, the axe audit above, and desktop parity (centred palette, no Cancel, masthead icon still links to `/search`). Neighbouring `MobileShellTest`/`MobileSheetsTest`/`MobileThreadPanelTest`/`A11yShellTest` re-run green (61 tests).
- **Gates**: `sail composer test` green at 100.0% coverage; `lint:check` / `format:check` / `types:check` / `test:js` / `build` all green.
- **Visual**: driven in a real browser against the seeded workspace at 360x740, 375x667, 390x844, 430x932, 740x360 and 768x1024 (the boundary, where the desktop palette must return), empty query and a query matching both groups, light + dark, French at 360px. Before/after screenshots captured at 390x844 (light + dark) and 360x740 fr — the `775-before-*.png` / `775-after-*.png` set, ready to drag into this PR.

## Found along the way

#798 — `NewDirectMessageModal`'s `CommandList` listbox has no accessible name (same primitive, not yet covered by any axe audit).

Local CodeRabbit review: one finding (fullscreen could be constrained by a call-site responsive width class between 640-767px) — applied, with a regression test. A confirmation re-run was rate-limited on the OSS tier; the app review on this PR is the backstop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787434352&installation_model_id=428379&pr_number=799&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F799&signature=a40f2550bda03220a016bff67d43456c190af2d7e5756a78a73aac5380c94dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
