### PR TITLE
fix: stop native text selection racing the mobile long-press sheet

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -724,6 +724,7 @@
   "The emoji is removed from the picker for everyone. Existing messages and reactions show its plain shortcode text instead, and the name becomes available again.": "L’emoji est retiré du sélecteur pour tout le monde. Les messages et réactions existants affichent son texte de raccourci à la place, et le nom redevient disponible.",
   "The file may not be larger than :size MB.": "Le fichier ne peut pas dépasser :size Mo.",
   "The image must be square and at most 128×128 pixels.": "L’image doit être carrée et faire au maximum 128×128 pixels.",
+  "The message text could not be copied.": "Le texte du message n’a pas pu être copié.",
   "The name may only contain lowercase letters, numbers, and hyphens.": "Le nom ne peut contenir que des lettres minuscules, des chiffres et des traits d’union.",
   "The page you’re looking for doesn’t exist or has been moved. Check the address, or head back to your workspace.": "La page que vous cherchez n’existe pas ou a été déplacée. Vérifiez l’adresse, ou revenez à votre espace de travail.",
   "The team name does not match.": "Le nom de l’équipe ne correspond pas.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1069,6 +1069,7 @@
   "CI alerts": "Alertes CI",
   "Copied": "Copié",
   "Copy": "Copier",
+  "Copy text": "Copier le texte",
   "Create bot": "Créer le bot",
   "Create subscription": "Créer l’abonnement",
   "Create token": "Créer le jeton",

--- a/resources/js/components/MessageActionsSheet.test.ts
+++ b/resources/js/components/MessageActionsSheet.test.ts
@@ -15,6 +15,8 @@ vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({ props }),
 }));
 
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
 // The sheet rides the app's dialog primitive; its portal/focus behaviour is the
 // primitive's own tested concern, so render it down to a passthrough.
 vi.mock('@/components/ui/dialog', () => {
@@ -255,6 +257,26 @@ describe('MessageActionsSheet action rows', () => {
 
         expect(writeText).toHaveBeenCalledExactlyOnceWith(
             'hi @Alice\n**bold**',
+        );
+        expect(emitted['update:open']).toEqual([[false]]);
+    });
+
+    it('reports a copy that could not reach the clipboard and still dismisses', async () => {
+        const { toast } = await import('vue-sonner');
+        const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+
+        const { host, emitted } = mount();
+
+        host.querySelector<HTMLElement>('[data-test="sheet-copy"]')!.click();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(toast.error).toHaveBeenCalledExactlyOnceWith(
+            'The message text could not be copied.',
         );
         expect(emitted['update:open']).toEqual([[false]]);
     });

--- a/resources/js/components/MessageActionsSheet.test.ts
+++ b/resources/js/components/MessageActionsSheet.test.ts
@@ -160,6 +160,7 @@ describe('MessageActionsSheet action rows', () => {
             'thread',
             'reply',
             'forward',
+            'copy',
             'pin',
             'remind',
         ]);
@@ -236,6 +237,34 @@ describe('MessageActionsSheet action rows', () => {
         expect(emitted['update:open']).toEqual([[false]]);
     });
 
+    it('copies the message text as typed and dismisses', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+
+        const { host, emitted } = mount({
+            message: message({
+                body: 'hi @[Alice](a1b2c3d4-e5f6-7890-1234-567890abcdef)\n**bold**',
+            }),
+        });
+
+        host.querySelector<HTMLElement>('[data-test="sheet-copy"]')!.click();
+        await Promise.resolve();
+
+        expect(writeText).toHaveBeenCalledExactlyOnceWith(
+            'hi @Alice\n**bold**',
+        );
+        expect(emitted['update:open']).toEqual([[false]]);
+    });
+
+    it('hides the copy row when the message has no text to copy', () => {
+        const { host } = mount({ message: message({ body: '' }) });
+
+        expect(rowNames(host)).not.toContain('copy');
+    });
+
     it('routes the remind row to the custom reminder flow', () => {
         const { host, emitted } = mount();
 
@@ -284,6 +313,36 @@ describe('MessageActionsSheet quick reactions', () => {
                 ?.getAttribute('src'),
         ).toBe('https://desk.test/shipit.png');
         expect(shortcut(host, '👍').querySelector('img')).toBeNull();
+    });
+});
+
+describe('MessageActionsSheet selection suppression', () => {
+    it('renders every surface non-selectable, like a native sheet', () => {
+        const { host } = mount();
+
+        const sheet = host.querySelector<HTMLElement>(
+            '[data-test="message-actions-sheet"]',
+        )!;
+
+        expect(sheet.classList.contains('select-none')).toBe(true);
+        expect(sheet.classList.contains('[-webkit-touch-callout:none]')).toBe(
+            true,
+        );
+    });
+
+    it('clears a selection that slipped through before the sheet opened', () => {
+        const stray = document.createElement('p');
+        stray.textContent = 'selected before the press landed';
+        document.body.appendChild(stray);
+        const range = document.createRange();
+        range.selectNodeContents(stray);
+        window.getSelection()?.addRange(range);
+
+        expect(window.getSelection()?.toString()).not.toBe('');
+
+        mount();
+
+        expect(window.getSelection()?.toString()).toBe('');
     });
 });
 

