### PR TITLE
ci: stop re-running the full ci suite on release-please pr updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,15 @@ on:
     branches:
       - develop
       - master
+    # Merging a release PR pushes a commit touching only files release-please
+    # owns, which contain no analyzable code. Push runs carry no required
+    # checks, so a plain `paths-ignore` is safe here (unlike on `pull_request`,
+    # see the job-level skip below). Guarded by
+    # tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
+    paths-ignore:
+      - 'VERSION'
+      - 'CHANGELOG.md'
+      - '.release-please-manifest*.json'
   pull_request:
     branches:
       - develop
@@ -28,6 +37,15 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    # Release-please PRs only touch VERSION/manifest/changelog files, none of
+    # which contain analyzable code. A job-level `if` (not a `paths` filter)
+    # keeps the PR mergeable: a skipped job reports its required check as
+    # *skipped*, which GitHub treats as satisfied, while a workflow that never
+    # starts leaves it stuck on *Expected*. The head-repo clause keeps the
+    # branch name from becoming a CI bypass: `head_ref` is attacker-controlled,
+    # so a fork branch named `release-please--anything` must still run
+    # everything. Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     permissions:
       # Required to upload results to the code-scanning (Security) tab.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - develop
       - master
+    # Merging a release PR pushes a commit touching only files release-please
+    # owns, which cannot affect the app. Push runs carry no required checks, so
+    # a plain `paths-ignore` is safe here (unlike on `pull_request`, see the
+    # job-level skip below). Guarded by
+    # tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
+    paths-ignore:
+      - 'VERSION'
+      - 'CHANGELOG.md'
+      - '.release-please-manifest*.json'
   pull_request:
     branches:
       - develop
@@ -19,6 +28,15 @@ permissions:
 
 jobs:
   quality:
+    # Release-please PRs only touch VERSION/manifest/changelog files, so this
+    # suite has nothing to check there. A job-level `if` (not a `paths` filter)
+    # keeps the PR mergeable: a skipped job reports its required check as
+    # *skipped*, which GitHub treats as satisfied, while a workflow that never
+    # starts leaves it stuck on *Expected*. The head-repo clause keeps the
+    # branch name from becoming a CI bypass: `head_ref` is attacker-controlled,
+    # so a fork branch named `release-please--anything` must still run
+    # everything. Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - develop
       - master
+    # Merging a release PR pushes a commit touching only files release-please
+    # owns, which cannot affect the app — the code it rides on was already fully
+    # tested when it landed. Push runs carry no required checks, so a plain
+    # `paths-ignore` is safe here (unlike on `pull_request`, see the job-level
+    # skip below). Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
+    paths-ignore:
+      - 'VERSION'
+      - 'CHANGELOG.md'
+      - '.release-please-manifest*.json'
   pull_request:
     branches:
       - develop
@@ -21,6 +30,17 @@ permissions:
 
 jobs:
   ci:
+    # Release-please PRs only touch VERSION/manifest/changelog files, already
+    # fully tested on the branch they were cut from — yet every push to the base
+    # branch force-updates the release branch and re-fires this suite on the PR.
+    # A job-level `if` (not a `paths` filter) is what keeps the PR mergeable: a
+    # skipped job reports its required check as *skipped*, which GitHub treats as
+    # satisfied, while a workflow that never starts leaves it stuck on
+    # *Expected*. The head-repo clause keeps the branch name from becoming a CI
+    # bypass: `head_ref` is attacker-controlled, so a fork branch named
+    # `release-please--anything` must still run everything. Guarded by
+    # tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     strategy:
       matrix:
@@ -137,6 +157,8 @@ jobs:
   # never folds into the 100% coverage gate above — the `browser` group is
   # excluded from phpunit's default suites and only runs via `pest tests/Browser`.
   browser:
+    # Skipped on release-please PRs for the same reason as the ci job above.
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     services:

