### PR TITLE
feat: badge the mobile sidebar toggle when a message lands elsewhere

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -774,6 +774,8 @@
   "Today at :time": "Aujourd’hui à :time",
   "Toggle Sidebar": "Afficher/masquer la barre latérale",
   "Toggle sidebar": "Afficher/masquer la barre latérale",
+  "Toggle sidebar, :count unread elsewhere": "Afficher/masquer la barre latérale, :count non lus ailleurs",
+  "Toggle sidebar, unread elsewhere": "Afficher/masquer la barre latérale, des messages non lus ailleurs",
   "Tomorrow": "Demain",
   "Tomorrow 9 AM": "Demain 9 h",
   "Tomorrow at :time": "Demain à :time",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -242,9 +242,12 @@
     --scrim: rgba(0, 0, 0, 0.6);
     --ring: #c9a35c;
     --brass: #c9a35c;
-    /* Light brass so badge/pill text stays legible on the dark brass fill; the
-       light value (#1d1a15) would render near-black on the dark surface (#518). */
-    --brass-foreground: #dcb56a;
+    /* Stays ink: --brass keeps its value in dark, so a solid-brass badge needs
+       the same dark text there as in light (7.4:1). It was lightened for the
+       settings version badge (#518), but that badge is a translucent
+       `bg-brass/10` tint and belongs to --brass-fill-foreground below; the swap
+       left every solid badge brass-on-brass at 1.2:1 (#881). */
+    --brass-foreground: #1d1a15;
     --brass-border: #c9a35c;
     --brass-fill: rgba(201, 163, 92, 0.14);
     --brass-fill-foreground: #dcb56a;

--- a/resources/js/components/SidebarPanelIcon.vue
+++ b/resources/js/components/SidebarPanelIcon.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+type Props = {
+    /**
+     * Inks the left rail brass, so the glyph reports "something is waiting"
+     * before any numeral does — and still reports it when the unread is the
+     * ordinary kind that earns no numeral at all.
+     */
+    unread?: boolean;
+};
+
+withDefaults(defineProps<Props>(), { unread: false });
+</script>
+
+<template>
+    <!--
+      The mobile sidebar toggle's glyph: Lucide's `PanelLeftOpen` panel with the
+      chevron dropped and the left rail inked instead. The chevron is a desktop
+      metaphor — on a phone the sheet it would point at is the whole screen —
+      and it fought the unread badge for the same corner.
+    -->
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden="true"
+    >
+        <rect
+            x="3.25"
+            y="4.25"
+            width="17.5"
+            height="15.5"
+            rx="3.25"
+            stroke="currentColor"
+            stroke-width="1.5"
+        />
+        <path d="M9 4.75v14.5" stroke="currentColor" stroke-width="1.5" />
+        <rect
+            data-test="sidebar-panel-rail"
+            :data-unread="unread"
+            x="4.9"
+            y="5.9"
+            width="2.6"
+            height="12.2"
+            rx="1.3"
+            :class="unread ? 'fill-brass' : 'fill-current opacity-[0.38]'"
+        />
+    </svg>
+</template>

