### PR TITLE
fix: stop a failed push opt-in from reading as enabled, and require https endpoints

### DIFF
--- a/app/Console/Commands/PushDoctorCommand.php
+++ b/app/Console/Commands/PushDoctorCommand.php
@@ -168,7 +168,7 @@ class PushDoctorCommand extends Command
             return;
         }
 
-        if (! str_starts_with($subject, 'mailto:') && ! str_starts_with($subject, 'https://') && ! str_starts_with($subject, 'http://')) {
+        if (! str_starts_with($subject, 'mailto:') && ! str_starts_with($subject, 'https://')) {
             $this->record(self::FAIL, 'VAPID subject', $subject.' must be a mailto: address or an https URL');
 
             return;

--- a/app/Http/Requests/Settings/StorePushSubscriptionRequest.php
+++ b/app/Http/Requests/Settings/StorePushSubscriptionRequest.php
@@ -18,12 +18,17 @@ class StorePushSubscriptionRequest extends FormRequest
      * services issue long URLs, and a longer one would fail at insert rather
      * than at validation.
      *
+     * HTTPS only. This value decides where the server itself posts every push,
+     * so a plaintext endpoint would put the delivery on the wire in the clear
+     * and let a signed-in user aim the instance's own requests wherever they
+     * like. Real push services are HTTPS without exception.
+     *
      * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
         return [
-            'endpoint' => ['required', 'string', 'url:https,http', 'max:500'],
+            'endpoint' => ['required', 'string', 'url:https', 'max:500'],
             'keys.p256dh' => ['required', 'string', 'max:255'],
             'keys.auth' => ['required', 'string', 'max:255'],
             // Firefox's older endpoints negotiate `aesgcm`; everything current

--- a/resources/js/lib/push.test.ts
+++ b/resources/js/lib/push.test.ts
@@ -144,6 +144,40 @@ describe('enablePush', () => {
         expect(fetchMock).toHaveBeenCalledOnce();
     });
 
+    it('unsubscribes a subscription it just created when the server refuses it', async () => {
+        const unsubscribe = vi.fn(() => Promise.resolve(true));
+        const { fetchMock } = stubBrowser({
+            subscribe: vi.fn(() =>
+                Promise.resolve({
+                    ...SUBSCRIPTION_JSON,
+                    toJSON: () => SUBSCRIPTION_JSON,
+                    unsubscribe,
+                }),
+            ),
+        });
+        fetchMock.mockResolvedValue({ ok: false });
+
+        await expect(enablePush('aGVsbG8')).rejects.toThrow();
+
+        expect(unsubscribe).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a subscription the browser already held when the server refuses it', async () => {
+        const unsubscribe = vi.fn(() => Promise.resolve(true));
+        const { fetchMock } = stubBrowser({
+            existing: {
+                ...SUBSCRIPTION_JSON,
+                toJSON: () => SUBSCRIPTION_JSON,
+                unsubscribe,
+            },
+        });
+        fetchMock.mockResolvedValue({ ok: false });
+
+        await expect(enablePush('aGVsbG8')).rejects.toThrow();
+
+        expect(unsubscribe).not.toHaveBeenCalled();
+    });
+
     it('gives up quietly when the user declines the permission prompt', async () => {
         const { subscribe, fetchMock } = stubBrowser({ permission: 'denied' });
 

--- a/resources/js/lib/push.ts
+++ b/resources/js/lib/push.ts
@@ -83,14 +83,29 @@ export async function enablePush(vapidPublicKey: string): Promise<boolean> {
 
     const registration = await navigator.serviceWorker.ready;
 
+    const existing = await registration.pushManager.getSubscription();
+
     const subscription =
-        (await registration.pushManager.getSubscription()) ??
+        existing ??
         (await registration.pushManager.subscribe({
             userVisibleOnly: true,
             applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
         }));
 
-    await send(storeSubscription().url, 'POST', subscription.toJSON());
+    try {
+        await send(storeSubscription().url, 'POST', subscription.toJSON());
+    } catch (error) {
+        // Nothing server-side can be pushed to now, so a subscription this call
+        // created has to go: the browser is what the toggle reads its state back
+        // from, and one left behind would report push as on forever. A
+        // subscription the browser already held is left alone, since it predates
+        // this attempt and may still have a row on the server.
+        if (existing === null) {
+            await subscription.unsubscribe().catch(() => undefined);
+        }
+
+        throw error;
+    }
 
     return true;
 }

--- a/tests/Feature/Console/PushDoctorCommandTest.php
+++ b/tests/Feature/Console/PushDoctorCommandTest.php
@@ -184,6 +184,15 @@ test('it fails when the VAPID subject is neither a mailto address nor a URL', fu
         ->and(Artisan::output())->toContain('must be a mailto: address or an https URL');
 });
 
+test('it fails on a plain http VAPID subject, which push services reject', function (): void {
+    configureWebPush(['webpush.vapid.subject' => 'http://desk.example.com']);
+
+    $exitCode = Artisan::call('push:doctor');
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('must be a mailto: address or an https URL');
+});
+
 test('it warns when no device has subscribed', function (): void {
     configureWebPush();
 

--- a/tests/Feature/Settings/PushSubscriptionTest.php
+++ b/tests/Feature/Settings/PushSubscriptionTest.php
@@ -156,6 +156,9 @@ test('the subscription payload is validated', function (array $payload, string $
     'a missing endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => null]), 'endpoint'],
     'a non-url endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'not-a-url']), 'endpoint'],
     'an over-long endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'https://push.example.test/'.str_repeat('x', 500)]), 'endpoint'],
+    // The server posts to this endpoint itself, so a plaintext one is both a
+    // push payload sent in the clear and a destination an operator never chose.
+    'a plaintext endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'http://push.example.test/device']), 'endpoint'],
     'a missing public key' => [fn (): array => pushSubscriptionPayload(['keys' => ['auth' => 'auth-only']]), 'keys.p256dh'],
     'a missing auth token' => [fn (): array => pushSubscriptionPayload(['keys' => ['p256dh' => 'key-only']]), 'keys.auth'],
     'an unknown content encoding' => [fn (): array => pushSubscriptionPayload(['contentEncoding' => 'rot13']), 'contentEncoding'],


### PR DESCRIPTION
Three defects in the web push code 1.17.0 introduces, surfaced by the CodeRabbit review on the
promotion PR #902 and verified against the code before fixing.

## A failed opt-in reported itself as enabled

`enablePush` created the browser subscription and then registered it with the server. When that
POST failed, the browser subscription survived, so `useWebPush`'s catch read
`currentSubscription() !== null` and set `subscribed` back to **true**, next to a toast saying the
update had failed. A reload read the same true from `onMounted`. The server had no row, so nothing
was ever delivered: the switch said push was on and the device never received a thing.

The comment on `useWebPush.ts:92` already stated the intended behaviour, "so a half-completed
opt-in doesn't read as on". The code did the opposite. A subscription this call created is now
unsubscribed when registration fails; one the browser already held is left alone, since it predates
the attempt and may still have a row.

## The store request accepted plaintext endpoints

`url:https,http`. That value is where the server itself posts every push, so a plaintext endpoint
put the delivery on the wire in the clear and let any signed-in user aim the instance's own
outbound requests at a host the operator never chose. Real push services are HTTPS without
exception, and every existing test fixture was already `https://`.

Rejecting **private and reserved hosts** on that same field, the way `App\Rules\PublicWebhookUrl`
already does for webhooks, is the deferred half of this finding: it needs a DNS-resolution story in
the tests, so it is tracked in #904 rather than rushed into the release.

## `push:doctor` accepted an http VAPID subject

`PushDoctorCommand.php:171` allowed `http://` while the failure it prints on the very next line,
its own docblock, `docs/.../environment-variables.md`, and RFC 8292 all say `mailto:` or `https`.
The check contradicted its own message, so an operator with a subject push services will reject was
told everything was fine.

## Dismissed from the same review

- **"Provide the VAPID subject fallback" on `config/webpush.php:28`** is wrong. The package already
  does it: `WebPushServiceProvider.php:64-65` sets `$config['VAPID']['subject'] = url('/')` when it
  is empty, which is exactly what the config comment, the docs table, and `push:doctor`'s WARN all
  describe. A second fallback in config would be duplicated logic.
- **"Localize the diagnostic output" in `PushDoctorCommand`** contradicts the convention. None of
  the six commands in `app/Console/Commands/` use `__()`. The i18n rule covers what an app user
  reads, not operator CLI output; translating one command would make it the outlier.

## Verification

- `sail composer test`: `Total: 100.0 %`, clean Rector dry-run.
- `sail npm run lint:check`, `format:check`, `types:check`, `test:js` (1378 passed), `build`: all
  green.
- Both push fixes are driven by tests written first: the JS test failed on the old code
  (`expected "vi.fn()" to be called once, but got 0 times`) before the change.

Refs #902, #904.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787653067&installation_model_id=428379&pr_number=905&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F905&signature=b591fbad46dbf9e788c702e188309385734b57a80f8c7ba1d85a64f938e65422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->