### PR TITLE
feat: web push notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -341,3 +341,15 @@ WEBHOOKS_BLOCK_PRIVATE_URLS=true
 # someone as away once every device they are signed in on has gone idle. Floored
 # at 1 minute; idle detection cannot be turned off.
 PRESENCE_AWAY_AFTER_MINUTES=10
+
+# Web push notifications. Off until a VAPID keypair is set: generate one per
+# instance with `php artisan webpush:vapid` (it appends both keys to this file)
+# and keep it stable — the public key is baked into every subscription a browser
+# has already granted, so rotating it silently invalidates them all. With the
+# keys set, each user opts in per device from Settings -> Appearance &
+# notifications; nothing is pushed until they do. VAPID_SUBJECT identifies the
+# operator to the browser vendors' push services (a mailto: or https: URL) and
+# falls back to APP_URL when unset.
+# VAPID_PUBLIC_KEY=
+# VAPID_PRIVATE_KEY=
+# VAPID_SUBJECT=mailto:admin@example.com

--- a/app/Http/Controllers/Settings/PushSubscriptionController.php
+++ b/app/Http/Controllers/Settings/PushSubscriptionController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\DeletePushSubscriptionRequest;
+use App\Http\Requests\Settings\StorePushSubscriptionRequest;
+use Illuminate\Http\Response;
+
+/**
+ * The per-device half of web push: one row per browser that has granted
+ * permission.
+ *
+ * Both writes are the browser reporting about *itself*, not a stored account
+ * preference — enabling push on a laptop must not start pushing to a phone — so
+ * they are plain no-content endpoints the settings toggle calls directly rather
+ * than Inertia redirects. Whether this device is subscribed is answered by the
+ * browser's own `pushManager.getSubscription()`, so there is no server state to
+ * hand back.
+ */
+class PushSubscriptionController extends Controller
+{
+    /**
+     * Register (or refresh) this browser's push subscription.
+     *
+     * Keyed on the endpoint, so a browser that re-subscribes — which it does
+     * whenever the push service rotates its keys — updates its existing row
+     * instead of accumulating dead ones. An endpoint previously claimed by
+     * another account is taken over, which is what makes a shared device work
+     * after a re-login.
+     */
+    public function store(StorePushSubscriptionRequest $request): Response
+    {
+        $request->user()->updatePushSubscription(
+            $request->endpoint(),
+            $request->publicKey(),
+            $request->authToken(),
+            $request->contentEncoding(),
+        );
+
+        return response()->noContent();
+    }
+
+    /**
+     * Revoke this browser's push subscription.
+     *
+     * Scoped to the caller's own rows, and silent about a miss: the toggle is
+     * turned off from a device that may already have been unsubscribed by the
+     * browser itself, and re-asserting "not subscribed" is not an error.
+     */
+    public function destroy(DeletePushSubscriptionRequest $request): Response
+    {
+        $request->user()->deletePushSubscription($request->endpoint());
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Middleware/EnsureWebPushEnabled.php
+++ b/app/Http/Middleware/EnsureWebPushEnabled.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Support\WebPushConfig;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Gate the push-subscription endpoints on the instance having a VAPID keypair.
+ * Without one nothing can be signed, so a stored subscription could never be
+ * delivered to — the endpoints 404 and the settings toggle stays hidden, which
+ * keeps the two sides of the feature in agreement.
+ */
+class EnsureWebPushEnabled
+{
+    /**
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        abort_unless(WebPushConfig::configured(), 404);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -25,6 +25,7 @@ use App\Support\FrequentEmoji;
 use App\Support\ReverbConfig;
 use App\Support\TranslationCatalog;
 use App\Support\UpdateChecker;
+use App\Support\WebPushConfig;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
@@ -74,6 +75,12 @@ class HandleInertiaRequests extends Middleware
             // single built image works for any operator without baking VITE_*
             // values into the bundle. Read by app.ts to configure Echo at boot.
             'reverb' => ReverbConfig::forFrontend(),
+            // Whether this instance can send web push, plus the VAPID public key
+            // a browser needs to subscribe. Resolved at runtime for the same
+            // reason as the Reverb block above: one published image serves every
+            // operator's keypair without a rebuild. Both are withheld when no
+            // keypair is configured, which is what hides the settings toggle.
+            'webPush' => WebPushConfig::forFrontend(),
             'locale' => app()->getLocale(),
             // The active locale's catalog rides the initial document as a "once"
             // prop: it reaches the SSR render and first hydration (so the first

--- a/app/Http/Requests/Settings/DeletePushSubscriptionRequest.php
+++ b/app/Http/Requests/Settings/DeletePushSubscriptionRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeletePushSubscriptionRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * Only the endpoint is needed to revoke: it is the subscription's identity,
+     * and the delete is scoped to the caller's own rows, so naming someone
+     * else's endpoint removes nothing.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'endpoint' => ['required', 'string', 'max:500'],
+        ];
+    }
+
+    /**
+     * The push service URL of the device being revoked.
+     */
+    public function endpoint(): string
+    {
+        return (string) $this->validated('endpoint');
+    }
+}

--- a/app/Http/Requests/Settings/StorePushSubscriptionRequest.php
+++ b/app/Http/Requests/Settings/StorePushSubscriptionRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePushSubscriptionRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * The body is the browser's own `PushSubscription.toJSON()`, posted
+     * verbatim: the push service's endpoint plus the two keys every payload is
+     * encrypted to. The endpoint is length-capped to the column's width — push
+     * services issue long URLs, and a longer one would fail at insert rather
+     * than at validation.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'endpoint' => ['required', 'string', 'url:https,http', 'max:500'],
+            'keys.p256dh' => ['required', 'string', 'max:255'],
+            'keys.auth' => ['required', 'string', 'max:255'],
+            // Firefox's older endpoints negotiate `aesgcm`; everything current
+            // uses `aes128gcm`, which is what the package assumes when absent.
+            'contentEncoding' => ['nullable', 'string', 'in:aes128gcm,aesgcm'],
+        ];
+    }
+
+    /**
+     * The push service URL this browser can be reached at.
+     */
+    public function endpoint(): string
+    {
+        return (string) $this->validated('endpoint');
+    }
+
+    /**
+     * The browser's ECDH public key.
+     */
+    public function publicKey(): string
+    {
+        return (string) $this->validated('keys.p256dh');
+    }
+
+    /**
+     * The browser's authentication secret.
+     */
+    public function authToken(): string
+    {
+        return (string) $this->validated('keys.auth');
+    }
+
+    /**
+     * The payload encoding this browser negotiated, when it stated one.
+     */
+    public function contentEncoding(): ?string
+    {
+        $encoding = $this->validated('contentEncoding');
+
+        return is_string($encoding) ? $encoding : null;
+    }
+}

