### PR TITLE
feat: prune security events and purge expired data-export archives

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,14 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # it at a configured S3 disk to store files in a bucket instead.
 # ATTACHMENT_DISK=local
 
+# How long a per-user security event (sign-in, credential change, session
+# revocation, data-export activity) is kept before the daily sweep deletes it.
+# One year by default, so an annual assessment period stays fully visible; the
+# window also caps how far back anyone can evidence an event, so keep it at least
+# as long as yours. Set 0 to keep events forever and enforce retention at the
+# database or backup layer instead.
+# SECURITY_EVENT_RETENTION_DAYS=365
+
 # Single sign-on (OpenID Connect). Point these at your identity provider (Okta,
 # Microsoft Entra ID, Google Workspace, Auth0, Keycloak, …) to add a "Sign in
 # with SSO" button. The app reads the provider's discovery document at

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -119,6 +119,17 @@ CSP_ENABLED=true
 # domain. Only for a domain you own outright, submitted at hstspreload.org.
 # HSTS_PRELOAD=false
 
+# --- Data retention ----------------------------------------------------------
+# How long a per-user security event (sign-in, credential change, session
+# revocation, data-export activity) is kept before the scheduler's daily sweep
+# deletes it. One year by default, so an annual assessment period stays fully
+# visible; the window also caps how far back anyone can evidence an event, so
+# keep it at least as long as yours. Set 0 to keep events forever and enforce
+# retention at the database or backup layer instead. Data-export archives and
+# audit-evidence exports have a fixed 7-day window; the workspace audit log is
+# not pruned by the app.
+# SECURITY_EVENT_RETENTION_DAYS=365
+
 # --- Single sign-on (OpenID Connect) -----------------------------------------
 # SSO_OIDC_ISSUER=https://your-idp.example.com
 # SSO_OIDC_CLIENT_ID=

--- a/app/Actions/Users/PruneSecurityEvents.php
+++ b/app/Actions/Users/PruneSecurityEvents.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Users;
+
+use App\Models\SecurityEvent;
+
+class PruneSecurityEvents
+{
+    /**
+     * Delete security events that have outlived the configured retention window.
+     *
+     * Every sign-in, credential change, and session revocation appends a row, and
+     * each carries an IP address and User-Agent, so this is a data-minimisation
+     * control an auditor asks about — not merely a disk-space sweep.
+     *
+     * Deliberately a query-builder bulk delete: {@see SecurityEvent} rejects a
+     * delete through an Eloquent instance to keep the log append-only, and a bulk
+     * delete fires no model events, which is the sanctioned path for pruning.
+     *
+     * A window of zero or less means "keep forever" — an explicit opt-out for a
+     * deployment that enforces retention at the database or backup layer instead.
+     *
+     * @return int the number of events pruned
+     */
+    public function handle(): int
+    {
+        $days = (int) config('security.events.retention_days');
+
+        if ($days < 1) {
+            return 0;
+        }
+
+        return SecurityEvent::query()
+            ->where('created_at', '<', now()->subDays($days))
+            ->delete();
+    }
+}

--- a/app/Actions/Users/PurgeExpiredDataExports.php
+++ b/app/Actions/Users/PurgeExpiredDataExports.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Users;
+
+use App\Jobs\ExportUserData;
+use App\Models\DataExport;
+use Illuminate\Support\Facades\Storage;
+
+class PurgeExpiredDataExports
+{
+    /**
+     * Delete personal-data archives whose download window has closed, removing
+     * both the file on the private disk and the row.
+     *
+     * The archive is a full copy of someone's profile, teams, messages, and
+     * security events, so leaving it on disk after the link stops working keeps
+     * the most sensitive object the app produces around forever. The row is
+     * dropped with it: an expired export already reads as "no export ready" in
+     * the Data & privacy panel, and the request and download are recorded as
+     * security events, so no evidence is lost.
+     *
+     * Pending and failed exports carry no `expires_at`, so only ready-then-expired
+     * ones are swept here; the file guard covers the row that never produced one.
+     *
+     * @return int the number of exports purged
+     */
+    public function handle(): int
+    {
+        $disk = Storage::disk(ExportUserData::DISK);
+
+        $purged = 0;
+
+        DataExport::query()
+            ->whereNotNull('expires_at')
+            ->where('expires_at', '<', now())
+            ->cursor()
+            ->each(function (DataExport $export) use ($disk, &$purged): void {
+                if ($export->path !== null) {
+                    $disk->delete($export->path);
+                }
+
+                $export->delete();
+
+                $purged++;
+            });
+
+        return $purged;
+    }
+}