--- a/tests/Unit/ReleasePullRequestCiSkipTest.php
+++ b/tests/Unit/ReleasePullRequestCiSkipTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Every merge into `develop` used to burn a third full CI suite: release-please
+ * reacts to the push by force-updating its `release-please--branches--develop`
+ * branch, which fires a `synchronize` event on the open release PR and re-runs
+ * the heavy workflows on a diff that touches only files release-please owns —
+ * `VERSION`, the manifests, `CHANGELOG.md` — none of which can affect the app,
+ * over code the feature PR's run and the push run had already tested. The same
+ * applied to the stable release PR on `master`, and again to the push a merged
+ * release PR produces. These tests pin the skip conditions so an edit to the
+ * heavy workflows cannot silently reintroduce the triple run (#820).
+ */
+$workflow = fn (string $name): array => Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/'.$name);
+
+/**
+ * The condition that spares a release PR the heavy jobs: `head_ref` is only set
+ * on pull request events, so every push, schedule, or dispatch run passes the
+ * first disjunct untouched. The head-repo disjunct is what keeps the branch
+ * name from becoming a CI bypass — `head_ref` is attacker-controlled, so a fork
+ * branch named `release-please--anything` would otherwise get every required
+ * check skipped (and skipped counts as satisfied). A same-repo branch with that
+ * name needs write access, which is already trusted.
+ */
+const RELEASE_PULL_REQUEST_SKIP = "github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository";
+
+/**
+ * The multi-minute jobs and the workflows they live in. `commitlint` and
+ * `dependency-review` are deliberately absent: they finish in seconds, so
+ * skipping them on a release PR would buy nothing.
+ *
+ * @return array<string, array{0: string, 1: string}>
+ */
+function heavyJobs(): array
+{
+    return [
+        'the test suite' => ['tests.yml', 'ci'],
+        'the browser suite' => ['tests.yml', 'browser'],
+        'the linter' => ['lint.yml', 'quality'],
+        'the CodeQL analysis' => ['codeql.yml', 'analyze'],
+    ];
+}
+
+test('the heavy jobs skip release-please pull requests', function (string $file, string $job) use ($workflow): void {
+    expect($workflow($file)['jobs'][$job]['if'] ?? null)->toBe(RELEASE_PULL_REQUEST_SKIP);
+})->with(heavyJobs());
+
+/*
+ * The skip must stay a job-level `if`, never a `paths` filter on the
+ * `pull_request` trigger: a skipped job still reports its check as *skipped*,
+ * which GitHub treats as satisfied for required status checks — whereas a
+ * workflow that never starts leaves them stuck on *Expected* and blocks the
+ * release PR from merging.
+ */
+test('the heavy workflows still trigger on release pull requests so their checks report skipped', function (string $file) use ($workflow): void {
+    $pullRequest = $workflow($file)['on']['pull_request'];
+
+    expect($pullRequest['branches'])->toEqualCanonicalizing(['develop', 'master'])
+        ->and($pullRequest)->not->toHaveKey('paths')
+        ->and($pullRequest)->not->toHaveKey('paths-ignore');
+})->with(collect(heavyJobs())->pluck(0)->unique()->values()->all());
+
+/*
+ * Merging a release PR pushes a commit touching only the files release-please
+ * owns, and that push used to run the full suite once more. Push runs carry no
+ * required checks, so a plain `paths-ignore` is safe where a `paths` filter on
+ * the pull request trigger would not be.
+ */
+test('a push touching only release-please-owned files does not run the heavy suites', function (string $file) use ($workflow): void {
+    expect($workflow($file)['on']['push']['paths-ignore'] ?? null)
+        ->toEqualCanonicalizing(['VERSION', 'CHANGELOG.md', '.release-please-manifest*.json']);
+})->with(collect(heavyJobs())->pluck(0)->unique()->values()->all());
+
+/*
+ * The push a merged release PR produces is exactly what makes release-please
+ * tag the version, so its own workflow must never be filtered by the paths the
+ * heavy suites ignore.
+ */
+test('the release workflow still runs on every push, release-owned files included', function () use ($workflow): void {
+    $push = $workflow('release-please.yml')['on']['push'];
+
+    expect($push)->not->toHaveKey('paths')
+        ->and($push)->not->toHaveKey('paths-ignore');
+});


### PR DESCRIPTION
Closes #820.

## What / why

Every merge into `develop` burned roughly three full CI suites: the feature PR's own run, the push run on `develop`, and a full re-run on the release-please RC PR — release-please force-updates its `release-please--branches--develop` branch on every push, firing a `synchronize` event on a PR whose diff only touches files release-please owns. The same happened on `master`'s stable release PR, and again on the `VERSION`/manifest-only push a merged release PR produces.

- **Job-level skip on release-please PRs** in `tests.yml` (`ci` + `browser`), `lint.yml` (`quality`), and `codeql.yml` (`analyze`). A job-level `if` (not a `paths` filter) is deliberate: a skipped job reports its required check as *skipped*, which GitHub treats as satisfied, so the release PR stays mergeable — a workflow that never starts would leave required checks stuck on *Expected*.
- **Fork-bypass hardening on top of the issue's proposed condition:** `github.head_ref` is attacker-controlled, so the skip also requires the head repo to be this repo (`github.event.pull_request.head.repo.full_name == github.repository`, same pattern as `integration-merge.yml`). A fork branch named `release-please--anything` still runs every check; a same-repo branch with that name needs write access, which is already trusted. This came out of the local CodeRabbit pass.
- **`paths-ignore` on the `push` triggers** of the same three workflows for `VERSION`, `CHANGELOG.md`, and `.release-please-manifest*.json`, so merging a release PR no longer re-runs the heavy suites. `release-please.yml` stays unfiltered — that push is what tags the release — and the guard test pins that too. `commitlint.yml` and `dependency-review.yml` keep running on release PRs; they finish in seconds.
- **Guard test** `tests/Unit/ReleasePullRequestCiSkipTest.php` (alongside `ReleaseFlowTest.php`) fails if the skip conditions are removed, if the skip is converted to a `paths` filter on `pull_request`, or if the release workflow's push trigger gains a paths filter.

**Deliberately not taken:** the issue's optional item 3 (dropping/limiting CodeQL's `push` trigger). The `paths-ignore` above already removes the release-file-only runs, and dropping develop's push analysis would let its code-scanning baseline go stale for PR alert diffing. Can be a follow-up if the extra job per merge is still worth chasing.

## Testing

- TDD: the guard test was written first (red on all four jobs and all three push triggers), then the workflow edits turned it green; the fork-hardening clause repeated the cycle.
- Full gate green: `./vendor/bin/sail composer test` (Pint + PHPStan + Rector + 100% coverage) and the frontend gate (`lint:check`, `format:check`, `types:check`, `test:js`, `build`) via `sail composer ci:check`.
- Local CodeRabbit review clean (its one finding — head_ref spoofability — was applied as the hardening above).

No user-facing, i18n, or operator-facing changes, hence the non-changelog `ci` type.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787486167&installation_model_id=428379&pr_number=821&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F821&signature=4a70c5ef4af63bc9c7679a49825773475ad0dcc2e78297fba8022da83f46d765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->