### PR TITLE
ci: scan, attest, and digest-pin the published Docker image

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -54,6 +54,29 @@ inputs:
     description: Newline-separated OCI labels for the image.
     required: false
     default: ''
+  provenance:
+    description: >-
+      Whether to attach a build-provenance attestation to the image — `false`,
+      `true`, or a buildx mode such as `mode=max`. Only the registry exporter
+      can carry an attestation, so this must stay off for a `load: true` build:
+      buildx fails such a build rather than quietly dropping the attestation.
+    required: false
+    default: 'false'
+  sbom:
+    description: >-
+      Whether to attach an SBOM attestation to the image. Subject to the same
+      registry-exporter constraint as `provenance`.
+    required: false
+    default: 'false'
+
+# The digest of what was built, so a caller can pin or attest the exact image it
+# just pushed. Only one provider path runs, and a skipped step contributes no
+# output, so the two are coalesced rather than chosen between — the caller does
+# not know which fleet it landed on.
+outputs:
+  digest:
+    description: The digest of the built image, from whichever provider path ran.
+    value: ${{ steps.blacksmith-build.outputs.digest || steps.buildx-build.outputs.digest }}
 
 runs:
   using: composite
@@ -68,6 +91,7 @@ runs:
 
     - name: Build with the Blacksmith builder
       if: startsWith(inputs.runner, 'blacksmith')
+      id: blacksmith-build
       uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2.2.0
       with:
         context: ${{ inputs.context }}
@@ -77,6 +101,8 @@ runs:
         load: ${{ inputs.load }}
         tags: ${{ inputs.tags }}
         labels: ${{ inputs.labels }}
+        provenance: ${{ inputs.provenance }}
+        sbom: ${{ inputs.sbom }}
 
     # ---- GitHub-hosted ----
     - name: Set up buildx
@@ -90,6 +116,7 @@ runs:
     # this path would reintroduce that failure the moment the fleet moved.
     - name: Build with buildx
       if: ${{ ! startsWith(inputs.runner, 'blacksmith') }}
+      id: buildx-build
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: ${{ inputs.context }}
@@ -99,5 +126,7 @@ runs:
         load: ${{ inputs.load }}
         tags: ${{ inputs.tags }}
         labels: ${{ inputs.labels }}
