### PR TITLE
docs: expand the README badge strip with project stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,18 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/deskhq/the-desk/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/deskhq/the-desk/tests.yml?branch=master&label=tests" alt="Tests"></a>
-  <a href="https://github.com/deskhq/the-desk/releases"><img src="https://img.shields.io/github/v/release/deskhq/the-desk?color=c9a35c" alt="Latest release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/deskhq/the-desk?color=c9a35c" alt="License: MIT"></a>
+  <a href="https://www.php.net"><img src="https://img.shields.io/badge/PHP-8.5-777bb4" alt="PHP 8.5"></a>
+  <a href="https://laravel.com"><img src="https://img.shields.io/badge/Laravel-13-ff2d20" alt="Laravel 13"></a>
+  <a href="https://vuejs.org"><img src="https://img.shields.io/badge/Vue-3-42b883" alt="Vue 3"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/deskhq/the-desk/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/deskhq/the-desk/tests.yml?branch=master&label=tests" alt="Tests"></a>
+  <a href="https://github.com/deskhq/the-desk/releases/latest"><img src="https://img.shields.io/github/v/release/deskhq/the-desk?color=c9a35c" alt="Latest release"></a>
+  <a href="https://github.com/deskhq/the-desk/releases"><img src="https://img.shields.io/github/release-date/deskhq/the-desk?color=c9a35c" alt="Latest release date"></a>
+  <a href="https://github.com/deskhq/the-desk/commits/master"><img src="https://img.shields.io/github/last-commit/deskhq/the-desk/master?color=c9a35c" alt="Last commit"></a>
+  <a href="https://github.com/deskhq/the-desk"><img src="https://img.shields.io/github/stars/deskhq/the-desk?style=flat&color=c9a35c" alt="GitHub stars"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Closes #895.

## What

Expands the README badge row from three badges (tests, release, license) to nine, split into two centred rows:

- **Stack + legal** — `license MIT` · `PHP 8.5` · `Laravel 13` · `Vue 3`
- **Liveness + adoption** — `tests` · `release` · `release date` · `last commit` · `stars`

All via shields.io, so they stay live with no CI job.

## Why

The badge row is the first thing a visitor reads after the banner. It answered "is CI green?" but not "is this maintained?", "what is it built on?", or "does anyone use it?" — the questions that decide whether someone keeps scrolling on a self-hosted project.

## Decisions the issue left open

- **Colour discipline.** Three tiers, applied consistently: the CI status badge stays dynamic (green/red is the whole point of it), GitHub-metric badges are pinned to the accent `#c9a35c`, and stack badges keep their ecosystem colours — matching the reference look in the issue, where `Go` keeps Go blue.
- **No downloads badge.** `github/downloads/deskhq/the-desk/total` resolves to `0` (releases carry no assets, and shields has no GHCR pull-count endpoint), so it is omitted per the issue's default.
- **`style=flat` on the stars badge.** `github/stars` defaults to the *social* style, which silently ignores `color` — it rendered as an off-palette white pill with a GitHub logo. Forcing `style=flat` puts it back on the accent.
- **Stars links to the repo root, not `/stargazers`.** `https://github.com/deskhq/the-desk/stargazers` returns **404 to logged-out visitors** (verified in a headless browser; `laravel/framework/stargazers` behaves the same, so GitHub gates those list pages behind sign-in). Linking there would hand a broken link to exactly the first-time visitor the badge exists for.
- **Static stack versions accepted as drift.** `PHP 8.5` / `Laravel 13` / `Vue 3` change roughly once a year and are deliberately not wired to anything release-please stamps. They are also invisible to `release:check-version-refs`, whose pattern requires a three-part semver.

## How tested

- Probed all nine badges live through shields' `.json` endpoint: every one returns a real value (`MIT`, `8.5`, `13`, `3`, `passing`, `v1.16.0`, `yesterday`, `yesterday`, `16`) — no `invalid`, `unknown`, or `0`.
- All eight link targets return HTTP 200 anonymously.
- Rendered the actual markdown through GitHub's `/markdown` API and screenshotted it against light (`#ffffff`) and dark (`#0d1117`) backgrounds: identical and legible in both, since shields SVGs are opaque and carry their own background.
- `alt` text present on every `<img>`.
- Layout holds at two rows at README width; at ~380px the metrics row wraps once (three rows total) — nine badges cannot hold two lines on a phone.
- Versions confirmed against the source, not memory: `compose.yaml` (`sail-8.5/app`), `composer.json` (`laravel/framework ^13.17`), `package.json` (`vue ^3.5.13`).

No i18n or `docs/` changes: the README is not part of the translation catalogs or the Starlight site.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787570355&installation_model_id=428379&pr_number=898&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F898&signature=37c58ed9e34061aa285f56cad6a304947db3391e4398a9c301233326d3e3d6cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->