### PR TITLE
fix: keep auth forms still when a validation error appears

### DIFF
--- a/resources/js/components/FieldError.test.ts
+++ b/resources/js/components/FieldError.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { createSSRApp, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import FieldError from './FieldError.vue';
+
+/**
+ * The reserved error slot, used by `<FormField>` for every field and directly
+ * by the few fields that cannot go through it. Its whole job is to occupy the
+ * same space whether or not there is a message, so it is worth pinning
+ * separately from the components that compose it.
+ */
+function renderFieldError(message?: string): Promise<string> {
+    return renderToString(
+        createSSRApp({ render: () => h(FieldError, { message }) }),
+    );
+}
+
+describe('FieldError', () => {
+    it('occupies the same slot whether or not there is a message', async () => {
+        const clean = await renderFieldError();
+        const failed = await renderFieldError('The email field is required.');
+
+        for (const html of [clean, failed]) {
+            expect(html).toContain('<div class="relative h-7">');
+        }
+
+        // Only the message differs between the two, never the slot.
+        expect(clean).not.toContain('role="alert"');
+        expect(failed).toContain('The email field is required.');
+    });
+
+    it('draws the message out of flow so it cannot grow the field', async () => {
+        const html = await renderFieldError('The email field is required.');
+
+        expect(html).toMatch(/class="[^"]*\babsolute\b/);
+        expect(html).toMatch(/class="[^"]*\bpointer-events-none\b/);
+        expect(html).toContain('role="alert"');
+    });
+});

--- a/resources/js/components/FieldError.vue
+++ b/resources/js/components/FieldError.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+
+/**
+ * A field's validation message in space that is reserved for it up front.
+ *
+ * The message is drawn out of flow inside a slot that is the same height with
+ * or without it, so an error cannot change the height of the form around it
+ * (#883). `h-7` is one line; a message that wraps to a second spills into the
+ * gap the form already leaves before the next field, so that case costs nothing
+ * either. It cannot take a click, because that second line is drawn over the
+ * space the next control occupies.
+ *
+ * `<FormField>` uses this for every field it renders. Reach for it directly
+ * only where a field cannot go through `<FormField>` — a checkbox whose label
+ * wraps it, say — rather than restating the positioning at the call site.
+ */
+defineProps<{
+    message?: string;
+}>();
+</script>
+
+<template>
+    <div class="relative h-7">
+        <InputError
+            :message="message"
+            class="pointer-events-none absolute inset-x-0 top-0"
+        />
+    </div>
+</template>

--- a/resources/js/components/FormField.test.ts
+++ b/resources/js/components/FormField.test.ts
@@ -52,8 +52,49 @@ describe('FormField', () => {
         const html = await renderField({ id: 'email', label: 'Email address' });
 
         expect(html).not.toContain('field is required');
-        // The error slot stays hidden rather than reserving space.
-        expect(html).toContain('style="display:none;"');
+        // Not merely hidden: absent, so a screen reader has no empty node to
+        // walk over on a field that is perfectly fine.
+        expect(html).not.toContain('display:none');
+        expect(html).not.toContain('role="alert"');
+    });
+
+    it('keeps the field the same height whether or not it is in error', async () => {
+        // The space for the message is reserved up front and the message is
+        // drawn out of flow inside it, so an error cannot grow the field and
+        // push the rest of the form around it (#883).
+        const clean = await renderField({
+            id: 'email',
+            label: 'Email address',
+        });
+        const failed = await renderField({
+            id: 'email',
+            label: 'Email address',
+            error: 'The email field is required.',
+        });
+
+        for (const html of [clean, failed]) {
+            // The gutter that reserves the line...
+            expect(html).toMatch(/<div class="[^"]*\bpb-7\b/);
+            // ...and the zero-height slot the message is drawn into, present in
+            // both states so the row and its gap never change.
+            expect(html).toContain('<div class="relative">');
+        }
+
+        expect(failed).toMatch(/class="[^"]*\babsolute\b/);
+    });
+
+    it('announces the error and keeps it clear of the next control', async () => {
+        const html = await renderField({
+            id: 'email',
+            label: 'Email address',
+            error: 'The email field is required.',
+        });
+
+        // Announced the moment it appears...
+        expect(html).toContain('role="alert"');
+        // ...and unable to swallow a click, since a wrapped second line is
+        // drawn over the space the next control occupies.
+        expect(html).toMatch(/class="[^"]*\bpointer-events-none\b/);
     });
 
     it('renders the optional hint line when provided', async () => {

--- a/resources/js/components/FormField.test.ts
+++ b/resources/js/components/FormField.test.ts
@@ -73,11 +73,9 @@ describe('FormField', () => {
         });
 
         for (const html of [clean, failed]) {
-            // The gutter that reserves the line...
-            expect(html).toMatch(/<div class="[^"]*\bpb-7\b/);
-            // ...and the zero-height slot the message is drawn into, present in
-            // both states so the row and its gap never change.
-            expect(html).toContain('<div class="relative">');
+            // The same reserved slot in both states, so the row it occupies and
+            // the gap before it never change.
+            expect(html).toContain('<div class="relative h-7">');
         }
 
         expect(failed).toMatch(/class="[^"]*\babsolute\b/);

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -29,7 +29,7 @@ const fieldId = props.id ?? useId();
 </script>
 
 <template>
