### PR TITLE
feat: surface web push failures with a push:doctor command and failed-job logging

### DIFF
--- a/app/Console/Commands/PushDoctorCommand.php
+++ b/app/Console/Commands/PushDoctorCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Notifications\NewMessageNotification;
 use App\Support\PhpExtensions;
 use App\Support\WebPushConfig;
 use ErrorException;
@@ -20,7 +21,7 @@ use Throwable;
 /**
  * Report whether this instance can actually deliver a web push notification.
  *
- * Web push is the app's only channel for message alerts — {@see \App\Notifications\NewMessageNotification::via()}
+ * Web push is the app's only channel for message alerts — {@see NewMessageNotification::via()}
  * deliberately sends nothing else — so a broken push setup produces exactly the
  * same silence as a user who never subscribed a device. Nothing fails visibly:
  * the notification job is consumed before it throws, so the queue drains and

--- a/app/Console/Commands/PushDoctorCommand.php
+++ b/app/Console/Commands/PushDoctorCommand.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Support\PhpExtensions;
+use App\Support\WebPushConfig;
+use ErrorException;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Minishlink\WebPush\VAPID;
+use NotificationChannels\WebPush\PushSubscription;
+use NotificationChannels\WebPush\WebPushChannel;
+use Throwable;
+
+/**
+ * Report whether this instance can actually deliver a web push notification.
+ *
+ * Web push is the app's only channel for message alerts — {@see \App\Notifications\NewMessageNotification::via()}
+ * deliberately sends nothing else — so a broken push setup produces exactly the
+ * same silence as a user who never subscribed a device. Nothing fails visibly:
+ * the notification job is consumed before it throws, so the queue drains and
+ * the worker stays up, and the only evidence is a row in `failed_jobs`.
+ *
+ * This command is the thing an operator can run to tell those two states apart.
+ * It checks configuration and runtime prerequisites separately, because they
+ * fail for different reasons and in different places: keys come from the
+ * operator's `.env`, extensions come from the image.
+ */
+#[Signature('push:doctor')]
+#[Description('Diagnose web push: VAPID configuration, runtime prerequisites, subscribed devices, and past delivery failures')]
+class PushDoctorCommand extends Command
+{
+    /**
+     * Nothing is wrong with this component.
+     */
+    private const string OK = 'ok';
+
+    /**
+     * Worth an operator's attention, but not a fault: push is switched off, or
+     * no device has subscribed yet. Never changes the exit code.
+     */
+    private const string WARN = 'warn';
+
+    /**
+     * Push cannot be delivered in this state. Fails the command.
+     */
+    private const string FAIL = 'fail';
+
+    /**
+     * Extensions `minishlink/web-push` cannot send a payload or sign a VAPID
+     * header without.
+     *
+     * @var list<string>
+     */
+    private const array REQUIRED_EXTENSIONS = ['curl', 'mbstring', 'openssl'];
+
+    /**
+     * The queued work a web push travels through — the listener that resolves
+     * recipients, and the notification that reaches a push service — matched
+     * against the serialized payload of a failed job.
+     *
+     * Matched on the class name alone: the payload holds it JSON-escaped, and a
+     * namespace separator is also LIKE's escape character on Postgres, so a
+     * fully-qualified pattern would have to be escaped twice over to mean what
+     * it says. Neither name is ambiguous without it.
+     *
+     * @var list<string>
+     */
+    private const array PUSH_JOBS = [
+        'SendMessagePushNotifications',
+        'NewMessageNotification',
+    ];
+
+    /**
+     * The checks run so far, in report order.
+     *
+     * @var list<array{status: string, label: string, detail: string}>
+     */
+    private array $checks = [];
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(PhpExtensions $extensions): int
+    {
+        $this->checkVapidKeypair();
+        $this->checkVapidSubject();
+        $this->checkRequiredExtensions($extensions);
+        $this->checkMathExtension($extensions);
+        $this->checkDeliveryChannel();
+        $this->checkSubscriptions();
+        $this->checkPastFailures();
+
+        $this->report();
+
+        return $this->hasFailures() ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * Check that the instance holds a usable VAPID keypair.
+     *
+     * Presence and validity are one check because they are one decision for the
+     * operator: keys that decode to the wrong length are as unusable as keys
+     * that were never set, and the library rejects both at the same point.
+     * Having neither half is not a fault — an instance is free to run without
+     * push, and every push surface hides itself when it does.
+     */
+    private function checkVapidKeypair(): void
+    {
+        $publicKey = (string) config('webpush.vapid.public_key');
+        $privateKey = (string) config('webpush.vapid.private_key');
+
+        if (! WebPushConfig::configured()) {
+            $missingBoth = $publicKey === '' && $privateKey === '';
+
+            $this->record(
+                $missingBoth ? self::WARN : self::FAIL,
+                'VAPID keypair',
+                $missingBoth
+                    ? 'not set: web push is disabled on this instance'
+                    : 'half-configured: set both VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY',
+            );
+
+            return;
+        }
+
+        try {
+            VAPID::validate([
+                'subject' => (string) (config('webpush.vapid.subject') ?? url('/')),
+                'publicKey' => $publicKey,
+                'privateKey' => $privateKey,
+            ]);
+        } catch (ErrorException $exception) {
+            $this->record(self::FAIL, 'VAPID keypair', $exception->getMessage());
+
+            return;
+        }
+
+        $this->record(self::OK, 'VAPID keypair', 'set and well-formed');
+    }
+
+    /**
+     * Check the contact the VAPID header identifies this instance by.
+     *
+     * A push service uses it to reach whoever runs the sender when something is
+     * wrong, and the spec allows only a `mailto:` address or an `https` URL.
+     * Leaving it unset is survivable — the package substitutes the app URL — but
+     * it is worth naming, because an operator who set `VAPID_SUBJECT` and got
+     * the format wrong sees the same silence either way. The library itself
+     * checks only that a subject exists, so the format check has to live here.
+     */
+    private function checkVapidSubject(): void
+    {
+        $subject = (string) config('webpush.vapid.subject');
+
+        if ($subject === '') {
+            $this->record(self::WARN, 'VAPID subject', 'not set: falling back to '.url('/'));
+
+            return;
+        }
+
+        if (! str_starts_with($subject, 'mailto:') && ! str_starts_with($subject, 'https://') && ! str_starts_with($subject, 'http://')) {
+            $this->record(self::FAIL, 'VAPID subject', $subject.' must be a mailto: address or an https URL');
+
+            return;
+        }
+
+        $this->record(self::OK, 'VAPID subject', $subject);
+    }
+
+    /**
+     * Check the extensions the library refuses to work without.
+     */
+    private function checkRequiredExtensions(PhpExtensions $extensions): void
+    {
+        $missing = $extensions->missing(self::REQUIRED_EXTENSIONS);
+
+        $this->record(
+            $missing === [] ? self::OK : self::FAIL,
+            'PHP extensions',
+            $missing === []
+                ? implode(', ', self::REQUIRED_EXTENSIONS).' loaded'
+                : 'missing: '.implode(', ', $missing),
+        );
+    }
+
+    /**
+     * Check that a big-number backend is available.
+     *
+     * The library only calls this one "highly recommended", but on this app it
+     * is fatal rather than slow: it announces the gap with `trigger_error()` at
+     * `E_USER_NOTICE`, Laravel's error handler promotes that to an
+     * `ErrorException`, and it is raised inside the container binding — so
+     * `WebPush` cannot be constructed at all and every queued notification dies
+     * (issue #865).
+     */
+    private function checkMathExtension(PhpExtensions $extensions): void
+    {
+        $candidates = ['gmp', 'bcmath'];
+        $missing = $extensions->missing($candidates);
+
+        if ($missing === $candidates) {
+            $this->record(
+                self::FAIL,
+                'Math extension',
+                'neither gmp nor bcmath is loaded: WebPush cannot be constructed',
+            );
+
+            return;
+        }
+
+        $this->record(
+            self::OK,
+            'Math extension',
+            implode(', ', array_values(array_diff($candidates, $missing))).' loaded',
+        );
+    }
+
+    /**
+     * Resolve the notification channel exactly as a queued notification would.
+     *
+     * The checks above name causes; this one asks the only question that
+     * matters, and it is the one the individual checks can never fully answer —
+     * a delivery attempt begins by resolving this channel out of the container,
+     * and anything that stops it (a missing extension, a rejected keypair, a
+     * future prerequisite nobody has thought of yet) surfaces here as the very
+     * error the failed job would have carried.
+     */
+    private function checkDeliveryChannel(): void
+    {
+        try {
+            app()->make(WebPushChannel::class);
+        } catch (Throwable $exception) {
+            $this->record(self::FAIL, 'Delivery channel', $exception->getMessage());
+
+            return;
+        }
+
+        $this->record(self::OK, 'Delivery channel', 'resolves');
+    }
+
+    /**
+     * Count the devices a notification could actually be delivered to.
+     *
+     * Everything above can be perfect and still reach nobody: a push needs a
+     * browser to have subscribed. Reporting the count is what lets an operator
+     * separate "delivery is broken" from "nobody has turned notifications on
+     * yet", which is the ambiguity this whole command exists to resolve.
+     */
+    private function checkSubscriptions(): void
+    {
+        $devices = PushSubscription::query()->count();
+
+        if ($devices === 0) {
+            $this->record(self::WARN, 'Subscriptions', 'no device has subscribed: nothing would be delivered');
+
+            return;
+        }
+
+        $people = PushSubscription::query()->distinct()->count('subscribable_id');
+
+        $this->record(self::OK, 'Subscriptions', sprintf('%d device(s) across %d user(s)', $devices, $people));
+    }
+
+    /**
+     * Look for push work that has already died.
+     *
+     * This is the table the issue was hiding in: a failed job is consumed
+     * before it throws, so the queue drains and every liveness signal reads
+     * green while the rows pile up unread. A count and a timestamp turn that
+     * into something an operator sees without knowing to go looking.
+     *
+     * Deliberately a warning, never a failure. These are historical: an
+     * instance that has been repaired would otherwise report red forever, until
+     * someone thought to run `queue:flush`.
+     */
+    private function checkPastFailures(): void
+    {
+        $driver = (string) config('queue.failed.driver');
+
+        if (! in_array($driver, ['database', 'database-uuids'], true)) {
+            $this->record(self::WARN, 'Past failures', "failed jobs are stored by the `{$driver}` driver: inspect them there");
+
+            return;
+        }
+
+        $failures = DB::connection(config('queue.failed.database'))
+            ->table((string) config('queue.failed.table'))
+            ->where(function (Builder $query): void {
+                foreach (self::PUSH_JOBS as $job) {
+                    $query->orWhere('payload', 'like', '%'.$job.'%');
+                }
+            });
+
+        $count = (clone $failures)->count();
+
+        if ($count === 0) {
+            $this->record(self::OK, 'Past failures', 'no push job has failed');
+
+            return;
+        }
+
+        $this->record(self::WARN, 'Past failures', sprintf(
+            '%d failed push job(s), most recently %s: inspect with `php artisan queue:failed`',
+            $count,
+            (string) $failures->max('failed_at'),
+        ));
+    }
+
+    /**
+     * Record a check's outcome.
+     */
+    private function record(string $status, string $label, string $detail): void
+    {
+        $this->checks[] = ['status' => $status, 'label' => $label, 'detail' => $detail];
+    }
+
+    /**
+     * Whether any check found something that stops push being delivered.
+     */
+    private function hasFailures(): bool
+    {
+        return array_any($this->checks, static fn (array $check): bool => $check['status'] === self::FAIL);
+    }
+
+    /**
+     * Print every check, then a one-line verdict.
+     */
+    private function report(): void
+    {
+        $this->newLine();
+
+        foreach ($this->checks as $check) {
+            $this->components->twoColumnDetail(
+                $check['label'],
+                $check['detail'].' '.$this->marker($check['status']),
+            );
+        }
+
+        $this->newLine();
+
+        if ($this->hasFailures()) {
+            $this->error('Web push cannot be delivered in this state.');
+
+            return;
+        }
+
+        if (array_any($this->checks, static fn (array $check): bool => $check['status'] === self::WARN)) {
+            $this->comment('Web push has no faults, but see the warnings above.');
+
+            return;
+        }
+
+        $this->info('Web push is healthy.');
+    }
+
+    /**
+     * The status marker a check is printed with.
+     *
+     * Spelled out in ASCII rather than drawn with a tick or a cross: this is
+     * read over `docker compose exec` on whatever terminal an operator's server
+     * happens to give them, and a word survives a font or an encoding that a
+     * glyph does not.
+     */
+    private function marker(string $status): string
+    {
+        return match ($status) {
+            self::OK => '<fg=green;options=bold>OK</>',
+            self::WARN => '<fg=yellow;options=bold>WARN</>',
+            default => '<fg=red;options=bold>FAIL</>',
+        };
+    }
+}

--- a/app/Console/Commands/PushDoctorCommand.php
+++ b/app/Console/Commands/PushDoctorCommand.php
@@ -131,8 +131,11 @@ class PushDoctorCommand extends Command
         }
 
         try {
+            // The subject is passed only because the library insists the key is
+            // present; it never inspects it. Whether it is a contact a push
+            // service would accept is {@see self::checkVapidSubject()}'s call.
             VAPID::validate([
-                'subject' => (string) (config('webpush.vapid.subject') ?? url('/')),
+                'subject' => (string) config('webpush.vapid.subject'),
                 'publicKey' => $publicKey,
                 'privateKey' => $privateKey,
             ]);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,8 +9,10 @@ use Carbon\CarbonImmutable;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Http\Request;
+use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
@@ -50,6 +52,32 @@ class AppServiceProvider extends ServiceProvider
         $this->configureDefaults();
         $this->configureRateLimiting();
         $this->configureQueueRouting();
+        $this->configureQueueFailureLogging();
+    }
+
+    /**
+     * Write every job that dies on a worker to the log.
+     *
+     * Without this, a failed job is invisible: it is consumed before it throws,
+     * so the queue drains, the worker stays up, and the only record is a row in
+     * `failed_jobs` that nothing reads (issue #866 — web push spent a whole
+     * staging cycle dead this way). One line in the log puts it in front of
+     * whatever an operator already watches, on the first failure rather than
+     * whenever someone thinks to look.
+     *
+     * Registered for every queued job, not just the push path: any job that can
+     * fail silently has the same problem, and there is no reason to learn this
+     * lesson once per subsystem.
+     */
+    protected function configureQueueFailureLogging(): void
+    {
+        Queue::failing(function (JobFailed $event): void {
+            Log::error('Queued job failed: '.$event->job->resolveName(), [
+                'connection' => $event->connectionName,
+                'queue' => $event->job->getQueue(),
+                'exception' => $event->exception,
+            ]);
+        });
     }
 
     /**

--- a/app/Support/PhpExtensions.php
+++ b/app/Support/PhpExtensions.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Thin, injectable view of which PHP extensions the running image loaded.
+ *
+ * A diagnostic that reports on the runtime has to be exercisable from a runtime
+ * that differs from the one under test — no process can unload an extension to
+ * prove it notices. Resolving the question through the container instead of
+ * calling `extension_loaded()` inline gives that seam.
+ */
+class PhpExtensions
+{
+    /**
+     * Whether the named extension is loaded.
+     */
+    public function loaded(string $extension): bool
+    {
+        return extension_loaded($extension);
+    }
+
+    /**
+     * Which of the named extensions are not loaded, in the order given.
+     *
+     * @param  list<string>  $extensions
+     * @return list<string>
+     */
+    public function missing(array $extensions): array
+    {
+        return array_values(array_filter(
+            $extensions,
+            fn (string $extension): bool => ! $this->loaded($extension),
+        ));
+    }
+}

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -414,3 +414,16 @@ Rotating it silently invalidates them all: those devices stop receiving anything
 until each member turns the toggle off and on again. Back the pair up with your
 other secrets.
 :::
