### PR TITLE
fix: emit the FormField label action after the control so Tab reaches the input

### DIFF
--- a/resources/js/components/FormField.test.ts
+++ b/resources/js/components/FormField.test.ts
@@ -102,4 +102,26 @@ describe('FormField', () => {
         expect(html).toContain('Forgot password?');
         expect(html).toContain('href="/forgot"');
     });
+
+    it('emits the labelAction after the control so Tab reaches the control first', async () => {
+        // Sequential focus follows the DOM, so a focusable label action drawn on
+        // the label row must still be emitted after the control — otherwise Tab
+        // out of the previous field lands on the link instead of this input.
+        const html = await renderField(
+            { id: 'password', label: 'Password' },
+            {
+                default: ({ id }) => h('input', { id, name: 'password' }),
+                labelAction: () =>
+                    h('a', { href: '/forgot' }, 'Forgot password?'),
+            },
+        );
+
+        const labelAt = html.indexOf('for="password"');
+        const controlAt = html.indexOf('name="password"');
+        const actionAt = html.indexOf('href="/forgot"');
+
+        expect(labelAt).toBeGreaterThanOrEqual(0);
+        expect(controlAt).toBeGreaterThan(labelAt);
+        expect(actionAt).toBeGreaterThan(controlAt);
+    });
 });

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -23,20 +23,39 @@ const fieldId = props.id ?? useId();
 
 <template>
     <div class="grid gap-2">
+        <!-- A label action is typically a link, so it is focusable and
+        sequential focus would visit it between the previous field and this
+        control if it came first in the DOM. It is therefore emitted last and
+        placed back on the label row with explicit grid coordinates, so reading
+        order stays label -> control -> action while the drawing stays put. -->
         <div
             v-if="$slots.labelAction"
-            class="flex items-center justify-between"
+            class="grid grid-cols-[1fr_auto] items-center gap-2"
         >
+            <Label
+                :for="fieldId"
+                :class="labelClass"
+                class="col-start-1 row-start-1"
+            >
+                <slot name="label">{{ label }}</slot>
+            </Label>
+
+            <div class="col-span-2 col-start-1 row-start-2">
+                <slot :id="fieldId" />
+            </div>
+
+            <div class="col-start-2 row-start-1">
+                <slot name="labelAction" />
+            </div>
+        </div>
+
+        <template v-else>
             <Label :for="fieldId" :class="labelClass">
                 <slot name="label">{{ label }}</slot>
             </Label>
-            <slot name="labelAction" />
-        </div>
-        <Label v-else :for="fieldId" :class="labelClass">
-            <slot name="label">{{ label }}</slot>
-        </Label>
 
-        <slot :id="fieldId" />
+            <slot :id="fieldId" />
+        </template>
 
         <InputError :message="error" />
 

--- a/tests/Browser/AuthSplitShellTest.php
+++ b/tests/Browser/AuthSplitShellTest.php
@@ -29,6 +29,37 @@ test('the login screen renders the split shell and still signs a user in', funct
         ->assertPathIsNot('/login');
 });
 
+/**
+ * Sequential focus order on the login form (#879). The "Forgot?" link is drawn
+ * on the password label row, so it is easy to emit before the control and steal
+ * the Tab stop the user is aiming for. Only a real browser resolves this: it is
+ * the browser's own tab-order algorithm reading layout and DOM order, not
+ * anything the component can assert about itself.
+ */
+test('tabbing out of the email field lands on the password input, not the reset link', function (): void {
+    $page = visit('/login')
+        ->keys('#email', ['Tab'])
+        ->assertScript('document.activeElement?.id', 'password')
+        // The link keeps its place in the tab order, one stop further on — it
+        // must stay reachable, not be removed with tabindex="-1".
+        ->keys('#password', ['Tab'])
+        ->assertScript(
+            "document.activeElement?.getAttribute('href')",
+            '/forgot-password',
+        );
+
+    // ...and it is still drawn above the field, flush with its right edge,
+    // proving the DOM reorder was undone visually rather than relocating it.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const link = document.querySelector('a[href="/forgot-password"]').getBoundingClientRect();
+        const input = document.getElementById('password').getBoundingClientRect();
+
+        return link.bottom <= input.top && Math.abs(link.right - input.right) <= 1;
+    })()
+    JS, true);
+});
+
 test('the register screen scores a password as it is typed', function (): void {
     // The meter is advisory, so it must actually report a score rather than
     // sitting silently at zero — the failure mode when the estimator throws.


### PR DESCRIPTION
Closes #879.

## What

`FormField` rendered the `labelAction` slot inside the label row, i.e. *before* the control in DOM order. Sequential focus follows the DOM, so a focusable label action stole the Tab stop the user was aiming for: on `/login`, Tab out of **Email address** landed on the **Forgot?** link instead of the password input, breaking the type-email → Tab → type-password muscle memory every password manager and keyboard user relies on.

## How

The action is now emitted **last**, after the control, and placed back onto the label row with explicit grid coordinates (`grid-cols-[1fr_auto]` + `col-start`/`row-start`) rather than source order. Reading and focus order is `label -> control -> action`; the drawing is unchanged.

The fix lives in the shared component, not patched per page, so any future field using `labelAction` inherits the correct order. The link keeps its place in the tab order — it is not removed with `tabindex="-1"`, since a keyboard user still needs to reach password reset. The non-`labelAction` branch is untouched, so no other field's layout moves.

## Testing

- `resources/js/components/FormField.test.ts` — asserts the emitted order is label → control → action.
- `tests/Browser/AuthSplitShellTest.php` — a real browser presses <kbd>Tab</kbd> from `#email` and asserts focus lands on `#password`, that one more <kbd>Tab</kbd> reaches `/forgot-password`, and that the link is still drawn above the field and flush with its right edge.

Both were verified red against the old markup before the fix. The auth-shell axe audit (light and dark) still passes.

Full gate green: `sail composer ci:check` exits 0 at `Total: 100.0 %`, plus `npm run build`.

## i18n / docs

No new user-facing copy and no operator-facing change, so no catalog or `docs/` updates.

## Noted while here

The unrelated `no-v-html-policy` vitest flake (#804) tripped once under full-suite load and passed on re-run; not addressed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787564899&installation_model_id=428379&pr_number=886&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F886&signature=bb04e829c36a36bfdfc9f685264083911a40d733c703fdd29d1dc09851d3af8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->