-    <div class="relative grid gap-2 pb-7">
+    <div class="grid gap-2">
         <!-- A label action is typically a link, so it is focusable and
         sequential focus would visit it between the previous field and this
         control if it came first in the DOM. It is therefore emitted last and
@@ -66,14 +66,13 @@ const fieldId = props.id ?? useId();
 
         <p v-if="hint" class="text-sm text-muted-foreground">{{ hint }}</p>
 
-        <!-- A zero-height slot, always present so the row and its gap are the
-        same whether or not there is a message, with the message itself drawn
-        out of flow inside it. The `pb-7` above reserves one line for it; a
-        message that wraps to a second line spills into the gap the form already
-        leaves before the next field, so nothing has to move to accommodate it.
-        It cannot take a click, because a wrapped line is drawn over the space
-        the next control occupies. -->
-        <div class="relative">
+        <!-- The error's space, reserved whether or not there is an error, with
+        the message itself drawn out of flow inside it. `h-7` is one line of it;
+        a message that wraps to a second line spills into the gap the form
+        already leaves before the next field, so nothing has to move to
+        accommodate it either. It cannot take a click, because that second line
+        is drawn over the space the next control occupies. -->
+        <div class="relative h-7">
             <InputError
                 :message="error"
                 class="pointer-events-none absolute inset-x-0 top-0"

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useId } from 'vue';
-import InputError from '@/components/InputError.vue';
+import FieldError from '@/components/FieldError.vue';
 import { Label } from '@/components/ui/label';
 
 /**
@@ -66,17 +66,6 @@ const fieldId = props.id ?? useId();
 
         <p v-if="hint" class="text-sm text-muted-foreground">{{ hint }}</p>
 
-        <!-- The error's space, reserved whether or not there is an error, with
-        the message itself drawn out of flow inside it. `h-7` is one line of it;
-        a message that wraps to a second line spills into the gap the form
-        already leaves before the next field, so nothing has to move to
-        accommodate it either. It cannot take a click, because that second line
-        is drawn over the space the next control occupies. -->
-        <div class="relative h-7">
-            <InputError
-                :message="error"
-                class="pointer-events-none absolute inset-x-0 top-0"
-            />
-        </div>
+        <FieldError :message="error" />
     </div>
 </template>

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -9,6 +9,13 @@ import { Label } from '@/components/ui/label';
  * hint line. The control lives in the default slot and receives the field `id`
  * via slot scope, so the label/control coupling is wired from one source and
  * cannot drift.
+ *
+ * The field's height is deliberately constant whether or not it is in error
+ * (#883). A message that joined the flow would grow the field, and on the auth
+ * pages the form column is vertically centred — so the heading slides up while
+ * the submit button slides down, out from under the pointer of someone about to
+ * click it again. Side by side, the taller cell would drag its neighbour's
+ * label and input out of alignment too.
  */
 const props = defineProps<{
     label?: string;
@@ -22,7 +29,7 @@ const fieldId = props.id ?? useId();
 </script>
 
 <template>
-    <div class="grid gap-2">
+    <div class="relative grid gap-2 pb-7">
         <!-- A label action is typically a link, so it is focusable and
         sequential focus would visit it between the previous field and this
         control if it came first in the DOM. It is therefore emitted last and
@@ -57,8 +64,20 @@ const fieldId = props.id ?? useId();
             <slot :id="fieldId" />
         </template>
 
-        <InputError :message="error" />
-
         <p v-if="hint" class="text-sm text-muted-foreground">{{ hint }}</p>
+
+        <!-- A zero-height slot, always present so the row and its gap are the
+        same whether or not there is a message, with the message itself drawn
+        out of flow inside it. The `pb-7` above reserves one line for it; a
+        message that wraps to a second line spills into the gap the form already
+        leaves before the next field, so nothing has to move to accommodate it.
+        It cannot take a click, because a wrapped line is drawn over the space
+        the next control occupies. -->
+        <div class="relative">
+            <InputError
+                :message="error"
+                class="pointer-events-none absolute inset-x-0 top-0"
+            />
+        </div>
     </div>
 </template>

--- a/resources/js/components/InputError.test.ts
+++ b/resources/js/components/InputError.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createSSRApp, h } from 'vue';
+import { renderToString } from 'vue/server-renderer';
+import InputError from './InputError.vue';
+
+/**
+ * `<InputError>` is used both through `<FormField>` and directly by the pages
+ * that lay their own fields out, so its own contract is worth pinning: it draws
+ * nothing at all when there is nothing to say, and what it does draw announces
+ * itself.
+ */
+function renderError(message?: string): Promise<string> {
+    return renderToString(
+        createSSRApp({ render: () => h(InputError, { message }) }),
+    );
+}
+
+describe('InputError', () => {
+    it('announces the message when there is one', async () => {
+        const html = await renderError('The email field is required.');
+
+        expect(html).toContain('The email field is required.');
+        expect(html).toContain('role="alert"');
+    });
+
+    it('renders nothing at all when there is no message', async () => {
+        // Absent rather than hidden — a permanently-present empty node is
+        // something assistive tech walks over for nothing (#883).
+        const html = await renderError();
+
+        expect(html).not.toContain('role="alert"');
+        expect(html).not.toContain('display:none');
+    });
+});

