### PR TITLE
feat: generate the VAPID keypair in gen-secrets.sh so fresh installs get web push

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -220,6 +220,20 @@ REVERB_SCHEME_PUBLIC=https
 # the app from.
 # REVERB_ALLOWED_ORIGINS=chat.example.com
 
+# --- Web push notifications --------------------------------------------------
+# Browser notifications for new messages, opt-in per member and per device. The
+# VAPID keypair signs every push; gen-secrets.sh mints one on a fresh install,
+# and an existing install generates its own with:
+#   docker compose exec app php artisan webpush:vapid --show
+# Never rotate the pair once devices have subscribed: the public key is baked
+# into every subscription a browser has already granted, so replacing it stops
+# delivery to all of them until each member turns the toggle off and on again.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+# How you identify yourself to the push services, as a mailto: or https: URL
+# they can reach you at. Falls back to APP_URL when left empty.
+VAPID_SUBJECT=
+
 # --- Container port mapping (host side) --------------------------------------
 # APP_BIND=127.0.0.1
 # APP_PORT=8000

--- a/docker/gen-secrets.sh
+++ b/docker/gen-secrets.sh
@@ -44,6 +44,44 @@ set_if_empty() {
     fi
 }
 
+# Encode stdin as base64url, the form the Web Push spec (and every browser) reads
+# VAPID keys in: standard base64 with the two URL-unsafe characters swapped and
+# the padding dropped.
+b64url() {
+    openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+# Mint a VAPID keypair, leaving it in $vapid_public_key / $vapid_private_key.
+#
+# It is a P-256 keypair: the public key is the 65-byte uncompressed point
+# (0x04 || X || Y) at the tail of the SubjectPublicKeyInfo DER, the private key
+# the raw 32-byte scalar the SEC1 ECPrivateKey DER carries after its fixed
+# 7-byte header (30 77 02 01 01 04 20). Both offsets are fixed for prime256v1
+# and are asserted against the web push library in
+# tests/Unit/GenSecretsScriptTest.php, since a wrong one still yields a
+# plausible-looking key that signs nothing.
+#
+# Returns non-zero without setting either half if this openssl cannot do the
+# curve, so a host that only half-works never writes a mismatched pair.
+generate_vapid_keys() {
+    vapid_public_key=""
+    vapid_private_key=""
+
+    tmp_key="$(mktemp)"
+    if ! openssl ecparam -name prime256v1 -genkey -noout -out "$tmp_key" 2>/dev/null; then
+        rm -f "$tmp_key"
+        return 1
+    fi
+
+    vapid_public_key="$(openssl ec -in "$tmp_key" -pubout -outform DER 2>/dev/null | tail -c 65 | b64url)"
+    vapid_private_key="$(openssl ec -in "$tmp_key" -outform DER 2>/dev/null | dd bs=1 skip=7 count=32 2>/dev/null | b64url)"
+    rm -f "$tmp_key"
+
+    # 65 and 32 raw bytes are 87 and 43 base64url characters; any other length
+    # means the DER was not shaped as assumed, and the pair must be discarded.
+    [ "${#vapid_public_key}" -eq 87 ] && [ "${#vapid_private_key}" -eq 43 ]
+}
+
 echo "Generating missing secrets in $ENV_FILE:"
 set_if_empty "APP_KEY"         "base64:$(openssl rand -base64 32)"
 set_if_empty "DB_PASSWORD"     "$(openssl rand -hex 24)"
@@ -54,6 +92,26 @@ set_if_empty "REVERB_APP_ID"   "$(openssl rand 4 | od -An -tu4 | tr -d ' ')"
 # at runtime), so it is generated once here.
 set_if_empty "REVERB_APP_KEY"    "$(openssl rand -hex 16)"
 set_if_empty "REVERB_APP_SECRET" "$(openssl rand -hex 16)"
+
+# Web push. The pair is generated only when both halves are empty: filling one
+# half of an operator's existing pair would leave a public key no private key
+# signs for, which browsers accept at subscribe time and push services reject at
+# send time. VAPID_SUBJECT is an address rather than a secret, so it is left to
+# the operator; config/webpush.php falls back to APP_URL.
+if grep -Eq "^VAPID_PUBLIC_KEY=$" "$ENV_FILE" && grep -Eq "^VAPID_PRIVATE_KEY=$" "$ENV_FILE"; then
+    if generate_vapid_keys; then
+        set_if_empty "VAPID_PUBLIC_KEY"  "$vapid_public_key"
+        set_if_empty "VAPID_PRIVATE_KEY" "$vapid_private_key"
+    else
+        echo "Warning: this openssl cannot generate a prime256v1 key, so no VAPID pair was written." >&2
+        echo "Web push stays off; generate a pair later with: php artisan webpush:vapid --show" >&2
+    fi
+elif grep -Eq "^VAPID_(PUBLIC|PRIVATE)_KEY=$" "$ENV_FILE"; then
+    echo "Warning: only one half of the VAPID pair is set, and the halves must come from" >&2
+    echo "the same key. Replace both with a fresh pair: php artisan webpush:vapid --show" >&2
+else
+    echo "  kept VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY (already set)"
+fi
 
 echo
 echo "Done. Review $ENV_FILE and set APP_URL, mail credentials, and the"

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -9,8 +9,9 @@ page: [Feature toggles](/reference/feature-toggles/).
 
 :::note
 Run `./docker/gen-secrets.sh` to generate the required secrets — it fills
-`APP_KEY`, `DB_PASSWORD`, `MEILISEARCH_KEY`, and the `REVERB_*` app credentials
-with fresh random values and never overwrites values you have already set.
+`APP_KEY`, `DB_PASSWORD`, `MEILISEARCH_KEY`, the `REVERB_*` app credentials, and
+the [web push](#web-push-notifications) `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY`
+pair with fresh random values, and never overwrites values you have already set.
 :::
 
 ## Docker Compose
@@ -380,8 +381,8 @@ same as before the feature existed.
 ## Web push notifications
 
 Members can opt in, **per device**, to browser notifications for new messages —
-so a mention still reaches them with the tab closed. The feature is **off** until
-you generate a VAPID keypair; see
+so a mention still reaches them with the tab closed. The feature needs a VAPID
+keypair, which signs every push; see
 [Feature toggles → Web push notifications](/reference/feature-toggles/#web-push-notifications)
 for what it does and how it behaves.
 
@@ -391,8 +392,15 @@ for what it does and how it behaves.
 | `VAPID_PRIVATE_KEY` | *(unset)*    | Private half. Never leaves the server.                                                                      |
 | `VAPID_SUBJECT`     | *(`APP_URL`)*| How you identify yourself to the push services: a `mailto:` or `https:` URL they can contact you at.         |
 
-Generate the pair once. Always pass `--show`, which **prints** the keys instead
-of writing them anywhere:
+**On a fresh install you already have a pair.** `./docker/gen-secrets.sh`
+generates one with the rest of your secrets, so push works as soon as members
+turn it on. Nothing else is needed here — optionally set `VAPID_SUBJECT`, which
+the script deliberately leaves empty because it is your contact address rather
+than a secret.
+
+Upgrading an existing install, or running on a platform where `gen-secrets.sh`
+has nothing to write into? Then generate the pair yourself, once. Always pass
+`--show`, which **prints** the keys instead of writing them anywhere:
 
 ```bash
 docker compose exec app php artisan webpush:vapid --show

--- a/docs/src/content/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/reference/feature-toggles.md
@@ -528,15 +528,18 @@ never appropriate for real data.
 
 ## Web push notifications
 
-| Variable                                 | Default                     | Effect                                              |
-| ---------------------------------------- | --------------------------- | --------------------------------------------------- |
-| `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | *(set by `gen-secrets.sh`)* | Enables browser push notifications for new messages. |
+| Variable                                 | Default                                | Effect                                              |
+| ---------------------------------------- | -------------------------------------- | --------------------------------------------------- |
+| `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | *(unset; filled on a fresh install)* | Enables browser push notifications for new messages. |
 
 Web push needs a VAPID keypair. A fresh install gets one from
-`./docker/gen-secrets.sh`; an existing install generates its own — see
-[Environment variables → Web push notifications](/reference/environment-variables/#web-push-notifications)
-for the `webpush:vapid --show` command. With no keypair the toggle never
-appears in Settings, and the subscription endpoints return **404**.
+`./docker/gen-secrets.sh`, which fills both keys with the rest of your secrets.
+An install that predates that — or a platform-managed deployment, where the
+script has nothing to write into — generates its own pair with the
+`webpush:vapid --show` command; see
+[Environment variables → Web push notifications](/reference/environment-variables/#web-push-notifications).
+With no keypair the toggle never appears in Settings, and the subscription
+endpoints return **404**.
 
 With the keys set, the feature is still **opt-in per member and per device**:
 nothing prompts on load or on login. Each member turns it on from

--- a/docs/src/content/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/reference/feature-toggles.md
@@ -528,11 +528,12 @@ never appropriate for real data.
 
 ## Web push notifications
 
-| Variable                                 | Default   | Effect                                              |
-| ---------------------------------------- | --------- | --------------------------------------------------- |
-| `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | *(unset)* | Enables browser push notifications for new messages. |
+| Variable                                 | Default                     | Effect                                              |
+| ---------------------------------------- | --------------------------- | --------------------------------------------------- |
+| `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` | *(set by `gen-secrets.sh`)* | Enables browser push notifications for new messages. |
 
-Web push is **off** until you generate a VAPID keypair — see
+Web push needs a VAPID keypair. A fresh install gets one from
+`./docker/gen-secrets.sh`; an existing install generates its own — see
 [Environment variables → Web push notifications](/reference/environment-variables/#web-push-notifications)
 for the `webpush:vapid --show` command. With no keypair the toggle never
 appears in Settings, and the subscription endpoints return **404**.

--- a/docs/src/content/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/reference/security-and-compliance.md
@@ -126,9 +126,11 @@ evidence for each of these from **your** environment, not from this project:
   [Upgrading](/self-hosting/upgrading/#backups). Encrypting and
   off-siting the resulting files remains yours.
 - **Secret management.** `APP_KEY`, `DB_PASSWORD`, `MEILISEARCH_KEY`, the
-  `REVERB_*` credentials, and any `SCIM_TOKEN` are full secrets. Generate them
-  with `./docker/gen-secrets.sh`, store them in a secret manager rather than a
-  committed `.env`, and rotate on exposure.
+  `REVERB_*` credentials, `VAPID_PRIVATE_KEY`, and any `SCIM_TOKEN` are full
+  secrets. Generate them with `./docker/gen-secrets.sh`, store them in a secret
+  manager rather than a committed `.env`, and rotate on exposure — except the
+  VAPID pair, which every subscribed browser is pinned to
+  ([why](/reference/environment-variables/#web-push-notifications)).
 - **Network isolation.** Expose only the web port publicly; keep PostgreSQL,
   Redis, Meilisearch, and Reverb on an internal network. Restrict administrative
   and database access to trusted operators.

--- a/docs/src/content/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/reference/security-and-compliance.md
@@ -128,8 +128,10 @@ evidence for each of these from **your** environment, not from this project:
 - **Secret management.** `APP_KEY`, `DB_PASSWORD`, `MEILISEARCH_KEY`, the
   `REVERB_*` credentials, `VAPID_PRIVATE_KEY`, and any `SCIM_TOKEN` are full
   secrets. Generate them with `./docker/gen-secrets.sh`, store them in a secret
-  manager rather than a committed `.env`, and rotate on exposure — except the
-  VAPID pair, which every subscribed browser is pinned to
+  manager rather than a committed `.env`, and rotate on exposure. Rotate the
+  VAPID pair **only** on exposure, never as routine hygiene: every browser that
+  has subscribed is pinned to the public key, so replacing it stops delivery to
+  all of them until each member turns push off and on again
   ([why](/reference/environment-variables/#web-push-notifications)).
 - **Network isolation.** Expose only the web port publicly; keep PostgreSQL,
   Redis, Meilisearch, and Reverb on an internal network. Restrict administrative

--- a/tests/Unit/GenSecretsScriptTest.php
+++ b/tests/Unit/GenSecretsScriptTest.php
@@ -103,7 +103,7 @@ function stubOpensslWithoutPrime256v1(string $workspace): string
  * @param  array<string, string>  $env
  * @return array{private: JWK, public: JWK}
  */
-function vapidKeyPair(array $env): array
+function genSecretsVapidKeyPair(array $env): array
 {
     $point = Base64Url::decode($env['VAPID_PUBLIC_KEY']);
     $coordinates = [
@@ -152,8 +152,8 @@ test('the generated private key is the one that signs for the generated public k
     runGenSecrets($workspace);
     runGenSecrets($otherWorkspace);
 
-    $pair = vapidKeyPair(genSecretsEnv($workspace));
-    $otherPair = vapidKeyPair(genSecretsEnv($otherWorkspace));
+    $pair = genSecretsVapidKeyPair(genSecretsEnv($workspace));
+    $otherPair = genSecretsVapidKeyPair(genSecretsEnv($otherWorkspace));
 
     $algorithm = new ES256;
     $signature = $algorithm->sign($pair['private'], 'the-desk');

--- a/tests/Unit/GenSecretsScriptTest.php
+++ b/tests/Unit/GenSecretsScriptTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Process\Process;
  * Drive docker/gen-secrets.sh as an operator does: a plain POSIX shell process
  * in a directory holding the shipped template, then read back the .env it wrote.
  *
- * The VAPID pair is the one secret the script cannot mint with a `openssl rand`
+ * The VAPID pair is the one secret the script cannot mint with an `openssl rand`
  * one-liner. It carves the key material out of DER at two fixed offsets
  * (`tail -c 65`, `skip=7`), and a wrong offset still yields a plausible-looking
  * base64url string of the right length — keys that sign nothing. So the pair is
@@ -54,10 +54,6 @@ function genSecretsWorkspace(): string
 
     return $workspace;
 }
-
-afterEach(function (): void {
-    (new Filesystem)->deleteDirectory(genSecretsRoot());
-});
 
 /**
  * @return array<string, string>
@@ -122,6 +118,10 @@ function vapidKeyPair(array $env): array
         'public' => new JWK($coordinates),
     ];
 }
+
+afterEach(function (): void {
+    (new Filesystem)->deleteDirectory(genSecretsRoot());
+});
 
 test('the production template ships the VAPID settings empty, which is what gen-secrets can fill', function (): void {
     $template = (string) file_get_contents(dirname(__DIR__, 2).'/.env.prod.example');

--- a/tests/Unit/GenSecretsScriptTest.php
+++ b/tests/Unit/GenSecretsScriptTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+use Base64Url\Base64Url;
+use Illuminate\Filesystem\Filesystem;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Minishlink\WebPush\VAPID;
+use Symfony\Component\Process\Process;
+
+/**
+ * Drive docker/gen-secrets.sh as an operator does: a plain POSIX shell process
+ * in a directory holding the shipped template, then read back the .env it wrote.
+ *
+ * The VAPID pair is the one secret the script cannot mint with a `openssl rand`
+ * one-liner. It carves the key material out of DER at two fixed offsets
+ * (`tail -c 65`, `skip=7`), and a wrong offset still yields a plausible-looking
+ * base64url string of the right length — keys that sign nothing. So the pair is
+ * checked against the library that has to use it, not by eye. See issue #869.
+ *
+ * @param  string|null  $pathPrefix  Prepended to PATH, to put a stub openssl in front of the real one.
+ */
+function runGenSecrets(string $workspace, ?string $pathPrefix = null): Process
+{
+    $process = new Process(
+        ['sh', dirname(__DIR__, 2).'/docker/gen-secrets.sh'],
+        $workspace,
+        $pathPrefix === null ? [] : ['PATH' => $pathPrefix.':'.getenv('PATH')],
+    );
+    $process->run();
+
+    return $process;
+}
+
+/**
+ * Everything this file writes, under one directory per process so parallel
+ * workers never clear each other's in-flight fixtures.
+ */
+function genSecretsRoot(): string
+{
+    return sys_get_temp_dir().'/gen-secrets-'.getmypid();
+}
+
+/**
+ * A throwaway directory seeded with the shipped template, which is what the
+ * script copies to .env and then fills.
+ */
+function genSecretsWorkspace(): string
+{
+    $workspace = genSecretsRoot().'/'.bin2hex(random_bytes(6));
+    mkdir($workspace, recursive: true);
+    copy(dirname(__DIR__, 2).'/.env.prod.example', $workspace.'/.env.prod.example');
+
+    return $workspace;
+}
+
+afterEach(function (): void {
+    (new Filesystem)->deleteDirectory(genSecretsRoot());
+});
+
+/**
+ * @return array<string, string>
+ */
+function genSecretsEnv(string $workspace): array
+{
+    $values = [];
+
+    foreach ((array) file($workspace.'/.env', FILE_IGNORE_NEW_LINES) as $line) {
+        if (preg_match('/^([A-Z][A-Z0-9_]*)=(.*)$/', (string) $line, $matches) === 1) {
+            $values[$matches[1]] = $matches[2];
+        }
+    }
+
+    return $values;
+}
+
+/**
+ * An openssl on PATH that refuses to generate a P-256 key and delegates
+ * everything else, standing in for a host whose openssl lacks the curve.
+ */
+function stubOpensslWithoutPrime256v1(string $workspace): string
+{
+    $binary = new Process(['sh', '-c', 'command -v openssl']);
+    $binary->mustRun();
+    $openssl = trim($binary->getOutput());
+
+    $directory = $workspace.'/stub-bin';
+    mkdir($directory);
+    file_put_contents($directory.'/openssl', <<<SH
+        #!/bin/sh
+        if [ "\$1" = "ecparam" ]; then
+            echo "ecparam: unknown curve" >&2
+            exit 1
+        fi
+        exec {$openssl} "\$@"
+        SH);
+    chmod($directory.'/openssl', 0o755);
+
+    return $directory;
+}
+
+/**
+ * The JWK halves of a generated pair: the private one signs, the public one
+ * verifies, so a scalar that does not belong to the point cannot pass both.
+ *
+ * @param  array<string, string>  $env
+ * @return array{private: JWK, public: JWK}
+ */
+function vapidKeyPair(array $env): array
+{
+    $point = Base64Url::decode($env['VAPID_PUBLIC_KEY']);
+    $coordinates = [
+        'kty' => 'EC',
+        'crv' => 'P-256',
+        'x' => Base64Url::encode(substr($point, 1, 32)),
+        'y' => Base64Url::encode(substr($point, 33, 32)),
+    ];
+
+    return [
+        'private' => new JWK([...$coordinates, 'd' => $env['VAPID_PRIVATE_KEY']]),
+        'public' => new JWK($coordinates),
+    ];
+}
+
+test('the production template ships the VAPID settings empty, which is what gen-secrets can fill', function (): void {
+    $template = (string) file_get_contents(dirname(__DIR__, 2).'/.env.prod.example');
+
+    expect($template)->toMatch('/^VAPID_PUBLIC_KEY=$/m')
+        ->and($template)->toMatch('/^VAPID_PRIVATE_KEY=$/m')
+        ->and($template)->toMatch('/^VAPID_SUBJECT=$/m');
+});
+
+test('a fresh .env comes out with a VAPID pair the web push library accepts', function (): void {
+    $workspace = genSecretsWorkspace();
+
+    $process = runGenSecrets($workspace);
+    $env = genSecretsEnv($workspace);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(VAPID::validate([
+            'subject' => 'mailto:admin@example.com',
+            'publicKey' => $env['VAPID_PUBLIC_KEY'],
+            'privateKey' => $env['VAPID_PRIVATE_KEY'],
+        ]))->toMatchArray(['subject' => 'mailto:admin@example.com']);
+});
+
+test('the generated private key is the one that signs for the generated public key', function (): void {
+    $workspace = genSecretsWorkspace();
+    $otherWorkspace = genSecretsWorkspace();
+
+    runGenSecrets($workspace);
+    runGenSecrets($otherWorkspace);
+
+    $pair = vapidKeyPair(genSecretsEnv($workspace));
+    $otherPair = vapidKeyPair(genSecretsEnv($otherWorkspace));
+
+    $algorithm = new ES256;
+    $signature = $algorithm->sign($pair['private'], 'the-desk');
+
+    expect($algorithm->verify($pair['public'], 'the-desk', $signature))->toBeTrue()
+        // Guard the guard: a check that passed for any pair would prove nothing.
+        ->and($algorithm->verify($otherPair['public'], 'the-desk', $signature))->toBeFalse();
+});
+
+test('VAPID_SUBJECT is left to the operator, since it is an address and not a secret', function (): void {
+    $workspace = genSecretsWorkspace();
+
+    runGenSecrets($workspace);
+
+    expect(genSecretsEnv($workspace)['VAPID_SUBJECT'])->toBe('');
+});
+
+test('re-running never rotates the pair, which every granted subscription is pinned to', function (): void {
+    $workspace = genSecretsWorkspace();
+
+    runGenSecrets($workspace);
+    $first = genSecretsEnv($workspace);
+
+    $process = runGenSecrets($workspace);
+    $second = genSecretsEnv($workspace);
+
+    expect($process->getOutput())->toContain('kept VAPID_PUBLIC_KEY')
+        ->and($second['VAPID_PUBLIC_KEY'])->toBe($first['VAPID_PUBLIC_KEY'])
+        ->and($second['VAPID_PRIVATE_KEY'])->toBe($first['VAPID_PRIVATE_KEY']);
+});
+
+test('a half-set pair is reported rather than completed with a key from another one', function (): void {
+    $workspace = genSecretsWorkspace();
+    runGenSecrets($workspace);
+    $generated = genSecretsEnv($workspace);
+
+    file_put_contents($workspace.'/.env', preg_replace(
+        '/^VAPID_PRIVATE_KEY=.*$/m',
+        'VAPID_PRIVATE_KEY=',
+        (string) file_get_contents($workspace.'/.env'),
+    ));
+    $process = runGenSecrets($workspace);
+    $env = genSecretsEnv($workspace);
+
+    expect($process->getErrorOutput())->toContain('only one half of the VAPID pair is set')
+        ->and($env['VAPID_PRIVATE_KEY'])->toBe('')
+        ->and($env['VAPID_PUBLIC_KEY'])->toBe($generated['VAPID_PUBLIC_KEY']);
+});
+
+test('an openssl that cannot do prime256v1 leaves both halves empty rather than writing one', function (): void {
+    $workspace = genSecretsWorkspace();
+
+    $process = runGenSecrets($workspace, stubOpensslWithoutPrime256v1($workspace));
+    $env = genSecretsEnv($workspace);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getErrorOutput())->toContain('VAPID')
+        ->and($env['VAPID_PUBLIC_KEY'])->toBe('')
+        ->and($env['VAPID_PRIVATE_KEY'])->toBe('')
+        // The rest of the install still gets its secrets; only web push stays off.
+        ->and($env['APP_KEY'])->toStartWith('base64:');
+});


### PR DESCRIPTION
Closes #869.

Web push was the one secret an operator still had to mint by hand: `VAPID_*` was
absent from `.env.prod.example`, so a fresh install meant exec'ing into the
container, running `webpush:vapid --show`, and pasting the output back. Install
time is also the right moment to mint the pair, since it must never rotate.

## What

- **`.env.prod.example`** ships a "Web push notifications" section with
  `VAPID_PUBLIC_KEY=`, `VAPID_PRIVATE_KEY=` and `VAPID_SUBJECT=` empty. This is
  the prerequisite for the next item: `set_if_empty` matches `^KEY=$`, so it can
  only fill a key the template already lists.
- **`docker/gen-secrets.sh`** mints the P-256 pair with `openssl` alone: the
  65-byte uncompressed point off the tail of the SubjectPublicKeyInfo DER, the
  32-byte scalar after the SEC1 ECPrivateKey DER's fixed 7-byte header, both
  base64url-encoded. It generates only when **both** halves are empty, checks the
  two encoded lengths before writing so a half-pair is never produced, and warns
  (exit 0, web push simply stays off) when the host's openssl cannot do
  `prime256v1`. An operator's existing pair is never overwritten, so re-running
  stays safe, and a half-set pair is reported rather than completed with a key
  from a different generation. `VAPID_SUBJECT` is left alone: it is a contact
  address, not a secret, and falls back to `APP_URL`.
- **`docker/upgrade.sh` is untouched.** It runs unattended (`--sync-env` in
  automation), and minting a secret mid-upgrade is a surprise nobody reviewed.
  Existing installs get the empty settings appended by `env-sync.sh` from the new
  template and generate their own pair with `webpush:vapid --show`.

## How tested

`tests/Unit/GenSecretsScriptTest.php` runs the real script against a temp `.env`
seeded with the shipped template, in the style of `EnvSyncScriptTest`:

- the generated pair passes `Minishlink\WebPush\VAPID::validate()`;
- the private key is the one that signs for the public key (ES256 sign/verify),
  with a cross-pair negative control so the check cannot pass vacuously;
- `VAPID_SUBJECT` stays empty, and re-running keeps the pair byte-for-byte;
- a half-set pair is reported, not completed;
- a stub `openssl` that refuses `ecparam` leaves both halves empty while the rest
  of the secrets are still written.

The two DER offsets are the load-bearing part, so they are checked against the
library rather than by eye. Verified by mutation: changing `skip=7` to `skip=8`
still passes `VAPID::validate()` (the length is unchanged) and fails the
sign/verify test.

Full gate green: `composer test` (Pint, PHPStan, Rector, 2472 tests, coverage
100.0%), the frontend checks, and `docs build`. Also ran the script by hand
against OpenSSL 3.6 and LibreSSL 3.3.

## Docs

- `reference/environment-variables.md`: fresh installs get a pair from
  `gen-secrets.sh`; `webpush:vapid --show` stays documented as the path for
  existing installs and platform-managed deployments.
- `reference/feature-toggles.md`: same split, and the default column no longer
  implies every install has keys.
- `reference/security-and-compliance.md`: `VAPID_PRIVATE_KEY` listed as a full
  secret, with rotation qualified — on exposure only, never as routine hygiene,
  because subscribed browsers are pinned to the public key.

No user-facing copy changed, so no i18n keys were added.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787538455&installation_model_id=428379&pr_number=876&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F876&signature=668b0f1e4c75cd595a12bfd1a5e39b1ec73656058a0006d86d7db183644d391c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->