### PR TITLE
fix: render the DM masthead add-people button icon-only below md

### DIFF
--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -454,18 +454,26 @@ const hasActivityReadout = computed(
             </span>
 
             <!-- Add people: opens the picker that grows this DM into (or reuses)
-                 a group conversation. Only shown to a member of a DM. -->
+                 a group conversation. Only shown to a member of a DM. Below the
+                 breakpoint the pill folds to an icon-only control like the
+                 neighbouring pins and search buttons, so the conversation name
+                 keeps the row's horizontal space (#801). -->
             <Button
                 v-if="props.canAddPeople"
-                variant="outline"
-                size="sm"
+                :variant="isMobile ? 'ghost' : 'outline'"
+                :size="isMobile ? 'icon' : 'sm'"
                 type="button"
                 data-test="masthead-add-people"
-                class="h-8 gap-1.5 rounded-full px-4 text-[12.5px] font-semibold"
+                :aria-label="$t('Add people')"
+                :class="
+                    isMobile
+                        ? 'size-9 rounded text-muted-foreground hover:bg-muted hover:text-foreground'
+                        : 'h-8 gap-1.5 rounded-full px-4 text-[12.5px] font-semibold'
+                "
                 @click="emit('addPeople')"
             >
-                <UserPlus class="size-3.5" />
-                {{ $t('Add people') }}
+                <UserPlus :class="isMobile ? 'size-4' : 'size-3.5'" />
+                <template v-if="!isMobile">{{ $t('Add people') }}</template>
             </Button>
 
             <!-- Pins: opens the pinned-messages popover. The pin glyph fills brass

--- a/tests/Browser/MobileMastheadAddPeopleTest.php
+++ b/tests/Browser/MobileMastheadAddPeopleTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Channels\OpenDirectMessage;
+use App\Enums\AppLocale;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * The DM masthead's "Add people" control below the breakpoint (#801).
+ *
+ * At a phone width the full icon + label pill crowded the header until the
+ * conversation name truncated to almost nothing. Below `md` the button folds
+ * to an icon-only control like the neighbouring pins/search buttons — keeping
+ * its accessible name and touch target — while the pill stays unchanged from
+ * `md` up.
+ */
+
+/**
+ * A team whose owner has a 1:1 DM open with a long-named counterpart — the
+ * masthead title that exposed the crowding.
+ *
+ * @return array{owner: User, team: Team, url: string}
+ */
+function browserDmWithLongTitle(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'team' => $team] = browserTeamWithChannel();
+
+    $bob->update(['name' => 'Bartholomew Montgomery Featherstone']);
+
+    $dm = app(OpenDirectMessage::class)->handle($team, $alice, $bob);
+
+    return ['owner' => $alice, 'team' => $team, 'url' => browserChannelUrl($team, $dm)];
+}
+
+test('the Add people button is icon-only with its accessible name and touch target at phone widths', function (int $width, int $height): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongTitle();
+
+    signInThroughBrowser($alice)
+        ->resize($width, $height)
+        ->navigate($url)
+        ->assertVisible('@masthead-add-people')
+        // Icon-only: the accessible name moves onto the control itself...
+        ->assertAttribute('@masthead-add-people', 'aria-label', 'Add people')
+        // ...and no text label is rendered inside it.
+        ->assertScript(<<<'JS'
+        (() => document.querySelector('[data-test="masthead-add-people"]')
+            .textContent.trim() === '')()
+        JS, true)
+        // The control keeps the masthead icon buttons' 36px (size-9) target.
+        ->assertScript(<<<'JS'
+        (() => {
+            const box = document.querySelector('[data-test="masthead-add-people"]')
+                .getBoundingClientRect();
+
+            return Math.round(box.width) >= 36 && Math.round(box.height) >= 36;
+        })()
+        JS, true);
+})->with([
+    'small phone' => [360, 740],
+    'iPhone SE' => [375, 667],
+    'iPhone 14' => [390, 844],
+    'large phone' => [430, 932],
+]);
+
+test('the long DM title keeps its horizontal space beside the icon-only control', function (): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongTitle();
+
+    // The defect: the pill plus the other controls squeezed the <h1> to ~40px,
+    // so the name read "Bob …". Icon-only, the title keeps a readable share
+    // (measured 114px at this width).
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate($url)
+        ->assertScript(<<<'JS'
+        (() => document.querySelector('header h1')
+            .getBoundingClientRect().width > 100)()
+        JS, true);
+});
+
+test('the pill keeps its icon and label from the breakpoint up', function (): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongTitle();
+
+    signInThroughBrowser($alice)
+        ->resize(1024, 800)
+        ->navigate($url)
+        ->assertSeeIn('@masthead-add-people', 'Add people');
+});
+
+test('the icon-only control still opens the add-people picker', function (): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongTitle();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate($url)
+        ->click('@masthead-add-people')
+        ->assertVisible('@add-people-input');
+});
+
+test('the accessible name follows the locale at the tightest viewport', function (): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongTitle();
+    $alice->update(['locale' => AppLocale::French]);
+
+    // French runs longer than English (#765); icon-only, the length lands in
+    // the aria-label rather than the row, so the existing key just has to
+    // reach the control.
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate($url)
+        ->assertAttribute('@masthead-add-people', 'aria-label', 'Ajouter des personnes');
+});


### PR DESCRIPTION
Closes #801. Part of the mobile breakpoint epic #770 (masthead area).

## What

Below `md`, the DM masthead's **Add people** pill (icon + label, 109px at 360px wide) crowded the header until the conversation name truncated to almost nothing (the `<h1>` measured **41px** with a long DM title). The button now folds to an **icon-only control** below the breakpoint — `ghost` variant, `size-9` (36px) target, matching the neighbouring pins/search icon buttons — and the title gets its space back (**114px** at 360px, name readable). At `md` and up the outline pill (icon + label) is unchanged.

- The control keeps its accessible name via `:aria-label="$t('Add people')"` (a naming-capable role, per the repo's a11y bar) and the 36px touch target of the masthead's other icon buttons.
- `data-test="masthead-add-people"` and the click behaviour (opens the add-people picker) are preserved.
- Branches on the existing `useIsMobile()` single source of truth, the same seam the masthead's search control already uses, so the JS and `md:` CSS sides of the breakpoint can't disagree.

## i18n

No new keys: "Add people" / "Ajouter des personnes" already exists and now feeds the `aria-label`. Verified in French at 360px (the label lands in the aria-label rather than the row, so the longer French string costs no width).

## How tested

- **Browser** (`tests/Browser/MobileMastheadAddPeopleTest.php`, 8 tests): icon-only with `aria-label` and a ≥36px box at 360/375/390/430; the long-DM-title `<h1>` keeps >100px at 360 (was ~40px before the fix — the test fails on the old markup); the pill keeps its label at 1024; the icon-only control still opens the add-people picker; the `aria-label` follows the French locale at 360.
- A11y suites `A11yShellTest` + `A11yAuditTest` green; backend gate green at 100% coverage; all five frontend gates green.
- Verified visually with Playwright against the seeded demo workspace at 360x740, 375x667, 390x844, 430x932 and 768x1024 (boundary: pill returns, unchanged), light and dark, English and French, with a long DM title ("Bartholomew Montgomery Featherstone") — before/after measurements above.

Local CodeRabbit review clean (0 findings).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787449923&installation_model_id=428379&pr_number=806&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F806&signature=3360dc615a38c83b3e19d5fd7946f5a8cf7bc77e5de7cc81adce6b6ba44a69f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->