### PR TITLE
docs: document webpush:vapid --show for the read-only container .env

### DIFF
--- a/config/webpush.php
+++ b/config/webpush.php
@@ -13,7 +13,8 @@ return [
     |
     | The keypair every push message is signed with, identifying this instance
     | to the browser vendors' push services. Generate one per instance with
-    | `php artisan webpush:vapid` and keep it stable: the public key is baked
+    | `php artisan webpush:vapid --show` (the bare form writes to .env, which is
+    | mounted read-only in production) and keep it stable: the public key is baked
     | into each browser's subscription, so rotating it invalidates every
     | subscription users have already granted. Web push stays switched off
     | until both keys are set — see App\Support\WebPushConfig.

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -389,14 +389,47 @@ for what it does and how it behaves.
 | `VAPID_PRIVATE_KEY` | *(unset)*    | Private half. Never leaves the server.                                                                      |
 | `VAPID_SUBJECT`     | *(`APP_URL`)*| How you identify yourself to the push services: a `mailto:` or `https:` URL they can contact you at.         |
 
-Generate the pair once, from inside the app container:
+Generate the pair once. Always pass `--show`, which **prints** the keys instead
+of writing them anywhere:
 
 ```bash
-docker compose exec app php artisan webpush:vapid
+docker compose exec app php artisan webpush:vapid --show
 ```
 
-It writes `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` into your `.env`. Restart
-the stack to pick them up.
+```
+VAPID_PUBLIC_KEY=BN4Gv…
+VAPID_PRIVATE_KEY=hAn5…
+```
+
+Paste both into the `.env` **on the host**, alongside your other secrets, and set
+`VAPID_SUBJECT` while you are there:
+
+```ini
+VAPID_PUBLIC_KEY=BN4Gv…
+VAPID_PRIVATE_KEY=hAn5…
+VAPID_SUBJECT=mailto:admin@example.com
+```
+
+Then restart the stack to pick them up:
+
+```bash
+docker compose up -d
+```
+
+:::caution[Run it with `--show`, never bare]
+Without `--show`, the command writes the keys into `.env` itself, and that cannot
+work here. The bundled stack bind-mounts the file **read-only**
+(`./.env:/app/.env:ro` in `docker-compose.prod.yml`) because the operator owns
+and edits it on the host, so the bare form fails with:
+
+```
+file_put_contents(/app/.env): Failed to open stream: Read-only file system
+```
+
+On a platform-managed deployment (Dokploy, Coolify, Kubernetes) there is no
+host `.env` to edit at all: generate the pair with `--show` and paste the three
+values into the platform's environment settings, then redeploy.
+:::
 
 :::caution[Keep the keypair stable]
 The public key is baked into every subscription a browser has already granted.

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -426,9 +426,11 @@ and edits it on the host, so the bare form fails with:
 file_put_contents(/app/.env): Failed to open stream: Read-only file system
 ```
 
-On a platform-managed deployment (Dokploy, Coolify, Kubernetes) there is no
-host `.env` to edit at all: generate the pair with `--show` and paste the three
-values into the platform's environment settings, then redeploy.
+On a platform-managed deployment (Dokploy, Coolify, Kubernetes) there is no host
+`.env` to edit at all. Run the same `--show` command through whatever that
+platform gives you to reach the running app container (a web terminal, a one-off
+task, `kubectl exec`), then paste the three values into the platform's
+environment settings and redeploy.
 :::
 
 :::caution[Keep the keypair stable]

--- a/docs/src/content/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/reference/feature-toggles.md
@@ -513,7 +513,7 @@ never appropriate for real data.
 
 Web push is **off** until you generate a VAPID keypair — see
 [Environment variables → Web push notifications](/reference/environment-variables/#web-push-notifications)
-for the `webpush:vapid` command. With no keypair the toggle never appears in
+for the `webpush:vapid --show` command. With no keypair the toggle never appears in
 Settings, and the subscription endpoints return **404**.
 
 With the keys set, the feature is still **opt-in per member and per device**:

--- a/docs/src/content/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/reference/feature-toggles.md
@@ -513,8 +513,8 @@ never appropriate for real data.
 
 Web push is **off** until you generate a VAPID keypair — see
 [Environment variables → Web push notifications](/reference/environment-variables/#web-push-notifications)
-for the `webpush:vapid --show` command. With no keypair the toggle never appears in
-Settings, and the subscription endpoints return **404**.
+for the `webpush:vapid --show` command. With no keypair the toggle never
+appears in Settings, and the subscription endpoints return **404**.
 
 With the keys set, the feature is still **opt-in per member and per device**:
 nothing prompts on load or on login. Each member turns it on from

--- a/tests/Unit/WebPushVapidGuidanceTest.php
+++ b/tests/Unit/WebPushVapidGuidanceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The production stack bind-mounts `.env` read-only, so the file-writing form of
+ * `webpush:vapid` cannot succeed inside the app container: an operator following
+ * it gets `file_put_contents(/app/.env): Failed to open stream: Read-only file
+ * system`. The `--show` form prints the pair instead, and it is the only shape
+ * that also works on platform-managed deployments (Dokploy, Coolify, Kubernetes)
+ * where no host `.env` exists at all. These tests keep the working command
+ * documented and its rationale attached to the fact that forces it. See #863.
+ */
+$repoRoot = dirname(__DIR__, 2);
+
+/**
+ * Every operator-facing surface that could name the command: the published docs
+ * and the config file's own guidance block, which had drifted the same way.
+ *
+ * @return list<string>
+ */
+$operatorGuidance = function () use ($repoRoot): array {
+    $files = [$repoRoot.'/config/webpush.php'];
+
+    $docs = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($repoRoot.'/docs/src/content/docs', FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($docs as $file) {
+        if (in_array($file->getExtension(), ['md', 'mdx'], true)) {
+            $files[] = $file->getPathname();
+        }
+    }
+
+    return $files;
+};
+
+test('every documented webpush:vapid invocation prints the keys rather than writing them', function () use ($operatorGuidance): void {
+    $writesToEnv = [];
+    $invocations = 0;
+
+    foreach ($operatorGuidance() as $path) {
+        // Capture what follows the command up to the end of the line or the
+        // closing backtick, so an invocation is judged by its own flags rather
+        // than by a `--show` mentioned elsewhere in the file.
+        preg_match_all('/webpush:vapid(?<flags>[^\n`]*)/', (string) file_get_contents($path), $matches);
+
+        foreach ($matches['flags'] as $flags) {
+            $invocations++;
+
+            if (! str_contains($flags, '--show')) {
+                $writesToEnv[] = basename((string) $path);
+            }
+        }
+    }
+
+    // Guard the guard: a rename or a moved page would empty the scan and leave
+    // this passing while checking nothing.
+    expect($invocations)->toBeGreaterThan(0)
+        ->and($writesToEnv)->toBe([]);
+});
+
+test('the production stack still mounts .env read-only, which is what forces --show', function () use ($repoRoot): void {
+    expect((string) file_get_contents($repoRoot.'/docker-compose.prod.yml'))
+        ->toContain('./.env:/app/.env:ro');
+});
+
+test('the web push setup explains the read-only mount and the keys to paste in', function () use ($repoRoot): void {
+    $page = (string) file_get_contents($repoRoot.'/docs/src/content/docs/reference/environment-variables.md');
+
+    expect($page)->toContain('./.env:/app/.env:ro')
+        ->and($page)->toContain('Read-only file system')
+        // VAPID_SUBJECT is set by hand in the same paste, since --show never prints it.
+        ->and($page)->toContain('VAPID_SUBJECT=');
+});