--- a/resources/js/components/ui/sidebar/SidebarTrigger.test.ts
+++ b/resources/js/components/ui/sidebar/SidebarTrigger.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest"
+import { computed, createSSRApp, h, ref } from "vue"
+import { renderToString } from "vue/server-renderer"
+
+/**
+ * The sidebar context the trigger reads, rewritten per test. `state` is a
+ * computed over `open` so the desktop open/close pair can be exercised.
+ */
+const sidebar = {
+  isMobile: ref(true),
+  open: ref(true),
+  toggleSidebar: vi.fn(),
+}
+
+const unread = ref({ count: 0, hasUnread: false })
+
+vi.mock("./utils", () => ({
+  useSidebar: () => ({
+    isMobile: sidebar.isMobile,
+    open: sidebar.open,
+    state: computed(() => (sidebar.open.value ? "expanded" : "collapsed")),
+    toggleSidebar: sidebar.toggleSidebar,
+  }),
+}))
+
+vi.mock("@lucide/vue", () => ({
+  PanelLeftOpen: { name: "PanelLeftOpen", template: '<svg data-test="panel-left-open" />' },
+  PanelLeftClose: { name: "PanelLeftClose", template: '<svg data-test="panel-left-close" />' },
+}))
+
+vi.mock("@/composables/useUnreadElsewhere", () => ({
+  useUnreadElsewhere: () => unread,
+}))
+
+const { default: SidebarTrigger } = await import("./SidebarTrigger.vue")
+
+type Scenario = {
+  isMobile?: boolean
+  open?: boolean
+  count?: number
+  hasUnread?: boolean
+}
+
+async function render({
+  isMobile = true,
+  open = true,
+  count = 0,
+  hasUnread = false,
+}: Scenario = {}): Promise<string> {
+  sidebar.isMobile.value = isMobile
+  sidebar.open.value = open
+  unread.value = { count, hasUnread }
+
+  const app = createSSRApp({
+    render: () => h(SidebarTrigger, { class: "size-9" }),
+  })
+
+  app.config.globalProperties.$t = (key: string) => key
+
+  return renderToString(app)
+}
+
+describe("SidebarTrigger glyph", () => {
+  it("draws the filled rail on mobile instead of the desktop panel/chevron pair", async () => {
+    const html = await render()
+
+    expect(html).toContain('data-test="sidebar-panel-rail"')
+    expect(html).not.toContain('data-test="panel-left-open"')
+    expect(html).not.toContain('data-test="panel-left-close"')
+  })
+
+  it("inks the rail brass as soon as anything is unread elsewhere", async () => {
+    expect(await render({ hasUnread: false })).toContain('data-unread="false"')
+    expect(await render({ hasUnread: true })).toContain('data-unread="true"')
+  })
+
+  it("keeps the Lucide open/close pair on the desktop trigger", async () => {
+    const collapsed = await render({ isMobile: false, open: false })
+    const expanded = await render({ isMobile: false, open: true })
+
+    expect(collapsed).toContain('data-test="panel-left-open"')
+    expect(expanded).toContain('data-test="panel-left-close"')
+    expect(collapsed).not.toContain('data-test="sidebar-panel-rail"')
+    expect(expanded).not.toContain('data-test="sidebar-panel-rail"')
+  })
+})
+
+describe("SidebarTrigger unread badge", () => {
+  it("renders a brass numeral for mentions and DM unread", async () => {
+    const html = await render({ count: 4, hasUnread: true })
+
+    expect(html).toContain('data-test="sidebar-toggle-unread-count"')
+    expect(html).toContain(">4<")
+    expect(html).toContain("bg-brass")
+    // Tabular figures and a ring in the surface colour, so the numeral reads
+    // clear of the glyph it overlaps.
+    expect(html).toContain("tabular-nums")
+    expect(html).toContain("ring-card")
+  })
+
+  it("caps the numeral at 99+", async () => {
+    const html = await render({ count: 132, hasUnread: true })
+
+    expect(html).toContain(">99+<")
+  })
+
+  it("renders no numeral when only plain unread is waiting", async () => {
+    const html = await render({ count: 0, hasUnread: true })
+
+    expect(html).not.toContain('data-test="sidebar-toggle-unread-count"')
+  })
+
+  it("renders nothing at all when everything is read", async () => {
+    const html = await render()
+
+    expect(html).not.toContain('data-test="sidebar-toggle-unread-count"')
+    expect(html).toContain('data-unread="false"')
+  })
+
+  it("stays silent on the desktop trigger, where the sidebar owns unread", async () => {
+    const html = await render({ isMobile: false, count: 4, hasUnread: true })
+
+    expect(html).not.toContain('data-test="sidebar-toggle-unread-count"')
+  })
+})
+
+describe("SidebarTrigger accessible name", () => {
+  it("names the count, so the state is never colour-only", async () => {
+    const html = await render({ count: 4, hasUnread: true })
+
+    expect(html).toContain("Toggle sidebar, 4 unread elsewhere")
+  })
+
+  it("names the true count, not the capped numeral", async () => {
+    const html = await render({ count: 132, hasUnread: true })
+
+    expect(html).toContain("Toggle sidebar, 132 unread elsewhere")
+  })
+
+  it("names the rail-only state too", async () => {
+    const html = await render({ count: 0, hasUnread: true })
+
+    expect(html).toContain("Toggle sidebar, unread elsewhere")
+  })
+
+  it("falls back to the plain name when nothing is unread", async () => {
+    const html = await render()
+
+    expect(html).toContain(">Toggle sidebar<")
+  })
+
+  it("keeps the plain name on desktop even with unread elsewhere", async () => {
+    const html = await render({ isMobile: false, count: 4, hasUnread: true })
+
+    expect(html).toContain(">Toggle sidebar<")
+  })
+
+  it("hides the numeral from assistive tech, since the name already carries it", async () => {
+    const html = await render({ count: 4, hasUnread: true })
+
+    expect(html).toMatch(/data-test="sidebar-toggle-unread-count"[^>]*aria-hidden="true"/)
+  })
+})
+
+describe("SidebarTrigger hit target", () => {
+  it("floors the mobile target at 44px without touching the desktop size", async () => {
+    const html = await render()
+
+    expect(html).toContain("max-md:min-h-11")
+    expect(html).toContain("max-md:min-w-11")
+    // The call-site size survives tailwind-merge, so desktop geometry is unchanged.
+    expect(html).toContain("size-9")
+  })
+})

