### PR TITLE
feat: offer an install path on macOS Safari

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1288,5 +1288,11 @@
   "Scroll to :action": "Faites défiler jusqu’à :action",
   "Tap :action — done": "Touchez :action — c’est fait",
   "Notifications on iPhone only work once :app is on your home screen.": "Sur iPhone, les notifications ne fonctionnent qu’une fois :app sur l’écran d’accueil.",
+  "Add to Dock": "Ajouter au Dock",
+  "From the Safari menu bar": "Depuis la barre de menus de Safari",
+  "Open :action in the Safari menu bar": "Ouvrez le menu :action dans la barre de menus de Safari",
+  "File": "Fichier",
+  "Choose :action": "Choisissez :action",
+  "Click :action to finish": "Cliquez sur :action pour terminer",
   "Got it": "C’est compris"
 }

--- a/resources/js/components/InstallAppDialog.test.ts
+++ b/resources/js/components/InstallAppDialog.test.ts
@@ -26,6 +26,7 @@ vi.mock('@lucide/vue', () => ({
     Bell: { render: () => h('svg') },
     Check: { render: () => h('svg') },
     Download: { render: () => h('svg') },
+    PanelTop: { render: () => h('svg') },
     Share: { render: () => h('svg') },
     SquarePlus: { render: () => h('svg') },
 }));
@@ -73,10 +74,28 @@ function translate(
     );
 }
 
