### PR TITLE
feat: pulse a short haptic when a long-press opens the actions sheet

### DIFF
--- a/resources/js/composables/useLongPress.test.ts
+++ b/resources/js/composables/useLongPress.test.ts
@@ -221,9 +221,10 @@ describe('useLongPress', () => {
         });
 
         it('pulses once at the moment a touch hold takes', () => {
+            const onLongPress = vi.fn();
             const press = useLongPress<string>({
                 enabled: ref(true),
-                onLongPress: vi.fn(),
+                onLongPress,
             });
 
             press.start(pointer('pointerdown'), 'm1');
@@ -232,6 +233,7 @@ describe('useLongPress', () => {
 
             vi.advanceTimersByTime(LONG_PRESS_MS);
 
+            expect(onLongPress).toHaveBeenCalledExactlyOnceWith('m1');
             expect(vibrate).toHaveBeenCalledExactlyOnceWith(
                 LONG_PRESS_VIBRATION_MS,
             );
@@ -253,19 +255,22 @@ describe('useLongPress', () => {
             expect(vibrate).not.toHaveBeenCalled();
         });
 
-        it('never vibrates for a mouse hold on a touch laptop', () => {
-            const onLongPress = vi.fn();
-            const press = useLongPress<string>({
-                enabled: ref(true),
-                onLongPress,
-            });
+        it.each(['mouse', 'pen'])(
+            'never vibrates for a %s hold on a touch laptop',
+            (pointerType) => {
+                const onLongPress = vi.fn();
+                const press = useLongPress<string>({
+                    enabled: ref(true),
+                    onLongPress,
+                });
 
-            press.start(pointer('pointerdown', { pointerType: 'mouse' }), 'm1');
-            vi.advanceTimersByTime(LONG_PRESS_MS);
+                press.start(pointer('pointerdown', { pointerType }), 'm1');
+                vi.advanceTimersByTime(LONG_PRESS_MS);
 
-            expect(onLongPress).toHaveBeenCalledExactlyOnceWith('m1');
-            expect(vibrate).not.toHaveBeenCalled();
-        });
+                expect(onLongPress).toHaveBeenCalledExactlyOnceWith('m1');
+                expect(vibrate).not.toHaveBeenCalled();
+            },
+        );
 
         it('opens the sheet unchanged without the Vibration API', () => {
             Reflect.deleteProperty(navigator, 'vibrate');

--- a/resources/js/composables/useLongPress.test.ts
+++ b/resources/js/composables/useLongPress.test.ts
@@ -2,7 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 
-import { LONG_PRESS_MS, useLongPress } from '@/composables/useLongPress';
+import {
+    LONG_PRESS_MS,
+    LONG_PRESS_VIBRATION_MS,
+    useLongPress,
+} from '@/composables/useLongPress';
 
 /**
  * A message row with a plain text body and an interactive child, the two kinds
@@ -189,6 +193,133 @@ describe('useLongPress', () => {
         press.end();
 
         expect(press.pressing.value).toBeNull();
+    });
+
+    describe('haptic confirmation', () => {
+        let vibrate: ReturnType<typeof vi.fn>;
+
+        /** Pretends the OS-level reduced-motion preference is on or off. */
+        function preferReducedMotion(matches: boolean): void {
+            Object.defineProperty(window, 'matchMedia', {
+                value: vi.fn((query: string) => ({ media: query, matches })),
+                configurable: true,
+            });
+        }
+
+        beforeEach(() => {
+            vibrate = vi.fn(() => true);
+            Object.defineProperty(navigator, 'vibrate', {
+                value: vibrate,
+                configurable: true,
+            });
+            preferReducedMotion(false);
+        });
+
+        afterEach(() => {
+            Reflect.deleteProperty(navigator, 'vibrate');
+            Reflect.deleteProperty(window, 'matchMedia');
+        });
+
+        it('pulses once at the moment a touch hold takes', () => {
+            const press = useLongPress<string>({
+                enabled: ref(true),
+                onLongPress: vi.fn(),
+            });
+
+            press.start(pointer('pointerdown'), 'm1');
+
+            expect(vibrate).not.toHaveBeenCalled();
+
+            vi.advanceTimersByTime(LONG_PRESS_MS);
+
+            expect(vibrate).toHaveBeenCalledExactlyOnceWith(
+                LONG_PRESS_VIBRATION_MS,
+            );
+        });
+
+        it('skips the pulse under a reduced-motion preference', () => {
+            preferReducedMotion(true);
+
+            const onLongPress = vi.fn();
+            const press = useLongPress<string>({
+                enabled: ref(true),
+                onLongPress,
+            });
+
+            press.start(pointer('pointerdown'), 'm1');
+            vi.advanceTimersByTime(LONG_PRESS_MS);
+
+            expect(onLongPress).toHaveBeenCalledExactlyOnceWith('m1');
+            expect(vibrate).not.toHaveBeenCalled();
+        });
+
+        it('never vibrates for a mouse hold on a touch laptop', () => {
+            const onLongPress = vi.fn();
+            const press = useLongPress<string>({
+                enabled: ref(true),
+                onLongPress,
+            });
+
+            press.start(pointer('pointerdown', { pointerType: 'mouse' }), 'm1');
+            vi.advanceTimersByTime(LONG_PRESS_MS);
+
+            expect(onLongPress).toHaveBeenCalledExactlyOnceWith('m1');
+            expect(vibrate).not.toHaveBeenCalled();
+        });
+
+        it('opens the sheet unchanged without the Vibration API', () => {
+            Reflect.deleteProperty(navigator, 'vibrate');
+            Reflect.deleteProperty(window, 'matchMedia');
+
+            const onLongPress = vi.fn();
+            const press = useLongPress<string>({
+                enabled: ref(true),
+                onLongPress,
+            });
+
+            press.start(pointer('pointerdown'), 'm1');
+            vi.advanceTimersByTime(LONG_PRESS_MS);
+
+            expect(onLongPress).toHaveBeenCalledExactlyOnceWith('m1');
+        });
+
+        it('does not pulse for a press that lifts early', () => {
+            const press = useLongPress<string>({
+                enabled: ref(true),
+                onLongPress: vi.fn(),
+            });
+
+            press.start(pointer('pointerdown'), 'm1');
+            press.end();
+            vi.advanceTimersByTime(LONG_PRESS_MS);
+
+            expect(vibrate).not.toHaveBeenCalled();
+        });
+
+        it('does not pulse for a press that drifts into a scroll', () => {
+            const press = useLongPress<string>({
+                enabled: ref(true),
+                onLongPress: vi.fn(),
+            });
+
+            press.start(pointer('pointerdown', { x: 0, y: 0 }), 'm1');
+            press.move(pointer('pointermove', { x: 0, y: 24 }));
+            vi.advanceTimersByTime(LONG_PRESS_MS);
+
+            expect(vibrate).not.toHaveBeenCalled();
+        });
+
+        it('does not pulse while the gesture is disabled on desktop', () => {
+            const press = useLongPress<string>({
+                enabled: ref(false),
+                onLongPress: vi.fn(),
+            });
+
+            press.start(pointer('pointerdown'), 'm1');
+            vi.advanceTimersByTime(LONG_PRESS_MS);
+
+            expect(vibrate).not.toHaveBeenCalled();
+        });
     });
 
     it('suppresses the native context menu for a press it is timing', () => {

--- a/resources/js/composables/useLongPress.ts
+++ b/resources/js/composables/useLongPress.ts
@@ -11,6 +11,30 @@ export const LONG_PRESS_MS = 500;
 export const LONG_PRESS_SLOP_PX = 10;
 
 /**
+ * Duration of the haptic pulse confirming that a hold took. Short enough to
+ * read as a tick, long enough for every vibration motor to render.
+ */
+export const LONG_PRESS_VIBRATION_MS = 15;
+
+/**
+ * Confirms a taken hold with a single short vibration pulse, the way native
+ * chat apps do. A silent no-op off touch, without the Vibration API (iOS
+ * Safari, desktop), or under a reduced-motion preference — the closest web
+ * proxy for a haptics opt-out.
+ */
+function hapticPulse(pointerType: string): void {
+    if (pointerType !== 'touch' || !('vibrate' in navigator)) {
+        return;
+    }
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        return;
+    }
+
+    navigator.vibrate(LONG_PRESS_VIBRATION_MS);
+}
+
+/**
  * Press targets that own their tap: holding one must never double as a
  * long-press on the row around it.
  */
@@ -48,6 +72,7 @@ export function useLongPress<T>(
     let timer: number | null = null;
     let origin: { x: number; y: number } | null = null;
     let selectionAtStart = '';
+    let pointerType = '';
     const pressing = ref(null) as Ref<T | null>;
 
     function disarm(): void {
@@ -97,6 +122,7 @@ export function useLongPress<T>(
 
         origin = { x: event.clientX, y: event.clientY };
         selectionAtStart = selectedText();
+        pointerType = event.pointerType;
         pressing.value = payload;
         timer = window.setTimeout(() => {
             timer = null;
@@ -107,6 +133,7 @@ export function useLongPress<T>(
                 return;
             }
 
+            hapticPulse(pointerType);
             options.onLongPress(payload);
         }, LONG_PRESS_MS);
     }


### PR DESCRIPTION
Closes #810.

## What

A completed long-press on a message row now emits a single short vibration pulse (15ms) at the exact moment the hold delay elapses and the actions sheet is about to open — the point where `useLongPress` invokes `onLongPress`. Native chat apps pair the moment a hold "takes" with a haptic tick; until now the only cue was visual.

## How

- New `LONG_PRESS_VIBRATION_MS` constant and a `hapticPulse` helper in `resources/js/composables/useLongPress.ts`, called from the hold timer right before `onLongPress`.
- Guards, per the issue's feasibility notes:
  - `event.pointerType === 'touch'` (captured at press start) — a mouse/pen long-press on a touch laptop below `md` never vibrates.
  - `'vibrate' in navigator` feature detection — iOS Safari and desktop browsers degrade to a silent no-op, the sheet behaves exactly as today.
  - `prefers-reduced-motion: reduce` skips the pulse (the accepted web proxy for a haptics opt-out).
- Cancelled presses (early lift, drift past slop, text selection, gesture disabled at `md`+) never pulse, since the pulse lives on the same code path as the sheet opening.

## Testing

Seven new Vitest cases in `useLongPress.test.ts` cover the pulse and every guard: touch hold pulses exactly once with the constant duration, reduced-motion skips, mouse/pen holds never vibrate (the sheet still opens), missing Vibration API is a clean no-op, and early-lift / drift / disabled-gesture presses stay silent. Full frontend gate (lint, format, types, vitest, build) and backend gate (100% coverage) are green.

No i18n or docs changes — the change adds no user-facing copy and nothing operator-facing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787500850&installation_model_id=428379&pr_number=831&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F831&signature=5b94b6f36165488a80512ff2cb68423820de16d449313f57796ac125a5387bf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->