### PR TITLE
fix: translate the audit-exports intro line in the French catalog

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -507,6 +507,7 @@
   "Offline": "Hors ligne",
   "Older": "Plus ancien",
   "Once your account is deleted, all of its resources and data will also be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.": "Une fois votre compte supprimé, toutes ses ressources et données seront également supprimées définitivement. Veuillez saisir votre mot de passe pour confirmer que vous souhaitez supprimer définitivement votre compte.",
+  "One log, one format, one file. You'll get an email when it's ready.": "Un journal, un format, un fichier. Vous recevrez un e-mail quand il sera prêt.",
   "One or more attachments are unavailable.": "Une ou plusieurs pièces jointes ne sont pas disponibles.",
   "One or more channels are not in your workspace.": "Un ou plusieurs salons ne font pas partie de votre espace de travail.",
   "Online": "En ligne",

--- a/tests/Feature/Teams/AuditExportTest.php
+++ b/tests/Feature/Teams/AuditExportTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\Teams\CreateTeam;
 use App\Data\AuditExportData;
+use App\Enums\AppLocale;
 use App\Enums\AuditAction;
 use App\Enums\AuditExportFormat;
 use App\Enums\AuditExportLogType;
@@ -89,6 +90,19 @@ test('the exports page lists exports newest first', function (): void {
         ->assertInertia(fn (Assert $page): Assert => $page
             ->where('exports.0.id', $newer->id)
             ->where('exports.1.id', $older->id));
+});
+
+test('the exports page catalog carries the new-export intro line in french', function (): void {
+    [, $team] = exportTeam();
+    $admin = exportMember($team, TeamRole::Admin);
+    $admin->update(['locale' => AppLocale::French->value]);
+
+    $page = $this->actingAs($admin)
+        ->get(route('teams.audit-exports.index', $team))
+        ->viewData('page');
+
+    expect($page['props']['translations'])
+        ->toHaveKey("One log, one format, one file. You'll get an email when it's ready.");
 });
 
 test('a plain member cannot view the exports page', function (): void {

--- a/tests/Feature/Teams/AuditExportTest.php
+++ b/tests/Feature/Teams/AuditExportTest.php
@@ -101,8 +101,8 @@ test('the exports page catalog carries the new-export intro line in french', fun
         ->get(route('teams.audit-exports.index', $team))
         ->viewData('page');
 
-    expect($page['props']['translations'])
-        ->toHaveKey("One log, one format, one file. You'll get an email when it's ready.");
+    expect($page['props']['translations']["One log, one format, one file. You'll get an email when it's ready."])
+        ->toBe('Un journal, un format, un fichier. Vous recevrez un e-mail quand il sera prêt.');
 });
 
 test('a plain member cannot view the exports page', function (): void {


### PR DESCRIPTION
Closes #823.

## What

`resources/js/pages/teams/AuditExports.vue` renders the new-export intro ("One log, one format, one file. You'll get an email when it's ready.") through `$t`, but the key was missing from `lang/fr.json`, so French users saw English on the audit-exports page.

## How

- Added the key to `lang/fr.json` in the catalog's alphabetical order: `"Un journal, un format, un fichier. Vous recevrez un e-mail quand il sera prêt."` (matching the catalog's existing "e-mail" phrasing).
- Re-scanned every `$t` key on the page against the catalog: this was the only missing one, matching the issue's finding.

## Testing

- New feature test in `tests/Feature/Teams/AuditExportTest.php` asserting the audit-exports page's shared `translations` once-prop carries the key with its French value for a French admin (written first, red before the catalog change).
- Full gate green: `sail composer test` at 100% coverage plus `lint:check`, `format:check`, `types:check`, `test:js`, and `build`.
- Local CodeRabbit pass clean (its one finding — assert the French value, not just key presence — applied).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787496155&installation_model_id=428379&pr_number=827&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F827&signature=d3a60102685f87a40c8e6e360d53e1ec5bb4df07d20777ca0927e8a00de42f60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->