### PR TITLE
ci: keep required check names static so release-please skips satisfy rulesets

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,14 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    # The display name must stay a static string that exactly matches the
+    # required-check context in the branch rulesets: a matrix job skipped by
+    # the job-level `if` below never expands, so it would report under the raw
+    # `Analyze (${{ matrix.language }})` name and the required context would
+    # sit on *Expected* forever (#825). JavaScript/TypeScript is the only
+    # CodeQL-supported language here anyway (see the header comment), so the
+    # matrix bought nothing.
+    name: Analyze (javascript-typescript)
     # Release-please PRs only touch VERSION/manifest/changelog files, none of
     # which contain analyzable code. A job-level `if` (not a `paths` filter)
     # keeps the PR mergeable: a skipped job reports its required check as
@@ -44,7 +51,8 @@ jobs:
     # starts leaves it stuck on *Expected*. The head-repo clause keeps the
     # branch name from becoming a CI bypass: `head_ref` is attacker-controlled,
     # so a fork branch named `release-please--anything` must still run
-    # everything. Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
+    # everything. Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php
+    # (#820, #825).
     if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     permissions:
@@ -53,12 +61,6 @@ jobs:
       # Needed by CodeQL to read the workflow run on private repos; harmless here.
       actions: read
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: javascript-typescript
-            build-mode: none
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -68,11 +70,11 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
+          languages: javascript-typescript
+          build-mode: none
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/language:javascript-typescript"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,16 +38,13 @@ jobs:
     # satisfied, while a workflow that never starts leaves it stuck on
     # *Expected*. The head-repo clause keeps the branch name from becoming a CI
     # bypass: `head_ref` is attacker-controlled, so a fork branch named
-    # `release-please--anything` must still run everything. Guarded by
-    # tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
+    # `release-please--anything` must still run everything. The job must also
+    # stay matrix-free: a matrix job skipped by a job-level `if` never expands,
+    # so its check would report under the raw name and a matrix-expanded
+    # required context (`ci (8.5)`) would sit on *Expected* forever (#825).
+    # Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php (#820, #825).
     if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    strategy:
-      matrix:
-        # We develop and ship on 8.5, so CI exercises 8.5 only to keep Actions
-        # minutes down (see #260). 8.4 remains the supported composer floor via
-        # composer.json's `require`; it's just no longer tested on every run.
-        php-version: ['8.5']
 
     # The schema relies on Postgres-only defaults (gen_random_uuid()), so tests
     # run against Postgres to match the local Sail environment.
@@ -83,7 +80,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: ${{ matrix.php-version }}
+          # We develop and ship on 8.5, so CI exercises 8.5 only to keep Actions
+          # minutes down (see #260). 8.4 remains the supported composer floor via
+          # composer.json's `require`; it's just no longer tested on every run.
+          php-version: '8.5'
           extensions: gd, imagick
           tools: composer:v2
           # CI does not enforce the coverage gate — that stays local via

--- a/tests/Unit/ReleasePullRequestCiSkipTest.php
+++ b/tests/Unit/ReleasePullRequestCiSkipTest.php
@@ -65,6 +65,23 @@ test('the heavy workflows still trigger on release pull requests so their checks
 })->with(collect(heavyJobs())->pluck(0)->unique()->values()->all());
 
 /*
+ * The skip only satisfies a required check whose ruleset context matches the
+ * name the *skipped* job reports — and a matrix job skipped by a job-level
+ * `if` never expands its matrix, so it reports under the raw, unexpanded name
+ * (`ci`, `Analyze (${{ matrix.language }})`) instead of the expanded one the
+ * ruleset requires (`ci (8.5)`, `Analyze (javascript-typescript)`). The
+ * required context then sits on *Expected* forever and the release PR is
+ * unmergeable (#825). Heavy jobs therefore must not use a matrix, and any
+ * explicit display name must be a static string.
+ */
+test('the heavy jobs report static check names even when skipped', function (string $file, string $job) use ($workflow): void {
+    $definition = $workflow($file)['jobs'][$job];
+
+    expect($definition['strategy']['matrix'] ?? null)->toBeNull()
+        ->and($definition['name'] ?? $job)->not->toContain('${{');
+})->with(heavyJobs());
+
+/*
  * Merging a release PR pushes a commit touching only the files release-please
  * owns, and that push used to run the full suite once more. Push runs carry no
  * required checks, so a plain `paths-ignore` is safe where a `paths` filter on


### PR DESCRIPTION
Closes #825.

## What / why

The job-level release-please skip from #821 assumed a skipped job satisfies its required check — true only when the skipped check's name matches the ruleset context. A matrix job skipped by a job-level `if` never expands its matrix, so `ci` and `analyze` reported under their raw names (`ci`, `Analyze (${{ matrix.language }})`) while the rulesets required the expanded ones (`ci (8.5)`, `Analyze (javascript-typescript)`). Those contexts sat on *Expected* forever, blocking every release-please PR from merging (first observed on #811) — the exact failure mode #821 set out to avoid, via name mismatch instead of a never-started workflow.

Both matrices were single-value, so this de-matrixes them:

- **`ci` (tests.yml)**: matrix removed, PHP 8.5 hardcoded at the setup step (keeping the #260 rationale). The check now reports as `ci` whether it runs or skips. The `develop`/`master` ruleset context needs a one-time update from `ci (8.5)` to `ci` alongside this merge — after which PHP version bumps never touch the rulesets again.
- **`analyze` (codeql.yml)**: matrix removed, language/build-mode/category hardcoded, and the display name is now the static string `Analyze (javascript-typescript)` — exactly the existing required context, so no ruleset change is needed for it.
- **Guard test** (`ReleasePullRequestCiSkipTest`): new red-first assertion that skip-guarded heavy jobs declare no matrix and no expression-bearing display name — the gap that let #821 land green.

The #821 fork-bypass hardening is untouched, and heavy work still does not re-run on release-please PR `synchronize` events.

## Testing

- TDD: the guard assertion was written first (red on `ci` and `analyze`, green on `browser`/`quality`), then the workflow edits turned it green.
- Full backend gate green: `./vendor/bin/sail composer test` (Pint + PHPStan + Rector + parallel suite at `Total: 100.0 %`).
- Local CodeRabbit review: 0 findings.

No user-facing, i18n, or operator-facing changes, hence the non-changelog `ci` type.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787494314&installation_model_id=428379&pr_number=826&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F826&signature=95ad97f7a65ad4f563636f4b090da48f7331bc90e20663bb72fdef4f5ee40579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->