+/** The two Safari agents that get a walkthrough rather than a prompt. */
+const IPHONE_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0) Safari';
+const MAC_SAFARI_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15';
+
+/** Whether the stubbed browser is one that would fire `beforeinstallprompt`. */
+function prompts(userAgent: string): boolean {
+    return userAgent !== IPHONE_AGENT && userAgent !== MAC_SAFARI_AGENT;
+}
+
+function platformFor(userAgent: string): string {
+    if (userAgent === IPHONE_AGENT) {
+        return 'iPhone';
+    }
+
+    return userAgent === MAC_SAFARI_AGENT ? 'MacIntel' : 'Linux x86_64';
+}
+
 function stubBrowser(userAgent: string): void {
     vi.stubGlobal('navigator', {
         userAgent,
-        platform: userAgent.includes('iPhone') ? 'iPhone' : 'Linux x86_64',
+        platform: platformFor(userAgent),
         maxTouchPoints: 0,
     });
     window.matchMedia = ((query: string) => ({
@@ -102,7 +121,7 @@ async function boot(
 
     initializeAppInstall();
 
-    if (!userAgent.includes('iPhone')) {
+    if (prompts(userAgent)) {
         window.dispatchEvent(
             Object.assign(
                 new Event('beforeinstallprompt', { cancelable: true }),
@@ -221,7 +240,7 @@ it('records "Not now" so the invitation does not come back', async () => {
 });
 
 it('walks iOS through the share sheet instead of offering a button', async () => {
-    await boot('Mozilla/5.0 (iPhone; CPU iPhone OS 18_0) Safari');
+    await boot(IPHONE_AGENT);
 
     const host = await mountDialog();
     const steps = host.querySelector('[data-test="install-app-steps"]');
@@ -246,7 +265,37 @@ it('walks iOS through the share sheet instead of offering a button', async () =>
 
 it('drops the iOS push note where the instance has no push', async () => {
     props.webPush = { enabled: false, publicKey: null };
-    await boot('Mozilla/5.0 (iPhone; CPU iPhone OS 18_0) Safari');
+    await boot(IPHONE_AGENT);
+
+    const host = await mountDialog();
+
+    expect(
+        host.querySelector('[data-test="install-app-push-note"]'),
+    ).toBeNull();
+});
+
+it('walks macOS Safari through Add to Dock instead of offering a button', async () => {
+    await boot(MAC_SAFARI_AGENT);
+
+    const host = await mountDialog();
+    const steps = host.querySelector('[data-test="install-app-steps"]');
+
+    expect(host.querySelector('h2')?.textContent).toContain('Add to Dock');
+    expect(host.querySelector('p')?.textContent).toContain(
+        'From the Safari menu bar',
+    );
+    expect(host.querySelector('[data-test="install-app-confirm"]')).toBeNull();
+    expect(steps?.textContent).toContain('Open File in the Safari menu bar');
+    expect(steps?.textContent).toContain('Choose Add to Dock');
+    expect(steps?.textContent).toContain('Click Add to finish');
+    expect(
+        host.querySelector('[data-test="install-app-acknowledge"]')
+            ?.textContent,
+    ).toContain('Got it');
+});
+
+it('makes no push claim on macOS, where Safari pushes from a plain tab', async () => {
+    await boot(MAC_SAFARI_AGENT);
 
     const host = await mountDialog();
 

--- a/resources/js/components/InstallAppDialog.vue
+++ b/resources/js/components/InstallAppDialog.vue
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { usePage } from '@inertiajs/vue3';
-import { Bell, Check, Download, Share, SquarePlus } from '@lucide/vue';
+import {
+    Bell,
+    Check,
+    Download,
+    PanelTop,
+    Share,
+    SquarePlus,
+} from '@lucide/vue';
 import type { Component } from 'vue';
 import { computed } from 'vue';
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
@@ -19,8 +26,9 @@ import { useTranslations } from '@/composables/useTranslations';
  * dialog so the viewer knows what they are agreeing to before Chromium's
  * terse prompt lands on top of it.
  *
- * On iOS it becomes the instructional variant instead — no browser there fires
- * an install prompt, so "Add to Home Screen" has to be spelled out by hand.
+ * In Safari it becomes an instructional variant instead — neither of its
+ * platforms fires an install prompt, so the action has to be spelled out by
+ * hand: the share sheet on iOS, File > Add to Dock on macOS.
  */
 const props = defineProps<{
     /** Whether the sheet is presented. */
@@ -33,7 +41,8 @@ const emit = defineEmits<{
 
 const page = usePage();
 const { t } = useTranslations();
-const { isInstructional, promptInstall, dismissCard } = useAppInstall();
+const { installGuide, isInstructional, promptInstall, dismissCard } =
+    useAppInstall();
 
 const appName = computed(() => page.props.name);
 const currentTeam = computed(() => page.props.currentTeam);
@@ -93,13 +102,56 @@ function instruction(
     return { before, term, after, icon };
 }
 
-const steps = computed<InstructionStep[]>(() => [
-    instruction('Tap :action in the Safari toolbar', t('Share'), Share),
-    instruction('Scroll to :action', t('Add to Home Screen'), SquarePlus),
-    // The last step's tile is the app's own mark: what the viewer is about to
-    // see land on their home screen.
-    instruction('Tap :action — done', t('Add'), null),
-]);
+const steps = computed<InstructionStep[]>(() =>
+    installGuide.value === 'macos'
+        ? [
+              instruction(
+                  'Open :action in the Safari menu bar',
+                  t('File'),
+                  PanelTop,
+              ),
+              instruction('Choose :action', t('Add to Dock'), SquarePlus),
+              // The last step's tile is the app's own mark: what the viewer is
+              // about to see land in their Dock.
+              instruction('Click :action to finish', t('Add'), null),
+          ]
+        : [
+              instruction(
+                  'Tap :action in the Safari toolbar',
+                  t('Share'),
+                  Share,
+              ),
+              instruction(
+                  'Scroll to :action',
+                  t('Add to Home Screen'),
+                  SquarePlus,
+              ),
+              // The last step's tile is the app's own mark: what the viewer is
+              // about to see land on their home screen.
+              instruction('Tap :action — done', t('Add'), null),
+          ],
+);
+
+/**
+ * The heading pair for the instructional variant: the action the viewer is
+ * looking for, and where in Safari they will find it.
+ */
+const instructionalHeading = computed(() =>
+    installGuide.value === 'macos'
+        ? { title: t('Add to Dock'), subtitle: t('From the Safari menu bar') }
+        : {
+              title: t('Add to Home Screen'),
+              subtitle: t('Two taps in Safari'),
+          },
+);
+
+/**
+ * Push is a reason to install on iOS alone: Safari on macOS delivers it from a
+ * plain tab, so the note would be untrue there.
+ */
+const showPushNote = computed(
+    () => pushAvailable.value && installGuide.value === 'ios',
+);
 
 function close(): void {
     emit('update:open', false);
@@ -143,7 +195,7 @@ function notNow(): void {
                     >
                         {{
                             isInstructional
-                                ? $t('Add to Home Screen')
+                                ? instructionalHeading.title
                                 : $t('Install :app', { app: appName })
                         }}
                     </DialogTitle>
@@ -151,14 +203,16 @@ function notNow(): void {
                         class="mt-0.5 truncate text-[12.5px] text-muted-foreground"
                     >
                         {{
-                            isInstructional ? $t('Two taps in Safari') : origin
+                            isInstructional
+                                ? instructionalHeading.subtitle
+                                : origin
                         }}
                     </DialogDescription>
                 </div>
             </div>
 
-            <!-- iOS: the share-sheet walkthrough, since nothing can be
-                 triggered from the page. -->
+            <!-- Safari: the walkthrough, since nothing can be triggered from
+                 the page on either of its platforms. -->
             <template v-if="isInstructional">
                 <!-- A real ordered list: the numbered discs are decorative, so
                      the ordering has to reach a screen reader some other way. -->
@@ -208,7 +262,7 @@ function notNow(): void {
                 </ol>
 
                 <div
-                    v-if="pushAvailable"
+                    v-if="showPushNote"
                     data-test="install-app-push-note"
                     class="mt-3.5 flex items-start gap-2.25 rounded-[11px] border border-brass-border/60 bg-brass/8 px-3 py-2.75"
                 >

--- a/resources/js/composables/useAppInstall.test.ts
+++ b/resources/js/composables/useAppInstall.test.ts
@@ -7,6 +7,10 @@ import type * as AppInstall from './useAppInstall';
 
 type InstallModule = typeof AppInstall;
 
+/** Safari's desktop agent, which an iPad in a tab reports verbatim. */
+const MAC_SAFARI_AGENT =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15';
+
 let app: App | null = null;
 
 /**
@@ -365,11 +369,30 @@ describe('iOS, which never fires an install prompt', () => {
 
         expect(install.showRow.value).toBe(true);
         expect(install.isInstructional.value).toBe(true);
+        expect(install.installGuide.value).toBe('ios');
     });
 
     it('recognises an iPad, which reports itself as a Mac', async () => {
         stubBrowser({
-            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari',
+            userAgent: MAC_SAFARI_AGENT,
+            platform: 'MacIntel',
+            maxTouchPoints: 5,
+            iosStandalone: false,
+        });
+
+        const { initializeAppInstall, useAppInstall } = await loadModule();
+
+        initializeAppInstall();
+
+        const install = inComponent(() => useAppInstall());
+        await nextTick();
+
+        expect(install.installGuide.value).toBe('ios');
+    });
+
+    it('takes a Mac driving a touch display for a Mac, not an iPad', async () => {
+        stubBrowser({
+            userAgent: MAC_SAFARI_AGENT,
             platform: 'MacIntel',
             maxTouchPoints: 5,
         });
@@ -381,14 +404,49 @@ describe('iOS, which never fires an install prompt', () => {
         const install = inComponent(() => useAppInstall());
         await nextTick();
 
-        expect(install.isInstructional.value).toBe(true);
+        expect(install.installGuide.value).toBe('macos');
     });
 
-    it('leaves a desktop Mac alone', async () => {
+    it('offers nothing on a browser that neither prompts nor is iOS', async () => {
+        stubBrowser({ userAgent: 'Mozilla/5.0 (X11; Linux x86_64) Firefox' });
+
+        const { initializeAppInstall, useAppInstall } = await loadModule();
+
+        initializeAppInstall();
+
+        const install = inComponent(() => useAppInstall());
+        await nextTick();
+
+        expect(install.showRow.value).toBe(false);
+    });
+});
+
+describe('Safari on macOS, which installs from its menu bar', () => {
+    /** Stub a Mac desktop, whose browser is chosen by the agent passed in. */
+    function stubMac(userAgent: string): void {
+        stubBrowser({ userAgent, platform: 'MacIntel', maxTouchPoints: 0 });
+    }
+
+    it('offers the instructional variant in a browser tab', async () => {
+        stubMac(MAC_SAFARI_AGENT);
+
+        const { initializeAppInstall, useAppInstall } = await loadModule();
+
+        initializeAppInstall();
+
+        const install = inComponent(() => useAppInstall());
+        await nextTick();
+
+        expect(install.showRow.value).toBe(true);
+        expect(install.isInstructional.value).toBe(true);
+        expect(install.installGuide.value).toBe('macos');
+    });
+
+    it('offers nothing once launched from the Dock', async () => {
         stubBrowser({
-            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari',
+            userAgent: MAC_SAFARI_AGENT,
             platform: 'MacIntel',
-            maxTouchPoints: 0,
+            standaloneDisplay: true,
         });
 
         const { initializeAppInstall, useAppInstall } = await loadModule();
@@ -399,11 +457,29 @@ describe('iOS, which never fires an install prompt', () => {
         await nextTick();
 
         expect(install.showRow.value).toBe(false);
-        expect(install.isInstructional.value).toBe(false);
+        expect(install.installGuide.value).toBeNull();
     });
 
-    it('offers nothing on a browser that neither prompts nor is iOS', async () => {
-        stubBrowser({ userAgent: 'Mozilla/5.0 (X11; Linux x86_64) Firefox' });
+    it('leaves Chrome on a Mac to its own install prompt', async () => {
+        stubMac(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+        );
+
+        const { initializeAppInstall, useAppInstall } = await loadModule();
+
+        initializeAppInstall();
+
+        const install = inComponent(() => useAppInstall());
+        await nextTick();
+
+        expect(install.installGuide.value).toBeNull();
+        expect(install.showRow.value).toBe(false);
+    });
+
+    it('stays silent in Firefox on a Mac, which cannot install at all', async () => {
+        stubMac(
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:130.0) Gecko/20100101 Firefox/130.0',
+        );
 
         const { initializeAppInstall, useAppInstall } = await loadModule();
 

--- a/resources/js/composables/useAppInstall.ts
+++ b/resources/js/composables/useAppInstall.ts
@@ -9,6 +9,13 @@ export type BeforeInstallPromptEvent = Event & {
     userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
 };
 
+/**
+ * Which hand-written walkthrough a browser needs, for the two that can install
+ * the app but expose no way to ask: iOS Safari's share sheet, and macOS Safari's
+ * File > Add to Dock.
+ */
+export type InstallGuide = 'ios' | 'macos';
+
 /** ISO timestamp of the ✕, "Not now", or a declined browser prompt. */
 const DISMISSED_KEY = 'install.dismissedAt';
 
@@ -30,6 +37,7 @@ const SESSIONS_BEFORE_CARD = 2;
 const deferredPrompt = ref<BeforeInstallPromptEvent | null>(null);
 const installed = ref(false);
 const ios = ref(false);
+const macSafari = ref(false);
 const dismissed = ref(false);
 const rowSeen = ref(false);
 const sessions = ref(0);
@@ -74,12 +82,37 @@ function isStandaloneLaunch(): boolean {
  * and installing means walking the user through the share sheet by hand.
  *
  * iPadOS 13+ reports a desktop Mac user agent, so a touch-capable "Mac" is the
- * only tell an iPad leaves.
+ * first tell an iPad leaves. It is not enough on its own — a Mac driving a
+ * touchscreen matches it too — so `navigator.standalone`, which only Safari on
+ * iOS and iPadOS defines, settles which of the two this is.
  */
 function isIos(): boolean {
     return (
         /iphone|ipad|ipod/i.test(navigator.userAgent) ||
-        (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+        (navigator.platform === 'MacIntel' &&
+            navigator.maxTouchPoints > 1 &&
+            (navigator as Navigator & { standalone?: boolean }).standalone !==
+                undefined)
+    );
+}
+
+/**
+ * Whether this is Safari on macOS, which can install the app (File > Add to
+ * Dock, Sonoma and later) but fires no `beforeinstallprompt` — so like iOS it
+ * has to be walked through by hand.
+ *
+ * Every Chromium browser carries `Safari` in its user agent, and each one that
+ * runs on macOS also fires the prompt, so they are excluded by name; Firefox
+ * cannot install a web app at all and never matches `Safari` in the first place.
+ */
+function isMacSafari(): boolean {
+    const agent = navigator.userAgent;
+
+    return (
+        /macintosh|mac os x/i.test(agent) &&
+        /safari/i.test(agent) &&
+        !/chrome|chromium|crios|edg|opr\//i.test(agent) &&
+        !isIos()
     );
 }
 
@@ -117,6 +150,7 @@ export function initializeAppInstall(): void {
 
     installed.value = isStandaloneLaunch();
     ios.value = isIos();
+    macSafari.value = isMacSafari();
     dismissed.value = read(window.localStorage, DISMISSED_KEY) !== null;
     rowSeen.value = read(window.localStorage, ROW_SEEN_KEY) !== null;
     sessions.value = countSession();
@@ -152,10 +186,26 @@ export function useAppInstall() {
     });
 
     /**
-     * Whether the install action can only be explained, not performed: iOS
-     * hides "Add to Home Screen" in the share sheet and exposes no API for it.
+     * Which walkthrough this browser needs, or `null` where the install can be
+     * triggered from the page — Safari buries the action in a menu on both of
+     * its platforms and exposes no API for it.
      */
-    const isInstructional = computed(() => ios.value && !installed.value);
+    const installGuide = computed<InstallGuide | null>(() => {
+        if (installed.value) {
+            return null;
+        }
+
+        if (ios.value) {
+            return 'ios';
+        }
+
+        return macSafari.value ? 'macos' : null;
+    });
+
+    /**
+     * Whether the install action can only be explained, not performed.
+     */
+    const isInstructional = computed(() => installGuide.value !== null);
 
     /** The permanent home for install, in the user menu. */
     const showRow = computed(
@@ -202,6 +252,7 @@ export function useAppInstall() {
     return {
         showRow,
         showCard,
+        installGuide,
         isInstructional,
         promptInstall,
         dismissCard: recordDismissal,


### PR DESCRIPTION
Closes #850.

Child of the `feat/pwa` epic branch, stacked on #853 — this PR targets `feat/pwa`, not `develop`.

## What

Safari on macOS can install a web app (File > Add to Dock, Sonoma and later) but fires no `beforeinstallprompt`. Both install surfaces gated on that event or on an iOS device, so a macOS Safari user saw neither the sidebar card nor the user-menu row and was never told the app could be installed.

- `useAppInstall` now detects desktop Safari and exposes an `installGuide` of `'ios' | 'macos' | null` — the walkthrough a browser needs, or `null` where the install can be triggered from the page. `isInstructional` is derived from it, so `showRow` / `showCard` pick up macOS with no change of their own.
- `InstallAppDialog` gains the macOS variant: same instructional layout, different heading pair, steps and icons. Nothing else about the sheet moves.
- No push note on the macOS variant. Safari on macOS pushes from a plain tab, so installing is not a prerequisite there and the claim would be untrue.
- `isIos()` is tightened. Matching a touch-capable `MacIntel` was catching a Mac driving a touch display as well as an iPad; `navigator.standalone`, which only Safari on iOS and iPadOS defines, now settles which of the two it is.

Chromium browsers all carry `Safari` in their user agent and each one on macOS fires the prompt, so they are excluded by name. Firefox never matches `Safari` at all and stays silent, which is correct — it cannot install a web app.

## Testing

- `useAppInstall.test.ts`: the macOS branch in a tab, launched from the Dock, Chrome on a Mac, Firefox on a Mac, plus the iPad/touch-Mac split the tightened `isIos()` now makes.
- `InstallAppDialog.test.ts`: the Add to Dock walkthrough and the absence of the push note on macOS.
- Verified in the running app with a spoofed Safari user agent: the row appears in the user menu, the dialog shows the Add to Dock steps, Firefox on a Mac shows nothing, and a standalone (Dock-launched) window offers neither surface.
- axe clean on the dialog in both light and dark themes.
- Full gate green: Pint, PHPStan, Rector, PHP suite at 100% coverage, and the frontend lint / format / types / vitest / build.

## i18n

Six new keys, all translated in `lang/fr.json`: `Add to Dock`, `From the Safari menu bar`, `Open :action in the Safari menu bar`, `File`, `Choose :action`, `Click :action to finish`.

## Docs

No operator-facing change: no new config, no toggle, no stack change. The existing push caveat in `reference/feature-toggles.md` already says a plain tab is enough on desktop, which stays true.

## Found while working on this

#856 — `lang/fr.json` defines the key `"to"` twice, so one of the two French translations is silently discarded, and nothing guards the catalog against a repeat. Filed rather than fixed inline; unrelated to this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787521651&installation_model_id=428379&pr_number=858&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F858&signature=a5c04a4baca5b4843243eeaccc6efcdb9ec1b7394529703ccd0512fab5849e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->