### PR TITLE
docs: generate the REVERB_APP_* trio with openssl, not reverb:secret

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -205,7 +205,10 @@ MEILISEARCH_KEY=
 MEILISEARCH_NO_ANALYTICS=true
 
 # --- Broadcasting (reverb service) -------------------------------------------
-# Required. Generate with: docker run --rm ghcr.io/deskhq/the-desk:latest php artisan reverb:secret
+# Required. ./docker/gen-secrets.sh fills these in; by hand, one command each:
+#   REVERB_APP_ID       openssl rand 4 | od -An -tu4 | tr -d ' '
+#   REVERB_APP_KEY      openssl rand -hex 16
+#   REVERB_APP_SECRET   openssl rand -hex 16
 REVERB_APP_ID=
 REVERB_APP_KEY=
 REVERB_APP_SECRET=

--- a/docs/src/content/docs/self-hosting/dokploy.md
+++ b/docs/src/content/docs/self-hosting/dokploy.md
@@ -93,9 +93,18 @@ locally and paste them:
 
 ```bash
 docker run --rm ghcr.io/deskhq/the-desk:latest php artisan key:generate --show
-docker run --rm ghcr.io/deskhq/the-desk:latest php artisan reverb:secret
-openssl rand -hex 32   # DB_PASSWORD, and again for MEILISEARCH_KEY
+
+openssl rand -hex 32                       # DB_PASSWORD, and again for MEILISEARCH_KEY
+openssl rand 4 | od -An -tu4 | tr -d ' '   # REVERB_APP_ID
+openssl rand -hex 16                       # REVERB_APP_KEY
+openssl rand -hex 16                       # REVERB_APP_SECRET (run it a second time)
 ```
