### PR TITLE
fix: keep mobile text fields at 16px so focusing them no longer zooms the app

### DIFF
--- a/eslint-rules/no-small-mobile-input-text.js
+++ b/eslint-rules/no-small-mobile-input-text.js
@@ -169,7 +169,7 @@ export function findSmallMobileFont(text) {
         }
 
         if (variants.length > 0 && !variants.every((variant) => MOBILE_VARIANT.test(variant))) {
-            hasDesktopSize = true;
+            hasDesktopSize ||= variants.includes('md');
             continue;
         }
 

--- a/eslint-rules/no-small-mobile-input-text.js
+++ b/eslint-rules/no-small-mobile-input-text.js
@@ -1,0 +1,347 @@
+/**
+ * Flags text-entry form controls whose font size drops below 16px on a phone,
+ * and auto-fixes them to the `text-base md:<size>` pattern the shared `Input`
+ * primitive already uses.
+ *
+ * iOS Safari auto-zooms the whole page onto a focused `<input>`, `<textarea>`
+ * or `<select>` whose computed `font-size` is under 16px, and does not zoom
+ * back out when the keyboard closes: the app is left scaled up and horizontally
+ * scrolled, with controls pushed off-screen (#855). Pinning the field to 16px
+ * below `md` and restoring the design size from `md` up removes the trigger
+ * without touching desktop typography — and without the `maximum-scale=1`
+ * viewport hack, which would break pinch-to-zoom for everyone (WCAG 1.4.4).
+ *
+ * Only sizes that actually apply on a phone are considered: a utility behind a
+ * min-width breakpoint (`md:text-sm`) or a state variant (`placeholder:`,
+ * `file:`, `@lg:`) is left alone, and a field with no font size at all inherits
+ * the 16px body size.
+ */
+
+/** Tailwind's named font-size scale, in pixels. */
+const NAMED_SIZES = {
+    xs: 12,
+    sm: 14,
+    base: 16,
+    lg: 18,
+    xl: 20,
+    '2xl': 24,
+    '3xl': 30,
+    '4xl': 36,
+    '5xl': 48,
+    '6xl': 60,
+    '7xl': 72,
+    '8xl': 96,
+    '9xl': 128,
+};
+
+/** Below this, iOS Safari zooms the page onto the focused field. */
+const MINIMUM_MOBILE_FONT_PX = 16;
+
+/** Root font size, for resolving `rem` / `em` arbitrary values. */
+const ROOT_FONT_PX = 16;
+
+/** Variants that still apply on a phone viewport (`max-md:` and friends). */
+const MOBILE_VARIANT = /^max-(sm|md|lg|xl|2xl)$/;
+
+/** Input types that open no keyboard, so never trigger the focus zoom. */
+const NON_TEXT_INPUT_TYPES = new Set([
+    'button',
+    'checkbox',
+    'color',
+    'file',
+    'hidden',
+    'image',
+    'radio',
+    'range',
+    'reset',
+    'submit',
+]);
+
+/** Native elements the browser zooms onto when focused. */
+const TEXT_ENTRY_ELEMENTS = new Set(['input', 'textarea', 'select']);
+
+/**
+ * Shared wrappers that render one of those elements, so a font size handed to
+ * them lands on the control itself. `ListboxFilter` is the reka-ui primitive
+ * `CommandInput` is built on.
+ */
+export const TEXT_ENTRY_COMPONENTS = new Set([
+    'Input',
+    'PasswordInput',
+    'SidebarInput',
+    'CommandInput',
+    'NativeSelect',
+    'Textarea',
+    'ListboxFilter',
+]);
+
+/**
+ * Splits a utility into its variants and its base utility, ignoring colons
+ * nested inside an arbitrary value (`text-[length:14px]`).
+ *
+ * @param {string} utility
+ * @returns {{ variants: string[], base: string }}
+ */
+function splitVariants(utility) {
+    const parts = [];
+    let depth = 0;
+    let current = '';
+
+    for (const character of utility) {
+        if (character === '[' || character === '(') {
+            depth += 1;
+        } else if (character === ']' || character === ')') {
+            depth -= 1;
+        }
+
+        if (character === ':' && depth === 0) {
+            parts.push(current);
+            current = '';
+            continue;
+        }
+
+        current += character;
+    }
+
+    parts.push(current);
+
+    return { variants: parts.slice(0, -1), base: parts.at(-1) };
+}
+
+/**
+ * Resolves a Tailwind font-size utility to pixels, or `null` when the utility
+ * is not a font size (a colour, an alignment, an unrelated class).
+ *
+ * @param {string} utility A base utility with its variants already stripped.
+ * @returns {number|null}
+ */
+export function fontSizeInPixels(utility) {
+    const match = /^!?text-(.+?)!?$/.exec(utility);
+
+    if (!match) {
+        return null;
+    }
+
+    const suffix = match[1];
+
+    if (suffix in NAMED_SIZES) {
+        return NAMED_SIZES[suffix];
+    }
+
+    const arbitrary = /^\[(?:length:)?(\d*\.?\d+)(px|rem|em)\]$/.exec(suffix);
+
+    if (!arbitrary) {
+        return null;
+    }
+
+    const [, value, unit] = arbitrary;
+
+    return unit === 'px' ? Number(value) : Number(value) * ROOT_FONT_PX;
+}
+
+/**
+ * @typedef {object} SmallMobileFont
+ * @property {number} start Offset of the offending utility within `text`.
+ * @property {string} original The utility that applies on a phone, e.g. `text-sm`.
+ * @property {number} pixels Its resolved size.
+ * @property {string} suggestion The replacement, e.g. `text-base md:text-sm`.
+ */
+
+/**
+ * Finds the font size a class string lands on for a phone viewport, and returns
+ * it only when that size would trigger the focus zoom. Later utilities win, so
+ * `text-sm max-md:text-base` reads as 16px, the same way the cascade (and
+ * `tailwind-merge`) resolves it.
+ *
+ * @param {string} text
+ * @returns {SmallMobileFont|null}
+ */
+export function findSmallMobileFont(text) {
+    let effective = null;
+    let hasDesktopSize = false;
+
+    for (const match of text.matchAll(/[^\s"'`]+/g)) {
+        const { variants, base } = splitVariants(match[0]);
+        const pixels = fontSizeInPixels(base);
+
+        if (pixels === null) {
+            continue;
+        }
+
+        if (variants.length > 0 && !variants.every((variant) => MOBILE_VARIANT.test(variant))) {
+            hasDesktopSize = true;
+            continue;
+        }
+
+        effective = { start: match.index, original: match[0], pixels };
+    }
+
+    if (!effective || effective.pixels >= MINIMUM_MOBILE_FONT_PX) {
+        return null;
+    }
+
+    return {
+        ...effective,
+        suggestion: hasDesktopSize ? 'text-base' : `text-base md:${effective.original}`,
+    };
+}
+
+/**
+ * The value of a plain (non-bound) attribute, or `null` when it is absent or
+ * bound to an expression.
+ *
+ * @param {import('vue-eslint-parser').AST.VElement} element
+ * @param {string} name
+ * @returns {string|null}
+ */
+function staticAttribute(element, name) {
+    const attribute = element.startTag.attributes.find(
+        (candidate) => !candidate.directive && candidate.key.name === name,
+    );
+
+    return attribute?.value?.value ?? null;
+}
+
+/**
+ * Whether focusing this element would make a phone browser zoom the page.
+ *
+ * @param {import('vue-eslint-parser').AST.VElement} element
+ * @returns {boolean}
+ */
+function isTextEntryElement(element) {
+    const tag = element.rawName;
+
+    if (TEXT_ENTRY_COMPONENTS.has(tag)) {
+        return true;
+    }
+
+    if (!TEXT_ENTRY_ELEMENTS.has(tag.toLowerCase())) {
+        return false;
+    }
+
+    const type = staticAttribute(element, 'type');
+
+    return type === null || !NON_TEXT_INPUT_TYPES.has(type.toLowerCase());
+}
+
+/**
+ * Collects every string literal in a subtree, so a bound `:class` is read the
+ * same way as a static one.
+ *
+ * @param {unknown} node
+ * @param {object[]} collected
+ * @returns {object[]}
+ */
+function collectStringNodes(node, collected = []) {
+    if (Array.isArray(node)) {
+        for (const child of node) {
+            collectStringNodes(child, collected);
+        }
+
+        return collected;
+    }
+
+    if (!node || typeof node !== 'object' || typeof node.type !== 'string') {
+        return collected;
+    }
+
+    if (node.type === 'TemplateElement' || (node.type === 'Literal' && typeof node.value === 'string')) {
+        collected.push(node);
+
+        return collected;
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+        if (key === 'parent' || key === 'range' || key === 'loc') {
+            continue;
+        }
+
+        collectStringNodes(value, collected);
+    }
+
+    return collected;
+}
+
+/**
+ * The nodes holding class strings for an element: the static `class` attribute
+ * and every string inside a bound `:class`.
+ *
+ * @param {import('vue-eslint-parser').AST.VElement} element
+ * @returns {object[]}
+ */
+function classNodes(element) {
+    return element.startTag.attributes.flatMap((attribute) => {
+        if (!attribute.value) {
+            return [];
+        }
+
+        if (!attribute.directive) {
+            return attribute.key.name === 'class' ? [attribute.value] : [];
+        }
+
+        const isClassBinding =
+            attribute.key.name.name === 'bind' && attribute.key.argument?.name === 'class';
+
+        return isClassBinding ? collectStringNodes(attribute.value) : [];
+    });
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+    meta: {
+        type: 'problem',
+        fixable: 'code',
+        docs: {
+            description:
+                'Keep text-entry controls at 16px or larger below the `md` breakpoint so focusing them does not zoom the page on iOS.',
+        },
+        schema: [],
+        messages: {
+            zoomsOnFocus:
+                "'{{ original }}' resolves to {{ pixels }}px on a phone, so iOS Safari zooms the whole page onto this field when it is focused. Use '{{ suggestion }}' to keep 16px below `md` and the design size from `md` up.",
+        },
+    },
+    create(context) {
+        const sourceCode = context.sourceCode;
+        const defineTemplateBodyVisitor = sourceCode.parserServices?.defineTemplateBodyVisitor;
+
+        if (!defineTemplateBodyVisitor) {
+            return {};
+        }
+
+        return defineTemplateBodyVisitor({
+            VElement(element) {
+                if (!isTextEntryElement(element)) {
+                    return;
+                }
+
+                for (const node of classNodes(element)) {
+                    const violation = findSmallMobileFont(sourceCode.getText(node));
+
+                    if (!violation) {
+                        continue;
+                    }
+
+                    const from = node.range[0] + violation.start;
+
+                    context.report({
+                        node,
+                        messageId: 'zoomsOnFocus',
+                        data: {
+                            original: violation.original,
+                            pixels: String(violation.pixels),
+                            suggestion: violation.suggestion,
+                        },
+                        fix: (fixer) =>
+                            fixer.replaceTextRange(
+                                [from, from + violation.original.length],
+                                violation.suggestion,
+                            ),
+                    });
+                }
+            },
+        });
+    },
+};
+
+export default rule;

--- a/eslint-rules/no-small-mobile-input-text.test.ts
+++ b/eslint-rules/no-small-mobile-input-text.test.ts
@@ -1,0 +1,229 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Linter, RuleTester } from 'eslint';
+import { describe, expect, it } from 'vitest';
+import { parser as tsParser } from 'typescript-eslint';
+import vueParser from 'vue-eslint-parser';
+import rule, { findSmallMobileFont, fontSizeInPixels } from './no-small-mobile-input-text.js';
+
+describe('fontSizeInPixels', () => {
+    it('resolves the named font-size scale', () => {
+        expect(fontSizeInPixels('text-xs')).toBe(12);
+        expect(fontSizeInPixels('text-sm')).toBe(14);
+        expect(fontSizeInPixels('text-base')).toBe(16);
+        expect(fontSizeInPixels('text-2xl')).toBe(24);
+    });
+
+    it('resolves arbitrary pixel, rem and em values', () => {
+        expect(fontSizeInPixels('text-[13.5px]')).toBe(13.5);
+        expect(fontSizeInPixels('text-[1rem]')).toBe(16);
+        expect(fontSizeInPixels('text-[0.875em]')).toBe(14);
+        expect(fontSizeInPixels('text-[length:14px]')).toBe(14);
+    });
+
+    it('ignores the `!` importance marker', () => {
+        expect(fontSizeInPixels('!text-sm')).toBe(14);
+    });
+
+    it('returns null for utilities that are not font sizes', () => {
+        expect(fontSizeInPixels('text-muted-foreground')).toBeNull();
+        expect(fontSizeInPixels('text-center')).toBeNull();
+        expect(fontSizeInPixels('text-[--brand]')).toBeNull();
+        expect(fontSizeInPixels('truncate')).toBeNull();
+    });
+});
+
+describe('findSmallMobileFont', () => {
+    it('flags an unprefixed sub-16px utility', () => {
+        expect(findSmallMobileFont('w-full text-sm text-foreground')).toMatchObject({
+            start: 7,
+            original: 'text-sm',
+            suggestion: 'text-base md:text-sm',
+        });
+    });
+
+    it('accepts the `text-base md:text-sm` pattern', () => {
+        expect(findSmallMobileFont('text-base md:text-sm')).toBeNull();
+    });
+
+    it('accepts a mobile override that lands back on 16px', () => {
+        expect(findSmallMobileFont('text-sm max-md:text-base')).toBeNull();
+    });
+
+    it('ignores utilities behind a min-width breakpoint or a state variant', () => {
+        expect(findSmallMobileFont('md:text-sm')).toBeNull();
+        expect(findSmallMobileFont('placeholder:text-xs')).toBeNull();
+        expect(findSmallMobileFont('file:text-sm')).toBeNull();
+        expect(findSmallMobileFont('@lg:text-sm')).toBeNull();
+    });
+
+    it('suggests plain `text-base` when a desktop size is already declared', () => {
+        expect(findSmallMobileFont('text-[13px] md:text-[13px]')).toMatchObject({
+            original: 'text-[13px]',
+            suggestion: 'text-base',
+        });
+    });
+
+    it('returns null for a class string with no font size at all', () => {
+        expect(findSmallMobileFont('h-9 w-full rounded-md')).toBeNull();
+    });
+});
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parser: vueParser,
+        ecmaVersion: 2022,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('no-small-mobile-input-text', rule, {
+    valid: [
+        {
+            // The blessed pattern: 16px on a phone, the design size from `md` up.
+            filename: 'resources/js/components/MessageComposer.vue',
+            code: '<template><textarea class="text-base md:text-sm"></textarea></template>',
+        },
+        {
+            // No font size at all inherits the 16px body size.
+            filename: 'resources/js/components/MessageComposer.vue',
+            code: '<template><input class="h-9 w-full" /></template>',
+        },
+        {
+            // Non-text inputs never trigger the focus zoom.
+            filename: 'resources/js/pages/teams/Emojis.vue',
+            code: '<template><input type="file" class="text-sm file:text-sm" /></template>',
+        },
+        {
+            filename: 'resources/js/components/MessageComposer.vue',
+            code: '<template><input type="checkbox" class="text-sm" /></template>',
+        },
+        {
+            // Only form controls are zoomed to; ordinary text is left alone.
+            filename: 'resources/js/components/MessageList.vue',
+            code: '<template><p class="text-xs">Edited</p></template>',
+        },
+        {
+            filename: 'resources/js/components/Foo.vue',
+            code: '<template><CustomThing class="text-xs" /></template>',
+        },
+        {
+            filename: 'resources/js/pages/channels/Search.vue',
+            code: '<template><Input class="text-base md:text-xs" /></template>',
+        },
+        {
+            filename: 'resources/js/components/Foo.vue',
+            code: '<template><input :class="[\'text-base\', \'md:text-sm\']" /></template>',
+        },
+    ],
+    invalid: [
+        {
+            filename: 'resources/js/components/MessageComposer.vue',
+            code: '<template><textarea class="flex-1 text-sm text-foreground"></textarea></template>',
+            output: '<template><textarea class="flex-1 text-base md:text-sm text-foreground"></textarea></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+        {
+            filename: 'resources/js/components/GifPickerPanel.vue',
+            code: '<template><input type="search" class="text-sm" /></template>',
+            output: '<template><input type="search" class="text-base md:text-sm" /></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+        {
+            filename: 'resources/js/components/ScheduledMessagesDialog.vue',
+            code: '<template><textarea class="text-[13.5px]"></textarea></template>',
+            output: '<template><textarea class="text-base md:text-[13.5px]"></textarea></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+        {
+            filename: 'resources/js/components/ui/native-select/NativeSelect.vue',
+            code: '<template><select class="text-sm"></select></template>',
+            output: '<template><select class="text-base md:text-sm"></select></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+        {
+            // A dynamic `type` is treated as text entry: the zoom is the safer default.
+            filename: 'resources/js/components/Foo.vue',
+            code: '<template><input :type="kind" class="text-xs" /></template>',
+            output: '<template><input :type="kind" class="text-base md:text-xs" /></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+        {
+            // The shared control wrappers carry the same hazard as a raw field.
+            filename: 'resources/js/pages/channels/Search.vue',
+            code: '<template><Input class="mb-1 h-8 text-xs max-md:h-11" /></template>',
+            output: '<template><Input class="mb-1 h-8 text-base md:text-xs max-md:h-11" /></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+        {
+            filename: 'resources/js/layouts/MainLayout.vue',
+            code: '<template><Input class="px-2 text-[13px] md:text-[13px]" /></template>',
+            output: '<template><Input class="px-2 text-base md:text-[13px]" /></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+        {
+            // Bound class strings are read the same way as a static attribute.
+            filename: 'resources/js/components/Foo.vue',
+            code: '<template><textarea :class="[\'text-sm\', extra]"></textarea></template>',
+            output: '<template><textarea :class="[\'text-base md:text-sm\', extra]"></textarea></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+        {
+            filename: 'resources/js/components/Foo.vue',
+            code: '<template><textarea :class="`text-sm ${extra}`"></textarea></template>',
+            output: '<template><textarea :class="`text-base md:text-sm ${extra}`"></textarea></template>',
+            errors: [{ messageId: 'zoomsOnFocus' }],
+        },
+    ],
+});
+
+/**
+ * `eslint.config.js` ignores `resources/js/components/ui/*`, so the shadcn
+ * primitives — `Input`, `CommandInput`, `NativeSelect`, the calendar's month and
+ * year selects — are the one place a sub-16px field could still land unseen.
+ * They are also the widest-reach fields in the app, so lint them here instead.
+ */
+describe('the shadcn primitives under components/ui/', () => {
+    const uiDirectory = fileURLToPath(
+        new URL('../resources/js/components/ui', import.meta.url),
+    );
+
+    const linter = new Linter();
+
+    const lint = (file: string): Linter.LintMessage[] =>
+        linter.verify(
+            readFileSync(join(uiDirectory, file), 'utf8'),
+            {
+                files: ['**/*.vue'],
+                languageOptions: {
+                    parser: vueParser,
+                    ecmaVersion: 2022,
+                    sourceType: 'module',
+                    parserOptions: { parser: tsParser },
+                },
+                plugins: { local: { rules: { 'no-small-mobile-input-text': rule } } },
+                rules: { 'local/no-small-mobile-input-text': 'error' },
+            },
+            file,
+        );
+
+    const vueFiles = readdirSync(uiDirectory, { recursive: true })
+        .map(String)
+        .filter((file) => file.endsWith('.vue'));
+
+    it('finds primitives to lint', () => {
+        expect(vueFiles.length).toBeGreaterThan(0);
+    });
+
+    it('keeps every field at 16px or larger below `md`', () => {
+        const violations = vueFiles.flatMap((file) =>
+            lint(file).map((message) => `${file}:${message.line} ${message.message}`),
+        );
+
+        expect(violations).toEqual([]);
+    });
+});

--- a/eslint-rules/no-small-mobile-input-text.test.ts
+++ b/eslint-rules/no-small-mobile-input-text.test.ts
@@ -65,6 +65,13 @@ describe('findSmallMobileFont', () => {
         });
     });
 
