### PR TITLE
fix: overlay the thread panel over the channel card at tablet widths

### DIFF
--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -220,7 +220,7 @@ watch(
 <template>
     <aside
         data-test="thread-panel"
-        class="flex w-full min-w-0 shrink-0 flex-col overflow-hidden max-md:absolute max-md:inset-0 max-md:z-30 max-md:bg-card md:m-3.5 md:w-96 md:rounded-[14px] md:border md:border-border md:bg-sidebar md:shadow-sm"
+        class="z-30 flex w-full min-w-0 shrink-0 flex-col overflow-hidden max-md:absolute max-md:inset-0 max-md:bg-card md:rounded-[14px] md:border md:border-border md:bg-sidebar md:shadow-sm md:max-lg:absolute md:max-lg:inset-0 md:max-lg:w-auto lg:relative lg:m-3.5 lg:w-96"
     >
         <header
             class="flex shrink-0 items-center gap-2.5 border-b border-border px-4 pt-4 pb-3 md:items-start md:gap-2 md:px-4.5"

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1177,9 +1177,10 @@ function archive(): void {
         {{ sendFailureAnnouncement }}
     </div>
 
-    <!-- `relative` anchors the thread panel below the breakpoint, where it is a
-         full-screen push over this whole pane — masthead included — rather than
-         a flex sibling squeezing the channel beside it. -->
+    <!-- `relative` anchors the thread panel below `lg`, where it covers this
+         whole pane — masthead included — rather than being a flex sibling
+         squeezing the channel beside it: a full-screen push below `md`, a
+         card-sized overlay through the tablet band (#788). -->
     <div class="relative flex min-h-0 flex-1 overflow-hidden">
         <div class="relative flex min-w-0 flex-1 flex-col">
             <ChannelMasthead

--- a/tests/Browser/MobileThreadPanelTest.php
+++ b/tests/Browser/MobileThreadPanelTest.php
@@ -131,15 +131,18 @@ test('at tablet widths the thread takes the full card instead of squeezing the c
         })()
         JS, true)
         ->assertNotPresent('[data-test=thread-replies-divider]')
-        // The panel spans the card instead of leaving the channel a sliver
-        // beside it: at 768px the dock and the fixed side pane would leave the
-        // channel ~56px.
+        // The panel covers the card edge to edge instead of leaving the channel
+        // a sliver beside it: at 768px the dock and the fixed side pane would
+        // leave the channel ~56px.
         ->assertScript(<<<'JS'
         (() => {
             const card = document.querySelector('#main').getBoundingClientRect();
             const panel = document.querySelector('[data-test=thread-panel]').getBoundingClientRect();
 
-            return panel.width >= card.width - 60;
+            return Math.abs(panel.left - card.left) <= 4
+                && Math.abs(panel.right - card.right) <= 4
+                && Math.abs(panel.top - card.top) <= 4
+                && Math.abs(panel.bottom - card.bottom) <= 4;
         })()
         JS, true)
         // The masthead paints under the overlay, so no masthead control can

--- a/tests/Browser/MobileThreadPanelTest.php
+++ b/tests/Browser/MobileThreadPanelTest.php
@@ -10,8 +10,11 @@ use App\Models\User;
 /**
  * The thread panel below `md`: a full-screen push over the channel with a back
  * chevron (per the mobile design's `m3`), never a side pane — a side pane on a
- * 390px viewport leaves neither the channel nor the thread readable. At and
- * above `md` the panel stays the side pane it is on desktop.
+ * 390px viewport leaves neither the channel nor the thread readable. From `md`
+ * to `lg` the panel keeps its desktop header but overlays the whole card: the
+ * dock (300px) plus the fixed side pane leave the channel a ~56px sliver at
+ * 768px, and its overflowing masthead controls painted over the panel (#788).
+ * Only at `lg` and up is there room for the side pane beside the channel.
  */
 
 /**
@@ -107,7 +110,60 @@ test('below md a thread opens as a full-screen push over the whole card', functi
     'the last mobile width' => [767, 800],
 ]);
 
-test('at and above md the thread stays the side pane it is today', function (int $width): void {
+test('at tablet widths the thread takes the full card instead of squeezing the channel', function (int $width): void {
+    ['owner' => $alice] = threadedChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize($width, 1024)
+        ->assertSee('Thread root message');
+
+    $page->click('[data-test=thread-summary]')
+        ->assertPresent('[data-test=thread-panel]')
+        // The desktop header survives: the X closes the thread, the back
+        // chevron stays a below-`md` affordance, and the reply count stays in
+        // the header rather than the push's divider.
+        ->assertVisible('[data-test=thread-close]')
+        ->assertScript(<<<'JS'
+        (() => {
+            const back = document.querySelector('[data-test=thread-back]');
+
+            return back === null || back.offsetParent === null;
+        })()
+        JS, true)
+        ->assertNotPresent('[data-test=thread-replies-divider]')
+        // The panel spans the card instead of leaving the channel a sliver
+        // beside it: at 768px the dock and the fixed side pane would leave the
+        // channel ~56px.
+        ->assertScript(<<<'JS'
+        (() => {
+            const card = document.querySelector('#main').getBoundingClientRect();
+            const panel = document.querySelector('[data-test=thread-panel]').getBoundingClientRect();
+
+            return panel.width >= card.width - 60;
+        })()
+        JS, true)
+        // The masthead paints under the overlay, so no masthead control can
+        // sit on top of the panel (the #788 overpaint).
+        ->assertScript(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-test=thread-panel]');
+            const controls = [...document.querySelectorAll('[data-test=masthead-search], [data-test=masthead-pins], [data-test=channel-options]')]
+                .filter((el) => el.getClientRects().length > 0);
+
+            return controls.length > 0 && controls.every((el) => {
+                const rect = el.getBoundingClientRect();
+                const top = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+
+                return top !== null && panel.contains(top);
+            });
+        })()
+        JS, true);
+})->with([
+    'the md boundary' => [768],
+    'the last tablet width' => [1023],
+]);
+
+test('at and above lg the thread stays the side pane it is today', function (int $width): void {
     ['owner' => $alice] = threadedChannel();
 
     $page = signInThroughBrowser($alice)
@@ -134,11 +190,24 @@ test('at and above md the thread stays the side pane it is today', function (int
             return back === null || back.offsetParent === null;
         })()
         JS, true)
+        // Every masthead control stays wholly inside the channel column — none
+        // reaches over the pane's left edge (the #788 overpaint).
+        ->assertScript(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-test=thread-panel]').getBoundingClientRect();
+            const controls = [...document.querySelectorAll('[data-test=masthead-search], [data-test=masthead-pins], [data-test=channel-options]')]
+                .filter((el) => el.getClientRects().length > 0);
+
+            return controls.length > 0 && controls.every(
+                (el) => el.getBoundingClientRect().right <= panel.left + 1,
+            );
+        })()
+        JS, true)
         // The desktop header keeps the count, so no divider splits the list.
         ->assertNotPresent('[data-test=thread-replies-divider]');
 })->with([
-    'the breakpoint itself' => [768],
-    'desktop' => [1024],
+    'the lg boundary' => [1024],
+    'wide desktop' => [1280],
 ]);
 
 test('back returns to the channel at the scroll position it was left at', function (): void {


### PR DESCRIPTION
Closes #788.

## What

From `md` to `lg` (768–1023px) the thread panel now absolutely covers the whole channel card — dock still visible, desktop header kept (X close, reply count in the header) — instead of sitting beside the channel as a fixed 384px side pane. From `lg` up the side-by-side layout is byte-for-byte what it was, and the panel now carries its own positioning + `z-30` so no masthead control can ever paint over it.

## Why

With a thread open in the tablet band, the dock (300px) plus the fixed `md:w-96` pane left the channel ~56px at 768px — a useless sliver — and the channel masthead's `z-20` controls overflowed it and painted on top of the thread panel's header. The tablet treatment picks the issue's "thread takes the full card" option: it extends the mechanism #773 built for the mobile push (the channel stays mounted underneath, so its scroll position is preserved on close), scoped to the card so the dock stays reachable, on the standard `lg` boundary rather than a magic width.

## How tested

- New browser test `at tablet widths the thread takes the full card instead of squeezing the channel` (768 and 1023): panel covers the card edge to edge (±4px on all four edges), the X close shows while the back chevron and the push's replies divider stay absent, and `elementFromPoint` over every rendered masthead control resolves inside the panel — the #788 overpaint cannot recur.
- The side-pane test is retargeted from `md`+ to `lg`+ (1024 and 1280) and now also asserts every masthead control stays wholly left of the pane.
- Visually verified in the real app at 768×1024 (light and dark), 1023×800, 1024×800, 1280×800, and 390×844 (mobile push unchanged).
- Full gate green: `composer test` at 100.0% coverage with clean Pint/PHPStan/Rector; `lint:check`, `format:check`, `types:check`, `test:js`, `build` all pass; the full `MobileThreadPanelTest` browser file passes (11 tests).

No new user-facing copy (no `lang/fr.json` changes) and nothing operator-facing (no docs changes). Local CodeRabbit review clean; its suggestion to harden the full-card assertion to per-edge comparison was applied.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787483236&installation_model_id=428379&pr_number=817&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F817&signature=8295c3a26034dfe901bcdad862dd3599232e6d91925b0033bd825d90bb0e7b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->