### PR TITLE
fix: give the new direct message palette listbox an accessible name

### DIFF
--- a/resources/js/components/NewDirectMessageModal.vue
+++ b/resources/js/components/NewDirectMessageModal.vue
@@ -64,7 +64,7 @@ function selectPerson(id: string): void {
                 class="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
             />
         </div>
-        <CommandList>
+        <CommandList :ariaLabel="$t('People')">
             <CommandGroup v-if="people.length > 0" :heading="$t('People')">
                 <CommandItem
                     v-for="person in people"

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -294,7 +294,7 @@ function openReminders(): void {
                     />
                 </div>
                 <CommandList
-                    :aria-label="$t('Quick switcher')"
+                    :ariaLabel="$t('Quick switcher')"
                     class="max-md:max-h-none max-md:flex-1 max-md:p-1.5"
                 >
                     <CommandGroup

--- a/resources/js/components/ui/command/CommandList.test.ts
+++ b/resources/js/components/ui/command/CommandList.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+
+import { Command, CommandList } from '@/components/ui/command';
+
+let app: App | null = null;
+
+/**
+ * Mounts a real `<Command>`/`<CommandList>` pair under jsdom and returns the
+ * element reka renders with `role="listbox"`, so the tests read the accessible
+ * name exactly where axe audits it.
+ */
+async function mount(ariaLabel: string): Promise<HTMLElement> {
+    app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(Command, () => [h(CommandList, { ariaLabel }, () => [])]),
+        }),
+    );
+    app.mount(document.body.appendChild(document.createElement('div')));
+
+    await nextTick();
+
+    const listbox = document.querySelector<HTMLElement>('[role="listbox"]');
+
+    expect(listbox).not.toBeNull();
+
+    return listbox as HTMLElement;
+}
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('CommandList', () => {
+    it('names the listbox with the required aria-label, where axe audits it (#798)', async () => {
+        const listbox = await mount('People');
+
+        expect(listbox.getAttribute('aria-label')).toBe('People');
+        expect(listbox.getAttribute('data-slot')).toBe('command-list');
+    });
+});

--- a/resources/js/components/ui/command/CommandList.vue
+++ b/resources/js/components/ui/command/CommandList.vue
@@ -5,9 +5,18 @@ import { reactiveOmit } from "@vueuse/core"
 import { ListboxContent, useForwardProps } from "reka-ui"
 import { cn } from "@/lib/utils"
 
-const props = defineProps<ListboxContentProps & { class?: HTMLAttributes["class"] }>()
+const props = defineProps<ListboxContentProps & {
+  class?: HTMLAttributes["class"]
+  /**
+   * Accessible name for the rendered `role="listbox"` element, required at the
+   * type level: an unnamed ARIA input field is a serious axe violation
+   * (`aria-input-field-name`, #798), so every call site must say what its list
+   * contains rather than rely on remembering to pass a loose attribute.
+   */
+  ariaLabel: string
+}>()
 
-const delegatedProps = reactiveOmit(props, "class")
+const delegatedProps = reactiveOmit(props, "class", "ariaLabel")
 
 const forwarded = useForwardProps(delegatedProps)
 </script>
@@ -16,6 +25,7 @@ const forwarded = useForwardProps(delegatedProps)
   <ListboxContent
     data-slot="command-list"
     v-bind="forwarded"
+    :aria-label="props.ariaLabel"
     :class="cn('max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto', props.class)"
   >
     <div role="presentation">

--- a/tests/Browser/A11yShellTest.php
+++ b/tests/Browser/A11yShellTest.php
@@ -28,6 +28,31 @@ test('the sidebar "New message" action is a keyboard-operable button', function 
         ->assertPresent('@new-dm-input');
 });
 
+test('the New Direct Message palette has no serious accessibility violations, light or dark', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // The settle lets the dialog's fade finish: axe blends the mid-animation
+    // opacity into its contrast arithmetic otherwise (#775).
+    $page = signInThroughBrowser($alice)
+        ->keys('@new-dm-trigger', 'Enter')
+        ->assertVisible('@new-dm-input')
+        ->wait(0.5)
+        ->assertNoAccessibilityIssues();
+
+    // Re-audit against the dark palette; persisting to localStorage first keeps
+    // the appearance controller from re-resolving 'system' back to light.
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});
+
 test('the sidebar "Create channel" action is a keyboard-operable button', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 


### PR DESCRIPTION
Closes #798.

## What

The `NewDirectMessageModal` people-picker rendered `role="listbox"` with no accessible name — a **serious** `aria-input-field-name` axe violation (the same defect #775 fixed on the quick switcher's instance, which this modal shared through the `CommandList` primitive).

- The palette's listbox is now named through the translation layer: `$t('People')` (the key already exists in `lang/fr.json`, so no catalog change was needed).
- `CommandList` now **requires** an accessible name at the type level: it declares a required `ariaLabel` prop and binds it explicitly onto the rendered listbox, so any future call site that forgets a name fails `vue-tsc` instead of silently shipping an unnamed ARIA input field (the issue's third acceptance criterion). `QuickSwitcher` was migrated to the prop spelling.

## How tested

- New axe browser audit in `tests/Browser/A11yShellTest.php` covering the open New DM palette in light **and** dark (mirrors the #775 pattern). Written first, red on the exact `aria-input-field-name` violation, green after the fix.
- New Vitest unit test (`CommandList.test.ts`) pinning that the required name lands on the `role="listbox"` element where axe audits it.
- Affected browser suites re-run green: `A11yShellTest`, `MobileQuickSwitcherTest`, `MobileShellTest`, `ComposerPlaceholderTest`, `MobileMastheadAddPeopleTest`.
- Full gate green: `composer test` at 100% coverage, `lint:check`, `format:check`, `types:check`, `test:js` (1189 tests), `build`.
- Local CodeRabbit review: 0 findings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787502800&installation_model_id=428379&pr_number=832&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F832&signature=9503e88d8cb4130cde5752a885a1037c2d31dd9e232c11c4dbc31695b9c8ab1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->