+
+These are the same recipes
+[`docker/gen-secrets.sh`](https://github.com/deskhq/the-desk/blob/master/docker/gen-secrets.sh)
+uses on the bare-VPS path, so the two installs end up with identically shaped
+values. There is no artisan command for the `REVERB_APP_*` trio: `laravel/reverb`
+ships only `reverb:install`, `reverb:start` and `reverb:restart`.
 
 ## The Domains tab
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -57,6 +57,11 @@ pest()->extend(TestCase::class)->in('Unit/Support/WebPushConfigTest.php');
 // needs the application booted (but no database).
 pest()->extend(TestCase::class)->in('Unit/OpenApiSpecTest.php');
 
+// The Reverb secret guidance test checks documented commands against the ones
+// Artisan actually registers, so it needs the application booted (but no
+// database).
+pest()->extend(TestCase::class)->in('Unit/ReverbSecretGuidanceTest.php');
+
 /*
 |--------------------------------------------------------------------------
 | Browser (E2E) Test Case

--- a/tests/Unit/ReverbSecretGuidanceTest.php
+++ b/tests/Unit/ReverbSecretGuidanceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * `laravel/reverb` ships `reverb:install`, `reverb:start` and `reverb:restart`
+ * and nothing else, so the Dokploy page's `php artisan reverb:secret` failed with
+ * `Command "reverb:secret" is not defined.` and left the operator without any of
+ * `REVERB_APP_ID`, `REVERB_APP_KEY` or `REVERB_APP_SECRET` — all three of which
+ * the stack refuses to start without. `docker/gen-secrets.sh` is the source of
+ * truth for how they are minted, so these tests hold the documented recipes to it
+ * and check every `reverb:` command we name against the ones actually registered.
+ * See #867.
+ */
+$repoRoot = dirname(__DIR__, 2);
+
+/**
+ * Every operator-facing surface that could name a command or a recipe: the
+ * published docs plus the environment template an operator copies from.
+ *
+ * @return list<string>
+ */
+$operatorGuidance = function () use ($repoRoot): array {
+    $files = [$repoRoot.'/.env.prod.example'];
+
+    $docs = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($repoRoot.'/docs/src/content/docs', FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($docs as $file) {
+        if (in_array($file->getExtension(), ['md', 'mdx'], true)) {
+            $files[] = $file->getPathname();
+        }
+    }
+
+    return $files;
+};
+
+/**
+ * The `REVERB_APP_*` recipes `docker/gen-secrets.sh` uses, keyed by variable, as
+ * the shell command inside each `set_if_empty "KEY" "$(…)"`.
+ *
+ * @return array<string, string>
+ */
+$generatedRecipes = function () use ($repoRoot): array {
+    preg_match_all(
+        '/set_if_empty\s+"(?<key>REVERB_APP_[A-Z_]+)"\s+"\$\((?<recipe>.+)\)"/',
+        (string) file_get_contents($repoRoot.'/docker/gen-secrets.sh'),
+        $matches,
+    );
+
+    return array_combine($matches['key'], $matches['recipe']);
+};
+
+test('every documented reverb: artisan command actually exists', function () use ($operatorGuidance): void {
+    $registered = array_keys(Artisan::all());
+    $invented = [];
+    $invocations = 0;
+
+    foreach ($operatorGuidance() as $path) {
+        preg_match_all('/\breverb:[a-z][a-z0-9:-]*/', (string) file_get_contents($path), $matches);
+
+        foreach ($matches[0] as $command) {
+            $invocations++;
+
+            if (! in_array($command, $registered, true)) {
+                $invented[] = $command.' in '.basename((string) $path);
+            }
+        }
+    }
+
+    // Guard the guard: a moved page or a renamed template would empty the scan
+    // and leave this passing while checking nothing.
+    expect($invocations)->toBeGreaterThan(0)
+        ->and($invented)->toBe([]);
+});
+
+test('gen-secrets.sh mints all three REVERB_APP_* values, which is what the docs mirror', function () use ($generatedRecipes): void {
+    expect(array_keys($generatedRecipes()))
+        ->toEqualCanonicalizing(['REVERB_APP_ID', 'REVERB_APP_KEY', 'REVERB_APP_SECRET']);
+});
+
+test('the Dokploy page generates each REVERB_APP_* value exactly as gen-secrets.sh does', function () use ($repoRoot, $generatedRecipes): void {
+    $page = (string) file_get_contents($repoRoot.'/docs/src/content/docs/self-hosting/dokploy.md');
+
+    foreach ($generatedRecipes() as $key => $recipe) {
+        expect($page)->toContain($recipe)
+            // The block hands over three interchangeable-looking commands, so
+            // each one has to say which value it is for.
+            ->and($page)->toContain($key);
+    }
+});


### PR DESCRIPTION
Closes #867.

## What was wrong

`docs/.../self-hosting/dokploy.md` told the operator to mint the `REVERB_APP_*` trio with:

```bash
docker run --rm ghcr.io/deskhq/the-desk:latest php artisan reverb:secret
```

There is no such command. `laravel/reverb` registers only `reverb:install`, `reverb:start` and `reverb:restart` (confirmed with `php artisan list` in the app container), so the step dies with `Command "reverb:secret" is not defined.` and the operator is left without `REVERB_APP_ID`, `REVERB_APP_KEY` or `REVERB_APP_SECRET` — all three of which the stack refuses to start without.

The issue expected one occurrence; there were **two**. `.env.prod.example:208` carried the same instruction as the comment above the three empty keys, which is the more likely place to be read, since the Dokploy page tells you to start from that template.

## What changed

- **`docs/.../self-hosting/dokploy.md`** — the paste-in block now uses the same `openssl` recipes `docker/gen-secrets.sh` uses, with a trailing comment naming which value each one is for. A short paragraph records where the recipes come from and states outright that there is no artisan command for the trio, naming the three that do exist so the next reader does not go looking.
- **`.env.prod.example`** — the `# Required. Generate with: … reverb:secret` comment becomes a three-line table pairing each key with its command, and points at `./docker/gen-secrets.sh` as the path that fills them in for you.
- **`tests/Unit/ReverbSecretGuidanceTest.php`** — a guard, registered in `tests/Pest.php` so it boots the app (no database). It scans the published docs and the environment template for anything matching `reverb:<command>` and asserts each one is in `Artisan::all()`, so this class of defect cannot come back under a different invented name, not just this one. It also parses the `set_if_empty "REVERB_APP_*"` lines out of `gen-secrets.sh` and asserts the Dokploy page contains each recipe verbatim alongside the key it is for, so the two paths cannot drift. Both scans guard themselves: the command scan requires at least one hit, and the recipe scan asserts the script still mints exactly the three keys.

## Testing

- Verified red-then-green: before the fix the guard failed naming `reverb:secret in .env.prod.example` and `reverb:secret in dokploy.md`, plus the missing recipes.
- `./vendor/bin/sail composer test` — Pint, PHPStan (0 errors), Rector dry-run clean; 2465 tests, **100.0%** coverage.
- `cd docs && npm run build` passes; checked the rendered `dist/self-hosting/dokploy/index.html` block reads correctly.
- `npm run format:check` passes. No frontend source is touched, so the remaining JS gates are unaffected by this diff.

No new user-facing copy, so no `lang/fr.json` change.

## Note on the review

The local CodeRabbit pass could not run: the free OSS tier is rate-limited and reported a 30-35 minute wait on both attempts. Leaving it to the app's review on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787535127&installation_model_id=428379&pr_number=873&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F873&signature=7e2c88500f034da24f94e2ce2758a8b8ebd17d4e25da602925c86d62c009be98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->