+    it('keeps the `md:` step when the declared desktop size sits at a wider breakpoint', () => {
+        expect(findSmallMobileFont('text-sm lg:text-base')).toMatchObject({
+            original: 'text-sm',
+            suggestion: 'text-base md:text-sm',
+        });
+    });
+
     it('returns null for a class string with no font size at all', () => {
         expect(findSmallMobileFont('h-9 w-full rounded-md')).toBeNull();
     });

--- a/eslint-rules/no-small-mobile-input-text.test.ts
+++ b/eslint-rules/no-small-mobile-input-text.test.ts
@@ -2,8 +2,8 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Linter, RuleTester } from 'eslint';
-import { describe, expect, it } from 'vitest';
 import { parser as tsParser } from 'typescript-eslint';
+import { describe, expect, it } from 'vitest';
 import vueParser from 'vue-eslint-parser';
 import rule, { findSmallMobileFont, fontSizeInPixels } from './no-small-mobile-input-text.js';
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import vuejsAccessibility from 'eslint-plugin-vuejs-accessibility';
 import noArbitraryTailwindSpacing from './eslint-rules/no-arbitrary-tailwind-spacing.js';
 import noDestructiveFillAsText from './eslint-rules/no-destructive-fill-as-text.js';
 import noRawButton from './eslint-rules/no-raw-button.js';
