### PR TITLE
fix: land every sign-in on the team workspace instead of the Welcome page

### DIFF
--- a/app/Http/Controllers/Auth/Sso/OidcController.php
+++ b/app/Http/Controllers/Auth/Sso/OidcController.php
@@ -7,10 +7,12 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Laravel\Socialite\AbstractUser;
 use Laravel\Socialite\Contracts\User as OidcUser;
 use Laravel\Socialite\Facades\Socialite;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
 class OidcController extends Controller
@@ -34,8 +36,13 @@ class OidcController extends Controller
      * key the identity), or a provisioning failure (e.g. a losing concurrent
      * first login hitting the unique constraint) fails gracefully back to the
      * login screen rather than surfacing an exception.
+     *
+     * A completed sign-in hands off to the app's login response rather than
+     * resolving a destination of its own, so single sign-on lands exactly where
+     * a password login lands — workspace, current-team URL default, and the
+     * unreachable-intended-URL cleanup included.
      */
-    public function callback(Request $request, ProvisionSsoUser $provisionSsoUser): RedirectResponse
+    public function callback(Request $request, ProvisionSsoUser $provisionSsoUser): Response
     {
         abort_unless(config('sso.oidc.enabled'), 404);
 
@@ -64,7 +71,7 @@ class OidcController extends Controller
         Auth::login($user);
         $request->session()->regenerate();
 
-        return redirect()->intended(config('fortify.home'));
+        return app(LoginResponseContract::class)->toResponse($request);
     }
 
     /**

--- a/app/Http/Responses/Concerns/RedirectsToCurrentTeam.php
+++ b/app/Http/Responses/Concerns/RedirectsToCurrentTeam.php
@@ -4,8 +4,8 @@ namespace App\Http\Responses\Concerns;
 
 use App\Models\Team;
 use App\Models\User;
+use App\Support\WorkspaceRedirect;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\URL;
 
 trait RedirectsToCurrentTeam
 {
@@ -14,11 +14,11 @@ trait RedirectsToCurrentTeam
      */
     protected function redirectPathForCurrentTeam(Request $request): string
     {
-        $team = $this->currentTeam($request);
+        $path = WorkspaceRedirect::pathFor($request->user());
 
-        URL::defaults(['current_team' => $team->slug]);
+        abort_if($path === null, 403);
 
-        return route('channels.index', ['team' => $team->slug], absolute: false);
+        return $path;
     }
 
     /**
@@ -52,6 +52,13 @@ trait RedirectsToCurrentTeam
             return false;
         }
 
+        // The site root is the public marketing page (route `home`), never a
+        // destination for someone who has just signed in — honouring it is how
+        // an authenticated user lands back on the Welcome screen.
+        if (trim($path, '/') === '') {
+            return false;
+        }
+
         $segments = explode('/', trim($path, '/'));
 
         if ($segments[0] !== 't') {
@@ -70,18 +77,5 @@ trait RedirectsToCurrentTeam
 
         return ($channelSlug = $segments[3] ?? null) !== null
             && $team->channels()->where('slug', $channelSlug)->exists();
-    }
-
-    protected function currentTeam(Request $request): Team
-    {
-        $user = $request->user();
-
-        abort_if(! $user, 403);
-
-        $team = $user->currentTeam ?? $user->personalTeam();
-
-        abort_if(! $team, 403);
-
-        return $team;
     }
 }

--- a/app/Http/Responses/PasskeyLoginResponse.php
+++ b/app/Http/Responses/PasskeyLoginResponse.php
@@ -4,6 +4,7 @@ namespace App\Http\Responses;
 
 use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Laravel\Passkeys\Contracts\PasskeyLoginResponse as PasskeyLoginResponseContract;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,7 +22,7 @@ class PasskeyLoginResponse implements PasskeyLoginResponseContract
      * the login screen drives the ceremony over JSON and navigates to the
      * `redirect` it gets back, so that is the branch a real browser takes.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      */
     public function toResponse($request): Response
     {

--- a/app/Http/Responses/PasskeyLoginResponse.php
+++ b/app/Http/Responses/PasskeyLoginResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Responses;
+
+use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
+use Illuminate\Http\JsonResponse;
+use Laravel\Passkeys\Contracts\PasskeyLoginResponse as PasskeyLoginResponseContract;
+use Symfony\Component\HttpFoundation\Response;
+
+class PasskeyLoginResponse implements PasskeyLoginResponseContract
+{
+    use RedirectsToCurrentTeam;
+
+    /**
+     * Send a completed passwordless sign-in to the current team's workspace.
+     *
+     * The vendor response reads `config('passkeys.redirect')`, which Fortify
+     * fills once at boot from `fortify.home` — a static string that cannot know
+     * which team the person signing in belongs to, so every passkey login landed
+     * on the public marketing page. Both branches resolve the same destination:
+     * the login screen drives the ceremony over JSON and navigates to the
+     * `redirect` it gets back, so that is the branch a real browser takes.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function toResponse($request): Response
+    {
+        $this->forgetUnreachableIntendedUrl($request);
+
+        $redirect = redirect()->intended($this->redirectPathForCurrentTeam($request));
+
+        return $request->wantsJson()
+            ? new JsonResponse(['redirect' => $redirect->getTargetUrl()], 200)
+            : $redirect;
+    }
+}

--- a/app/Http/Responses/PasswordConfirmedResponse.php
+++ b/app/Http/Responses/PasswordConfirmedResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Responses;
+
+use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
+use Symfony\Component\HttpFoundation\Response;
+
+class PasswordConfirmedResponse implements PasswordConfirmedResponseContract
+{
+    use RedirectsToCurrentTeam;
+
+    /**
+     * Return to the guarded page the confirmation was raised for.
+     *
+     * That page is normally waiting in the intended URL, put there by the
+     * `password.confirm` middleware. When it is not — someone opened the confirm
+     * screen directly — Fortify falls back to `fortify.home`, the public
+     * marketing page, so the workspace stands in instead.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     */
+    public function toResponse($request): Response
+    {
+        if ($request->wantsJson()) {
+            return new JsonResponse('', 201);
+        }
+
+        $this->forgetUnreachableIntendedUrl($request);
+
+        return redirect()->intended($this->redirectPathForCurrentTeam($request));
+    }
+}

--- a/app/Http/Responses/PasswordConfirmedResponse.php
+++ b/app/Http/Responses/PasswordConfirmedResponse.php
@@ -4,6 +4,7 @@ namespace App\Http\Responses;
 
 use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,7 +20,7 @@ class PasswordConfirmedResponse implements PasswordConfirmedResponseContract
      * screen directly — Fortify falls back to `fortify.home`, the public
      * marketing page, so the workspace stands in instead.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      */
     public function toResponse($request): Response
     {

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,13 +7,17 @@ use App\Actions\Fortify\ResetUserPassword;
 use App\Data\TeamInvitationContextData;
 use App\Http\Responses\LoginResponse;
 use App\Http\Responses\LogoutResponse;
+use App\Http\Responses\PasskeyLoginResponse;
+use App\Http\Responses\PasswordConfirmedResponse;
 use App\Http\Responses\RegisterResponse;
 use App\Http\Responses\TwoFactorLoginResponse;
 use App\Http\Responses\VerifyEmailResponse;
 use App\Models\TeamInvitation;
 use App\Services\Sso\LdapAuthenticator;
 use App\Support\LegalConsent;
+use App\Support\WorkspaceRedirect;
 use Database\Seeders\DemoSeeder;
+use Illuminate\Auth\Middleware\RedirectIfAuthenticated;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Http\Request;
@@ -24,11 +28,13 @@ use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Laravel\Fortify\Contracts\LogoutResponse as LogoutResponseContract;
+use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
+use Laravel\Passkeys\Contracts\PasskeyLoginResponse as PasskeyLoginResponseContract;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -43,6 +49,8 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(RegisterResponseContract::class, RegisterResponse::class);
         $this->app->singleton(VerifyEmailResponseContract::class, VerifyEmailResponse::class);
         $this->app->singleton(TwoFactorLoginResponseContract::class, TwoFactorLoginResponse::class);
+        $this->app->singleton(PasskeyLoginResponseContract::class, PasskeyLoginResponse::class);
+        $this->app->singleton(PasswordConfirmedResponseContract::class, PasswordConfirmedResponse::class);
     }
 
     /**
@@ -54,6 +62,26 @@ class FortifyServiceProvider extends ServiceProvider
         $this->configureViews();
         $this->configureRateLimiting();
         $this->configureLdapAuthentication();
+        $this->configureAuthenticatedRedirect();
+    }
+
+    /**
+     * Send an already-authenticated visitor of a guest-only auth route to their
+     * workspace.
+     *
+     * Opening the login screen with a live session (a second tab, a bookmark, the
+     * back button right after signing in) is short-circuited by the `guest`
+     * middleware, which with no callback registered falls back to the route named
+     * `home` — the public marketing page. This is what makes the misdirection feel
+     * random rather than tied to one sign-in method. A user with no team has
+     * nowhere better to go, so they keep Fortify's home path.
+     */
+    private function configureAuthenticatedRedirect(): void
+    {
+        RedirectIfAuthenticated::redirectUsing(
+            fn (Request $request): string => WorkspaceRedirect::pathFor($request->user())
+                ?? (string) config('fortify.home'),
+        );
     }
 
     /**

--- a/app/Support/WorkspaceRedirect.php
+++ b/app/Support/WorkspaceRedirect.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Where a signed-in user belongs: their current team's channels workspace.
+ *
+ * Every way into the app resolves its destination here, so no sign-in path can
+ * quietly fall back to Fortify's `/` default and drop someone on the public
+ * marketing page instead of their workspace.
+ */
+class WorkspaceRedirect
+{
+    /**
+     * The path of the user's channels workspace, or null when they have no team
+     * to land in.
+     *
+     * Registering the team as the default `current_team` route parameter is part
+     * of resolving the destination rather than an afterthought: the workspace
+     * page that renders next generates its Wayfinder URLs from that default.
+     */
+    public static function pathFor(?User $user): ?string
+    {
+        $team = $user?->currentTeam ?? $user?->personalTeam();
+
+        if (! $team instanceof Team) {
+            return null;
+        }
+
+        URL::defaults(['current_team' => $team->slug]);
+
+        return route('channels.index', ['team' => $team->slug], absolute: false);
+    }
+}

--- a/app/Support/WorkspaceRedirect.php
+++ b/app/Support/WorkspaceRedirect.php
@@ -27,7 +27,7 @@ class WorkspaceRedirect
      */
     public static function pathFor(?User $user): ?string
     {
-        $team = $user?->currentTeam ?? $user?->personalTeam();
+        $team = $user instanceof User ? $user->currentTeam ?? $user->personalTeam() : null;
 
         if (! $team instanceof Team) {
             return null;

--- a/tests/Feature/Auth/AuthenticatedRedirectTest.php
+++ b/tests/Feature/Auth/AuthenticatedRedirectTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\User;
+
+test('an authenticated visit to the login page lands on the current team workspace', function (): void {
+    // The guest middleware short-circuits an already-signed-in visitor — a second
+    // tab, a bookmark, the back button right after signing in. Without a redirect
+    // callback it falls back to the route named `home`, i.e. the marketing page.
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('login'))
+        ->assertRedirect(route('channels.index', ['team' => $user->currentTeam->slug]));
+});
+
+test('an authenticated post to the login route lands on the current team workspace', function (): void {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('login.store'), ['email' => $user->email, 'password' => 'password'])
+        ->assertRedirect(route('channels.index', ['team' => $user->currentTeam->slug]));
+});
+
+test('an authenticated visit to any guest-only auth route lands on the current team workspace', function (): void {
+    // The callback is registered on the guest middleware itself, so every route
+    // carrying it gets the workspace destination, not just login.
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('password.request'))
+        ->assertRedirect(route('channels.index', ['team' => $user->currentTeam->slug]));
+});
+
+test('an authenticated visit falls back to the home page for a user with no team', function (): void {
+    $user = User::factory()->create();
+    $user->teams()->detach();
+    $user->forceFill(['current_team_id' => null])->save();
+
+    $this->actingAs($user->fresh())
+        ->get(route('login'))
+        ->assertRedirect(route('home'));
+});