--- a/config/security.php
+++ b/config/security.php
@@ -57,4 +57,30 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Account-Activity Retention
+    |--------------------------------------------------------------------------
+    |
+    | The per-user security-event log (sign-ins, credential and two-factor
+    | changes, session revocations, data-export activity) gains a row on every
+    | such action, each carrying an IP address and User-Agent. A scheduled sweep
+    | deletes events older than the window below, so the log answers "how far
+    | back can you see, and how long do you keep it" with one number instead of
+    | growing without bound.
+    |
+    | One year is the default because assessment periods are annual: an auditor
+    | sampling the last twelve months still finds every event.
+    |
+    | Set 0 (or lower) to keep events forever — an explicit "no window", for a
+    | deployment that enforces retention at the database or backup layer instead.
+    |
+    */
+
+    'events' => [
+
+        'retention_days' => (int) env('SECURITY_EVENT_RETENTION_DAYS', 365),
+
+    ],
+
 ];

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -206,11 +206,12 @@ deployment where the `scheduler` container is running.
 | ------------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
 | `SECURITY_EVENT_RETENTION_DAYS` | `365`   | Days a per-user security event (sign-in, credential change, session revocation, data-export activity) is kept before a daily sweep deletes it. One year covers an annual assessment period. Set `0` to keep events forever. |
 
-Two more windows are fixed rather than configurable, and are listed here so the
-whole picture is in one place:
+Two more windows are set elsewhere, and are listed here so the whole picture is in
+one place:
 
