### PR TITLE
fix: install gmp in the production image so web push can send

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,12 +86,14 @@ FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS runtime
 # pdo_pgsql: Postgres. redis: phpredis client for the cache/session/queue drivers.
 # pcntl/posix: queue worker + Reverb signal handling.
 # intl/zip/opcache: framework recommendations + performance.
-# gmp: big-number calculator for web push (minishlink/web-push). It guards on
+# gmp: big-number calculator web push needs. minishlink/web-push guards on
 # `gmp || bcmath` and, when both are missing, raises a notice that Laravel
 # promotes to an exception inside the WebPush binding — so the channel cannot
-# resolve and every queued push dies in failed_jobs (#865). Neither extension is
-# a hard requirement of any package, so only tests/Unit/DockerfileExtensionPinsTest.php
-# keeps it here. Sail ships bcmath instead; both are supported backends.
+# resolve and every queued push dies in failed_jobs (#865). Either extension
+# satisfies it; this image picks GMP (the library's own first recommendation and
+# fastest backend) while Sail ships BCMath. Composer cannot catch a regression
+# here — both are `suggest`, never `require`, so the image builds clean without
+# one; tests/Unit/DockerfileExtensionPinsTest.php is what guards the list.
 # gd/imagick: image processing for attachments (Intervention Image, installed via
 # Composer) — EXIF-stripping and thumbnail generation. Imagick is the default
 # driver (ATTACHMENT_IMAGE_DRIVER); GD is the fallback.

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,12 @@ FROM dunglas/frankenphp:1-php${PHP_VERSION}-alpine AS runtime
 # pdo_pgsql: Postgres. redis: phpredis client for the cache/session/queue drivers.
 # pcntl/posix: queue worker + Reverb signal handling.
 # intl/zip/opcache: framework recommendations + performance.
+# gmp: big-number calculator for web push (minishlink/web-push). It guards on
+# `gmp || bcmath` and, when both are missing, raises a notice that Laravel
+# promotes to an exception inside the WebPush binding — so the channel cannot
+# resolve and every queued push dies in failed_jobs (#865). Neither extension is
+# a hard requirement of any package, so only tests/Unit/DockerfileExtensionPinsTest.php
+# keeps it here. Sail ships bcmath instead; both are supported backends.
 # gd/imagick: image processing for attachments (Intervention Image, installed via
 # Composer) — EXIF-stripping and thumbnail generation. Imagick is the default
 # driver (ATTACHMENT_IMAGE_DRIVER); GD is the fallback.
@@ -142,6 +148,7 @@ RUN set -eu; \
             intl \
             zip \
             opcache \
+            gmp \
             gd \
             ldap \
             /tmp/phpredis \

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -398,6 +398,14 @@ docker compose exec app php artisan webpush:vapid
 It writes `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` into your `.env`. Restart
 the stack to pick them up.
 
+:::note[Web push needs a big-number PHP extension]
+Signing a push message needs either the **GMP** or the **BCMath** PHP extension. The bundled
+production image ships **GMP**, alongside the **Imagick** and **GD** extensions it ships for image
+processing, so nothing extra is required there. If you build your own image or run the app outside
+the bundled one, install one of the two: without either, the push channel cannot start and every
+notification fails in the queue instead of being delivered.
+:::
+
 :::caution[Keep the keypair stable]
 The public key is baked into every subscription a browser has already granted.
 Rotating it silently invalidates them all: those devices stop receiving anything

--- a/tests/Unit/DockerfileExtensionPinsTest.php
+++ b/tests/Unit/DockerfileExtensionPinsTest.php
@@ -95,6 +95,16 @@ test('phpredis is built from its git tag with the submodule it needs', function 
     expect(installPhpExtensionsArguments())->toContain('/tmp/phpredis');
 });
 
