### PR TITLE
fix: keep the composer placeholder on a single line

### DIFF
--- a/resources/js/components/MessageComposer.placeholder.test.ts
+++ b/resources/js/components/MessageComposer.placeholder.test.ts
@@ -45,9 +45,8 @@ afterEach(() => {
         container.remove();
     });
     active = [];
-    delete (
-        HTMLTextAreaElement.prototype as { clientWidth?: number }
-    ).clientWidth;
+    delete (HTMLTextAreaElement.prototype as { clientWidth?: number })
+        .clientWidth;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
 });

--- a/resources/js/components/MessageComposer.placeholder.test.ts
+++ b/resources/js/components/MessageComposer.placeholder.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import MessageComposer from './MessageComposer.vue';
+
+/**
+ * Covers the composer's single-line placeholder (#802): a long DM placeholder
+ * is ellipsized to the textarea's width so it never wraps (and never grows the
+ * empty composer), while the aria-label keeps the full untruncated text.
+ *
+ * Width and text metrics are stubbed — jsdom performs no layout — so ten
+ * units per code point against a 200-unit-wide textarea drive the fitting.
+ */
+
+const LONG_PLACEHOLDER = 'Message Bartholomew Montgomery Featherstone';
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+class ImmediateResizeObserver {
+    constructor(private callback: () => void) {}
+
+    observe(): void {}
+
+    disconnect(): void {}
+}
+
+beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', ImmediateResizeObserver);
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+        font: '',
+        measureText: (candidate: string) => ({
+            width: [...candidate].length * 10,
+        }),
+    } as unknown as CanvasRenderingContext2D);
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'clientWidth', {
+        value: 200,
+        configurable: true,
+    });
+});
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+    delete (
+        HTMLTextAreaElement.prototype as { clientWidth?: number }
+    ).clientWidth;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+function mountComposer(placeholder?: string): HTMLTextAreaElement {
+    const container = document.createElement('div');
+
+    document.body.appendChild(container);
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(MessageComposer as Component, {
+                    channelName: 'general',
+                    members: [],
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                    placeholder,
+                }),
+        }),
+    );
+
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(container);
+    active.push({ app, container });
+
+    return container.querySelector<HTMLTextAreaElement>(
+        '[data-test="message-composer-input"]',
+    )!;
+}
+
+describe('MessageComposer placeholder', () => {
+    it('ellipsizes a long placeholder to a single line and keeps the full aria-label', async () => {
+        const textarea = mountComposer(LONG_PLACEHOLDER);
+
+        await nextTick();
+
+        expect(textarea.placeholder).toBe('Message Bartholomew…');
+        expect(textarea.getAttribute('aria-label')).toBe(LONG_PLACEHOLDER);
+    });
+
+    it('leaves a fitting placeholder untouched', async () => {
+        const textarea = mountComposer('Message Zoe');
+
+        await nextTick();
+
+        expect(textarea.placeholder).toBe('Message Zoe');
+        expect(textarea.getAttribute('aria-label')).toBe('Message Zoe');
+    });
+});

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -31,6 +31,7 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
+import { useEllipsizedText } from '@/composables/useEllipsizedText';
 import { useInitials } from '@/composables/useInitials';
 import { useKeyboardInset } from '@/composables/useKeyboardInset';
 import type {
@@ -334,6 +335,13 @@ const composerPlaceholder = computed(
         props.placeholder ??
         t('Message #:channel', { channel: props.channelName }),
 );
+
+/**
+ * The placeholder as actually rendered: ellipsized to one line of the
+ * textarea so a long DM recipient name never wraps and grows the empty
+ * composer (#802). The aria-label keeps the full `composerPlaceholder`.
+ */
+const visiblePlaceholder = useEllipsizedText(textarea, composerPlaceholder);
 
 // Focus on mount when asked (e.g. the thread composer when a thread opens) so
 // the user can type straight away without clicking into the field. A restored
@@ -1776,7 +1784,7 @@ function onKeydown(event: KeyboardEvent): void {
                         ref="textarea"
                         v-model="body"
                         rows="1"
-                        :placeholder="composerPlaceholder"
+                        :placeholder="visiblePlaceholder"
                         :aria-label="composerPlaceholder"
                         data-test="message-composer-input"
                         role="combobox"

--- a/resources/js/composables/useEllipsizedText.test.ts
+++ b/resources/js/composables/useEllipsizedText.test.ts
@@ -205,4 +205,53 @@ describe('useEllipsizedText', () => {
 
         expect(result.value).toBe('Message Bartholomew');
     });
+
+    it('still fits the text where ResizeObserver is unavailable', async () => {
+        vi.stubGlobal('ResizeObserver', undefined);
+
+        const { result } = mountHarness(
+            textareaOfWidth(120),
+            'Message Bartholomew',
+        );
+
+        await nextTick();
+
+        expect(result.value).toBe('Message Bar…');
+    });
+
+    it('re-fits once webfonts finish loading', async () => {
+        let fontsLoaded!: () => void;
+
+        Object.defineProperty(document, 'fonts', {
+            value: {
+                ready: new Promise<void>((resolve) => {
+                    fontsLoaded = resolve;
+                }),
+            },
+            configurable: true,
+        });
+
+        const { result } = mountHarness(
+            textareaOfWidth(120),
+            'Message Bartholomew',
+        );
+
+        await nextTick();
+        expect(result.value).toBe('Message Bar…');
+
+        // The loaded webfont measures narrower, so the whole text now fits.
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+            font: '',
+            measureText: (candidate: string) => ({
+                width: [...candidate].length * 6,
+            }),
+        } as unknown as CanvasRenderingContext2D);
+
+        fontsLoaded();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(result.value).toBe('Message Bartholomew');
+
+        delete (document as { fonts?: unknown }).fonts;
+    });
 });