+        provenance: ${{ inputs.provenance }}
+        sbom: ${{ inputs.sbom }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,17 +36,30 @@ jobs:
   build:
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
 
-    # Whether this ref is a release candidate, decided once (see the classify
-    # step) so the image tags and the release notes cannot disagree about it.
     outputs:
+      # Whether this ref is a release candidate, decided once (see the classify
+      # step) so the image tags and the release notes cannot disagree about it.
       is_candidate: ${{ steps.tag.outputs.is_candidate }}
+      # The digest of the image this run pushed. Tags are mutable, so this is
+      # the only reference an operator can pin and be sure of; the release-note
+      # job below can only offer it if the build hands it over (#836).
+      digest: ${{ steps.publish.outputs.digest }}
 
     # `contents: read` to check out; `packages: write` to publish to GHCR. The
     # push steps below only run for master / `v*`-tag pushes, so PR and fork code
     # is built but never published.
+    #
+    # `id-token` + `attestations` are what `actions/attest-build-provenance`
+    # signs and records the provenance with; `security-events` is what lets the
+    # vulnerability scan reach the code-scanning tab. On a fork PR the token is
+    # read-only regardless, and both the attest and publish steps are gated on
+    # PUBLISH anyway.
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
+      security-events: write
 
     # Publish on a push to master (moving `edge` tag) or to a `v*` release tag
     # (created by release-please). Everything else — pull requests and pushes to
@@ -69,6 +82,9 @@ jobs:
       # run turned each PECL outage into a red build on a commit that changed
       # nothing (#626). Cached, that layer is only rebuilt when the Dockerfile
       # lines above it actually change.
+      # `load: true` rather than a build straight into the cache: the scan below
+      # needs a real image in the local daemon to point at, and validating a
+      # build whose contents nobody looks at is half the job (#836).
       - name: Build production image
         if: env.PUBLISH != 'true'
         uses: ./.github/actions/docker-build
@@ -78,7 +94,76 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64
           push: false
+          load: true
           tags: the-desk:ci
+
+      # Deliberately non-blocking (`exit-code: 0`). Most of what turns up here
+      # is a base-image or OS-package CVE with no fixed version published yet —
+      # failing on those would red a PR that changed nothing and teach everyone
+      # to ignore the check. `ignore-unfixed` keeps the report to what a rebuild
+      # or a pin can actually resolve. Tighten to a failing CRITICAL gate once
+      # the baseline is clean.
+      - name: Scan the built image for known vulnerabilities
+        if: env.PUBLISH != 'true'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: the-desk:ci
+          format: sarif
+          output: trivy-results.sarif
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '0'
+
+      # The code-scanning tab is what gives the findings history and dedup: the
+      # same CVE across ten runs is one alert that closes itself when a rebuild
+      # drops it, rather than ten run logs nobody re-reads.
+      #
+      # Skipped for a pull request from a fork: that run's token is read-only
+      # whatever the job asks for, so the upload would 403 and red a
+      # contributor's PR. The scan itself still runs, and its table is still on
+      # the run summary below, which is what a reviewer reads anyway.
+      - name: Upload the scan to code scanning
+        if: env.PUBLISH != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image
+
+      # `skip-setup-trivy` and the shared cache: the scan above already
+      # installed the binary and pulled the vulnerability database, and pulling
+      # it twice is what runs into the registry's rate limit.
+      - name: Re-render the scan as a table
+        if: env.PUBLISH != 'true'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: the-desk:ci
+          format: table
+          output: trivy-report.txt
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '0'
+          skip-setup-trivy: true
+
+      # Findings belong on the run that produced them, not only behind the
+      # Security tab, which most reviewers never open on a PR.
+      - name: Publish the scan to the run summary
+        if: env.PUBLISH != 'true'
+        run: |
+          set -euo pipefail
+
+          {
+            echo '### 🔎 Image vulnerability scan'
+            echo
+            echo '`the-desk:ci` — CRITICAL and HIGH, fixed vulnerabilities only.'
+            echo
+            echo '```'
+            if [ -s trivy-report.txt ]; then
+              cat trivy-report.txt
+            else
+              echo 'No fixed CRITICAL or HIGH vulnerabilities found.'
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # Decide once whether this tag is a candidate, and decide it strictly.
       # A substring test for `-rc.` would also match a tag that merely contains
@@ -136,8 +221,18 @@ jobs:
       # amd64 only for now (arm64 emulation is deferred — see #205). No VITE_*
       # build args: the app name and browser-facing Reverb settings are served to
       # the SPA at runtime, so this single image works for any operator's host.
+      #
+      # `provenance: mode=max` and `sbom: true` ride along with the push: they
+      # are exported as OCI attestation manifests beside the image, so
+      # `docker buildx imagetools inspect` hands an operator the SBOM and the
+      # build record without trusting anything but the registry. `mode=max`
+      # rather than the default `min` because `min` records only the materials,
+      # which says nothing about *how* the image was built. Both are only ever
+      # set on this path — the docker exporter that `load: true` uses cannot
+      # represent an attestation, and buildx fails such a build outright.
       - name: Build and push image
         if: env.PUBLISH == 'true'
+        id: publish
         uses: ./.github/actions/docker-build
         with:
           runner: ${{ vars.CI_RUNNER }}
@@ -147,6 +242,21 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+
+      # The buildx attestations above prove what is in the image; this one
+      # proves *this repository's CI* built it, signed through OIDC and
+      # verifiable with a single `gh attestation verify` — no buildx, no jq, no
+      # trust in the tag. `push-to-registry` puts it beside the image as well,
+      # so it survives an operator who only ever talks to GHCR.
+      - name: Attest the published image
+        if: env.PUBLISH == 'true'
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.publish.outputs.digest }}
+          push-to-registry: true
 
   # release-please creates the GitHub Release (CHANGELOG body + `v*` tag) BEFORE
   # the image exists — that tag is exactly what triggers the publish above. So
@@ -181,6 +291,10 @@ jobs:
           # Taken from `build` rather than re-derived here, so the warning on the
           # notes and the moving `rc` image tag can never disagree.
           IS_CANDIDATE: ${{ needs.build.outputs.is_candidate }}
+          # Likewise the digest: it is what the push actually produced, so it
+          # cannot be re-derived from the tag. Empty means the publish step did
+          # not report one, in which case the notes fall back to the tag alone.
+          DIGEST: ${{ needs.build.outputs.digest }}
         run: |
           set -euo pipefail
 
@@ -210,8 +324,22 @@ jobs:
             heading="$(printf '### 🚧 Release candidate\n\nThis is a **release candidate**, published for testing ahead of %s. It is **not supported for production** — run it against a copy of your data, not your live workspace, and expect it to be superseded without notice. Self-hosters should stay on the [latest stable release](https://github.com/%s/releases/latest).' "${version%%-rc.*}" "$REPO")"
           fi
 
+          # A tag is mutable — `X.Y.Z` can be repushed, and `latest` certainly
+          # will be. The digest is the only reference that cannot move under an
+          # operator once they pin it, and it is also what `gh attestation
+          # verify` checks the CI provenance against. Offer both ready to paste
+          # rather than sending them to the package page to dig the digest out
+          # by hand. Skipped if the publish reported no digest, so the notes
+          # degrade to the tag alone rather than to a broken reference.
+          pin=""
+          if [ -n "${DIGEST:-}" ]; then
+            digest_ref="ghcr.io/${REPO}@${DIGEST}"
+            # shellcheck disable=SC2016  # printf format is intentionally literal; values are the %s args.
+            pin="$(printf 'Pin by digest for a reference that cannot move, and verify the image was built by this repository:\n\n```\n%s\n\ngh attestation verify oci://%s --repo %s\n```\n' "$digest_ref" "$digest_ref" "$REPO")"
+          fi
+
           # shellcheck disable=SC2016  # printf format is intentionally literal; values are the %s args.
