### PR TITLE
feat: open the mobile dock full screen and close it on navigation

### DIFF
--- a/resources/js/components/ui/sidebar/Sidebar.vue
+++ b/resources/js/components/ui/sidebar/Sidebar.vue
@@ -18,6 +18,35 @@ const props = withDefaults(defineProps<SidebarProps>(), {
 })
 
 const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+/**
+ * Navigate = close (#834). The provider's Inertia `navigate` listener covers
+ * URL-changing visits, but a tap on the row of the channel the user is already
+ * in replaces the history entry and never fires that event — so any activation
+ * that runs through a link inside the sheet closes it too. Buttons (section
+ * collapse, context menus, drag handles) fall through and keep it open.
+ */
+function closeOnLinkActivation(event: MouseEvent): void {
+  if ((event.target as HTMLElement | null)?.closest("a[href]")) {
+    setOpenMobile(false)
+  }
+}
+
+/**
+ * Where focus goes when the mobile sheet closes. The element reka would restore
+ * it to is usually the row that just navigated — unmounted with the sheet — so
+ * focus would strand on <body>. Hand it to the destination pane instead: the
+ * same #main the skip link targets, which carries tabindex="-1" for exactly
+ * this kind of programmatic focus.
+ */
+function focusDestinationPane(event: Event): void {
+  const main = document.getElementById("main")
+
+  if (main) {
+    event.preventDefault()
+    main.focus()
+  }
+}
 </script>
 
 <template>
@@ -36,16 +65,17 @@ const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
       data-slot="sidebar"
       data-mobile="true"
       :side="side"
-      class="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+      class="bg-sidebar text-sidebar-foreground w-(--sidebar-width) sm:max-w-none p-0 [&>button]:hidden"
       :style="{
         '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
       }"
+      @close-auto-focus="focusDestinationPane"
     >
       <SheetHeader class="sr-only">
         <SheetTitle>{{ $t('Sidebar') }}</SheetTitle>
         <SheetDescription>{{ $t('Displays the mobile sidebar.') }}</SheetDescription>
       </SheetHeader>
-      <div class="flex h-full w-full flex-col">
+      <div class="flex h-full w-full flex-col" @click="closeOnLinkActivation">
         <slot />
       </div>
     </SheetContent>

