### PR TITLE
test: fail the suite on a duplicate key in a locale catalog

### DIFF
--- a/tests/Unit/TranslationCatalogIntegrityTest.php
+++ b/tests/Unit/TranslationCatalogIntegrityTest.php
@@ -84,7 +84,7 @@ function duplicateCatalogKeys(string $json): array
  */
 function localeCatalogPaths(): array
 {
-    return array_values((array) glob(dirname(__DIR__, 2).'/lang/*.json'));
+    return array_values(glob(dirname(__DIR__, 2).'/lang/*.json') ?: []);
 }
 
 test('the locale catalogs are discoverable, so the guard below cannot pass vacuously', function (): void {

--- a/tests/Unit/TranslationCatalogIntegrityTest.php
+++ b/tests/Unit/TranslationCatalogIntegrityTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+|--------------------------------------------------------------------------
+| Duplicate keys in a locale catalog (#856)
+|--------------------------------------------------------------------------
+|
+| A JSON object may not hold the same key twice, but nothing complains when it
+| does: every parser keeps the last occurrence and drops the earlier
+| translation. The file still parses, the catalog still loads, and both call
+| sites still resolve — so a mistranslation ships with nothing to report it.
+| That is how `"to"` lost its `au` translation to the `à` defined further down.
+|
+| `json_decode` cannot see the collision either (it collapses duplicates the
+| same way), so the guard walks the raw text for key tokens instead.
+|
+*/
+
+/**
+ * Every key token of a JSON document: a quoted string followed by a colon.
+ *
+ * The scan is a left-to-right walk rather than a regular expression because it
+ * must never resync inside a string — a value holding a colon or an escaped
+ * quote would otherwise be read as a key.
+ *
+ * @return list<string>
+ */
+function catalogKeyTokens(string $json): array
+{
+    $keys = [];
+    $length = strlen($json);
+    $index = 0;
+
+    while ($index < $length) {
+        if ($json[$index] !== '"') {
+            $index++;
+
+            continue;
+        }
+
+        $opening = $index++;
+
+        while ($index < $length && $json[$index] !== '"') {
+            $index += $json[$index] === '\\' ? 2 : 1;
+        }
+
+        $index++;
+        $token = substr($json, $opening, $index - $opening);
+
+        $colon = $index;
+
+        while ($colon < $length && ctype_space($json[$colon])) {
+            $colon++;
+        }
+
+        if (($json[$colon] ?? '') === ':') {
+            $keys[] = (string) json_decode($token);
+            $index = $colon + 1;
+        }
+    }
+
+    return $keys;
+}
+
+/**
+ * The keys a catalog defines more than once, mapped to their occurrence count.
+ *
+ * @return array<array-key, int>
+ */
+function duplicateCatalogKeys(string $json): array
+{
+    return array_filter(
+        array_count_values(catalogKeyTokens($json)),
+        static fn (int $count): bool => $count > 1,
+    );
+}
+
+/**
+ * Every locale catalog shipped with the application.
+ *
+ * @return list<string>
+ */
+function localeCatalogPaths(): array
+{
+    return array_values((array) glob(dirname(__DIR__, 2).'/lang/*.json'));
+}
+
+test('the locale catalogs are discoverable, so the guard below cannot pass vacuously', function (): void {
+    expect(localeCatalogPaths())->not->toBeEmpty();
+});
+
+test('no locale catalog defines the same key twice', function (): void {
+    foreach (localeCatalogPaths() as $path) {
+        $duplicates = duplicateCatalogKeys((string) file_get_contents($path));
+
+        expect($duplicates)->toBe(
+            [],
+            basename($path).' defines '.implode(', ', array_keys($duplicates)).' more than once, so only the last translation survives',
+        );
+    }
+});
+
+test('every locale catalog translates each message to a single line', function (): void {
+    foreach (localeCatalogPaths() as $path) {
+        $messages = (array) json_decode((string) file_get_contents($path), true);
+
+        expect($messages)->not->toBeEmpty(basename($path).' must decode to a message map');
+
+        foreach ($messages as $key => $line) {
+            expect($line)->toBeString(basename($path).' must translate '.$key.' to a single line');
+        }
+    }
+});
+
+test('the scan reports a key defined twice', function (): void {
+    $catalog = <<<'JSON'
+        {
+          "requested by :name": "demandé par :name",
+          "to": "au",
+          "From": "De",
+          "to": "à"
+        }
+        JSON;
+
+    expect(duplicateCatalogKeys($catalog))->toBe(['to' => 2]);
+});
+
+test('the scan is not fooled by values that read like keys', function (): void {
+    $catalog = <<<'JSON'
+        {
+          ":action to join the “:team” team.": ":action pour rejoindre l’équipe « :team ».",
+          "Quiet hours": "Heures calmes : 22:00",
+          "Say \"hello\"": "Dites \"bonjour\" : maintenant",
+          "to": "à"
+        }
+        JSON;
+
+    expect(catalogKeyTokens($catalog))->toBe([
+        ':action to join the “:team” team.',
+        'Quiet hours',
+        'Say "hello"',
+        'to',
+    ]);
+    expect(duplicateCatalogKeys($catalog))->toBe([]);
+});


### PR DESCRIPTION
Closes #856.

## What

Adds `tests/Unit/TranslationCatalogIntegrityTest.php`, a guard that fails the suite when any `lang/*.json` catalog defines the same key twice.

## Why

A duplicate key is silently legal: every JSON parser keeps the last occurrence and drops the earlier translation. The file still parses, the catalog still loads, and both call sites still resolve, so a mistranslation ships with nothing to report it.

## On the `"to"` collision itself

It is already gone from `develop`, but not deliberately. PR #864 (the auth-screen rebuild) hand-collapsed it: it deleted the later `"to": "à"` and overwrote the earlier `"to": "au"` with `"à"`. So the `au` translation was lost for good, exactly the silent loss the issue predicted, with no tooling noticing.

The key has exactly two call sites repo-wide:

- `resources/js/pages/settings/Appearance.vue:282`, quiet hours: "From 22:00 to 07:00" renders "De 22:00 à 07:00".
- `resources/js/pages/teams/AuditExports.vue:314`, export period: "[start date] to [end date]" renders "01/01/2026 à 05/02/2026".

`à` is correct French at both, so this takes the issue's "one shared translation" branch and leaves the catalog as it stands. The `au` form only wins inside a "du ... au ..." construction, which neither site builds. Splitting into two self-describing keys was the issue's stated preference, but in this app the key *is* the English source string (there is no `lang/en.json`, and `translate()` falls back to the key), so two distinct keys would force different English copy at one of the two sites, or a new English catalog that contradicts the documented "English needs no file" convention. Not worth a copy change on a designed screen for a word that is already right.

## How the guard works

`json_decode` cannot see a collision (it collapses duplicates the same way), so the scan walks the raw text left to right and collects every quoted string followed by a colon. It is a walk rather than a regex on purpose: a regex resyncs inside string values, and catalog keys like `":action to join the “:team” team."` make it report dozens of phantom duplicates.

## Testing

Five unit tests, no database or app boot:

- the catalogs are discoverable, so the sweep cannot pass vacuously
- no catalog defines the same key twice
- every catalog translates each message to a single line
- the scan reports a key defined twice (fixture reproducing the `"to"` collision)
- the scan is not fooled by values that read like keys (placeholder-leading keys, colons and escaped quotes inside values)

Proven against the real file: run over `lang/fr.json` as it stood at `3f85593^` (before #864 collapsed it), the scan reports `['to' => 2]`.

Full gate green: Pint, PHPStan, Rector, `Total: 100.0 %`. Frontend gate green too, though no frontend file changed.

## i18n and docs

No copy, config, or operator-facing change, so no catalog or `docs/` update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787536727&installation_model_id=428379&pr_number=875&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F875&signature=dda4a8d96c77dd96364b4a5231c028883ed884136f27718f822db6e8dae97da4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->