-- **Data-export archives and audit-evidence exports** are downloadable for
-  **7 days**, after which a daily sweep deletes both the file and its record.
+- **Data-export archives and audit-evidence exports** are downloadable for a
+  fixed **7 days** — not configurable — after which a daily sweep deletes both
+  the file and its record.
 - **Uploaded-but-never-sent attachments** are swept after
   `ATTACHMENT_PENDING_TTL_HOURS` (see [Attachments](#attachments)).
 

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -196,6 +196,28 @@ when TLS is terminated at a hostname other than the one `APP_URL` names. Setting
 it to `true` on a deployment served over plain HTTP means the browser will never
 return the cookie and nobody can stay signed in.
 
+## Data retention
+
+How long the app keeps the records it writes about people. Enforced by the
+[scheduler](/self-hosting/configuration/), so these windows only apply on a
+deployment where the `scheduler` container is running.
+
+| Variable                        | Default | Notes                                                                                              |
+| ------------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `SECURITY_EVENT_RETENTION_DAYS` | `365`   | Days a per-user security event (sign-in, credential change, session revocation, data-export activity) is kept before a daily sweep deletes it. One year covers an annual assessment period. Set `0` to keep events forever. |
+
+Two more windows are fixed rather than configurable, and are listed here so the
+whole picture is in one place:
+
+- **Data-export archives and audit-evidence exports** are downloadable for
+  **7 days**, after which a daily sweep deletes both the file and its record.
+- **Uploaded-but-never-sent attachments** are swept after
+  `ATTACHMENT_PENDING_TTL_HOURS` (see [Attachments](#attachments)).
+
+The workspace audit log is not pruned by the app. See
+[Security & compliance](/reference/security-and-compliance/) for what that means
+for an assessment.
+
 ## Single sign-on (OpenID Connect)
 
 Let members authenticate through your identity provider (Okta, Microsoft Entra

--- a/docs/src/content/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/reference/security-and-compliance.md
@@ -41,7 +41,7 @@ criterion in the context of your whole system.
 | **Provisioning and deprovisioning (SSO / SCIM)** | SSO logins just-in-time provision accounts. SCIM 2.0 lets your IdP push lifecycle changes: removing someone from the directory deactivates their account here, revoking access and ending all their sessions immediately, while retaining history. Reactivation is a later `active: true`. | CC6.1, CC6.2, CC6.3 | A.5.16, A.5.18 |
 | **Data export (portability)** | A user can request a self-service export of their own data: a ZIP of JSON files (profile, teams, messages, and their security events), delivered by email and downloadable for 7 days. | (Privacy) P5 | A.5.34, A.8.11 |
 | **Account deletion and erasure** | Deleting an account removes the user record and reassigns their authored messages to a shared "Deleted User" tombstone, so conversations stay coherent while personal attribution is removed. The user's personal teams are deleted. | (Privacy) P4 | A.8.10, A.5.34 |
-| **Retention windows** | Uploaded-but-unsent attachments are swept after `ATTACHMENT_PENDING_TTL_HOURS` (default 24). Data-export archives and audit-evidence export files are downloadable for a fixed 7-day window, after which a scheduled task deletes both the file and its record. Long-term retention of the audit and activity logs themselves is an operator decision (see the note below). | (Privacy) P4 | A.8.10, A.5.34 |
+| **Retention windows** | Account-activity (security) events are deleted after `SECURITY_EVENT_RETENTION_DAYS` (default 365, so an annual assessment period stays fully visible; `0` keeps them forever). Uploaded-but-unsent attachments are swept after `ATTACHMENT_PENDING_TTL_HOURS` (default 24). Data-export archives and audit-evidence export files are downloadable for a fixed 7-day window, after which a scheduled task deletes both the file and its record. Retention of the workspace audit log itself is an operator decision (see the note below). | (Privacy) P4 | A.8.10, A.5.34 |
 | **Encryption and transport posture** | The application encrypts session data and any encrypted attributes with `APP_KEY` (AES-256). Containers speak plain HTTP by design; TLS termination is delegated to your reverse proxy (see operator responsibilities). | CC6.1, CC6.7 | A.8.24, A.5.14 |
 | **Backups** | Durable state is one PostgreSQL database plus the uploaded-files volume; the search index and Redis are derived or transient. `docker/backup.sh` and `docker/restore.sh` ship with the stack and cover the dump, restore, and retention (`--keep=N`), but scheduling, testing, encrypting, and off-siting backups is an operator responsibility. | A1.2 | A.8.13 |
 
@@ -56,10 +56,16 @@ criterion in the context of your whole system.
   passkey enrollment today. The supported way to require MFA is to front all
   access with SSO (`AUTH_SSO_ONLY=true`) and enforce the factor at your identity
   provider, which is where most SOC 2 and ISO 27001 programs already manage it.
-- **Long-term log retention and disposal is yours to schedule.** The app does not
-  automatically prune the audit or account-activity logs, so they accumulate.
-  Define a retention window that matches your policy and enforce it at the
-  database or backup layer.
+- **The account-activity log is disposed of on a schedule; the workspace audit log
+  is not.** Security events are deleted once they pass
+  `SECURITY_EVENT_RETENTION_DAYS` (default one year) by a daily task in the
+  `scheduler` container — so on a deployment running the bundled stack, disposal
+  of that log is automatic and its window is the number you can point an assessor
+  at. The workspace audit log has no such sweep and accumulates: define a
+  retention window that matches your policy and enforce it at the database or
+  backup layer. Note that both windows cap how far back you can evidence an
+  event, so keep the security-event window at least as long as your assessment
+  period.
 - **The password policy is enforced in production.** The full complexity and
   breach-check rules apply when the app runs in its production environment, which
   is the configuration you audit.

--- a/docs/src/content/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/reference/security-and-compliance.md
@@ -61,7 +61,10 @@ criterion in the context of your whole system.
   `SECURITY_EVENT_RETENTION_DAYS` (default one year) by a daily task in the
   `scheduler` container — so on a deployment running the bundled stack, disposal
   of that log is automatic and its window is the number you can point an assessor
-  at. The workspace audit log has no such sweep and accumulates: define a
+  at. Setting the variable to `0` turns that sweep off and keeps security events
+  indefinitely, which makes disposal of this log your responsibility too, exactly
+  as it already is for the audit log. The workspace audit log has no such sweep
+  and accumulates however it is set: define a
   retention window that matches your policy and enforce it at the database or
   backup layer. Note that both windows cap how far back you can evidence an
   event, so keep the security-event window at least as long as your assessment

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,6 +11,8 @@ use App\Actions\Users\BroadcastDndScheduleEdges;
 use App\Actions\Users\ClearExpiredUserStatuses;
 use App\Actions\Users\ClearLapsedDndPauses;
 use App\Actions\Users\ClearLapsedDndScheduleSnoozes;
+use App\Actions\Users\PruneSecurityEvents;
+use App\Actions\Users\PurgeExpiredDataExports;
 use App\Models\TeamInvitation;
 use Illuminate\Support\Facades\Schedule;
 
@@ -68,6 +70,18 @@ Schedule::call(fn (PurgeExpiredAuditExports $purge): int => $purge->handle())
     ->daily()
     ->withoutOverlapping()
     ->description('Purge expired audit-log exports (files and rows)');
+
+Schedule::call(fn (PurgeExpiredDataExports $purge): int => $purge->handle())
+    ->name('purge-expired-data-exports')
+    ->daily()
+    ->withoutOverlapping()
+    ->description('Purge expired data-export archives (files and rows)');
+
+Schedule::call(fn (PruneSecurityEvents $prune): int => $prune->handle())
+    ->name('prune-security-events')
+    ->daily()
+    ->withoutOverlapping()
+    ->description('Prune security events past the retention window');
 
 Schedule::call(fn (PurgeCachedProxyImages $purge): int => $purge->handle())
     ->name('purge-cached-proxy-images')

--- a/tests/Feature/Console/PruneSecurityEventsTest.php
+++ b/tests/Feature/Console/PruneSecurityEventsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Actions\Users\PruneSecurityEvents;
+use App\Models\SecurityEvent;
+
+/**
+ * Record a security event as having happened the given number of days ago.
+ */
+function agedSecurityEvent(int $daysAgo): SecurityEvent
+{
+    return SecurityEvent::factory()->create(['created_at' => now()->subDays($daysAgo)]);
+}
+
+test('an event older than the retention window is pruned and a newer one survives', function (): void {
+    config()->set('security.events.retention_days', 365);
+    $stale = agedSecurityEvent(366);
+    $recent = agedSecurityEvent(364);
+
+    $pruned = app(PruneSecurityEvents::class)->handle();
+
+    expect($pruned)->toBe(1);
+    $this->assertDatabaseMissing('security_events', ['id' => $stale->id]);
+    $this->assertDatabaseHas('security_events', ['id' => $recent->id]);
+});
+
+test('the retention window is configurable', function (): void {
+    config()->set('security.events.retention_days', 30);
+    $stale = agedSecurityEvent(31);
+    $recent = agedSecurityEvent(29);
+
+    $pruned = app(PruneSecurityEvents::class)->handle();
+
+    expect($pruned)->toBe(1);
+    $this->assertDatabaseMissing('security_events', ['id' => $stale->id]);
+    $this->assertDatabaseHas('security_events', ['id' => $recent->id]);
+});
+
+test('it prunes across every user, not just one', function (): void {
+    config()->set('security.events.retention_days', 90);
+    $first = agedSecurityEvent(120);
+    $second = agedSecurityEvent(200);
+
+    $pruned = app(PruneSecurityEvents::class)->handle();
+
+    expect($pruned)->toBe(2);
+    expect($first->user_id)->not->toBe($second->user_id);
+    expect(SecurityEvent::query()->count())->toBe(0);
+});
+
+test('a window of zero or less keeps events forever', function (int $days): void {
+    config()->set('security.events.retention_days', $days);
+    $ancient = agedSecurityEvent(3_650);
+
+    $pruned = app(PruneSecurityEvents::class)->handle();
+
+    expect($pruned)->toBe(0);
+    $this->assertDatabaseHas('security_events', ['id' => $ancient->id]);
+})->with([0, -1]);

--- a/tests/Feature/Console/PurgeExpiredDataExportsTest.php
+++ b/tests/Feature/Console/PurgeExpiredDataExportsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Actions\Users\PurgeExpiredDataExports;
+use App\Enums\DataExportStatus;
+use App\Models\DataExport;
+use Illuminate\Support\Facades\Storage;
+
+test('it deletes expired archives and rows and keeps live ones', function (): void {
+    Storage::fake('local');
+
+    $expired = DataExport::factory()->expired()->create();
+    Storage::disk('local')->put($expired->path, 'zip-bytes');
+
+    $live = DataExport::factory()->ready()->create();
+    Storage::disk('local')->put($live->path, 'zip-bytes');
+
+    $purged = app(PurgeExpiredDataExports::class)->handle();
+
+    expect($purged)->toBe(1);
+    Storage::disk('local')->assertMissing($expired->path);
+    Storage::disk('local')->assertExists($live->path);
+    $this->assertDatabaseMissing('data_exports', ['id' => $expired->id]);
+    $this->assertDatabaseHas('data_exports', ['id' => $live->id]);
+});
+
+test('a pending export with no expiry is never touched', function (): void {
+    Storage::fake('local');
+
+    $pending = DataExport::factory()->create();
+
+    $purged = app(PurgeExpiredDataExports::class)->handle();
+
+    expect($purged)->toBe(0);
+    $this->assertDatabaseHas('data_exports', ['id' => $pending->id]);
+});
+
+test('it deletes an expired export that never produced an archive', function (): void {
+    Storage::fake('local');
+
+    $export = DataExport::factory()->create([
+        'status' => DataExportStatus::Failed,
+        'path' => null,
+        'expires_at' => now()->subDay(),
+    ]);
+
+    $purged = app(PurgeExpiredDataExports::class)->handle();
+
+    expect($purged)->toBe(1);
+    $this->assertDatabaseMissing('data_exports', ['id' => $export->id]);
+});

--- a/tests/Feature/Console/RetentionScheduleTest.php
+++ b/tests/Feature/Console/RetentionScheduleTest.php
@@ -50,10 +50,12 @@ test('the scheduled data-export sweep purges expired archives', function (): voi
     $expired = DataExport::factory()->expired()->create();
     Storage::disk('local')->put($expired->path, 'zip-bytes');
     $live = DataExport::factory()->ready()->create();
+    Storage::disk('local')->put($live->path, 'zip-bytes');
 
     dailyRetentionSweep('Purge expired data-export archives (files and rows)')->run($this->app);
 
     Storage::disk('local')->assertMissing($expired->path);
+    Storage::disk('local')->assertExists($live->path);
     $this->assertDatabaseMissing('data_exports', ['id' => $expired->id]);
     $this->assertDatabaseHas('data_exports', ['id' => $live->id]);
 });

--- a/tests/Feature/Console/RetentionScheduleTest.php
+++ b/tests/Feature/Console/RetentionScheduleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * Find a scheduled event by its description, loading the console schedule first
+ * so a fresh (post-reload) application has its events registered.
+ */
+function scheduledEventDescribed(string $description): ?Event
+{
+    Artisan::call('schedule:list');
+
+    return collect(app(Schedule::class)->events())
+        ->first(fn (Event $event): bool => $event->description === $description);
+}
+
+test('the retention sweeps run daily, without overlapping', function (string $description): void {
+    $event = scheduledEventDescribed($description);
+
+    expect($event)->not->toBeNull();
+    expect($event->expression)->toBe('0 0 * * *');
+    expect($event->withoutOverlapping)->toBeTrue();
+})->with([
+    'Prune security events past the retention window',
+    'Purge expired data-export archives (files and rows)',
+]);

--- a/tests/Feature/Console/RetentionScheduleTest.php
+++ b/tests/Feature/Console/RetentionScheduleTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Models\DataExport;
+use App\Models\SecurityEvent;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * Find a scheduled event by its description, loading the console schedule first
@@ -16,13 +19,41 @@ function scheduledEventDescribed(string $description): ?Event
         ->first(fn (Event $event): bool => $event->description === $description);
 }
 
-test('the retention sweeps run daily, without overlapping', function (string $description): void {
+/**
+ * Assert a retention sweep is registered to run once a day and not to overlap a
+ * still-running pass, then hand the event back so the caller can run it.
+ */
+function dailyRetentionSweep(string $description): Event
+{
     $event = scheduledEventDescribed($description);
 
     expect($event)->not->toBeNull();
     expect($event->expression)->toBe('0 0 * * *');
     expect($event->withoutOverlapping)->toBeTrue();
-})->with([
-    'Prune security events past the retention window',
-    'Purge expired data-export archives (files and rows)',
-]);
+
+    return $event;
+}
+
+test('the scheduled security-event sweep prunes past the retention window', function (): void {
+    config()->set('security.events.retention_days', 365);
+    $stale = SecurityEvent::factory()->create(['created_at' => now()->subDays(400)]);
+    $recent = SecurityEvent::factory()->create();
+
+    dailyRetentionSweep('Prune security events past the retention window')->run($this->app);
+
+    $this->assertDatabaseMissing('security_events', ['id' => $stale->id]);
+    $this->assertDatabaseHas('security_events', ['id' => $recent->id]);
+});
+
+test('the scheduled data-export sweep purges expired archives', function (): void {
+    Storage::fake('local');
+    $expired = DataExport::factory()->expired()->create();
+    Storage::disk('local')->put($expired->path, 'zip-bytes');
+    $live = DataExport::factory()->ready()->create();
+
+    dailyRetentionSweep('Purge expired data-export archives (files and rows)')->run($this->app);
+
+    Storage::disk('local')->assertMissing($expired->path);
+    $this->assertDatabaseMissing('data_exports', ['id' => $expired->id]);
+    $this->assertDatabaseHas('data_exports', ['id' => $live->id]);
+});

--- a/tests/Unit/SecurityEventRetentionDefaultTest.php
+++ b/tests/Unit/SecurityEventRetentionDefaultTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The account-activity retention window an operator inherits when they never set
+ * `SECURITY_EVENT_RETENTION_DAYS`. One year, because assessment periods are
+ * annual: an auditor sampling the last twelve months still finds every event.
+ * See issue #423.
+ */
+const DEFAULT_SECURITY_EVENT_RETENTION_DAYS = 365;
+
+/**
+ * The default is stated in five places an operator can read — the config
+ * fallback, both env templates, the env-variable table, and the compliance
+ * control mapping — and a change to one of them that misses the others hands out
+ * contradictory answers about how long the log is kept.
+ */
+function statedSecurityEventRetention(string $relativePath, string $pattern): ?int
+{
+    $contents = (string) file_get_contents(dirname(__DIR__, 2).'/'.$relativePath);
+
+    if (preg_match($pattern, $contents, $matches) !== 1) {
+        return null;
+    }
+
+    return (int) $matches[1];
+}
+
+test('the config fallback is one year', function (): void {
+    expect(statedSecurityEventRetention('config/security.php', "/env\('SECURITY_EVENT_RETENTION_DAYS',\s*(\d+)\)/"))
+        ->toBe(DEFAULT_SECURITY_EVENT_RETENTION_DAYS);
+});
+
+test('both env templates ship the config fallback', function (string $template): void {
+    expect(statedSecurityEventRetention($template, '/^#\s*SECURITY_EVENT_RETENTION_DAYS=(\d+)$/m'))
+        ->toBe(DEFAULT_SECURITY_EVENT_RETENTION_DAYS);
+})->with(['.env.example', '.env.prod.example']);
+
+test('the documented default matches the shipped one', function (): void {
+    expect(statedSecurityEventRetention(
+        'docs/src/content/docs/reference/environment-variables.md',
+        '/\|\s*`SECURITY_EVENT_RETENTION_DAYS`\s*\|\s*`(\d+)`/',
+    ))->toBe(DEFAULT_SECURITY_EVENT_RETENTION_DAYS);
+});
+
+test('the compliance control mapping states the shipped default', function (): void {
+    expect(statedSecurityEventRetention(
+        'docs/src/content/docs/reference/security-and-compliance.md',
+        '/`SECURITY_EVENT_RETENTION_DAYS`\s*\(default\s*(\d+)/',
+    ))->toBe(DEFAULT_SECURITY_EVENT_RETENTION_DAYS);
+});


### PR DESCRIPTION
Closes #423. Part of #417 (compliance-readiness epic).

## Why

Two stores grew without bound, which is the retention/data-minimisation control an auditor actually asks about:

- `security_events` gained a row on every sign-in, credential change, and session revocation — each carrying an IP address and User-Agent — with **no retention window at all**.
- Data-export archives outlived their download link on the private disk **forever**. `ExportUserData` set `expires_at`, so the link stopped working, but nothing deleted the ZIP. That is the most sensitive object the app builds (profile, teams, every message, security events), kept indefinitely — and `docs/reference/security-and-compliance.md` already claimed "a scheduled task deletes both the file and its record", so the docs were over-claiming.

## What

Two scheduled sweeps in `routes/console.php`, alongside the existing `purge-expired-audit-exports`:

- **`App\Actions\Users\PruneSecurityEvents`** — deletes events past `security.events.retention_days` (`SECURITY_EVENT_RETENTION_DAYS`, default `365`; `0` or lower means "keep forever" for a deployment enforcing retention at the database or backup layer). One year because assessment periods are annual. It is a query-builder bulk delete, which is the path `SecurityEvent`'s append-only guard deliberately leaves open for pruning — the model docblock and `SecurityEventImmutabilityTest` both already say so.
- **`App\Actions\Users\PurgeExpiredDataExports`** — deletes the archive then the row once `expires_at` has passed, mirroring `PurgeExpiredAuditExports`. Dropping the row loses no evidence: an expired export already renders as "no export ready" in the Data & privacy panel, and the request and download are recorded as security events.

Both run `daily()` and `withoutOverlapping()`, like their neighbours.

## Testing

- `tests/Feature/Console/PruneSecurityEventsTest.php` — window boundary either side of the cutoff, a configurable window, multi-user, and `0`/`-1` keeping events forever.
- `tests/Feature/Console/PurgeExpiredDataExportsTest.php` — expired file+row deleted, a live export untouched, a pending export with no expiry untouched, and an expired export that never produced a file.
- `tests/Feature/Console/RetentionScheduleTest.php` — both sweeps are registered daily and non-overlapping, and each event is **run** so a description wired to the wrong action fails.
- `tests/Unit/SecurityEventRetentionDefaultTest.php` — drift guard over the five places the 365-day default is stated (config fallback, both env templates, the env-variable table, the control mapping), following the `SessionLifetimeDefaultTest` precedent.
- `./vendor/bin/sail composer test` green at `Total: 100.0 %` (Pint, PHPStan, Rector all clean); `cd docs && npm run build` green; frontend gate green (no frontend changes).

## Docs

- `reference/environment-variables.md` — new **Data retention** section documenting `SECURITY_EVENT_RETENTION_DAYS`, plus the fixed 7-day export window and the attachment TTL so the whole picture is in one place.
- `reference/security-and-compliance.md` — **Retention windows** row updated, and the "long-term log retention" auditor note rewritten: the account-activity log is now disposed of on a schedule (unless set to `0`), while the workspace audit log still is not.
- `.env.example` and `.env.prod.example` — commented `SECURITY_EVENT_RETENTION_DAYS` block; the prod template gains a `# --- Data retention ---` section.

No i18n changes: nothing user-facing is added (both sweeps are scheduler-only).

## Found while doing this

The issue's premise that "the activity log already prunes" is false — `config/activitylog.php` sets `clean_after_days = 365`, but `activitylog:clean` is **never scheduled**, so that window is inert and the workspace audit log grows forever. Left out of scope here and filed as #913; the docs in this PR describe the real behaviour rather than papering over it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787657107&installation_model_id=428379&pr_number=918&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F918&signature=774063bb13499b2cb1c48349f4b66e385178a52220162274dd5e1b14cb388aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->