-          note="$(printf '\n\n%s\n\n---\n\n%s\n\n### 📦 Docker image\n\nThis release is published to the GitHub Container Registry:\n\n```\n%s\n```\n\nPull it directly or browse the [package page](%s). See the [upgrade guide](https://docs.thedeskhq.app/self-hosting/upgrading/) for self-hosting steps.\n' "$marker" "$heading" "$image" "$package_url")"
+          note="$(printf '\n\n%s\n\n---\n\n%s\n\n### 📦 Docker image\n\nThis release is published to the GitHub Container Registry:\n\n```\n%s\n```\n\n%s\n\nPull it directly or browse the [package page](%s). See the [upgrade guide](https://docs.thedeskhq.app/self-hosting/upgrading/) for self-hosting steps.\n' "$marker" "$heading" "$image" "$pin" "$package_url")"
 
           gh release edit "$TAG" --repo "$REPO" --notes "${body}${note}"
           echo "Linked $image on release $TAG."

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,122 @@
+name: image-scan
+
+# The image published to GHCR is what self-hosters actually run, and its base
+# image and OS packages acquire CVEs without a single commit landing in this
+# repository. The scan on the build path only ever looks at what a change
+# produced, so between releases nothing looks at the image people are running
+# (#836). This does: once a week, against the two moving tags, reporting into
+# one rolling issue the way extension-pins.yml reports a stale pin.
+
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  scan-published-images:
+    name: Scan the published images
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+
+    permissions:
+      contents: read
+      # Anonymous pulls from GHCR are rate limited; the job token is not.
+      packages: read
+      # The scan reports by opening an issue.
+      issues: write
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The binary rather than the per-image action: both tags are scanned in
+      # one loop below, and one rolling issue has to weigh them together.
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+
+      - name: Scan each published tag and report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ghcr.io/${{ github.repository }}
+          TITLE: "fix: patch the vulnerabilities found in the published image"
+        run: |
+          set -euo pipefail
+
+          findings=''
+
+          # `latest` is what most operators run and `rc` is what candidate
+          # testers run, and a disclosure can reach either one first. `rc` is
+          # absent until the first candidate of a cycle is published, so a
+          # missing tag is skipped rather than failed — the alternative is a
+          # red scheduled run that says nothing about the image's security.
+          for tag in latest rc; do
+            reference="${IMAGE}:${tag}"
+
+            if ! docker manifest inspect "$reference" >/dev/null 2>&1; then
+              echo "${reference}: not published yet, skipping"
+              continue
+            fi
+
+            # --ignore-unfixed: an unfixed upstream CVE is not something this
+            # repository can act on, and an issue nobody can close is noise.
+            trivy image \
+              --severity CRITICAL,HIGH \
+              --ignore-unfixed \
+              --format json \
+              --output "scan-${tag}.json" \
+              "$reference"
+
+            count="$(jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0' "scan-${tag}.json")"
+
+            if [ "$count" -eq 0 ]; then
+              echo "${reference}: clean"
+              continue
+            fi
+
+            echo "${reference}: ${count} fixable CRITICAL/HIGH vulnerabilities"
+
+            table="$(jq -r '
+              [.Results[]?.Vulnerabilities // [] | .[]]
+              | sort_by(.Severity, .VulnerabilityID)
+              | .[]
+              | "| \(.VulnerabilityID) | \(.Severity) | \(.PkgName) | \(.InstalledVersion) | \(.FixedVersion // "n/a") |"
+            ' "scan-${tag}.json")"
+
+            findings="${findings}#### \`${reference}\`"$'\n\n'
+            findings="${findings}| CVE | Severity | Package | Installed | Fixed in |"$'\n'
+            findings="${findings}| --- | --- | --- | --- | --- |"$'\n'
+            findings="${findings}${table}"$'\n\n'
+          done
+
+          # One rolling issue: comment on the open one rather than filing a
+          # duplicate every week the image stays vulnerable, and close it once a
+          # rebuild has cleared them so a current repo has no stale alarm open.
+          existing="$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')"
+
+          if [ -z "$findings" ]; then
+            echo 'every published tag is clean'
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --comment 'The published images no longer report any fixable CRITICAL or HIGH vulnerability.'
+            fi
+            exit 0
+          fi
+
+          # printf rather than a quoted literal: this whole script is a YAML
+          # block scalar, so an indented body would reach GitHub as a markdown
+          # code block.
+          body="$(printf '%s\n\n%s\n%s\n\n%s\n' \
+            'The published images carry known vulnerabilities with a fixed version available:' \
+            "$findings" \
+            'Most are base-image or OS-package CVEs: rebuilding the image on a current base usually clears them. Anything left needs a pin bumped in `Dockerfile`.' \
+            'Opened by `.github/workflows/image-scan.yml`.')"
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$TITLE" --label tech-debt --label area:security --body "$body"
+          fi

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Scan each published tag and report
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job never checks the repository out — it only talks to a
+          # registry — so `gh` has no remote to infer the repository from and
+          # every issue command below would fail without this.
+          GH_REPO: ${{ github.repository }}
           IMAGE: ghcr.io/${{ github.repository }}
           TITLE: "fix: patch the vulnerabilities found in the published image"
         run: |

--- a/docs/src/content/docs/reference/security.md
+++ b/docs/src/content/docs/reference/security.md
@@ -34,12 +34,42 @@ findings surface in the repository's **Security** tab:
 | **Dependency review** | Every pull request                        | Blocks introducing a dependency that has a known advisory.                |
 | **Dependabot**        | Weekly, and on new advisories             | Opens PRs to update vulnerable or outdated dependencies.                  |
 | **Secret scanning**   | Continuous, with push protection          | Detects committed credentials and blocks pushes that contain them.        |
+| **Image scanning**    | On every image build, plus weekly         | Scans the production container image for known CVEs with a fix available. |
 
 :::note
 CodeQL does not support PHP, so the Laravel backend is covered by PHPStan
 (Larastan), Rector, and Dependabot rather than CodeQL. See the project's quality
 gates in the repository for details.
 :::
+
+The weekly image scan matters for a reason the others do not cover: a CVE in the
+base image or its OS packages appears without a single commit landing in this
+repository, so a check that only runs on changes would never see it. When the
+published `latest` or `rc` image picks one up, the scan opens a tracking issue
+and closes it once a rebuild has cleared it.
+
+## Supply chain of the published image
+
+The image published to `ghcr.io/deskhq/the-desk` is built only by this
+repository's CI, and every published image carries:
+
+- a **signed build provenance** attestation, recorded with GitHub and pushed
+  alongside the image, so you can prove which workflow and which commit produced
+  it;
+- an in-registry **provenance** record and an **SBOM**, attached as OCI
+  attestation manifests and readable with `docker buildx imagetools inspect`.
+
+Verify an image before running it:
+
+```bash
+gh attestation verify oci://ghcr.io/deskhq/the-desk:X.Y.Z \
+  --repo deskhq/the-desk
+```
+
+Stable release notes also publish the image **digest** next to the tag, so an
+operator whose change-control process requires an immutable reference can pin to
+it. See
+[Verify the image, and pin it by digest](/self-hosting/installation/#verify-the-image-and-pin-it-by-digest).
 
 ## HTTPS is pinned once it is available
 

--- a/docs/src/content/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/self-hosting/installation.md
@@ -82,9 +82,10 @@ gh attestation verify oci://ghcr.io/deskhq/the-desk:$APP_VERSION \
   --repo deskhq/the-desk
 ```
 
-A pass tells you the image was built by a workflow in `deskhq/the-desk`, on a
-GitHub-hosted runner, from the commit the release was cut at. A failure means the
-image did not come from here: do not run it.
+A pass tells you the image was built by a workflow in `deskhq/the-desk`, from the
+commit the release was cut at. A failure means the image did not come from here:
+do not run it. If you set `APP_IMAGE` yourself, verify that reference instead,
+since it is what the stack actually runs.
 
 Inspect the attached SBOM and provenance without any extra tooling:
 
@@ -113,8 +114,12 @@ docker buildx imagetools inspect ghcr.io/deskhq/the-desk:$APP_VERSION \
   --format '{{ .Manifest.Digest }}'
 ```
 
-The trade-off is that upgrades become a digest swap rather than an `APP_VERSION`
-bump, so `upgrade.sh` no longer knows what to target. Pin by digest if your
+You do not lose `upgrade.sh` by doing this. An upgrade becomes two steps instead
+of one: set `APP_IMAGE` to the new release's digest, then run
+`./docker/upgrade.sh --target=X.Y.Z /srv/backups` naming that same release. The
+script still takes the backup, still runs the migrations, and still verifies that
+the instance came back reporting the version you asked for, because `APP_VERSION`
+and the pinned digest describe the same image. Pin by digest if your
 change-control process needs it; stay on `APP_VERSION` otherwise.
 
 ## The COMPOSE_FILE variable

--- a/docs/src/content/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/self-hosting/installation.md
@@ -66,6 +66,57 @@ To run a tag on another registry, an air-gapped mirror, or a floating tag like
 `APP_VERSION` entirely. Upgrades bump `APP_VERSION` and restart — see
 [Upgrading](/self-hosting/upgrading/).
 
+## Verify the image, and pin it by digest
+
+Every published image is built by this repository's CI, which attaches three
+things to it: a **signed build provenance** attestation, an in-registry
+**provenance** record, and an **SBOM** listing what is inside. You do not have to
+use any of them, but if your policy asks where a container came from, this is the
+answer.
+
+Verify that an image really was built by this repository, using the
+[GitHub CLI](https://cli.github.com/):
+
+```bash
+gh attestation verify oci://ghcr.io/deskhq/the-desk:$APP_VERSION \
+  --repo deskhq/the-desk
+```
+
+A pass tells you the image was built by a workflow in `deskhq/the-desk`, on a
+GitHub-hosted runner, from the commit the release was cut at. A failure means the
+image did not come from here: do not run it.
+
+Inspect the attached SBOM and provenance without any extra tooling:
+
+```bash
+docker buildx imagetools inspect ghcr.io/deskhq/the-desk:$APP_VERSION \
+  --format '{{ json .SBOM }}'
+```
+
+### Pinning by digest
+
+Tags are mutable. `latest` moves every release by design, and even `X.Y.Z` is a
+pointer that could in principle be repushed. A digest is content-addressed, so it
+can never resolve to different bytes later:
+
+```
+APP_IMAGE=ghcr.io/deskhq/the-desk@sha256:0123456789abcdef...
+```
+
+Set that in `.env` and it overrides `APP_VERSION`, exactly like a tag would.
+Every stable release's notes carry the digest for that version, ready to paste,
+next to the tag-based pull reference. You can also read it back from a registry
+at any time:
+
+```bash
+docker buildx imagetools inspect ghcr.io/deskhq/the-desk:$APP_VERSION \
+  --format '{{ .Manifest.Digest }}'
+```
+
+The trade-off is that upgrades become a digest swap rather than an `APP_VERSION`
+bump, so `upgrade.sh` no longer knows what to target. Pin by digest if your
+change-control process needs it; stay on `APP_VERSION` otherwise.
+
 ## The COMPOSE_FILE variable
 
 Production commands on this site are a bare `docker compose`, with no

--- a/docs/src/content/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/self-hosting/upgrading.md
@@ -130,6 +130,32 @@ Useful flags:
 | `--sync-env` | Append any [new settings](#new-settings-in-a-release) to `.env` without asking, for unattended runs that should adopt the template defaults. |
 | `--no-sync-env` | Skip the new-settings check entirely. |
 
+### Verify the image you are upgrading to
+
+Every published image carries a signed build provenance attestation, so you can
+confirm it was built by this repository's CI before you run it. With the
+[GitHub CLI](https://cli.github.com/):
+
+```bash
+gh attestation verify oci://ghcr.io/deskhq/the-desk:X.Y.Z \
+  --repo deskhq/the-desk
+```
+
+A pass means the image was produced by a workflow in `deskhq/the-desk` from the
+commit that release was cut at. A failure means it was not: stop and do not
+upgrade. The image also carries an SBOM, readable with
+`docker buildx imagetools inspect ... --format '{{ json .SBOM }}'`.
+
+Every stable release's notes include the image **digest** next to the tag, for
+example `ghcr.io/deskhq/the-desk@sha256:0123...`. A digest is content-addressed
+and can never resolve to different bytes later, unlike a tag. If your
+change-control process needs that guarantee, set the digest as `APP_IMAGE` in
+`.env` instead of letting `APP_VERSION` pick the tag. Note that `upgrade.sh`
+targets versions, not digests, so a digest-pinned install upgrades by editing
+`APP_IMAGE` and restarting. See
+[Verify the image, and pin it by digest](/self-hosting/installation/#verify-the-image-and-pin-it-by-digest)
+for the full detail.
+
 ### New settings in a release
 
 A new release often introduces settings — a feature toggle, a new tunable — that

--- a/docs/src/content/docs/self-hosting/upgrading.md
+++ b/docs/src/content/docs/self-hosting/upgrading.md
@@ -150,9 +150,14 @@ Every stable release's notes include the image **digest** next to the tag, for
 example `ghcr.io/deskhq/the-desk@sha256:0123...`. A digest is content-addressed
 and can never resolve to different bytes later, unlike a tag. If your
 change-control process needs that guarantee, set the digest as `APP_IMAGE` in
-`.env` instead of letting `APP_VERSION` pick the tag. Note that `upgrade.sh`
-targets versions, not digests, so a digest-pinned install upgrades by editing
-`APP_IMAGE` and restarting. See
+`.env` instead of letting `APP_VERSION` pick the tag.
+
+Upgrading a digest-pinned install is two steps rather than one: set `APP_IMAGE`
+to the new release's digest, then run `./docker/upgrade.sh --target=X.Y.Z
+/srv/backups` naming that same release. Do not just swap the digest and restart:
+the script is what takes the backup, waits for `/up`, and confirms the instance
+came back reporting the version you asked for. Because `APP_VERSION` and the
+pinned digest describe the same image, that verification still holds. See
 [Verify the image, and pin it by digest](/self-hosting/installation/#verify-the-image-and-pin-it-by-digest)
 for the full detail.
 

--- a/tests/Unit/ImageSupplyChainTest.php
+++ b/tests/Unit/ImageSupplyChainTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * The published image is the artifact self-hosters actually run, and nothing in
+ * this repository changes when a CVE lands in its base image or OS packages. So
+ * the supply chain around it is guarded here rather than left to review (#836):
+ * every published image carries provenance and an SBOM, every build is scanned,
+ * a scheduled scan catches what is disclosed between releases, and the release
+ * notes offer a digest an operator can pin to.
+ *
+ * These are file assertions, not a CI run — the workflows themselves only ever
+ * execute on GitHub. What they buy is that a step deleted or renamed in passing
+ * fails here instead of silently un-hardening the image.
+ */
+function supplyChainWorkflow(string $name): array
+{
+    return Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/'.$name.'.yml');
+}
+
+/**
+ * The `on:` block of a workflow. YAML 1.1 reads a bare `on` as the boolean key
+ * `true`, which is what Symfony's parser follows.
+ */
+function supplyChainTriggers(array $workflow): array
+{
+    return $workflow[true] ?? $workflow['on'];
+}
+
+function supplyChainBuildAction(): array
+{
+    return Yaml::parseFile(dirname(__DIR__, 2).'/.github/actions/docker-build/action.yml');
+}
+
+/**
+ * @return Collection<int, array<string, mixed>>
+ */
+function supplyChainSteps(string $workflow, string $job): Collection
+{
+    return collect(supplyChainWorkflow($workflow)['jobs'][$job]['steps'] ?? []);
+}
+
+/**
+ * Every call into the composite action made by the given job.
+ *
+ * @return Collection<int, array<string, mixed>>
+ */
+function supplyChainImageBuilds(string $workflow, string $job): Collection
+{
+    return supplyChainSteps($workflow, $job)
+        ->filter(static fn (array $step): bool => ($step['uses'] ?? null) === './.github/actions/docker-build');
+}
+
+function supplyChainStepUsing(string $workflow, string $job, string $action): ?array
+{
+    return supplyChainSteps($workflow, $job)
+        ->first(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), $action));
+}
+
+/**
+ * Every `run:` script in a job, concatenated — the shell is where the rolling
+ * issue and the release-note editing actually live.
+ */
+function supplyChainRunScripts(string $workflow, string $job): string
+{
+    return supplyChainSteps($workflow, $job)->pluck('run')->filter()->implode("\n");
+}
+
+test('the composite action can attach provenance and an SBOM to what it pushes', function (): void {
+    $action = supplyChainBuildAction();
+
+    expect($action['inputs'])->toHaveKeys(['provenance', 'sbom']);
+
+    // Off unless a call site asks for them: the docker exporter cannot carry an
+    // attestation, so a `load: true` build fails outright if either is on.
+    expect($action['inputs']['provenance']['default'] ?? null)->toBe('false')
+        ->and($action['inputs']['sbom']['default'] ?? null)->toBe('false');
+});
+
+test('the composite action reports the digest of whichever path built the image', function (): void {
+    $value = supplyChainBuildAction()['outputs']['digest']['value'] ?? '';
+
+    // A skipped step contributes no output, so the two provider paths are
+    // coalesced rather than picked between — the caller cannot know which ran,
+    // which is what the `||` is doing there.
+    expect($value)
+        ->toContain('.outputs.digest')
+        ->toContain('||');
+});
+
+test('both provider paths attach the same attestations', function (string $input): void {
+    $builds = collect(supplyChainBuildAction()['runs']['steps'])
+        ->filter(static fn (array $step): bool => str_contains((string) ($step['uses'] ?? ''), '/build-push-action@'));
+
+    expect($builds)->toHaveCount(2);
+
+    foreach ($builds as $build) {
+        expect($build['with'][$input] ?? null)
+            ->toBe('${{ inputs.'.$input.' }}', $build['uses'].' drops the '.$input.' input, so the published image would depend on which fleet built it');
+    }
+})->with(['provenance', 'sbom']);
+
+test('the published image is built with provenance and an SBOM', function (): void {
+    $publish = supplyChainImageBuilds('docker', 'build')
+        ->first(static fn (array $step): bool => ($step['with']['push'] ?? false) === true);
+
+    expect($publish)->not->toBeNull('the publish path must still build through the composite action');
+
+    // `mode=max` rather than the default `mode=min`: min records only the
+    // materials, which tells an operator nothing about how the image was built.
+    expect($publish['with']['provenance'] ?? null)->toBe('mode=max')
+        ->and($publish['with']['sbom'] ?? null)->toBeTrue();
+});
+
+test('no build that loads into the local daemon asks for an attestation', function (): void {
+    $loads = collect(supplyChainWorkflow('docker')['jobs'])
+        ->flatMap(static fn (array $job): array => $job['steps'] ?? [])
+        ->filter(static fn (array $step): bool => ($step['uses'] ?? null) === './.github/actions/docker-build')
+        ->filter(static fn (array $step): bool => ($step['with']['load'] ?? false) === true);
+
+    expect($loads)->not->toBeEmpty('the backup/upgrade jobs still build into the daemon');
+
+    // The docker exporter has no way to represent an attestation, so buildx
+    // fails the build rather than dropping it. Keeping these off is what lets
+    // the publish path turn them on.
+    foreach ($loads as $step) {
+        expect($step['with']['provenance'] ?? 'false')->toBe('false')
+            ->and($step['with']['sbom'] ?? 'false')->toBe('false');
+    }
+});
+
+test('the publish job attests the pushed image to the registry', function (): void {
+    $attest = supplyChainStepUsing('docker', 'build', 'actions/attest-build-provenance@');
+
+    expect($attest)->not->toBeNull('nothing produces an attestation verifiable with `gh attestation verify`');
+
+    expect($attest['with']['subject-name'] ?? null)->toBe('ghcr.io/${{ github.repository }}')
+        ->and($attest['with']['subject-digest'] ?? '')->toContain('.outputs.digest')
+        // Without this the attestation only lives in the API, so an operator
+        // pulling the image has nothing attached to inspect.
+        ->and($attest['with']['push-to-registry'] ?? null)->toBeTrue();
+});
+
+test('the publish job holds the scopes attesting and scanning need', function (): void {
+    $permissions = supplyChainWorkflow('docker')['jobs']['build']['permissions'];
+
+    expect($permissions)
+        ->toHaveKey('packages', 'write')
+        // The attestation is signed through OIDC and recorded against the repo.
+        ->toHaveKey('id-token', 'write')
+        ->toHaveKey('attestations', 'write')
+        // The scan below reports into the code-scanning tab.
+        ->toHaveKey('security-events', 'write');
+});
+
+test('the build-only path loads the image so there is something to scan', function (): void {
+    $build = supplyChainImageBuilds('docker', 'build')
+        ->first(static fn (array $step): bool => ($step['with']['push'] ?? false) !== true);
+
+    expect($build)->not->toBeNull()
+        // Without this the image only ever exists in the builder's cache, and
+        // the scanner has nothing to point at.
+        ->and($build['with']['load'] ?? null)->toBeTrue()
+        ->and($build['with']['tags'] ?? null)->toBe('the-desk:ci');
+});
+
+test('the build-only path scans the image it just built', function (): void {
+    $scans = supplyChainSteps('docker', 'build')
+        ->filter(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), 'aquasecurity/trivy-action@'));
+
+    expect($scans)->not->toBeEmpty('nothing scans the freshly built image');
+
+    foreach ($scans as $scan) {
+        expect($scan['with']['image-ref'] ?? null)->toBe('the-desk:ci')
+            // Non-blocking for now: the point is visibility, and a base-image
+            // CVE with no fix available must not red a PR that changed nothing.
+            ->and((string) ($scan['with']['exit-code'] ?? '0'))->toBe('0');
+    }
+
+    $sarif = supplyChainStepUsing('docker', 'build', 'github/codeql-action/upload-sarif@');
+    expect($sarif)->not->toBeNull('the findings must reach the code-scanning tab, where they dedupe and carry history');
+
+    // A fork's token is read-only whatever the job asks for, so an unguarded
+    // upload 403s and reds an external contributor's pull request.
+    expect($sarif['if'] ?? '')->toContain('github.event.pull_request.head.repo.full_name == github.repository');
+
+    // Readable on the run itself, not only behind the Security tab, which most
+    // reviewers never open on a PR.
+    expect(supplyChainRunScripts('docker', 'build'))->toContain('GITHUB_STEP_SUMMARY');
+});
+
+test('the build job publishes the digest of the image it pushed', function (): void {
+    $outputs = supplyChainWorkflow('docker')['jobs']['build']['outputs'];
+
+    // The release-note job below can only pin by digest if the build hands it
+    // one; the push is the only place it exists.
+    expect($outputs['digest'] ?? '')->toContain('.outputs.digest');
+});
+
+test('the release notes offer an immutable digest reference beside the tag', function (): void {
+    $job = supplyChainWorkflow('docker')['jobs']['link-release-image'];
+    $step = collect($job['steps'])->firstWhere(fn (array $step): bool => isset($step['run']));
+
+    expect($step['env']['DIGEST'] ?? null)->toBe('${{ needs.build.outputs.digest }}');
+
+    $run = (string) $step['run'];
+
+    // Tags are mutable; the digest is the only reference that cannot be moved
+    // under an operator after they pin it.
+    expect($run)
+        ->toContain('${REPO}@${DIGEST}')
+        // Still one appended block, still guarded by the marker: a re-run of the
+        // publish must not append a second copy.
+        ->toContain('ghcr-image-link')
+        ->toContain('grep -qF "$marker"');
+});
+
+test('a scheduled scan watches the images that are already published', function (): void {
+    $triggers = supplyChainTriggers(supplyChainWorkflow('image-scan'));
+
+    expect($triggers['schedule'][0]['cron'] ?? null)->toBeString()
+        // On demand too, so a disclosure can be checked without waiting a week.
+        ->and(array_key_exists('workflow_dispatch', $triggers))->toBeTrue();
+
+    $job = supplyChainWorkflow('image-scan')['jobs']['scan-published-images'];
+
+    expect($job['permissions']['issues'] ?? null)->toBe('write', 'the scan reports by opening an issue');
+
+    $step = collect($job['steps'])->last(fn (array $step): bool => isset($step['run']));
+
+    // Tracks the repository rather than a literal name, so a rename does not
+    // leave the scan pointed at a package that no longer moves.
+    expect($step['env']['IMAGE'] ?? null)->toBe('ghcr.io/${{ github.repository }}');
+
+    $run = supplyChainRunScripts('image-scan', 'scan-published-images');
+
+    // Both moving tags: `latest` is what most operators run, `rc` is what the
+    // candidate testers run, and a CVE can reach either first.
+    expect($run)
+        ->toContain('latest')
+        ->toContain('rc');
+
+    // One rolling issue, like extension-pins.yml: comment while it stays dirty,
+    // close once it is clean, so a current repo has no stale reminder open.
+    expect($run)
+        ->toContain('gh issue list')
+        ->toContain('gh issue create')
+        ->toContain('gh issue comment')
+        ->toContain('gh issue close');
+});
+
+test('the self-hosting docs explain how to verify and pin the image', function (string $page): void {
+    $contents = (string) file_get_contents(dirname(__DIR__, 2).'/docs/src/content/docs/'.$page);
+
+    expect($contents)
+        ->toContain('gh attestation verify')
+        ->toContain('ghcr.io/deskhq/the-desk@sha256:');
+})->with(['self-hosting/installation.md', 'self-hosting/upgrading.md']);

--- a/tests/Unit/RunnerLabelTest.php
+++ b/tests/Unit/RunnerLabelTest.php
@@ -96,7 +96,7 @@ test('the composite action is what actually holds the two provider paths', funct
 
     expect($action['runs']['using'] ?? null)->toBe('composite')
         ->and(array_keys($action['inputs'] ?? []))
-        ->toEqualCanonicalizing(['runner', 'context', 'file', 'platforms', 'push', 'load', 'tags', 'labels']);
+        ->toEqualCanonicalizing(['runner', 'context', 'file', 'platforms', 'push', 'load', 'tags', 'labels', 'provenance', 'sbom']);
 });
 
 /**
@@ -170,7 +170,7 @@ test('both provider paths build the same image from the same inputs', function (
         expect($build['with'][$input] ?? null)
             ->toBe('${{ inputs.'.$input.' }}', $build['uses'].' drops the '.$input.' input, so the two paths would build different images');
     }
-})->with(['context', 'file', 'platforms', 'push', 'load', 'tags', 'labels']);
+})->with(['context', 'file', 'platforms', 'push', 'load', 'tags', 'labels', 'provenance', 'sbom']);
 
 test('every docker build in the workflow goes through the composite action', function (): void {
     $steps = collect(workflowJobs(dirname(__DIR__, 2).'/.github/workflows/docker.yml'))


### PR DESCRIPTION
Closes #836.

## What

Closes the three supply-chain gaps around `ghcr.io/deskhq/the-desk`.

**Provenance + SBOM on every published image.** The composite action
`.github/actions/docker-build` gains `provenance` / `sbom` inputs (default
`false`) and a `digest` output coalesced from whichever provider path ran, so
the GitHub-hosted and Blacksmith fleets produce equivalent artifacts. The
publish step sets `provenance: mode=max` + `sbom: true`, and
`actions/attest-build-provenance` pushes a signed attestation to the registry so
operators can run a plain `gh attestation verify`. Attestations stay off on
every `load: true` build: the docker exporter cannot represent one, and buildx
fails such a build outright rather than dropping it.

**Scanning.** The PR/build path now builds with `load: true` and runs Trivy over
the real image: SARIF into the code-scanning tab, and the table onto the run
summary where a reviewer actually looks. It is deliberately non-blocking
(`exit-code: 0`, `--ignore-unfixed`) so an unfixed base-image CVE cannot red a
PR that changed nothing; tightening to a failing `CRITICAL` gate is a follow-up
once the baseline is clean. The SARIF upload is skipped for fork PRs, whose
token is read-only regardless and would 403.

A new `.github/workflows/image-scan.yml` scans the published `latest` and `rc`
weekly and reports into one rolling issue (open / comment / close), following
the `extension-pins.yml` pattern. That is the part that catches CVEs disclosed
between releases, when nothing in this repo changes.

**Digest in the release notes.** The `build` job exports the pushed digest and
`link-release-image` appends `ghcr.io/deskhq/the-desk@sha256:…` plus a
ready-to-paste `gh attestation verify` line, inside the existing idempotency
marker. If no digest is reported the notes degrade to the tag alone.

## Testing

New `tests/Unit/ImageSupplyChainTest.php` (15 tests) guards every one of the
above: the composite inputs and digest output, both provider paths taking the
same attestation inputs, no attestation on a `load: true` build, the scan and
its fork guard, the job scopes, the digest reaching the release notes, the
scheduled scan's rolling-issue shape, and the docs. `RunnerLabelTest`'s
input-parity dataset and input list are extended to cover `provenance`/`sbom`.

The `printf` that builds the release note and the scan's `jq` expressions were
rendered locally against fixtures to confirm the markdown and the CVE table come
out right, including the empty-digest and no-findings paths.

Full gate green: Pint, PHPStan, Rector, `--min=100` coverage, plus lint, format,
types, Vitest, Vite build and the Starlight docs build.

## Docs

Operator-facing, so updated in the same PR: a new *Verify the image, and pin it
by digest* section in `self-hosting/installation.md`, a *Verify the image you
are upgrading to* section in `self-hosting/upgrading.md` (including that a
digest-pinned upgrade still goes through `upgrade.sh --target=` so the backup
and version verification are not lost), and an *Image scanning* row plus a
*Supply chain of the published image* section in `reference/security.md`.

## Review notes

A local CodeRabbit pass raised 5 findings. Applied: the missing `GH_REPO` in
`image-scan.yml` (a real bug: that job never checks the repo out, so every `gh
issue` call would have failed to resolve a repository), and both docs findings
about the digest-pinned upgrade path and the effective `APP_IMAGE` reference.
Declined: a suggestion to split the test file across layers (the
implementations it says are missing are all in this same diff), and a suggestion
to document `gh attestation verify --deny-self-hosted-runners --signer-workflow`
(both break the moment `CI_RUNNER` moves the fleet or the workflow is renamed,
so they are worse advice than the plain verify). The re-run to confirm clean was
rate-limited on the free OSS tier; CodeRabbit will review the PR itself.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787520165&installation_model_id=428379&pr_number=854&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F854&signature=4a8846d355147e7f97266b55d46367eaa396c29b643b4667a91d77f4d7ee8806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->