+
+To confirm the setup works, ask the instance rather than waiting for a
+notification that may never come:
+
+```bash
+docker compose exec app php artisan push:doctor
+```
+
+It reports on the keypair, the subject, the extensions the push library needs,
+whether the delivery channel constructs, how many devices are subscribed, and any
+push jobs that have already failed — and exits non-zero when push cannot be
+delivered. See
+[Troubleshooting → Nobody receives push notifications](/self-hosting/troubleshooting/#nobody-receives-push-notifications).

--- a/docs/src/content/docs/self-hosting/troubleshooting.md
+++ b/docs/src/content/docs/self-hosting/troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting
-description: Fix the two first-run gotchas a healthy stack can still hit — a "Reconnecting…" banner from a wrong APP_URL, and .env edits that need a container recreate to take effect.
+description: Fix the first-run gotchas a healthy stack can still hit — a "Reconnecting…" banner from a wrong APP_URL, push notifications that silently never arrive, and .env edits that need a container recreate to take effect.
 ---
 
 A fresh deploy can report every container `healthy` and still look broken, because
@@ -54,6 +54,51 @@ After editing `APP_URL` or any `REVERB_*` value, you must **recreate** the
 containers for the change to take effect, not just save the file. See
 [Changed `.env` but nothing changed](#changed-env-but-nothing-changed) below.
 :::
+
+## Nobody receives push notifications
+
+**Symptom.** Members have turned browser notifications on, but nothing ever
+arrives. Every container reports `healthy`, the queue is empty, and the logs look
+ordinary.
+
+**Cause.** Web push is the only channel the app sends message alerts through, on
+purpose: there is no notification centre and no email for message traffic. So a
+delivery that fails produces exactly the silence a member who never subscribed a
+device would see. Worse, the notification is consumed off the queue *before* it
+fails, so the queue drains to zero and the worker stays up: every surface-level
+signal reads green while nothing is delivered.
+
+**Fix.** Ask the instance directly:
+
+```bash
+docker compose exec app php artisan push:doctor
+```
+
+It checks the whole delivery path — the VAPID keypair is set and well-formed, the
+subject is a contact a push service accepts, the image loads the extensions the
+push library needs, the notification channel actually constructs, how many devices
+are subscribed, and whether push jobs have already died — and exits non-zero when
+push cannot be delivered, so you can also run it from a monitor.
+
+Each line names its own fix:
+
+- **VAPID keypair `WARN`, "not set".** Push is switched off. Generate a pair; see
+  [Environment variables → Web push notifications](/reference/environment-variables/#web-push-notifications).
+- **VAPID keypair `FAIL`.** Only one half is set, or a key was truncated when it
+  was pasted in. Set both, in full.
+- **Math extension or PHP extensions `FAIL`.** The image is missing something the
+  push library needs. It cannot be fixed from `.env` — upgrade to a release that
+  ships it.
+- **Subscriptions `WARN`, "no device has subscribed".** Delivery is fine; nobody
+  has opted in yet. Members turn it on per device under **Settings →
+  Notifications**, and a browser only offers it over HTTPS.
+- **Past failures `WARN`.** Push jobs have already died. Read them with
+  `docker compose exec app php artisan queue:failed`; the exception names the
+  cause. Once it is fixed, clear the backlog with `php artisan queue:flush`.
+
+Failed jobs are also written to the log from the moment they fail, so
+`docker compose logs app queue --tail=100` shows the underlying exception without
+waiting for anyone to inspect the queue.
 
 ## Changed `.env` but nothing changed
 

--- a/tests/Feature/Console/PushDoctorCommandTest.php
+++ b/tests/Feature/Console/PushDoctorCommandTest.php
@@ -1,0 +1,218 @@
+<?php
+
+use App\Models\User;
+use App\Support\PhpExtensions;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Minishlink\WebPush\WebPush;
+use NotificationChannels\WebPush\WebPushChannel;
+
+/**
+ * A real VAPID keypair, generated once with `VAPID::createVapidKeys()`.
+ *
+ * The library validates the decoded byte length of each half (65 and 32), so a
+ * placeholder string cannot stand in for a well-formed pair.
+ */
+function vapidKeypair(): array
+{
+    return [
+        'public' => 'BO7VvBAiqRfu7aE_Vjpq0TMpi8NhlVuGRvipudmbdB2MqzZ6Y_V2qPoqKNGXVaCQkGAsShvrAI0AOeKjLewsGc0',
+        'private' => 'TdMzo3G0qCBNQ6JP_vOcWUm58mbb86gbMXzDrkVpDX0',
+    ];
+}
+
+/**
+ * Configure the instance the way an operator who set web push up correctly would.
+ */
+function configureWebPush(array $overrides = []): void
+{
+    config(array_replace([
+        'webpush.vapid.public_key' => vapidKeypair()['public'],
+        'webpush.vapid.private_key' => vapidKeypair()['private'],
+        'webpush.vapid.subject' => 'mailto:admin@example.com',
+    ], $overrides));
+}
+
+/**
+ * Report the given extensions as loaded or missing, so a check that reads the
+ * PHP runtime can be exercised from an environment that cannot unload one.
+ *
+ * @param  array<string, bool>  $overrides
+ */
+function fakeExtensions(array $overrides): void
+{
+    app()->bind(PhpExtensions::class, fn (): PhpExtensions => new class($overrides) extends PhpExtensions
+    {
+        /**
+         * @param  array<string, bool>  $overrides
+         */
+        public function __construct(private readonly array $overrides) {}
+
+        #[Override]
+        public function loaded(string $extension): bool
+        {
+            return $this->overrides[$extension] ?? parent::loaded($extension);
+        }
+    });
+}
+
+/**
+ * Record a failed queued job the way a worker would.
+ */
+function recordFailedJob(string $displayName, ?CarbonImmutable $failedAt = null): void
+{
+    DB::table('failed_jobs')->insert([
+        'uuid' => (string) Str::uuid(),
+        'connection' => 'redis',
+        'queue' => 'default',
+        'payload' => json_encode(['displayName' => $displayName, 'job' => $displayName]),
+        'exception' => 'ErrorException: It is highly recommended to install the GMP or BCMath extension',
+        'failed_at' => $failedAt ?? now(),
+    ]);
+}
+
+test('a correctly configured instance passes every check', function (): void {
+    configureWebPush();
+    User::factory()->create()->updatePushSubscription('https://fcm.googleapis.com/fcm/send/laptop', 'key', 'token');
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toContain('Web push is healthy');
+});
+
+test('warnings are reported without failing the command', function (): void {
+    configureWebPush();
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toContain('Web push has no faults, but see the warnings above');
+});
+
+test('it surfaces push jobs that already died in failed_jobs', function (): void {
+    configureWebPush();
+    recordFailedJob('App\\Notifications\\NewMessageNotification', CarbonImmutable::parse('2026-07-20 09:15:00'));
+    recordFailedJob('App\\Listeners\\SendMessagePushNotifications');
+    recordFailedJob('App\\Jobs\\DeliverWebhook');
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toContain('2 failed push job(s)');
+});
+
+test('it points at the right place when failed jobs are not kept in the database', function (): void {
+    configureWebPush();
+    config(['queue.failed.driver' => 'null']);
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toContain('stored by the `null` driver');
+});
+
+test('an instance with no keypair reports push as disabled rather than broken', function (): void {
+    configureWebPush(['webpush.vapid.public_key' => null, 'webpush.vapid.private_key' => null]);
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toContain('web push is disabled on this instance');
+});
+
+test('a half-configured keypair fails', function (): void {
+    configureWebPush(['webpush.vapid.private_key' => null]);
+
+    $exitCode = Artisan::call('push:doctor');
+    $output = Artisan::output();
+
+    expect($exitCode)->toBe(1)
+        ->and($output)->toContain('half-configured')
+        ->and($output)->toContain('Web push cannot be delivered');
+});
+
+test('a malformed keypair fails with the reason it was rejected', function (): void {
+    configureWebPush(['webpush.vapid.public_key' => 'dG9vLXNob3J0']);
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('Public key should be 65 bytes long');
+});
+
+test('it fails when the image ships neither gmp nor bcmath', function (): void {
+    configureWebPush();
+    fakeExtensions(['gmp' => false, 'bcmath' => false]);
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('neither gmp nor bcmath is loaded');
+});
+
+test('it names the required extensions the image is missing', function (): void {
+    configureWebPush();
+    fakeExtensions(['curl' => false, 'openssl' => false]);
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('missing: curl, openssl');
+});
+
+test('it warns when no VAPID subject is set, naming what the library falls back to', function (): void {
+    configureWebPush(['webpush.vapid.subject' => null]);
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toContain('not set: falling back to '.url('/'));
+});
+
+test('it fails when the VAPID subject is neither a mailto address nor a URL', function (): void {
+    configureWebPush(['webpush.vapid.subject' => 'admin@example.com']);
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('must be a mailto: address or an https URL');
+});
+
+test('it warns when no device has subscribed', function (): void {
+    configureWebPush();
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toContain('no device has subscribed');
+});
+
+test('it reports how many devices are subscribed and how many people they belong to', function (): void {
+    configureWebPush();
+
+    $user = User::factory()->create();
+    $user->updatePushSubscription('https://fcm.googleapis.com/fcm/send/laptop', 'key', 'token');
+    $user->updatePushSubscription('https://fcm.googleapis.com/fcm/send/phone', 'key', 'token');
+    User::factory()->create()->updatePushSubscription('https://fcm.googleapis.com/fcm/send/desktop', 'key', 'token');
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(0)
+        ->and(Artisan::output())->toContain('3 device(s) across 2 user(s)');
+});
+
+test('it fails when the delivery channel cannot be constructed', function (): void {
+    configureWebPush();
+
+    app()->when(WebPushChannel::class)
+        ->needs(WebPush::class)
+        ->give(fn (): WebPush => throw new ErrorException('It is highly recommended to install the GMP or BCMath extension'));
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('It is highly recommended to install the GMP or BCMath extension');
+});

--- a/tests/Feature/Console/PushDoctorCommandTest.php
+++ b/tests/Feature/Console/PushDoctorCommandTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Jobs\DeliverWebhook;
+use App\Listeners\SendMessagePushNotifications;
 use App\Models\User;
+use App\Notifications\NewMessageNotification;
 use App\Support\PhpExtensions;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Artisan;
@@ -94,9 +97,9 @@ test('warnings are reported without failing the command', function (): void {
 
 test('it surfaces push jobs that already died in failed_jobs', function (): void {
     configureWebPush();
-    recordFailedJob('App\\Notifications\\NewMessageNotification', CarbonImmutable::parse('2026-07-20 09:15:00'));
-    recordFailedJob('App\\Listeners\\SendMessagePushNotifications');
-    recordFailedJob('App\\Jobs\\DeliverWebhook');
+    recordFailedJob(NewMessageNotification::class, CarbonImmutable::parse('2026-07-20 09:15:00'));
+    recordFailedJob(SendMessagePushNotifications::class);
+    recordFailedJob(DeliverWebhook::class);
 
     $exitCode = Artisan::call('push:doctor');
 

--- a/tests/Feature/Providers/AppServiceProviderTest.php
+++ b/tests/Feature/Providers/AppServiceProviderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Notifications\NewMessageNotification;
 use App\Providers\AppServiceProvider;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobFailed;
@@ -12,7 +13,7 @@ test('a queued job that dies is written to the log', function (): void {
     Log::spy();
 
     $job = Mockery::mock(Job::class);
-    $job->shouldReceive('resolveName')->andReturn('App\Notifications\NewMessageNotification');
+    $job->shouldReceive('resolveName')->andReturn(NewMessageNotification::class);
     $job->shouldReceive('getQueue')->andReturn('default');
 
     event(new JobFailed('redis', $job, new RuntimeException('It is highly recommended to install GMP')));
@@ -20,7 +21,7 @@ test('a queued job that dies is written to the log', function (): void {
     Log::shouldHaveReceived('error')
         ->once()
         ->withArgs(function (string $message, array $context): bool {
-            expect($message)->toContain('App\Notifications\NewMessageNotification')
+            expect($message)->toContain(NewMessageNotification::class)
                 ->and($context['connection'])->toBe('redis')
                 ->and($context['queue'])->toBe('default')
                 ->and($context['exception'])->toBeInstanceOf(RuntimeException::class);

--- a/tests/Feature/Providers/AppServiceProviderTest.php
+++ b/tests/Feature/Providers/AppServiceProviderTest.php
@@ -1,9 +1,33 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+
+test('a queued job that dies is written to the log', function (): void {
+    Log::spy();
+
+    $job = Mockery::mock(Job::class);
+    $job->shouldReceive('resolveName')->andReturn('App\Notifications\NewMessageNotification');
+    $job->shouldReceive('getQueue')->andReturn('default');
+
+    event(new JobFailed('redis', $job, new RuntimeException('It is highly recommended to install GMP')));
+
+    Log::shouldHaveReceived('error')
+        ->once()
+        ->withArgs(function (string $message, array $context): bool {
+            expect($message)->toContain('App\Notifications\NewMessageNotification')
+                ->and($context['connection'])->toBe('redis')
+                ->and($context['queue'])->toBe('default')
+                ->and($context['exception'])->toBeInstanceOf(RuntimeException::class);
+
+            return true;
+        });
+});
 
 test('production enforces a strong default password policy', function (): void {
     $this->app->detectEnvironment(fn (): string => 'production');


### PR DESCRIPTION
Closes #866.

Web push is the only channel the app sends message alerts through, on purpose. That makes a broken push setup indistinguishable from "nobody subscribed a device": the notification job is consumed *before* it throws, so the queue drains to zero and the worker stays up, and the only record is a row in `failed_jobs` that nothing reads. #865 spent a whole staging cycle dead that way.

The issue was labelled `needs-scoping` with acceptance criteria left open. Scope agreed before implementing:

## What this adds

**`php artisan push:doctor`** — an operator-runnable diagnostic covering the whole delivery path, exiting non-zero when push cannot be delivered so it also works from a monitor:

| Check | Fails when |
| --- | --- |
| VAPID keypair | only one half is set, or a key does not decode to the length the library requires (warns, does not fail, when neither is set: push is simply off) |
| VAPID subject | set to something no push service accepts (warns when unset, naming the URL the library falls back to) |
| PHP extensions | `curl` / `mbstring` / `openssl` missing |
| Math extension | neither `gmp` nor `bcmath` loaded — the #865 failure exactly |
| Delivery channel | `WebPushChannel` cannot be resolved from the container, reported with the very exception the failed job would have carried |
| Subscriptions | never fails; warns when no device has subscribed, which is the ambiguity the whole command exists to resolve |
| Past failures | never fails; warns with a count and a timestamp when push jobs already died |

**A `Queue::failing` listener that logs.** Registered for every queued job, not just the push path — any job that can fail silently has the same problem. This is the piece that would have surfaced #865 on the first message rather than whenever someone thought to look.

**Docs.** A symptom-first "Nobody receives push notifications" section in `self-hosting/troubleshooting.md` that walks each `WARN`/`FAIL` line to its fix, plus a pointer from the web push section of `reference/environment-variables.md`.

## Deliberately not done

- **Failing loudly at boot.** A push misconfiguration would then take the whole instance down — trading a dead optional subsystem for a dead app.
- **Extending `/up`.** It already exists (registered as `health: '/up'` in `bootstrap/app.php`, which is why the issue found nothing in `routes/`), but it is a liveness probe whose consumers restart or page on red. A degraded optional subsystem should not turn it red.
- **A fallback delivery channel**, per the issue.

## Testing

- 14 new tests for the command (`tests/Feature/Console/PushDoctorCommandTest.php`), one per check outcome. The extension checks resolve through a small injectable `App\Support\PhpExtensions`, since no process can unload an extension to prove the check notices; the channel-resolution failure is driven by a contextual binding that throws.
- One new test for the failed-job log (`tests/Feature/Providers/AppServiceProviderTest.php`).
- `composer test` green: Pint, PHPStan, Rector, and the suite at **Total: 100.0 %**.
- `cd docs && npm run build` passes; anchors verified in `dist`.

## Notes

- Rebased onto `develop` after #870 landed, so the `gmp` check now guards a fix that is already in rather than reporting a live outage.
- Console output is not translated, matching the existing `Check*Command` siblings — it is operator-facing, not user-facing.
- The local CodeRabbit pass hit the free-tier rate limit (30 min); leaning on the PR-side review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787535153&installation_model_id=428379&pr_number=874&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F874&signature=aa55290f84dd7d3252aec167810fb84643aa2128f5bbd4b11e53197d11e95001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->