### PR TITLE
fix: stack the demo banner into two rows below the md breakpoint

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1182,6 +1182,8 @@
   "Sign in with the shared demo account": "Connectez-vous avec le compte de démonstration partagé",
   "You're exploring a": "Vous explorez une",
   "live demo": "démo en direct",
+  "Live demo": "Démo en direct",
+  "Shared account, some actions are disabled.": "Compte partagé, certaines actions sont désactivées.",
   "— everyone shares one account, it resets hourly, and some actions are disabled.": "— tout le monde partage un seul compte, elle est réinitialisée toutes les heures, et certaines actions sont désactivées.",
   "Record a voice message": "Enregistrer un message vocal",
   "Stop recording": "Arrêter l’enregistrement",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -172,7 +172,13 @@
     --demo-chip: #ffffff;
     --demo-chip-foreground: #7d6023;
     /* Height of the fixed demo strip, so the shell can reserve space beneath it
-       (the banner is `position: fixed`, out of flow). Theme-independent. */
+       (the banner is `position: fixed`, out of flow). Theme-independent.
+
+       This is the pre-hydration fallback only: the strip stacks into two rows
+       below `md` and its copy wraps to a width- and locale-dependent number of
+       lines, so DemoBanner.vue measures itself on mount and overrides this with
+       the height it really occupies (#841). Keep it matching the desktop strip's
+       own `md:h-10`. */
     --demo-banner-height: 2.5rem;
     --chart-1: #c9a35c;
     --chart-2: #7d6023;
@@ -190,6 +196,16 @@
     --sidebar-ring: #8a6a1f;
     --sidebar: #fbfaf7;
     --sidebar-rail: #eeeade;
+}
+
+/* The stacked, two-row treatment of the demo strip below `md`. Still only the
+   pre-hydration fallback — DemoBanner.vue replaces it with the measured height
+   as soon as it mounts — but it keeps that first paint from underlapping by a
+   whole row. */
+@media (width < 48rem) {
+    :root {
+        --demo-banner-height: 3.75rem;
+    }
 }
 
 .dark {

--- a/resources/js/components/DemoBanner.test.ts
+++ b/resources/js/components/DemoBanner.test.ts
@@ -85,10 +85,9 @@ beforeEach(() => {
     disconnected = 0;
     renderedHeight = 40;
     vi.stubGlobal('ResizeObserver', FakeResizeObserver);
-    vi.spyOn(
-        HTMLElement.prototype,
-        'getBoundingClientRect',
-    ).mockImplementation(() => ({ height: renderedHeight }) as DOMRect);
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+        () => ({ height: renderedHeight }) as DOMRect,
+    );
 });
 
 afterEach(() => {
@@ -118,7 +117,11 @@ describe('DemoBanner', () => {
         expect(banner).not.toBeNull();
         expect(banner?.getAttribute('role')).toBe('status');
         expect(banner?.textContent).toContain('live demo');
-        expect(banner?.querySelector('strong')?.textContent).toBe('live demo');
+        expect(
+            [...(banner?.querySelectorAll('strong') ?? [])].map((emphasis) =>
+                emphasis.textContent?.trim(),
+            ),
+        ).toContain('live demo');
     });
 
     it('shows the minutes until the next hourly reset', () => {
@@ -167,6 +170,20 @@ describe('DemoBanner', () => {
             host.querySelector('[data-test="demo-reset-countdown"]')
                 ?.textContent,
         ).toContain('Resets in 59 min');
+    });
+
+    it('carries a phone-sized wording of the notice alongside the full sentence', () => {
+        props.demoMode = true;
+
+        const banner = mount().querySelector('[data-test="demo-banner"]');
+
+        // The phone rows say what the countdown chip cannot, and no more; the
+        // full sentence stays for `md` and up.
+        expect(banner?.textContent).toContain('Live demo');
+        expect(banner?.textContent).toContain(
+            'Shared account, some actions are disabled.',
+        );
+        expect(banner?.textContent).toContain("You're exploring a");
     });
 
     it('publishes its rendered height so the layouts below reserve the real space', () => {

--- a/resources/js/components/DemoBanner.test.ts
+++ b/resources/js/components/DemoBanner.test.ts
@@ -22,6 +22,37 @@ import DemoBanner from './DemoBanner.vue';
 
 let app: App | null = null;
 
+type ResizeCallback = () => void;
+
+/** Captured so a test can replay a resize the way the browser would. */
+let resizeCallbacks: ResizeCallback[] = [];
+let disconnected = 0;
+
+class FakeResizeObserver {
+    constructor(private callback: ResizeCallback) {}
+
+    observe(): void {
+        resizeCallbacks.push(this.callback);
+    }
+
+    disconnect(): void {
+        disconnected += 1;
+    }
+}
+
+/** jsdom lays nothing out, so the banner's rendered height is dictated here. */
+let renderedHeight = 40;
+
+function stubRenderedHeight(height: number): void {
+    renderedHeight = height;
+}
+
+function publishedHeight(): string {
+    return document.documentElement.style.getPropertyValue(
+        '--demo-banner-height',
+    );
+}
+
 /** Minimal `$t` that also resolves `:token` placeholders so counts render. */
 function translate(
     key: string,
@@ -50,6 +81,14 @@ function mount() {
 
 beforeEach(() => {
     vi.useFakeTimers();
+    resizeCallbacks = [];
+    disconnected = 0;
+    renderedHeight = 40;
+    vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+    vi.spyOn(
+        HTMLElement.prototype,
+        'getBoundingClientRect',
+    ).mockImplementation(() => ({ height: renderedHeight }) as DOMRect);
 });
 
 afterEach(() => {
@@ -58,6 +97,9 @@ afterEach(() => {
     props.demoMode = false;
     props.demoResetsAt = null;
     document.body.innerHTML = '';
+    document.documentElement.style.removeProperty('--demo-banner-height');
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     vi.useRealTimers();
 });
 
@@ -125,6 +167,45 @@ describe('DemoBanner', () => {
             host.querySelector('[data-test="demo-reset-countdown"]')
                 ?.textContent,
         ).toContain('Resets in 59 min');
+    });
+
+    it('publishes its rendered height so the layouts below reserve the real space', () => {
+        props.demoMode = true;
+        stubRenderedHeight(76);
+
+        mount();
+
+        expect(publishedHeight()).toBe('76px');
+    });
+
+    it('republishes the height when the strip reflows to more lines', () => {
+        props.demoMode = true;
+        stubRenderedHeight(40);
+
+        mount();
+        stubRenderedHeight(94);
+        resizeCallbacks.forEach((notify) => notify());
+
+        expect(publishedHeight()).toBe('94px');
+    });
+
+    it('leaves the height alone off the demo', () => {
+        props.demoMode = false;
+
+        mount();
+
+        expect(publishedHeight()).toBe('');
+    });
+
+    it('releases the published height when it goes away', () => {
+        props.demoMode = true;
+
+        mount();
+        app?.unmount();
+        app = null;
+
+        expect(publishedHeight()).toBe('');
+        expect(disconnected).toBe(1);
     });
 
     it('hides the countdown chip when no reset timestamp is shared', () => {

--- a/resources/js/components/DemoBanner.vue
+++ b/resources/js/components/DemoBanner.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { FlaskConical, RotateCcw } from '@lucide/vue';
-import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, useTemplateRef } from 'vue';
 import { useDemoMode } from '@/composables/useDemoMode';
 
 /**
@@ -23,16 +23,54 @@ const MS_PER_MINUTE = 60_000;
 const nowMs = ref(Date.now());
 let ticker: ReturnType<typeof setInterval> | undefined;
 
+const bannerElement = useTemplateRef<HTMLElement>('banner');
+let heightObserver: ResizeObserver | undefined;
+
+/**
+ * Publish the strip's real rendered height as `--demo-banner-height`, the
+ * variable every layout beneath it offsets by.
+ *
+ * The strip is `position: fixed` and therefore out of flow, so that reservation
+ * is the only thing keeping the page from sliding under it. Below `md` the copy
+ * wraps to a number of lines that depends on the viewport width *and* on the
+ * active locale (French runs longer than English), so a hardcoded height either
+ * clips the notice or leaves a dead gap — which is exactly how #841 surfaced.
+ * Measuring sidesteps the guesswork: whatever the strip ends up occupying is
+ * what the layouts reserve.
+ */
+function publishHeight(): void {
+    const element = bannerElement.value;
+
+    if (!element) {
+        return;
+    }
+
+    document.documentElement.style.setProperty(
+        '--demo-banner-height',
+        `${element.getBoundingClientRect().height}px`,
+    );
+}
+
 onMounted(() => {
     ticker = setInterval(() => {
         nowMs.value = Date.now();
     }, MS_PER_MINUTE);
+
+    if (bannerElement.value && typeof ResizeObserver !== 'undefined') {
+        heightObserver = new ResizeObserver(publishHeight);
+        heightObserver.observe(bannerElement.value);
+    }
+
+    publishHeight();
 });
 
 onUnmounted(() => {
     if (ticker !== undefined) {
         clearInterval(ticker);
     }
+
+    heightObserver?.disconnect();
+    document.documentElement.style.removeProperty('--demo-banner-height');
 });
 
 /**
@@ -65,6 +103,7 @@ const minutesUntilReset = computed<number | null>(() => {
 <template>
     <div
         v-if="demoMode"
+        ref="banner"
         role="status"
         data-test="demo-banner"
         class="fixed inset-x-0 top-0 z-40 flex h-(--demo-banner-height) items-center gap-2.5 border-b border-demo-banner-border bg-demo-banner px-4 text-demo-banner-foreground shadow-sm"

--- a/resources/js/components/DemoBanner.vue
+++ b/resources/js/components/DemoBanner.vue
@@ -106,7 +106,7 @@ const minutesUntilReset = computed<number | null>(() => {
         ref="banner"
         role="status"
         data-test="demo-banner"
-        class="fixed inset-x-0 top-0 z-40 flex h-(--demo-banner-height) items-center gap-2.5 border-b border-demo-banner-border bg-demo-banner px-4 text-demo-banner-foreground shadow-sm"
+        class="fixed inset-x-0 top-0 z-40 flex min-h-10 flex-wrap items-center gap-x-2.5 gap-y-1 border-b border-demo-banner-border bg-demo-banner px-4 py-1.5 text-demo-banner-foreground shadow-sm md:h-10 md:flex-nowrap md:py-0"
     >
         <span
             class="flex size-5.5 shrink-0 items-center justify-center rounded-full bg-demo-badge"
@@ -116,7 +116,31 @@ const minutesUntilReset = computed<number | null>(() => {
                 aria-hidden="true"
             />
         </span>
-        <span class="text-center text-[13px] leading-snug">
+        <!-- Below `md` the strip stacks in two rows: this short heading shares
+             the first with the countdown chip, and the detail below takes the
+             second on its own. One row cannot hold all three at phone widths —
+             squeezing the full sentence between the badge and the chip is what
+             wrapped it to three lines and overflowed the strip (#841). -->
+        <strong
+            class="text-[13px] leading-snug font-semibold text-demo-banner-strong md:hidden"
+        >
+            {{ $t('Live demo') }}
+        </strong>
+        <span
+            v-if="minutesUntilReset !== null"
+            data-test="demo-reset-countdown"
+            aria-live="off"
+            class="ml-auto inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-demo-banner-border bg-demo-chip px-2.75 text-[11.5px] font-semibold whitespace-nowrap text-demo-chip-foreground md:order-last"
+        >
+            <RotateCcw class="size-2.75" aria-hidden="true" />
+            {{ $t('Resets in :count min', { count: minutesUntilReset }) }}
+        </span>
+        <!-- The chip already carries the reset schedule, so the phone copy drops
+             it and keeps only what the chip cannot say. -->
+        <span class="basis-full text-[13px] leading-snug md:hidden">
+            {{ $t('Shared account, some actions are disabled.') }}
+        </span>
+        <span class="hidden text-center text-[13px] leading-snug md:inline">
             {{ $t("You're exploring a") }}
             <strong class="font-semibold text-demo-banner-strong">{{
                 $t('live demo')
@@ -126,15 +150,6 @@ const minutesUntilReset = computed<number | null>(() => {
                     '— everyone shares one account, it resets hourly, and some actions are disabled.',
                 )
             }}
-        </span>
-        <span
-            v-if="minutesUntilReset !== null"
-            data-test="demo-reset-countdown"
-            aria-live="off"
-            class="ml-auto inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-demo-banner-border bg-demo-chip px-2.75 text-[11.5px] font-semibold whitespace-nowrap text-demo-chip-foreground"
-        >
-            <RotateCcw class="size-2.75" aria-hidden="true" />
-            {{ $t('Resets in :count min', { count: minutesUntilReset }) }}
         </span>
     </div>
 </template>

--- a/tests/Browser/MobileDemoBannerTest.php
+++ b/tests/Browser/MobileDemoBannerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The demo strip at phone widths (#841).
+ *
+ * The banner is `position: fixed`, so the only thing keeping the page from
+ * sliding under it is the height every layout reserves through
+ * `--demo-banner-height`. That used to be a hardcoded 2.5rem while the copy
+ * wrapped to three lines below `md`: the first line was clipped at the top of
+ * the viewport and the rest spilled over the conversation underneath.
+ *
+ * These assertions are about geometry rather than class names, so they hold for
+ * any future treatment of the strip: nothing inside it may render past its own
+ * bottom edge, the reserved height must be the height it actually occupies, and
+ * the countdown chip must keep clear of the copy.
+ */
+
+/** Turn the instance into the public demo for the life of the test. */
+function useDemoModeForBrowserTests(): void
+{
+    config(['demo.mode' => true]);
+}
+
+/**
+ * How far the banner's content spills past the strip, in CSS pixels. Zero when
+ * every line is inside the strip; positive is the #841 overflow.
+ */
+function demoBannerContentOverflow(): string
+{
+    return <<<'JS'
+    (() => {
+        const banner = document.querySelector('[data-test="demo-banner"]');
+
+        if (banner === null) {
+            return -1;
+        }
+
+        const bottom = banner.getBoundingClientRect().bottom;
+        const spill = [...banner.querySelectorAll('*')]
+            .map((child) => child.getBoundingClientRect())
+            .filter((rect) => rect.height > 0)
+            .reduce((worst, rect) => Math.max(worst, rect.bottom - bottom), 0);
+
+        return Math.round(spill);
+    })()
+    JS;
+}
+
+/**
+ * The gap, in CSS pixels, between the height the layouts reserve and the height
+ * the strip really occupies. Zero means nothing hides under it and no dead band
+ * sits below it.
+ */
+function demoBannerReservationGap(): string
+{
+    return <<<'JS'
+    (() => {
+        const banner = document.querySelector('[data-test="demo-banner"]');
+
+        if (banner === null) {
+            return -1;
+        }
+
+        const reserved = Number.parseFloat(
+            getComputedStyle(document.documentElement)
+                .getPropertyValue('--demo-banner-height'),
+        );
+
+        return Math.round(Math.abs(reserved - banner.getBoundingClientRect().height));
+    })()
+    JS;
+}
+
+/** Whether the countdown chip's box overlaps any of the banner's copy. */
+function demoCountdownOverlapsCopy(): string
+{
+    return <<<'JS'
+    (() => {
+        const chip = document.querySelector('[data-test="demo-reset-countdown"]');
+
+        if (chip === null) {
+            return true;
+        }
+
+        const chipRect = chip.getBoundingClientRect();
+
+        return [...document.querySelectorAll('[data-test="demo-banner"] span, [data-test="demo-banner"] strong')]
+            .filter((element) => ! chip.contains(element) && element !== chip && element.textContent.trim() !== '')
+            .some((element) => {
+                const rect = element.getBoundingClientRect();
+
+                return rect.height > 0
+                    && rect.left < chipRect.right
+                    && rect.right > chipRect.left
+                    && rect.top < chipRect.bottom
+                    && rect.bottom > chipRect.top;
+            });
+    })()
+    JS;
+}
+
+/** Where the main pane starts, relative to the bottom of the demo strip. */
+function mainPaneOffsetBelowBanner(): string
+{
+    return <<<'JS'
+    (() => {
+        const banner = document.querySelector('[data-test="demo-banner"]');
+        const main = document.getElementById('main');
+
+        if (banner === null || main === null) {
+            return -1;
+        }
+
+        return Math.round(
+            main.getBoundingClientRect().top - banner.getBoundingClientRect().bottom,
+        );
+    })()
+    JS;
+}
+
+test('the demo strip contains its own copy at every phone width', function (int $width, int $height): void {
+    useDemoModeForBrowserTests();
+
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize($width, $height)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertScript(demoBannerContentOverflow(), 0)
+        ->assertScript(demoBannerReservationGap(), 0)
+        ->assertScript(demoCountdownOverlapsCopy(), false);
+})->with([
+    'the tightest phone' => [360, 740],
+    'iPhone SE' => [375, 667],
+    'the design canvas' => [390, 844],
+    'a large phone' => [430, 932],
+    'the breakpoint itself' => [768, 1024],
+    'landscape phone' => [740, 360],
+]);
+
+test('the stacked demo strip has no serious accessibility violations, light or dark', function (): void {
+    useDemoModeForBrowserTests();
+
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // Only one wording of the notice is ever in the accessibility tree: the
+    // treatment each side of `md` hides the other with `display: none`.
+    $page = signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertVisible('[data-test="demo-banner"]')
+        ->assertNoAccessibilityIssues();
+
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertNoAccessibilityIssues();
+});
+
+test('the workspace starts below the demo strip instead of under it', function (): void {
+    useDemoModeForBrowserTests();
+
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // The main pane keeps its own 8px canvas gutter below the strip, so the
+    // reservation is honoured without swallowing the layout's own breathing room.
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertScript(mainPaneOffsetBelowBanner(), 8);
+});


### PR DESCRIPTION
Closes #841.

## What was broken

At phone widths the demo notice wrapped to three lines inside a strip hard-sized to `--demo-banner-height: 2.5rem`. The first line was clipped at the top of the viewport and the rest spilled over the conversation underneath, because every layout offset (`MainLayout.vue`, `AuthCardLayout.vue`) reserves exactly that variable.

Measured on the seeded demo before the fix — content spilling past the strip's bottom border:

| Viewport | 360 | 375 | 390 | 430 | 768 |
| --- | --- | --- | --- | --- | --- |
| Overflow | 34px | 34px | 25px | 16px | 0px |

## What changed

**The strip stacks below `md`.** Row one carries the flask badge, a short bold "Live demo" heading and the countdown chip; row two carries a phone-sized detail line on its own full width. One row cannot hold badge + sentence + chip at 360px, and squeezing it is what forced the three-line wrap. The phone copy drops "it resets hourly" because the countdown chip already says it. From `md` up the markup, copy and 40px height are exactly as before.

**The banner publishes its real height.** `DemoBanner.vue` measures itself on mount and through a `ResizeObserver`, writing the result into `--demo-banner-height` on the root element, so every layout below reserves precisely what the strip occupies at any width. A hardcoded height (even a responsive one) cannot be right here: the number of wrapped lines depends on the viewport *and* the locale. French at 360px renders three rows (85px) where English renders two (59px), and both now offset correctly. The CSS variable stays as the pre-hydration fallback, with a below-`md` value closer to the stacked treatment.

After the fix, at 360 / 375 / 390 / 430 / 768 and landscape 740x360: 0px overflow, and the reserved height matches the rendered height exactly.

## Testing

- `tests/Browser/MobileDemoBannerTest.php` (new) asserts geometry rather than class names, so it holds for any future treatment of the strip: nothing inside the banner renders past its own bottom edge, the reserved height equals the height it occupies, the countdown chip never overlaps the copy, and the workspace starts below the strip (its own 8px canvas gutter, no more). Runs across 360x740, 375x667, 390x844, 430x932, 768x1024 and landscape 740x360. It also runs an axe audit of the stacked strip in light and dark.
- `resources/js/components/DemoBanner.test.ts` covers the published height, its republication on reflow, its release on unmount, and the two wordings.
- Verified in a real browser at the epic's viewport matrix, signed into the seeded demo, in English and French, light and dark.
- Full gate green: `composer test` (Pint, PHPStan, Rector, 100% coverage), `lint:check`, `format:check`, `types:check`, `test:js`, `build`.

## i18n

New keys `Live demo` and `Shared account, some actions are disabled.`, both translated in `lang/fr.json`. French was checked at the tightest viewport, where it is the case that pushes the strip to three rows.

Part of the mobile polish effort tracked by #770.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787512580&installation_model_id=428379&pr_number=844&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F844&signature=0d0c506523d817c7615758b5887faa2f5a2fbb70da02923c72172238a7937de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->