--- a/tests/Feature/Auth/IntendedRedirectTest.php
+++ b/tests/Feature/Auth/IntendedRedirectTest.php
@@ -94,3 +94,16 @@ test('login falls back when the intended URL has no path', function (): void {
         route('channels.index', ['team' => $user->currentTeam->slug]),
     );
 });
+
+test('login ignores an intended URL pointing at the public marketing page', function (): void {
+    // The site root is the Welcome screen, so honouring it as an intended target
+    // lands someone who just signed in back on the marketing page. An absolute
+    // `http://localhost` is already dropped for having no path at all; a bare `/`
+    // parses to a real path and would otherwise sail through as "not a workspace
+    // URL, honour it as-is".
+    $user = User::factory()->create();
+
+    loginWithIntended($user, '/')->assertRedirect(
+        route('channels.index', ['team' => $user->currentTeam->slug]),
+    );
+});

--- a/tests/Feature/Auth/PasskeyLoginRedirectTest.php
+++ b/tests/Feature/Auth/PasskeyLoginRedirectTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Testing\TestResponse;
+use Laravel\Passkeys\Contracts\PasskeyLoginResponse;
+
+/**
+ * The response the passkey login controller hands back once the WebAuthn
+ * ceremony has verified the credential and signed the user in. The ceremony
+ * itself belongs to laravel/passkeys; what the app owns is where it sends
+ * someone afterwards, so that is the seam under test.
+ */
+function passkeyLoginResponse(User $user, bool $wantsJson = false): TestResponse
+{
+    $request = Request::create(route('passkey.login'), 'POST', server: $wantsJson ? ['HTTP_ACCEPT' => 'application/json'] : []);
+
+    $request->setLaravelSession(app('session.store'));
+    $request->setUserResolver(fn (): User => $user);
+
+    return TestResponse::fromBaseResponse(app(PasskeyLoginResponse::class)->toResponse($request));
+}
+
+test('passkey login lands on the current team workspace', function (): void {
+    // The vendor response reads `passkeys.redirect`, a static string Fortify
+    // fills from `fortify.home` — the public marketing page.
+    $user = User::factory()->create();
+
+    passkeyLoginResponse($user)->assertRedirect(
+        route('channels.index', ['team' => $user->currentTeam->slug]),
+    );
+});
+
+test('passkey login answers the login screen with the workspace URL', function (): void {
+    // The login screen drives the ceremony over JSON and navigates to whatever
+    // `redirect` comes back, so this is the branch a real browser takes.
+    $user = User::factory()->create();
+
+    passkeyLoginResponse($user, wantsJson: true)
+        ->assertOk()
+        ->assertJson(['redirect' => route('channels.index', ['team' => $user->currentTeam->slug])]);
+});
+
+test('passkey login honours an intended URL the user can reach', function (): void {
+    $user = User::factory()->create();
+
+    $intended = route('profile.edit');
+    session(['url.intended' => $intended]);
+
+    passkeyLoginResponse($user)->assertRedirect($intended);
+});
+
+test('passkey login drops an intended URL the user cannot reach', function (): void {
+    $user = User::factory()->create();
+
+    session(['url.intended' => url('/t/does-not-exist')]);
+
+    passkeyLoginResponse($user)->assertRedirect(
+        route('channels.index', ['team' => $user->currentTeam->slug]),
+    );
+});

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -32,6 +32,15 @@ test('confirming a password with no intended URL lands on the current team works
         ->assertRedirect(route('channels.index', ['team' => $user->currentTeam->slug]));
 });
 