### PR DESCRIPTION
Closes #863.

## What was wrong

The web push setup told operators to run `docker compose exec app php artisan webpush:vapid`, which writes the keypair into `.env`. That cannot succeed on the stack we ship: `docker-compose.prod.yml` bind-mounts the file read-only (`./.env:/app/.env:ro`) by design, because the operator owns it on the host. Following the documented step gives:

```
file_put_contents(/app/.env): Failed to open stream: Read-only file system
```

It surfaced setting up web push on a Dokploy-hosted staging instance of v1.17.0-rc.0.

## What changed

- **`docs/.../reference/environment-variables.md`** — `webpush:vapid --show` is now the documented command, with the printed output, a paste-in block for the **host** `.env` that includes `VAPID_SUBJECT` (`--show` never prints it, and it is set the same way), and the restart. A caution explains *why* the bare form fails, quoting the real error and the read-only mount, and covers platform-managed deployments (Dokploy, Coolify, Kubernetes) where there is no host `.env` at all.
- **`docs/.../reference/feature-toggles.md`** — the cross-reference now names `webpush:vapid --show`.
- **`config/webpush.php`** — the config's own guidance block carried the same wrong instruction; corrected.
- **`tests/Unit/WebPushVapidGuidanceTest.php`** — a guard so the file-writing form cannot come back: every `webpush:vapid` invocation across the published docs and the config block must carry `--show`, the scan must find at least one invocation (so a moved page cannot leave it passing while checking nothing), and `docker-compose.prod.yml` must still mount `.env` read-only, since that is the fact the guidance rests on.

## Testing

- `./vendor/bin/sail composer test` — Pint, PHPStan, Rector clean; 2449 tests, **100.0%** coverage.
- `cd docs && npm run build` passes; verified the rendered page and the `#web-push-notifications` anchor.
- The new guard was verified red-then-green: reverting the config block to the bare command fails it naming the offending file.
- No frontend files are touched, so the JS gates are unaffected.

No new user-facing copy, so no `lang/fr.json` change.

## Found while auditing sibling docs

The issue asked for sibling secret-generation docs to be checked. Three findings, filed rather than folded in:

- **#867** — `dokploy.md` documents `php artisan reverb:secret`, which does not exist (`laravel/reverb` ships only `install`/`start`/`restart`). Operators following it get no `REVERB_APP_*` values.
- **#869** — `gen-secrets.sh` could mint the VAPID pair at install with `openssl` alone, removing the round-trip entirely for fresh installs. Recipe verified against `minishlink/web-push`. Blocked on #865.
- **#871** — the published image is amd64-only (intentional, #205 closed not-planned) but `requirements.md` never says so, so ARM hosts fail at install with an opaque `no matching manifest` error.

That last check is also why this PR does not tell operators to `docker run ... :latest` for the platform-managed case: `latest` is the 1.16.0 stable line and has no `webpush` namespace at all.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787534168&installation_model_id=428379&pr_number=872&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F872&signature=df78c741debbf2192782bddd941c6b566cc137534a1557ad8ade8c1100058e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->