+test('the runtime image carries the big-number extension web push needs', function (): void {
+    // minishlink/web-push guards on `gmp || bcmath`, and when both are missing it
+    // raises an E_USER_NOTICE that Laravel promotes to an ErrorException inside
+    // the WebPush binding closure — so the channel never resolves and every
+    // queued push dies in failed_jobs (#865). Neither extension is required by
+    // any package (both sit under `suggest`), so the image builds clean without
+    // one and nothing but this test keeps it installed.
+    expect(array_intersect(['gmp', 'bcmath'], installPhpExtensionsArguments()))->not->toBeEmpty();
+});
+
 test('imagick is built from its GitHub release archive', function (): void {
     expect(productionDockerfile())->toContain(
         'https://github.com/Imagick/imagick/archive/refs/tags/${IMAGICK_VERSION}.tar.gz',

--- a/tests/Unit/DockerfileExtensionRetryTest.php
+++ b/tests/Unit/DockerfileExtensionRetryTest.php
@@ -127,6 +127,7 @@ test('the bundled extension list is unchanged', function (): void {
         'intl',
         'zip',
         'opcache',
+        'gmp',
         'gd',
         'ldap',
     ]);


### PR DESCRIPTION
Closes #865.

## What

The production runtime image installed neither `gmp` nor `bcmath`, so `minishlink/web-push` could not construct: it guards on `gmp || bcmath` and raises an `E_USER_NOTICE` when both are missing, which Laravel promotes to an `ErrorException` inside the `WebPush` binding closure. `NewMessageNotification::via()` returns only `[WebPushChannel::class]`, so every queued push died in `failed_jobs` rather than degrading. Web push was dead in every self-hosted deployment built from this image, and nothing warned at build time.

`gmp` is now installed in the runtime stage. It is the library's own first recommendation and its fastest calculator, and either extension satisfies the guard, so it alone is enough.

## Why it built clean

Neither extension is required by any package: both appear only under `suggest` in `composer.lock`, so `composer install` succeeds without them. The Sail dev container ships `bcmath`, so local dev, `tinker` and `Notification::sendNow()` never tripped the notice. The failure only reproduced in the production image, on a queue worker, and the job failed after being consumed so `Queue::size()` read 0 and every surface-level health signal looked fine.

This leaves dev on BCMath and prod on GMP. Both are supported backends.

## How it was tested

- `tests/Unit/DockerfileExtensionPinsTest.php` gains a test asserting the `install-php-extensions` arguments contain `gmp` or `bcmath`, so a future prune of the list cannot silently break push again. Written red first: it failed with `Expecting [] not to be empty` before the Dockerfile change.
- `tests/Unit/DockerfileExtensionRetryTest.php` pins the exact bundled extension list and is updated to match.
- The real image was built (`docker build --target runtime`) and verified end to end: replaying the issue's exact failure path there (Laravel-style notice-to-`ErrorException` promotion around `new WebPush([])`) now constructs cleanly, while the same image with the extension unloaded reproduces the reported `ErrorException: It is highly recommended to install the GMP or BCMath extension...` verbatim.
- Full backend gate green at 100.0% coverage (Pint, PHPStan, Rector, 2447 tests); frontend lint/format/types green; docs site builds.

## Docs

`docs/src/content/docs/reference/environment-variables.md` gains a note under *Web push notifications*: the bundled image ships GMP alongside the Imagick/GD extensions it ships for image processing, and anyone building their own image needs one of GMP or BCMath.

No i18n changes: nothing user-facing.

## Notes

- Targets `develop`, not a hotfix: #862 is on `develop` only and `master` is still 1.16.0, so no stable release ships the defect.
- Related but distinct: #863 (`webpush:vapid` cannot write `.env` in the documented container setup).
- The single-channel fallback gap called out in the issue's scope notes is filed separately as #866.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787533594&installation_model_id=428379&pr_number=870&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F870&signature=717bd38b7f89ab240fe7f5f128138325a81458fd087dd2f1d26e0e5d1c4b2f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->