--- a/resources/js/components/MessageActionsSheet.vue
+++ b/resources/js/components/MessageActionsSheet.vue
@@ -11,6 +11,7 @@ import {
     Trash2,
 } from '@lucide/vue';
 import { computed, watch } from 'vue';
+import { toast } from 'vue-sonner';
 import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -226,8 +227,14 @@ function react(emoji: string): void {
  * deliberate copy path that replaces it.
  */
 async function copyMessageText(): Promise<void> {
-    await navigator.clipboard.writeText(copyText.value);
-    close();
+    try {
+        // Also guards the API being absent altogether (a plain-http install).
+        await navigator.clipboard.writeText(copyText.value);
+    } catch {
+        toast.error(t('The message text could not be copied.'));
+    } finally {
+        close();
+    }
 }
 
 /** The shared look of one 46px action row (design m4). */

--- a/resources/js/components/MessageActionsSheet.vue
+++ b/resources/js/components/MessageActionsSheet.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
     AlarmClock,
+    Copy,
     CornerUpLeft,
     Forward,
     MessageSquareText,
@@ -9,7 +10,7 @@ import {
     Plus,
     Trash2,
 } from '@lucide/vue';
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -25,6 +26,7 @@ import { useInitials } from '@/composables/useInitials';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatTimeOfDay } from '@/lib/datetime';
 import {
+    canCopyMessage,
     canDeleteMessage,
     canEditMessage,
     canForwardMessage,
@@ -35,7 +37,7 @@ import {
     canStartThreadFromMessage,
 } from '@/lib/messageActions';
 import type { MessageActionContext } from '@/lib/messageActions';
-import { messageBodyPreview } from '@/lib/messageBody';
+import { messageBodyCopyText, messageBodyPreview } from '@/lib/messageBody';
 import { hasReacted } from '@/lib/reactions';
 import type { Message } from '@/types';
 
@@ -110,6 +112,20 @@ const showForward = computed(
         props.message !== null &&
         canForwardMessage(props.message, context.value),
 );
+/**
+ * The text the copy row puts on the clipboard: the body as typed, with mention
+ * tokens resolved. An empty value (attachment-only or poll message) hides the
+ * row — there is nothing to copy.
+ */
+const copyText = computed(() =>
+    props.message === null ? '' : messageBodyCopyText(props.message.body),
+);
+const showCopy = computed(
+    () =>
+        props.message !== null &&
+        canCopyMessage(props.message, context.value) &&
+        copyText.value.trim() !== '',
+);
 const showPin = computed(
     () => props.message !== null && canPinMessage(props.message, context.value),
 );
@@ -166,6 +182,19 @@ function close(): void {
     emit('update:open', false);
 }
 
+// WebKit starts its selection gesture in parallel with the long-press timer, so
+// a selection can land just before the sheet does; left alive, its handles sit
+// on top of the scrim (#800). Immediate, so a sheet mounted open clears it too.
+watch(
+    () => props.open,
+    (open) => {
+        if (open) {
+            window.getSelection()?.removeAllRanges();
+        }
+    },
+    { immediate: true },
+);
+
 type ActionEvent =
     | 'openThread'
     | 'reply'
@@ -191,6 +220,16 @@ function react(emoji: string): void {
     close();
 }
 
+/**
+ * The mobile stand-in for selecting the text: the rows below `md` suppress
+ * native selection so the long-press can win (#800), and this row is the
+ * deliberate copy path that replaces it.
+ */
+async function copyMessageText(): Promise<void> {
+    await navigator.clipboard.writeText(copyText.value);
+    close();
+}
+
 /** The shared look of one 46px action row (design m4). */
 const rowClass =
     'flex h-11.5 w-full items-center gap-3 rounded-[11px] px-3.5 text-left text-[14.5px] font-medium text-foreground transition-colors hover:bg-muted/50 active:bg-muted';
@@ -201,7 +240,7 @@ const rowClass =
         <DialogContent
             data-test="message-actions-sheet"
             :show-close-button="false"
-            class="gap-0 overflow-visible px-2.5"
+            class="gap-0 overflow-visible px-2.5 select-none [-webkit-touch-callout:none]"
         >
             <DialogTitle class="sr-only">{{
                 $t('Message actions')
@@ -332,6 +371,18 @@ const rowClass =
                 >
                     <Forward class="size-4 text-muted-foreground" />
                     {{ $t('Forward') }}
+                </Button>
+                <Button
+                    v-if="showCopy"
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    data-test="sheet-copy"
+                    :class="rowClass"
+                    @click="copyMessageText"
+                >
+                    <Copy class="size-4 text-muted-foreground" />
+                    {{ $t('Copy text') }}
                 </Button>
                 <Button
                     v-if="showPin"

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -877,6 +877,7 @@ function confirmDelete(): void {
 
                 <div
                     v-else-if="item.type === 'divider'"
+                    data-test="day-divider"
                     class="my-4 flex items-center gap-3"
                 >
                     <span aria-hidden="true" class="h-px flex-1 bg-border" />
@@ -1027,7 +1028,7 @@ function confirmDelete(): void {
                                         viewerTimeZone,
                                     )
                                 "
-                                class="group/message relative -mx-2 rounded-md px-2 transition-colors duration-1000 hover:bg-muted/40"
+                                class="group/message relative -mx-2 rounded-md px-2 transition-colors duration-1000 hover:bg-muted/40 max-md:select-none max-md:[-webkit-touch-callout:none]"
                                 :class="[
                                     index === 0 ? 'mt-0.5' : 'mt-1.5',
                                     message.id === props.highlightMessageId

--- a/resources/js/lib/messageActions.test.ts
+++ b/resources/js/lib/messageActions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    canCopyMessage,
     canDeleteMessage,
     canEditMessage,
     canForwardMessage,
@@ -142,6 +143,29 @@ describe('messageActions guards', () => {
             ).toBe(false);
             expect(
                 canForwardMessage(message(), context({ pending: true })),
+            ).toBe(false);
+        });
+    });
+
+    describe('canCopyMessage', () => {
+        it('is true for any live message, including inside a thread', () => {
+            expect(canCopyMessage(message(), context({ inThread: true }))).toBe(
+                true,
+            );
+        });
+
+        it('is false for a deleted or pending message', () => {
+            expect(
+                canCopyMessage(message({ isDeleted: true }), context()),
+            ).toBe(false);
+            expect(canCopyMessage(message(), context({ pending: true }))).toBe(
+                false,
+            );
+        });
+
+        it('is false for a system notice, which has no authored text', () => {
+            expect(
+                canCopyMessage(message({ type: 'member_joined' }), context()),
             ).toBe(false);
         });
     });

--- a/resources/js/lib/messageActions.ts
+++ b/resources/js/lib/messageActions.ts
@@ -102,6 +102,19 @@ export function canForwardMessage(
 }
 
 /**
+ * Any live message's text can be copied to the clipboard. A sheet-only action:
+ * on a hover-capable layout the text is simply selected, but the mobile rows
+ * suppress native selection so the long-press gesture can win (#800), making
+ * this the deliberate copy path there.
+ */
+export function canCopyMessage(
+    message: Message,
+    context: MessageActionContext,
+): boolean {
+    return isActionable(message, context);
+}
+
+/**
  * The viewer may react to any live message when they're a member of the
  * (non-archived) channel.
  */

--- a/resources/js/lib/messageBody.test.ts
+++ b/resources/js/lib/messageBody.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CustomEmojiMap } from '@/lib/customEmoji';
 import {
+    messageBodyCopyText,
     messageBodyPreview,
     renderMessageBody,
     tokenizeMessageBody,
@@ -445,6 +446,26 @@ describe('messageBodyPreview', () => {
     it('collapses a group token to its handle', () => {
         expect(messageBodyPreview(`hi @[dev-team](group:${devs.id})`)).toBe(
             'hi @dev-team',
+        );
+    });
+});
+
+describe('messageBodyCopyText', () => {
+    it('returns the body exactly as typed, newlines and mark syntax intact', () => {
+        expect(messageBodyCopyText('a **b**\n_c_ and `code`')).toBe(
+            'a **b**\n_c_ and `code`',
+        );
+    });
+
+    it('collapses a mention token to the @Name the author typed', () => {
+        expect(messageBodyCopyText(`hi @[Alice](${alice.id})`)).toBe(
+            'hi @Alice',
+        );
+    });
+
+    it('collapses a group token to its handle', () => {
+        expect(messageBodyCopyText(`ping @[dev-team](group:${devs.id})`)).toBe(
+            'ping @dev-team',
         );
     });
 });

--- a/resources/js/lib/messageBody.ts
+++ b/resources/js/lib/messageBody.ts
@@ -416,6 +416,15 @@ export function renderMessageBody(
 }
 
 /**
+ * The message body as the author typed it, ready for the clipboard: mention and
+ * group tokens collapse to their visible `@Name` text, while newlines and the
+ * inline Markdown syntax are kept verbatim — they are the text the author wrote.
+ */
+export function messageBodyCopyText(body: string): string {
+    return body.replace(MENTION_PATTERN, (_match, name: string) => `@${name}`);
+}
+
+/**
  * Flatten a raw message body to a single line of plain text for a compact quote
  * preview: inline Markdown syntax is stripped (marks removed, inline-code
  * content kept literal), mention tokens collapse to their `@Name` text, and runs

--- a/tests/Browser/MobileMessageActionsSheetTest.php
+++ b/tests/Browser/MobileMessageActionsSheetTest.php
@@ -72,6 +72,7 @@ test('a long-press on a peer message opens the sheet without the author-only act
         ->assertPresent('@sheet-thread')
         ->assertPresent('@sheet-reply')
         ->assertPresent('@sheet-forward')
+        ->assertPresent('@sheet-copy')
         ->assertPresent('@sheet-pin')
         ->assertPresent('@sheet-remind')
         // ...and nothing it would hide: Bob may neither edit nor delete it.
@@ -178,6 +179,107 @@ test('the sheet survives French at the tightest width', function (): void {
         ->assertScript(<<<'JS'
         (() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)()
         JS, true);
+});
+
+test('below md the rows and the sheet suppress selection; from md up text stays selectable', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $alice->id,
+        'body' => 'Nothing here should be selectable on a phone.',
+    ]);
+
+    $page = signInThroughBrowser($bob)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertPresent("#message-{$message->id}");
+
+    // The suppression is static CSS, so WebKit never begins the selection
+    // gesture that races the long-press timer (#800).
+    $page->assertScript(<<<JS
+    (() => getComputedStyle(document.getElementById('message-{$message->id}')).userSelect)()
+    JS, 'none');
+
+    longPressMessage($page, $message->id)
+        ->assertPresent('@message-actions-sheet')
+        ->assertScript(<<<'JS'
+        (() => getComputedStyle(document.querySelector('[data-test="message-actions-sheet"]')).userSelect)()
+        JS, 'none');
+
+    // From md up the hover toolbar owns the actions and the text must stay
+    // selectable — the desktop copy path is selection itself.
+    signInThroughBrowser($bob)
+        ->resize(768, 1024)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertPresent("#message-{$message->id}")
+        ->assertScript(<<<JS
+        (() => getComputedStyle(document.getElementById('message-{$message->id}')).userSelect)()
+        JS, 'auto');
+});
+
+test('a selection that slipped through is cleared when the sheet opens', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $alice->id,
+        'body' => 'Selected just before the sheet lands.',
+    ]);
+
+    $page = signInThroughBrowser($bob)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertPresent("#message-{$message->id}");
+
+    // Select the day divider by hand, standing in for WebKit's native gesture
+    // winning the race just before our timer fires — on the phone the spill
+    // landed on exactly this kind of neighbouring chrome, which stays
+    // selectable (the static suppression covers only the message rows).
+    $page->script(<<<'JS'
+    (() => {
+        const range = document.createRange();
+        range.selectNodeContents(document.querySelector('[data-test="day-divider"]'));
+        window.getSelection().addRange(range);
+    })()
+    JS);
+    $page->assertScript('(() => window.getSelection().toString().length > 0)()', true);
+
+    longPressMessage($page, $message->id)
+        ->assertPresent('@message-actions-sheet')
+        ->assertScript('(() => window.getSelection().toString())()', '');
+});
+
+test('the copy row puts the message text on the clipboard and dismisses', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $alice->id,
+        'body' => 'Words worth copying.',
+    ]);
+
+    $page = signInThroughBrowser($bob)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertPresent("#message-{$message->id}");
+
+    // Chromium gates clipboard-write behind a permission the harness does not
+    // grant; a recording stub keeps the assertion deterministic.
+    $page->script(<<<'JS'
+    (() => {
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText: (text) => { window.__copied = text; return Promise.resolve(); } },
+            configurable: true,
+        });
+    })()
+    JS);
+
+    longPressMessage($page, $message->id)
+        ->assertPresent('@sheet-copy')
+        ->click('@sheet-copy')
+        ->assertScript('(() => window.__copied)()', 'Words worth copying.')
+        ->assertNotPresent('@message-actions-sheet');
 });
 
 test('the open sheet has no serious accessibility violations in either theme', function (): void {


### PR DESCRIPTION
Closes #800.

## What

On iOS Safari, long-pressing a message raced WebKit's own selection gesture: sometimes the native callout won, sometimes both fired and selection handles sat on top of the actions sheet, and the sheet's own labels were text-selectable. The JS-level guard in `useLongPress` cannot win this race (no `contextmenu` on touch, selection starts natively in parallel), so the fix is CSS-level:

- **Message rows below `md` are statically non-selectable** (`max-md:select-none max-md:[-webkit-touch-callout:none]`), so WebKit never begins the selection gesture that competes with the long-press timer. At and above `md` nothing changes — desktop text stays fully selectable.
- **The actions sheet content is non-selectable** (`select-none` + `-webkit-touch-callout: none` on its `DialogContent`), covering the quick-reaction strip, action rows, and the lifted message card, matching native sheet behaviour.
- **Any live selection is cleared when the sheet opens** (`getSelection().removeAllRanges()` on the open watch), so a selection that slipped through never sits on top of the scrim.
- **A deliberate copy path replaces native selection on mobile:** a new **Copy text** action row in the sheet (between Forward and Pin) writes the message text to the clipboard — mention tokens resolved to `@Name`, newlines and Markdown syntax kept as typed (`messageBodyCopyText`). It hides when there is nothing to copy (attachment-only/poll messages) and, if the clipboard is unavailable (plain-http install) or the write is denied, the sheet still dismisses and a translated error toast reports it.

## Testing

- Vitest: new coverage for `messageBodyCopyText`, `canCopyMessage`, the copy row (success, failure toast, hidden-when-empty), the sheet's `select-none` classes, and selection clearing on open. Full `test:js` suite green (1139 tests).
- Pest browser (`MobileMessageActionsSheetTest`): computed `user-select: none` on rows and sheet at 390×844 and `auto` at 768×1024; a stray selection over the day divider is cleared when the sheet opens; the copy row writes the body text (clipboard stubbed) and dismisses. 9/9 green.
- Full gate green: `sail composer test` at 100 % coverage, `lint:check` / `format:check` / `types:check` / `test:js` / `build`.
- Verified visually at 390×844 in Chromium: the Copy text row renders in the sheet with the shared row styling.
- ⚠️ **Real-WebKit verification still needed:** the selection race itself is iOS-Safari behaviour Playwright/Chromium cannot reproduce — please confirm on an actual iPhone/simulator before closing #800 (the issue calls this out).

## i18n

New keys `Copy text` and `The message text could not be copied.` added to `lang/fr.json`.

## Notes

- Local CodeRabbit review applied: clipboard failure is now reported via the existing `vue-sonner` toast instead of hanging the sheet. Re-run clean (0 findings).
- Unrelated flaky vitest discovered while running the full suite, filed as #804.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787449902&installation_model_id=428379&pr_number=805&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F805&signature=dfead9182d268dab71b6932e6f145c63f1e7aba9f43b3b8c340408b15169d018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->