--- a/resources/js/composables/useEllipsizedText.test.ts
+++ b/resources/js/composables/useEllipsizedText.test.ts
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, nextTick, ref } from 'vue';
+import { ellipsizeToWidth, useEllipsizedText } from './useEllipsizedText';
+
+/**
+ * Covers the single-line ellipsizing used for the composer placeholder (#802):
+ * the pure width-fitting algorithm, and the composable that wires it to an
+ * element's measured width via canvas text metrics and a ResizeObserver.
+ */
+
+/** Ten units per code point, so expected widths are trivial to derive. */
+const measureByLength = (candidate: string): number =>
+    [...candidate].length * 10;
+
+describe('ellipsizeToWidth', () => {
+    it('returns the text unchanged when it fits', () => {
+        expect(ellipsizeToWidth('Message Ann', 110, measureByLength)).toBe(
+            'Message Ann',
+        );
+    });
+
+    it('truncates an overflowing text and appends an ellipsis', () => {
+        // 12 units available: 11 code points of text + the ellipsis itself.
+        expect(
+            ellipsizeToWidth('Message Bartholomew', 120, measureByLength),
+        ).toBe('Message Bar…');
+    });
+
+    it('trims trailing whitespace before the ellipsis', () => {
+        expect(
+            ellipsizeToWidth('Message Bartholomew', 90, measureByLength),
+        ).toBe('Message…');
+    });
+
+    it('degrades to the ellipsis alone when nothing fits', () => {
+        expect(ellipsizeToWidth('Message Bob', 5, measureByLength)).toBe('…');
+    });
+
+    it('never splits a surrogate pair', () => {
+        // Each 🎉 is one code point (two UTF-16 units); slicing by code
+        // points keeps the emoji intact or drops it whole.
+        expect(ellipsizeToWidth('Message 🎉🎉🎉', 100, measureByLength)).toBe(
+            'Message 🎉…',
+        );
+    });
+});
+
+describe('useEllipsizedText', () => {
+    type ResizeCallback = () => void;
+
+    let resizeCallbacks: ResizeCallback[] = [];
+    let observed: Element[] = [];
+    let active: Array<{ app: App; container: HTMLElement }> = [];
+
+    class FakeResizeObserver {
+        constructor(private callback: ResizeCallback) {}
+
+        observe(element: Element): void {
+            observed.push(element);
+            resizeCallbacks.push(this.callback);
+        }
+
+        disconnect(): void {}
+    }
+
+    beforeEach(() => {
+        vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+        vi.spyOn(
+            HTMLCanvasElement.prototype,
+            'getContext',
+        ).mockReturnValue({
+            font: '',
+            measureText: (candidate: string) => ({
+                width: measureByLength(candidate),
+            }),
+        } as unknown as CanvasRenderingContext2D);
+    });
+
+    afterEach(() => {
+        active.forEach(({ app, container }) => {
+            app.unmount();
+            container.remove();
+        });
+        active = [];
+        resizeCallbacks = [];
+        observed = [];
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    function textareaOfWidth(clientWidth: number): HTMLTextAreaElement {
+        const element = document.createElement('textarea');
+
+        Object.defineProperty(element, 'clientWidth', {
+            value: clientWidth,
+            configurable: true,
+        });
+        document.body.appendChild(element);
+
+        return element;
+    }
+
+    function mountHarness(element: HTMLElement | null, initialText: string) {
+        const elementRef = ref<HTMLElement | null>(element);
+        const text = ref(initialText);
+        let result!: Readonly<{ value: string }>;
+        const container = document.createElement('div');
+
+        document.body.appendChild(container);
+
+        const app = createApp(
+            defineComponent({
+                setup: () => {
+                    result = useEllipsizedText(elementRef, () => text.value);
+
+                    return () => h('div');
+                },
+            }),
+        );
+
+        app.mount(container);
+        active.push({ app, container });
+
+        return { result: result!, text, elementRef };
+    }
+
+    it('ellipsizes the text to the element width', async () => {
+        const { result } = mountHarness(
+            textareaOfWidth(120),
+            'Message Bartholomew',
+        );
+
+        await nextTick();
+
+        expect(result.value).toBe('Message Bar…');
+    });
+
+    it('keeps a fitting text untouched', async () => {
+        const { result } = mountHarness(textareaOfWidth(120), 'Message Ann');
+
+        await nextTick();
+
+        expect(result.value).toBe('Message Ann');
+    });
+
+    it('re-fits when the text changes', async () => {
+        const { result, text } = mountHarness(
+            textareaOfWidth(120),
+            'Message Bartholomew',
+        );
+
+        await nextTick();
+        text.value = 'Message Zoe';
+        await nextTick();
+
+        expect(result.value).toBe('Message Zoe');
+    });
+
+    it('re-fits when the element resizes', async () => {
+        const element = textareaOfWidth(120);
+        const { result } = mountHarness(element, 'Message Bartholomew');
+
+        await nextTick();
+        expect(observed).toContain(element);
+
+        Object.defineProperty(element, 'clientWidth', {
+            value: 200,
+            configurable: true,
+        });
+        resizeCallbacks.forEach((callback) => callback());
+        await nextTick();
+
+        expect(result.value).toBe('Message Bartholomew');
+    });
+
+    it('returns the full text while the element is absent', async () => {
+        const { result } = mountHarness(null, 'Message Bartholomew');
+
+        await nextTick();
+
+        expect(result.value).toBe('Message Bartholomew');
+    });
+
+    it('returns the full text when canvas measurement is unavailable', async () => {
+        vi.spyOn(
+            HTMLCanvasElement.prototype,
+            'getContext',
+        ).mockReturnValue(null);
+
+        const { result } = mountHarness(
+            textareaOfWidth(120),
+            'Message Bartholomew',
+        );
+
+        await nextTick();
+
+        expect(result.value).toBe('Message Bartholomew');
+    });
+
+    it('returns the full text when the element has no width yet', async () => {
+        const { result } = mountHarness(
+            textareaOfWidth(0),
+            'Message Bartholomew',
+        );
+
+        await nextTick();
+
+        expect(result.value).toBe('Message Bartholomew');
+    });
+});

--- a/resources/js/composables/useEllipsizedText.test.ts
+++ b/resources/js/composables/useEllipsizedText.test.ts
@@ -67,10 +67,7 @@ describe('useEllipsizedText', () => {
 
     beforeEach(() => {
         vi.stubGlobal('ResizeObserver', FakeResizeObserver);
-        vi.spyOn(
-            HTMLCanvasElement.prototype,
-            'getContext',
-        ).mockReturnValue({
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
             font: '',
             measureText: (candidate: string) => ({
                 width: measureByLength(candidate),
@@ -184,10 +181,9 @@ describe('useEllipsizedText', () => {
     });
 
     it('returns the full text when canvas measurement is unavailable', async () => {
-        vi.spyOn(
-            HTMLCanvasElement.prototype,
-            'getContext',
-        ).mockReturnValue(null);
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+            null,
+        );
 
         const { result } = mountHarness(
             textareaOfWidth(120),

--- a/resources/js/composables/useEllipsizedText.test.ts
+++ b/resources/js/composables/useEllipsizedText.test.ts
@@ -53,6 +53,7 @@ describe('useEllipsizedText', () => {
     let resizeCallbacks: ResizeCallback[] = [];
     let observed: Element[] = [];
     let active: Array<{ app: App; container: HTMLElement }> = [];
+    let documentFontsDescriptor: PropertyDescriptor | undefined;
 
     class FakeResizeObserver {
         constructor(private callback: ResizeCallback) {}
@@ -66,6 +67,10 @@ describe('useEllipsizedText', () => {
     }
 
     beforeEach(() => {
+        documentFontsDescriptor = Object.getOwnPropertyDescriptor(
+            document,
+            'fonts',
+        );
         vi.stubGlobal('ResizeObserver', FakeResizeObserver);
         vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
             font: '',
@@ -83,6 +88,12 @@ describe('useEllipsizedText', () => {
         active = [];
         resizeCallbacks = [];
         observed = [];
+        if (documentFontsDescriptor) {
+            Object.defineProperty(document, 'fonts', documentFontsDescriptor);
+        } else {
+            delete (document as { fonts?: unknown }).fonts;
+        }
+        documentFontsDescriptor = undefined;
         vi.unstubAllGlobals();
         vi.restoreAllMocks();
     });
@@ -251,7 +262,5 @@ describe('useEllipsizedText', () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(result.value).toBe('Message Bartholomew');
-
-        delete (document as { fonts?: unknown }).fonts;
     });
 });

--- a/resources/js/composables/useEllipsizedText.test.ts
+++ b/resources/js/composables/useEllipsizedText.test.ts
@@ -88,11 +88,13 @@ describe('useEllipsizedText', () => {
         active = [];
         resizeCallbacks = [];
         observed = [];
+
         if (documentFontsDescriptor) {
             Object.defineProperty(document, 'fonts', documentFontsDescriptor);
         } else {
             delete (document as { fonts?: unknown }).fonts;
         }
+
         documentFontsDescriptor = undefined;
         vi.unstubAllGlobals();
         vi.restoreAllMocks();

--- a/resources/js/composables/useEllipsizedText.ts
+++ b/resources/js/composables/useEllipsizedText.ts
@@ -1,0 +1,121 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { onBeforeUnmount, readonly, ref, toValue, watch } from 'vue';
+
+const ELLIPSIS = '…';
+
+/**
+ * Keep `text` fitting on a single line of `element`, truncating it with an
+ * ellipsis when it would overflow (and wrap). Built for the composer
+ * placeholder (#802): textarea placeholders wrap by default and
+ * `::placeholder` overflow styling is inconsistent across browsers, so the
+ * string itself is truncated instead, via canvas text metrics matching the
+ * element's computed font.
+ *
+ * Falls back to the full text whenever it cannot measure (no element yet, no
+ * canvas 2D context, zero width) and re-fits when the text changes, when the
+ * element resizes, and once webfonts finish loading.
+ */
+export function useEllipsizedText(
+    element: Ref<HTMLElement | null>,
+    text: MaybeRefOrGetter<string>,
+): Readonly<Ref<string>> {
+    const ellipsized = ref(toValue(text));
+
+    function update(): void {
+        ellipsized.value = fitToElement(element.value, toValue(text));
+    }
+
+    const observer =
+        typeof ResizeObserver === 'undefined'
+            ? null
+            : new ResizeObserver(update);
+
+    watch(
+        [element, (): string => toValue(text)],
+        () => {
+            observer?.disconnect();
+
+            if (element.value) {
+                observer?.observe(element.value);
+            }
+
+            update();
+        },
+        { immediate: true },
+    );
+
+    if (typeof document !== 'undefined') {
+        document.fonts?.ready.then(update);
+    }
+
+    onBeforeUnmount(() => observer?.disconnect());
+
+    return readonly(ellipsized);
+}
+
+function fitToElement(element: HTMLElement | null, text: string): string {
+    if (!element) {
+        return text;
+    }
+
+    const style = window.getComputedStyle(element);
+    const available =
+        element.clientWidth -
+        (Number.parseFloat(style.paddingLeft) || 0) -
+        (Number.parseFloat(style.paddingRight) || 0);
+
+    if (available <= 0) {
+        return text;
+    }
+
+    const context = document.createElement('canvas').getContext('2d');
+
+    if (!context) {
+        return text;
+    }
+
+    context.font =
+        style.font ||
+        `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+
+    return ellipsizeToWidth(
+        text,
+        available,
+        (candidate) => context.measureText(candidate).width,
+    );
+}
+
+/**
+ * Fit `text` on a single line of at most `maxWidth` units, truncating with an
+ * ellipsis when it overflows. `measure` returns the rendered width of a
+ * candidate string; the search is over code points so surrogate pairs (emoji
+ * in a recipient or channel name) are never split.
+ */
+export function ellipsizeToWidth(
+    text: string,
+    maxWidth: number,
+    measure: (candidate: string) => number,
+): string {
+    if (measure(text) <= maxWidth) {
+        return text;
+    }
+
+    const codePoints = [...text];
+    const candidate = (length: number): string =>
+        codePoints.slice(0, length).join('').trimEnd() + ELLIPSIS;
+
+    let low = 0;
+    let high = codePoints.length - 1;
+
+    while (low < high) {
+        const mid = Math.ceil((low + high) / 2);
+
+        if (measure(candidate(mid)) <= maxWidth) {
+            low = mid;
+        } else {
+            high = mid - 1;
+        }
+    }
+
+    return candidate(low);
+}

--- a/tests/Browser/ComposerPlaceholderTest.php
+++ b/tests/Browser/ComposerPlaceholderTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Channels\OpenDirectMessage;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * The composer placeholder stays on a single line (#802).
+ *
+ * On a phone, a DM with a long-named counterpart used to wrap its
+ * "Message <name>" placeholder onto three lines, growing the empty composer
+ * as if it were pre-filled. The rendered placeholder is now ellipsized to the
+ * textarea's width while the accessible name keeps the full text.
+ */
+
+const COMPOSER_FULL_PLACEHOLDER = 'Message Bartholomew Montgomery Featherstone';
+
+/**
+ * A team whose owner has a 1:1 DM open with a long-named counterpart — the
+ * name whose placeholder wrapped the empty composer on a phone.
+ *
+ * @return array{owner: User, team: Team, url: string}
+ */
+function browserDmWithLongRecipient(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'team' => $team] = browserTeamWithChannel();
+
+    $bob->update(['name' => 'Bartholomew Montgomery Featherstone']);
+
+    $dm = app(OpenDirectMessage::class)->handle($team, $alice, $bob);
+
+    return ['owner' => $alice, 'team' => $team, 'url' => browserChannelUrl($team, $dm)];
+}
+
+test('the placeholder is ellipsized to a single line at phone widths', function (int $width, int $height): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongRecipient();
+
+    signInThroughBrowser($alice)
+        ->resize($width, $height)
+        ->navigate($url)
+        ->assertVisible('@message-composer-input')
+        // The rendered placeholder is truncated with an ellipsis...
+        ->assertScript(<<<'JS'
+        (() => {
+            const placeholder = document.querySelector('[data-test="message-composer-input"]').placeholder;
+
+            return placeholder.endsWith('…')
+                && placeholder.length < 'Message Bartholomew Montgomery Featherstone'.length;
+        })()
+        JS, true)
+        // ...so the empty composer stands one line tall, not three.
+        ->assertScript(<<<'JS'
+        (() => {
+            const el = document.querySelector('[data-test="message-composer-input"]');
+
+            return el.getBoundingClientRect().height
+                < 2 * Number.parseFloat(getComputedStyle(el).lineHeight);
+        })()
+        JS, true);
+})->with([
+    'small phone' => [360, 740],
+    'iPhone 14' => [390, 844],
+]);
+
+test('the accessible name keeps the full untruncated text', function (): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongRecipient();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate($url)
+        ->assertAttribute(
+            '@message-composer-input',
+            'aria-label',
+            COMPOSER_FULL_PLACEHOLDER,
+        );
+});
+
+test('the empty composer with a long placeholder matches the single-line height it has once typed in', function (): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongRecipient();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate($url)
+        ->assertVisible('@message-composer-input');
+
+    $page->script(<<<'JS'
+    (() => {
+        const el = document.querySelector('[data-test="message-composer-input"]');
+
+        window.__emptyComposerHeight = Math.round(el.getBoundingClientRect().height);
+    })()
+    JS);
+
+    // One typed character is the canonical single-line composer; the empty
+    // composer (placeholder only) must be exactly as tall.
+    $page->type('@message-composer-input', 'x')
+        ->assertScript(<<<'JS'
+        (() => {
+            const el = document.querySelector('[data-test="message-composer-input"]');
+
+            return Math.round(el.getBoundingClientRect().height) === window.__emptyComposerHeight;
+        })()
+        JS, true);
+});
+
+test('the full name returns once the composer is wide enough', function (): void {
+    ['owner' => $alice, 'url' => $url] = browserDmWithLongRecipient();
+
+    // Truncation follows the textarea's own width, not the viewport: on a
+    // desktop-wide window the whole name fits, so nothing is ellipsized.
+    signInThroughBrowser($alice)
+        ->resize(1440, 900)
+        ->navigate($url)
+        ->assertAttribute(
+            '@message-composer-input',
+            'placeholder',
+            COMPOSER_FULL_PLACEHOLDER,
+        );
+});

--- a/tests/Browser/ComposerPlaceholderTest.php
+++ b/tests/Browser/ComposerPlaceholderTest.php
@@ -14,7 +14,6 @@ use App\Models\User;
  * as if it were pre-filled. The rendered placeholder is now ellipsized to the
  * textarea's width while the accessible name keeps the full text.
  */
-
 const COMPOSER_FULL_PLACEHOLDER = 'Message Bartholomew Montgomery Featherstone';
 
 /**


### PR DESCRIPTION
Closes #802.

## What

On phone-width viewports, a DM with a long recipient name (e.g. "Bartholomew Montgomery Featherstone") wrapped the composer's `Message :name` placeholder onto three lines, and the empty composer grew with it because the textarea auto-resize reads `scrollHeight`. The rendered placeholder is now ellipsized to a single line that fits the textarea, while the `aria-label` keeps the full untruncated text.

## How

- New `useEllipsizedText` composable (`resources/js/composables/useEllipsizedText.ts`): fits a string to an element's content width via canvas text metrics matching the element's computed font, with a code-point-safe binary search (`ellipsizeToWidth`) so emoji surrogate pairs are never split. It re-fits when the text changes, when the element resizes (ResizeObserver), and once webfonts finish loading, and falls back to the full text whenever it cannot measure (SSR, no element, no 2D context, zero width). Truncating the string in JS was chosen over CSS because textarea `::placeholder` overflow styling is inconsistent across browsers (see the issue notes).
- `MessageComposer.vue` binds `:placeholder` to the ellipsized text and keeps `:aria-label` on the full `composerPlaceholder`.

## Testing

- Vitest: `useEllipsizedText.test.ts` (pure fitting algorithm + composable reactivity/fallbacks, 14 tests) and `MessageComposer.placeholder.test.ts` (truncated `placeholder` attribute, full `aria-label`).
- Browser (Pest): `tests/Browser/ComposerPlaceholderTest.php` — at 360×740 and 390×844 the placeholder is ellipsized and the empty composer stands one line tall; the empty composer's height equals its height once a character is typed; the `aria-label` keeps the full name; at 1440×900 the full name fits untruncated. Verified the suite fails against the unfixed code (rebuilt without the binding) and passes with it.
- Full gates green: `sail composer test` at 100.0% coverage, `lint:check`, `format:check`, `types:check`, `test:js` (1155 tests), `build`, plus `A11yTimelineTest` for the composer's a11y contract.

## Notes

- Local CodeRabbit review applied: extra tests for the ResizeObserver-less and webfont re-fit paths, and `document.fonts` stub restoration in `afterEach`. Declined: returning an empty string when even the ellipsis doesn't fit — a lone ellipsis cannot wrap (the defect was wrapping, not clipping) and keeps a visible hint.
- No new i18n keys (existing `Message :name` / `Message #:channel` keys are reused); no operator-facing changes.
- Found while running the gate: transient Postgres deadlocks in the parallel test harness — filed #812.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787453642&installation_model_id=428379&pr_number=813&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F813&signature=bddf46f5f8417b82dc512eec844b6fe6893f58f22da4a8cd22373289b14ba9bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->