+test('confirming a password over JSON answers without a redirect', function (): void {
+    // An API client has no page to land on, so it gets Fortify's bare 201.
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->postJson(route('password.confirm.store'), ['password' => 'password'])
+        ->assertCreated();
+});
+
 test('confirming a password honours the guarded URL it was raised for', function (): void {
     $user = User::factory()->create();
 

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -20,3 +20,25 @@ test('password confirmation requires authentication', function (): void {
 
     $response->assertRedirect(route('login'));
 });
+
+test('confirming a password with no intended URL lands on the current team workspace', function (): void {
+    // The guarded route someone was heading for is normally stored as the
+    // intended URL; when it is not, the fallback used to be the public marketing
+    // page rather than the workspace.
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->post(route('password.confirm.store'), ['password' => 'password'])
+        ->assertRedirect(route('channels.index', ['team' => $user->currentTeam->slug]));
+});
+
+test('confirming a password honours the guarded URL it was raised for', function (): void {
+    $user = User::factory()->create();
+
+    $intended = route('security.edit');
+
+    $this->actingAs($user)
+        ->withSession(['url.intended' => $intended])
+        ->post(route('password.confirm.store'), ['password' => 'password'])
+        ->assertRedirect($intended);
+});

--- a/tests/Feature/Auth/Sso/OidcLoginTest.php
+++ b/tests/Feature/Auth/Sso/OidcLoginTest.php
@@ -248,6 +248,40 @@ test('a callback that errors or is denied fails gracefully back to login', funct
     $response->assertSessionHas('status');
 });
 
+test('a successful callback lands on the current team workspace', function (): void {
+    // Single sign-on has to arrive where a password login arrives; resolving its
+    // own destination is how it ended up on the public marketing page instead.
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp.test']);
+    $existing = User::factory()->create(['email' => 'ada@example.com']);
+    Socialite::fake('oidc', fakeOidcUser());
+
+    $this->get(route('sso.oidc.callback'))->assertRedirect(
+        route('channels.index', ['team' => $existing->currentTeam->slug]),
+    );
+});
+
+test('a successful callback honours a reachable intended URL', function (): void {
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp.test']);
+    $existing = User::factory()->create(['email' => 'ada@example.com']);
+    Socialite::fake('oidc', fakeOidcUser());
+
+    $intended = route('channels.index', ['team' => $existing->currentTeam->slug]);
+
+    $this->withSession(['url.intended' => $intended])
+        ->get(route('sso.oidc.callback'))
+        ->assertRedirect($intended);
+});
+
+test('a successful callback drops an intended URL the user cannot reach', function (): void {
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp.test']);
+    $existing = User::factory()->create(['email' => 'ada@example.com']);
+    Socialite::fake('oidc', fakeOidcUser());
+
+    $this->withSession(['url.intended' => url('/t/does-not-exist')])
+        ->get(route('sso.oidc.callback'))
+        ->assertRedirect(route('channels.index', ['team' => $existing->currentTeam->slug]));
+});
+
 test('a provisioning failure fails gracefully back to login', function (): void {
     config(['sso.oidc.enabled' => true]);
     Socialite::fake('oidc', fakeOidcUser());

--- a/tests/Feature/Auth/Sso/OidcLoginTest.php
+++ b/tests/Feature/Auth/Sso/OidcLoginTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\Sso\ProvisionSsoUser;
 use App\Enums\TeamRole;
+use App\Models\Channel;
 use App\Models\SsoIdentity;
 use App\Models\Team;
 use App\Models\User;
@@ -265,7 +266,11 @@ test('a successful callback honours a reachable intended URL', function (): void
     $existing = User::factory()->create(['email' => 'ada@example.com']);
     Socialite::fake('oidc', fakeOidcUser());
 
-    $intended = route('channels.index', ['team' => $existing->currentTeam->slug]);
+    // A channel inside the team, so honouring the intended URL is distinguishable
+    // from simply falling back to the workspace.
+    $channel = Channel::factory()->create(['team_id' => $existing->currentTeam->id, 'slug' => 'random']);
+
+    $intended = route('channels.show', ['team' => $existing->currentTeam->slug, 'channel' => $channel->slug]);
 
     $this->withSession(['url.intended' => $intended])
         ->get(route('sso.oidc.callback'))


### PR DESCRIPTION
Closes #884.

## What

Every way into the app now resolves the same destination — the current team's channels workspace — instead of falling through to `config('fortify.home')`, which is `/`, the public marketing page. Only the password and 2FA paths got this right before.

| Path | Before | After |
| --- | --- | --- |
| Passkey login | Welcome | workspace |
| OIDC SSO login | Welcome | workspace |
| Authenticated hit on a guest-only auth route (`GET`/`POST /login`, register, forgot-password) | Welcome | workspace |
| Password confirmation with no intended URL | Welcome | workspace |
| Stored `url.intended` of a bare `/` | Welcome | workspace |

## How

- **`App\Support\WorkspaceRedirect`** is the single resolver: it returns the workspace path (or null for a user with no team) and registers the team as the default `current_team` route parameter, so Wayfinder URLs keep working on the first page after sign-in. `RedirectsToCurrentTeam` now delegates to it, which is what puts every path on the same answer.
- **Passkeys:** bound our own `PasskeyLoginResponse` to the vendor contract, the same pattern the five Fortify response contracts already use. Note the issue's suggestion to set `fortify.redirects.login` would not work — Fortify fills `passkeys.redirect` once at boot from a *static string*, which cannot know which team the person signing in belongs to. Both branches are covered: the login screen drives the ceremony over JSON and navigates to the `redirect` it gets back, so that is the branch a real browser takes.
- **OIDC:** `OidcController::callback()` now hands off to the app's `LoginResponse` (exactly as `DemoLoginController` already does) rather than resolving a destination of its own, so SSO gets the workspace, the `URL::defaults` call, and the unreachable-intended-URL cleanup for free.
- **Guest middleware:** registered `RedirectIfAuthenticated::redirectUsing(...)` in `FortifyServiceProvider::boot()`. This is the row that made the bug feel random — any live session opening the login page (second tab, bookmark, back button) was short-circuited to the route named `home`. A user with no team keeps Fortify's home path.
- **Password confirmation:** overrode `PasswordConfirmedResponse` too, the same `fortify.home` fallback the issue flags in its closing note.
- **Intended URLs:** `intendedUrlIsReachable()` now rejects the site root. An absolute `http://localhost` was already dropped for having no path; a bare `/` parses to a real path and used to sail through as "not a workspace URL, honour it as-is".

## Testing

Feature tests cover each path: `AuthenticatedRedirectTest` (guest middleware, including the no-team fallback), `PasskeyLoginRedirectTest` (redirect + JSON branches, intended-URL honouring and cleanup), `OidcLoginTest` (workspace landing, intended honoured against a distinct destination, unreachable intended dropped), `PasswordConfirmationTest`, and `IntendedRedirectTest`.

Full gate green — Pint, PHPStan, Rector, and `php artisan test --parallel --coverage --min=100` at `Total: 100.0 %` — plus the frontend five (`lint:check`, `format:check`, `types:check`, `test:js`, `build`). Local CodeRabbit pass is clean.

No user-facing copy and no operator-facing settings changed, so no i18n catalog or `docs/` updates were needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787568034&installation_model_id=428379&pr_number=893&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F893&signature=b527af7d9947a96694c86b5193c0cd87ab13d70df6bda517d5db47d75f6fe00a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->