--- a/resources/js/components/ui/sidebar/SidebarTrigger.vue
+++ b/resources/js/components/ui/sidebar/SidebarTrigger.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from "vue"
 import { PanelLeftClose, PanelLeftOpen } from "@lucide/vue"
+import { computed } from "vue"
 import { cn } from "@/lib/utils"
 import { Button } from '@/components/ui/button'
+import SidebarPanelIcon from "@/components/SidebarPanelIcon.vue"
+import { useTranslations } from "@/composables/useTranslations"
+import { useUnreadElsewhere } from "@/composables/useUnreadElsewhere"
+import { formatUnreadCount } from "@/lib/unreadElsewhere"
 import { useSidebar } from "./utils"
 
 const props = defineProps<{
@@ -10,6 +15,24 @@ const props = defineProps<{
 }>()
 
 const { isMobile, state, toggleSidebar } = useSidebar()
+const { t } = useTranslations()
+
+const unread = useUnreadElsewhere()
+
+// Below `md` the sidebar is a sheet, so every badge it carries is off screen
+// while a conversation is open and the trigger has to report them; at `md` and
+// up the sidebar is on screen and owns unread outright.
+const showsUnread = computed(() => isMobile.value && unread.value.hasUnread)
+
+const accessibleName = computed(() => {
+  if (!showsUnread.value) {
+    return t("Toggle sidebar")
+  }
+
+  return unread.value.count > 0
+    ? t("Toggle sidebar, :count unread elsewhere", { count: unread.value.count })
+    : t("Toggle sidebar, unread elsewhere")
+})
 </script>
 
 <template>
@@ -19,11 +42,19 @@ const { isMobile, state, toggleSidebar } = useSidebar()
     data-test="sidebar-toggle"
     variant="ghost"
     size="icon"
-    :class="cn('h-7 w-7', props.class)"
+    :class="cn('relative h-7 w-7 max-md:min-h-11 max-md:min-w-11', props.class)"
     @click="toggleSidebar"
   >
-    <PanelLeftOpen v-if="isMobile || state === 'collapsed'" />
+    <SidebarPanelIcon v-if="isMobile" class="size-6" :unread="showsUnread" />
+    <PanelLeftOpen v-else-if="state === 'collapsed'" />
     <PanelLeftClose v-else />
-    <span class="sr-only">{{ $t('Toggle sidebar') }}</span>
+    <span
+      v-if="showsUnread && unread.count > 0"
+      data-test="sidebar-toggle-unread-count"
+      aria-hidden="true"
+      class="absolute top-1 right-1 flex h-4.25 min-w-4.25 items-center justify-center rounded-full bg-brass px-1 text-[10px] font-bold text-brass-foreground tabular-nums ring-2 ring-card"
+      >{{ formatUnreadCount(unread.count) }}</span
+    >
+    <span class="sr-only">{{ accessibleName }}</span>
   </Button>
 </template>

--- a/resources/js/composables/useUnreadElsewhere.test.ts
+++ b/resources/js/composables/useUnreadElsewhere.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+import type { Channel } from '@/types/channels';
+
+const page = reactive<{ props: Record<string, unknown> }>({ props: {} });
+
+vi.mock('@inertiajs/vue3', () => ({ usePage: () => page }));
+
+const { useUnreadElsewhere } = await import('@/composables/useUnreadElsewhere');
+
+function channel(overrides: Partial<Channel> = {}): Channel {
+    return {
+        id: 'ch-1',
+        name: 'design',
+        slug: 'design',
+        visibility: 'public',
+        topic: null,
+        isGeneral: false,
+        isArchived: false,
+        muted: false,
+        notificationLevel: 'all',
+        unreadCount: 0,
+        mentionCount: 0,
+        hasDraft: false,
+        draft: null,
+        starred: false,
+        sectionId: null,
+        position: 0,
+        isDirect: false,
+        isGroupDirect: false,
+        dmUserId: null,
+        dmParticipants: null,
+        lastActivityAt: null,
+        ...overrides,
+    };
+}
+
+describe('useUnreadElsewhere', () => {
+    it('reports nothing on a page that carries no sidebar channels', () => {
+        page.props = {};
+
+        expect(useUnreadElsewhere().value).toEqual({
+            count: 0,
+            hasUnread: false,
+        });
+    });
+
+    it('derives the rollup from the shared channels prop', () => {
+        page.props = {
+            channels: [
+                channel({ id: 'ch-design', unreadCount: 3 }),
+                channel({ id: 'dm-ep', isDirect: true, unreadCount: 1 }),
+            ],
+        };
+
+        expect(useUnreadElsewhere().value).toEqual({
+            count: 1,
+            hasUnread: true,
+        });
+    });
+
+    it('excludes the open conversation named by the page', () => {
+        page.props = {
+            channel: { id: 'dm-ep' },
+            channels: [
+                channel({ id: 'dm-ep', isDirect: true, unreadCount: 1 }),
+            ],
+        };
+
+        expect(useUnreadElsewhere().value).toEqual({
+            count: 0,
+            hasUnread: false,
+        });
+    });
+
+    it('tracks the channels prop, so the partial reload behind the sidebar badges moves it too', () => {
+        page.props = { channels: [channel({ id: 'ch-design' })] };
+
+        const summary = useUnreadElsewhere();
+
+        expect(summary.value.hasUnread).toBe(false);
+
+        page.props = {
+            channels: [
+                channel({ id: 'dm-ep', isDirect: true, unreadCount: 2 }),
+            ],
+        };
+
+        expect(summary.value).toEqual({ count: 2, hasUnread: true });
+    });
+});

--- a/resources/js/composables/useUnreadElsewhere.ts
+++ b/resources/js/composables/useUnreadElsewhere.ts
@@ -1,0 +1,28 @@
+import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import type { ComputedRef } from 'vue';
+import { summarizeUnreadElsewhere } from '@/lib/unreadElsewhere';
+import type { UnreadElsewhereSummary } from '@/lib/unreadElsewhere';
+
+/**
+ * The unread rollup behind the mobile sidebar toggle's badge.
+ *
+ * Purely derived: the shared `channels` prop already carries every
+ * conversation's counts on each channel route, and {@see useSidebarBadges}
+ * already keeps it fresh — an arrival, or a read on another device via
+ * `ReadStateAdvanced`, debounces a partial reload of that prop. So the badge
+ * tracks both without subscribing to anything of its own.
+ *
+ * Pages that carry no sidebar (auth, settings) simply have no `channels` prop
+ * and roll up to nothing.
+ */
+export function useUnreadElsewhere(): ComputedRef<UnreadElsewhereSummary> {
+    const page = usePage();
+
+    return computed(() =>
+        summarizeUnreadElsewhere(
+            page.props.channels ?? [],
+            (page.props.channel as { id?: string } | undefined)?.id ?? null,
+        ),
+    );
+}

--- a/resources/js/lib/unreadElsewhere.test.ts
+++ b/resources/js/lib/unreadElsewhere.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import {
+    formatUnreadCount,
+    summarizeUnreadElsewhere,
+} from '@/lib/unreadElsewhere';
+import type { Channel } from '@/types/channels';
+
+function channel(overrides: Partial<Channel> = {}): Channel {
+    return {
+        id: 'ch-1',
+        name: 'design',
+        slug: 'design',
+        visibility: 'public',
+        topic: null,
+        isGeneral: false,
+        isArchived: false,
+        muted: false,
+        notificationLevel: 'all',
+        unreadCount: 0,
+        mentionCount: 0,
+        hasDraft: false,
+        draft: null,
+        starred: false,
+        sectionId: null,
+        position: 0,
+        isDirect: false,
+        isGroupDirect: false,
+        dmUserId: null,
+        dmParticipants: null,
+        lastActivityAt: null,
+        ...overrides,
+    };
+}
+
+describe('summarizeUnreadElsewhere', () => {
+    it('reports nothing for an empty conversation list', () => {
+        expect(summarizeUnreadElsewhere([], null)).toEqual({
+            count: 0,
+            hasUnread: false,
+        });
+    });
+
+    it('leaves plain channel unread out of the numeral but still inks the rail', () => {
+        const summary = summarizeUnreadElsewhere(
+            [channel({ unreadCount: 3 })],
+            null,
+        );
+
+        expect(summary).toEqual({ count: 0, hasUnread: true });
+    });
+
+    it('counts channel @mentions', () => {
+        const summary = summarizeUnreadElsewhere(
+            [channel({ unreadCount: 5, mentionCount: 2 })],
+            null,
+        );
+
+        expect(summary).toEqual({ count: 2, hasUnread: true });
+    });
+
+    it('counts every unread message in a DM, mention or not', () => {
+        const summary = summarizeUnreadElsewhere(
+            [channel({ id: 'dm-1', isDirect: true, unreadCount: 1 })],
+            null,
+        );
+
+        expect(summary).toEqual({ count: 1, hasUnread: true });
+    });
+
+    it('does not count an @mention inside a DM twice', () => {
+        const summary = summarizeUnreadElsewhere(
+            [
+                channel({
+                    id: 'dm-1',
+                    isDirect: true,
+                    unreadCount: 2,
+                    mentionCount: 1,
+                }),
+            ],
+            null,
+        );
+
+        expect(summary.count).toBe(2);
+    });
+
+    it('adds the design brief up to one DM, with the three plain unread only inking the rail', () => {
+        const summary = summarizeUnreadElsewhere(
+            [
+                channel({ id: 'ch-design', unreadCount: 3 }),
+                channel({ id: 'dm-ep', isDirect: true, unreadCount: 1 }),
+            ],
+            null,
+        );
+
+        expect(summary).toEqual({ count: 1, hasUnread: true });
+    });
+
+    it('excludes the conversation the viewer already has open', () => {
+        const summary = summarizeUnreadElsewhere(
+            [
+                channel({ id: 'dm-open', isDirect: true, unreadCount: 4 }),
+                channel({ id: 'ch-other', unreadCount: 2 }),
+            ],
+            'dm-open',
+        );
+
+        expect(summary).toEqual({ count: 0, hasUnread: true });
+    });
+
+    it('reports nothing when the only unread sits in the open conversation', () => {
+        const summary = summarizeUnreadElsewhere(
+            [channel({ id: 'ch-open', unreadCount: 9, mentionCount: 2 })],
+            'ch-open',
+        );
+
+        expect(summary).toEqual({ count: 0, hasUnread: false });
+    });
+
+    it('silences a muted conversation entirely', () => {
+        const summary = summarizeUnreadElsewhere(
+            [
+                channel({
+                    id: 'dm-muted',
+                    isDirect: true,
+                    muted: true,
+                    unreadCount: 6,
+                    mentionCount: 3,
+                }),
+            ],
+            null,
+        );
+
+        expect(summary).toEqual({ count: 0, hasUnread: false });
+    });
+
+    it('silences a conversation set to the "nothing" notification level', () => {
+        const summary = summarizeUnreadElsewhere(
+            [
+                channel({
+                    notificationLevel: 'nothing',
+                    unreadCount: 6,
+                    mentionCount: 3,
+                }),
+            ],
+            null,
+        );
+
+        expect(summary).toEqual({ count: 0, hasUnread: false });
+    });
+
+    it('keeps a "mentions only" conversation, whose ordinary unread the server has already zeroed', () => {
+        const summary = summarizeUnreadElsewhere(
+            [
+                channel({
+                    notificationLevel: 'mentions',
+                    unreadCount: 0,
+                    mentionCount: 2,
+                }),
+            ],
+            null,
+        );
+
+        expect(summary).toEqual({ count: 2, hasUnread: true });
+    });
+
+    it('sums the numeral across every remaining conversation', () => {
+        const summary = summarizeUnreadElsewhere(
+            [
+                channel({ id: 'ch-a', mentionCount: 2, unreadCount: 4 }),
+                channel({ id: 'dm-b', isDirect: true, unreadCount: 3 }),
+                channel({ id: 'ch-c', unreadCount: 1 }),
+            ],
+            null,
+        );
+
+        expect(summary).toEqual({ count: 5, hasUnread: true });
+    });
+});
+
+describe('formatUnreadCount', () => {
+    it('spells out a count within the cap', () => {
+        expect(formatUnreadCount(4)).toBe('4');
+        expect(formatUnreadCount(99)).toBe('99');
+    });
+
+    it('caps anything past 99', () => {
+        expect(formatUnreadCount(100)).toBe('99+');
+        expect(formatUnreadCount(1240)).toBe('99+');
+    });
+});

--- a/resources/js/lib/unreadElsewhere.ts
+++ b/resources/js/lib/unreadElsewhere.ts
@@ -1,0 +1,76 @@
+import type { Channel } from '@/types/channels';
+
+/** Highest numeral the badge spells out; anything past it renders as `99+`. */
+const UNREAD_BADGE_CAP = 99;
+
+/**
+ * What the mobile sidebar toggle has to report: one numeral plus one boolean,
+ * rolled up from every conversation the viewer is not currently reading.
+ */
+export type UnreadElsewhereSummary = {
+    /**
+     * The conversations that earn a numeral — @mentions, and DM traffic, which
+     * is addressed to the viewer by definition.
+     */
+    count: number;
+    /**
+     * Whether anything at all is waiting, numeral-worthy or not. Ordinary
+     * channel unread only reaches this flag, which inks the toggle's rail.
+     */
+    hasUnread: boolean;
+};
+
+/**
+ * Roll the sidebar's per-conversation badges up into the single signal the
+ * mobile toggle carries, since below `md` the sidebar itself is a sheet and
+ * every badge it holds is off screen while a conversation is open.
+ *
+ * Three rules shape the rollup, all of them narrowing what the sidebar shows:
+ *
+ * - The open conversation is excluded — the badge means "unread *elsewhere*",
+ *   and its own unread is already in front of the viewer.
+ * - Muted conversations and those at the `nothing` notification level are
+ *   excluded outright. The sidebar dims a muted row rather than silencing it,
+ *   but a single aggregate cannot be dimmed per row, so a muted room would
+ *   shout exactly as loudly as a live one.
+ * - Only mentions and DM unread reach the numeral. Everything else contributes
+ *   the `hasUnread` flag alone, which the glyph carries as a brass rail.
+ */
+export function summarizeUnreadElsewhere(
+    channels: Channel[],
+    activeChannelId: string | null,
+): UnreadElsewhereSummary {
+    let count = 0;
+    let hasUnread = false;
+
+    for (const channel of channels) {
+        if (channel.id === activeChannelId) {
+            continue;
+        }
+
+        if (channel.muted || channel.notificationLevel === 'nothing') {
+            continue;
+        }
+
+        // A DM's whole unread run is addressed to the viewer, so all of it
+        // counts; a channel contributes only its @mentions. Taking the larger of
+        // the two on a DM keeps an @mention inside one from counting twice.
+        count += channel.isDirect
+            ? Math.max(channel.unreadCount, channel.mentionCount)
+            : channel.mentionCount;
+
+        if (channel.unreadCount > 0 || channel.mentionCount > 0) {
+            hasUnread = true;
+        }
+    }
+
+    return { count, hasUnread };
+}
+
+/**
+ * Render a rollup count for the badge, capping it so a long-neglected inbox
+ * cannot widen the toggle out of its hit target.
+ */
+export function formatUnreadCount(count: number): string {
+    return count > UNREAD_BADGE_CAP ? `${UNREAD_BADGE_CAP}+` : String(count);
+}

--- a/resources/js/pages/settings/About.vue
+++ b/resources/js/pages/settings/About.vue
@@ -56,7 +56,7 @@ const isUpToDate = computed(
                 <div class="ml-auto flex items-center gap-2">
                     <template v-if="isBehind">
                         <span
-                            class="inline-flex items-center gap-1.5 rounded-full border border-brass-border bg-brass/10 px-2.5 py-0.5 text-[11px] font-semibold text-brass-foreground"
+                            class="inline-flex items-center gap-1.5 rounded-full border border-brass-border bg-brass/10 px-2.5 py-0.5 text-[11px] font-semibold text-brass-fill-foreground"
                         >
                             <span
                                 aria-hidden="true"

--- a/resources/js/theme/contrast.test.ts
+++ b/resources/js/theme/contrast.test.ts
@@ -198,13 +198,14 @@ describe('theme contrast (WCAG AA)', () => {
     // which measured 2.94:1 (#278); lock the surfaces it renders on so the brass
     // debt can't creep back. The channel axe audit can't guard it: to stay scoped
     // to #268 it seeds a *read* message, so the divider never renders there.
-    // The "Version X.Y.Z available" badge (settings/About.vue, `isBehind`) paints
-    // --brass-foreground on a `bg-brass/10` fill composited over the settings
-    // card. Dark mode overrode --brass but not --brass-foreground, leaving
-    // near-black text on the dark fill (#518); lock body-text AA in both themes.
+    // The "Version X.Y.Z available" badge (settings/About.vue, `isBehind`) is a
+    // translucent `bg-brass/10` fill composited over the settings card, so it
+    // takes --brass-fill-foreground like every other brass tint. It briefly
+    // painted --brass-foreground instead, which is why that token was lightened
+    // in dark (#518) — a fix that broke the *solid* brass badges below (#881).
     const BADGE_FILL_ALPHA = 0.1; // matches the `bg-brass/10` utility
 
-    it('light --brass-foreground meets AA on the version badge', () => {
+    it('light --brass-fill-foreground meets AA on the version badge', () => {
         const badge = flatten(
             hexToRgb(light['brass']),
             BADGE_FILL_ALPHA,
@@ -212,11 +213,11 @@ describe('theme contrast (WCAG AA)', () => {
         );
 
         expect(
-            contrast(hexToRgb(light['brass-foreground']), badge),
+            contrast(hexToRgb(light['brass-fill-foreground']), badge),
         ).toBeGreaterThanOrEqual(AA_TEXT);
     });
 
-    it('dark --brass-foreground meets AA on the version badge', () => {
+    it('dark --brass-fill-foreground meets AA on the version badge', () => {
         const badge = flatten(
             hexToRgb(dark['brass']),
             BADGE_FILL_ALPHA,
@@ -224,7 +225,26 @@ describe('theme contrast (WCAG AA)', () => {
         );
 
         expect(
-            contrast(hexToRgb(dark['brass-foreground']), badge),
+            contrast(hexToRgb(dark['brass-fill-foreground']), badge),
+        ).toBeGreaterThanOrEqual(AA_TEXT);
+    });
+
+    // --brass-foreground is the *opaque* pair: text and glyphs painted straight
+    // onto a solid `bg-brass` chip — the sidebar mention badge, the DM unread
+    // pill, the mobile sidebar-toggle count (#881), the jump pill, the poll
+    // checkmark. Lightening it for the tinted badge above left brass-on-brass at
+    // 1.2:1 in dark, where the numeral simply disappeared.
+    it.each([
+        ['light', () => light],
+        ['dark', () => dark],
+    ])('%s --brass-foreground meets AA on a solid brass badge', (_, theme) => {
+        const tokens = theme();
+
+        expect(
+            contrast(
+                hexToRgb(tokens['brass-foreground']),
+                hexToRgb(tokens['brass']),
+            ),
         ).toBeGreaterThanOrEqual(AA_TEXT);
     });
 

--- a/resources/js/theme/designTokens.test.ts
+++ b/resources/js/theme/designTokens.test.ts
@@ -86,6 +86,9 @@ describe('"The Desk" design foundation', () => {
 
         it('keeps solid-brass badge text ink in both themes', () => {
             expect(tokenValue(':root', '--brass-foreground')).toBe('#1d1a15');
+            // Brass keeps its value in dark, so lightening its foreground there
+            // put brass on brass and made the numeral vanish (#881).
+            expect(tokenValue('.dark', '--brass-foreground')).toBe('#1d1a15');
         });
 
         it('exposes brass as Tailwind color utilities via @theme inline', () => {


### PR DESCRIPTION
Closes #881.

## What

Below `md` the sidebar is a Sheet, so every unread badge it carries is off screen while you read a conversation. The toggle already *is* the sidebar there, so the badge goes on it.

- **`lib/unreadElsewhere.ts`** — the pure rollup. The numeral is @mentions plus DM unread (`max(unreadCount, mentionCount)` on a DM, so an @mention inside one is not counted twice); everything else only raises `hasUnread`. The open conversation, muted rooms and `notification_level = nothing` are excluded, and the numeral caps at `99+`.
- **`composables/useUnreadElsewhere.ts`** — derives the rollup from the shared `channels` prop, so it rides the partial reload `useSidebarBadges` already drives (an arrival, and `ReadStateAdvanced` for a read on another device). Nothing new subscribes.
- **`components/SidebarPanelIcon.vue`** — the chosen "filled rail" glyph: the same panel outline, chevron dropped, left rail inked. The rail turns brass whenever anything is unread, so the icon carries state before the count does.
- **`ui/sidebar/SidebarTrigger.vue`** — badge plus glyph. Putting it in the primitive covers all four mobile screens (channel, Threads, Search, Browse) rather than the masthead alone.

Two deliberate reads of the design, both flagged in the issue's analysis:

- The mock's badge reads `4` for "3 unread in #design and 1 DM", which contradicts its own stated rule. The rule wins: the numeral is `1` and the three plain unread only ink the rail.
- With the filled rail carrying unread-only state, a separate dot in the same 24pt box says the same thing twice, so there is no dot. Three states: grey rail, brass rail, brass rail plus numeral.

## Accessibility

- The accessible name carries the state, never colour alone: "Toggle sidebar, 4 unread elsewhere", or "Toggle sidebar, unread elsewhere" for the rail-only case. The numeral itself is `aria-hidden` so it is not announced twice.
- The mobile hit target goes from 32/36px to 44px. `max-md:min-h-11 max-md:min-w-11` on the primitive floors it, so the four call sites keep their own `size-8`/`size-9` and desktop geometry is untouched.
- Nothing renders at `md` and up — the sidebar owns unread there.

## Dark-mode contrast fix (found on this surface)

The new badge is a solid `bg-brass` chip with `text-brass-foreground`, and the numeral was invisible in dark. `--brass-foreground` had been flipped to light brass `#dcb56a` in dark by #518, but `--brass` keeps its value there, so brass-on-brass measured **1.2:1**. #518 was really fixing the settings "Version available" badge, which is a translucent `bg-brass/10` tint and belongs to `--brass-fill-foreground`.

So dark `--brass-foreground` returns to ink `#1d1a15` (7.4:1) and `settings/About.vue` moves to `text-brass-fill-foreground` (7.5:1 dark, 6.7:1 light). That also repairs the sidebar mention badge, the DM unread pill, the jump pill, the onboarding and reminder CTAs, and the poll checkmark, all of which were brass-on-brass in dark.

## Testing

- 33 new Vitest cases: the rollup's precedence, muted / "nothing" suppression, active-conversation exclusion and the `99+` cap; the composable's reactivity to the `channels` prop; and the trigger's rendered states (glyph per breakpoint, badge, accessible name, hit target).
- `contrast.test.ts` gains a solid-brass assertion in both themes, and `designTokens.test.ts`'s "both themes" test now actually checks `.dark` — the two guards that would have caught #518's regression.
- Verified live at 390px on the channel, Threads and Browse screens (44x44 box, badge, correct accessible name) in both themes, and at 1200px (hidden, no badge, plain name).
- Full gate green: `composer test` at `Total: 100.0 %`, plus `lint:check`, `format:check`, `types:check`, `test:js` (1362 passed) and `build`.

No PHP change, and `lang/fr.json` carries the two new keys.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787565835&installation_model_id=428379&pr_number=888&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F888&signature=b414a51742f0bc4150c7629f7e96205a3e175bb181827cf74a6808337c961316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->