--- a/app/Listeners/SendMessagePushNotifications.php
+++ b/app/Listeners/SendMessagePushNotifications.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Data\MentionData;
+use App\Events\MessageSent;
+use App\Models\ChannelMember;
+use App\Notifications\NewMessageNotification;
+use App\Support\PushDecision;
+use App\Support\WebPushConfig;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * Fans a new message out to the channel members who should be alerted on a
+ * device that isn't looking at the app.
+ *
+ * This is the app's first per-recipient server-side dispatch: until now a send
+ * produced one channel-wide broadcast and every alerting decision was made in
+ * the browser. Resolving recipients means a query per message, so it is
+ * `ShouldQueue` — auto-discovered (the app has no EventServiceProvider) and run
+ * off-request, well behind the latency-critical broadcast.
+ *
+ * The alerting rule itself lives in {@see PushDecision}, the server-side twin of
+ * the client's `shouldChime`, so a push and a chime never disagree about whether
+ * a message was worth interrupting someone for.
+ */
+class SendMessagePushNotifications implements ShouldQueue
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(MessageSent $event): void
+    {
+        if (! WebPushConfig::configured() || $event->message->type->isSystem()) {
+            return;
+        }
+
+        $message = $event->message;
+
+        /** @var list<string> $mentionedIds */
+        $mentionedIds = array_map(
+            static fn (MentionData $mention): string => $mention->id,
+            $message->mentions,
+        );
+
+        // A thread-only reply is not ordinary channel traffic: it stays out of
+        // the timeline and out of the sidebar's unread badge, so it only ever
+        // alerts through the mention path.
+        $isChannelMessage = $message->threadRootId === null || $message->sentToChannel;
+
+        foreach ($this->recipients($event) as $member) {
+            $recipient = $member->user;
+
+            $shouldPush = PushDecision::shouldPush(
+                isOwnMessage: $recipient->id === $message->user->id,
+                isChannelMessage: $isChannelMessage,
+                mentionsRecipient: in_array($recipient->id, $mentionedIds, true),
+                muted: $member->muted,
+                level: $member->notification_level,
+                dndActive: $recipient->isDndActive(),
+            );
+
+            if ($shouldPush) {
+                $recipient->notify(new NewMessageNotification($event->channel, $message));
+            }
+        }
+    }
+
+    /**
+     * The channel's memberships worth even considering, with their user loaded.
+     *
+     * Narrowed in SQL to members who have a live account and at least one
+     * subscribed device: a member with no device could not be reached whatever
+     * the gate decided, so leaving them in would queue a notification job per
+     * message per member for nothing. Everyone else — the author included — is
+     * left for the gate to rule on, so the decision lives in one place.
+     *
+     * @return Collection<int, ChannelMember>
+     */
+    private function recipients(MessageSent $event): Collection
+    {
+        return ChannelMember::query()
+            ->where('channel_id', $event->channel->id)
+            ->whereHas('user', fn (Builder $query): Builder => $query
+                ->whereNull('deactivated_at')
+                ->whereHas('pushSubscriptions'))
+            ->with('user')
+            ->get();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,6 +45,8 @@ use Laravel\Fortify\PasskeyAuthenticatable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Passkeys\Passkey;
 use Laravel\Sanctum\HasApiTokens;
+use NotificationChannels\WebPush\HasPushSubscriptions;
+use NotificationChannels\WebPush\PushSubscription;
 
 /**
  * @property string $id
@@ -99,6 +101,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read Collection<int, DataExport> $dataExports
  * @property-read Collection<int, Passkey> $passkeys
  * @property-read Collection<int, UserGroup> $userGroups
+ * @property-read Collection<int, PushSubscription> $pushSubscriptions
  */
 #[Appends(['avatar', 'status', 'presence', 'dnd'])]
 #[Fillable(['name', 'email', 'avatar_url', 'pronouns', 'title', 'phone', 'timezone', 'locale', 'time_format', 'password', 'current_team_id', 'chime_sound', 'share_read_receipts', 'sidebar_position', 'presence_state', 'onboarding_completed_at', 'collapsed_channel_sections', 'is_tombstone'])]
@@ -107,7 +110,7 @@ use Laravel\Sanctum\HasApiTokens;
 class User extends Authenticatable implements HasLocalePreference, MustVerifyEmail, PasskeyUser
 {
     /** @use HasFactory<UserFactory> */
-    use HasApiTokens, HasFactory, HasTeams, HasUuids, Notifiable, PasskeyAuthenticatable, TwoFactorAuthenticatable;
+    use HasApiTokens, HasFactory, HasPushSubscriptions, HasTeams, HasUuids, Notifiable, PasskeyAuthenticatable, TwoFactorAuthenticatable;
 
     /**
      * Determine if the user has verified their email address.

--- a/app/Notifications/NewMessageNotification.php
+++ b/app/Notifications/NewMessageNotification.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Data\MessageData;
+use App\Enums\MessageType;
+use App\Models\Channel;
+use App\Support\MessagePlainText;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Str;
+use NotificationChannels\WebPush\WebPushChannel;
+use NotificationChannels\WebPush\WebPushMessage;
+
+class NewMessageNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * How much of the message body the banner carries. Long enough to be worth
+     * reading on a lock screen, short enough that the platforms don't truncate
+     * mid-thought on their own.
+     */
+    private const int PREVIEW_LENGTH = 120;
+
+    public function __construct(
+        private readonly Channel $channel,
+        private readonly MessageData $message,
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * Web push only: the app has no notification centre and sends no email for
+     * message traffic, so a user with no subscribed device simply receives
+     * nothing (the channel short-circuits on an empty subscription set).
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return [WebPushChannel::class];
+    }
+
+    /**
+     * Build the banner the recipient's device shows.
+     *
+     * Notifications are sent under the recipient's own locale (User implements
+     * HasLocalePreference), so the copy here resolves per recipient rather than
+     * per sender.
+     *
+     * The `tag` collapses the conversation: a second message in the same channel
+     * replaces the banner already on screen instead of stacking beside it, which
+     * is what keeps a busy channel from burying the lock screen. `renotify`
+     * makes that replacement alert again rather than swap in silently.
+     */
+    public function toWebPush(object $notifiable): WebPushMessage
+    {
+        return (new WebPushMessage)
+            ->title($this->title($notifiable))
+            ->body($this->preview())
+            ->icon('/icons/icon-192.png')
+            ->badge('/icons/icon-192.png')
+            ->tag('channel-'.$this->channel->id)
+            ->renotify(true)
+            ->data([
+                'url' => $this->url(),
+                'channelId' => $this->channel->id,
+                'messageId' => $this->message->id,
+            ]);
+    }
+
+    /**
+     * Who the banner is from.
+     *
+     * A DM is already identified by its sender, so naming the conversation as
+     * well would just repeat them; a standard channel needs both, because the
+     * sender alone doesn't say where to look.
+     */
+    private function title(object $notifiable): string
+    {
+        if ($this->channel->isDirectMessage()) {
+            return $this->message->user->name;
+        }
+
+        return __(':sender in #:channel', [
+            'sender' => $this->message->user->name,
+            'channel' => (string) $this->channel->name,
+        ]);
+    }
+
+    /**
+     * The line of the message the banner shows.
+     *
+     * Mention tokens are unwrapped to the readable names a reader sees, so a
+     * banner never leaks the composer's `@[Name](uuid)` markup. A message
+     * carrying no text of its own — a poll, or files posted without a caption —
+     * describes itself instead of showing an empty line.
+     */
+    private function preview(): string
+    {
+        if ($this->message->type === MessageType::Poll) {
+            return __('Posted a poll');
+        }
+
+        $body = trim(MessagePlainText::from($this->message->body));
+
+        if ($body !== '') {
+            return Str::limit($body, self::PREVIEW_LENGTH);
+        }
+
+        $attachments = count($this->message->attachments);
+
+        return $attachments === 1
+            ? __('Sent an attachment')
+            : __('Sent :count attachments', ['count' => $attachments]);
+    }
+
+    /**
+     * Where clicking the banner lands: the message itself.
+     *
+     * `channels.show` already windows the timeline around `?message=`, scrolls
+     * to it and highlights it, so the deep link needs no route of its own.
+     */
+    private function url(): string
+    {
+        return route('channels.show', [
+            'team' => $this->channel->team->slug,
+            'channel' => $this->channel->slug,
+            'message' => $this->message->id,
+        ]);
+    }
+}

--- a/app/Notifications/NewMessageNotification.php
+++ b/app/Notifications/NewMessageNotification.php
@@ -60,7 +60,7 @@ class NewMessageNotification extends Notification implements ShouldQueue
     public function toWebPush(object $notifiable): WebPushMessage
     {
         return (new WebPushMessage)
-            ->title($this->title($notifiable))
+            ->title($this->title())
             ->body($this->preview())
             ->icon('/icons/icon-192.png')
             ->badge('/icons/icon-192.png')
@@ -80,7 +80,7 @@ class NewMessageNotification extends Notification implements ShouldQueue
      * well would just repeat them; a standard channel needs both, because the
      * sender alone doesn't say where to look.
      */
-    private function title(object $notifiable): string
+    private function title(): string
     {
         if ($this->channel->isDirectMessage()) {
             return $this->message->user->name;

--- a/app/Support/AccountDeleter.php
+++ b/app/Support/AccountDeleter.php
@@ -24,11 +24,17 @@ class AccountDeleter
      * personal teams are torn down with them, while their memberships of shared
      * teams simply drop via the cascade — the sole-owner-of-a-shared-team case is
      * blocked upstream in {@see ProfileDeleteRequest}.
+     *
+     * Their web-push subscriptions are dropped explicitly: the owning column is
+     * a polymorphic reference, so no foreign key sweeps them, and a stale row
+     * would keep this instance pushing to a device whose account is gone.
      */
     public function delete(User $user): void
     {
         DB::transaction(function () use ($user): void {
             $tombstone = User::tombstone();
+
+            $user->pushSubscriptions()->delete();
 
             Message::withTrashed()
                 ->where('user_id', $user->id)

--- a/app/Support/PushDecision.php
+++ b/app/Support/PushDecision.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Enums\NotificationLevel;
+
+final class PushDecision
+{
+    /**
+     * Decide whether one channel member should be pushed about a new message.
+     *
+     * This is the server-side twin of the client's `shouldChime` gate
+     * (`resources/js/lib/shouldChime.ts`), and it deliberately reads the same
+     * way: a direct @mention alerts unless the channel is muted or set to
+     * "nothing"; ordinary traffic alerts only at the "all" level, and a
+     * thread-only reply never counts as ordinary traffic (it lives in the thread
+     * view, and the sidebar badge excludes it too). Do-not-disturb and the
+     * member's own messages suppress everything.
+     *
+     * The three inputs `shouldChime` also takes but this cannot — whether a
+     * chime is selected, whether the tab has focus, and whether the message
+     * landed in the channel already on screen — are the browser's to answer.
+     * The last two are answered there too: the service worker drops a
+     * notification whose app window is already visible, so a tab that just
+     * chimed does not also raise a banner.
+     */
+    public static function shouldPush(
+        bool $isOwnMessage,
+        bool $isChannelMessage,
+        bool $mentionsRecipient,
+        bool $muted,
+        NotificationLevel $level,
+        bool $dndActive,
+    ): bool {
+        if ($dndActive || $isOwnMessage || $muted) {
+            return false;
+        }
+
+        if ($mentionsRecipient) {
+            return $level->alertsOnMention();
+        }
+
+        return $isChannelMessage && $level->alertsOnUnread();
+    }
+}

--- a/app/Support/WebPushConfig.php
+++ b/app/Support/WebPushConfig.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class WebPushConfig
+{
+    /**
+     * Whether this instance can send web push at all.
+     *
+     * Push is signed with a VAPID keypair the operator generates once (see
+     * `php artisan webpush:vapid`), so without both halves there is nothing to
+     * sign with and no subscription a browser would accept. Every push surface
+     * keys on this: the settings toggle hides, the subscribe endpoints 404, and
+     * the fan-out never queues a notification.
+     */
+    public static function configured(): bool
+    {
+        return filled(config('webpush.vapid.public_key'))
+            && filled(config('webpush.vapid.private_key'));
+    }
+
+    /**
+     * The browser-facing push details, served to the SPA at runtime (via an
+     * Inertia shared prop) rather than baked into the JS bundle at build time —
+     * the same reason {@see ReverbConfig::forFrontend()} exists: one published
+     * image has to work for any operator's keypair without a rebuild.
+     *
+     * The public key is what `pushManager.subscribe()` needs; the private key
+     * never leaves the server. Both are withheld when push is unconfigured, so
+     * the frontend cannot offer a toggle that could only fail.
+     *
+     * @return array{enabled: bool, publicKey: string|null}
+     */
+    public static function forFrontend(): array
+    {
+        if (! self::configured()) {
+            return ['enabled' => false, 'publicKey' => null];
+        }
+
+        return ['enabled' => true, 'publicKey' => (string) config('webpush.vapid.public_key')];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "geoip2/geoip2": "^3.3",
         "inertiajs/inertia-laravel": "^3.0",
         "intervention/image": "^4.2",
+        "laravel-notification-channels/webpush": "^11.0",
         "laravel/chisel": "^0.1.0",
         "laravel/fortify": "^1.37.2",
         "laravel/framework": "^13.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79ebe866239e2387006d879c0046c4ad",
+    "content-hash": "6bd49093fb1cf88d4ba1e608cda785fd",
     "packages": [
         {
             "name": "arietimmerman/laravel-scim-server",
@@ -124,16 +124,16 @@
         },
         {
             "name": "brick/math",
-            "version": "0.18.0",
+            "version": "0.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "82944324d1c1bdb2c2618e89978d4e2ad78d69ad"
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/82944324d1c1bdb2c2618e89978d4e2ad78d69ad",
-                "reference": "82944324d1c1bdb2c2618e89978d4e2ad78d69ad",
+                "url": "https://api.github.com/repos/brick/math/zipball/8189e751995f9e15729c1aa2f89fa8f166ffe818",
+                "reference": "8189e751995f9e15729c1aa2f89fa8f166ffe818",
                 "shasum": ""
             },
             "require": {
@@ -171,7 +171,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.18.0"
+                "source": "https://github.com/brick/math/tree/0.17.2"
             },
             "funding": [
                 {
@@ -179,7 +179,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-14T18:21:03+00:00"
+            "time": "2026-05-25T20:34:43+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -2111,6 +2111,72 @@
             "time": "2026-02-19T20:12:01+00:00"
         },
         {
+            "name": "laravel-notification-channels/webpush",
+            "version": "11.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel-notification-channels/webpush.git",
+                "reference": "85b577e64459a9df06a24062e2b300abbaa99fa9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel-notification-channels/webpush/zipball/85b577e64459a9df06a24062e2b300abbaa99fa9",
+                "reference": "85b577e64459a9df06a24062e2b300abbaa99fa9",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/notifications": "^12.0|^13.0",
+                "illuminate/support": "^12.0|^13.0",
+                "minishlink/web-push": "^10.0.1",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3.1",
+                "laravel/pint": "^1.25",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^9.2|^10.0|^11.0",
+                "phpunit/phpunit": "^11.5.3|^12.5.12|^13.1.11",
+                "rector/rector": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NotificationChannels\\WebPush\\WebPushServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NotificationChannels\\WebPush\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cretu Eusebiu",
+                    "email": "me@cretueusebiu.com",
+                    "homepage": "http://cretueusebiu.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Joost de Bruijn",
+                    "email": "joost@aqualabs.nl",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Web Push Notifications driver for Laravel.",
+            "homepage": "https://github.com/laravel-notification-channels/webpush",
+            "support": {
+                "issues": "https://github.com/laravel-notification-channels/webpush/issues",
+                "source": "https://github.com/laravel-notification-channels/webpush/tree/11.0.0"
+            },
+            "time": "2026-05-24T13:22:27+00:00"
+        },
+        {
             "name": "laravel/chisel",
             "version": "v0.1.1",
             "source": {
@@ -3896,6 +3962,77 @@
                 "source": "https://github.com/meilisearch/meilisearch-php/tree/v1.16.1"
             },
             "time": "2025-09-18T10:15:45+00:00"
+        },
+        {
+            "name": "minishlink/web-push",
+            "version": "v10.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-push-libs/web-push-php.git",
+                "reference": "c922021b4ed1a61e6604d8dc33a2e0378b4382e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-push-libs/web-push-php/zipball/c922021b4ed1a61e6604d8dc33a2e0378b4382e3",
+                "reference": "c922021b4ed1a61e6604d8dc33a2e0378b4382e3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "guzzlehttp/guzzle": "^7.9.2",
+                "php": ">=8.2",
+                "psr/log": "^2.0|^3.0",
+                "spomky-labs/base64url": "^2.0.4",
+                "symfony/polyfill-php83": "^1.33",
+                "web-token/jwt-library": "^3.4.9|^4.0.6"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.92.2",
+                "phpstan/phpstan": "^2.1.33",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11.5.46|^12.5.2",
+                "symfony/polyfill-iconv": "^1.33"
+            },
+            "suggest": {
+                "ext-bcmath": "Optional for performance.",
+                "ext-gmp": "Optional for performance."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Minishlink\\WebPush\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Louis Lagrange",
+                    "email": "lagrange.louis@gmail.com",
+                    "homepage": "https://github.com/Minishlink"
+                }
+            ],
+            "description": "Web Push library for PHP",
+            "homepage": "https://github.com/web-push-libs/web-push-php",
+            "keywords": [
+                "Push API",
+                "WebPush",
+                "notifications",
+                "push",
+                "web"
+            ],
+            "support": {
+                "issues": "https://github.com/web-push-libs/web-push-php/issues",
+                "source": "https://github.com/web-push-libs/web-push-php/tree/v10.1.0"
+            },
+            "time": "2026-05-28T09:37:37+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -7079,6 +7216,71 @@
             "time": "2026-06-19T14:00:51+00:00"
         },
         {
+            "name": "spomky-labs/base64url",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/base64url.git",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/base64url/zipball/7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.11|^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.11|^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.11|^0.12",
+                "phpstan/phpstan-phpunit": "^0.11|^0.12",
+                "phpstan/phpstan-strict-rules": "^0.11|^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Base64Url\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky-Labs/base64url/contributors"
+                }
+            ],
+            "description": "Base 64 URL Safe Encoding/Decoding PHP Library",
+            "homepage": "https://github.com/Spomky-Labs/base64url",
+            "keywords": [
+                "base64",
+                "rfc4648",
+                "safe",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/base64url/issues",
+                "source": "https://github.com/Spomky-Labs/base64url/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-11-03T09:10:25+00:00"
+        },
+        {
             "name": "spomky-labs/cbor-php",
             "version": "3.3.0",
             "source": {
@@ -8903,6 +9105,86 @@
             "time": "2026-05-26T12:45:58+00:00"
         },
         {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:51:48+00:00"
+        },
+        {
             "name": "symfony/polyfill-php84",
             "version": "v1.38.1",
             "source": {
@@ -10604,6 +10886,95 @@
                 }
             ],
             "time": "2026-05-31T15:00:08+00:00"
+        },
+        {
+            "name": "web-token/jwt-library",
+            "version": "4.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-token/jwt-library.git",
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.12|^0.13|^0.14|^0.15|^0.16|^0.17",
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "spomky-labs/pki-framework": "^1.2.1"
+            },
+            "conflict": {
+                "spomky-labs/jose": "*"
+            },
+            "suggest": {
+                "ext-bcmath": "GMP or BCMath is highly recommended to improve the library performance",
+                "ext-gmp": "GMP or BCMath is highly recommended to improve the library performance",
+                "ext-openssl": "For key management (creation, optimization, etc.) and some algorithms (AES, RSA, ECDSA, etc.)",
+                "ext-sodium": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
+                "paragonie/sodium_compat": "Sodium is required for OKP key creation, EdDSA signature algorithm and ECDH-ES key encryption with OKP keys",
+                "spomky-labs/aes-key-wrap": "For all Key Wrapping algorithms (AxxxKW, AxxxGCMKW, PBES2-HSxxx+AyyyKW...)",
+                "symfony/console": "Needed to use console commands",
+                "symfony/http-client": "To enable JKU/X5U support."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jose\\Component\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-token/jwt-framework/contributors"
+                }
+            ],
+            "description": "JWT library",
+            "homepage": "https://github.com/web-token",
+            "keywords": [
+                "JOSE",
+                "JWE",
+                "JWK",
+                "JWKSet",
+                "JWS",
+                "Jot",
+                "RFC7515",
+                "RFC7516",
+                "RFC7517",
+                "RFC7518",
+                "RFC7519",
+                "RFC7520",
+                "bundle",
+                "jwa",
+                "jwt",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/web-token/jwt-library/issues",
+                "source": "https://github.com/web-token/jwt-library/tree/4.1.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-06-06T18:12:39+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -1,0 +1,62 @@
+<?php
+
+use NotificationChannels\WebPush\PushSubscription;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | VAPID Keys
+    |--------------------------------------------------------------------------
+    |
+    | The keypair every push message is signed with, identifying this instance
+    | to the browser vendors' push services. Generate one per instance with
+    | `php artisan webpush:vapid` and keep it stable: the public key is baked
+    | into each browser's subscription, so rotating it invalidates every
+    | subscription users have already granted. Web push stays switched off
+    | until both keys are set — see App\Support\WebPushConfig.
+    |
+    | The subject identifies the operator to the push service (a mailto: or an
+    | https: URL); it falls back to the instance's own URL when unset.
+    |
+    */
+
+    'vapid' => [
+        'subject' => env('VAPID_SUBJECT'),
+        'public_key' => env('VAPID_PUBLIC_KEY'),
+        'private_key' => env('VAPID_PRIVATE_KEY'),
+        'pem_file' => env('VAPID_PEM_FILE'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Subscription Storage
+    |--------------------------------------------------------------------------
+    |
+    | One row per browser that has granted permission. The connection is left
+    | null so the table lives on the app's default connection, whatever the
+    | operator configured it to be.
+    |
+    */
+
+    'model' => PushSubscription::class,
+
+    'table_name' => 'push_subscriptions',
+
+    'database_connection' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Delivery
+    |--------------------------------------------------------------------------
+    |
+    | Guzzle options for the outbound calls to the push services, and the
+    | automatic payload padding that hides a message's true length from them.
+    |
+    */
+
+    'client_options' => [],
+
+    'automatic_padding' => env('WEBPUSH_AUTOMATIC_PADDING', true),
+
+];

--- a/config/webpush.php
+++ b/config/webpush.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use NotificationChannels\WebPush\PushSubscription;
 
 return [

--- a/database/migrations/2026_07_24_200726_create_push_subscriptions_table.php
+++ b/database/migrations/2026_07_24_200726_create_push_subscriptions_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * The columns are the shape `laravel-notification-channels/webpush` reads —
+     * its `PushSubscription` model and `HasPushSubscriptions` trait bind to these
+     * names — with one deviation from the package's published stub: the morph is
+     * a `uuidMorphs`, because every model in this app (the `User` that owns a
+     * subscription included) keys on a UUID string rather than an auto-increment
+     * integer.
+     *
+     * One row is one browser on one device: a push endpoint is issued per
+     * service-worker registration, so enabling push on a laptop and on a phone
+     * yields two rows and either can be revoked on its own. The endpoint is
+     * unique because the push service already treats it as the subscription's
+     * identity — re-subscribing the same browser has to update the existing row
+     * rather than add a second one.
+     */
+    public function up(): void
+    {
+        Schema::create('push_subscriptions', function (Blueprint $table): void {
+            // The package's model is a plain auto-increment Eloquent model with
+            // no HasUuids, so the primary key stays a bigint; only the owning
+            // reference has to speak this app's UUID keys.
+            $table->bigIncrements('id');
+            $table->uuidMorphs('subscribable', 'push_subscriptions_subscribable_morph_idx');
+            $table->string('endpoint', 500)->unique();
+            // The browser's ECDH public key and auth secret. Every payload is
+            // encrypted to them, so the push service relays ciphertext it cannot
+            // read. Nullable because the spec allows an unencrypted subscription.
+            $table->string('public_key')->nullable();
+            $table->string('auth_token')->nullable();
+            $table->string('content_encoding')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('push_subscriptions');
+    }
+};

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -374,3 +374,33 @@ stack). Nothing is written to the database except a member's own manual away
 setting, and if the cache is unavailable everyone simply reads as active — the
 same as before the feature existed.
 :::
+
+## Web push notifications
+
+Members can opt in, **per device**, to browser notifications for new messages —
+so a mention still reaches them with the tab closed. The feature is **off** until
+you generate a VAPID keypair; see
+[Feature toggles → Web push notifications](/reference/feature-toggles/#web-push-notifications)
+for what it does and how it behaves.
+
+| Variable            | Default      | Notes                                                                                                     |
+| ------------------- | ------------ | --------------------------------------------------------------------------------------------------------- |
+| `VAPID_PUBLIC_KEY`  | *(unset)*    | Public half of the signing keypair. Served to the browser so it can subscribe. Both keys must be set.       |
+| `VAPID_PRIVATE_KEY` | *(unset)*    | Private half. Never leaves the server.                                                                      |
+| `VAPID_SUBJECT`     | *(`APP_URL`)*| How you identify yourself to the push services: a `mailto:` or `https:` URL they can contact you at.         |
+
+Generate the pair once, from inside the app container:
+
+```bash
+docker compose exec app php artisan webpush:vapid
+```
+
+It writes `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` into your `.env`. Restart
+the stack to pick them up.
+
+:::caution[Keep the keypair stable]
+The public key is baked into every subscription a browser has already granted.
+Rotating it silently invalidates them all: those devices stop receiving anything
+until each member turns the toggle off and on again. Back the pair up with your
+other secrets.
+:::

--- a/docs/src/content/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/reference/feature-toggles.md
@@ -504,3 +504,49 @@ The hourly reset **force-deletes** the demo team and its accounts, so any
 in-flight visitor session breaks when it runs — expected for a throwaway demo,
 never appropriate for real data.
 :::
+
+## Web push notifications
+
+| Variable                                 | Default   | Effect                                              |
+| ---------------------------------------- | --------- | --------------------------------------------------- |
+| `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | *(unset)* | Enables browser push notifications for new messages. |
+
+Web push is **off** until you generate a VAPID keypair — see
+[Environment variables → Web push notifications](/reference/environment-variables/#web-push-notifications)
+for the `webpush:vapid` command. With no keypair the toggle never appears in
+Settings, and the subscription endpoints return **404**.
+
+With the keys set, the feature is still **opt-in per member and per device**:
+nothing prompts on load or on login. Each member turns it on from
+**Settings → Appearance & notifications → Push notifications on this device**,
+which is what asks the browser for permission. Turning it on on a laptop does not
+subscribe their phone, and either can be turned off on its own.
+
+What gets pushed follows the same rules as the in-app chime, so a push never
+contradicts a badge:
+
+- Direct messages and channels at the default **All messages** level push on every
+  message; a channel set to **Mentions only** pushes only when the member is
+  @mentioned; **Nothing** and **muted** channels never push.
+- A member is never pushed about their own message, and **quiet hours** or a
+  manual do-not-disturb pause suppress everything.
+- Notifications are **collapsed per conversation**: a second message in the same
+  channel replaces the banner already on screen rather than stacking up.
+- If a window of the app is **visible** when the message lands, the banner is
+  dropped — that tab has already chimed and badged.
+
+Clicking a notification focuses an open window (or opens one) directly on the
+message, scrolled to and highlighted.
+
+:::note[Delivery uses the queue]
+Fan-out runs on the queue, so the [queue worker](/self-hosting/configuration/)
+must be running or nothing is delivered. Payloads are encrypted end-to-end to
+each device: the browser vendors' push services relay ciphertext they cannot
+read.
+:::
+
+:::caution[iOS needs the app installed]
+Safari only allows web push from a PWA **added to the home screen** (iOS 16.4+).
+In a plain Safari tab the toggle does not appear at all. On desktop and Android,
+a regular browser tab is enough.
+:::

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1262,5 +1262,13 @@
   "Hide compose tools": "Masquer les outils de rédaction",
   "User menu": "Menu utilisateur",
   "Your status, appearance and account.": "Votre statut, votre apparence et votre compte.",
-  "Choose how long to pause notifications.": "Choisissez la durée de la pause des notifications."
+  "Choose how long to pause notifications.": "Choisissez la durée de la pause des notifications.",
+  ":sender in #:channel": ":sender dans #:channel",
+  "Posted a poll": "A publié un sondage",
+  "Sent an attachment": "A envoyé un fichier",
+  "Sent :count attachments": "A envoyé :count fichiers",
+  "Push notifications on this device": "Notifications push sur cet appareil",
+  "Get alerted to new messages when the app is closed or in the background. This applies to this browser only, and follows the same mute and notification-level settings as the chime.": "Soyez alerté des nouveaux messages quand l'application est fermée ou en arrière-plan. Ce réglage ne concerne que ce navigateur, et suit les mêmes préférences de silence et de niveau de notification que le carillon.",
+  "Notifications are blocked for this site. Allow them in your browser settings, then turn this on.": "Les notifications sont bloquées pour ce site. Autorisez-les dans les réglages de votre navigateur, puis activez cette option.",
+  "Could not update push notifications on this device.": "Impossible de modifier les notifications push sur cet appareil."
 }

--- a/resources/js/composables/useWebPush.ts
+++ b/resources/js/composables/useWebPush.ts
@@ -50,7 +50,10 @@ export function useWebPush(): WebPush {
     // to subscribe at all — on iOS that means an installed home-screen app
     // (#845 adds the in-app prompt that makes installing discoverable).
     const available = computed(
-        () => page.props.webPush.enabled && supported.value,
+        () =>
+            page.props.webPush.enabled &&
+            page.props.webPush.publicKey !== null &&
+            supported.value,
     );
 
     onMounted(async () => {

--- a/resources/js/composables/useWebPush.ts
+++ b/resources/js/composables/useWebPush.ts
@@ -1,0 +1,101 @@
+import { usePage } from '@inertiajs/vue3';
+import { computed, onMounted, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { toast } from 'vue-sonner';
+import { useTranslations } from '@/composables/useTranslations';
+import {
+    currentSubscription,
+    disablePush,
+    enablePush,
+    pushSupported,
+} from '@/lib/push';
+
+export interface WebPush {
+    /** Whether the toggle should be offered on this instance and device at all. */
+    available: ComputedRef<boolean>;
+    /** Whether this device is subscribed right now. */
+    subscribed: Ref<boolean>;
+    /** The user blocked notifications for this site; only they can undo it. */
+    blocked: Ref<boolean>;
+    /** A subscribe/unsubscribe round-trip is in flight. */
+    busy: Ref<boolean>;
+    /** Subscribe or unsubscribe this device. */
+    toggle: (next: boolean) => Promise<void>;
+}
+
+/**
+ * Own the per-device web push opt-in.
+ *
+ * Deliberately per device, not per account: a push subscription belongs to one
+ * browser, so enabling it on a laptop must not start pushing to a phone that
+ * was never asked. That makes the browser — not a shared Inertia prop — the
+ * source of truth for whether the toggle reads as on, which is why the state is
+ * read back from `pushManager` on mount rather than seeded from the server.
+ *
+ * Permission is requested only on an explicit toggle. Nothing prompts on load
+ * or on login: an unprompted permission dialog is the fastest way to a
+ * permanent block, and a block can only be lifted from the browser's own site
+ * settings.
+ */
+export function useWebPush(): WebPush {
+    const page = usePage();
+    const { t } = useTranslations();
+
+    const supported = ref(false);
+    const subscribed = ref(false);
+    const blocked = ref(false);
+    const busy = ref(false);
+
+    // The instance has to have a VAPID keypair, and the browser has to be able
+    // to subscribe at all — on iOS that means an installed home-screen app
+    // (#845 adds the in-app prompt that makes installing discoverable).
+    const available = computed(
+        () => page.props.webPush.enabled && supported.value,
+    );
+
+    onMounted(async () => {
+        supported.value = pushSupported();
+
+        if (!supported.value) {
+            return;
+        }
+
+        blocked.value = Notification.permission === 'denied';
+        subscribed.value = (await currentSubscription()) !== null;
+    });
+
+    async function toggle(next: boolean): Promise<void> {
+        const publicKey = page.props.webPush.publicKey;
+
+        if (busy.value || publicKey === null) {
+            return;
+        }
+
+        busy.value = true;
+
+        try {
+            if (next) {
+                // A declined prompt is an answer, not a failure: the switch
+                // falls back to off and the blocked note explains the rest.
+                subscribed.value = await enablePush(publicKey);
+                blocked.value = Notification.permission === 'denied';
+
+                return;
+            }
+
+            await disablePush();
+            subscribed.value = false;
+        } catch {
+            // Leave the switch reflecting what the browser actually holds, so a
+            // half-completed opt-in doesn't read as on.
+            subscribed.value = (await currentSubscription()) !== null;
+            toast.error(
+                t('Could not update push notifications on this device.'),
+            );
+        } finally {
+            busy.value = false;
+        }
+    }
+
+    return { available, subscribed, blocked, busy, toggle };
+}

--- a/resources/js/lib/push.test.ts
+++ b/resources/js/lib/push.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    currentSubscription,
+    disablePush,
+    enablePush,
+    pushSupported,
+    urlBase64ToUint8Array,
+} from '@/lib/push';
+
+const SUBSCRIPTION_JSON = {
+    endpoint: 'https://push.example.test/device-one',
+    keys: { p256dh: 'device-key', auth: 'device-auth' },
+};
+
+/** The shape both push endpoints are called with. */
+type JsonRequest = {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+};
+
+/**
+ * A browser that can do push, with an optional existing subscription.
+ */
+function stubBrowser(
+    options: {
+        existing?: unknown;
+        permission?: NotificationPermission;
+        subscribe?: ReturnType<typeof vi.fn>;
+    } = {},
+) {
+    const getSubscription = vi.fn(() =>
+        Promise.resolve(options.existing ?? null),
+    );
+    const subscribe =
+        options.subscribe ??
+        vi.fn(() =>
+            Promise.resolve({
+                ...SUBSCRIPTION_JSON,
+                toJSON: () => SUBSCRIPTION_JSON,
+                unsubscribe: vi.fn(() => Promise.resolve(true)),
+            }),
+        );
+    const requestPermission = vi.fn(() =>
+        Promise.resolve(options.permission ?? 'granted'),
+    );
+
+    vi.stubGlobal('navigator', {
+        serviceWorker: {
+            ready: Promise.resolve({
+                pushManager: { getSubscription, subscribe },
+            }),
+        },
+    });
+    vi.stubGlobal('window', { PushManager: class {}, Notification: class {} });
+    vi.stubGlobal('Notification', { requestPermission });
+    vi.stubGlobal('document', { cookie: 'XSRF-TOKEN=tok%20en' });
+
+    const fetchMock = vi.fn<
+        (url: string, init: JsonRequest) => Promise<{ ok: boolean }>
+    >(() => Promise.resolve({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    return { getSubscription, subscribe, requestPermission, fetchMock };
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('urlBase64ToUint8Array', () => {
+    it('decodes an unpadded url-safe key', () => {
+        // "hello" as base64url, unpadded.
+        expect(Array.from(urlBase64ToUint8Array('aGVsbG8'))).toEqual([
+            104, 101, 108, 108, 111,
+        ]);
+    });
+
+    it('restores the url-safe alphabet before decoding', () => {
+        // Bytes 0xFB 0xFF 0xBF encode as "-_-_" only in the url-safe alphabet.
+        expect(Array.from(urlBase64ToUint8Array('-_-_'))).toEqual([
+            251, 255, 191,
+        ]);
+    });
+
+    it('produces bytes backed by a plain ArrayBuffer, as subscribe() requires', () => {
+        expect(urlBase64ToUint8Array('aGVsbG8').buffer).toBeInstanceOf(
+            ArrayBuffer,
+        );
+    });
+});
+
+describe('pushSupported', () => {
+    it('is true when the browser has all three capabilities', () => {
+        stubBrowser();
+
+        expect(pushSupported()).toBe(true);
+    });
+
+    it('is false without a PushManager, as in a plain iOS tab', () => {
+        stubBrowser();
+        vi.stubGlobal('window', { Notification: class {} });
+
+        expect(pushSupported()).toBe(false);
+    });
+
+    it('is false without a service worker', () => {
+        stubBrowser();
+        vi.stubGlobal('navigator', {});
+
+        expect(pushSupported()).toBe(false);
+    });
+});
+
+describe('enablePush', () => {
+    it('subscribes the device and registers it with the server', async () => {
+        const { subscribe, fetchMock } = stubBrowser();
+
+        await expect(enablePush('aGVsbG8')).resolves.toBe(true);
+
+        expect(subscribe).toHaveBeenCalledWith(
+            expect.objectContaining({ userVisibleOnly: true }),
+        );
+
+        const [url, init] = fetchMock.mock.calls[0];
+
+        expect(url).toBe('/settings/push-subscriptions');
+        expect(init.method).toBe('POST');
+        expect(init.headers['X-XSRF-TOKEN']).toBe('tok en');
+        expect(JSON.parse(init.body)).toEqual(SUBSCRIPTION_JSON);
+    });
+
+    it('reuses a subscription the browser already holds', async () => {
+        const { subscribe, fetchMock } = stubBrowser({
+            existing: {
+                ...SUBSCRIPTION_JSON,
+                toJSON: () => SUBSCRIPTION_JSON,
+            },
+        });
+
+        await expect(enablePush('aGVsbG8')).resolves.toBe(true);
+
+        expect(subscribe).not.toHaveBeenCalled();
+        expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('gives up quietly when the user declines the permission prompt', async () => {
+        const { subscribe, fetchMock } = stubBrowser({ permission: 'denied' });
+
+        await expect(enablePush('aGVsbG8')).resolves.toBe(false);
+
+        expect(subscribe).not.toHaveBeenCalled();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('does nothing on a browser that cannot do push', async () => {
+        stubBrowser();
+        vi.stubGlobal('window', {});
+
+        await expect(enablePush('aGVsbG8')).resolves.toBe(false);
+    });
+
+    it('throws when the server refuses the subscription', async () => {
+        stubBrowser();
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(() => Promise.resolve({ ok: false })),
+        );
+
+        await expect(enablePush('aGVsbG8')).rejects.toThrow(
+            'push-subscription-failed',
+        );
+    });
+});
+
+describe('disablePush', () => {
+    const unsubscribe = vi.fn(() => Promise.resolve(true));
+
+    beforeEach(() => {
+        unsubscribe.mockClear();
+    });
+
+    it('revokes the device server-side before unsubscribing it', async () => {
+        const { fetchMock } = stubBrowser({
+            existing: { ...SUBSCRIPTION_JSON, unsubscribe },
+        });
+
+        await disablePush();
+
+        const [url, init] = fetchMock.mock.calls[0];
+
+        expect(url).toBe('/settings/push-subscriptions');
+        expect(init.method).toBe('DELETE');
+        expect(JSON.parse(init.body)).toEqual({
+            endpoint: SUBSCRIPTION_JSON.endpoint,
+        });
+        expect(unsubscribe).toHaveBeenCalled();
+    });
+
+    it('does nothing when this device was never subscribed', async () => {
+        const { fetchMock } = stubBrowser();
+
+        await disablePush();
+
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('currentSubscription', () => {
+    it('reads the subscription back from the browser', async () => {
+        stubBrowser({ existing: SUBSCRIPTION_JSON });
+
+        await expect(currentSubscription()).resolves.toEqual(SUBSCRIPTION_JSON);
+    });
+
+    it('is null on a browser that cannot do push', async () => {
+        stubBrowser();
+        vi.stubGlobal('window', {});
+
+        await expect(currentSubscription()).resolves.toBeNull();
+    });
+});

--- a/resources/js/lib/push.ts
+++ b/resources/js/lib/push.ts
@@ -1,0 +1,151 @@
+import {
+    destroy as destroySubscription,
+    store as storeSubscription,
+} from '@/actions/App/Http/Controllers/Settings/PushSubscriptionController';
+import { parseXsrfToken } from '@/lib/uploadAttachment';
+
+/**
+ * Whether this browser can do web push at all.
+ *
+ * Three separate capabilities have to line up, and on iOS they only do once the
+ * app has been installed to the home screen (Safari 16.4+) — a plain tab there
+ * reports no `PushManager`, which is exactly the case this guard covers.
+ */
+export function pushSupported(): boolean {
+    return (
+        typeof navigator !== 'undefined' &&
+        'serviceWorker' in navigator &&
+        typeof window !== 'undefined' &&
+        'PushManager' in window &&
+        'Notification' in window
+    );
+}
+
+/**
+ * Decode a base64url VAPID key into the raw bytes `pushManager.subscribe()`
+ * wants. The server hands the key over in the URL-safe alphabet the spec uses,
+ * unpadded; `atob` accepts neither, so both are restored first.
+ */
+export function urlBase64ToUint8Array(
+    base64Url: string,
+): Uint8Array<ArrayBuffer> {
+    const padded = base64Url.padEnd(
+        base64Url.length + ((4 - (base64Url.length % 4)) % 4),
+        '=',
+    );
+    const binary = atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+
+    // Backed by a plain ArrayBuffer rather than `Uint8Array.from`'s
+    // implementation-defined buffer, which is what `applicationServerKey`
+    // accepts as a BufferSource.
+    const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+
+    for (let index = 0; index < binary.length; index++) {
+        bytes[index] = binary.charCodeAt(index);
+    }
+
+    return bytes;
+}
+
+/**
+ * This device's push subscription, or null when it has none.
+ *
+ * Read from the browser rather than the server, because the browser is the
+ * authority: a subscription can be revoked from the site settings, or dropped
+ * when the push service rotates its keys, without the server ever hearing.
+ */
+export async function currentSubscription(): Promise<PushSubscription | null> {
+    if (!pushSupported()) {
+        return null;
+    }
+
+    const registration = await navigator.serviceWorker.ready;
+
+    return registration.pushManager.getSubscription();
+}
+
+/**
+ * Ask for permission, subscribe this device, and register it with the server.
+ *
+ * Resolves false when the user dismisses or blocks the permission prompt —
+ * their answer, not an error. `userVisibleOnly` is mandatory: every push this
+ * app sends raises a banner, and Chrome refuses to subscribe without the
+ * promise that it will.
+ */
+export async function enablePush(vapidPublicKey: string): Promise<boolean> {
+    if (!pushSupported()) {
+        return false;
+    }
+
+    if ((await Notification.requestPermission()) !== 'granted') {
+        return false;
+    }
+
+    const registration = await navigator.serviceWorker.ready;
+
+    const subscription =
+        (await registration.pushManager.getSubscription()) ??
+        (await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+        }));
+
+    await send(storeSubscription().url, 'POST', subscription.toJSON());
+
+    return true;
+}
+
+/**
+ * Unsubscribe this device and forget it server-side.
+ *
+ * The server is told first: if the browser-side unsubscribe then fails, the
+ * worst case is a device that stays subscribed but is never pushed to, rather
+ * than one the server keeps pushing at forever.
+ */
+export async function disablePush(): Promise<void> {
+    const subscription = await currentSubscription();
+
+    if (subscription === null) {
+        return;
+    }
+
+    await send(destroySubscription().url, 'DELETE', {
+        endpoint: subscription.endpoint,
+    });
+
+    await subscription.unsubscribe();
+}
+
+/**
+ * A same-origin JSON write carrying the CSRF header the stateful `web` guard
+ * expects. These endpoints answer 204 and change no rendered state, so they are
+ * called directly rather than through an Inertia visit that would reload every
+ * shared prop for nothing.
+ */
+async function send(
+    url: string,
+    method: 'POST' | 'DELETE',
+    body: unknown,
+): Promise<void> {
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+    };
+
+    const token = parseXsrfToken(document.cookie);
+
+    if (token) {
+        headers['X-XSRF-TOKEN'] = token;
+    }
+
+    const response = await fetch(url, {
+        method,
+        headers,
+        body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+        throw new Error('push-subscription-failed');
+    }
+}

--- a/resources/js/pages/settings/Appearance.vue
+++ b/resources/js/pages/settings/Appearance.vue
@@ -20,6 +20,7 @@ import { Switch } from '@/components/ui/switch';
 import { useChimes } from '@/composables/useChimes';
 import { useReadReceipts } from '@/composables/useReadReceipts';
 import { useTranslations } from '@/composables/useTranslations';
+import { useWebPush } from '@/composables/useWebPush';
 import { formatWallTime } from '@/lib/datetime';
 import { quietHoursSegments, quietHoursTicks } from '@/lib/dnd';
 import { translate } from '@/lib/i18n';
@@ -61,6 +62,14 @@ function choose(value: ChimeSound): void {
 }
 
 const { shareReadReceipts, updateShareReadReceipts } = useReadReceipts();
+
+const {
+    available: pushAvailable,
+    subscribed: pushSubscribed,
+    blocked: pushBlocked,
+    busy: pushBusy,
+    toggle: togglePush,
+} = useWebPush();
 
 const page = usePage();
 const { t } = useTranslations();
@@ -337,6 +346,40 @@ function chooseBound(bound: 'startsAt' | 'endsAt', value: unknown): void {
                     </div>
                 </div>
             </div>
+        </SettingsPaneSection>
+
+        <SettingsPaneSection
+            v-if="pushAvailable"
+            :title="$t('Push notifications on this device')"
+            :description="
+                $t(
+                    'Get alerted to new messages when the app is closed or in the background. This applies to this browser only, and follows the same mute and notification-level settings as the chime.',
+                )
+            "
+        >
+            <template #action>
+                <Switch
+                    id="push-notifications"
+                    data-test="push-notifications"
+                    :model-value="pushSubscribed"
+                    :disabled="pushBusy || pushBlocked"
+                    :aria-label="$t('Push notifications on this device')"
+                    class="relative max-md:before:absolute max-md:before:-inset-3.5 max-md:before:content-['']"
+                    @update:model-value="togglePush"
+                />
+            </template>
+
+            <p
+                v-if="pushBlocked"
+                data-test="push-notifications-blocked"
+                class="text-[12.5px] text-muted-foreground"
+            >
+                {{
+                    $t(
+                        'Notifications are blocked for this site. Allow them in your browser settings, then turn this on.',
+                    )
+                }}
+            </p>
         </SettingsPaneSection>
 
         <SettingsPaneSection

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -23,6 +23,7 @@ declare module '@inertiajs/core' {
         sharedPageProps: {
             name: string;
             reverb: ReverbRuntimeConfig;
+            webPush: { enabled: boolean; publicKey: string | null };
             auth: Auth;
             registrationEnabled: boolean;
             emailVerificationEnabled: boolean;

--- a/resources/pwa/service-worker.test.ts
+++ b/resources/pwa/service-worker.test.ts
@@ -235,6 +235,21 @@ describe('push', () => {
         expect(scope.registration.showNotification).not.toHaveBeenCalled();
     });
 
+    it('never sets renotify without a tag, which the platform rejects', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(
+            scope,
+            'push',
+            pushEventData({ title: 'Ada Lovelace', renotify: true }),
+        );
+
+        expect(scope.registration.showNotification).toHaveBeenCalledWith(
+            'Ada Lovelace',
+            expect.objectContaining({ tag: undefined, renotify: false }),
+        );
+    });
+
     it('drops payload members that are not strings', async () => {
         const scope = await loadWorker();
 

--- a/resources/pwa/service-worker.test.ts
+++ b/resources/pwa/service-worker.test.ts
@@ -1,14 +1,46 @@
-import { afterEach, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 type Listener = (event: never) => void;
 
-function createScope() {
+type FakeWindow = {
+    url: string;
+    visibilityState: string;
+    focus: ReturnType<typeof vi.fn>;
+    navigate: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * An open app window the worker can find, focus and navigate.
+ */
+function appWindow(overrides: Partial<FakeWindow> = {}): FakeWindow {
+    return {
+        url: 'https://desk.test/t/acme/c/general',
+        visibilityState: 'hidden',
+        focus: vi.fn(() => Promise.resolve()),
+        navigate: vi.fn(() => Promise.resolve()),
+        ...overrides,
+    };
+}
+
+function createScope(windows: FakeWindow[] = []) {
     const listeners = new Map<string, Listener>();
 
     return {
         listeners,
         skipWaiting: vi.fn(() => Promise.resolve()),
-        clients: { claim: vi.fn(() => Promise.resolve()) },
+        clients: {
+            claim: vi.fn(() => Promise.resolve()),
+            matchAll: vi.fn(() => Promise.resolve(windows)),
+            openWindow: vi.fn(() => Promise.resolve()),
+        },
+        registration: {
+            showNotification: vi.fn<
+                (
+                    title: string,
+                    options?: Record<string, unknown>,
+                ) => Promise<void>
+            >(() => Promise.resolve()),
+        },
         addEventListener: vi.fn((type: string, listener: Listener) => {
             listeners.set(type, listener);
         }),
@@ -19,8 +51,8 @@ function createScope() {
  * Loads the worker with a stubbed global scope, mimicking how the browser
  * evaluates it: the module wires its listeners as a side effect of importing.
  */
-async function loadWorker() {
-    const scope = createScope();
+async function loadWorker(windows: FakeWindow[] = []) {
+    const scope = createScope(windows);
 
     vi.stubGlobal('self', scope);
     vi.resetModules();
@@ -41,6 +73,45 @@ function dispatch(
 
     listener?.(event as never);
 }
+
+/**
+ * Dispatch an event whose handler defers its work to `waitUntil`, and settle
+ * that work before returning — the worker's async handlers all hand their
+ * promise to the browser this way.
+ */
+async function dispatchAndSettle(
+    scope: ReturnType<typeof createScope>,
+    type: string,
+    event: Record<string, unknown>,
+) {
+    let held: Promise<unknown> = Promise.resolve();
+
+    dispatch(scope, type, {
+        ...event,
+        waitUntil: (promise: Promise<unknown>) => {
+            held = promise;
+        },
+    });
+
+    await held;
+}
+
+/**
+ * A push event carrying the given (already decrypted) payload.
+ */
+function pushEventData(payload: unknown) {
+    return { data: { json: () => payload } };
+}
+
+const NEW_MESSAGE = {
+    title: 'Ada Lovelace in #deploys',
+    body: 'Deploy is green',
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    tag: 'channel-abc',
+    renotify: true,
+    data: { url: 'https://desk.test/t/acme/c/deploys?message=42' },
+};
 
 afterEach(() => {
     vi.unstubAllGlobals();
@@ -71,4 +142,202 @@ it('lets every request fall through to the network, caching nothing', async () =
     dispatch(scope, 'fetch', event);
 
     expect(event.respondWith).not.toHaveBeenCalled();
+});
+
+describe('push', () => {
+    it('raises a banner for a pushed message', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(scope, 'push', pushEventData(NEW_MESSAGE));
+
+        expect(scope.registration.showNotification).toHaveBeenCalledWith(
+            'Ada Lovelace in #deploys',
+            {
+                body: 'Deploy is green',
+                icon: '/icons/icon-192.png',
+                badge: '/icons/icon-192.png',
+                tag: 'channel-abc',
+                renotify: true,
+                data: { url: 'https://desk.test/t/acme/c/deploys?message=42' },
+            },
+        );
+    });
+
+    it('tags the banner per channel so a second message replaces the first', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(scope, 'push', pushEventData(NEW_MESSAGE));
+        await dispatchAndSettle(
+            scope,
+            'push',
+            pushEventData({ ...NEW_MESSAGE, body: 'And rolled out' }),
+        );
+
+        const tags = scope.registration.showNotification.mock.calls.map(
+            ([, options]) => options?.tag,
+        );
+
+        expect(tags).toEqual(['channel-abc', 'channel-abc']);
+    });
+
+    it('stays silent while a window of the app is on screen', async () => {
+        const scope = await loadWorker([
+            appWindow({ visibilityState: 'visible' }),
+        ]);
+
+        await dispatchAndSettle(scope, 'push', pushEventData(NEW_MESSAGE));
+
+        expect(scope.registration.showNotification).not.toHaveBeenCalled();
+    });
+
+    it('still raises a banner when every window is backgrounded', async () => {
+        const scope = await loadWorker([
+            appWindow({ visibilityState: 'hidden' }),
+        ]);
+
+        await dispatchAndSettle(scope, 'push', pushEventData(NEW_MESSAGE));
+
+        expect(scope.registration.showNotification).toHaveBeenCalled();
+    });
+
+    it('ignores a push carrying no payload', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(scope, 'push', { data: null });
+
+        expect(scope.registration.showNotification).not.toHaveBeenCalled();
+    });
+
+    it('ignores a payload that is not the object this app sends', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(scope, 'push', pushEventData('a bare string'));
+        await dispatchAndSettle(
+            scope,
+            'push',
+            pushEventData({ body: 'no title' }),
+        );
+
+        expect(scope.registration.showNotification).not.toHaveBeenCalled();
+    });
+
+    it('ignores a payload that will not decode', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(scope, 'push', {
+            data: {
+                json: () => {
+                    throw new SyntaxError('undecryptable');
+                },
+            },
+        });
+
+        expect(scope.registration.showNotification).not.toHaveBeenCalled();
+    });
+
+    it('drops payload members that are not strings', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(
+            scope,
+            'push',
+            pushEventData({ title: 'Ada Lovelace', body: 42, renotify: 'yes' }),
+        );
+
+        expect(scope.registration.showNotification).toHaveBeenCalledWith(
+            'Ada Lovelace',
+            expect.objectContaining({ body: undefined, renotify: false }),
+        );
+    });
+});
+
+describe('notificationclick', () => {
+    function clickEvent(data: unknown) {
+        return { notification: { close: vi.fn(), data } };
+    }
+
+    it('dismisses the banner it was raised from', async () => {
+        const scope = await loadWorker();
+        const event = clickEvent(NEW_MESSAGE.data);
+
+        await dispatchAndSettle(scope, 'notificationclick', event);
+
+        expect(event.notification.close).toHaveBeenCalled();
+    });
+
+    it('opens a window at the message when the app is closed', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(
+            scope,
+            'notificationclick',
+            clickEvent(NEW_MESSAGE.data),
+        );
+
+        expect(scope.clients.openWindow).toHaveBeenCalledWith(
+            'https://desk.test/t/acme/c/deploys?message=42',
+        );
+    });
+
+    it('steers an already-open window to the message instead of opening another', async () => {
+        const open = appWindow();
+        const scope = await loadWorker([open]);
+
+        await dispatchAndSettle(
+            scope,
+            'notificationclick',
+            clickEvent(NEW_MESSAGE.data),
+        );
+
+        expect(open.focus).toHaveBeenCalled();
+        expect(open.navigate).toHaveBeenCalledWith(
+            'https://desk.test/t/acme/c/deploys?message=42',
+        );
+        expect(scope.clients.openWindow).not.toHaveBeenCalled();
+    });
+
+    it('only focuses a window already showing the message', async () => {
+        const open = appWindow({ url: NEW_MESSAGE.data.url });
+        const scope = await loadWorker([open]);
+
+        await dispatchAndSettle(
+            scope,
+            'notificationclick',
+            clickEvent(NEW_MESSAGE.data),
+        );
+
+        expect(open.focus).toHaveBeenCalled();
+        expect(open.navigate).not.toHaveBeenCalled();
+    });
+
+    it('opens a fresh window when the open one refuses to navigate', async () => {
+        const open = appWindow({
+            navigate: vi.fn(() => Promise.reject(new Error('not controlled'))),
+        });
+        const scope = await loadWorker([open]);
+
+        await dispatchAndSettle(
+            scope,
+            'notificationclick',
+            clickEvent(NEW_MESSAGE.data),
+        );
+
+        expect(scope.clients.openWindow).toHaveBeenCalledWith(
+            'https://desk.test/t/acme/c/deploys?message=42',
+        );
+    });
+
+    it('does nothing for a notification carrying no link', async () => {
+        const scope = await loadWorker();
+
+        await dispatchAndSettle(scope, 'notificationclick', clickEvent(null));
+        await dispatchAndSettle(scope, 'notificationclick', clickEvent({}));
+        await dispatchAndSettle(
+            scope,
+            'notificationclick',
+            clickEvent({ url: '' }),
+        );
+
+        expect(scope.clients.openWindow).not.toHaveBeenCalled();
+    });
 });

--- a/resources/pwa/service-worker.ts
+++ b/resources/pwa/service-worker.ts
@@ -7,23 +7,91 @@ interface ExtendableEvent {
 }
 
 /**
+ * A push delivered by the browser vendor's push service. `data` is absent for a
+ * payload-less push, which the spec permits and this worker ignores.
+ */
+interface PushEvent extends ExtendableEvent {
+    data: { json(): unknown } | null;
+}
+
+/**
+ * A click on one of this worker's notifications.
+ */
+interface NotificationEvent extends ExtendableEvent {
+    notification: { close(): void; data: unknown };
+}
+
+/**
+ * One of the app's open windows, as the worker sees it.
+ */
+interface AppWindow {
+    url: string;
+    visibilityState: string;
+    focus(): Promise<unknown>;
+    navigate(url: string): Promise<unknown>;
+}
+
+/**
+ * The banner options this worker sets. Declared here rather than taken from the
+ * DOM's `NotificationOptions`, which omits the service-worker-only members —
+ * `renotify` is one, and it is only legal alongside a `tag`.
+ */
+interface BannerOptions {
+    body?: string;
+    icon?: string;
+    badge?: string;
+    tag?: string;
+    renotify?: boolean;
+    data?: unknown;
+}
+
+/**
+ * The payload the server encrypts into a push, mirroring what
+ * `NotificationChannels\WebPush\WebPushMessage` serialises.
+ */
+interface PushPayload {
+    title?: unknown;
+    body?: unknown;
+    icon?: unknown;
+    badge?: unknown;
+    tag?: unknown;
+    renotify?: unknown;
+    data?: unknown;
+}
+
+/**
  * The worker's global scope. The app's tsconfig models `self` as a DOM
  * `Window`, so the worker-only members are declared here instead of pulling the
  * WebWorker lib into the whole program, where its globals clash with the DOM's.
  */
 interface ServiceWorkerScope {
     skipWaiting(): Promise<void>;
-    clients: { claim(): Promise<void> };
+    clients: {
+        claim(): Promise<void>;
+        matchAll(options?: {
+            type?: string;
+            includeUncontrolled?: boolean;
+        }): Promise<AppWindow[]>;
+        openWindow(url: string): Promise<unknown>;
+    };
+    registration: {
+        showNotification(title: string, options?: BannerOptions): Promise<void>;
+    };
     addEventListener(
-        type: string,
+        type: 'install' | 'activate' | 'fetch',
         listener: (event: ExtendableEvent) => void,
+    ): void;
+    addEventListener(type: 'push', listener: (event: PushEvent) => void): void;
+    addEventListener(
+        type: 'notificationclick',
+        listener: (event: NotificationEvent) => void,
     ): void;
 }
 
 /**
- * The instance's service worker. It exists to make the app installable and to
- * host the push handlers a later issue adds (#532) — it caches nothing, so the
- * app is never served from a stale bundle and offline reading stays out of scope.
+ * The instance's service worker. It makes the app installable and hosts the
+ * push handlers below — it caches nothing, so the app is never served from a
+ * stale bundle and offline reading stays out of scope.
  */
 const worker = self as unknown as ServiceWorkerScope;
 
@@ -41,5 +109,139 @@ worker.addEventListener('activate', (event) => {
 worker.addEventListener('fetch', () => {
     return;
 });
+
+worker.addEventListener('push', (event) => {
+    event.waitUntil(showBanner(readPayload(event)));
+});
+
+worker.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+
+    event.waitUntil(openMessage(readTargetUrl(event.notification.data)));
+});
+
+/**
+ * Decode the pushed payload, tolerating anything that isn't the JSON object
+ * this app sends. A push from an unexpected source, or one whose body failed to
+ * decrypt, must not throw inside the handler: the browser answers an unhandled
+ * push with its own generic "site updated in the background" notice.
+ */
+function readPayload(event: PushEvent): PushPayload | null {
+    try {
+        const payload = event.data?.json();
+
+        return typeof payload === 'object' && payload !== null
+            ? (payload as PushPayload)
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Raise the banner, unless the user is already looking at the app.
+ *
+ * A visible window has alerted them itself — the in-tab chime, the unread badge
+ * — so a banner on top of that would be a second alert for one message. This is
+ * the whole double-alert suppression: the server always sends, and the device
+ * decides whether the user still needs telling.
+ */
+async function showBanner(payload: PushPayload | null): Promise<void> {
+    if (payload === null || typeof payload.title !== 'string') {
+        return;
+    }
+
+    if (await appIsVisible()) {
+        return;
+    }
+
+    await worker.registration.showNotification(payload.title, {
+        body: asString(payload.body),
+        icon: asString(payload.icon),
+        badge: asString(payload.badge),
+        // The tag collapses a conversation: a second message in the same channel
+        // replaces the banner already on screen rather than stacking beside it.
+        // `renotify` makes that replacement alert again instead of swapping in
+        // silently.
+        tag: asString(payload.tag),
+        renotify: payload.renotify === true,
+        data: payload.data,
+    });
+}
+
+/**
+ * Focus an open app window on the message, or open one there.
+ *
+ * Reusing a window is what keeps a click from stacking up tabs over a day of
+ * notifications. `navigate` only works on a window this worker controls, so a
+ * failure falls back to opening a fresh one rather than leaving the click doing
+ * nothing at all.
+ */
+async function openMessage(url: string | null): Promise<void> {
+    if (url === null) {
+        return;
+    }
+
+    const [existing] = await openWindows();
+
+    if (existing === undefined) {
+        await worker.clients.openWindow(url);
+
+        return;
+    }
+
+    await existing.focus();
+
+    if (existing.url === url) {
+        return;
+    }
+
+    try {
+        await existing.navigate(url);
+    } catch {
+        await worker.clients.openWindow(url);
+    }
+}
+
+/**
+ * Whether any of the app's windows is on screen right now.
+ */
+async function appIsVisible(): Promise<boolean> {
+    const windows = await openWindows();
+
+    return windows.some((window) => window.visibilityState === 'visible');
+}
+
+/**
+ * The app's open windows, including ones this worker version does not yet
+ * control: right after an update the previous worker still controls them, and
+ * they are just as much "the app is open" as any other.
+ */
+function openWindows(): Promise<AppWindow[]> {
+    return worker.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+    });
+}
+
+/**
+ * The deep link a notification carries, or null when it carries none.
+ */
+function readTargetUrl(data: unknown): string | null {
+    if (typeof data !== 'object' || data === null) {
+        return null;
+    }
+
+    const url = (data as { url?: unknown }).url;
+
+    return typeof url === 'string' && url !== '' ? url : null;
+}
+
+/**
+ * Narrow a payload member to a string, dropping anything else.
+ */
+function asString(value: unknown): string | undefined {
+    return typeof value === 'string' ? value : undefined;
+}
 
 export {};

--- a/resources/pwa/service-worker.ts
+++ b/resources/pwa/service-worker.ts
@@ -155,16 +155,19 @@ async function showBanner(payload: PushPayload | null): Promise<void> {
         return;
     }
 
+    // The tag collapses a conversation: a second message in the same channel
+    // replaces the banner already on screen rather than stacking beside it.
+    // `renotify` makes that replacement alert again instead of swapping in
+    // silently — and is only legal alongside a tag, so a payload that somehow
+    // arrived without one must not carry it either, or showNotification rejects.
+    const tag = asString(payload.tag);
+
     await worker.registration.showNotification(payload.title, {
         body: asString(payload.body),
         icon: asString(payload.icon),
         badge: asString(payload.badge),
-        // The tag collapses a conversation: a second message in the same channel
-        // replaces the banner already on screen rather than stacking beside it.
-        // `renotify` makes that replacement alert again instead of swapping in
-        // silently.
-        tag: asString(payload.tag),
-        renotify: payload.renotify === true,
+        tag,
+        renotify: tag !== undefined && payload.renotify === true,
         data: payload.data,
     });
 }

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Settings\NotificationController;
 use App\Http\Controllers\Settings\PersonalAccessTokenController;
 use App\Http\Controllers\Settings\PresenceController;
 use App\Http\Controllers\Settings\ProfileController;
+use App\Http\Controllers\Settings\PushSubscriptionController;
 use App\Http\Controllers\Settings\ReadReceiptsController;
 use App\Http\Controllers\Settings\SecurityController;
 use App\Http\Controllers\Settings\SessionController;
@@ -38,6 +39,7 @@ use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Controllers\Teams\TeamMemberController;
 use App\Http\Controllers\Teams\UserGroupController;
 use App\Http\Middleware\EnsureTeamMembership;
+use App\Http\Middleware\EnsureWebPushEnabled;
 use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Support\Facades\Route;
 
@@ -98,6 +100,17 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
     Route::patch('settings/notifications', [NotificationController::class, 'update'])->name('notifications.update');
 
     Route::patch('settings/read-receipts', [ReadReceiptsController::class, 'update'])->name('read-receipts.update');
+
+    // Web push opt-in, per browser. Not stored preferences: the device reports
+    // its own push endpoint, so these answer 204 rather than redirecting, and
+    // they 404 outright on an instance with no VAPID keypair. Throttled because
+    // an honest client writes once per opt-in, not per page.
+    Route::middleware([EnsureWebPushEnabled::class, 'throttle:30,1'])->group(function (): void {
+        Route::post('settings/push-subscriptions', [PushSubscriptionController::class, 'store'])
+            ->name('push-subscriptions.store');
+        Route::delete('settings/push-subscriptions', [PushSubscriptionController::class, 'destroy'])
+            ->name('push-subscriptions.destroy');
+    });
 
     Route::patch('settings/sidebar-position', [SidebarPositionController::class, 'update'])->name('sidebar-position.update');
 

--- a/tests/Feature/Channels/MessagePushNotificationTest.php
+++ b/tests/Feature/Channels/MessagePushNotificationTest.php
@@ -1,0 +1,314 @@
+<?php
+
+use App\Data\MessageData;
+use App\Enums\ChannelType;
+use App\Enums\NotificationLevel;
+use App\Models\Attachment;
+use App\Models\Channel;
+use App\Models\ChannelMember;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use App\Notifications\NewMessageNotification;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
+
+beforeEach(function (): void {
+    config([
+        'webpush.vapid.public_key' => 'test-public-key',
+        'webpush.vapid.private_key' => 'test-private-key',
+    ]);
+
+    Notification::fake();
+});
+
+/**
+ * Give the user a subscribed device, so the fan-out considers them at all.
+ */
+function subscribeDevice(User $user): User
+{
+    $user->updatePushSubscription(
+        'https://push.example.test/'.Str::uuid(),
+        'public-key',
+        'auth-token',
+    );
+
+    return $user;
+}
+
+/**
+ * A team with a channel, its author, and one subscribed recipient at the given
+ * preference.
+ *
+ * @return array{0: User, 1: User, 2: Team, 3: Channel}
+ */
+function pushScenario(NotificationLevel $level = NotificationLevel::All, bool $muted = false): array
+{
+    $team = Team::factory()->create();
+    $author = User::factory()->create(['name' => 'Ada Lovelace']);
+    $recipient = subscribeDevice(User::factory()->create());
+
+    $team->members()->attach([$author->id => ['role' => 'member'], $recipient->id => ['role' => 'member']]);
+
+    $channel = Channel::factory()->create(['team_id' => $team->id, 'name' => 'deploys', 'slug' => 'deploys']);
+
+    foreach ([$author, $recipient] as $member) {
+        ChannelMember::factory()->create([
+            'channel_id' => $channel->id,
+            'user_id' => $member->id,
+            'muted' => $member->is($recipient) && $muted,
+            'notification_level' => $member->is($recipient) ? $level : NotificationLevel::All,
+        ]);
+    }
+
+    return [$author, $recipient, $team, $channel];
+}
+
+/**
+ * Post a message as the author through the real send endpoint.
+ */
+function postPushMessage(User $author, Team $team, Channel $channel, string $body): void
+{
+    test()->actingAs($author)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
+            'body' => $body,
+            'client_uuid' => (string) Str::uuid7(),
+        ])
+        ->assertRedirect();
+}
+
+test('a new channel message pushes to a subscribed member', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario();
+
+    postPushMessage($author, $team, $channel, 'Standing up the new deploy');
+
+    Notification::assertSentTo($recipient, NewMessageNotification::class);
+});
+
+test('the author is never pushed about their own message', function (): void {
+    [$author, , $team, $channel] = pushScenario();
+    subscribeDevice($author);
+
+    postPushMessage($author, $team, $channel, 'Talking to myself');
+
+    Notification::assertNotSentTo($author, NewMessageNotification::class);
+});
+
+test('a muted channel never pushes', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario(muted: true);
+
+    postPushMessage($author, $team, $channel, 'Quiet in here');
+
+    Notification::assertNotSentTo($recipient, NewMessageNotification::class);
+});
+
+test('ordinary traffic stays silent at the mentions level', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario(NotificationLevel::Mentions);
+
+    postPushMessage($author, $team, $channel, 'Just chatter');
+
+    Notification::assertNotSentTo($recipient, NewMessageNotification::class);
+});
+
+test('a mention pushes at the mentions level', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario(NotificationLevel::Mentions);
+
+    postPushMessage($author, $team, $channel, "@[{$recipient->name}]({$recipient->id}) can you look?");
+
+    Notification::assertSentTo($recipient, NewMessageNotification::class);
+});
+
+test('the nothing level silences even a mention', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario(NotificationLevel::Nothing);
+
+    postPushMessage($author, $team, $channel, "@[{$recipient->name}]({$recipient->id}) hello?");
+
+    Notification::assertNotSentTo($recipient, NewMessageNotification::class);
+});
+
+test('do-not-disturb suppresses the push', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario();
+    $recipient->forceFill(['dnd_until' => now()->addHour()])->save();
+
+    postPushMessage($author, $team, $channel, 'Deploy is green');
+
+    Notification::assertNotSentTo($recipient, NewMessageNotification::class);
+});
+
+test('a member with no subscribed device is never queued a notification', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario();
+    $recipient->pushSubscriptions()->delete();
+
+    postPushMessage($author, $team, $channel, 'Nobody to reach');
+
+    Notification::assertNothingSent();
+});
+
+test('a deactivated member is not pushed to', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario();
+    $recipient->forceFill(['deactivated_at' => now()])->save();
+
+    postPushMessage($author, $team, $channel, 'Gone from the directory');
+
+    Notification::assertNotSentTo($recipient, NewMessageNotification::class);
+});
+
+test('a system notice never pushes', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario();
+
+    $this->actingAs($recipient)
+        ->post(route('channels.leave', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertRedirect();
+
+    Notification::assertNothingSent();
+});
+
+test('nothing is pushed on an instance with no vapid keypair', function (): void {
+    config(['webpush.vapid.public_key' => null, 'webpush.vapid.private_key' => null]);
+
+    [$author, , $team, $channel] = pushScenario();
+
+    postPushMessage($author, $team, $channel, 'No keys, no push');
+
+    Notification::assertNothingSent();
+});
+
+test('a thread-only reply pushes only through the mention path', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario();
+
+    $root = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $author->id,
+    ]);
+
+    $this->actingAs($author)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
+            'body' => 'A quiet thread reply',
+            'client_uuid' => (string) Str::uuid7(),
+            'thread_root_id' => $root->id,
+        ])
+        ->assertRedirect();
+
+    Notification::assertNotSentTo($recipient, NewMessageNotification::class);
+
+    $this->actingAs($author)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
+            'body' => "@[{$recipient->name}]({$recipient->id}) in the thread",
+            'client_uuid' => (string) Str::uuid7(),
+            'thread_root_id' => $root->id,
+        ])
+        ->assertRedirect();
+
+    Notification::assertSentTo($recipient, NewMessageNotification::class);
+});
+
+test('a thread reply also sent to the channel pushes as ordinary traffic', function (): void {
+    [$author, $recipient, $team, $channel] = pushScenario();
+
+    $root = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $author->id,
+    ]);
+
+    $this->actingAs($author)
+        ->post(route('channels.messages.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
+            'body' => 'Sharing this back to the channel',
+            'client_uuid' => (string) Str::uuid7(),
+            'thread_root_id' => $root->id,
+            'sent_to_channel' => true,
+        ])
+        ->assertRedirect();
+
+    Notification::assertSentTo($recipient, NewMessageNotification::class);
+});
+
+test('the banner names the sender and the channel, and links to the message', function (): void {
+    [$author, $recipient, , $channel] = pushScenario();
+
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $author->id,
+        'body' => 'Deploy is green',
+    ]);
+    $message->loadMessageDataRelations();
+
+    $push = (new NewMessageNotification($channel, MessageData::fromMessage($message)))
+        ->toWebPush($recipient)
+        ->toArray();
+
+    expect($push['title'])->toBe('Ada Lovelace in #deploys')
+        ->and($push['body'])->toBe('Deploy is green')
+        ->and($push['tag'])->toBe('channel-'.$channel->id)
+        ->and($push['renotify'])->toBeTrue()
+        ->and($push['icon'])->toBe('/icons/icon-192.png')
+        ->and($push['data']['url'])->toContain('?message='.$message->id)
+        ->and($push['data']['messageId'])->toBe($message->id);
+});
+
+test('a direct message banner is titled by its sender alone', function (): void {
+    [$author, $recipient, $team] = pushScenario();
+
+    $dm = Channel::factory()->create([
+        'team_id' => $team->id,
+        'name' => null,
+        'type' => ChannelType::Direct,
+    ]);
+
+    $message = Message::factory()->create([
+        'channel_id' => $dm->id,
+        'user_id' => $author->id,
+        'body' => 'Got a minute?',
+    ]);
+    $message->loadMessageDataRelations();
+
+    $push = (new NewMessageNotification($dm, MessageData::fromMessage($message)))
+        ->toWebPush($recipient)
+        ->toArray();
+
+    expect($push['title'])->toBe('Ada Lovelace')
+        ->and($push['body'])->toBe('Got a minute?');
+});
+
+test('the preview unwraps mention tokens and truncates a long body', function (): void {
+    [$author, $recipient, , $channel] = pushScenario();
+
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $author->id,
+        'body' => "@[Ada Lovelace]({$author->id}) ".str_repeat('long ', 60),
+    ]);
+    $message->loadMessageDataRelations();
+
+    $body = (new NewMessageNotification($channel, MessageData::fromMessage($message)))
+        ->toWebPush($recipient)
+        ->toArray()['body'];
+
+    expect($body)->toStartWith('@Ada Lovelace long')
+        ->and(mb_strlen((string) $body))->toBeLessThanOrEqual(124);
+});
+
+test('a message with no text of its own describes itself', function (array $attributes, int $attachments, string $expected): void {
+    [$author, $recipient, , $channel] = pushScenario();
+
+    $message = Message::factory()->create([
+        'channel_id' => $channel->id,
+        'user_id' => $author->id,
+        ...$attributes,
+    ]);
+
+    if ($attachments > 0) {
+        Attachment::factory()->count($attachments)->attachedTo($message)->create(['user_id' => $author->id]);
+    }
+
+    $message->loadMessageDataRelations();
+
+    $body = (new NewMessageNotification($channel, MessageData::fromMessage($message)))
+        ->toWebPush($recipient)
+        ->toArray()['body'];
+
+    expect($body)->toBe($expected);
+})->with([
+    'a poll' => [['body' => '', 'type' => 'poll'], 0, 'Posted a poll'],
+    'a single file' => [['body' => ''], 1, 'Sent an attachment'],
+    'several files' => [['body' => ''], 2, 'Sent 2 attachments'],
+]);

--- a/tests/Feature/Settings/PushSubscriptionTest.php
+++ b/tests/Feature/Settings/PushSubscriptionTest.php
@@ -1,0 +1,197 @@
+<?php
+
+use App\Models\User;
+use NotificationChannels\WebPush\PushSubscription;
+
+beforeEach(function (): void {
+    config([
+        'webpush.vapid.public_key' => 'test-public-key',
+        'webpush.vapid.private_key' => 'test-private-key',
+    ]);
+});
+
+/**
+ * The body a browser's `PushSubscription.toJSON()` produces.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function pushSubscriptionPayload(array $overrides = []): array
+{
+    return array_replace([
+        'endpoint' => 'https://fcm.googleapis.com/fcm/send/device-one',
+        'keys' => ['p256dh' => 'device-one-public-key', 'auth' => 'device-one-auth'],
+    ], $overrides);
+}
+
+test('a device can subscribe itself to push notifications', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNoContent();
+
+    $subscription = $user->pushSubscriptions()->sole();
+
+    expect($subscription->endpoint)->toBe('https://fcm.googleapis.com/fcm/send/device-one')
+        ->and($subscription->public_key)->toBe('device-one-public-key')
+        ->and($subscription->auth_token)->toBe('device-one-auth');
+});
+
+test('each device gets its own subscription row', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNoContent();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload([
+            'endpoint' => 'https://fcm.googleapis.com/fcm/send/device-two',
+            'keys' => ['p256dh' => 'device-two-public-key', 'auth' => 'device-two-auth'],
+        ]))
+        ->assertNoContent();
+
+    expect($user->pushSubscriptions()->count())->toBe(2);
+});
+
+test('re-subscribing the same device refreshes its keys instead of duplicating it', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNoContent();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload([
+            'keys' => ['p256dh' => 'rotated-public-key', 'auth' => 'rotated-auth'],
+        ]))
+        ->assertNoContent();
+
+    $subscription = $user->pushSubscriptions()->sole();
+
+    expect($subscription->public_key)->toBe('rotated-public-key')
+        ->and($subscription->auth_token)->toBe('rotated-auth');
+});
+
+test('a negotiated content encoding is stored with the subscription', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload(['contentEncoding' => 'aesgcm']))
+        ->assertNoContent();
+
+    expect($user->pushSubscriptions()->sole()->content_encoding->value)->toBe('aesgcm');
+});
+
+test('signing in on a shared device takes the endpoint over from the previous account', function (): void {
+    $previous = User::factory()->create();
+    $next = User::factory()->create();
+
+    $this->actingAs($previous)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNoContent();
+
+    $this->actingAs($next)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNoContent();
+
+    expect($previous->pushSubscriptions()->count())->toBe(0)
+        ->and($next->pushSubscriptions()->count())->toBe(1);
+});
+
+test('a device can unsubscribe itself without touching the user other devices', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNoContent();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload([
+            'endpoint' => 'https://fcm.googleapis.com/fcm/send/device-two',
+        ]))
+        ->assertNoContent();
+
+    $this->actingAs($user)
+        ->deleteJson(route('push-subscriptions.destroy'), ['endpoint' => 'https://fcm.googleapis.com/fcm/send/device-one'])
+        ->assertNoContent();
+
+    expect($user->pushSubscriptions()->pluck('endpoint')->all())
+        ->toBe(['https://fcm.googleapis.com/fcm/send/device-two']);
+});
+
+test('unsubscribing an endpoint that is already gone is not an error', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->deleteJson(route('push-subscriptions.destroy'), ['endpoint' => 'https://fcm.googleapis.com/fcm/send/nothing'])
+        ->assertNoContent();
+});
+
+test('a user cannot revoke another user subscription', function (): void {
+    $owner = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    $this->actingAs($owner)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNoContent();
+
+    $this->actingAs($stranger)
+        ->deleteJson(route('push-subscriptions.destroy'), ['endpoint' => 'https://fcm.googleapis.com/fcm/send/device-one'])
+        ->assertNoContent();
+
+    expect($owner->pushSubscriptions()->count())->toBe(1);
+});
+
+test('the subscription payload is validated', function (array $payload, string $field): void {
+    $this->actingAs(User::factory()->create())
+        ->postJson(route('push-subscriptions.store'), $payload)
+        ->assertJsonValidationErrorFor($field);
+})->with([
+    'a missing endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => null]), 'endpoint'],
+    'a non-url endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'not-a-url']), 'endpoint'],
+    'an over-long endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'https://push.example.test/'.str_repeat('x', 500)]), 'endpoint'],
+    'a missing public key' => [fn (): array => pushSubscriptionPayload(['keys' => ['auth' => 'auth-only']]), 'keys.p256dh'],
+    'a missing auth token' => [fn (): array => pushSubscriptionPayload(['keys' => ['p256dh' => 'key-only']]), 'keys.auth'],
+    'an unknown content encoding' => [fn (): array => pushSubscriptionPayload(['contentEncoding' => 'rot13']), 'contentEncoding'],
+]);
+
+test('the revoke payload requires an endpoint', function (): void {
+    $this->actingAs(User::factory()->create())
+        ->deleteJson(route('push-subscriptions.destroy'), [])
+        ->assertJsonValidationErrorFor('endpoint');
+});
+
+test('guests cannot manage push subscriptions', function (): void {
+    $this->post(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertRedirect(route('login'));
+});
+
+test('the subscription endpoints do not exist without a vapid keypair', function (): void {
+    config(['webpush.vapid.public_key' => null, 'webpush.vapid.private_key' => null]);
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNotFound();
+
+    $this->actingAs($user)
+        ->deleteJson(route('push-subscriptions.destroy'), ['endpoint' => 'https://fcm.googleapis.com/fcm/send/device-one'])
+        ->assertNotFound();
+});
+
+test('deleting an account takes its push subscriptions with it', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
+        ->assertNoContent();
+
+    $this->actingAs($user)
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertRedirect();
+
+    expect(PushSubscription::count())->toBe(0);
+});

--- a/tests/Feature/Settings/PushSubscriptionTest.php
+++ b/tests/Feature/Settings/PushSubscriptionTest.php
@@ -35,7 +35,11 @@ test('a device can subscribe itself to push notifications', function (): void {
 
     expect($subscription->endpoint)->toBe('https://fcm.googleapis.com/fcm/send/device-one')
         ->and($subscription->public_key)->toBe('device-one-public-key')
-        ->and($subscription->auth_token)->toBe('device-one-auth');
+        ->and($subscription->auth_token)->toBe('device-one-auth')
+        // The published package migration morphs on an integer key; ours is a
+        // uuidMorphs, because every model in this app keys on a UUID string.
+        ->and($subscription->subscribable_id)->toBe($user->id)
+        ->and($subscription->subscribable_type)->toBe($user->getMorphClass());
 });
 
 test('each device gets its own subscription row', function (): void {
@@ -182,16 +186,24 @@ test('the subscription endpoints do not exist without a vapid keypair', function
         ->assertNotFound();
 });
 
-test('deleting an account takes its push subscriptions with it', function (): void {
-    $user = User::factory()->create();
+test('deleting an account takes its push subscriptions with it, and only its own', function (): void {
+    $leaving = User::factory()->create();
+    $staying = User::factory()->create();
 
-    $this->actingAs($user)
+    $this->actingAs($leaving)
         ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload())
         ->assertNoContent();
 
-    $this->actingAs($user)
+    $this->actingAs($staying)
+        ->postJson(route('push-subscriptions.store'), pushSubscriptionPayload([
+            'endpoint' => 'https://fcm.googleapis.com/fcm/send/device-two',
+        ]))
+        ->assertNoContent();
+
+    $this->actingAs($leaving)
         ->delete(route('profile.destroy'), ['password' => 'password'])
         ->assertRedirect();
 
-    expect(PushSubscription::count())->toBe(0);
+    expect(PushSubscription::pluck('endpoint')->all())
+        ->toBe(['https://fcm.googleapis.com/fcm/send/device-two']);
 });

--- a/tests/Feature/Settings/WebPushConfigSharingTest.php
+++ b/tests/Feature/Settings/WebPushConfigSharingTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('the vapid public key is shared to the frontend when push is configured', function (): void {
+    config(['webpush.vapid.public_key' => 'test-public-key', 'webpush.vapid.private_key' => 'test-private-key']);
+
+    $this->get(route('home'))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('webPush.enabled', true)
+            ->where('webPush.publicKey', 'test-public-key')
+        );
+});
+
+test('no push key reaches the frontend when the instance has no vapid keypair', function (): void {
+    config(['webpush.vapid.public_key' => null, 'webpush.vapid.private_key' => null]);
+
+    $this->get(route('home'))
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('webPush.enabled', false)
+            ->where('webPush.publicKey', null)
+        );
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -49,6 +49,10 @@ pest()->extend(TestCase::class)->in('Unit/Support/GiphyClientTest.php');
 // application booted (but no database).
 pest()->extend(TestCase::class)->in('Unit/Support/ReverbConfigTest.php');
 
+// The web push config unit test reads the VAPID config, so it needs the
+// application booted (but no database).
+pest()->extend(TestCase::class)->in('Unit/Support/WebPushConfigTest.php');
+
 // The OpenAPI spec test diffs the document against the live route table, so it
 // needs the application booted (but no database).
 pest()->extend(TestCase::class)->in('Unit/OpenApiSpecTest.php');

--- a/tests/Unit/Support/PushDecisionTest.php
+++ b/tests/Unit/Support/PushDecisionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\NotificationLevel;
+use App\Support\PushDecision;
+
+/**
+ * The default case: ordinary channel traffic reaching an unmuted member at the
+ * "all" level, with no do-not-disturb running. Each test below flips exactly one
+ * input away from it.
+ *
+ * @param  array<string, mixed>  $overrides
+ */
+function pushDecision(array $overrides = []): bool
+{
+    return PushDecision::shouldPush(...array_replace([
+        'isOwnMessage' => false,
+        'isChannelMessage' => true,
+        'mentionsRecipient' => false,
+        'muted' => false,
+        'level' => NotificationLevel::All,
+        'dndActive' => false,
+    ], $overrides));
+}
+
+test('ordinary traffic pushes at the all level', function (): void {
+    expect(pushDecision())->toBeTrue();
+});
+
+test('the author is never pushed about their own message', function (): void {
+    expect(pushDecision(['isOwnMessage' => true]))->toBeFalse();
+});
+
+test('a muted channel never pushes, not even a mention', function (): void {
+    expect(pushDecision(['muted' => true]))->toBeFalse()
+        ->and(pushDecision(['muted' => true, 'mentionsRecipient' => true]))->toBeFalse();
+});
+
+test('do-not-disturb suppresses everything, mentions included', function (): void {
+    expect(pushDecision(['dndActive' => true]))->toBeFalse()
+        ->and(pushDecision(['dndActive' => true, 'mentionsRecipient' => true]))->toBeFalse();
+});
+
+test('ordinary traffic stays silent at the mentions level', function (): void {
+    expect(pushDecision(['level' => NotificationLevel::Mentions]))->toBeFalse();
+});
+
+test('a mention pushes at the mentions level', function (): void {
+    expect(pushDecision(['level' => NotificationLevel::Mentions, 'mentionsRecipient' => true]))->toBeTrue();
+});
+
+test('the nothing level silences ordinary traffic and mentions alike', function (): void {
+    expect(pushDecision(['level' => NotificationLevel::Nothing]))->toBeFalse()
+        ->and(pushDecision(['level' => NotificationLevel::Nothing, 'mentionsRecipient' => true]))->toBeFalse();
+});
+
+test('a thread-only reply does not push as ordinary traffic', function (): void {
+    expect(pushDecision(['isChannelMessage' => false]))->toBeFalse();
+});
+
+test('a thread-only reply still pushes when it mentions the recipient', function (): void {
+    expect(pushDecision(['isChannelMessage' => false, 'mentionsRecipient' => true]))->toBeTrue();
+});

--- a/tests/Unit/Support/WebPushConfigTest.php
+++ b/tests/Unit/Support/WebPushConfigTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\WebPushConfig;
+
+test('web push is configured only when both vapid keys are set', function (): void {
+    config(['webpush.vapid.public_key' => 'public', 'webpush.vapid.private_key' => 'private']);
+
+    expect(WebPushConfig::configured())->toBeTrue();
+});
+
+test('web push is unconfigured when the public key is missing', function (): void {
+    config(['webpush.vapid.public_key' => null, 'webpush.vapid.private_key' => 'private']);
+
+    expect(WebPushConfig::configured())->toBeFalse();
+});
+
+test('web push is unconfigured when the private key is missing', function (): void {
+    config(['webpush.vapid.public_key' => 'public', 'webpush.vapid.private_key' => '']);
+
+    expect(WebPushConfig::configured())->toBeFalse();
+});
+
+test('the frontend payload carries the public key when configured', function (): void {
+    config(['webpush.vapid.public_key' => 'public', 'webpush.vapid.private_key' => 'private']);
+
+    expect(WebPushConfig::forFrontend())->toBe(['enabled' => true, 'publicKey' => 'public']);
+});
+
+test('the frontend payload withholds the public key when unconfigured', function (): void {
+    config(['webpush.vapid.public_key' => 'public', 'webpush.vapid.private_key' => null]);
+
+    expect(WebPushConfig::forFrontend())->toBe(['enabled' => false, 'publicKey' => null]);
+});


### PR DESCRIPTION
Closes #532.

Web push so a message still reaches you with the tab closed. Builds on the service worker #530 registered — its `push` / `notificationclick` handlers land here.

## What ships

- **`laravel-notification-channels/webpush` v11.** `push_subscriptions` migration hand-adapted from the published stub to a `uuidMorphs` (every model here keys on a UUID string, not an integer). `User` uses `HasPushSubscriptions`; `AccountDeleter` drops a leaving user's rows, since a polymorphic column has no foreign key to sweep them.
- **VAPID config + `config/webpush.php`.** `App\Support\WebPushConfig` is the single "is push configured" answer; the public key rides an Inertia shared prop, resolved at runtime the same way `ReverbConfig` is, so one published image serves any operator's keypair.
- **Per-device subscribe/unsubscribe endpoints** (`POST` / `DELETE /settings/push-subscriptions`). Plain 204s, not Inertia redirects: the browser is reporting about *itself*, and whether a device is subscribed is answered by `pushManager.getSubscription()`, so there is no server state to hand back. `EnsureWebPushEnabled` 404s the pair on an instance with no keypair.
- **`App\Support\PushDecision`** — the server-side twin of `resources/js/lib/shouldChime.ts`, unit-tested per branch: skip your own messages, muted channels and do-not-disturb; `all` pushes ordinary traffic, `mentions` only @mentions, `nothing` neither; a thread-only reply alerts only through the mention path. A DM at the default level therefore pushes on every message, and a member who quiets a DM is honoured — the same rule the chime already follows.
- **`SendMessagePushNotifications`** (`ShouldQueue`) fans `MessageSent` out per recipient, narrowing in SQL to members with a live account and at least one subscribed device. `NewMessageNotification` is itself queued, so one slow push service can't hold up the rest. Payload: sender + channel, a mention-unwrapped truncated preview (a poll or caption-less upload describes itself), the app icon, a per-channel `tag`, and the `?message=` deep link.
- **Service worker `push`** shows the banner, collapses per channel via `tag`, and drops it outright while a window of the app is visible — that tab has already chimed. **`notificationclick`** focuses an open window and steers it to the message, or opens one, falling back to a fresh window if `navigate` is refused.
- **Settings toggle** on Appearance & notifications, hidden unless the instance has a keypair *and* the browser can subscribe. Permission is requested only on an explicit toggle; nothing prompts on load or login.

## Testing

- `sail composer test` green at **Total: 100.0 %** (Pint, PHPStan, Rector clean).
- `lint:check`, `format:check`, `types:check`, `test:js` (1228 tests), `build` all green.
- 21 vitest cases over the worker's push/notificationclick handlers, 15 over the browser push lib, 9 unit cases over the gate, 18 feature cases over the endpoints and 19 over the fan-out.
- **Verified in a real browser** (Chromium in the worktree container, synthetic pushes delivered over CDP): the worker activates at `/` and exposes a `PushManager`, the public key reaches the page, the toggle renders and starts off, a push is suppressed while a window is visible, banners are raised once none is, two messages in one channel collapse onto one banner and a second channel gets its own. `pushManager.subscribe()` itself could not be exercised — headless Chromium has no connection to a vendor push service — so that hop is covered by the feature tests instead.

## i18n & docs

- Every new string goes through `__()` / `$t`, with French added to `lang/fr.json`.
- `docs/reference/environment-variables.md` gains a **Web push notifications** section (the `VAPID_*` keys, the `webpush:vapid` command, and why the keypair must stay stable) and `docs/reference/feature-toggles.md` a matching section covering the opt-in model, what gets pushed, and the iOS constraint. `.env.example` documents the keys. Docs site builds.

## Notes

- Installing the package downgrades `brick/math` 0.18 -> 0.17.2, the only version `web-token/jwt-library` accepts; Laravel 13 allows it. Nothing else in the lock moved.
- On iOS, push requires the PWA to be installed to the home screen (16.4+); in a plain Safari tab the toggle does not appear at all. #845 tracks the in-app install button that makes installing discoverable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787517984&installation_model_id=428379&pr_number=849&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F849&signature=6950741f082268e5212b8dc98314b0dd48fff67d82ee87d8d23d6e510ccbc0be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->