### PR TITLE
docs: span the release banner across the viewport and correct the stale push-notification copy

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -25,6 +25,14 @@ export default defineConfig({
 			],
 			// Brand theme override (The Desk): Newsreader/Instrument Sans + brass palette.
 			customCss: ['./src/styles/custom.css'],
+			// The default layout renders the release banner inside `<main>`, so a
+			// site-wide notice ends up boxed between the sidebars. `PageFrame`
+			// hoists it to the top of the page shell instead, and the `Banner`
+			// override empties the slot it used to occupy. See #885.
+			components: {
+				Banner: './src/components/Banner.astro',
+				PageFrame: './src/components/PageFrame.astro',
+			},
 			// Renders `public/openapi.yaml` — the hand-authored, route-verified
 			// contract for /api/v1 — into a browsable reference at build time.
 			// The same file stays downloadable at /openapi.yaml because it lives
@@ -99,7 +107,9 @@ export default defineConfig({
 					label: 'Start Here',
 					items: [
 						{ label: 'Introduction', link: '/' },
-						{ label: 'The Desk vs Slack, Mattermost & Rocket.Chat', slug: 'comparison' },
+						// Short enough to stay on one line at the default sidebar width;
+						// the page keeps its long, keyword-bearing title and H1.
+						{ label: 'vs Slack & alternatives', slug: 'comparison' },
 						{ label: 'FAQ', slug: 'faq' },
 					],
 				},

--- a/docs/src/components/Banner.astro
+++ b/docs/src/components/Banner.astro
@@ -1,0 +1,9 @@
+---
+/**
+ * Starlight calls this component from inside `<main>`, between the two
+ * sidebars, which makes the site-wide release banner read as a callout attached
+ * to the article. The banner is rendered by the `PageFrame` override instead,
+ * at the top of the page shell and full-bleed, so this slot is deliberately
+ * left empty. See #885.
+ */
+---

--- a/docs/src/components/PageFrame.astro
+++ b/docs/src/components/PageFrame.astro
@@ -1,0 +1,147 @@
+---
+/**
+ * Fork of Starlight 0.41's `PageFrame`, kept deliberately close to the original
+ * so a version bump is easy to reconcile. The only change is the banner: the
+ * default layout renders it inside `<main>`, where the sidebars flank it and the
+ * active-page pill paints over its left edge, so it is hoisted here instead —
+ * full-bleed, above the header, outside the content column. Everything else
+ * Starlight pins to the viewport is shifted down by `--td-banner-height`, set
+ * below and consumed by the rest of the chrome in `src/styles/custom.css`.
+ * See #885.
+ */
+// Starlight's own component, imported directly rather than through
+// `virtual:starlight/components/Banner` — that specifier now resolves to the
+// blank override which exists to empty the in-`<main>` slot.
+import Banner from '@astrojs/starlight/components/Banner.astro';
+import MobileMenuToggle from 'virtual:starlight/components/MobileMenuToggle';
+
+const { hasSidebar } = Astro.locals.starlightRoute;
+---
+
+<div class="page sl-flex">
+	<div class="banner-region" data-banner-region><Banner /></div>
+	{/*
+		Inline so it runs while the document parses, before first paint: a
+		deferred module would let the page paint once with the chrome at
+		Starlight's unshifted offsets, on top of the banner.
+	*/}
+	<script is:inline>
+		(() => {
+			const region = document.querySelector('[data-banner-region]');
+
+			if (!region) return;
+
+			// How much of the banner is still on screen, so the chrome rides up
+			// with it as the page scrolls instead of reserving a permanent gap.
+			const sync = () => {
+				const visible = Math.max(0, region.getBoundingClientRect().bottom);
+
+				document.documentElement.style.setProperty('--td-banner-height', `${visible}px`);
+			};
+
+			sync();
+			addEventListener('scroll', sync, { passive: true });
+			addEventListener('resize', sync, { passive: true });
+			// The banner rewraps on a font swap or an orientation change, neither
+			// of which fires a scroll or resize event on its own.
+			new ResizeObserver(sync).observe(region);
+		})();
+	</script>
+	<header class="header"><slot name="header" /></header>
+	{
+		hasSidebar && (
+			<nav class="sidebar print:hidden" aria-label={Astro.locals.t('sidebarNav.accessibleLabel')}>
+				<MobileMenuToggle />
+				<div id="starlight__sidebar" class="sidebar-pane">
+					<div class="sidebar-content sl-flex">
+						<slot name="sidebar" />
+					</div>
+				</div>
+			</nav>
+		)
+	}
+	<div class="main-frame"><slot /></div>
+</div>
+
+<style>
+	@layer starlight.core {
+		.page {
+			flex-direction: column;
+			min-height: 100vh;
+		}
+
+		/* Above the navbar so no chrome can ever be painted over the banner,
+		   below the skip link so it stays reachable first. */
+		.banner-region {
+			position: relative;
+			z-index: calc(var(--sl-z-index-navbar) + 1);
+		}
+
+		.header {
+			z-index: var(--sl-z-index-navbar);
+			position: fixed;
+			inset-inline-start: 0;
+			inset-block-start: var(--td-banner-height);
+			width: 100%;
+			height: var(--sl-nav-height);
+			border-bottom: 1px solid var(--sl-color-hairline-shade);
+			padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
+			padding-inline-end: var(--sl-nav-pad-x);
+			background-color: var(--sl-color-bg-nav);
+		}
+
+		:global([data-has-sidebar]) .header {
+			padding-inline-end: calc(
+				var(--sl-nav-gap) + var(--sl-nav-pad-x) + var(--sl-menu-button-size)
+			);
+		}
+
+		.sidebar-pane {
+			visibility: var(--sl-sidebar-visibility, hidden);
+			position: fixed;
+			z-index: var(--sl-z-index-menu);
+			inset-block: calc(var(--sl-nav-height) + var(--td-banner-height)) 0;
+			inset-inline-start: 0;
+			width: 100%;
+			background-color: var(--sl-color-black);
+			overflow-y: auto;
+			scrollbar-gutter: stable;
+		}
+
+		:global([aria-expanded='true']) ~ .sidebar-pane {
+			--sl-sidebar-visibility: visible;
+		}
+
+		.sidebar-content {
+			height: 100%;
+			min-height: max-content;
+			padding: 1rem var(--sl-sidebar-pad-x) 0;
+			flex-direction: column;
+			gap: 1rem;
+		}
+
+		@media (min-width: 50rem) {
+			.sidebar-content::after {
+				content: '';
+				padding-bottom: 1px;
+			}
+		}
+
+		.main-frame {
+			padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
+			padding-inline-start: var(--sl-content-inline-start);
+		}
+
+		@media (min-width: 50rem) {
+			:global([data-has-sidebar]) .header {
+				padding-inline-end: var(--sl-nav-pad-x);
+			}
+			.sidebar-pane {
+				--sl-sidebar-visibility: visible;
+				width: var(--sl-sidebar-width);
+				background-color: var(--sl-color-bg-sidebar);
+				border-inline-end: 1px solid var(--sl-color-hairline-shade);
+			}
+		}
+	}
+</style>

--- a/docs/src/content/docs/comparison.md
+++ b/docs/src/content/docs/comparison.md
@@ -64,8 +64,11 @@ Being honest saves you a wasted afternoon. As of **v1.16.0**, The Desk does **no
 have:
 
 - **Voice or video calls** — not planned for the near term.
-- **Native mobile apps** — the web app is fully responsive, but there's no
-  dedicated iOS/Android app or push notifications yet.
+- **A store-listed mobile app** — the web app is fully responsive and installs
+  to the home screen as a PWA on iOS and Android, and it sends
+  [push notifications](/reference/feature-toggles/#web-push-notifications) once
+  a VAPID keypair is set. What's missing is the store listing: there is nothing
+  to download from the App Store or the Play Store.
 - **A prebuilt-integrations marketplace** — bots, a [REST
   API](/reference/api/), and [webhooks](/reference/webhooks/) are built
   in, but there's no directory of hundreds of ready-made apps. If your workflow

--- a/docs/src/content/docs/faq.md
+++ b/docs/src/content/docs/faq.md
@@ -51,8 +51,11 @@ toggle. Turn it off and the workspace is invitation-only. You can also require
 
 ## Is there a mobile app?
 
-Not yet. The web app is fully responsive and works well in a mobile browser, but
-there's no dedicated iOS/Android app or mobile push notifications today.
+The web app **installs as a PWA** — add it to the home screen on iOS or Android
+and it runs in its own window, with
+[push notifications](/reference/feature-toggles/#web-push-notifications) for new
+messages once you set a VAPID keypair. What you won't find is a native app in
+the App Store or the Play Store; the installed PWA is the mobile experience.
 
 ## Does it support file attachments, voice, or video?
 

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -15,6 +15,42 @@
 	--td-brass-ink: #7d6023;
 	--td-ink: #1d1a15;
 	--td-paper: #f3efe4;
+	/* How much of the release banner is still on screen. Published by the
+	   inline script in src/components/PageFrame.astro; the 0px here is what a
+	   page without a banner (the generated API reference, 404) keeps, so those
+	   pages fall back to Starlight's own offsets. See #885. */
+	--td-banner-height: 0px;
+}
+
+/* ---------- Site-wide release banner ----------
+   The banner is hoisted out of `<main>` by the PageFrame override so it spans
+   the viewport. Everything Starlight pins to the viewport therefore has to be
+   pushed down past it — the pieces below live in other Starlight components, so
+   they are shifted from here rather than from that override's scoped styles. */
+@media (min-width: 72rem) {
+	.right-sidebar {
+		top: var(--td-banner-height);
+		height: calc(100vh - var(--td-banner-height));
+	}
+}
+mobile-starlight-toc nav {
+	top: calc(var(--sl-nav-height) - 1px + var(--td-banner-height));
+}
+starlight-menu-button button {
+	top: calc((var(--sl-nav-height) - var(--sl-menu-button-size)) / 2 + var(--td-banner-height));
+}
+
+/* An anchor jump lands under the header otherwise: while any of the banner is
+   still on screen the header sits that much lower than Starlight assumes. */
+html {
+	scroll-padding-top: calc(
+		1.5rem + var(--sl-nav-height) + var(--sl-mobile-toc-height) + var(--td-banner-height)
+	);
+}
+@media (min-width: 72rem) {
+	html {
+		scroll-padding-top: calc(1.5rem + var(--sl-nav-height) + var(--td-banner-height));
+	}
 }
 
 /* ---------- Dark palette (default) ---------- */

--- a/tests/Unit/DocsBannerLayoutTest.php
+++ b/tests/Unit/DocsBannerLayoutTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Starlight renders the release banner inside `<main>`, between the two
+ * sidebars, so a site-wide notice reads as a callout bolted onto the article —
+ * and the sidebar's active-page pill paints over its left edge. The fix hoists
+ * the banner out of `<main>` and into the page shell, then offsets every piece
+ * of chrome Starlight pins to the viewport by however much of the banner is
+ * still on screen. Each half is inert on its own: hoisting without the offsets
+ * puts the banner *under* the fixed header, and offsets without the hoist move
+ * chrome away from a banner that never left the content column. These tests
+ * keep both halves, and the sidebar label that was wrapping beside them,
+ * from drifting apart. See #885.
+ */
+$docsPath = fn (string $file): string => dirname(__DIR__, 2).'/docs/'.$file;
+
+$docsFile = fn (string $file): string => (string) file_get_contents(dirname(__DIR__, 2).'/docs/'.$file);
+
+test('starlight is told to use the banner and page frame overrides', function (string $component) use ($docsPath, $docsFile): void {
+    expect($docsFile('astro.config.mjs'))->toContain($component.": './src/components/".$component.".astro'")
+        ->and($docsPath('src/components/'.$component.'.astro'))->toBeFile();
+})->with(['Banner', 'PageFrame']);
+
+/**
+ * The override has to render *nothing*: Starlight calls it from inside `<main>`,
+ * which is the position being moved away from. Anything left in its template
+ * would put a second banner back where the first one was.
+ */
+test('the banner slot starlight calls from inside main renders nothing', function () use ($docsFile): void {
+    $template = preg_replace('/^---.*?^---/ms', '', $docsFile('src/components/Banner.astro'));
+
+    expect(trim((string) $template))->toBe('');
+});
+
+test('the page frame renders the real banner above the header and outside the content column', function () use ($docsFile): void {
+    $frame = $docsFile('src/components/PageFrame.astro');
+
+    // Importing Starlight's own component rather than re-implementing it keeps
+    // the banner's markup, styling and `banner` frontmatter handling intact —
+    // and sidesteps the override indirection, which now resolves to the blank
+    // component above.
+    expect($frame)->toContain("import Banner from '@astrojs/starlight/components/Banner.astro';");
+
+    $banner = strpos($frame, '<Banner />');
+    $header = strpos($frame, '<header class="header">');
+    $mainFrame = strpos($frame, '<div class="main-frame">');
+
+    expect($banner)->toBeInt()->toBeLessThan($header)
+        ->and($banner)->toBeLessThan($mainFrame);
+});
+
+/**
+ * One published custom property drives every offset, so the chrome tracks the
+ * banner as it scrolls away instead of reserving a fixed gap forever.
+ */
+test('the page frame publishes how much of the banner is still on screen', function () use ($docsFile): void {
+    $frame = $docsFile('src/components/PageFrame.astro');
+
+    expect($frame)->toContain("setProperty('--td-banner-height'")
+        // Without a scroll listener the offset freezes at the banner's full
+        // height and the header never reaches the top of the viewport; without
+        // the observer it never survives a reflow (font swap, viewport rotation)
+        // that rewraps the banner text.
+        ->and($frame)->toContain("addEventListener('scroll'")
+        ->and($frame)->toContain('ResizeObserver');
+});
+
+test('the offset falls back to zero so pages without a banner keep starlight layout', function () use ($docsFile): void {
+    expect($docsFile('src/styles/custom.css'))->toMatch('/--td-banner-height:\s*0px;/');
+});
+
+/**
+ * Every element Starlight pins to the viewport, paired with the file that has
+ * to shift it down. Miss one and it is the piece that paints over the banner.
+ *
+ * @return list<array{string, string}>
+ */
+$pinnedChrome = [
+    // The fixed top bar, moved below the banner rather than over it.
+    ['src/components/PageFrame.astro', '.header'],
+    // The desktop sidebar pane, whose active-page pill was the visible overlap.
+    ['src/components/PageFrame.astro', '.sidebar-pane'],
+    ['src/styles/custom.css', '.right-sidebar'],
+    ['src/styles/custom.css', 'mobile-starlight-toc nav'],
+    ['src/styles/custom.css', 'starlight-menu-button button'],
+];
+
+test('every viewport-pinned element is offset by the visible part of the banner', function (string $file, string $selector) use ($docsFile): void {
+    $rule = [];
+    preg_match('/'.preg_quote($selector, '/').'\s*\{(?<body>[^}]*)\}/', $docsFile($file), $rule);
+
+    expect($rule['body'] ?? '')->toContain('--td-banner-height');
+})->with($pinnedChrome);
+
+/**
+ * Anchor jumps land under the header otherwise: the header sits a banner's
+ * height lower while any of the banner is still on screen.
+ */
+test('anchor scroll padding accounts for the banner too', function () use ($docsFile): void {
+    $css = $docsFile('src/styles/custom.css');
+
+    preg_match_all('/scroll-padding-top:(?<value>[^;]*);/', $css, $matches);
+
+    expect($matches['value'])->not->toBeEmpty()
+        ->each->toContain('--td-banner-height');
+});
+
+/**
+ * The sidebar has no width to spare, so the bound is the longest entry that is
+ * already known to render on one line — every other leaf in the tree. Judging
+ * the comparison entry against its own neighbours keeps the check honest as the
+ * sidebar grows, instead of freezing a magic number.
+ */
+test('the comparison sidebar entry is no longer than the entries that already fit on one line', function () use ($docsFile): void {
+    preg_match_all("/\{ label: '(?<label>[^']*)', (?:slug|link): '(?<target>[^']*)' \}/", $docsFile('astro.config.mjs'), $entries, PREG_SET_ORDER);
+
+    $labels = collect($entries)->pluck('label', 'target');
+    $comparison = $labels->get('comparison', '');
+
+    // Guard the guard: a changed entry shape would empty the scan and leave
+    // this comparing one label against nothing.
+    expect($labels->count())->toBeGreaterThan(10)
+        ->and($comparison)->not->toBeEmpty()
+        ->and(strlen($comparison))->toBeLessThanOrEqual(
+            $labels->forget('comparison')->map(fn (string $label): int => strlen($label))->max()
+        );
+});
+
+/**
+ * Shortening the sidebar label must not reach the page itself: the long title
+ * and its description are what rank the page for "self-hosted Slack
+ * alternative", which is the whole reason the page exists.
+ */
+test('the comparison page keeps the long title and description the sidebar no longer repeats', function () use ($docsFile): void {
+    $page = $docsFile('src/content/docs/comparison.md');
+
+    expect($page)->toContain('title: The Desk vs Slack, Mattermost & Rocket.Chat')
+        ->and($page)->toContain('self-hosted Slack alternative');
+});

--- a/tests/Unit/DocsMobileClaimsTest.php
+++ b/tests/Unit/DocsMobileClaimsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The installable PWA and web push shipped (#862, #870, #872, #874, #876) while
+ * the comparison page and the FAQ still listed push notifications among the
+ * things The Desk cannot do — the same drift #552 fixed for SSO. Correcting the
+ * copy is easy; keeping it corrected is what needs a guard, because both pages
+ * are honest-about-the-gaps prose that gets re-edited whenever a gap closes.
+ * The other half matters just as much: there is still no App Store or Play
+ * Store listing, so neither page may swing into claiming a native app. See #887.
+ *
+ * @return list<string>
+ */
+$mobileClaimPages = ['comparison.md', 'faq.md'];
+
+$page = fn (string $file): string => (string) file_get_contents(dirname(__DIR__, 2).'/docs/src/content/docs/'.$file);
+
+/**
+ * Sentences of the collapsed page text. Markdown wraps mid-sentence, so the
+ * source line breaks say nothing about where a claim starts or ends; a period
+ * followed by whitespace does, and it leaves "Rocket.Chat" and "v1.16.0" whole.
+ *
+ * @return list<string>
+ */
+function sentencesOf(string $markdown): array
+{
+    return preg_split('/(?<=[.!?])\s+/', (string) preg_replace('/\s+/', ' ', $markdown)) ?: [];
+}
+
+/**
+ * Pinned by sentence rather than by the exact stale wording, which a reword
+ * would slip past: whatever sentence carries the push claim may not also carry
+ * a negation. Both stale bullets read "…no dedicated iOS/Android app or push
+ * notifications yet", so both were exactly that shape.
+ */
+test('neither page still claims push notifications are unavailable', function (string $file) use ($page): void {
+    $claims = array_values(array_filter(
+        sentencesOf($page($file)),
+        static fn (string $sentence): bool => (bool) preg_match('/push notifications/i', $sentence)
+    ));
+
+    expect($claims)->not->toBeEmpty('the page has to say something about push notifications for this to guard anything')
+        ->each->not->toMatch("/\b(no|not|never|without|lacks?|missing|unavailable|isn't|aren't|don't|doesn't)\b/i");
+})->with($mobileClaimPages);
+
+test('both pages describe the pwa install and web push instead', function (string $file) use ($page): void {
+    expect($page($file))->toContain('PWA')
+        // Linking the reference page keeps the configuration documented in one
+        // place rather than restated in prose that would drift again.
+        ->and($page($file))->toContain('/reference/feature-toggles/#web-push-notifications');
+})->with($mobileClaimPages);
+
+/**
+ * Dropping the "no native mobile app" entry outright would overclaim in the
+ * other direction, on the two pages whose entire premise is being straight
+ * about what is missing.
+ */
+test('both pages still say plainly that there is no store app', function (string $file) use ($page): void {
+    expect($page($file))->toMatch('/App Store/i')
+        ->and($page($file))->toMatch('/Play Store/i');
+})->with($mobileClaimPages);
+
+/**
+ * The "As of vX.Y.Z" line sits inside the section being edited, and release-please
+ * only restamps lines carrying this annotation.
+ */
+test('the comparison page keeps the annotation release-please stamps the version into', function () use ($page): void {
+    expect($page('comparison.md'))->toMatch('/As of \*\*v\d+\.\d+\.\d+\*\*.*<!-- x-release-please-version -->/');
+});


### PR DESCRIPTION
Closes #885. Closes #887.

Two docs-site problems, shipped together because they touch the same project.

## 1. The release banner is confined to the content column (#885)

Starlight renders `Banner` from inside `<main>`, so the site-wide release notice
sat boxed between the two sidebars and the active-page pill painted over its
left edge.

- `PageFrame` is overridden (a close fork of Starlight 0.41's, so a version bump
  stays easy to reconcile) to hoist the banner to the top of the page shell,
  full-bleed and above the header. The `Banner` override empties the slot it
  used to occupy, so exactly one banner is rendered.
- CSS alone cannot offset fixed siblings by an auto-height element, so an inline
  script (inline to run before first paint, like Starlight's own theme script)
  publishes `--td-banner-height` — how much of the banner is *still on screen*.
  Every viewport-pinned element consumes it: the header, the sidebar pane, the
  right-hand TOC, the mobile TOC, the menu button, and anchor scroll padding.
  The chrome therefore rides up with the banner as the page scrolls and lands
  back on Starlight's exact default offsets once the banner is gone.
- Pages with no banner (the 404) resolve the variable to its `0px` default and
  keep stock Starlight layout.

## 2. The comparison sidebar label wrapped to two lines (#885)

`The Desk vs Slack, Mattermost & Rocket.Chat` → `vs Slack & alternatives`. The
page's own `title`, `description` and H1 are untouched, so the SEO value of the
long title stays put.

## 3. The comparison page and FAQ still denied push notifications (#887)

Both pages listed push under what The Desk cannot do, which stopped being true
when the installable PWA and web push landed. Both bullets now describe the PWA
install and push support and link
`/reference/feature-toggles/#web-push-notifications` rather than restating the
configuration — while still saying plainly that there is no App Store or Play
Store listing. The `<!-- x-release-please-version -->` annotation is untouched
(`release:check-version-refs` passes). A sweep of the rest of `docs/` found no
other claim the PWA work invalidated.

## Testing

- `tests/Unit/DocsBannerLayoutTest.php` pins both halves of the banner fix
  together (hoisting without the offsets buries the banner under the header;
  offsets without the hoist move chrome away from a banner that never left the
  content column), plus the sidebar label bound and the page title it must not
  touch.
- `tests/Unit/DocsMobileClaimsTest.php` guards the push copy by *sentence* — the
  sentence carrying the push claim may not also carry a negation — so a reword
  cannot slip the old claim back in, and asserts both pages still name the App
  Store and Play Store.
- `cd docs && npm run build` passes; the built HTML has exactly one `.sl-banner`
  per page and none inside `<main>`.
- Verified in a real browser at 1440 / 900 / 390 px, light and dark: banner
  edge-to-edge with nothing painted over it, chrome tracking it correctly at
  scroll 0 / 30 / 600, anchor jumps clearing the header, the mobile drawer
  opening below the banner, all three Start Here labels on one line, and no
  horizontal overflow.
- Full backend gate green at 100% coverage; all five frontend checks green.

No i18n impact (the docs site is English-only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787566393&installation_model_id=428379&pr_number=891&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F891&signature=b88bba1e1523c0116665511771f5f9cdeb9389815acdaf20e0cdb496b9954c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->