--- a/resources/js/components/ui/sidebar/SidebarProvider.vue
+++ b/resources/js/components/ui/sidebar/SidebarProvider.vue
@@ -62,10 +62,11 @@ useEdgeSwipe({
 
 // Navigate = close (#834): landing somewhere new is the dock's job done, so
 // the full-screen sheet dismisses itself rather than sitting on top of the
-// destination. Inertia only fires `navigate` for visits that push a new
-// history entry — same-URL visits and partial reloads (section collapse,
-// background `router.reload`s) go through `replaceState` and never fire it,
-// which is exactly the "non-navigating interactions keep the dock open" rule.
+// destination. Inertia fires `navigate` for URL-changing visits and history
+// traversal, but not for same-URL visits or partial reloads (section collapse,
+// background `router.reload`s) — those replace the current history entry and
+// skip the event, which is exactly the "non-navigating interactions keep the
+// dock open" rule.
 const stopNavigateListener = router.on("navigate", () => setOpenMobile(false))
 
 onUnmounted(stopNavigateListener)

--- a/resources/js/components/ui/sidebar/SidebarProvider.vue
+++ b/resources/js/components/ui/sidebar/SidebarProvider.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { HTMLAttributes, Ref } from "vue"
+import { router } from "@inertiajs/vue3"
 import { defaultDocument, useEventListener, useVModel } from "@vueuse/core"
 import { TooltipProvider } from "reka-ui"
-import { computed, ref } from "vue"
+import { computed, onUnmounted, ref } from "vue"
 import { useEdgeSwipe } from "@/composables/useEdgeSwipe"
 import { useIsMobile } from "@/composables/useIsMobile"
 import { useSidebarPosition } from "@/composables/useSidebarPosition"
@@ -58,6 +59,16 @@ useEdgeSwipe({
   onOpen: () => setOpenMobile(true),
   onClose: () => setOpenMobile(false),
 })
+
+// Navigate = close (#834): landing somewhere new is the dock's job done, so
+// the full-screen sheet dismisses itself rather than sitting on top of the
+// destination. Inertia only fires `navigate` for visits that push a new
+// history entry — same-URL visits and partial reloads (section collapse,
+// background `router.reload`s) go through `replaceState` and never fire it,
+// which is exactly the "non-navigating interactions keep the dock open" rule.
+const stopNavigateListener = router.on("navigate", () => setOpenMobile(false))
+
+onUnmounted(stopNavigateListener)
 
 useEventListener("keydown", (event: KeyboardEvent) => {
   if (event.key === SIDEBAR_KEYBOARD_SHORTCUT && (event.metaKey || event.ctrlKey)) {

--- a/resources/js/components/ui/sidebar/utils.ts
+++ b/resources/js/components/ui/sidebar/utils.ts
@@ -4,8 +4,8 @@ import { createContext } from "reka-ui"
 export const SIDEBAR_COOKIE_NAME = "sidebar_state"
 export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 export const SIDEBAR_WIDTH = "16rem"
-/** The dock's width as a left Sheet below the breakpoint (300px, per the mobile design). */
-export const SIDEBAR_WIDTH_MOBILE = "300px"
+/** The dock's width below the breakpoint: the whole viewport (#834 supersedes the design's 300px strip). */
+export const SIDEBAR_WIDTH_MOBILE = "100dvw"
 export const SIDEBAR_WIDTH_ICON = "3rem"
 export const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -14,6 +14,7 @@ import {
     Search,
     Trash2,
     UserPlus,
+    X,
 } from '@lucide/vue';
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { toast } from 'vue-sonner';
@@ -63,6 +64,7 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import { SheetClose } from '@/components/ui/sheet';
 import {
     Sidebar,
     SidebarContent,
@@ -95,6 +97,7 @@ import {
 } from '@/composables/useOnboardingTour';
 import { usePresenceReporter } from '@/composables/usePresenceReporter';
 import { useQuickSwitcher } from '@/composables/useQuickSwitcher';
+import { useIsMobile } from '@/composables/useIsMobile';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
 import { useTeamPresence } from '@/composables/useTeamPresence';
@@ -695,6 +698,13 @@ const { timezone, syncDetectedTimezone } = useTimezone();
  */
 const { sidebarPosition } = useSidebarPosition();
 
+/**
+ * Whether the dock currently renders as the full-screen mobile Sheet, which is
+ * when its header carries the close affordance (#834): full screen leaves no
+ * visible scrim to tap, so the header X is the visible way out.
+ */
+const isMobileViewport = useIsMobile();
+
 onMounted(() => {
     // Lazily pull the (optional) shared invitations so the post-login prompt
     // appears. It lands moments after the first render, when the user may already
@@ -849,6 +859,18 @@ onMounted(() => {
                                 }}</span>
                             </Button>
                         </CreateTeamModal>
+                        <SheetClose v-if="isMobileViewport" as-child>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                :title="$t('Close')"
+                                data-test="dock-close"
+                                class="size-9 rounded-[10px] text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                            >
+                                <X class="size-4" />
+                                <span class="sr-only">{{ $t('Close') }}</span>
+                            </Button>
+                        </SheetClose>
                     </div>
                 </div>
             </SidebarHeader>

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -87,6 +87,7 @@ import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useDemoMode } from '@/composables/useDemoMode';
 import { useDndPauseDialog } from '@/composables/useDndPauseDialog';
 import { useInitials } from '@/composables/useInitials';
+import { useIsMobile } from '@/composables/useIsMobile';
 import { useKeyboardShortcuts } from '@/composables/useKeyboardShortcuts';
 import { useKeyboardShortcutsModal } from '@/composables/useKeyboardShortcutsModal';
 import { useMessageReminders } from '@/composables/useMessageReminders';
@@ -97,7 +98,6 @@ import {
 } from '@/composables/useOnboardingTour';
 import { usePresenceReporter } from '@/composables/usePresenceReporter';
 import { useQuickSwitcher } from '@/composables/useQuickSwitcher';
-import { useIsMobile } from '@/composables/useIsMobile';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
 import { useTeamPresence } from '@/composables/useTeamPresence';

--- a/tests/Browser/MobileShellTest.php
+++ b/tests/Browser/MobileShellTest.php
@@ -299,11 +299,23 @@ test('collapsing a section keeps the dock open', function (): void {
         ->navigate(browserChannelUrl($team, $channel))
         ->click('@sidebar-toggle')
         ->assertVisible('@section-content-channels')
+        // Flag the persisting PATCH's completion so the final assertions run on
+        // the far side of the round trip — a wrongful close would fire there,
+        // after the optimistic assertions had already passed.
+        ->assertScript(<<<'JS'
+        (() => {
+            window.__collapsePersisted = false;
+            document.addEventListener('inertia:finish', () => {
+                window.__collapsePersisted = true;
+            }, { once: true });
+
+            return true;
+        })()
+        JS, true)
         ->click('@section-toggle-channels')
         ->assertMissing('@section-content-channels')
+        ->assertScript('window.__collapsePersisted', true)
         ->assertPresent('@channels-nav')
-        // The persisting PATCH has round-tripped once its prop lands; the dock
-        // is still on screen on the far side of it.
         ->assertScript(<<<'JS'
         (() => document.querySelector('[data-slot="sidebar"][data-mobile="true"]') !== null)()
         JS, true);

--- a/tests/Browser/MobileShellTest.php
+++ b/tests/Browser/MobileShellTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Actions\Channels\JoinChannel;
 use App\Enums\AppLocale;
+use App\Models\Channel;
 
 /**
  * The mobile breakpoint's shell: one pane below `md`, and no width at which the
@@ -140,19 +142,25 @@ test('a long channel name truncates rather than pushing the search icon off scre
         JS, true);
 });
 
-test('the dock opens as a 300px sheet whose every row clears a 44px touch target', function (): void {
+test('the dock opens full screen and its every row clears a 44px touch target', function (int $width, int $height): void {
     ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
 
+    // A 300px strip left a sliver of dimmed channel behind it that served no
+    // purpose on a phone (#834): the open dock now owns the whole viewport,
+    // edge to edge.
     signInThroughBrowser($alice)
-        ->resize(390, 844)
+        ->resize($width, $height)
         ->navigate(browserChannelUrl($team, $channel))
         ->click('@sidebar-toggle')
         ->assertPresent('@channels-nav')
         ->assertScript(<<<'JS'
-        (() => Math.round(
-            document.querySelector('[data-slot="sidebar"][data-mobile="true"]')
-                .getBoundingClientRect().width
-        ) === 300)()
+        (() => {
+            const box = document.querySelector('[data-slot="sidebar"][data-mobile="true"]')
+                .getBoundingClientRect();
+
+            return Math.round(box.width) === window.innerWidth
+                && Math.round(box.height) === window.innerHeight;
+        })()
         JS, true)
         // Channel and direct-message rows are the ones a thumb hits most, and
         // they carry the full 44px target.
@@ -175,6 +183,30 @@ test('the dock opens as a 300px sheet whose every row clears a 44px touch target
             return row !== null && Math.round(row.getBoundingClientRect().height) >= 38;
         }))()
         JS, true);
+})->with([
+    'small phone' => [360, 740],
+    'iPhone 14' => [390, 844],
+    // Landscape trips the sheet primitive's `sm:max-w-sm` cap, which only a
+    // full-screen dock needs lifted.
+    'landscape phone' => [740, 360],
+]);
+
+test('the dock header carries its own close affordance below the breakpoint', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // Full screen leaves no visible scrim to tap (#834), so the header takes
+    // over as the visible way out. The desktop rail is no dialog and offers no
+    // such button.
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@sidebar-toggle')
+        ->assertVisible('@dock-close')
+        ->click('@dock-close')
+        ->assertNotPresent('@channels-nav')
+        ->resize(1280, 800)
+        ->assertPresent('@channels-nav')
+        ->assertNotPresent('@dock-close');
 });
 
 test('the dock dismisses without a reload', function (): void {
@@ -192,6 +224,89 @@ test('the dock dismisses without a reload', function (): void {
         // its own unit tests over `swipeIntent`.
         ->keys('@channels-nav', ['Escape'])
         ->assertNotPresent('@channels-nav');
+});
+
+test('tapping a channel in the dock navigates and closes it in the same gesture', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    $planning = Channel::factory()->for($team)->create([
+        'name' => 'planning',
+        'slug' => 'planning',
+    ]);
+    app(JoinChannel::class)->handle($planning, $alice);
+
+    // Navigation used to leave the sheet open on top of the destination, a tap
+    // tax on the most common action in the app (#834): the visit and the
+    // dismissal are now the same gesture.
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $general))
+        ->click('@sidebar-toggle')
+        ->assertPresent('@channels-nav')
+        ->click('[data-test="section-content-channels"] a[href$="/planning"]')
+        ->assertPathIs(browserChannelUrl($team, $planning))
+        ->assertNotPresent('@channels-nav');
+});
+
+test('closing on navigation hands focus to the destination pane', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    $planning = Channel::factory()->for($team)->create([
+        'name' => 'planning',
+        'slug' => 'planning',
+    ]);
+    app(JoinChannel::class)->handle($planning, $alice);
+
+    // The sheet's focus trap must release cleanly: the row it would restore
+    // focus to unmounts with the sheet, and letting focus drop to <body> strands
+    // keyboard users. It lands on the destination pane instead — the same
+    // #main the skip link targets.
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $general))
+        ->click('@sidebar-toggle')
+        ->assertPresent('@channels-nav')
+        ->click('[data-test="section-content-channels"] a[href$="/planning"]')
+        ->assertNotPresent('@channels-nav')
+        ->assertScript(<<<'JS'
+        (() => document.activeElement === document.getElementById('main'))()
+        JS, true);
+});
+
+test('tapping the channel the user is already in still closes the dock', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    // A same-URL visit never fires Inertia's `navigate` event (it replaces the
+    // history entry instead of pushing one), but the row is still a navigating
+    // gesture to the user: the dock has to get out of the way all the same.
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $general))
+        ->click('@sidebar-toggle')
+        ->assertPresent('@channels-nav')
+        ->click("[data-test=\"section-content-channels\"] a[href$=\"/{$general->slug}\"]")
+        ->assertPathIs(browserChannelUrl($team, $general))
+        ->assertNotPresent('@channels-nav');
+});
+
+test('collapsing a section keeps the dock open', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // The collapse persists through an Inertia partial reload, which must not
+    // read as a navigation: the user is arranging the dock, not leaving it.
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@sidebar-toggle')
+        ->assertVisible('@section-content-channels')
+        ->click('@section-toggle-channels')
+        ->assertMissing('@section-content-channels')
+        ->assertPresent('@channels-nav')
+        // The persisting PATCH has round-tripped once its prop lands; the dock
+        // is still on screen on the far side of it.
+        ->assertScript(<<<'JS'
+        (() => document.querySelector('[data-slot="sidebar"][data-mobile="true"]') !== null)()
+        JS, true);
 });
 
 test('the composer stays a pill that keeps its field and Send button usable', function (int $width, int $height): void {


### PR DESCRIPTION
Closes #834.

## What

Below `md`, the dock sheet now covers the whole viewport (edge to edge, `100dvw`, the sheet primitive's `sm:max-w-sm` cap lifted) instead of a 300px strip with a purposeless scrim sliver. Any navigating row — a channel, a DM, Threads, Search messages, Browse channels, a jump-to result, a user-menu item — performs the visit and closes the dock in the same gesture. The dock header gains a mobile-only X close button (the scrim-tap dismissal disappears with the scrim), and focus hands off to `#main` when the sheet closes so the trap releases cleanly onto the destination pane.

## How

- **Shared layer, not per-row wiring:** `SidebarProvider` listens to Inertia's `navigate` event, which fires for URL-changing visits and history traversal but not for same-URL visits or partial reloads — so section collapse (`router.patch` + `only`) and background reloads keep the dock open by construction.
- A link-activation click handler on the mobile sheet body covers the one case `navigate` misses: tapping the row of the channel the user is already in.
- `Sidebar.vue`'s mobile `SheetContent` redirects `closeAutoFocus` to `#main` (already `tabindex="-1"` as the skip-link target) because reka's default restore target unmounts with the sheet.
- The header X is a `SheetClose` rendered only below `md`; desktop rail markup and behaviour are untouched.

## Tested

- New/updated Pest browser tests in `tests/Browser/MobileShellTest.php`: dock full-screen at 360x740, 390x844, and 740x360 (44px/38px row targets kept); tapping a channel navigates and closes; tapping the current channel still closes; section collapse keeps the dock open across the far side of the persistence round trip; header close affordance present below `md` and absent on desktop; focus lands on `#main` after a navigate-close. Escape/swipe dismissal tests unchanged and green.
- Adjacent suites green: MobileSheetsTest, SidebarPositionTest, MobileQuickSwitcherTest, MobileUserMenuSheetTest, A11yShellTest, A11yAuditTest, MobileThreadPanelTest.
- Visually verified with Playwright at 360x740, 375x667, 390x844, 430x932, 740x360 landscape (full-screen dock; channel/DM/Threads/Browse taps land and close) and 768x1024 (desktop rail unchanged at the boundary); French checked at 360px; light and dark themes checked.
- Full gates green: `sail composer test` at 100.0% coverage, `lint:check`, `format:check`, `types:check`, `test:js` (121 files / 1189 tests), `build`.

## i18n / docs

- The close button reuses the existing `Close` key (already in `lang/fr.json` as "Fermer"); no new user-facing copy.
- No operator-facing settings changed, so no `docs/` updates.

## Review

Local CodeRabbit pass applied both findings (collapse test now waits for the persistence round trip; navigate-event comment corrected for history traversal) before the CLI hit the free-tier rate limit; the remaining delta since is a comment rewording only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787511975&installation_model_id=428379&pr_number=843&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F843&signature=923959c59848619a92b0af403832b3f0439adf152776cf30f34b86a582e1d588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->