### PR TITLE
feat: carry "keep me signed in" through the SSO sign-in path

### DIFF
--- a/app/Http/Controllers/Auth/Sso/OidcController.php
+++ b/app/Http/Controllers/Auth/Sso/OidcController.php
@@ -18,11 +18,30 @@ use Throwable;
 class OidcController extends Controller
 {
     /**
-     * Send the user to the configured OpenID Connect provider.
+     * The session key the "keep me signed in" choice waits under while the user
+     * is away at the identity provider.
+     *
+     * The choice is made on the login screen but the sign-in happens in the
+     * callback, a full round-trip later, so it cannot simply ride along with the
+     * request the way the password form's checkbox does.
      */
-    public function redirect(): SymfonyRedirectResponse
+    private const string REMEMBER_KEY = 'sso.remember';
+
+    /**
+     * Send the user to the configured OpenID Connect provider, parking the
+     * "keep me signed in" choice the login screen sends along.
+     *
+     * The login screen carries the same flag the password form and the passkey
+     * button read, so an installed-app sign-in outlives the session lifetime
+     * here too. Parking it server side is what survives the round-trip: the
+     * callback reads the session, never its own query string, so this route —
+     * the actual start of the flow — is the only thing that can set it.
+     */
+    public function redirect(Request $request): SymfonyRedirectResponse
     {
         abort_unless(config('sso.oidc.enabled'), 404);
+
+        $request->session()->put(self::REMEMBER_KEY, $request->boolean('remember'));
 
         return Socialite::driver('oidc')->redirect();
     }
@@ -46,6 +65,12 @@ class OidcController extends Controller
     {
         abort_unless(config('sso.oidc.enabled'), 404);
 
+        // Read back from the session and never from this request, so the flag
+        // stays something only the start of the flow can set. Consumed up here,
+        // ahead of anything that can fail, so a bounced callback cannot leave it
+        // behind to colour a later sign-in.
+        $remember = (bool) $request->session()->pull(self::REMEMBER_KEY, false);
+
         try {
             $oidcUser = Socialite::driver('oidc')->user();
 
@@ -68,7 +93,7 @@ class OidcController extends Controller
             return $this->failed();
         }
 
-        Auth::login($user);
+        Auth::login($user, $remember);
         $request->session()->regenerate();
 
         return app(LoginResponseContract::class)->toResponse($request);

--- a/docs/src/content/docs/reference/security.md
+++ b/docs/src/content/docs/reference/security.md
@@ -276,6 +276,14 @@ default only decides where the checkbox starts. There is nothing to configure,
 and [`SESSION_LIFETIME`](/reference/environment-variables/#session-cookies) still
 governs everyone who leaves it unticked.
 
+Every way in honours the same choice: the password form, passkey sign-in, and
+single sign-on. Passkeys and SSO carry it without a control of their own, so on
+an instance where the password form is hidden (`AUTH_SSO_ONLY`, or one where
+everybody uses a passkey) the installed-app default is what applies, with no
+checkbox on screen. For SSO the choice is held server side while the browser is
+away at the identity provider, so it can only be set by starting a sign-in from
+the login screen.
+
 ### `XSRF-TOKEN` is readable by JavaScript on purpose
 
 A surface scanner will flag `XSRF-TOKEN` as a cookie missing `HttpOnly`. That is

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -248,7 +248,11 @@ const {
 
         <!-- Single sign-on sits below the password form as the secondary route
         in. A full-page navigation (native anchor) hands off to the IdP; an
-        Inertia visit would break the OAuth redirect. -->
+        Inertia visit would break the OAuth redirect. Like the passkey button it
+        inherits "keep me signed in" rather than offering a control of its own —
+        on an SSO-only instance the password form, and with it the checkbox, is
+        never rendered. The sign-in happens in the callback a round-trip later,
+        so the redirect route parks the flag in the session until it returns. -->
         <template v-if="$page.props.sso.oidcEnabled">
             <div
                 v-if="$page.props.sso.passwordLoginEnabled"
@@ -265,7 +269,7 @@ const {
                 class="h-13 w-full rounded-full text-[15px] font-medium"
                 data-test="sso-login-button"
             >
-                <a :href="oidcRedirect.url()">
+                <a :href="oidcRedirect.url({ query: { remember } })">
                     <Lock class="text-muted-foreground" aria-hidden="true" />
                     {{ $t('Continue with SSO') }}
                 </a>

--- a/tests/Feature/Auth/Sso/OidcLoginTest.php
+++ b/tests/Feature/Auth/Sso/OidcLoginTest.php
@@ -7,6 +7,8 @@ use App\Models\SsoIdentity;
 use App\Models\Team;
 use App\Models\User;
 use GuzzleHttp\Handler\MockHandler;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Support\Facades\Auth;
 use Laravel\Socialite\Contracts\Provider;
 use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
@@ -41,6 +43,28 @@ test('the redirect route sends the user to the identity provider authorize endpo
     $this->get(route('sso.oidc.redirect'))
         ->assertRedirectContains('https://idp.test/authorize')
         ->assertRedirectContains('client_id=client-id');
+});
+
+test('the redirect route parks the "keep me signed in" choice for the callback', function (string $submitted, bool $parked): void {
+    $mock = new MockHandler([oidcDiscoveryResponse()]);
+    config(['sso.oidc.enabled' => true, 'services.oidc' => oidcServicesConfig($mock)]);
+    Socialite::forgetDrivers();
+
+    $this->get(route('sso.oidc.redirect', ['remember' => $submitted]))->assertSessionHas('sso.remember');
+
+    // Asserted strictly: `assertSessionHas` compares loosely, so an absent key
+    // would satisfy an expected `false` without the flag ever being parked.
+    expect(session()->get('sso.remember'))->toBe($parked);
+})->with(['on' => ['1', true], 'off' => ['0', false]]);
+
+test('the redirect route parks the choice as off when the login screen sends nothing', function (): void {
+    $mock = new MockHandler([oidcDiscoveryResponse()]);
+    config(['sso.oidc.enabled' => true, 'services.oidc' => oidcServicesConfig($mock)]);
+    Socialite::forgetDrivers();
+
+    $this->get(route('sso.oidc.redirect'))->assertSessionHas('sso.remember');
+
+    expect(session()->get('sso.remember'))->toBeFalse();
 });
 
 test('the redirect route is hidden when oidc is not configured', function (): void {
@@ -285,6 +309,70 @@ test('a successful callback drops an intended URL the user cannot reach', functi
     $this->withSession(['url.intended' => url('/t/does-not-exist')])
         ->get(route('sso.oidc.callback'))
         ->assertRedirect(route('channels.index', ['team' => $existing->currentTeam->slug]));
+});
+
+test('a callback with "keep me signed in" parked queues the long-lived recaller cookie', function (): void {
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp.test']);
+    User::factory()->create(['email' => 'ada@example.com']);
+    Socialite::fake('oidc', fakeOidcUser());
+
+    $response = $this->withSession(['sso.remember' => true])->get(route('sso.oidc.callback'));
+
+    $this->assertAuthenticated();
+
+    /** @var SessionGuard $guard */
+    $guard = Auth::guard('web');
+    $recaller = $response->getCookie($guard->getRecallerName(), decrypt: false);
+
+    expect($recaller)->not->toBeNull()
+        // The recaller is what outlives session expiry, so it has to be dated
+        // well past any session lifetime — Laravel's own default is 400 days.
+        ->and($recaller->getExpiresTime())->toBeGreaterThan(now()->addYear()->getTimestamp());
+});
+
+test('a callback without "keep me signed in" parked queues no recaller cookie', function (): void {
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp.test']);
+    User::factory()->create(['email' => 'ada@example.com']);
+    Socialite::fake('oidc', fakeOidcUser());
+
+    $response = $this->withSession(['sso.remember' => false])->get(route('sso.oidc.callback'));
+
+    $this->assertAuthenticated();
+
+    /** @var SessionGuard $guard */
+    $guard = Auth::guard('web');
+
+    expect($response->getCookie($guard->getRecallerName(), decrypt: false))->toBeNull();
+});
+
+test('the callback ignores a "keep me signed in" flag on its own query string', function (): void {
+    // The flag is only ever read back from the session, so appending it to the
+    // callback URL cannot buy an attacker a persistent sign-in from outside the
+    // flow.
+    config(['sso.oidc.enabled' => true, 'services.oidc.issuer' => 'https://idp.test']);
+    User::factory()->create(['email' => 'ada@example.com']);
+    Socialite::fake('oidc', fakeOidcUser());
+
+    $response = $this->get(route('sso.oidc.callback', ['remember' => 1]));
+
+    $this->assertAuthenticated();
+
+    /** @var SessionGuard $guard */
+    $guard = Auth::guard('web');
+
+    expect($response->getCookie($guard->getRecallerName(), decrypt: false))->toBeNull();
+});
+
+test('a bounced callback still consumes the parked flag', function (): void {
+    // Otherwise a failed attempt would leave it behind to quietly persist the
+    // next sign-in, however that one was started.
+    config(['sso.oidc.enabled' => true]);
+    Socialite::fake('oidc', fakeOidcUser(email: null));
+
+    $this->withSession(['sso.remember' => true])
+        ->get(route('sso.oidc.callback'))
+        ->assertRedirect(route('login'))
+        ->assertSessionMissing('sso.remember');
 });
 
 test('a provisioning failure fails gracefully back to login', function (): void {


### PR DESCRIPTION
Closes #897.

## What

Single sign-on now honours "keep me signed in" like the password form and the
passkey button already do. `OidcController` called `Auth::login($user)` with no
remember flag, so on an `AUTH_SSO_ONLY` instance an installed-app user was still
signed out after `SESSION_LIFETIME`, with no checkbox anywhere that would change
it.

The open question in the issue was whether SSO should surface a control of its
own. It does not: it inherits the same `remember` ref the passkey button reads,
which is the shape #896 already settled on. That gives the right behaviour in
both instance shapes for free. Where the password form is rendered, the visible
checkbox governs the SSO button too; where it is hidden (`AUTH_SSO_ONLY`, or an
all-passkey instance) there is no checkbox at all and the installed-app default
applies. A second control for one flag would only ever disagree with the first.

## How

Unlike the password form, the flag cannot ride along with the request: the choice
is made on the login screen, but the sign-in happens in the callback a full
round-trip through the identity provider later. So `redirect()` parks
`$request->boolean('remember')` in the session and `callback()` pulls it into
`Auth::login($user, $remember)`.

Two details that matter:

- The callback reads the session and **never** its own query string, so the flag
  can only be set by starting a sign-in from the login screen. Appending
  `?remember=1` to the callback URL buys nothing.
- It is consumed at the top of the callback, ahead of anything that can fail, so
  a bounced attempt cannot leave the flag behind to quietly persist a later
  sign-in.

## Testing

Six cases added to `tests/Feature/Auth/Sso/OidcLoginTest.php`, in the shape of the
recaller assertions #896 added to `AuthenticationTest.php`:

- the callback queues the long-lived recaller when the flag is parked, and queues
  none when it is not;
- the redirect route parks the choice, on and off, and parks it off when the
  login screen sends nothing;
- the callback ignores a `remember` flag on its own query string;
- a bounced callback still consumes the parked flag.

The parked-value assertions are made with `expect(...)->toBe()` rather than
`assertSessionHas($key, $value)` alone, because the latter compares loosely and
an absent key would satisfy an expected `false` without anything being parked.

Backend gate green at 100% coverage with a clean Pint/PHPStan/Rector run;
frontend lint, format, types, Vitest and build green; docs site builds.

Verified in a real browser against a running instance, since the link is where
the flag starts:

| instance | display | checkbox | SSO link |
| --- | --- | --- | --- |
| password + SSO | browser tab | unticked | `?remember=0` |
| password + SSO | browser tab | ticked by hand | `?remember=1` |
| `AUTH_SSO_ONLY` | browser tab | not rendered | `?remember=0` |
| `AUTH_SSO_ONLY` | installed app | not rendered | `?remember=1` |

The last row is the case the issue was filed for: no checkbox on screen anywhere,
and the installed-app default still reaches the sign-in.

## Docs

`reference/security.md` said the box "starts ticked" in the installed app but not
which sign-in paths carry the choice. It now states that all three honour it, and
that on an instance with the password form hidden the default applies with no
checkbox on screen, which is exactly the operator situation this fixes.

## i18n

No new user-facing copy: the SSO button inherits an existing, already-translated
control rather than adding one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787594847&installation_model_id=428379&pr_number=900&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F900&signature=aeced07676c5a9577e6106fd2ffa60407f250ccf47f97a6a63efbc1e53b145ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->