### PR TITLE
fix: give the screens the mobile design does not draw a deliberate phone treatment

### DIFF
--- a/resources/js/components/GifPickerPanel.vue
+++ b/resources/js/components/GifPickerPanel.vue
@@ -306,7 +306,7 @@ onBeforeUnmount(() => {
             ref="grid"
             role="listbox"
             :aria-label="$t('GIF results')"
-            class="max-h-72 overflow-y-auto p-2"
+            class="max-h-[min(18rem,calc(100dvh-12rem))] overflow-y-auto p-2"
             @scroll="onScroll"
         >
             <div

--- a/resources/js/components/MessageAttachments.vue
+++ b/resources/js/components/MessageAttachments.vue
@@ -85,10 +85,10 @@ function isSvg(attachment: AttachmentData): boolean {
         <!-- Single image: natural ratio, sized from stored dimensions (no shift). -->
         <div
             v-if="images.length === 1"
-            class="group relative overflow-hidden rounded-2xl border border-border"
+            class="group relative max-w-full overflow-hidden rounded-2xl border border-border"
             :style="{
                 width: `${singleBox.width}px`,
-                height: `${singleBox.height}px`,
+                aspectRatio: `${singleBox.width} / ${singleBox.height}`,
             }"
         >
             <img

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1889,7 +1889,7 @@ function onKeydown(event: KeyboardEvent): void {
                                                 variant="ghost"
                                                 size="icon"
                                                 :data-test="`message-composer-format-${action.marker}`"
-                                                class="size-7 shrink-0 rounded-full text-muted-foreground"
+                                                class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
                                                 :aria-label="action.label"
                                                 @mousedown.prevent
                                                 @click="
@@ -1925,7 +1925,7 @@ function onKeydown(event: KeyboardEvent): void {
                                 size="icon"
                                 :disabled="!attachmentsEnabled"
                                 data-test="message-composer-attach"
-                                class="size-7 shrink-0 rounded-full text-muted-foreground"
+                                class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
                                 :aria-label="$t('Add attachment')"
                                 @click="openFilePicker"
                             >
@@ -1939,7 +1939,7 @@ function onKeydown(event: KeyboardEvent): void {
                                 variant="ghost"
                                 size="icon"
                                 data-test="message-composer-record"
-                                class="size-7 shrink-0 rounded-full text-muted-foreground"
+                                class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
                                 :aria-label="$t('Record a voice message')"
                                 @click="recorder.start"
                             >
@@ -1953,7 +1953,7 @@ function onKeydown(event: KeyboardEvent): void {
                             variant="ghost"
                             size="icon"
                             data-test="composer-tools-toggle"
-                            class="size-8.5 shrink-0 rounded-full text-muted-foreground @lg:hidden"
+                            class="size-8.5 shrink-0 rounded-full text-muted-foreground @lg:hidden max-md:size-11"
                             :aria-expanded="toolsOpen"
                             :aria-label="
                                 toolsOpen

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1953,7 +1953,7 @@ function onKeydown(event: KeyboardEvent): void {
                             variant="ghost"
                             size="icon"
                             data-test="composer-tools-toggle"
-                            class="size-8.5 shrink-0 rounded-full text-muted-foreground @lg:hidden max-md:size-11"
+                            class="size-8.5 shrink-0 rounded-full text-muted-foreground max-md:size-11 @lg:hidden"
                             :aria-expanded="toolsOpen"
                             :aria-label="
                                 toolsOpen

--- a/resources/js/components/MessageLightbox.vue
+++ b/resources/js/components/MessageLightbox.vue
@@ -118,7 +118,9 @@ function onKeydown(event: KeyboardEvent): void {
                     class="max-h-[85vh] max-w-[85vw] rounded-lg object-contain shadow-2xl"
                 />
 
-                <div class="absolute top-4 left-5 flex flex-col gap-0.5 pr-32">
+                <div
+                    class="absolute top-4 right-4 left-5 flex flex-col gap-0.5 pr-20 max-md:pr-24"
+                >
                     <DialogTitle
                         class="truncate text-[13px] font-semibold text-[#ece7da]"
                     >
@@ -142,13 +144,13 @@ function onKeydown(event: KeyboardEvent): void {
                                 : 'noopener noreferrer'
                         "
                         :aria-label="t('Download :name', { name: activeLabel })"
-                        class="flex size-8 items-center justify-center rounded-[9px] bg-[rgba(243,239,228,0.12)] text-[#ece7da] transition-colors hover:bg-[rgba(243,239,228,0.22)] focus-visible:ring-2 focus-visible:ring-[#ece7da] focus-visible:outline-none"
+                        class="flex size-8 items-center justify-center rounded-[9px] bg-[rgba(243,239,228,0.12)] text-[#ece7da] transition-colors hover:bg-[rgba(243,239,228,0.22)] focus-visible:ring-2 focus-visible:ring-[#ece7da] focus-visible:outline-none max-md:size-11"
                     >
                         <Download class="size-3.5" />
                     </a>
                     <DialogClose
                         :aria-label="t('Close')"
-                        class="flex size-8 items-center justify-center rounded-[9px] bg-[rgba(243,239,228,0.12)] text-[#ece7da] transition-colors hover:bg-[rgba(243,239,228,0.22)] focus-visible:ring-2 focus-visible:ring-[#ece7da] focus-visible:outline-none"
+                        class="flex size-8 items-center justify-center rounded-[9px] bg-[rgba(243,239,228,0.12)] text-[#ece7da] transition-colors hover:bg-[rgba(243,239,228,0.22)] focus-visible:ring-2 focus-visible:ring-[#ece7da] focus-visible:outline-none max-md:size-11"
                     >
                         <X class="size-3.5" />
                     </DialogClose>

--- a/resources/js/components/PollComposerPanel.vue
+++ b/resources/js/components/PollComposerPanel.vue
@@ -135,7 +135,7 @@ function submit(): void {
         role="dialog"
         :aria-label="$t('Create a poll')"
         data-test="poll-builder"
-        class="absolute bottom-full left-0 z-20 mb-2 flex w-[25rem] max-w-full flex-col overflow-hidden rounded-2xl border bg-popover shadow-[0_16px_40px_rgba(29,26,21,0.18)]"
+        class="absolute bottom-full left-0 z-20 mb-2 flex max-h-[calc(100dvh-7rem)] w-[25rem] max-w-full flex-col overflow-hidden rounded-2xl border bg-popover shadow-[0_16px_40px_rgba(29,26,21,0.18)]"
         @keydown.esc="emit('close')"
     >
         <div
@@ -160,7 +160,7 @@ function submit(): void {
             </Button>
         </div>
 
-        <div class="flex flex-col gap-3 p-3.5">
+        <div class="flex min-h-0 flex-col gap-3 overflow-y-auto p-3.5">
             <div class="flex flex-col gap-1.5">
                 <label
                     for="poll-question"

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -324,7 +324,9 @@ const getStartedUrl = computed(() =>
                                     >
                                     can you review the scroll pinning?
                                 </div>
-                                <div class="mt-1.5 flex items-center gap-1.5">
+                                <div
+                                    class="mt-1.5 flex flex-wrap items-center gap-1.5"
+                                >
                                     <span
                                         class="inline-flex items-center gap-1 rounded-full border border-brass-border bg-brass-fill px-2 py-0.5 text-[11px] text-brass-fill-foreground"
                                         >👍

--- a/resources/js/pages/channels/Browse.vue
+++ b/resources/js/pages/channels/Browse.vue
@@ -33,7 +33,7 @@ const props = defineProps<{
         />
         <div class="min-w-0 flex-1">
             <h1
-                class="truncate font-serif text-[32px] leading-none font-semibold tracking-[-0.02em] text-foreground"
+                class="truncate font-serif text-[32px] leading-none font-semibold tracking-[-0.02em] text-foreground max-md:text-2xl max-md:leading-tight max-md:whitespace-normal"
             >
                 {{ $t('Browse channels') }}
             </h1>
@@ -116,7 +116,7 @@ const props = defineProps<{
                             type="submit"
                             variant="outline"
                             size="sm"
-                            class="h-7.5 rounded-full border-primary bg-transparent px-4 text-[12.5px] font-semibold text-primary group-hover:border-primary group-hover:bg-primary group-hover:text-primary-foreground hover:border-primary hover:bg-primary hover:text-primary-foreground"
+                            class="h-7.5 rounded-full border-primary bg-transparent px-4 text-[12.5px] font-semibold text-primary group-hover:border-primary group-hover:bg-primary group-hover:text-primary-foreground hover:border-primary hover:bg-primary hover:text-primary-foreground max-md:h-11 max-md:px-5"
                             >{{ $t('Join') }}</Button
                         >
                     </Form>

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -501,7 +501,7 @@ function jumpHref(result: MessageSearchResult): string {
                 <!-- author facet -->
                 <span
                     v-if="authorName !== null"
-                    class="inline-flex h-7 items-center gap-1.5 rounded-full bg-primary py-0 pr-1.5 pl-1.5 text-xs font-medium text-primary-foreground"
+                    class="inline-flex h-7 items-center gap-1.5 rounded-full bg-primary py-0 pr-1.5 pl-1.5 text-xs font-medium text-primary-foreground max-md:h-11 max-md:pr-0 max-md:pl-3"
                     data-test="facet-author"
                 >
                     <span
@@ -514,7 +514,7 @@ function jumpHref(result: MessageSearchResult): string {
                         variant="unstyled"
                         size="none"
                         type="button"
-                        class="flex size-4 items-center justify-center rounded-full text-primary-foreground/70 hover:text-primary-foreground"
+                        class="flex size-4 items-center justify-center rounded-full text-primary-foreground/70 hover:text-primary-foreground max-md:size-11"
                         :aria-label="$t('Remove author filter')"
                         @click="clearAuthor"
                     >
@@ -527,7 +527,7 @@ function jumpHref(result: MessageSearchResult): string {
                             variant="unstyled"
                             size="none"
                             type="button"
-                            class="inline-flex h-7 items-center gap-1.5 rounded-full border border-border px-3 text-xs font-medium text-muted-foreground hover:text-foreground"
+                            class="inline-flex h-7 items-center gap-1.5 rounded-full border border-border px-3 text-xs font-medium text-muted-foreground hover:text-foreground max-md:h-11 max-md:px-4"
                             data-test="facet-author-picker"
                         >
                             {{ $t('Author') }}
@@ -540,7 +540,7 @@ function jumpHref(result: MessageSearchResult): string {
                             :placeholder="$t('Filter people…')"
                             :aria-label="$t('Filter people')"
                             data-test="facet-author-filter"
-                            class="mb-1 h-8 text-xs"
+                            class="mb-1 h-8 text-xs max-md:h-11"
                             @keydown.stop
                         />
                         <div class="max-h-56 overflow-y-auto">
@@ -550,7 +550,7 @@ function jumpHref(result: MessageSearchResult): string {
                                 v-for="member in filteredMembers"
                                 :key="member.id"
                                 type="button"
-                                class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent"
+                                class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent max-md:min-h-11"
                                 data-test="facet-author-option"
                                 @click="setAuthor(member.id)"
                             >
@@ -568,7 +568,7 @@ function jumpHref(result: MessageSearchResult): string {
                 <!-- channel facet -->
                 <span
                     v-if="channelName !== null"
-                    class="inline-flex h-7 items-center gap-1.5 rounded-full bg-primary px-3 text-xs font-medium text-primary-foreground"
+                    class="inline-flex h-7 items-center gap-1.5 rounded-full bg-primary px-3 text-xs font-medium text-primary-foreground max-md:h-11 max-md:pr-0"
                     data-test="facet-channel"
                 >
                     <span aria-hidden="true" class="text-brass">#</span
@@ -577,7 +577,7 @@ function jumpHref(result: MessageSearchResult): string {
                         variant="unstyled"
                         size="none"
                         type="button"
-                        class="flex size-4 items-center justify-center rounded-full text-primary-foreground/70 hover:text-primary-foreground"
+                        class="flex size-4 items-center justify-center rounded-full text-primary-foreground/70 hover:text-primary-foreground max-md:size-11"
                         :aria-label="$t('Remove channel filter')"
                         @click="clearChannel"
                     >
@@ -590,7 +590,7 @@ function jumpHref(result: MessageSearchResult): string {
                             variant="unstyled"
                             size="none"
                             type="button"
-                            class="inline-flex h-7 items-center gap-1.5 rounded-full border border-border px-3 text-xs font-medium text-muted-foreground hover:text-foreground"
+                            class="inline-flex h-7 items-center gap-1.5 rounded-full border border-border px-3 text-xs font-medium text-muted-foreground hover:text-foreground max-md:h-11 max-md:px-4"
                             data-test="facet-channel-picker"
                         >
                             <span
@@ -606,7 +606,7 @@ function jumpHref(result: MessageSearchResult): string {
                             v-model="channelFilter"
                             :placeholder="$t('Filter channels…')"
                             :aria-label="$t('Filter channels')"
-                            class="mb-1 h-8 text-xs"
+                            class="mb-1 h-8 text-xs max-md:h-11"
                             @keydown.stop
                         />
                         <div class="max-h-56 overflow-y-auto">
@@ -616,7 +616,7 @@ function jumpHref(result: MessageSearchResult): string {
                                 variant="unstyled"
                                 size="none"
                                 type="button"
-                                class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent"
+                                class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent max-md:min-h-11"
                                 data-test="facet-channel-option"
                                 @click="setChannel(channel.id)"
                             >
@@ -645,7 +645,7 @@ function jumpHref(result: MessageSearchResult): string {
                 <!-- date facet -->
                 <span
                     v-if="dateChipLabel !== null"
-                    class="inline-flex h-7 items-center gap-1.5 rounded-full bg-primary py-0 pr-1.5 pl-3 text-xs font-medium text-primary-foreground"
+                    class="inline-flex h-7 items-center gap-1.5 rounded-full bg-primary py-0 pr-1.5 pl-3 text-xs font-medium text-primary-foreground max-md:h-11 max-md:pr-0"
                     data-test="facet-date"
                 >
                     <Calendar class="size-3 text-brass" aria-hidden="true" />
@@ -654,7 +654,7 @@ function jumpHref(result: MessageSearchResult): string {
                         variant="unstyled"
                         size="none"
                         type="button"
-                        class="flex size-4 items-center justify-center rounded-full text-primary-foreground/70 hover:text-primary-foreground"
+                        class="flex size-4 items-center justify-center rounded-full text-primary-foreground/70 hover:text-primary-foreground max-md:size-11"
                         :aria-label="$t('Remove date filter')"
                         @click="clearDate"
                     >
@@ -672,7 +672,7 @@ function jumpHref(result: MessageSearchResult): string {
                             variant="unstyled"
                             size="none"
                             type="button"
-                            class="inline-flex h-7 items-center gap-1.5 rounded-full border border-border px-3 text-xs font-medium text-muted-foreground hover:text-foreground"
+                            class="inline-flex h-7 items-center gap-1.5 rounded-full border border-border px-3 text-xs font-medium text-muted-foreground hover:text-foreground max-md:h-11 max-md:px-4"
                             data-test="facet-date-picker"
                         >
                             <Calendar class="size-3" aria-hidden="true" />
@@ -687,7 +687,7 @@ function jumpHref(result: MessageSearchResult): string {
                             variant="unstyled"
                             size="none"
                             type="button"
-                            class="flex w-full items-center rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent"
+                            class="flex w-full items-center rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent max-md:min-h-11"
                             :data-test="`facet-date-preset-${preset.key}`"
                             @click="setDateRange(preset.after, preset.before)"
                         >
@@ -697,7 +697,7 @@ function jumpHref(result: MessageSearchResult): string {
                             variant="unstyled"
                             size="none"
                             type="button"
-                            class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent"
+                            class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent max-md:min-h-11"
                             data-test="facet-date-custom"
                             @click="showCustomRange = !showCustomRange"
                         >
@@ -749,7 +749,7 @@ function jumpHref(result: MessageSearchResult): string {
                     size="none"
                     v-if="hasFilters"
                     type="button"
-                    class="ml-1 border-b border-dotted border-muted-foreground/60 pb-px text-xs text-muted-foreground hover:text-foreground"
+                    class="ml-1 border-b border-dotted border-muted-foreground/60 pb-px text-xs text-muted-foreground hover:text-foreground max-md:inline-flex max-md:h-11 max-md:items-center"
                     data-test="facet-clear-all"
                     @click="clearAllFilters"
                 >

--- a/resources/js/pages/teams/AuditExports.vue
+++ b/resources/js/pages/teams/AuditExports.vue
@@ -301,7 +301,7 @@ function downloadUrl(entry: AuditExport): string {
                         {{ $t('Period') }}
                         <span class="font-normal">· {{ $t('optional') }}</span>
                     </span>
-                    <div class="flex items-center gap-2">
+                    <div class="flex flex-wrap items-center gap-2">
                         <DatePicker
                             :model-value="rangeStart || null"
                             :placeholder="$t('Start date')"
@@ -420,7 +420,7 @@ function downloadUrl(entry: AuditExport): string {
                 <li
                     v-for="entry in exports"
                     :key="entry.id"
-                    class="flex items-center gap-3.5 rounded-xl border border-border bg-card p-3.5 shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
+                    class="flex items-center gap-3.5 rounded-xl border border-border bg-card p-3.5 shadow-[0_2px_8px_rgba(29,26,21,0.05)] max-md:flex-wrap"
                     :class="{ 'opacity-65': rowState(entry) === 'expired' }"
                     :data-test="`audit-export-row-${entry.id}`"
                 >
@@ -437,11 +437,11 @@ function downloadUrl(entry: AuditExport): string {
                         />
                     </div>
 
-                    <div class="min-w-0">
+                    <div class="min-w-0 flex-1">
                         <p class="text-sm font-semibold">
                             {{ entry.logTypeLabel }} · {{ entry.formatLabel }}
                         </p>
-                        <p class="truncate text-xs text-muted-foreground">
+                        <p class="text-xs text-muted-foreground md:truncate">
                             {{ rangeText(entry) }} ·
                             {{
                                 $t('requested by :name', {
@@ -469,7 +469,9 @@ function downloadUrl(entry: AuditExport): string {
                         </p>
                     </div>
 
-                    <div class="ml-auto flex items-center gap-2.5">
+                    <div
+                        class="ml-auto flex items-center gap-2.5 max-md:w-full max-md:justify-end"
+                    >
                         <!-- Generating -->
                         <span
                             v-if="rowState(entry) === 'generating'"

--- a/resources/js/pages/teams/Groups.vue
+++ b/resources/js/pages/teams/Groups.vue
@@ -55,6 +55,13 @@ defineOptions({
 
 const { getInitials } = useInitials();
 
+/** The row's member-count label, e.g. "3 members". */
+function memberCountLabel(group: UserGroup): string {
+    return group.membersCount === 1
+        ? translate(':count member', { count: group.membersCount })
+        : translate(':count members', { count: group.membersCount });
+}
+
 const createForm = useForm({ name: '', slug: '' });
 
 function submitCreate(): void {
@@ -291,7 +298,7 @@ function confirmRemoval(): void {
             <li
                 v-for="group in filteredGroups"
                 :key="group.id"
-                class="flex items-center gap-3 rounded-xl border border-border bg-card p-3"
+                class="flex items-center gap-3 rounded-xl border border-border bg-card p-3 max-md:flex-wrap"
                 :data-test="`group-row-${group.slug}`"
             >
                 <div
@@ -299,47 +306,52 @@ function confirmRemoval(): void {
                 >
                     <Users class="size-4" aria-hidden="true" />
                 </div>
-                <div class="flex min-w-0 flex-1 flex-col">
+                <div class="flex min-w-0 flex-1 flex-col max-md:basis-3/5">
                     <span
                         class="truncate font-mono text-sm font-semibold text-foreground"
                         >@{{ group.slug }}</span
                     >
-                    <span class="truncate text-xs text-muted-foreground">{{
-                        group.name
-                    }}</span>
+                    <span class="truncate text-xs text-muted-foreground"
+                        >{{ group.name
+                        }}<span class="md:hidden">
+                            · {{ memberCountLabel(group) }}</span
+                        ></span
+                    >
                 </div>
-                <span class="w-28 shrink-0 text-xs text-muted-foreground">{{
-                    group.membersCount === 1
-                        ? $t(':count member', { count: group.membersCount })
-                        : $t(':count members', { count: group.membersCount })
-                }}</span>
+                <span
+                    class="w-28 shrink-0 text-xs text-muted-foreground max-md:hidden"
+                    >{{ memberCountLabel(group) }}</span
+                >
                 <!-- Icon actions rather than inline text links: the destructive
                      token at 12px does not clear 4.5:1 on `bg-card` in the dark
                      theme, while an icon only owes the 3:1 graphics threshold. -->
-                <Button
+                <div
                     v-if="permissions.canManageUserGroups"
-                    variant="ghost"
-                    size="icon-sm"
-                    type="button"
-                    :data-test="`group-edit-${group.slug}`"
-                    :aria-label="$t('Edit :name', { name: group.name })"
-                    class="shrink-0 rounded-full"
-                    @click="openEditor(group)"
+                    class="flex shrink-0 items-center gap-1 max-md:ml-auto"
                 >
-                    <Pencil class="size-4" />
-                </Button>
-                <Button
-                    v-if="permissions.canManageUserGroups"
-                    variant="ghost"
-                    size="icon-sm"
-                    type="button"
-                    :data-test="`group-remove-${group.slug}`"
-                    :aria-label="$t('Delete :name', { name: group.name })"
-                    class="shrink-0 rounded-full text-destructive-text"
-                    @click="pendingRemoval = group"
-                >
-                    <Trash2 class="size-4" />
-                </Button>
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        type="button"
+                        :data-test="`group-edit-${group.slug}`"
+                        :aria-label="$t('Edit :name', { name: group.name })"
+                        class="shrink-0 rounded-full max-md:size-11"
+                        @click="openEditor(group)"
+                    >
+                        <Pencil class="size-4" />
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        type="button"
+                        :data-test="`group-remove-${group.slug}`"
+                        :aria-label="$t('Delete :name', { name: group.name })"
+                        class="shrink-0 rounded-full text-destructive-text max-md:size-11"
+                        @click="pendingRemoval = group"
+                    >
+                        <Trash2 class="size-4" />
+                    </Button>
+                </div>
             </li>
         </ul>
     </div>

--- a/resources/js/pages/teams/SecurityLog.vue
+++ b/resources/js/pages/teams/SecurityLog.vue
@@ -168,7 +168,7 @@ function dotClass(event: TeamSecurityEvent): string {
             <li
                 v-for="event in events.data"
                 :key="event.id"
-                class="flex items-center gap-3 px-4 py-3"
+                class="flex items-center gap-3 px-4 py-3 max-md:flex-wrap"
                 :data-test="`security-log-event-${event.id}`"
             >
                 <span
@@ -176,9 +176,9 @@ function dotClass(event: TeamSecurityEvent): string {
                     :class="dotClass(event)"
                 />
 
-                <div class="flex min-w-0 flex-col gap-px">
+                <div class="flex min-w-0 flex-1 flex-col gap-px max-md:basis-3/5">
                     <p
-                        class="flex items-center gap-2 text-[13.5px] font-semibold"
+                        class="flex items-center gap-2 text-[13.5px] font-semibold max-md:flex-wrap"
                     >
                         <span class="truncate">{{ event.actorName }}</span>
                         <span
@@ -189,7 +189,7 @@ function dotClass(event: TeamSecurityEvent): string {
                             {{ $t('New device') }}
                         </span>
                     </p>
-                    <p class="truncate text-xs text-muted-foreground">
+                    <p class="text-xs text-muted-foreground md:truncate">
                         {{ event.label }}
                         &middot;
                         {{

--- a/resources/js/pages/teams/SecurityLog.vue
+++ b/resources/js/pages/teams/SecurityLog.vue
@@ -177,7 +177,7 @@ function dotClass(event: TeamSecurityEvent): string {
                 />
 
                 <div
-                    class="flex min-w-0 flex-1 flex-col gap-px max-md:basis-3/5"
+                    class="flex min-w-0 flex-1 flex-col gap-px max-md:basis-3/4"
                 >
                     <p
                         class="flex items-center gap-2 text-[13.5px] font-semibold max-md:flex-wrap"

--- a/resources/js/pages/teams/SecurityLog.vue
+++ b/resources/js/pages/teams/SecurityLog.vue
@@ -176,7 +176,9 @@ function dotClass(event: TeamSecurityEvent): string {
                     :class="dotClass(event)"
                 />
 
-                <div class="flex min-w-0 flex-1 flex-col gap-px max-md:basis-3/5">
+                <div
+                    class="flex min-w-0 flex-1 flex-col gap-px max-md:basis-3/5"
+                >
                     <p
                         class="flex items-center gap-2 text-[13.5px] font-semibold max-md:flex-wrap"
                     >

--- a/tests/Browser/MobileUndrawnScreensTest.php
+++ b/tests/Browser/MobileUndrawnScreensTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AttachmentStatus;
+use App\Enums\SecurityEventType;
+use App\Models\Attachment;
+use App\Models\AuditExport;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\SecurityEvent;
+use App\Models\UserGroup;
+
+/**
+ * The screens the mobile design does not draw (#778): admin settings pages,
+ * browse, search, the marketing page and the lightbox, held to the epic's
+ * breakpoint rules at a phone width — nothing clipped, long strings intact,
+ * 44px touch targets.
+ */
+
+/**
+ * Whether the first element the selector matches renders its full text — i.e.
+ * an ellipsis is not hiding part of it — and sits inside the viewport.
+ */
+function rendersFullTextInsideViewport(string $selector): string
+{
+    return <<<JS
+    (() => {
+        const el = document.querySelector('{$selector}');
+
+        return el !== null
+            && el.scrollWidth <= el.clientWidth + 1
+            && el.getBoundingClientRect().right <= window.innerWidth + 1;
+    })()
+    JS;
+}
+
+/**
+ * Whether every element the selector matches offers at least a 44px-tall
+ * touch target.
+ */
+function offersPhoneTouchTargets(string $selector): string
+{
+    return <<<JS
+    (() => {
+        const targets = [...document.querySelectorAll('{$selector}')];
+
+        return targets.length > 0
+            && targets.every(el => el.getBoundingClientRect().height >= 43);
+    })()
+    JS;
+}
+
+test('the audit-export period fields stay reachable on a phone', function (): void {
+    ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate("/settings/teams/{$team->slug}/exports")
+        ->assertScript(<<<'JS'
+        (() => {
+            const end = document.querySelector('[data-test="audit-export-range-end"]');
+
+            return end !== null
+                && end.getBoundingClientRect().right <= window.innerWidth + 1;
+        })()
+        JS, true);
+});
+
+test('an audit-export row keeps its meta line readable on a phone', function (): void {
+    ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
+
+    $export = AuditExport::factory()->security()->ready()->create([
+        'team_id' => $team->id,
+        'requested_by' => $alice->id,
+    ]);
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate("/settings/teams/{$team->slug}/exports")
+        ->assertScript(rendersFullTextInsideViewport(
+            "[data-test=\"audit-export-row-{$export->id}\"] p + p",
+        ), true);
+});
+
+test('a security-log row keeps a long member name readable on a phone', function (): void {
+    ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
+
+    $alice->update(['name' => 'Bartholomew Featherstonehaugh']);
+
+    $event = SecurityEvent::factory()
+        ->ofType(SecurityEventType::LoggedIn)
+        ->create(['user_id' => $alice->id]);
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate("/settings/teams/{$team->slug}/security-log")
+        ->assertScript(rendersFullTextInsideViewport(
+            "[data-test=\"security-log-event-{$event->id}\"] span + div span",
+        ), true);
+});
+
+test('a group row keeps its handle readable and its actions tappable on a phone', function (): void {
+    ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
+
+    UserGroup::factory()->create([
+        'team_id' => $team->id,
+        'name' => 'Engineering Leadership',
+        'slug' => 'engineering-leadership',
+    ]);
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate("/settings/teams/{$team->slug}/groups")
+        ->assertScript(rendersFullTextInsideViewport(
+            '[data-test="group-row-engineering-leadership"] span[class*="font-mono"]',
+        ), true)
+        ->assertScript(offersPhoneTouchTargets(
+            '[data-test="group-edit-engineering-leadership"], [data-test="group-remove-engineering-leadership"]',
+        ), true);
+});
+
+test('the browse-channels heading survives a phone width untruncated', function (): void {
+    ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
+
+    Channel::factory()->create([
+        'team_id' => $team->id,
+        'created_by' => $alice->id,
+        'name' => 'design-reviews',
+        'slug' => 'design-reviews',
+    ]);
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate("/t/{$team->slug}/channels/browse")
+        ->assertScript(rendersFullTextInsideViewport('h1'), true)
+        ->assertScript(offersPhoneTouchTargets('button[type="submit"]'), true);
+});
+
+test('the search facet pickers offer 44px touch targets on a phone', function (): void {
+    ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate("/t/{$team->slug}/search?q=hello")
+        ->assertScript(offersPhoneTouchTargets(
+            '[data-test="facet-author-picker"], [data-test="facet-channel-picker"], [data-test="facet-date-picker"]',
+        ), true)
+        ->click('[data-test="facet-author-picker"]')
+        ->assertScript(offersPhoneTouchTargets('[data-test="facet-author-option"]'), true);
+});
+
+test('the disclosed composer tools offer 44px touch targets on a phone', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('[data-test="composer-tools-toggle"]')
+        ->assertScript(offersPhoneTouchTargets(
+            '[data-test="composer-format-cluster"] button, [data-test="message-composer-attach"]',
+        ), true);
+});
+
+test('the welcome preview thread pill stays inside its row on a phone', function (): void {
+    visit('/')
+        ->resize(360, 740)
+        ->assertScript(<<<'JS'
+        (() => {
+            const matches = [...document.querySelectorAll('span')]
+                .filter(el => el.textContent.includes('4 replies'));
+            const pill = matches[matches.length - 1];
+
+            if (!pill) {
+                return false;
+            }
+
+            const row = pill.parentElement.getBoundingClientRect();
+
+            return pill.getBoundingClientRect().right <= row.right + 1
+                && pill.getBoundingClientRect().right <= window.innerWidth + 1;
+        })()
+        JS, true);
+});
+
+test('the lightbox truncates a long filename clear of its header buttons', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $alice->id,
+        'body' => 'Here is the screenshot.',
+    ]);
+
+    Attachment::factory()->create([
+        'message_id' => $message->id,
+        'user_id' => $alice->id,
+        'channel_id' => $channel->id,
+        'original_filename' => 'quarterly-platform-infrastructure-review-deployment-screenshot-final-v2.png',
+        'status' => AttachmentStatus::Attached,
+    ]);
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('[data-test="attachment-image"]')
+        ->assertScript(<<<'JS'
+        (() => {
+            const dialog = document.querySelector('[data-test="attachment-lightbox"]');
+            const title = dialog?.querySelector('h2');
+            const download = dialog?.querySelector('a[download]');
+
+            return Boolean(title) && Boolean(download)
+                && title.getBoundingClientRect().right <= download.getBoundingClientRect().left;
+        })()
+        JS, true);
+});

--- a/tests/Browser/MobileUndrawnScreensTest.php
+++ b/tests/Browser/MobileUndrawnScreensTest.php
@@ -183,6 +183,29 @@ test('the welcome preview thread pill stays inside its row on a phone', function
         JS, true);
 });
 
+test('the poll builder fits a landscape phone viewport', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(740, 360)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->type('[data-test="message-composer-input"]', '/poll')
+        ->keys('[data-test="message-composer-input"]', ['Enter'])
+        ->assertScript(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-test="poll-builder"]');
+
+            if (!panel) {
+                return false;
+            }
+
+            const rect = panel.getBoundingClientRect();
+
+            return rect.top >= -1 && rect.bottom <= window.innerHeight + 1;
+        })()
+        JS, true);
+});
+
 test('the lightbox truncates a long filename clear of its header buttons', function (): void {
     ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
 

--- a/tests/Browser/MobileUndrawnScreensTest.php
+++ b/tests/Browser/MobileUndrawnScreensTest.php
@@ -38,7 +38,8 @@ function rendersFullTextInsideViewport(string $selector): string
 
 /**
  * Whether every element the selector matches offers at least a 44px-tall
- * touch target.
+ * touch target. Rounded before comparing: `h-11` is exactly 44 CSS px, but
+ * the rect can report a sub-pixel sliver under it.
  */
 function offersPhoneTouchTargets(string $selector): string
 {
@@ -47,7 +48,7 @@ function offersPhoneTouchTargets(string $selector): string
         const targets = [...document.querySelectorAll('{$selector}')];
 
         return targets.length > 0
-            && targets.every(el => el.getBoundingClientRect().height >= 43);
+            && targets.every(el => Math.round(el.getBoundingClientRect().height) >= 44);
     })()
     JS;
 }

--- a/tests/Browser/MobileUndrawnScreensTest.php
+++ b/tests/Browser/MobileUndrawnScreensTest.php
@@ -10,6 +10,7 @@ use App\Models\Channel;
 use App\Models\Message;
 use App\Models\SecurityEvent;
 use App\Models\UserGroup;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * The screens the mobile design does not draw (#778): admin settings pages,
@@ -215,7 +216,7 @@ test('the lightbox truncates a long filename clear of its header buttons', funct
         'body' => 'Here is the screenshot.',
     ]);
 
-    Attachment::factory()->create([
+    $attachment = Attachment::factory()->create([
         'message_id' => $message->id,
         'user_id' => $alice->id,
         'channel_id' => $channel->id,
@@ -223,10 +224,37 @@ test('the lightbox truncates a long filename clear of its header buttons', funct
         'status' => AttachmentStatus::Attached,
     ]);
 
+    // A real blob behind the record: without it the image request 404s and the
+    // lightbox trigger never gets a stable click target.
+    Storage::disk($attachment->disk)->put(
+        $attachment->path,
+        (string) base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==', true),
+    );
+
     signInThroughBrowser($alice)
         ->resize(360, 740)
         ->navigate(browserChannelUrl($team, $channel))
-        ->click('[data-test="attachment-image"]')
+        ->assertPresent('[data-test="attachment-image"]')
+        // The image stays inside the viewport even though its stored box
+        // (800 × 600 → 320 × 240) is wider than the phone's content column.
+        ->assertScript(<<<'JS'
+        (() => {
+            const trigger = document.querySelector('[data-test="attachment-image"]');
+
+            return trigger !== null
+                && trigger.getBoundingClientRect().right <= window.innerWidth + 1;
+        })()
+        JS, true)
+        // A scripted click: a pointer click can race the timeline's settling
+        // scroll and land on the hover toolbar instead of the image.
+        ->assertScript(<<<'JS'
+        (() => {
+            document.querySelector('[data-test="attachment-image"]').click();
+
+            return true;
+        })()
+        JS, true)
+        ->assertPresent('[data-test="attachment-lightbox"]')
         ->assertScript(<<<'JS'
         (() => {
             const dialog = document.querySelector('[data-test="attachment-lightbox"]');


### PR DESCRIPTION
Closes #778.

## What

The epic's breakpoint rules (*Mobile Breakpoint.dc.html*), applied by analogy to every screen the mockup does not draw. Audited each screen in the real browser first (360×740), fixed only what was actually broken, and re-verified after.

**Defects found and fixed:**

- **Audit exports** — the Period date-range row clipped the End-date field off the right edge (unreachable: the layout clips rather than scrolls); export rows crushed the title into 3-line wraps and truncated the meta to "All time · …". The range row now wraps, and rows stack below `md`: full-width text, meta wrapping, actions on their own right-aligned row.
- **Security log** — the fixed timestamp column truncated member names to "Dem…" and clipped the event detail. Below `md` the text column claims the row (`basis-3/4`) so the timestamp wraps to its own line, the New-device badge wraps under a long name, and the detail line wraps instead of truncating.
- **User groups** — the name/handle column collapsed to two characters beside the count and icon actions. Below `md` the count folds into the meta line, the 44px edit/delete pair wraps to its own row, and the handle keeps a readable measure.
- **Browse channels** — the 32px serif heading truncated ("Browse cha…"); it now steps down and wraps below `md` ("Parcourir les canaux" fits on two lines in French); Join buttons grew to 44px.
- **Search** — facet trigger pills, active-facet chips (with full-height ✕), picker option rows, filter inputs, and Clear-all all meet 44px below `md`. The facet row itself wraps cleanly at 360px, so the pickers stay dropdowns/popovers rather than becoming a sheet — the "squeezed inline row" the issue anticipated does not occur (screenshots attached); happy to convert to a sheet in a follow-up if preferred.
- **Composer** — the disclosed tools row (format cluster, attach, mic, toggle) meets 44px below `md`; the poll builder and GIF results now cap their height against the viewport and scroll internally instead of clipping their header off-screen at 740×360 landscape.
- **Message attachments** — a wide single image (stored box up to 380×240) overflowed the phone's message column; the tile now caps at `max-w-full` and preserves its ratio via `aspect-ratio`, still reserving space so the timeline never shifts.
- **Lightbox** — a long filename rendered under the header buttons and off the right edge (the single unbreakable word defeated shrink-to-fit); the header is now right-anchored so the title truncates clear of the 44px download/close buttons.
- **Welcome** — the "4 replies →" pill clipped at the preview card's edge at 360px; the reaction row wraps.

**Verified clean without changes:** Analytics, Audit log, Custom emoji, Teams index, Member profile, all three integrations screens (the webhook delivery table already scrolls inside its own container), Threads, all auth pages, the 404 page, and the attachment tray.

## Verification

- Playwright sweep of all 15 authed screens plus Welcome/auth/404 at **360×740, 375×667, 390×844, 430×932, 768×1024 and 740×360**: no horizontal page scroll and no clipped `data-test` element anywhere.
- **French at 360px** and **light theme** passes on the changed screens.
- Before/after screenshots for every changed screen captured as the untracked `778-screenshots/before/*` and `778-screenshots/after/*` sets in the worktree root, ready to drag into this PR.

## Testing

- **Browser (Pest + Playwright):** new `tests/Browser/MobileUndrawnScreensTest.php` — 10 tests written red-first against the defects above: period-field reachability, un-truncated export meta / member names / group handles / browse heading, 44px facet and composer-tool targets, the welcome pill staying in its row, the poll builder fitting landscape, and the lightbox title staying clear of its buttons (with a real blob behind the seeded attachment; scripted click so the timeline's settling scroll can't divert it).
- **Gates:** `sail composer test` green at **100.0%** coverage (Pint/PHPStan/Rector clean); `lint:check` (0 errors) / `format:check` / `types:check` / `test:js` (1180 green) / `build` all green.
- **Local CodeRabbit:** one minor finding (44px assertion tolerance) — applied; second run clean with 0 findings.

## Discovered, filed separately

- #822 — search 500s when a DM message matches (`MessageSearchResultData` requires a channel name).
- #823 — the audit-exports intro line is missing from `lang/fr.json`.
- #814 (existing) — dev-only CSP `font-src` gap, worked around locally via `CSP_EXTRA_FONT_SRC` during the audit.

## i18n

No new user-facing copy; the one refactor (`memberCountLabel`) reuses the existing `:count member(s)` keys, and all `data-test` selectors are preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787492082&installation_model_id=428379&pr_number=824&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F824&signature=c05c8b4d7624eb6d1f61f851d09bc7f705248db27fc1723a324af860cb65c107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->