--- a/resources/js/components/InputError.vue
+++ b/resources/js/components/InputError.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
+/**
+ * A field's validation message.
+ *
+ * Rendered only when there is something to say, rather than kept in the DOM and
+ * hidden: an always-present empty node is something a screen reader walks over
+ * for nothing, and `role="alert"` on a node that appears is what gets the
+ * message announced at the moment it arrives.
+ */
 defineProps<{
     message?: string;
 }>();
 </script>
 
 <template>
-    <div v-show="message">
-        <p class="text-sm text-destructive-text">
-            {{ message }}
-        </p>
-    </div>
+    <p v-if="message" role="alert" class="text-sm text-destructive-text">
+        {{ message }}
+    </p>
 </template>

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -4,8 +4,8 @@ import { Check } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import AuthInput from '@/components/auth/AuthInput.vue';
 import AuthSubmit from '@/components/auth/AuthSubmit.vue';
+import FieldError from '@/components/FieldError.vue';
 import FormField from '@/components/FormField.vue';
-import InputError from '@/components/InputError.vue';
 import PasswordInput from '@/components/PasswordInput.vue';
 import PasswordStrengthMeter from '@/components/PasswordStrengthMeter.vue';
 import TextLink from '@/components/TextLink.vue';
@@ -208,7 +208,11 @@ const consentParts = computed(() =>
                     </template>
                 </span>
             </Label>
-            <InputError :message="errors.terms" />
+            <!-- The consent checkbox lives inside its own label so the whole
+            sentence toggles it, which is not a shape `FormField` renders — so
+            it reserves the error's space itself rather than shifting the form
+            when the box is left unticked. -->
+            <FieldError :message="errors.terms" />
         </div>
 
         <AuthSubmit

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -130,7 +130,10 @@ const consentParts = computed(() =>
             />
         </FormField>
 
-        <div class="grid gap-3.5 sm:grid-cols-2">
+        <!-- `items-start` so neither cell can ever be stretched to match the
+        other's height; `FormField` already keeps both the same, this keeps that
+        true if one of them ever grows for some other reason. -->
+        <div class="grid items-start gap-3.5 sm:grid-cols-2">
             <FormField
                 id="password"
                 :label="$t('Password')"

--- a/tests/Browser/AuthSplitShellTest.php
+++ b/tests/Browser/AuthSplitShellTest.php
@@ -170,6 +170,59 @@ test('a rejected submit leaves the register form exactly where it was', function
 });
 
 /**
+ * The consent row is the one field on this page that cannot go through
+ * `FormField` — its checkbox lives inside its own label so the whole sentence
+ * toggles it — so it reserves the error's space itself. It is also the only
+ * error here that a user reaches without mistyping anything, by leaving the box
+ * alone.
+ */
+test('a rejected consent leaves the register form exactly where it was', function (): void {
+    config([
+        'legal.terms_url' => 'https://example.com/terms',
+        'legal.privacy_url' => 'https://example.com/privacy',
+    ]);
+
+    $page = visit('/register')
+        ->type('#name', 'Ada Lovelace')
+        ->type('#email', 'ada@example.com')
+        ->type('#password', 'correct horse battery staple')
+        ->type('#password_confirmation', 'correct horse battery staple')
+        ->assertPresent('@terms-checkbox')
+        ->assertSee('Very strong');
+
+    $page->script(<<<'JS'
+    () => {
+        window.__watched = {
+            heading: 'h1',
+            submit: '[data-test="register-user-button"]',
+            terms: '[data-test="terms-checkbox"]',
+        };
+
+        window.__layoutBefore = Object.fromEntries(
+            Object.entries(window.__watched).map(([name, selector]) => [
+                name,
+                document.querySelector(selector).getBoundingClientRect().top,
+            ]),
+        );
+    }
+    JS);
+
+    // Submitted with the box deliberately left unticked.
+    $page->click('@register-user-button')
+        ->assertSee('Please accept the terms');
+
+    $page->assertScript(<<<'JS'
+    (() => {
+        return Object.entries(window.__layoutBefore).every(([name, before]) => {
+            const now = document.querySelector(window.__watched[name]).getBoundingClientRect().top;
+
+            return Math.abs(now - before) < 0.5;
+        });
+    })()
+    JS, true);
+});
+
+/**
  * The sibling half of #883: `Password` and `Confirm` share a two-column grid
  * row, so an error under one used to stretch the row and drag the other's label
  * and input down with it.

--- a/tests/Browser/AuthSplitShellTest.php
+++ b/tests/Browser/AuthSplitShellTest.php
@@ -111,6 +111,94 @@ test('registering under an invitation creates the account on the invited address
     expect(User::where('email', 'maya@acme.co')->exists())->toBeTrue();
 });
 
+/**
+ * Layout stability across a rejected submit (#883).
+ *
+ * The form column is vertically centred, so any growth in the form is split
+ * between the heading above and the button below — the submit button slides out
+ * from under the pointer at the exact moment someone is reaching for it again.
+ * Only a real browser can settle this: it is the browser's own layout, and the
+ * message that triggers it wraps to two lines at the width the cell happens to
+ * have.
+ */
+test('a rejected submit leaves the register form exactly where it was', function (): void {
+    $page = visit('/register')
+        ->type('#name', 'Maya Chen')
+        ->type('#email', 'maya@example.com')
+        // Short enough to be rejected, and long enough that the message wraps
+        // to two lines in the half-width password cell.
+        ->type('#password', 'short')
+        ->type('#password_confirmation', 'short')
+        // The strength meter scores asynchronously and grows by its verdict
+        // line when it resolves. Wait for that here, or the baseline below is
+        // recorded against a meter that is still settling and the comparison
+        // measures zxcvbn rather than the error line.
+        ->assertSee('Too weak');
+
+    // Recorded after typing, so the strength meter is already drawn and the
+    // only thing the submit can add is the error line itself.
+    $page->script(<<<'JS'
+    () => {
+        window.__watched = {
+            heading: 'h1',
+            submit: '[data-test="register-user-button"]',
+            password: '#password',
+            confirm: '#password_confirmation',
+        };
+
+        window.__layoutBefore = Object.fromEntries(
+            Object.entries(window.__watched).map(([name, selector]) => [
+                name,
+                document.querySelector(selector).getBoundingClientRect().top,
+            ]),
+        );
+    }
+    JS);
+
+    $page->click('@register-user-button')
+        ->assertSee('The password field must be at least');
+
+    $page->assertScript(<<<'JS'
+    (() => {
+        return Object.entries(window.__layoutBefore).every(([name, before]) => {
+            const now = document.querySelector(window.__watched[name]).getBoundingClientRect().top;
+
+            return Math.abs(now - before) < 0.5;
+        });
+    })()
+    JS, true);
+});
+
+/**
+ * The sibling half of #883: `Password` and `Confirm` share a two-column grid
+ * row, so an error under one used to stretch the row and drag the other's label
+ * and input down with it.
+ */
+test('an error under the password keeps the confirm field aligned with it', function (): void {
+    // Every field is filled because they are `required`: the browser's own
+    // validation would block the submit before the server ever sees it.
+    $page = visit('/register')
+        ->type('#name', 'Maya Chen')
+        ->type('#email', 'maya@example.com')
+        ->type('#password', 'short')
+        ->type('#password_confirmation', 'short')
+        ->click('@register-user-button')
+        ->assertSee('The password field must be at least');
+
+    $page->assertScript(<<<'JS'
+    (() => {
+        const top = (selector) => document.querySelector(selector).getBoundingClientRect().top;
+
+        const labels = Math.abs(
+            top('label[for="password"]') - top('label[for="password_confirmation"]'),
+        );
+        const inputs = Math.abs(top('#password') - top('#password_confirmation'));
+
+        return labels < 0.5 && inputs < 0.5;
+    })()
+    JS, true);
+});
+
 test('the auth shell has no serious accessibility violations in either theme', function (): void {
     $page = visit('/login')->assertNoAccessibilityIssues();
 


### PR DESCRIPTION
Closes #883.

## What was happening

Submitting an auth form with invalid input moved the whole card. Measured on `/register` with a too-short password: the heading slid **up 41px**, the submit button and footer link slid **down 41px**, and `Confirm` dropped **24px** out of alignment with `Password`.

Two causes, one shared root. `InputError` was a `v-show` wrapper with no height when empty, so a message joined the flow and grew its field. The form column is vertically centred (`lg:mt-auto` / `lg:mb-auto`), so that growth was split between the heading above and the button below — the submit button moves out from under the pointer at the exact moment someone is reaching for it again after a rejected submit. And because `Password` and `Confirm` share a `sm:grid-cols-2` row, the taller cell stretched the row and dragged its sibling's label and input down.

## What changed

The error's space is now reserved up front and the message is drawn out of flow inside it, so a field is the same height whether or not it is in error. No message length can move anything.

- **`FieldError.vue`** (new) — the reserved slot: `h-7` with the message absolutely positioned inside it. `pointer-events-none`, because a wrapped second line is drawn over the space the next control occupies and must not swallow its clicks.
- **`FormField.vue`** — renders `FieldError` for every field, so every consumer inherits the fix: the auth pages, `pages/settings/*`, and the modals.
- **`InputError.vue`** — `v-if` instead of `v-show`, plus `role="alert"`. It is now absent rather than hidden when there is nothing to say, so a screen reader has no empty node to walk over, and the message is announced at the moment it arrives (it previously wasn't announced at all).
- **`Register.vue`** — the consent row uses `FieldError` directly. Its checkbox lives inside its own label so the whole sentence toggles it, which is not a shape `FormField` renders. This was easy to miss: `terms` is server-validated with `['accepted']` and the checkbox carries no `required` attribute, so leaving the box alone is an error a user reaches without mistyping anything. Also `items-start` on the password row, so neither cell can be stretched to match the other.

## On the reservation size

`h-7` is 28px: one line of message, with a wrapped second line spilling into the gap the form already leaves before the next field. Verified rather than assumed — a two-line error (the normal case in the 203px password cell) clears the strength meter by **6px** in a real browser, and the tightest consumer elsewhere is `gap-4`/`space-y-4` at 28+16 = 44px against the 40px a two-line message needs.

Reserving two full lines inside every field instead would add ~120px to the register form to buy a case that already clears. A three-line message — a long translation in the half-width password cell — would overlap; that degrades rather than breaking, and the alternative costs every field on every form.

## Testing

- `tests/Browser/AuthSplitShellTest.php` — three new browser tests: the submit button, heading, and both password inputs are unmoved across a real rejected submit (the AC's own suggested test); `Confirm` stays aligned with `Password`; and the consent row holds still when the box is left unticked. Only a real browser settles this — it is the browser's own layout, and the message wraps to two lines at the width the cell happens to have.
- `FieldError.test.ts` (new), `InputError.test.ts` (new), and `FormField.test.ts` cover the slot being identical with and without a message, the out-of-flow positioning, and the `role="alert"` announcement.
- Full gate green: `composer test` at **100.0%** coverage with Pint, PHPStan, and Rector clean; `lint:check`, `format:check`, `types:check`, `test:js` (1334), `build`, and the full `tests/Browser` suite.

One `FormField.test.ts` assertion changed rather than being added: it asserted `style="display:none;"` on the empty error slot, which was the exact behaviour this fixes.

No i18n or docs changes — no new user-facing copy, nothing operator-facing.

## Follow-up

#894 covers the 23 remaining call sites in `pages/teams/*` that still place `InputError` directly. They were deliberately left out: neither symptom here shows up there (no centred column, no side-by-side row), and those are tight inline rows — `Groups.vue`'s create row puts two inputs beside a Create button — where a 28px gutter would read as a band of dead space. That wants deciding per row with the page open, not a mechanical sweep.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787570418&installation_model_id=428379&pr_number=899&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F899&signature=78374de5c1e31f9428a454fd4c6a7d7047704bfeab007016de28ab39faa3af41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->