### PR TITLE
feat: overlay the reconnecting pill below md instead of taking masthead space

### DIFF
--- a/resources/js/components/ChannelMasthead.connectionPill.test.ts
+++ b/resources/js/components/ChannelMasthead.connectionPill.test.ts
@@ -108,7 +108,7 @@ async function render(connectionPill: ConnectionPill): Promise<string> {
                 channel: channel(),
                 teamSlug: 'acme',
                 members: [],
-                presenceFor: () => 'active',
+                presenceFor: () => 'active' as const,
                 title: 'general',
                 canManagePreferences: false,
                 canArchive: false,
@@ -183,6 +183,25 @@ describe('ChannelMasthead connection pill mobile overlay', () => {
         expect(pill).toContain('md:px-2.5');
         expect(pill).toContain('md:py-1');
         expect(pill).toContain('md:shadow-none');
+    });
+
+    it('keeps the floating pill surface opaque in dark mode, restoring the translucent wash inline', async () => {
+        const reconnecting = openingTag(
+            await render('reconnecting'),
+            'connection-reconnecting',
+        );
+        const backOnline = openingTag(
+            await render('back-online'),
+            'connection-back-online',
+        );
+
+        // Floating over arbitrary timeline content (a poll bar, an image), the
+        // desktop's 40% dark wash lets whatever is behind bleed through and
+        // garble the label — the overlay needs a solid surface.
+        expect(reconnecting).toContain('dark:bg-amber-950 ');
+        expect(reconnecting).toContain('md:dark:bg-amber-950/40');
+        expect(backOnline).toContain('dark:bg-emerald-950 ');
+        expect(backOnline).toContain('md:dark:bg-emerald-950/40');
     });
 
     it('gives the transient back-online pill the same overlay placement and sizing', async () => {

--- a/resources/js/components/ChannelMasthead.connectionPill.test.ts
+++ b/resources/js/components/ChannelMasthead.connectionPill.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSSRApp, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import type { ConnectionPill } from '@/composables/useConnectionState';
+import type { Channel } from '@/types/channels';
+
+/**
+ * Inertia + Wayfinder + UI stubs so the masthead's own markup (the connection
+ * pill) can be rendered in isolation without the full app/router context.
+ * `stub(tag)` builds a passthrough component; hoisted so the vi.mock factories
+ * (which run before the module body) can reach it.
+ */
+const { stub } = await vi.hoisted(async () => {
+    const { defineComponent, h: hyper } = await import('vue');
+
+    return {
+        stub: (tag: string) =>
+            defineComponent({
+                setup:
+                    (_: unknown, ctx: { slots: { default?: () => unknown } }) =>
+                    () =>
+                        hyper(tag, ctx.slots.default?.() as never),
+            }),
+    };
+});
+
+vi.mock('@inertiajs/vue3', () => ({
+    Link: stub('a'),
+    usePage: () => ({
+        props: { auth: { user: { avatar: null, presence: 'active' } } },
+    }),
+}));
+vi.mock('@lucide/vue', () => ({
+    Archive: stub('svg'),
+    Bot: stub('svg'),
+    Check: stub('svg'),
+    EllipsisVertical: stub('svg'),
+    LogOut: stub('svg'),
+    Pin: stub('svg'),
+    Search: stub('svg'),
+    Star: stub('svg'),
+    UserPlus: stub('svg'),
+}));
+vi.mock('@/actions/App/Http/Controllers/Channels/SearchController', () => ({
+    index: () => ({ url: '/acme/search' }),
+}));
+vi.mock('@/components/AvatarStack.vue', () => ({ default: stub('div') }));
+vi.mock('@/components/PresenceDot.vue', () => ({ default: stub('div') }));
+vi.mock('@/components/ui/avatar', () => ({
+    Avatar: stub('div'),
+    AvatarImage: stub('div'),
+    AvatarFallback: stub('div'),
+}));
+vi.mock('@/components/ui/button', () => ({ Button: stub('button') }));
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: stub('div'),
+    DropdownMenuCheckboxItem: stub('div'),
+    DropdownMenuContent: stub('div'),
+    DropdownMenuItem: stub('div'),
+    DropdownMenuLabel: stub('div'),
+    DropdownMenuRadioGroup: stub('div'),
+    DropdownMenuRadioItem: stub('div'),
+    DropdownMenuSeparator: stub('div'),
+    DropdownMenuTrigger: stub('div'),
+}));
+vi.mock('@/components/ui/sidebar', () => ({ SidebarTrigger: stub('button') }));
+vi.mock('@/components/ui/tooltip', () => ({
+    Tooltip: stub('div'),
+    TooltipTrigger: stub('div'),
+    TooltipContent: stub('div'),
+}));
+vi.mock('@/composables/useQuickSwitcher', () => ({
+    useQuickSwitcher: () => ({ open: vi.fn() }),
+}));
+
+import ChannelMasthead from './ChannelMasthead.vue';
+
+function channel(): Channel {
+    return {
+        id: 'ch-1',
+        name: 'general',
+        slug: 'general',
+        visibility: 'public',
+        topic: null,
+        isGeneral: true,
+        isArchived: false,
+        muted: false,
+        notificationLevel: 'all',
+        unreadCount: 0,
+        mentionCount: 0,
+        hasDraft: false,
+        draft: null,
+        starred: false,
+        sectionId: null,
+        position: 0,
+        isDirect: false,
+        isGroupDirect: false,
+        dmUserId: null,
+        dmParticipants: [],
+        lastActivityAt: null,
+    };
+}
+
+async function render(connectionPill: ConnectionPill): Promise<string> {
+    const app = createSSRApp({
+        render: () =>
+            h(ChannelMasthead, {
+                channel: channel(),
+                teamSlug: 'acme',
+                members: [],
+                presenceFor: () => 'active',
+                title: 'general',
+                canManagePreferences: false,
+                canArchive: false,
+                canLeave: false,
+                canAddPeople: false,
+                notificationLevels: [],
+                starred: false,
+                muted: false,
+                pinCount: 0,
+                notificationLevel: 'all',
+                notificationStatus: null,
+                connectionPill,
+            }),
+    });
+
+    app.config.globalProperties.$t = (key: string) => key;
+
+    return renderToString(app);
+}
+
+/** The opening tag of the element carrying the given data-test selector. */
+function openingTag(html: string, dataTest: string): string {
+    const tag = new RegExp(`<[a-z]+[^>]*data-test="${dataTest}"[^>]*>`).exec(
+        html,
+    )?.[0];
+
+    expect(tag, `element with data-test="${dataTest}"`).toBeDefined();
+
+    return tag ?? '';
+}
+
+describe('ChannelMasthead connection pill mobile overlay', () => {
+    it('overlays the reconnecting pill below md instead of taking masthead space', async () => {
+        const html = await render('reconnecting');
+
+        const pill = openingTag(html, 'connection-reconnecting');
+
+        // Below the breakpoint the pill leaves the masthead's flex row entirely:
+        // it hangs centered under the masthead, anchored to the header...
+        expect(pill).toContain('absolute');
+        expect(pill).toContain('top-full');
+        expect(pill).toContain('left-1/2');
+        expect(pill).toContain('-translate-x-1/2');
+        // ...and can never block the masthead actions or the first message row.
+        expect(pill).toContain('pointer-events-none');
+
+        // From md up it rejoins the action cluster exactly as before.
+        expect(pill).toContain('md:static');
+        expect(pill).toContain('md:translate-x-0');
+
+        // The header is the overlay's positioning anchor.
+        const header = /<header[^>]*>/.exec(html)?.[0] ?? '';
+        expect(header).toContain('relative');
+
+        // The selectors and semantics the rest of the suite relies on survive.
+        expect(pill).toContain('role="status"');
+    });
+
+    it('renders the reconnecting pill larger below md, keeping the desktop size from md up', async () => {
+        const html = await render('reconnecting');
+
+        const pill = openingTag(html, 'connection-reconnecting');
+
+        // Phone-legible size plus toast elevation while floating...
+        expect(pill).toContain('text-[13px]');
+        expect(pill).toContain('px-3.5');
+        expect(pill).toContain('py-1.5');
+        expect(pill).toContain('shadow-md');
+
+        // ...and the exact pre-existing badge sizing once inline again.
+        expect(pill).toContain('md:text-[11.5px]');
+        expect(pill).toContain('md:px-2.5');
+        expect(pill).toContain('md:py-1');
+        expect(pill).toContain('md:shadow-none');
+    });
+
+    it('gives the transient back-online pill the same overlay placement and sizing', async () => {
+        const html = await render('back-online');
+
+        const pill = openingTag(html, 'connection-back-online');
+
+        expect(pill).toContain('role="status"');
+        expect(pill).toContain('absolute');
+        expect(pill).toContain('top-full');
+        expect(pill).toContain('left-1/2');
+        expect(pill).toContain('-translate-x-1/2');
+        expect(pill).toContain('pointer-events-none');
+        expect(pill).toContain('text-[13px]');
+        expect(pill).toContain('shadow-md');
+        expect(pill).toContain('md:static');
+        expect(pill).toContain('md:translate-x-0');
+        expect(pill).toContain('md:text-[11.5px]');
+        expect(pill).toContain('md:shadow-none');
+    });
+});

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -355,7 +355,7 @@ const hasActivityReadout = computed(
                 v-if="props.connectionPill === 'reconnecting'"
                 data-test="connection-reconnecting"
                 role="status"
-                class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3.5 py-1.5 text-[13px] font-semibold text-amber-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-500"
+                class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3.5 py-1.5 text-[13px] font-semibold text-amber-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-amber-900/50 dark:bg-amber-950 dark:text-amber-500 md:dark:bg-amber-950/40"
             >
                 <span
                     class="size-1.5 animate-pulse rounded-full bg-amber-500"
@@ -375,7 +375,7 @@ const hasActivityReadout = computed(
                 v-else-if="props.connectionPill === 'back-online'"
                 data-test="connection-back-online"
                 role="status"
-                class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3.5 py-1.5 text-[13px] font-semibold text-emerald-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-500"
+                class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3.5 py-1.5 text-[13px] font-semibold text-emerald-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-emerald-900/50 dark:bg-emerald-950 dark:text-emerald-500 md:dark:bg-emerald-950/40"
             >
                 <Check class="size-3" />
                 {{ $t('Back online') }}

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -209,7 +209,7 @@ const hasActivityReadout = computed(
          tablet, where the dock takes 300px of a 768px screen and leaves the
          masthead the room of a large phone. -->
     <header
-        class="@container z-20 flex shrink-0 items-center gap-2.5 border-b border-border bg-card/80 px-4 pt-4 pb-3 backdrop-blur-md transition-shadow @2xl:items-end @2xl:gap-4 @2xl:bg-transparent @2xl:px-7 @2xl:pt-5 @2xl:pb-3.5 @2xl:backdrop-blur-none"
+        class="@container relative z-20 flex shrink-0 items-center gap-2.5 border-b border-border bg-card/80 px-4 pt-4 pb-3 backdrop-blur-md transition-shadow @2xl:items-end @2xl:gap-4 @2xl:bg-transparent @2xl:px-7 @2xl:pt-5 @2xl:pb-3.5 @2xl:backdrop-blur-none"
         :class="
             props.scrolled
                 ? 'shadow-[0_2px_10px_rgba(60,55,40,0.07)] @2xl:shadow-none'
@@ -346,12 +346,16 @@ const hasActivityReadout = computed(
         <div class="flex shrink-0 items-center gap-1 @2xl:gap-3 @2xl:pb-1">
             <!-- Realtime connection cue: a quiet amber pill while reconnecting,
                  flipping to a brief green confirmation once the socket recovers.
-                 The app stays fully usable throughout. -->
+                 The app stays fully usable throughout. Below the breakpoint the
+                 masthead has no room for it, so it hangs toast-style under the
+                 header (which anchors it) over the timeline instead of squeezing
+                 the flex row — pointer-events pass through, so it never blocks
+                 the first message row it floats over. -->
             <span
                 v-if="props.connectionPill === 'reconnecting'"
                 data-test="connection-reconnecting"
                 role="status"
-                class="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[11.5px] font-semibold text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-500"
+                class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3.5 py-1.5 text-[13px] font-semibold text-amber-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-500"
             >
                 <span
                     class="size-1.5 animate-pulse rounded-full bg-amber-500"
@@ -371,7 +375,7 @@ const hasActivityReadout = computed(
                 v-else-if="props.connectionPill === 'back-online'"
                 data-test="connection-back-online"
                 role="status"
-                class="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11.5px] font-semibold text-emerald-700 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-500"
+                class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3.5 py-1.5 text-[13px] font-semibold text-emerald-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-500"
             >
                 <Check class="size-3" />
                 {{ $t('Back online') }}


### PR DESCRIPTION
Closes #794. Part of the mobile breakpoint epic #770.

## What

Below `md`, the realtime connection cue (the "Reconnecting…" / "Back online" pill in `ChannelMasthead.vue`) no longer participates in the masthead's flex row. It is absolutely positioned as a toast-style overlay, centered and hanging just below the masthead (which now anchors it via `relative`), so it takes no layout space and nothing reflows when it appears or disappears. It is also larger on a phone (`text-[13px]`, `px-3.5 py-1.5`, `shadow-md`) than the desktop badge.

At `md` and up the pill keeps the exact pre-existing inline placement and sizing via `md:` overrides.

Two details found during visual verification:

- The overlay carries `pointer-events-none`, so it can never block the masthead actions or the first message row it floats over.
- In dark mode the desktop pill's 40% background wash (`dark:bg-amber-950/40`) let timeline content (a poll's progress bar) bleed through and garble the label while floating; the overlay uses a solid `dark:bg-amber-950` surface, and `md:dark:bg-amber-950/40` restores the translucent wash inline (same for the emerald back-online variant).

Both `data-test` selectors (`connection-reconnecting`, `connection-back-online`) and the `role="status"` semantics are unchanged. No copy changes, so no new i18n keys.

## How tested

- New Vitest component tests (`ChannelMasthead.connectionPill.test.ts`, 4 tests) assert the overlay placement, mobile sizing, dark-mode opaque surface, back-online parity, and the preserved selectors/semantics — following the repo's SSR `renderToString` pattern. Full `test:js` suite green (1132 tests).
- Visually verified with Playwright at the epic's viewports — 360x740, 375x667, 390x844, 430x932, 740x360 landscape, and 768x1024 (the `md` boundary, where the pill correctly reverts to the inline badge) — in light and dark themes, with the reconnecting state forced by running the app without Reverb.
- Frontend gates green: `lint:check`, `format:check`, `types:check`, `test:js`, `build`.
- No Pest browser test was added: the pill's state is driven by the live Reverb socket, and forcing a mid-test disconnect in the single-process browser harness is the kind of flake `tests/Browser` constraints warn against; the placement assertions live in the Vitest layer instead.

## Notes

- The local CodeRabbit CLI pass hit the free-tier rate limit; leaning on the app's PR review as backstop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787450862&installation_model_id=428379&pr_number=808&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F808&signature=dd1fa02e8e22ae815ab9a34723db65736ebbac7b491c3045055e777d27d7aded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->