+import noSmallMobileInputText from './eslint-rules/no-small-mobile-input-text.js';
 
 const controlStatements = [
     'if',
@@ -37,6 +38,7 @@ export default defineConfigWithVueTs(
                     'no-arbitrary-tailwind-spacing': noArbitraryTailwindSpacing,
                     'no-destructive-fill-as-text': noDestructiveFillAsText,
                     'no-raw-button': noRawButton,
+                    'no-small-mobile-input-text': noSmallMobileInputText,
                 },
             },
         },
@@ -86,6 +88,12 @@ export default defineConfigWithVueTs(
             // `./vendor/bin/sail npm run lint`) because every occurrence was
             // migrated to `text-destructive-text`, so the gate stays clean.
             'local/no-destructive-fill-as-text': 'error',
+            // iOS Safari zooms the whole page onto a focused field whose font
+            // size is under 16px, and never zooms back out (#855). `error`
+            // (auto-fixable via `./vendor/bin/sail npm run lint`) because every
+            // occurrence was migrated to `text-base md:<size>`, so the gate
+            // stays clean and a new sub-16px field cannot land silently.
+            'local/no-small-mobile-input-text': 'error',
             // XSS trust boundary. Every run of HTML the client renders as markup
             // must go through `<SafeHtml>`, which sanitizes it with DOMPurify
             // against a named allowlist; a raw `v-html` anywhere else would

--- a/resources/js/components/AddDirectMessagePeopleModal.vue
+++ b/resources/js/components/AddDirectMessagePeopleModal.vue
@@ -184,7 +184,7 @@ function submit(): void {
                         :placeholder="$t('Type a name…')"
                         :aria-label="$t('Add people')"
                         data-test="add-people-input"
-                        class="h-7 w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
+                        class="h-7 w-full bg-transparent text-base md:text-sm outline-hidden placeholder:text-muted-foreground"
                     />
                 </div>
             </div>

--- a/resources/js/components/AddDirectMessagePeopleModal.vue
+++ b/resources/js/components/AddDirectMessagePeopleModal.vue
@@ -184,7 +184,7 @@ function submit(): void {
                         :placeholder="$t('Type a name…')"
                         :aria-label="$t('Add people')"
                         data-test="add-people-input"
-                        class="h-7 w-full bg-transparent text-base md:text-sm outline-hidden placeholder:text-muted-foreground"
+                        class="h-7 w-full bg-transparent text-base outline-hidden placeholder:text-muted-foreground md:text-sm"
                     />
                 </div>
             </div>

--- a/resources/js/components/ForwardMessageDialog.vue
+++ b/resources/js/components/ForwardMessageDialog.vue
@@ -146,7 +146,7 @@ function submit(): void {
                         type="text"
                         :placeholder="$t('Search channels and people…')"
                         data-test="forward-channel-search"
-                        class="h-full w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
+                        class="h-full w-full bg-transparent text-base md:text-sm outline-hidden placeholder:text-muted-foreground"
                     />
                 </div>
                 <div
@@ -256,7 +256,7 @@ function submit(): void {
                     rows="2"
                     :placeholder="$t('Say something about this…')"
                     data-test="forward-note"
-                    class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-sm leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                    class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-base md:text-sm leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                 ></textarea>
             </div>
 

--- a/resources/js/components/ForwardMessageDialog.vue
+++ b/resources/js/components/ForwardMessageDialog.vue
@@ -146,7 +146,7 @@ function submit(): void {
                         type="text"
                         :placeholder="$t('Search channels and people…')"
                         data-test="forward-channel-search"
-                        class="h-full w-full bg-transparent text-base md:text-sm outline-hidden placeholder:text-muted-foreground"
+                        class="h-full w-full bg-transparent text-base outline-hidden placeholder:text-muted-foreground md:text-sm"
                     />
                 </div>
                 <div
@@ -256,7 +256,7 @@ function submit(): void {
                     rows="2"
                     :placeholder="$t('Say something about this…')"
                     data-test="forward-note"
-                    class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-base md:text-sm leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                    class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-base leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring md:text-sm"
                 ></textarea>
             </div>
 

--- a/resources/js/components/GifPickerPanel.vue
+++ b/resources/js/components/GifPickerPanel.vue
@@ -287,7 +287,7 @@ onBeforeUnmount(() => {
                 "
                 :aria-label="$t('Search GIFs')"
                 :placeholder="$t('Search GIFs')"
-                class="h-8 flex-1 rounded-full bg-muted px-3 text-base md:text-sm outline-none focus:ring-2 focus:ring-brass"
+                class="h-8 flex-1 rounded-full bg-muted px-3 text-base outline-none focus:ring-2 focus:ring-brass md:text-sm"
             />
             <Button
                 type="button"

--- a/resources/js/components/GifPickerPanel.vue
+++ b/resources/js/components/GifPickerPanel.vue
@@ -287,7 +287,7 @@ onBeforeUnmount(() => {
                 "
                 :aria-label="$t('Search GIFs')"
                 :placeholder="$t('Search GIFs')"
-                class="h-8 flex-1 rounded-full bg-muted px-3 text-sm outline-none focus:ring-2 focus:ring-brass"
+                class="h-8 flex-1 rounded-full bg-muted px-3 text-base md:text-sm outline-none focus:ring-2 focus:ring-brass"
             />
             <Button
                 type="button"

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1812,7 +1812,7 @@ function onKeydown(event: KeyboardEvent): void {
                         data-lpignore="true"
                         data-bwignore
                         data-form-type="other"
-                        class="max-h-[200px] min-w-0 flex-1 resize-none self-center bg-transparent py-1 text-base md:text-sm text-foreground outline-none placeholder:text-muted-foreground"
+                        class="max-h-[200px] min-w-0 flex-1 resize-none self-center bg-transparent py-1 text-base text-foreground outline-none placeholder:text-muted-foreground md:text-sm"
                         @input="
                             (resize(),
                             refreshSuggestions(),

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1812,7 +1812,7 @@ function onKeydown(event: KeyboardEvent): void {
                         data-lpignore="true"
                         data-bwignore
                         data-form-type="other"
-                        class="max-h-[200px] min-w-0 flex-1 resize-none self-center bg-transparent py-1 text-sm text-foreground outline-none placeholder:text-muted-foreground"
+                        class="max-h-[200px] min-w-0 flex-1 resize-none self-center bg-transparent py-1 text-base md:text-sm text-foreground outline-none placeholder:text-muted-foreground"
                         @input="
                             (resize(),
                             refreshSuggestions(),

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1186,7 +1186,7 @@ function confirmDelete(): void {
                                         v-model="editDraft"
                                         data-test="message-edit-input"
                                         rows="1"
-                                        class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-base md:text-[14.5px] leading-[1.55] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                                        class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-base leading-[1.55] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring md:text-[14.5px]"
                                         @keydown.enter.exact.prevent="
                                             saveEdit(message)
                                         "

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1186,7 +1186,7 @@ function confirmDelete(): void {
                                         v-model="editDraft"
                                         data-test="message-edit-input"
                                         rows="1"
-                                        class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-[14.5px] leading-[1.55] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                                        class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-base md:text-[14.5px] leading-[1.55] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                                         @keydown.enter.exact.prevent="
                                             saveEdit(message)
                                         "

--- a/resources/js/components/NewDirectMessageModal.vue
+++ b/resources/js/components/NewDirectMessageModal.vue
@@ -61,7 +61,7 @@ function selectPerson(id: string): void {
                 auto-focus
                 :placeholder="$t('Search people…')"
                 data-test="new-dm-input"
-                class="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                class="flex h-10 w-full rounded-md bg-transparent py-3 text-base outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
             />
         </div>
         <CommandList :ariaLabel="$t('People')">

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -265,7 +265,7 @@ function openReminders(): void {
                                 $t('Jump to a channel or search messages…')
                             "
                             data-test="quick-switcher-input"
-                            class="h-full w-full min-w-0 bg-transparent text-[15px] outline-hidden placeholder:text-muted-foreground"
+                            class="h-full w-full min-w-0 bg-transparent text-base outline-hidden placeholder:text-muted-foreground md:text-[15px]"
                         />
                     </div>
                     <Button
@@ -290,7 +290,7 @@ function openReminders(): void {
                             $t('Jump to a channel or search messages…')
                         "
                         data-test="quick-switcher-input"
-                        class="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                        class="flex h-10 w-full rounded-md bg-transparent py-3 text-base outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
                     />
                 </div>
                 <CommandList

--- a/resources/js/components/ScheduledMessagesDialog.vue
+++ b/resources/js/components/ScheduledMessagesDialog.vue
@@ -149,7 +149,7 @@ function bodyPreview(body: string): string {
                             rows="2"
                             :aria-label="$t('Scheduled message body')"
                             data-test="scheduled-edit-body"
-                            class="w-full resize-none rounded-lg border border-input bg-popover px-3 py-2.5 text-base md:text-[13.5px] leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                            class="w-full resize-none rounded-lg border border-input bg-popover px-3 py-2.5 text-base leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring md:text-[13.5px]"
                         ></textarea>
                         <div class="flex items-center gap-2">
                             <Button

--- a/resources/js/components/ScheduledMessagesDialog.vue
+++ b/resources/js/components/ScheduledMessagesDialog.vue
@@ -149,7 +149,7 @@ function bodyPreview(body: string): string {
                             rows="2"
                             :aria-label="$t('Scheduled message body')"
                             data-test="scheduled-edit-body"
-                            class="w-full resize-none rounded-lg border border-input bg-popover px-3 py-2.5 text-[13.5px] leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                            class="w-full resize-none rounded-lg border border-input bg-popover px-3 py-2.5 text-base md:text-[13.5px] leading-[1.5] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring"
                         ></textarea>
                         <div class="flex items-center gap-2">
                             <Button

--- a/resources/js/components/ui/calendar/Calendar.vue
+++ b/resources/js/components/ui/calendar/Calendar.vue
@@ -50,7 +50,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
           {{ formatter.custom(toDate(date), { month: 'short' }) }}
         </div>
         <NativeSelect
-          class="text-xs h-8 pr-6 pl-2 text-transparent relative"
+          class="text-base md:text-xs h-8 pr-6 pl-2 text-transparent relative"
           :model-value="date.month"
           @change="(e: Event) => {
             placeholder = placeholder.set({
@@ -73,7 +73,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
           {{ formatter.custom(toDate(date), { year: 'numeric' }) }}
         </div>
         <NativeSelect
-          class="text-xs h-8 pr-6 pl-2 text-transparent relative"
+          class="text-base md:text-xs h-8 pr-6 pl-2 text-transparent relative"
           :model-value="date.year"
           @change="(e: Event) => {
             placeholder = placeholder.set({

--- a/resources/js/components/ui/command/CommandInput.vue
+++ b/resources/js/components/ui/command/CommandInput.vue
@@ -33,7 +33,7 @@ const { filterState } = useCommand()
       v-model="filterState.search"
       data-slot="command-input"
       auto-focus
-      :class="cn('placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50', props.class)"
+      :class="cn('placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-base md:text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50', props.class)"
     />
   </div>
 </template>

--- a/resources/js/components/ui/native-select/NativeSelect.vue
+++ b/resources/js/components/ui/native-select/NativeSelect.vue
@@ -33,7 +33,7 @@ const delegatedProps = reactiveOmit(props, "class")
       v-model="modelValue"
       data-slot="native-select"
       :class="cn(
-        'border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed',
+        'border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 dark:hover:bg-input/50 h-9 w-full min-w-0 appearance-none rounded-md border bg-transparent px-3 py-2 pr-9 text-base md:text-sm shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed',
         'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-3',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         props.class,

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -994,7 +994,7 @@ onMounted(() => {
                                         "
                                         v-model="renameValue"
                                         :data-test="`section-rename-input-${group.section.id}`"
-                                        class="h-auto min-w-0 flex-1 rounded-sm border-sidebar-border bg-sidebar px-1 py-0.5 text-[11px] tracking-normal text-sidebar-foreground normal-case md:text-[11px] dark:bg-sidebar"
+                                        class="h-auto min-w-0 flex-1 rounded-sm border-sidebar-border bg-sidebar px-1 py-0.5 text-base tracking-normal text-sidebar-foreground normal-case md:text-[11px] dark:bg-sidebar"
                                         type="text"
                                         maxlength="50"
                                         @keydown.enter.prevent="
@@ -1312,7 +1312,7 @@ onMounted(() => {
                                 <Input
                                     v-model="newSectionName"
                                     data-test="create-section-input"
-                                    class="h-8 w-full rounded-md border-sidebar-border bg-sidebar px-2 py-1 text-[13px] text-sidebar-foreground md:text-[13px] dark:bg-sidebar"
+                                    class="h-8 w-full rounded-md border-sidebar-border bg-sidebar px-2 py-1 text-base text-sidebar-foreground md:text-[13px] dark:bg-sidebar"
                                     type="text"
                                     maxlength="50"
                                     :placeholder="$t('New section name')"

--- a/resources/js/pages/channels/Browse.vue
+++ b/resources/js/pages/channels/Browse.vue
@@ -71,7 +71,7 @@ const props = defineProps<{
                 <Input
                     type="search"
                     :placeholder="$t('Search channels')"
-                    class="h-9 rounded-full border-0 bg-muted pl-10 text-[13.5px]"
+                    class="h-9 rounded-full border-0 bg-muted pl-10 text-base md:text-[13.5px]"
                     :aria-label="$t('Search channels')"
                 />
             </div>

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -540,7 +540,7 @@ function jumpHref(result: MessageSearchResult): string {
                             :placeholder="$t('Filter people…')"
                             :aria-label="$t('Filter people')"
                             data-test="facet-author-filter"
-                            class="mb-1 h-8 text-xs max-md:h-11"
+                            class="mb-1 h-8 text-base md:text-xs max-md:h-11"
                             @keydown.stop
                         />
                         <div class="max-h-56 overflow-y-auto">
@@ -606,7 +606,7 @@ function jumpHref(result: MessageSearchResult): string {
                             v-model="channelFilter"
                             :placeholder="$t('Filter channels…')"
                             :aria-label="$t('Filter channels')"
-                            class="mb-1 h-8 text-xs max-md:h-11"
+                            class="mb-1 h-8 text-base md:text-xs max-md:h-11"
                             @keydown.stop
                         />
                         <div class="max-h-56 overflow-y-auto">

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -540,7 +540,7 @@ function jumpHref(result: MessageSearchResult): string {
                             :placeholder="$t('Filter people…')"
                             :aria-label="$t('Filter people')"
                             data-test="facet-author-filter"
-                            class="mb-1 h-8 text-base md:text-xs max-md:h-11"
+                            class="mb-1 h-8 text-base max-md:h-11 md:text-xs"
                             @keydown.stop
                         />
                         <div class="max-h-56 overflow-y-auto">
@@ -606,7 +606,7 @@ function jumpHref(result: MessageSearchResult): string {
                             v-model="channelFilter"
                             :placeholder="$t('Filter channels…')"
                             :aria-label="$t('Filter channels')"
-                            class="mb-1 h-8 text-base md:text-xs max-md:h-11"
+                            class="mb-1 h-8 text-base max-md:h-11 md:text-xs"
                             @keydown.stop
                         />
                         <div class="max-h-56 overflow-y-auto">


### PR DESCRIPTION
Closes #855.

## What

On a phone, tapping the message composer made iOS Safari zoom the whole app in and leave it scaled up and horizontally scrolled, pushing the send and `+` buttons off-screen. iOS auto-zooms onto any focused `input` / `textarea` / `select` whose computed `font-size` is under 16px, and does not zoom back out when the keyboard closes.

Every such field is now pinned to 16px below `md` and restored to its design size from `md` up, following the `text-base md:text-sm` pattern the shared `Input` primitive already used. Desktop typography is untouched.

Deliberately **not** done: `maximum-scale=1` / `user-scalable=no` on the viewport meta. That would suppress the symptom by breaking pinch-to-zoom for everyone (WCAG 1.4.4).

## Fields fixed

- `MessageComposer` textarea (the reported case), `MessageList` inline edit, `ScheduledMessagesDialog` edit body
- `ForwardMessageDialog` (search + note), `AddDirectMessagePeopleModal`, `GifPickerPanel` search
- `QuickSwitcher` (both layouts) and `NewDirectMessageModal` search
- `MainLayout` section create/rename inputs, `channels/Search` author + channel facet filters, `channels/Browse` search
- The shadcn primitives: `CommandInput`, `NativeSelect`, and the calendar's month/year selects

## Regression guard

New custom ESLint rule `local/no-small-mobile-input-text` (`eslint-rules/`), at `error` and auto-fixable, so a new sub-16px mobile field cannot land silently. It reads the effective phone-viewport font size of a class string (ignoring `md:` and state variants such as `placeholder:` / `file:`, honouring `max-md:` overrides), covers static `class` and bound `:class`, skips non-text input types, and follows the shared control wrappers (`Input`, `NativeSelect`, `CommandInput`, reka-ui's `ListboxFilter`, …) as well as raw elements. Adding `ListboxFilter` is what surfaced the quick switcher and new-DM fields.

`eslint.config.js` ignores `resources/js/components/ui/*`, so the rule is additionally run over those primitives from the Vitest suite — otherwise the three primitives fixed here could regress unseen.

## How tested

- 30 new Vitest cases (`eslint-rules/no-small-mobile-input-text.test.ts`): the pixel resolver, the class-string analysis, `RuleTester` valid/invalid + autofix output, and the `components/ui/**` audit. Confirmed the audit fails on the pre-fix primitives.
- Verified in a real browser (Playwright, iPhone 13 viewport): the composer computes to `16px` on a phone and `14px` at 1440px, with the send and `+` buttons visible while the field is focused.
- Full gate green: `composer test` at `Total: 100.0 %`, plus `lint:check`, `format:check`, `types:check`, `test:js` (1226 tests) and `build`.

No user-facing copy changed, so no i18n catalog updates. Nothing operator-facing, so no `docs/` changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787523118&installation_model_id=428379&pr_number=861&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F861&signature=31d07741b23ae03c7094bbea810476c7a0adab551470523c9f05d993f4280a4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->