### PR TITLE
ci: skip the heavy suites on the automated candidate-baseline PRs too

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,16 +44,17 @@ jobs:
     # CodeQL-supported language here anyway (see the header comment), so the
     # matrix bought nothing.
     name: Analyze (javascript-typescript)
-    # Release-please PRs only touch VERSION/manifest/changelog files, none of
-    # which contain analyzable code. A job-level `if` (not a `paths` filter)
-    # keeps the PR mergeable: a skipped job reports its required check as
-    # *skipped*, which GitHub treats as satisfied, while a workflow that never
-    # starts leaves it stuck on *Expected*. The head-repo clause keeps the
-    # branch name from becoming a CI bypass: `head_ref` is attacker-controlled,
-    # so a fork branch named `release-please--anything` must still run
-    # everything. Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php
-    # (#820, #825).
-    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
+    # Automation-owned PRs (release-please's own PRs and the candidate-baseline
+    # PR, #839) only touch VERSION/manifest/changelog files, none of which
+    # contain analyzable code. A job-level `if` (not a `paths` filter) keeps
+    # the PR mergeable: a skipped job reports its required check as *skipped*,
+    # which GitHub treats as satisfied, while a workflow that never starts
+    # leaves it stuck on *Expected*. The head-repo clause keeps the branch name
+    # from becoming a CI bypass: `head_ref` is attacker-controlled, so a fork
+    # branch named `release-please--anything` or
+    # `chore/candidate-baseline-anything` must still run everything. Guarded by
+    # tests/Unit/ReleasePullRequestCiSkipTest.php (#820, #825, #839).
+    if: github.event_name != 'pull_request' || !(startsWith(github.head_ref, 'release-please--') || startsWith(github.head_ref, 'chore/candidate-baseline-')) || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     permissions:
       # Required to upload results to the code-scanning (Security) tab.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,15 +28,17 @@ permissions:
 
 jobs:
   quality:
-    # Release-please PRs only touch VERSION/manifest/changelog files, so this
-    # suite has nothing to check there. A job-level `if` (not a `paths` filter)
-    # keeps the PR mergeable: a skipped job reports its required check as
-    # *skipped*, which GitHub treats as satisfied, while a workflow that never
-    # starts leaves it stuck on *Expected*. The head-repo clause keeps the
-    # branch name from becoming a CI bypass: `head_ref` is attacker-controlled,
-    # so a fork branch named `release-please--anything` must still run
-    # everything. Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php (#820).
-    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
+    # Automation-owned PRs (release-please's own PRs and the candidate-baseline
+    # PR, #839) only touch VERSION/manifest/changelog files, so this suite has
+    # nothing to check there. A job-level `if` (not a `paths` filter) keeps the
+    # PR mergeable: a skipped job reports its required check as *skipped*,
+    # which GitHub treats as satisfied, while a workflow that never starts
+    # leaves it stuck on *Expected*. The head-repo clause keeps the branch name
+    # from becoming a CI bypass: `head_ref` is attacker-controlled, so a fork
+    # branch named `release-please--anything` or
+    # `chore/candidate-baseline-anything` must still run everything. Guarded by
+    # tests/Unit/ReleasePullRequestCiSkipTest.php (#820, #839).
+    if: github.event_name != 'pull_request' || !(startsWith(github.head_ref, 'release-please--') || startsWith(github.head_ref, 'chore/candidate-baseline-')) || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,20 +30,24 @@ permissions:
 
 jobs:
   ci:
-    # Release-please PRs only touch VERSION/manifest/changelog files, already
-    # fully tested on the branch they were cut from — yet every push to the base
-    # branch force-updates the release branch and re-fires this suite on the PR.
-    # A job-level `if` (not a `paths` filter) is what keeps the PR mergeable: a
-    # skipped job reports its required check as *skipped*, which GitHub treats as
-    # satisfied, while a workflow that never starts leaves it stuck on
-    # *Expected*. The head-repo clause keeps the branch name from becoming a CI
-    # bypass: `head_ref` is attacker-controlled, so a fork branch named
-    # `release-please--anything` must still run everything. The job must also
-    # stay matrix-free: a matrix job skipped by a job-level `if` never expands,
-    # so its check would report under the raw name and a matrix-expanded
-    # required context (`ci (8.5)`) would sit on *Expected* forever (#825).
-    # Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php (#820, #825).
-    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
+    # Automation-owned PRs only touch VERSION/manifest/changelog files, already
+    # fully tested on the branch they were cut from: release-please PRs re-fire
+    # this suite on every push to the base branch (which force-updates the
+    # release branch), and the candidate-baseline PR the release workflow opens
+    # against `develop` after a stable release burns a full suite on a one-line
+    # manifest bump (#839). A job-level `if` (not a `paths` filter) is what
+    # keeps the PR mergeable: a skipped job reports its required check as
+    # *skipped*, which GitHub treats as satisfied, while a workflow that never
+    # starts leaves it stuck on *Expected*. The head-repo clause keeps the
+    # branch name from becoming a CI bypass: `head_ref` is attacker-controlled,
+    # so a fork branch named `release-please--anything` or
+    # `chore/candidate-baseline-anything` must still run everything. The job
+    # must also stay matrix-free: a matrix job skipped by a job-level `if`
+    # never expands, so its check would report under the raw name and a
+    # matrix-expanded required context (`ci (8.5)`) would sit on *Expected*
+    # forever (#825).
+    # Guarded by tests/Unit/ReleasePullRequestCiSkipTest.php (#820, #825, #839).
+    if: github.event_name != 'pull_request' || !(startsWith(github.head_ref, 'release-please--') || startsWith(github.head_ref, 'chore/candidate-baseline-')) || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     # The schema relies on Postgres-only defaults (gen_random_uuid()), so tests
@@ -157,8 +161,8 @@ jobs:
   # never folds into the 100% coverage gate above — the `browser` group is
   # excluded from phpunit's default suites and only runs via `pest tests/Browser`.
   browser:
-    # Skipped on release-please PRs for the same reason as the ci job above.
-    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository
+    # Skipped on automation-owned PRs for the same reason as the ci job above.
+    if: github.event_name != 'pull_request' || !(startsWith(github.head_ref, 'release-please--') || startsWith(github.head_ref, 'chore/candidate-baseline-')) || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
     services:

--- a/tests/Unit/ReleasePullRequestCiSkipTest.php
+++ b/tests/Unit/ReleasePullRequestCiSkipTest.php
@@ -18,15 +18,20 @@ use Symfony\Component\Yaml\Yaml;
 $workflow = fn (string $name): array => Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/'.$name);
 
 /**
- * The condition that spares a release PR the heavy jobs: `head_ref` is only set
- * on pull request events, so every push, schedule, or dispatch run passes the
- * first disjunct untouched. The head-repo disjunct is what keeps the branch
+ * The condition that spares an automation-owned PR the heavy jobs: `head_ref`
+ * is only set on pull request events, so every push, schedule, or dispatch run
+ * passes the first disjunct untouched. Two branch prefixes qualify — the
+ * release PRs release-please maintains (`release-please--`, #820) and the
+ * candidate-baseline PR the release workflow opens against `develop` after a
+ * stable release (`chore/candidate-baseline-`, #839); both carry diffs limited
+ * to files release-please owns. The head-repo disjunct is what keeps the branch
  * name from becoming a CI bypass — `head_ref` is attacker-controlled, so a fork
- * branch named `release-please--anything` would otherwise get every required
- * check skipped (and skipped counts as satisfied). A same-repo branch with that
- * name needs write access, which is already trusted.
+ * branch named `release-please--anything` or `chore/candidate-baseline-anything`
+ * would otherwise get every required check skipped (and skipped counts as
+ * satisfied). A same-repo branch with either name needs write access, which is
+ * already trusted.
  */
-const RELEASE_PULL_REQUEST_SKIP = "github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') || github.event.pull_request.head.repo.full_name != github.repository";
+const AUTOMATION_PULL_REQUEST_SKIP = "github.event_name != 'pull_request' || !(startsWith(github.head_ref, 'release-please--') || startsWith(github.head_ref, 'chore/candidate-baseline-')) || github.event.pull_request.head.repo.full_name != github.repository";
 
 /**
  * The multi-minute jobs and the workflows they live in. `commitlint` and
@@ -45,8 +50,8 @@ function heavyJobs(): array
     ];
 }
 
-test('the heavy jobs skip release-please pull requests', function (string $file, string $job) use ($workflow): void {
-    expect($workflow($file)['jobs'][$job]['if'] ?? null)->toBe(RELEASE_PULL_REQUEST_SKIP);
+test('the heavy jobs skip automation-owned pull requests', function (string $file, string $job) use ($workflow): void {
+    expect($workflow($file)['jobs'][$job]['if'] ?? null)->toBe(AUTOMATION_PULL_REQUEST_SKIP);
 })->with(heavyJobs());
 
 /*


### PR DESCRIPTION
Closes #839.

## What

Extends the job-level skip condition on the four heavy jobs (`ci` + `browser` in `tests.yml`, `quality` in `lint.yml`, `analyze` in `codeql.yml`) so it also matches the `chore/candidate-baseline-` branch prefix, alongside the existing `release-please--` prefix:

```yaml
if: github.event_name != 'pull_request' || !(startsWith(github.head_ref, 'release-please--') || startsWith(github.head_ref, 'chore/candidate-baseline-')) || github.event.pull_request.head.repo.full_name != github.repository
```

## Why

The `chore/candidate-baseline-<version>` PR that `sync-candidate-baseline` opens against `develop` after every stable release carries a one-line rewrite of `.release-please-manifest.develop.json`, yet ran `ci`, `browser`, `quality`, and `analyze` in full before its `--auto --squash` merge could complete. That is one full heavy suite per stable release spent validating a manifest bump, and it delays the baseline landing on `develop` — the exact window in which the stale-baseline rc-series bug (#637) lives.

Same mechanics as #821: a job-level `if` (not a `paths` filter) so the skipped checks report as *skipped*, which the rulesets treat as satisfied; the head-repo clause keeps a fork branch named `chore/candidate-baseline-anything` running everything. The check names stayed static after #826, so no ruleset change is needed. `commitlint` and `dependency-review` remain unfiltered.

## Testing

- `tests/Unit/ReleasePullRequestCiSkipTest.php` extended red-first: the pinned skip condition (now `AUTOMATION_PULL_REQUEST_SKIP`) was updated before the workflows, watched fail on all four heavy jobs, then went green once the workflows were updated. Removing the new clause — or reintroducing a matrix/expression-bearing name on a guarded job — fails the build.
- Full backend gate green (`composer test`: Pint, PHPStan, Rector, parallel suite at 100.0% coverage) and all frontend checks pass (`lint:check`, `format:check`, `types:check`, `test:js`, `build`).
- Local CodeRabbit review against `develop`: 0 findings.

No i18n or docs impact (no user-facing or operator-facing change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787510187&installation_model_id=428379&pr_number=840&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F840&signature=63ac41d16afbc058bfeda7e9f63f59a52b5a5e7822bc2c12730f5b5babb04966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->