### PR TITLE
feat: slim the mobile message row gutter and break cards out edge to edge

### DIFF
--- a/resources/js/components/AudioPlayer.vue
+++ b/resources/js/components/AudioPlayer.vue
@@ -226,7 +226,7 @@ function isPlayed(index: number): boolean {
         :class="
             compact
                 ? 'h-19 w-70 border-input bg-muted px-3'
-                : 'w-85 max-w-full border-border bg-card px-3.5 py-2.5'
+                : 'w-85 max-w-full border-border bg-card px-3.5 py-2.5 max-md:w-full max-md:rounded-none max-md:border-x-0 max-md:px-5'
         "
     >
         <!-- A user-recorded clip or an uploaded audio file has no caption track

--- a/resources/js/components/MessageAttachments.vue
+++ b/resources/js/components/MessageAttachments.vue
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { useTranslations } from '@/composables/useTranslations';
 import {
     fileTypeLabel,
+    fillsBleedWidth,
     imageGridColumns,
     imageGridTiles,
     partitionAttachments,
@@ -82,10 +83,18 @@ function isSvg(attachment: AttachmentData): boolean {
 
 <template>
     <div class="mt-1.5 flex flex-col gap-1.5" data-test="message-attachments">
-        <!-- Single image: natural ratio, sized from stored dimensions (no shift). -->
+        <!-- Single image: natural ratio, sized from stored dimensions (no shift).
+             Below `md` a photo fills the width the block broke out to, keeping
+             its aspect ratio; one too small to fill it steps back into the
+             message's text column rather than being upscaled into a band. -->
         <div
             v-if="images.length === 1"
             class="group relative max-w-full overflow-hidden rounded-2xl border border-border"
+            :class="
+                fillsBleedWidth(images[0].width)
+                    ? 'max-md:w-full! max-md:rounded-none max-md:border-x-0'
+                    : 'max-md:ml-14'
+            "
             :style="{
                 width: `${singleBox.width}px`,
                 aspectRatio: `${singleBox.width} / ${singleBox.height}`,
@@ -125,13 +134,13 @@ function isSvg(attachment: AttachmentData): boolean {
             </span>
         </div>
 
-        <!-- 2+ images: a grid, with a "+N" tile folding the overflow. -->
+        <!-- 2+ images: a grid, with a "+N" tile folding the overflow. Tiles cap
+             at 150px on desktop; below `md` they share the width the block broke
+             out to, so the grid reaches both screen edges. -->
         <div
             v-else-if="images.length >= 2"
-            class="grid w-fit gap-1.5"
-            :style="{
-                gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 150px))`,
-            }"
+            class="grid w-fit grid-cols-[repeat(var(--attachment-grid-columns),minmax(0,150px))] gap-1.5 max-md:w-full max-md:grid-cols-[repeat(var(--attachment-grid-columns),minmax(0,1fr))]"
+            :style="{ '--attachment-grid-columns': gridColumns }"
             data-test="attachment-grid"
         >
             <Button
@@ -182,7 +191,7 @@ function isSvg(attachment: AttachmentData): boolean {
             :rel="file.filename ? undefined : 'noopener noreferrer'"
             data-test="attachment-file"
             :aria-label="t('Download :name', { name: file.filename ?? '' })"
-            class="flex w-95 max-w-full items-center gap-3 rounded-xl border border-border bg-muted/40 px-3 py-2.5 transition-colors hover:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            class="flex w-95 max-w-full items-center gap-3 rounded-xl border border-border bg-muted/40 px-3 py-2.5 transition-colors hover:bg-muted/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none max-md:w-full max-md:rounded-none max-md:border-x-0 max-md:px-5"
         >
             <span
                 class="flex size-10 shrink-0 items-center justify-center rounded-[10px] bg-muted text-muted-foreground"

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -183,6 +183,19 @@ const viewerTimezone = computed<string | null>(
 /** How many participant avatars to preview on a root's "N replies" affordance. */
 const MAX_THREAD_AVATARS = 3;
 
+/**
+ * Below `md`, a rich card (poll, attachments, reply quote) breaks out of the
+ * message row so it runs the full width of the timeline instead of the
+ * 36px-indented text column, trading its rounded box for hairline top and
+ * bottom rules (design "Mobile Message List", screen `1c`).
+ *
+ * The offsets are this row's own geometry — 20px of timeline padding plus the
+ * 36px avatar gutter on the left, 20px of padding on the right — so they live
+ * beside the row that defines them rather than inside each card.
+ */
+const CARD_BLEED =
+    'max-md:-ml-14 max-md:-mr-5 max-md:rounded-none max-md:border-x-0';
+
 function threadAvatars(message: Message): Mention[] {
     return message.threadParticipants.slice(0, MAX_THREAD_AVATARS);
 }
@@ -905,9 +918,16 @@ function confirmDelete(): void {
                     </span>
                 </div>
 
-                <div v-else class="mt-4.5 flex">
+                <div
+                    v-else
+                    data-test="message-group"
+                    class="mt-4.5 flex max-md:mt-3.5"
+                >
+                    <!-- The avatar gutter: 64px of centred column on desktop,
+                         a 26px avatar plus a 10px gap below `md`, where 64px of
+                         a 390px screen is a quarter of the row spent on chrome. -->
                     <div
-                        class="flex w-16 shrink-0 flex-col items-center gap-1 pt-0.5"
+                        class="flex w-16 shrink-0 flex-col items-center gap-1 pt-0.5 max-md:w-9 max-md:items-start max-md:gap-0 max-md:pt-0"
                     >
                         <UserHoverCard
                             :team-slug="props.teamSlug"
@@ -917,13 +937,16 @@ function confirmDelete(): void {
                             :is-dnd="dndOf(item.author.id)"
                             @mention="(member) => emit('mention', member)"
                         >
-                            <div class="relative size-8.5 cursor-pointer">
+                            <div
+                                data-test="message-avatar"
+                                class="relative size-8.5 cursor-pointer max-md:size-6.5"
+                            >
                                 <!-- A bot squares off its avatar (rounded-lg vs a
                                      human's full circle) and shows a glyph on the
                                      ink-stone fill, so it reads as non-human at a
                                      glance; a human keeps their gravatar/initials. -->
                                 <Avatar
-                                    class="size-8.5 text-[11px]"
+                                    class="size-8.5 text-[11px] max-md:size-6.5 max-md:text-[9px]"
                                     :class="
                                         item.author.isBot ? 'rounded-lg' : ''
                                     "
@@ -963,18 +986,23 @@ function confirmDelete(): void {
                                     :presence="presenceOf(item.author.id)"
                                     :is-dnd="dndOf(item.author.id)"
                                     surface-class="bg-card"
-                                    size="36"
+                                    :size="isMobile ? '24' : '36'"
                                     class="ring-card"
                                 />
                             </div>
                         </UserHoverCard>
+                        <!-- The stacked time sets a tall floor on every row even
+                             for a one-word message, so below `md` it gives way
+                             to the inline stamp on the author's own line. -->
                         <span
-                            class="font-mono text-[9.5px] text-muted-foreground"
+                            data-test="message-group-time"
+                            class="font-mono text-[9.5px] text-muted-foreground max-md:hidden"
                             >{{ formatTime(item.leadCreatedAt) }}</span
                         >
                     </div>
                     <div
-                        class="min-w-0 flex-1 pl-4.5"
+                        data-test="message-column"
+                        class="min-w-0 flex-1 pl-4.5 max-md:border-l-0 max-md:pl-0"
                         :class="
                             isThreadRoot(item)
                                 ? 'border-l-2 border-brass'
@@ -1014,6 +1042,17 @@ function confirmDelete(): void {
                         <span v-else class="sr-only">{{
                             $t(presenceLabelKey(presenceOf(item.author.id)))
                         }}</span>
+                        <!-- Below `md` the group's time rides beside the author
+                             name instead of stacking under the avatar, where a
+                             36px gutter has no room for it. Hidden from AT on
+                             both layouts: each row's accessible name already
+                             carries its own time. -->
+                        <span
+                            data-test="message-group-time-inline"
+                            aria-hidden="true"
+                            class="ml-1.5 font-mono text-[10.5px] text-muted-foreground md:hidden"
+                            >{{ formatTime(item.leadCreatedAt) }}</span
+                        >
                         <div role="list">
                             <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- a touch-only long-press gesture; every action it opens stays reachable through the toolbar's focusable buttons -->
                             <div
@@ -1030,7 +1069,9 @@ function confirmDelete(): void {
                                 "
                                 class="group/message relative -mx-2 rounded-md px-2 transition-colors duration-1000 hover:bg-muted/40 max-md:select-none max-md:[-webkit-touch-callout:none]"
                                 :class="[
-                                    index === 0 ? 'mt-0.5' : 'mt-1.5',
+                                    index === 0
+                                        ? 'mt-0.5'
+                                        : 'mt-1.5 max-md:mt-0.5',
                                     message.id === props.highlightMessageId
                                         ? 'bg-primary/10'
                                         : '',
@@ -1061,11 +1102,15 @@ function confirmDelete(): void {
                                  time above, so revealing this here would stack a
                                  duplicate on top of it. The lead's <time> stays
                                  present but never fades in, so its machine-
-                                 readable value is unchanged. -->
+                                 readable value is unchanged.
+                                 Touch has no hover to reveal it with, so below
+                                 `md` it drops out entirely rather than compete
+                                 for a 36px gutter. -->
                                 <time
                                     :datetime="message.createdAt"
+                                    data-test="message-hover-time"
                                     aria-hidden="true"
-                                    class="pointer-events-none absolute top-1.5 -left-10.75 -translate-x-1/2 font-mono text-[9.5px] text-muted-foreground opacity-0 transition-opacity"
+                                    class="pointer-events-none absolute top-1.5 -left-10.75 -translate-x-1/2 font-mono text-[9.5px] text-muted-foreground opacity-0 transition-opacity max-md:hidden"
                                     :class="
                                         index > 0
                                             ? 'group-hover/message:opacity-100'
@@ -1111,7 +1156,8 @@ function confirmDelete(): void {
                                             },
                                         )
                                     "
-                                    class="mt-0.5 flex max-w-full items-center rounded pr-1 text-left hover:opacity-80"
+                                    class="mt-0.5 flex max-w-full items-center rounded pr-1 text-left hover:opacity-80 max-md:border-y max-md:border-border max-md:bg-card max-md:py-1.5 max-md:pr-5 max-md:pl-5"
+                                    :class="CARD_BLEED"
                                     @click="emit('jump', message.replyTo.id)"
                                 >
                                     <MessageQuote
@@ -1175,7 +1221,7 @@ function confirmDelete(): void {
                                 <p
                                     v-else-if="message.body !== ''"
                                     :data-test="'message-body'"
-                                    class="py-0.5 text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90"
+                                    class="py-0.5 text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90 max-md:text-[15px] max-md:leading-[1.45]"
                                     :class="
                                         isPending(message) ? 'opacity-60' : ''
                                     "
@@ -1304,6 +1350,7 @@ function confirmDelete(): void {
                                         !message.isDeleted &&
                                         editingId !== message.id
                                     "
+                                    :class="CARD_BLEED"
                                     :attachments="message.attachments"
                                     :author-name="message.user.name"
                                     :created-at="message.createdAt"
@@ -1316,6 +1363,7 @@ function confirmDelete(): void {
                                         !message.isDeleted &&
                                         editingId !== message.id
                                     "
+                                    :class="CARD_BLEED"
                                     :poll="message.poll"
                                     :current-user-id="props.currentUserId"
                                     :can-vote="canReactTo(message)"

--- a/resources/js/components/MessagePoll.vue
+++ b/resources/js/components/MessagePoll.vue
@@ -116,7 +116,7 @@ function roster(option: PollOption): string {
 <template>
     <div
         data-test="poll-card"
-        class="mt-1 flex max-w-[30rem] flex-col gap-2.5 rounded-2xl border border-border bg-card px-4 py-3.5"
+        class="mt-1 flex flex-col gap-2.5 rounded-2xl border border-border bg-card px-4 py-3.5 max-md:px-5 md:max-w-[30rem]"
     >
         <div class="flex items-center gap-1.5">
             <BarChart3 class="size-3 text-brass" />
@@ -180,7 +180,11 @@ function roster(option: PollOption): string {
                     :style="{ width: `${share(option)}%` }"
                     aria-hidden="true"
                 ></div>
-                <div class="relative flex items-center gap-2.5 px-3 py-2">
+                <!-- Below `md` the row is a real touch target: 44px minimum,
+                     the floor a finger needs. -->
+                <div
+                    class="relative flex items-center gap-2.5 px-3 py-2 max-md:min-h-11"
+                >
                     <Trophy
                         v-if="isWinner(option)"
                         class="size-3.25 shrink-0 text-brass"
@@ -207,6 +211,7 @@ function roster(option: PollOption): string {
                     </span>
 
                     <span
+                        data-test="poll-option-label"
                         class="flex-1 text-[13.5px] text-foreground"
                         :class="
                             selected(option) || isWinner(option)

--- a/resources/js/lib/attachmentLayout.test.ts
+++ b/resources/js/lib/attachmentLayout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
     fileTypeLabel,
+    fillsBleedWidth,
     imageGridColumns,
     imageGridTiles,
     partitionAttachments,
@@ -78,6 +79,22 @@ describe('singleImageSize', () => {
     it('falls back to the full box when dimensions are unknown', () => {
         expect(singleImageSize(null, 200)).toEqual({ width: 380, height: 240 });
         expect(singleImageSize(200, null)).toEqual({ width: 380, height: 240 });
+    });
+});
+
+describe('fillsBleedWidth', () => {
+    it('lets an image at least as wide as the box fill the break-out', () => {
+        expect(fillsBleedWidth(2400)).toBe(true);
+        expect(fillsBleedWidth(380)).toBe(true);
+    });
+
+    it('holds a smaller image back rather than upscaling it', () => {
+        expect(fillsBleedWidth(379)).toBe(false);
+        expect(fillsBleedWidth(120)).toBe(false);
+    });
+
+    it('treats unknown dimensions as the full box, matching singleImageSize', () => {
+        expect(fillsBleedWidth(null)).toBe(true);
     });
 });
 

--- a/resources/js/lib/attachmentLayout.test.ts
+++ b/resources/js/lib/attachmentLayout.test.ts
@@ -95,6 +95,7 @@ describe('fillsBleedWidth', () => {
 
     it('treats unknown dimensions as the full box, matching singleImageSize', () => {
         expect(fillsBleedWidth(null)).toBe(true);
+        expect(fillsBleedWidth(0)).toBe(true);
     });
 });
 

--- a/resources/js/lib/attachmentLayout.ts
+++ b/resources/js/lib/attachmentLayout.ts
@@ -71,11 +71,11 @@ export function singleImageSize(
  * Filling the width means stretching the reserved box, which is right for a
  * photo but would upscale a small graphic into a blurry, `object-cover`-cropped
  * band. Anything narrower than the reserved box stays in the message's text
- * column instead. An image with no stored dimensions takes the full box (the
- * same guess {@see singleImageSize} makes for it) and so fills the width.
+ * column instead. A missing or zero width takes the full box — the same guess
+ * {@see singleImageSize} makes for it — and so fills the width.
  */
 export function fillsBleedWidth(width: number | null): boolean {
-    return (width ?? SINGLE_MAX_WIDTH) >= SINGLE_MAX_WIDTH;
+    return (width || SINGLE_MAX_WIDTH) >= SINGLE_MAX_WIDTH;
 }
 
 /**

--- a/resources/js/lib/attachmentLayout.ts
+++ b/resources/js/lib/attachmentLayout.ts
@@ -65,6 +65,20 @@ export function singleImageSize(
 }
 
 /**
+ * Whether a single image is wide enough to fill the timeline when rich cards
+ * break out edge to edge below `md`.
+ *
+ * Filling the width means stretching the reserved box, which is right for a
+ * photo but would upscale a small graphic into a blurry, `object-cover`-cropped
+ * band. Anything narrower than the reserved box stays in the message's text
+ * column instead. An image with no stored dimensions takes the full box (the
+ * same guess {@see singleImageSize} makes for it) and so fills the width.
+ */
+export function fillsBleedWidth(width: number | null): boolean {
+    return (width ?? SINGLE_MAX_WIDTH) >= SINGLE_MAX_WIDTH;
+}
+
+/**
  * The number of grid columns for a multi-image message: two share a row, three
  * tile in a row, and four-or-more fall into a 2×2 block (the fifth image onward
  * hides behind the "+N" tile).

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1464,9 +1464,12 @@ function archive(): void {
                         </Button>
                     </div>
 
+                    <!-- Below `md` the line is indented to the message text
+                         column, so it reads as the next message rather than a
+                         stray note against the screen edge. -->
                     <TypingIndicator
                         :names="typingNames"
-                        class="mx-5 shrink-0"
+                        class="mx-5 shrink-0 max-md:pl-9"
                     />
 
                     <ScheduledCountChip

--- a/tests/Browser/MobileMessageRowTest.php
+++ b/tests/Browser/MobileMessageRowTest.php
@@ -61,7 +61,7 @@ function mobileRowChannel(): array
         ]);
     }
 
-    $quoted = Message::factory()->for($channel)->for($bob)->replyTo($root)->create([
+    Message::factory()->for($channel)->for($bob)->replyTo($root)->create([
         'body' => 'Agreed, let us vote on it.',
         'created_at' => now()->subMinutes(60),
     ]);
@@ -107,7 +107,6 @@ function mobileRowChannel(): array
         'channel' => $channel,
         'poll' => $pollMessage,
         'root' => $root,
-        'quoted' => $quoted,
     ];
 }
 
@@ -437,6 +436,9 @@ test('a tall channel still lands on the newest message at a phone width', functi
     }
     JS);
 
+    // The scroll holds where it was put — a late pin would snap it back — and
+    // history renders into the window rather than leaving it blank, which is
+    // what a badly-drifted row estimate looks like.
     $page->wait(1)
         ->assertScript(<<<'JS'
         (() => {
@@ -444,7 +446,7 @@ test('a tall channel still lands on the newest message at a phone width', functi
             const rows = [...timeline.querySelectorAll('[id^="message-"]')];
             const container = timeline.getBoundingClientRect();
 
-            return rows.some((row) => {
+            return timeline.scrollTop <= 4 && rows.some((row) => {
                 const rect = row.getBoundingClientRect();
 
                 return rect.top < container.bottom && rect.bottom > container.top;

--- a/tests/Browser/MobileMessageRowTest.php
+++ b/tests/Browser/MobileMessageRowTest.php
@@ -1,0 +1,513 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AttachmentStatus;
+use App\Models\Attachment;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\MessageReaction;
+use App\Models\Poll;
+use App\Models\User;
+
+/**
+ * The message row below `md` (design `Mobile Message List.dc.html`, screen `1c`).
+ *
+ * The desktop row was carried onto the phone unchanged: a 64px avatar gutter, a
+ * vertical rail and an 18px inset spent 123px of a 390px screen on chrome, so
+ * cards and poll options wrapped mid-phrase and roughly three messages fit per
+ * screen. Below the breakpoint the gutter slims to 36px (a 26px avatar plus a
+ * 10px gap), the rail and inset go, the group timestamp moves inline beside the
+ * author name, and rich cards break out of the gutter to run edge to edge.
+ *
+ * From `md` up nothing moves — the desktop rhythm is unchanged, which is what
+ * the last test in this file pins.
+ */
+
+/**
+ * Seed #general with the mix the design draws: an author burst of short
+ * messages, a closed two-option poll whose labels are the design's own, a
+ * reply quote, reactions and a thread summary.
+ *
+ * @return array{owner: User, member: User, channel: Channel, poll: Message, root: Message}
+ */
+function mobileRowChannel(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $root = Message::factory()->for($channel)->for($alice)->create([
+        'body' => 'Offsite logistics doc is updated.',
+        'created_at' => now()->subMinutes(90),
+        'reply_count' => 2,
+        'last_reply_at' => now()->subMinutes(80),
+    ]);
+
+    foreach ([1, 2] as $i) {
+        Message::factory()->for($channel)->inThread($root)->create([
+            'user_id' => $bob->id,
+            'body' => "Thread reply {$i}",
+            'created_at' => now()->subMinutes(80)->addSeconds($i),
+        ]);
+    }
+
+    MessageReaction::factory()->for($root)->for($bob)->emoji('🎉')->create();
+
+    // A burst of short one-line messages from one author: the grouped
+    // continuation rows whose left edge has to stay put.
+    foreach (range(1, 6) as $i) {
+        Message::factory()->for($channel)->for($alice)->create([
+            'body' => "Short line {$i}",
+            'created_at' => now()->subMinutes(70)->addSeconds($i),
+        ]);
+    }
+
+    $quoted = Message::factory()->for($channel)->for($bob)->replyTo($root)->create([
+        'body' => 'Agreed, let us vote on it.',
+        'created_at' => now()->subMinutes(60),
+    ]);
+
+    $withFiles = Message::factory()->for($channel)->for($alice)->create([
+        'body' => 'Venue photo and the signed quote.',
+        'created_at' => now()->subMinutes(55),
+    ]);
+
+    Attachment::factory()->create([
+        'message_id' => $withFiles->id,
+        'channel_id' => $channel->id,
+        'user_id' => $alice->id,
+        'status' => AttachmentStatus::Attached,
+        'original_filename' => 'venue.png',
+        'width' => 1200,
+        'height' => 800,
+    ]);
+
+    Attachment::factory()->create([
+        'message_id' => $withFiles->id,
+        'channel_id' => $channel->id,
+        'user_id' => $alice->id,
+        'status' => AttachmentStatus::Attached,
+        'mime_type' => 'application/pdf',
+        'original_filename' => 'offsite-quote.pdf',
+        'width' => null,
+        'height' => null,
+    ]);
+
+    $pollMessage = Message::factory()->for($channel)->for($alice)->poll()->create([
+        'created_at' => now()->subMinutes(50),
+    ]);
+
+    Poll::factory()->for($pollMessage, 'message')->closed()->withOptions([
+        'Bold serif',
+        'Minimal sans',
+    ])->create(['question' => 'Which logo direction do you prefer?']);
+
+    return [
+        'owner' => $alice,
+        'member' => $bob,
+        'channel' => $channel,
+        'poll' => $pollMessage,
+        'root' => $root,
+        'quoted' => $quoted,
+    ];
+}
+
+/**
+ * Measures one author group's horizontal budget: the avatar box, the text
+ * column, and the rail that used to sit between them.
+ */
+const MEASURE_GUTTER = <<<'JS'
+(() => {
+    const group = [...document.querySelectorAll('[data-test=message-group]')]
+        .find((el) => el.querySelector('[data-test=message-body]'));
+    const avatar = group.querySelector('[data-test=message-avatar]').getBoundingClientRect();
+    const column = group.querySelector('[data-test=message-column]');
+    const body = group.querySelector('[data-test=message-body]').getBoundingClientRect();
+
+    return {
+        avatarWidth: Math.round(avatar.width),
+        gutter: Math.round(body.left - group.getBoundingClientRect().left),
+        textWidth: Math.round(body.width),
+        railWidth: getComputedStyle(column).borderLeftWidth,
+        columnPaddingLeft: getComputedStyle(column).paddingLeft,
+    };
+})()
+JS;
+
+test('below md the avatar gutter is 36px with no rail and no inset', function (): void {
+    ['owner' => $alice] = mobileRowChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee('Which logo direction do you prefer?');
+
+    $measurements = $page->script(MEASURE_GUTTER);
+
+    expect($measurements['avatarWidth'])->toBe(26)
+        ->and($measurements['gutter'])->toBe(36)
+        ->and($measurements['railWidth'])->toBe('0px')
+        ->and($measurements['columnPaddingLeft'])->toBe('0px');
+
+    // The freed width lands in the text column: the desktop row left 249px of a
+    // 390px screen for the message itself, this one clears 290px.
+    expect($measurements['textWidth'])->toBeGreaterThanOrEqual(290);
+});
+
+test('below md the group timestamp rides beside the author name', function (): void {
+    ['owner' => $alice] = mobileRowChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee('Which logo direction do you prefer?')
+        // The inline stamp shows on every group; nothing is stacked under an
+        // avatar any more.
+        ->assertScript(<<<'JS'
+        (() => {
+            const inline = [...document.querySelectorAll('[data-test=message-group-time-inline]')];
+            const stacked = [...document.querySelectorAll('[data-test=message-group-time]')];
+
+            return inline.length > 0
+                && inline.every((el) => el.offsetParent !== null)
+                && stacked.every((el) => el.offsetParent === null);
+        })()
+        JS, true)
+        // ...and the inline stamp sits on the author's own line, to its right.
+        ->assertScript(<<<'JS'
+        (() => {
+            const name = document.querySelector('[data-test=message-author-name]').getBoundingClientRect();
+            const time = document.querySelector('[data-test=message-group-time-inline]').getBoundingClientRect();
+
+            return time.left >= name.right && Math.abs(time.bottom - name.bottom) <= 4;
+        })()
+        JS, true)
+        // The hover-only per-message stamp cannot be revealed by touch, so it
+        // stops competing for the 36px gutter.
+        ->assertScript(<<<'JS'
+        (() => [...document.querySelectorAll('[data-test=message-hover-time]')]
+            .every((el) => el.offsetParent === null))()
+        JS, true);
+});
+
+test('below md rich cards break out of the gutter and run edge to edge', function (): void {
+    ['owner' => $alice] = mobileRowChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee('Which logo direction do you prefer?');
+
+    // The poll spans the timeline's full width — not the 36px-indented text
+    // column — and trades its rounded box for hairline top and bottom rules.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const timeline = document.querySelector('[data-test="message-history"]').getBoundingClientRect();
+        const card = document.querySelector('[data-test=poll-card]');
+        const rect = card.getBoundingClientRect();
+        const style = getComputedStyle(card);
+
+        return Math.abs(rect.left - timeline.left) <= 1
+            && Math.abs(rect.right - timeline.right) <= 1
+            && style.borderTopLeftRadius === '0px'
+            && style.borderLeftWidth === '0px'
+            && style.borderRightWidth === '0px'
+            && style.borderTopWidth !== '0px'
+            && style.borderBottomWidth !== '0px';
+    })()
+    JS, true)
+        // The quoted reply breaks out with it.
+        ->assertScript(<<<'JS'
+        (() => {
+            const timeline = document.querySelector('[data-test="message-history"]').getBoundingClientRect();
+            const quote = document.querySelector('[data-test=message-quote]').getBoundingClientRect();
+
+            return Math.abs(quote.left - timeline.left) <= 1;
+        })()
+        JS, true)
+        // An image and a download card break out too.
+        ->assertScript(<<<'JS'
+        (() => {
+            const timeline = document.querySelector('[data-test="message-history"]').getBoundingClientRect();
+            const file = document.querySelector('[data-test=attachment-file]');
+            const image = document.querySelector('[data-test=attachment-image]').parentElement;
+
+            return [file, image].every((el) => {
+                const rect = el.getBoundingClientRect();
+                const style = getComputedStyle(el);
+
+                return Math.abs(rect.left - timeline.left) <= 1
+                    && Math.abs(rect.right - timeline.right) <= 1
+                    && style.borderTopLeftRadius === '0px'
+                    && style.borderLeftWidth === '0px';
+            });
+        })()
+        JS, true)
+        // Breaking out never pushes the page sideways.
+        ->assertScript(
+            '(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)()',
+            true,
+        );
+});
+
+test('below md a small image is not upscaled by the break-out', function (): void {
+    ['owner' => $alice, 'channel' => $channel] = mobileRowChannel();
+
+    $message = Message::factory()->for($channel)->for($alice)->create([
+        'body' => 'A tiny badge, not a photo.',
+        'created_at' => now()->subMinutes(5),
+    ]);
+
+    Attachment::factory()->create([
+        'message_id' => $message->id,
+        'channel_id' => $channel->id,
+        'user_id' => $alice->id,
+        'status' => AttachmentStatus::Attached,
+        'original_filename' => 'badge.png',
+        'width' => 120,
+        'height' => 80,
+    ]);
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee('A tiny badge, not a photo.')
+        // It holds its stored 120px and stays in the text column rather than
+        // stretching into a blurry band against the screen edge.
+        ->assertScript(<<<'JS'
+        (() => {
+            const body = [...document.querySelectorAll('[data-test=message-body]')]
+                .find((el) => el.textContent.includes('A tiny badge'));
+            const box = body.closest('[role=listitem]')
+                .querySelector('[data-test=attachment-image]').parentElement
+                .getBoundingClientRect();
+
+            return Math.round(box.width) === 120
+                && Math.abs(box.left - body.getBoundingClientRect().left) <= 1;
+        })()
+        JS, true);
+});
+
+test('below md a two-option poll keeps every label and its footer on one line', function (): void {
+    ['owner' => $alice] = mobileRowChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(360, 740)
+        ->assertSee('Which logo direction do you prefer?')
+        // Each label fits its line rather than wrapping mid-phrase, and each row
+        // is a 44px touch target.
+        ->assertScript(<<<'JS'
+        (() => {
+            const options = [...document.querySelectorAll('[data-test=poll-option]')];
+
+            return options.length === 2 && options.every((option) => {
+                const label = option.querySelector('[data-test=poll-option-label]');
+                const lineHeight = parseFloat(getComputedStyle(label).lineHeight);
+
+                return label.getBoundingClientRect().height <= lineHeight + 1
+                    && option.getBoundingClientRect().height >= 44;
+            });
+        })()
+        JS, true)
+        // "4 votes · Closed" stays on one line too.
+        ->assertScript(<<<'JS'
+        (() => {
+            const footer = document.querySelector('[data-test=poll-total]').parentElement;
+            const lineHeight = parseFloat(getComputedStyle(footer).lineHeight);
+
+            return footer.getBoundingClientRect().height <= lineHeight + 1;
+        })()
+        JS, true);
+});
+
+test('below md grouped continuations, reactions and the thread pill hold the 36px indent', function (): void {
+    ['owner' => $alice] = mobileRowChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee('Short line 6')
+        ->assertScript(<<<'JS'
+        (() => {
+            const lead = document.querySelector('[data-test=message-author-name]').getBoundingClientRect();
+            const bodies = [...document.querySelectorAll('[data-test=message-body]')];
+            const reactions = [...document.querySelectorAll('[data-test=reaction-pill]')];
+            const threads = [...document.querySelectorAll('[data-test=thread-summary]')];
+
+            return bodies.length > 1
+                && [...bodies, ...reactions, ...threads]
+                    .every((el) => Math.abs(el.getBoundingClientRect().left - lead.left) <= 1);
+        })()
+        JS, true)
+        // The typing line is indented to the same text column.
+        ->assertScript(<<<'JS'
+        (() => {
+            const lead = document.querySelector('[data-test=message-author-name]').getBoundingClientRect();
+            const typing = document.querySelector('[data-test=typing-indicator]');
+            const inset = typing.getBoundingClientRect().left
+                + parseFloat(getComputedStyle(typing).paddingLeft);
+
+            return Math.abs(inset - lead.left) <= 1;
+        })()
+        JS, true);
+});
+
+test('below md a sentence costs fewer lines and bursts sit closer together', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = mobileRowChannel();
+
+    // A realistic back-and-forth: sentence-length messages from two authors, so
+    // every row pays for an avatar and a name. Fitting more of these per screen
+    // is what the redesign is for, and it comes from two places — the text
+    // column stopped forcing a third line, and bursts sit 14px apart, not 18px.
+    foreach (range(1, 12) as $i) {
+        Message::factory()->for($channel)->for($i % 2 === 0 ? $alice : $bob)->create([
+            'body' => "Message {$i}: the venue quote came back a little over budget.",
+            'created_at' => now()->subMinutes(20)->addSeconds($i),
+        ]);
+    }
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee('the venue quote came back');
+
+    $rhythm = $page->script(<<<'JS'
+    (() => {
+        const bodies = [...document.querySelectorAll('[data-test=message-body]')]
+            .filter((el) => el.textContent.includes('the venue quote came back'));
+        const body = bodies[bodies.length - 1];
+        const style = getComputedStyle(body);
+        const padding = parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+        const group = body.closest('[data-test=message-group]');
+
+        return {
+            lines: Math.round((body.getBoundingClientRect().height - padding) / parseFloat(style.lineHeight)),
+            burstGap: parseFloat(getComputedStyle(group).marginTop),
+        };
+    })()
+    JS);
+
+    expect($rhythm['lines'])->toBe(2)
+        ->and($rhythm['burstGap'])->toEqual(14);
+});
+
+test('a tall channel still lands on the newest message at a phone width', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = mobileRowChannel();
+
+    // The slimmer row measures shorter than the virtualizer's desktop-derived
+    // 84px estimate, which widens the estimate-to-real gap that used to strand
+    // the initial auto-pin short of the newest message (#500). Tall rows on a
+    // short viewport are the worst case for it.
+    $filler = str_repeat("lorem ipsum dolor sit amet consectetur\n", 4);
+    $newest = 60;
+
+    foreach (range(1, $newest) as $i) {
+        Message::factory()->for($channel)->for($i % 2 === 0 ? $alice : $bob)->create([
+            'body' => "Row {$i}\n{$filler}",
+            'created_at' => now()->subMinutes(20)->addSeconds($i),
+        ]);
+    }
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee("Row {$newest}")
+        ->wait(2);
+
+    // The newest row sits at the foot of the viewport, not a screen above it.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const timeline = document.querySelector('[data-test=message-history]');
+        const rows = [...timeline.querySelectorAll('[id^="message-"]')];
+        const last = rows[rows.length - 1];
+
+        if (!last) {
+            return false;
+        }
+
+        const container = timeline.getBoundingClientRect();
+        const row = last.getBoundingClientRect();
+
+        return row.top < container.bottom
+            && row.bottom > container.top
+            && Math.abs(container.bottom - row.bottom) <= 120;
+    })()
+    JS, true)
+        ->assertNotPresent('[data-test=jump-to-latest]');
+
+    // Jumping to an old message lands it on screen rather than short of it.
+    $page->script(<<<'JS'
+    () => {
+        const timeline = document.querySelector('[data-test=message-history]');
+
+        timeline.scrollTop = 0;
+        timeline.dispatchEvent(new Event('scroll'));
+    }
+    JS);
+
+    $page->wait(1)
+        ->assertScript(<<<'JS'
+        (() => {
+            const timeline = document.querySelector('[data-test=message-history]');
+            const rows = [...timeline.querySelectorAll('[id^="message-"]')];
+            const container = timeline.getBoundingClientRect();
+
+            return rows.some((row) => {
+                const rect = row.getBoundingClientRect();
+
+                return rect.top < container.bottom && rect.bottom > container.top;
+            });
+        })()
+        JS, true);
+});
+
+test('the thread push inherits the slim row', function (): void {
+    ['owner' => $alice] = mobileRowChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee('Offsite logistics doc is updated.');
+
+    $page->click('[data-test=thread-summary]')
+        ->assertVisible('[data-test=thread-back]')
+        ->assertSee('Thread reply 2');
+
+    $measurements = $page->script(MEASURE_GUTTER);
+
+    expect($measurements['avatarWidth'])->toBe(26)
+        ->and($measurements['gutter'])->toBe(36)
+        ->and($measurements['railWidth'])->toBe('0px');
+});
+
+test('from md up the row keeps the desktop gutter, rail and stacked timestamp', function (int $width): void {
+    ['owner' => $alice] = mobileRowChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize($width, 900)
+        ->assertSee('Which logo direction do you prefer?')
+        // The stacked stamp is back under the avatar and the inline one is gone.
+        ->assertScript(<<<'JS'
+        (() => {
+            const stacked = [...document.querySelectorAll('[data-test=message-group-time]')];
+            const inline = [...document.querySelectorAll('[data-test=message-group-time-inline]')];
+
+            return stacked.length > 0
+                && stacked.every((el) => el.offsetParent !== null)
+                && inline.every((el) => el.offsetParent === null);
+        })()
+        JS, true)
+        // The poll keeps its rounded, bordered card inside the text column.
+        ->assertScript(<<<'JS'
+        (() => {
+            const timeline = document.querySelector('[data-test="message-history"]').getBoundingClientRect();
+            const card = document.querySelector('[data-test=poll-card]');
+            const style = getComputedStyle(card);
+
+            return card.getBoundingClientRect().left > timeline.left + 60
+                && style.borderTopLeftRadius !== '0px'
+                && style.borderLeftWidth !== '0px';
+        })()
+        JS, true);
+
+    $measurements = $page->script(MEASURE_GUTTER);
+
+    expect($measurements['avatarWidth'])->toBe(34)
+        ->and($measurements['gutter'])->toBe(83)
+        ->and($measurements['railWidth'])->toBe('1px')
+        ->and($measurements['columnPaddingLeft'])->toBe('18px');
+})->with([
+    'the md boundary' => [768],
+    'wide desktop' => [1280],
+]);


### PR DESCRIPTION
Closes #842. Part of #770.

## What

Below `md` the desktop message row was carried onto the phone unchanged, spending 123px of a 390px screen on chrome: a 64px avatar gutter, a vertical rail, an 18px inset. Cards and poll options wrapped mid-phrase and roughly three messages fit per screen.

This implements screen `1c` of the `Mobile Message List` design (the slim-gutter variant). `1b` (full bleed, no gutter) was explicitly out of scope and is not built.

- **Gutter slims to 36px** — a 26px avatar plus a 10px gap. The `border-l` rail and the `pl-4.5` inset go below `md`. Measured at a 390px viewport, the text column goes from **249px to 296px (+19%)**, the gain the issue specifies. (The issue's "~318px" was computed against a bare 390px page; the real timeline also carries the shell's ~9px canvas inset each side, so the same +19% lands at 296px.)
- **Timestamp moves inline** beside the author name. Nothing is stacked under the avatar any more, and the hover-only per-message stamp — which touch can never reveal — drops out rather than compete for a 36px gutter.
- **Rich cards break out edge to edge.** Polls, attachments (single image, image grid, file card, audio player) and reply quotes take negative margins so they run the full width of the timeline, with hairline top and bottom rules on a card background instead of a rounded bordered box. Their inner padding matches the page margin, so card content still lines up with the text column's left edge.
- **Poll options stop wrapping.** The `max-w-[30rem]` cap becomes a desktop-only concern and option rows take a 44px minimum height, so each label and the vote footer fit on one line at 360px.
- **Vertical rhythm** — message text at 15px/1.45, 2px between grouped lines, 14px between author bursts. The typing line is indented to the same 36px so it reads as the next message.
- **Continuations stay aligned** — grouped messages, reactions and the thread reply pill already live in the content column, so they hold the 36px indent for free; the browser test pins that.
- **From `md` up the row is unchanged** — same gutter, rail, inset, stacked timestamp and rounded in-column cards.

The thread view inherits all of it (`ThreadPanel` renders the same `MessageList`); verified in the browser and asserted in the tests rather than re-implemented.

## Judgement calls

- **A small image does not bleed.** Stretching a 120px graphic to the full width would upscale and `object-cover`-crop it into a blurry band, so anything narrower than the reserved 380px box keeps the text column's indent instead. That predicate (`fillsBleedWidth`) is the only logic added, and it is unit-tested.
- **Link previews have no inline surface to break out.** `LinkPreview` only renders inside a desktop `HoverCard`, so below `md` there is nothing to give margins to. Giving link previews an inline card on touch would be a feature change beyond this issue — flagging rather than building it.
- **`MessageForward` was left alone** — the issue's list is polls, attachments, link previews and quotes.
- **`ESTIMATED_ROW_HEIGHT` is unchanged.** The issue asked to re-check the #500 landing-short bug at mobile widths and adjust the estimate only if drift got worse. A new test opens a 60-message channel of tall rows at 390x844 and asserts the newest row lands at the foot of the viewport with no jump pill, then that a scroll to the top holds and renders; it passes with the estimate as it is.

## Testing

- New `tests/Browser/MobileMessageRowTest.php` — 11 tests over the gutter/rail/inset geometry, the inline timestamp, the card break-out (poll, quote, image, file), poll option lines and 44px rows, continuation and typing alignment, line count and burst rhythm, the #500 guard at a phone width, the thread push, and desktop parity at 768 and 1280. Verified red against the previous layout before implementing.
- `resources/js/lib/attachmentLayout.test.ts` covers `fillsBleedWidth`.
- Existing timeline suites re-run green: initial pin, jump-to-present, thread virtualization, timestamp hover, the a11y timeline audit, the mobile shell, thread panel and actions sheet (56 tests).
- Full gate green: `composer test` (Pint, PHPStan, Rector, 2364 tests, `Total: 100.0 %`) plus `lint:check`, `format:check`, `types:check`, `test:js`, `build`.
- Driven in a real browser at 360x740, 375x667, 390x844, 430x932, 768x1024 and landscape 740x360, in the channel timeline and the thread push, light and dark, with a poll, an image, an image grid, a file card and a quoted message on screen, and re-checked in French at 360.

No new user-facing copy, so no `lang/fr.json` additions; nothing operator-facing, so no `docs/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787516048&installation_model_id=428379&pr_number=848&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F848&signature=72853ccaf540985bb8f181fd02afec495854fcbb22cc7fae771f507ff68bf9f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->