### PR TITLE
fix: keep the bottom-sheet close button visible and pinned on mobile

### DIFF
--- a/resources/js/components/ui/dialog/DialogContent.test.ts
+++ b/resources/js/components/ui/dialog/DialogContent.test.ts
@@ -100,6 +100,26 @@ describe('below the md breakpoint', () => {
         ).not.toBeNull();
     });
 
+    it('keeps the close button clear of the grab handle and pinned with it', async () => {
+        const content = await open();
+        const close = content.querySelector('[data-test="dialog-close-button"]');
+
+        expect(close).not.toBeNull();
+        // Pinned in the same sticky strip as the handle, so it neither scrolls
+        // away with the content nor gets painted over by the strip's opaque
+        // background (#803).
+        const strip = close!.closest('.sticky');
+
+        expect(strip).not.toBeNull();
+        expect(
+            strip!.contains(
+                content.querySelector('[data-test="sheet-grab-handle"]'),
+            ),
+        ).toBe(true);
+        // A real control: never inside the handle's decorative aria-hidden.
+        expect(close!.closest('[aria-hidden="true"]')).toBeNull();
+    });
+
     it('pins a detail sheet to 85% of the screen', async () => {
         // The stand-in for a desktop right-hand pane: a fixed height, so a list
         // does not resize under the thumb as it is worked through.
@@ -152,6 +172,17 @@ describe('from the md breakpoint up', () => {
         expect(
             content.querySelector('[data-test="sheet-grab-handle"]'),
         ).toBeNull();
+    });
+
+    it('keeps the close button in its corner, outside any sticky strip', async () => {
+        const close = (await open()).querySelector(
+            '[data-test="dialog-close-button"]',
+        );
+
+        expect(close).not.toBeNull();
+        expect(close!.className).toContain('top-4');
+        expect(close!.className).toContain('right-4');
+        expect(close!.closest('.sticky')).toBeNull();
     });
 
     it('keeps a fullscreen-below-md dialog centred from md up', async () => {

--- a/resources/js/components/ui/dialog/DialogContent.vue
+++ b/resources/js/components/ui/dialog/DialogContent.vue
@@ -106,6 +106,13 @@ const contentClass = computed(() => {
  * for its desktop dialog, and it sizes against the on-screen keyboard, which
  * only the visual viewport knows the height of.
  */
+/**
+ * The close affordance's look, shared by every presentation — only its
+ * position differs: pinned in the sheet's sticky strip below `md`, parked in
+ * the top-right corner otherwise.
+ */
+const closeButtonClass = "ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+
 const contentStyle = computed<CSSProperties | undefined>(() => {
   if (asFullscreen.value) {
     // `inset-0` anchors to the layout viewport, which the on-screen keyboard
@@ -145,29 +152,51 @@ const contentStyle = computed<CSSProperties | undefined>(() => {
       :class="contentClass"
       :style="contentStyle"
     >
-      <!-- The grab handle: a touch affordance for a gesture that Escape, the
-           scrim and the close button each offer another way to, so it is
-           decorative to a screen reader. -->
-      <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- a pointer-only drag target, not a control -->
+      <!-- The sheet's sticky strip carries both top affordances: the grab
+           handle, and the close button — which must live here rather than
+           float over the scrolling content, or the strip's opaque background
+           paints over it and scrolling carries it away (#803). -->
       <div
         v-if="asSheet"
-        aria-hidden="true"
-        data-test="sheet-grab-handle"
-        class="bg-inherit sticky top-0 z-10 flex shrink-0 cursor-grab touch-none justify-center py-1.5"
-        @pointerdown="drag.start"
-        @pointermove="drag.move"
-        @pointerup="drag.end"
-        @pointercancel="drag.cancel"
+        class="bg-inherit sticky top-0 z-10 shrink-0"
       >
-        <span class="bg-muted-foreground/30 h-1 w-11 rounded-full" />
+        <!-- The grab handle: a touch affordance for a gesture that Escape, the
+             scrim and the close button each offer another way to, so it is
+             decorative to a screen reader. -->
+        <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- a pointer-only drag target, not a control -->
+        <div
+          aria-hidden="true"
+          data-test="sheet-grab-handle"
+          class="flex cursor-grab touch-none justify-center py-1.5"
+          @pointerdown="drag.start"
+          @pointermove="drag.move"
+          @pointerup="drag.end"
+          @pointercancel="drag.cancel"
+        >
+          <span class="bg-muted-foreground/30 h-1 w-11 rounded-full" />
+        </div>
+
+        <!-- `-right-2` undoes part of the root's `p-6` inset, landing the
+             button at the same 16px from the sheet edge as every other
+             presentation's `right-4`. -->
+        <DialogClose
+          v-if="showCloseButton"
+          data-slot="dialog-close"
+          data-test="dialog-close-button"
+          :class="cn(closeButtonClass, 'absolute top-1/2 -right-2 -translate-y-1/2')"
+        >
+          <X />
+          <span class="sr-only">{{ $t('Close') }}</span>
+        </DialogClose>
       </div>
 
       <slot />
 
       <DialogClose
-        v-if="showCloseButton"
+        v-if="showCloseButton && !asSheet"
         data-slot="dialog-close"
-        class="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+        data-test="dialog-close-button"
+        :class="cn(closeButtonClass, 'absolute top-4 right-4')"
       >
         <X />
         <span class="sr-only">{{ $t('Close') }}</span>

--- a/tests/Browser/MobileSheetsTest.php
+++ b/tests/Browser/MobileSheetsTest.php
@@ -173,6 +173,83 @@ test('a sheet keeps every control it draws inside the viewport', function (int $
     'large phone' => [430, 932],
 ]);
 
+test('the close button is fully visible with nothing painted over it', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // The defect (#803): the grab-handle strip is sticky with an opaque
+    // background, and the close button sat underneath it — hit-testing a spread
+    // of points inside the button proves the whole of it is on top, where a
+    // class assertion could not.
+    openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        390,
+        844,
+        browserChannelUrl($team, $channel),
+    )
+        ->assertScript(<<<'JS'
+        (() => {
+            const close = document.querySelector('[data-test="dialog-close-button"]');
+
+            if (close === null) {
+                return false;
+            }
+
+            const box = close.getBoundingClientRect();
+
+            if (box.top < 0 || box.left < 0
+                || box.bottom > window.innerHeight || box.right > window.innerWidth) {
+                return false;
+            }
+
+            // Inset past the button's 2px corner radius, so a corner sample
+            // lands on the button rather than just outside its rounded shape.
+            return [
+                [box.left + 3, box.top + 3],
+                [box.right - 3, box.top + 3],
+                [box.left + 3, box.bottom - 3],
+                [box.right - 3, box.bottom - 3],
+                [box.left + box.width / 2, box.top + box.height / 2],
+            ].every(([x, y]) => {
+                const hit = document.elementFromPoint(x, y);
+
+                return hit !== null && close.contains(hit);
+            });
+        })()
+        JS, true);
+});
+
+test('the close button stays reachable while the sheet scrolls', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // A landscape phone is 360px tall; the create-channel form is not. The
+    // button used to be positioned against the scroll container's content, so
+    // scrolling to the primary action carried the way out off the top (#803).
+    openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        740,
+        360,
+        browserChannelUrl($team, $channel),
+    )
+        ->assertScript(<<<'JS'
+        (() => {
+            const sheet = document.querySelector('[data-slot="dialog-content"]');
+            sheet.scrollTop = sheet.scrollHeight;
+
+            const close = document.querySelector('[data-test="dialog-close-button"]');
+            const box = close.getBoundingClientRect();
+            const hit = document.elementFromPoint(
+                box.left + box.width / 2,
+                box.top + box.height / 2,
+            );
+
+            return box.top >= 0
+                && box.bottom <= window.innerHeight
+                && hit !== null
+                && close.contains(hit);
+        })()
+        JS, true);
+});
+
 test('a sheet traps focus, and Escape closes it', function (): void {
     ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
 


### PR DESCRIPTION
Closes #803.

## What

In sheet presentation (below `md`), the X close button was painted over by the grab-handle strip — the strip is `sticky top-0 z-10` with an opaque `bg-inherit` background, while the button was `absolute top-4 right-4` with no z-index of its own. Because the sheet root is also the scroll container, the absolutely positioned button additionally scrolled out of view with the content.

The sheet's sticky strip now carries both top affordances: the grab handle (still `aria-hidden`, still the drag target, same `data-test`) and the close button as a sibling inside the strip. The button therefore paints above the strip's opaque background and stays pinned with it while the content scrolls. Desktop (centred) and `fullscreen` presentations keep their exact previous DOM and classes — the shared look is extracted into one `closeButtonClass`, with only the position differing per presentation.

The primitive's own close button also gains `data-test="dialog-close-button"`: every `DialogClose` (including form Cancel buttons) shares `data-slot="dialog-close"`, so tests targeting the X by that slot silently matched the wrong button.

## Testing

- 2 new Vitest cases in `DialogContent.test.ts`: the sheet's close button lives in the same sticky strip as the handle and outside any `aria-hidden` subtree; the desktop button stays `absolute top-4 right-4` outside any sticky strip.
- 2 new browser tests in `MobileSheetsTest.php`, both verified red against the pre-fix bundle: hit-testing a spread of points inside the button proves nothing paints over it at 390×844, and at 740×360 the button stays inside the viewport and hit-testable after scrolling the sheet to the bottom.
- Full `MobileSheetsTest` suite (20 tests, incl. axe in light and dark themes), the other mobile browser suites (45 tests), the full Vitest suite (1130), and the backend gate (`composer test`, 100.0% coverage, clean Pint/PHPStan/Rector) all pass.
- Visually confirmed in a real browser at a phone viewport.

No i18n or docs changes: the button reuses the existing `Close` key and nothing operator-facing changed.

Note: the local CodeRabbit CLI pass hit the free-tier rate limit; relying on the app's PR review as backstop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787451255&installation_model_id=428379&pr_number=809&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F809&signature=82f2790ab0a46148c3c021a33f5f987f32b603db05094e2aeab9944539083de0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->