### PR TITLE
fix: keep the teams pages still when a validation error appears

### DIFF
--- a/eslint-rules/no-standalone-input-error.js
+++ b/eslint-rules/no-standalone-input-error.js
@@ -27,6 +27,18 @@ export function isErrorSlotOwner(filename) {
     return filename.replaceAll('\\', '/').endsWith(OWNER_FILE);
 }
 
+/**
+ * Whether a tag name refers to the `<InputError>` component. Vue resolves a
+ * PascalCase component from a kebab-case tag too, so `<input-error>` is the
+ * same placement written differently and has to be caught the same way.
+ *
+ * @param {string} rawName
+ * @returns {boolean}
+ */
+export function isInputErrorTag(rawName) {
+    return rawName.replaceAll('-', '').toLowerCase() === 'inputerror';
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 const rule = {
     meta: {
@@ -54,7 +66,11 @@ const rule = {
         }
 
         return defineTemplateBodyVisitor({
-            "VElement[rawName='InputError']"(node) {
+            VElement(node) {
+                if (!isInputErrorTag(node.rawName)) {
+                    return;
+                }
+
                 context.report({
                     node: node.startTag,
                     messageId: 'preferFieldError',

--- a/eslint-rules/no-standalone-input-error.js
+++ b/eslint-rules/no-standalone-input-error.js
@@ -1,0 +1,67 @@
+/**
+ * Flags `<InputError>` placed directly by a page or component, steering every
+ * field onto `<FormField>` (label + control + error decided in one place) or,
+ * where a field cannot take that shape, onto `<FieldError>`.
+ *
+ * The two placements are not interchangeable: `<FieldError>` reserves the
+ * message's space up front and draws the message out of flow inside it, so an
+ * error cannot grow the form around it (#883). An `<InputError>` dropped
+ * straight into a column joins the flow instead, so the same field behaves
+ * differently depending on which page it is on (#894) — and that is the
+ * difference that gets copied into the next form somebody builds.
+ *
+ * `FieldError.vue` is exempt: it is the one place `<InputError>` is positioned,
+ * which is precisely what the rule exists to guarantee everywhere else.
+ */
+
+const OWNER_FILE = 'components/FieldError.vue';
+
+/**
+ * Whether a file is exempt from the rule: the reserved-slot wrapper that owns
+ * the app's only direct `<InputError>` placement.
+ *
+ * @param {string} filename
+ * @returns {boolean}
+ */
+export function isErrorSlotOwner(filename) {
+    return filename.replaceAll('\\', '/').endsWith(OWNER_FILE);
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description:
+                'Place a field error through `<FormField>` or `<FieldError>` rather than dropping `<InputError>` into the page.',
+        },
+        schema: [],
+        messages: {
+            preferFieldError:
+                'Render this error through `<FormField>` (`@/components/FormField.vue`), or `<FieldError>` (`@/components/FieldError.vue`) where the field cannot take that shape. Both reserve the space for the message and draw it out of flow, so an error cannot shift the form; a bare `<InputError>` joins the flow instead.',
+        },
+    },
+    create(context) {
+        if (isErrorSlotOwner(context.filename)) {
+            return {};
+        }
+
+        const defineTemplateBodyVisitor =
+            context.sourceCode.parserServices?.defineTemplateBodyVisitor;
+
+        if (!defineTemplateBodyVisitor) {
+            return {};
+        }
+
+        return defineTemplateBodyVisitor({
+            "VElement[rawName='InputError']"(node) {
+                context.report({
+                    node: node.startTag,
+                    messageId: 'preferFieldError',
+                });
+            },
+        });
+    },
+};
+
+export default rule;

--- a/eslint-rules/no-standalone-input-error.test.ts
+++ b/eslint-rules/no-standalone-input-error.test.ts
@@ -1,7 +1,30 @@
 import { RuleTester } from 'eslint';
 import { describe, expect, it } from 'vitest';
 import vueParser from 'vue-eslint-parser';
-import rule, { isErrorSlotOwner } from './no-standalone-input-error.js';
+import rule, {
+    isErrorSlotOwner,
+    isInputErrorTag,
+} from './no-standalone-input-error.js';
+
+describe('isInputErrorTag', () => {
+    it('matches the component written in PascalCase', () => {
+        expect(isInputErrorTag('InputError')).toBe(true);
+    });
+
+    it('matches the kebab-case tag Vue resolves to the same component', () => {
+        expect(isInputErrorTag('input-error')).toBe(true);
+    });
+
+    it('leaves the components that are allowed to render it alone', () => {
+        expect(isInputErrorTag('FieldError')).toBe(false);
+        expect(isInputErrorTag('field-error')).toBe(false);
+        expect(isInputErrorTag('FormField')).toBe(false);
+    });
+
+    it('leaves a plain input alone', () => {
+        expect(isInputErrorTag('input')).toBe(false);
+    });
+});
 
 describe('isErrorSlotOwner', () => {
     it('exempts the reserved-slot wrapper that owns the placement', () => {
@@ -83,6 +106,13 @@ ruleTester.run('no-standalone-input-error', rule, {
             // A component is no more entitled to place it than a page is.
             filename: 'resources/js/components/CreateChannelModal.vue',
             code: '<template><InputError :message="errors.name" /></template>',
+            errors: [{ messageId: 'preferFieldError' }],
+        },
+        {
+            // The kebab-case tag resolves to the same component, so writing it
+            // that way is not a way around the rule.
+            filename: 'resources/js/pages/teams/Groups.vue',
+            code: '<template><input-error :message="errors.slug" /></template>',
             errors: [{ messageId: 'preferFieldError' }],
         },
     ],

--- a/eslint-rules/no-standalone-input-error.test.ts
+++ b/eslint-rules/no-standalone-input-error.test.ts
@@ -1,0 +1,89 @@
+import { RuleTester } from 'eslint';
+import { describe, expect, it } from 'vitest';
+import vueParser from 'vue-eslint-parser';
+import rule, { isErrorSlotOwner } from './no-standalone-input-error.js';
+
+describe('isErrorSlotOwner', () => {
+    it('exempts the reserved-slot wrapper that owns the placement', () => {
+        expect(
+            isErrorSlotOwner('resources/js/components/FieldError.vue'),
+        ).toBe(true);
+    });
+
+    it('exempts it on a Windows-style path too', () => {
+        expect(
+            isErrorSlotOwner(
+                'C:\\repo\\resources\\js\\components\\FieldError.vue',
+            ),
+        ).toBe(true);
+    });
+
+    it('does not exempt the component it wraps', () => {
+        expect(
+            isErrorSlotOwner('resources/js/components/InputError.vue'),
+        ).toBe(false);
+    });
+
+    it('does not exempt a file that merely mentions the name', () => {
+        expect(
+            isErrorSlotOwner('resources/js/pages/teams/FieldError.test.ts'),
+        ).toBe(false);
+    });
+});
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parser: vueParser,
+        ecmaVersion: 2022,
+        sourceType: 'module',
+    },
+});
+
+ruleTester.run('no-standalone-input-error', rule, {
+    valid: [
+        {
+            // The one blessed placement: the wrapper that reserves the space.
+            filename: 'resources/js/components/FieldError.vue',
+            code: '<template><div class="relative h-7"><InputError :message="message" class="absolute" /></div></template>',
+        },
+        {
+            filename: 'resources/js/pages/teams/Groups.vue',
+            code: '<template><FormField :error="form.errors.name" v-slot="{ id }"><Input :id="id" /></FormField></template>',
+        },
+        {
+            filename: 'resources/js/pages/teams/integrations/Index.vue',
+            code: '<template><fieldset><legend>Events</legend><FieldError :message="form.errors.events" /></fieldset></template>',
+        },
+        {
+            // Importing the module is not placing it; `<FormField>` and
+            // `<FieldError>` both legitimately reach for it.
+            filename: 'resources/js/components/FormField.vue',
+            code: "<script setup lang=\"ts\">import InputError from '@/components/InputError.vue';</script>",
+        },
+    ],
+    invalid: [
+        {
+            filename: 'resources/js/pages/teams/Edit.vue',
+            code: '<template><div><Input id="name" /><InputError :message="errors.name" /></div></template>',
+            errors: [{ messageId: 'preferFieldError' }],
+        },
+        {
+            // Every occurrence is flagged, not just the first on the page.
+            filename: 'resources/js/pages/teams/Emojis.vue',
+            code: '<template><form><InputError :message="form.errors.image" /><InputError :message="form.errors.name" /></form></template>',
+            errors: [
+                { messageId: 'preferFieldError' },
+                { messageId: 'preferFieldError' },
+            ],
+        },
+        {
+            // A component is no more entitled to place it than a page is.
+            filename: 'resources/js/components/CreateChannelModal.vue',
+            code: '<template><InputError :message="errors.name" /></template>',
+            errors: [{ messageId: 'preferFieldError' }],
+        },
+    ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,7 @@ import noArbitraryTailwindSpacing from './eslint-rules/no-arbitrary-tailwind-spa
 import noDestructiveFillAsText from './eslint-rules/no-destructive-fill-as-text.js';
 import noRawButton from './eslint-rules/no-raw-button.js';
 import noSmallMobileInputText from './eslint-rules/no-small-mobile-input-text.js';
+import noStandaloneInputError from './eslint-rules/no-standalone-input-error.js';
 
 const controlStatements = [
     'if',
@@ -39,6 +40,7 @@ export default defineConfigWithVueTs(
                     'no-destructive-fill-as-text': noDestructiveFillAsText,
                     'no-raw-button': noRawButton,
                     'no-small-mobile-input-text': noSmallMobileInputText,
+                    'no-standalone-input-error': noStandaloneInputError,
                 },
             },
         },
@@ -94,6 +96,14 @@ export default defineConfigWithVueTs(
             // occurrence was migrated to `text-base md:<size>`, so the gate
             // stays clean and a new sub-16px field cannot land silently.
             'local/no-small-mobile-input-text': 'error',
+            // A field's error belongs to `<FormField>` or, where the field
+            // cannot take that shape, to `<FieldError>`: both reserve its space
+            // and draw it out of flow, so an error cannot shift the form
+            // (#883). A bare `<InputError>` joins the flow instead, which left
+            // the same field behaving differently depending on the page it was
+            // on (#894). `error` because every occurrence was converted, so a
+            // new fork cannot land silently.
+            'local/no-standalone-input-error': 'error',
             // XSS trust boundary. Every run of HTML the client renders as markup
             // must go through `<SafeHtml>`, which sanitizes it with DOMPurify
             // against a named allowlist; a raw `v-html` anywhere else would

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -300,6 +300,7 @@
   "Emoji": "Emoji",
   "Emoji added.": "Emoji ajouté.",
   "Emoji image": "Image de l'emoji",
+  "Emoji name": "Nom de l'emoji",
   "Emoji removed.": "Emoji supprimé.",
   "Ensure your account is using a long, random password to stay secure": "Assurez-vous que votre compte utilise un mot de passe long et aléatoire pour rester sécurisé",
   "Enter team name": "Saisissez le nom de l’équipe",

--- a/resources/js/components/FieldError.test.ts
+++ b/resources/js/components/FieldError.test.ts
@@ -9,9 +9,12 @@ import FieldError from './FieldError.vue';
  * same space whether or not there is a message, so it is worth pinning
  * separately from the components that compose it.
  */
-function renderFieldError(message?: string): Promise<string> {
+function renderFieldError(
+    message?: string,
+    props: Record<string, unknown> = {},
+): Promise<string> {
     return renderToString(
-        createSSRApp({ render: () => h(FieldError, { message }) }),
+        createSSRApp({ render: () => h(FieldError, { message, ...props }) }),
     );
 }
 
@@ -35,5 +38,28 @@ describe('FieldError', () => {
         expect(html).toMatch(/class="[^"]*\babsolute\b/);
         expect(html).toMatch(/class="[^"]*\bpointer-events-none\b/);
         expect(html).toContain('role="alert"');
+    });
+
+    it('puts the message back in flow when the space is not reserved', async () => {
+        // A field in an inline row that ends at its container's edge has
+        // nothing below to absorb a wrapped message, so there the message has
+        // to push the container open rather than be drawn over it (#894).
+        const html = await renderFieldError('The email field is required.', {
+            reserve: false,
+        });
+
+        expect(html).toContain('The email field is required.');
+        expect(html).toContain('role="alert"');
+        expect(html).not.toContain('h-7');
+        expect(html).not.toMatch(/class="[^"]*\babsolute\b/);
+    });
+
+    it('draws nothing at all when unreserved and there is no message', async () => {
+        // Without the reserved slot there is no wrapper either: an unreserved
+        // clean field costs no node and no height.
+        const html = await renderFieldError(undefined, { reserve: false });
+
+        expect(html).not.toContain('role="alert"');
+        expect(html).not.toContain('h-7');
     });
 });

--- a/resources/js/components/FieldError.vue
+++ b/resources/js/components/FieldError.vue
@@ -2,7 +2,7 @@
 import InputError from '@/components/InputError.vue';
 
 /**
- * A field's validation message in space that is reserved for it up front.
+ * A field's validation message, in space that is reserved for it up front.
  *
  * The message is drawn out of flow inside a slot that is the same height with
  * or without it, so an error cannot change the height of the form around it
@@ -13,18 +13,35 @@ import InputError from '@/components/InputError.vue';
  *
  * `<FormField>` uses this for every field it renders. Reach for it directly
  * only where a field cannot go through `<FormField>` — a checkbox whose label
- * wraps it, say — rather than restating the positioning at the call site.
+ * wraps it, or a `<fieldset>` named by its `<legend>` — rather than restating
+ * the positioning at the call site.
  */
-defineProps<{
+const { message, reserve = true } = defineProps<{
     message?: string;
+    /**
+     * Whether to reserve the message's space and draw it out of flow. Set this
+     * `false` for a field in an inline row that ends at its container's edge:
+     * there is nothing below to spill a wrapped message into, so drawing it out
+     * of flow would run it past the container's own border. Such a row has no
+     * reason to hold still either — nothing sits under it to be pushed around —
+     * so the message joins the flow and the row grows to hold it (#894).
+     */
+    reserve?: boolean;
 }>();
 </script>
 
 <template>
-    <div class="relative h-7">
+    <div v-if="reserve" class="relative h-7">
         <InputError
             :message="message"
             class="pointer-events-none absolute inset-x-0 top-0"
         />
     </div>
+
+    <!-- `w-0 min-w-full` keeps an in-flow message from widening the field it
+    belongs to: a definite zero width contributes nothing when the browser sizes
+    the cell around the control, and the percentage minimum then fills whatever
+    width that gave. Without it a long message stretches its cell and shoves the
+    rest of an inline row — the submit button included — sideways. -->
+    <InputError v-else :message="message" class="w-0 min-w-full" />
 </template>

--- a/resources/js/components/FormField.test.ts
+++ b/resources/js/components/FormField.test.ts
@@ -95,6 +95,25 @@ describe('FormField', () => {
         expect(html).toMatch(/class="[^"]*\bpointer-events-none\b/);
     });
 
+    it('forwards the unreserved gutter down to the error slot', async () => {
+        // The reservation is the default because most fields sit in a column
+        // with something below them. A field in an inline row that ends at its
+        // container's edge opts out, so the message pushes the container open
+        // instead of being drawn past it (#894).
+        const html = await renderField({
+            id: 'slug',
+            label: 'Group handle',
+            error: 'The handle may only contain lowercase letters.',
+            reserve: false,
+        });
+
+        expect(html).toContain(
+            'The handle may only contain lowercase letters.',
+        );
+        expect(html).not.toContain('h-7');
+        expect(html).not.toMatch(/class="[^"]*\babsolute\b/);
+    });
+
     it('renders the optional hint line when provided', async () => {
         const html = await renderField({
             id: 'locale',

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -17,13 +17,24 @@ import { Label } from '@/components/ui/label';
  * click it again. Side by side, the taller cell would drag its neighbour's
  * label and input out of alignment too.
  */
-const props = defineProps<{
-    label?: string;
-    id?: string;
-    error?: string;
-    hint?: string;
-    labelClass?: string;
-}>();
+const props = withDefaults(
+    defineProps<{
+        label?: string;
+        id?: string;
+        error?: string;
+        hint?: string;
+        labelClass?: string;
+        /**
+         * Whether to reserve the error's space and draw the message out of
+         * flow. Forwarded to `<FieldError>`, which documents when a field
+         * should opt out. Declared with an explicit default because Vue casts
+         * an absent `Boolean` prop to `false`, which would silently drop the
+         * reservation from every field that does not mention it.
+         */
+        reserve?: boolean;
+    }>(),
+    { reserve: true },
+);
 
 const fieldId = props.id ?? useId();
 </script>
@@ -66,6 +77,6 @@ const fieldId = props.id ?? useId();
 
         <p v-if="hint" class="text-sm text-muted-foreground">{{ hint }}</p>
 
-        <FieldError :message="error" />
+        <FieldError :message="error" :reserve="reserve" />
     </div>
 </template>

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -21,7 +21,7 @@ import { computed, ref } from 'vue';
 import CancelInvitationModal from '@/components/CancelInvitationModal.vue';
 import DeleteTeamModal from '@/components/DeleteTeamModal.vue';
 import DemoLock from '@/components/DemoLock.vue';
-import InputError from '@/components/InputError.vue';
+import FormField from '@/components/FormField.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import RemoveMemberModal from '@/components/RemoveMemberModal.vue';
 import TransferOwnershipModal from '@/components/TransferOwnershipModal.vue';
@@ -239,18 +239,28 @@ const confirmTransferOwnership = (member: TeamMember) => {
                 v-slot="{ errors, processing }"
             >
                 <div class="flex flex-wrap items-start gap-3">
-                    <div class="w-full max-w-sm">
+                    <!-- The section heading above already reads "Team name", so
+                         the field's own label is hidden rather than repeated.
+                         It stays a real `<label for>` all the same: it names
+                         the control for assistive tech and voice control, and
+                         it focuses the input when clicked. -->
+                    <FormField
+                        id="name"
+                        :label="$t('Team name')"
+                        label-class="sr-only"
+                        :error="errors.name"
+                        class="w-full max-w-sm"
+                        v-slot="{ id }"
+                    >
                         <Input
-                            id="name"
+                            :id="id"
                             name="name"
                             data-test="team-name-input"
                             :default-value="team.name"
-                            :aria-label="$t('Team name')"
                             class="rounded-lg"
                             required
                         />
-                        <InputError :message="errors.name" />
-                    </div>
+                    </FormField>
 
                     <DemoLock v-slot="{ disabled }">
                         <Button

--- a/resources/js/pages/teams/Emojis.vue
+++ b/resources/js/pages/teams/Emojis.vue
@@ -2,8 +2,8 @@
 import { Head, useForm, usePage } from '@inertiajs/vue3';
 import { Plus, Search, Upload } from '@lucide/vue';
 import { computed, ref } from 'vue';
+import FormField from '@/components/FormField.vue';
 import Heading from '@/components/Heading.vue';
-import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -162,21 +162,43 @@ function addedAt(iso: string): string {
                         )
                     }}</span>
                 </div>
+                <!-- The row heading above names the pair, so each field's own
+                     label is hidden rather than repeated. It stays a real
+                     `<label for>` all the same: a placeholder disappears the
+                     moment someone types, which leaves the field unnamed
+                     exactly when they might look for the name again.
+
+                     The error's space is not reserved here, for the same reason
+                     as the create row on the user-groups page: the cells are
+                     narrow enough to wrap a message over several lines, and the
+                     row is the last thing in the card. -->
                 <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
-                    <div class="flex flex-col gap-1">
+                    <FormField
+                        :label="$t('Emoji image')"
+                        label-class="sr-only"
+                        :error="form.errors.image"
+                        :reserve="false"
+                        v-slot="{ id }"
+                    >
                         <input
+                            :id="id"
                             ref="imageInput"
                             type="file"
                             accept="image/png,image/gif"
                             data-test="emoji-image-input"
-                            :aria-label="$t('Emoji image')"
                             class="block w-full text-sm text-muted-foreground file:mr-3 file:rounded-full file:border file:border-border file:bg-background file:px-3 file:py-1.5 file:text-sm file:font-medium hover:file:bg-muted max-md:file:py-2.75"
                             @change="onFileChange"
                         />
-                        <InputError :message="form.errors.image" />
-                    </div>
-                    <div class="flex flex-col gap-1">
+                    </FormField>
+                    <FormField
+                        :label="$t('Emoji name')"
+                        label-class="sr-only"
+                        :error="form.errors.name"
+                        :reserve="false"
+                        v-slot="{ id }"
+                    >
                         <Input
+                            :id="id"
                             v-model="form.name"
                             data-test="emoji-name-input"
                             placeholder=":name:"
@@ -185,8 +207,7 @@ function addedAt(iso: string): string {
                             autocomplete="off"
                             spellcheck="false"
                         />
-                        <InputError :message="form.errors.name" />
-                    </div>
+                    </FormField>
                     <Button
                         type="submit"
                         data-test="emoji-add-button"

--- a/resources/js/pages/teams/Groups.vue
+++ b/resources/js/pages/teams/Groups.vue
@@ -2,8 +2,8 @@
 import { Head, useForm } from '@inertiajs/vue3';
 import { Pencil, Plus, Search, Trash2, Users, X } from '@lucide/vue';
 import { computed, ref, watch } from 'vue';
+import FormField from '@/components/FormField.vue';
 import Heading from '@/components/Heading.vue';
-import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -239,19 +239,43 @@ function confirmRemoval(): void {
                         )
                     }}</span>
                 </div>
+                <!-- The row heading above names the pair, so each field's own
+                     label is hidden rather than repeated. It stays a real
+                     `<label for>` all the same: a placeholder disappears the
+                     moment someone types, which leaves the field unnamed
+                     exactly when they might look for the name again.
+
+                     The error's space is not reserved here. These cells are
+                     narrow enough that a message wraps to three lines, and the
+                     row is the last thing in the card — so drawn out of flow it
+                     would run past the card's own border, and there is nothing
+                     below it to be pushed around by letting it grow instead. -->
                 <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
-                    <div class="flex flex-col gap-1">
+                    <FormField
+                        :label="$t('Group name')"
+                        label-class="sr-only"
+                        :error="createForm.errors.name"
+                        :reserve="false"
+                        v-slot="{ id }"
+                    >
                         <Input
+                            :id="id"
                             v-model="createForm.name"
                             data-test="group-name-input"
                             :placeholder="$t('Dev Team')"
                             class="max-md:h-11 sm:w-56"
                             autocomplete="off"
                         />
-                        <InputError :message="createForm.errors.name" />
-                    </div>
-                    <div class="flex flex-col gap-1">
+                    </FormField>
+                    <FormField
+                        :label="$t('Group handle')"
+                        label-class="sr-only"
+                        :error="createForm.errors.slug"
+                        :reserve="false"
+                        v-slot="{ id }"
+                    >
                         <Input
+                            :id="id"
                             v-model="createForm.slug"
                             data-test="group-slug-input"
                             placeholder="@dev-team"
@@ -260,8 +284,7 @@ function confirmRemoval(): void {
                             autocomplete="off"
                             spellcheck="false"
                         />
-                        <InputError :message="createForm.errors.slug" />
-                    </div>
+                    </FormField>
                     <Button
                         type="submit"
                         data-test="group-create-button"
@@ -377,27 +400,37 @@ function confirmRemoval(): void {
                 data-test="group-rename-form"
                 @submit.prevent="submitRename"
             >
-                <div class="flex flex-1 flex-col gap-1">
+                <FormField
+                    :label="$t('Group name')"
+                    label-class="sr-only"
+                    :error="editForm.errors.name"
+                    class="flex-1"
+                    v-slot="{ id }"
+                >
                     <Input
+                        :id="id"
                         v-model="editForm.name"
                         data-test="group-edit-name-input"
-                        :aria-label="$t('Group name')"
                         autocomplete="off"
                     />
-                    <InputError :message="editForm.errors.name" />
-                </div>
-                <div class="flex flex-1 flex-col gap-1">
+                </FormField>
+                <FormField
+                    :label="$t('Group handle')"
+                    label-class="sr-only"
+                    :error="editForm.errors.slug"
+                    class="flex-1"
+                    v-slot="{ id }"
+                >
                     <Input
+                        :id="id"
                         v-model="editForm.slug"
                         data-test="group-edit-slug-input"
-                        :aria-label="$t('Group handle')"
                         class="font-mono"
                         autocapitalize="off"
                         autocomplete="off"
                         spellcheck="false"
                     />
-                    <InputError :message="editForm.errors.slug" />
-                </div>
+                </FormField>
                 <Button
                     type="submit"
                     class="rounded-full"

--- a/resources/js/pages/teams/integrations/Bot.vue
+++ b/resources/js/pages/teams/integrations/Bot.vue
@@ -2,7 +2,8 @@
 import { Head, useForm } from '@inertiajs/vue3';
 import { Bot, Lock, Plus, Trash2 } from '@lucide/vue';
 import { ref } from 'vue';
-import InputError from '@/components/InputError.vue';
+import FieldError from '@/components/FieldError.vue';
+import FormField from '@/components/FormField.vue';
 import RevealSecretDialog from '@/components/integrations/RevealSecretDialog.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -16,7 +17,6 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
     Select,
     SelectContent,
@@ -422,43 +422,50 @@ function confirmDeleteBot(): void {
                         $t('The bot can post in every channel it belongs to.')
                     }}</DialogDescription>
                 </DialogHeader>
-                <div class="flex flex-col gap-2 py-4">
-                    <Label for="add-channel-select">{{ $t('Channel') }}</Label>
-                    <Select v-model="addChannelForm.channel_id">
-                        <SelectTrigger
-                            id="add-channel-select"
-                            data-test="add-channel-select"
-                            class="w-full"
-                        >
-                            <SelectValue
-                                :placeholder="$t('Select a channel')"
-                            />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem
-                                v-for="channel in addableChannels"
-                                :key="channel.id"
-                                :value="channel.id"
-                                :data-test="`add-channel-option-${channel.id}`"
+                <div class="py-4">
+                    <FormField
+                        id="add-channel-select"
+                        :label="$t('Channel')"
+                        :error="addChannelForm.errors.channel_id"
+                        v-slot="{ id }"
+                    >
+                        <Select v-model="addChannelForm.channel_id">
+                            <SelectTrigger
+                                :id="id"
+                                data-test="add-channel-select"
+                                class="w-full"
                             >
-                                <span class="flex items-center gap-2">
-                                    <Lock
-                                        v-if="channel.visibility === 'private'"
-                                        class="size-3.5 text-muted-foreground"
-                                        aria-hidden="true"
-                                    />
-                                    <span
-                                        v-else
-                                        aria-hidden="true"
-                                        class="text-brass"
-                                        >#</span
-                                    >
-                                    {{ channel.name }}
-                                </span>
-                            </SelectItem>
-                        </SelectContent>
-                    </Select>
-                    <InputError :message="addChannelForm.errors.channel_id" />
+                                <SelectValue
+                                    :placeholder="$t('Select a channel')"
+                                />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem
+                                    v-for="channel in addableChannels"
+                                    :key="channel.id"
+                                    :value="channel.id"
+                                    :data-test="`add-channel-option-${channel.id}`"
+                                >
+                                    <span class="flex items-center gap-2">
+                                        <Lock
+                                            v-if="
+                                                channel.visibility === 'private'
+                                            "
+                                            class="size-3.5 text-muted-foreground"
+                                            aria-hidden="true"
+                                        />
+                                        <span
+                                            v-else
+                                            aria-hidden="true"
+                                            class="text-brass"
+                                            >#</span
+                                        >
+                                        {{ channel.name }}
+                                    </span>
+                                </SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </FormField>
                 </div>
                 <DialogFooter>
                     <DialogClose as-child>
@@ -540,17 +547,20 @@ function confirmDeleteBot(): void {
                 <div
                     class="flex max-h-[60vh] flex-col gap-4 overflow-y-auto py-4"
                 >
-                    <div class="flex flex-col gap-2">
-                        <Label for="token-name">{{ $t('Name') }}</Label>
+                    <FormField
+                        id="token-name"
+                        :label="$t('Name')"
+                        :error="tokenForm.errors.name"
+                        v-slot="{ id }"
+                    >
                         <Input
-                            id="token-name"
+                            :id="id"
                             v-model="tokenForm.name"
                             data-test="token-name-input"
                             :placeholder="$t('ci-pipeline')"
                             autocomplete="off"
                         />
-                        <InputError :message="tokenForm.errors.name" />
-                    </div>
+                    </FormField>
                     <fieldset class="flex flex-col gap-2">
                         <legend class="text-sm font-medium">
                             {{ $t('Scopes') }}
@@ -584,7 +594,7 @@ function confirmDeleteBot(): void {
                                 }}</span>
                             </span>
                         </label>
-                        <InputError :message="tokenForm.errors.abilities" />
+                        <FieldError :message="tokenForm.errors.abilities" />
                     </fieldset>
                 </div>
                 <DialogFooter>

--- a/resources/js/pages/teams/integrations/Index.vue
+++ b/resources/js/pages/teams/integrations/Index.vue
@@ -8,7 +8,8 @@ import {
     Plus,
 } from '@lucide/vue';
 import { computed, ref } from 'vue';
-import InputError from '@/components/InputError.vue';
+import FieldError from '@/components/FieldError.vue';
+import FormField from '@/components/FormField.vue';
 import IncomingWebhookRevoke from '@/components/integrations/IncomingWebhookRevoke.vue';
 import RevealSecretDialog from '@/components/integrations/RevealSecretDialog.vue';
 import { Button } from '@/components/ui/button';
@@ -23,7 +24,6 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
     NativeSelect,
     NativeSelectOption,
@@ -500,16 +500,21 @@ function submitOutgoing(): void {
                         )
                     }}</DialogDescription>
                 </DialogHeader>
-                <div class="flex flex-col gap-2 py-4">
-                    <Label for="bot-name">{{ $t('Name') }}</Label>
-                    <Input
+                <div class="py-4">
+                    <FormField
                         id="bot-name"
-                        v-model="botForm.name"
-                        data-test="bot-name-input"
-                        :placeholder="$t('Deploy Bot')"
-                        autocomplete="off"
-                    />
-                    <InputError :message="botForm.errors.name" />
+                        :label="$t('Name')"
+                        :error="botForm.errors.name"
+                        v-slot="{ id }"
+                    >
+                        <Input
+                            :id="id"
+                            v-model="botForm.name"
+                            data-test="bot-name-input"
+                            :placeholder="$t('Deploy Bot')"
+                            autocomplete="off"
+                        />
+                    </FormField>
                 </div>
                 <DialogFooter>
                     <DialogClose as-child>
@@ -546,23 +551,28 @@ function submitOutgoing(): void {
                     }}</DialogDescription>
                 </DialogHeader>
                 <div class="flex flex-col gap-4 py-4">
-                    <div class="flex flex-col gap-2">
-                        <Label for="incoming-name">{{ $t('Name') }}</Label>
+                    <FormField
+                        id="incoming-name"
+                        :label="$t('Name')"
+                        :error="incomingForm.errors.name"
+                        v-slot="{ id }"
+                    >
                         <Input
-                            id="incoming-name"
+                            :id="id"
                             v-model="incomingForm.name"
                             data-test="incoming-name-input"
                             :placeholder="$t('CI alerts')"
                             autocomplete="off"
                         />
-                        <InputError :message="incomingForm.errors.name" />
-                    </div>
-                    <div class="flex flex-col gap-2">
-                        <Label for="incoming-channel">{{
-                            $t('Channel')
-                        }}</Label>
+                    </FormField>
+                    <FormField
+                        id="incoming-channel"
+                        :label="$t('Channel')"
+                        :error="incomingForm.errors.channel_id"
+                        v-slot="{ id }"
+                    >
                         <NativeSelect
-                            id="incoming-channel"
+                            :id="id"
                             v-model="incomingForm.channel_id"
                             data-test="incoming-channel-select"
                             class="w-full"
@@ -578,14 +588,16 @@ function submitOutgoing(): void {
                                 #{{ channel.name }}
                             </NativeSelectOption>
                         </NativeSelect>
-                        <InputError :message="incomingForm.errors.channel_id" />
-                    </div>
-                    <div class="flex flex-col gap-2">
-                        <Label for="incoming-bot">{{
-                            $t('Post as bot')
-                        }}</Label>
+                    </FormField>
+                    <FormField
+                        id="incoming-bot"
+                        :label="$t('Post as bot')"
+                        :hint="$t('The bot must be a member of the channel.')"
+                        :error="incomingForm.errors.bot_id"
+                        v-slot="{ id }"
+                    >
                         <NativeSelect
-                            id="incoming-bot"
+                            :id="id"
                             v-model="incomingForm.bot_id"
                             data-test="incoming-bot-select"
                             class="w-full"
@@ -601,11 +613,7 @@ function submitOutgoing(): void {
                                 {{ bot.name }}
                             </NativeSelectOption>
                         </NativeSelect>
-                        <InputError :message="incomingForm.errors.bot_id" />
-                        <span class="text-xs text-muted-foreground">{{
-                            $t('The bot must be a member of the channel.')
-                        }}</span>
-                    </div>
+                    </FormField>
                     <label
                         class="flex items-center gap-2 text-sm"
                         data-test="incoming-signing-toggle"
@@ -660,31 +668,35 @@ function submitOutgoing(): void {
                 <div
                     class="flex max-h-[60vh] flex-col gap-4 overflow-y-auto py-4"
                 >
-                    <div class="flex flex-col gap-2">
-                        <Label for="outgoing-name">{{ $t('Name') }}</Label>
+                    <FormField
+                        id="outgoing-name"
+                        :label="$t('Name')"
+                        :error="outgoingForm.errors.name"
+                        v-slot="{ id }"
+                    >
                         <Input
-                            id="outgoing-name"
+                            :id="id"
                             v-model="outgoingForm.name"
                             data-test="outgoing-name-input"
                             :placeholder="$t('Ops mirror')"
                             autocomplete="off"
                         />
-                        <InputError :message="outgoingForm.errors.name" />
-                    </div>
-                    <div class="flex flex-col gap-2">
-                        <Label for="outgoing-url">{{
-                            $t('Endpoint URL')
-                        }}</Label>
+                    </FormField>
+                    <FormField
+                        id="outgoing-url"
+                        :label="$t('Endpoint URL')"
+                        :error="outgoingForm.errors.url"
+                        v-slot="{ id }"
+                    >
                         <Input
-                            id="outgoing-url"
+                            :id="id"
                             v-model="outgoingForm.url"
                             data-test="outgoing-url-input"
                             type="url"
                             placeholder="https://ops.example.com/desk"
                             autocomplete="off"
                         />
-                        <InputError :message="outgoingForm.errors.url" />
-                    </div>
+                    </FormField>
                     <fieldset class="flex flex-col gap-2">
                         <legend class="text-sm font-medium">
                             {{ $t('Events') }}
@@ -714,7 +726,7 @@ function submitOutgoing(): void {
                                 option.label
                             }}</span>
                         </label>
-                        <InputError :message="outgoingForm.errors.events" />
+                        <FieldError :message="outgoingForm.errors.events" />
                     </fieldset>
                     <fieldset
                         v-if="channels.length > 0"
@@ -750,7 +762,7 @@ function submitOutgoing(): void {
                             />
                             #{{ channel.name }}
                         </label>
-                        <InputError
+                        <FieldError
                             :message="outgoingForm.errors.channel_ids"
                         />
                     </fieldset>

--- a/tests/Browser/TeamsFieldErrorTest.php
+++ b/tests/Browser/TeamsFieldErrorTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\UserGroup;
+
+/**
+ * Layout stability on the teams pages when a validation message appears (#894).
+ *
+ * The tail of #883: these five pages placed `<InputError>` themselves, so their
+ * fields grew by a line when the server rejected a submit while every
+ * `<FormField>` consumer held still. Only a real browser can settle this — it is
+ * the browser's own layout, and whether a message wraps depends on the width the
+ * cell happens to have.
+ *
+ * @return array{owner: User, team: Team}
+ */
+function browserTeamForFieldErrors(): array
+{
+    ['owner' => $owner, 'team' => $team] = browserTeamWithChannel();
+
+    return ['owner' => $owner, 'team' => $team];
+}
+
+/**
+ * Records the top and left of each watched element, so a later assertion can
+ * prove none of them moved when the message arrived.
+ *
+ * @param  array<string, string>  $watched  name => CSS selector
+ */
+function browserRecordLayout(array $watched): string
+{
+    $json = json_encode($watched, JSON_THROW_ON_ERROR);
+
+    return <<<JS
+    () => {
+        window.__watched = {$json};
+
+        window.__layoutBefore = Object.fromEntries(
+            Object.entries(window.__watched).map(([name, selector]) => {
+                const box = document.querySelector(selector).getBoundingClientRect();
+
+                return [name, { top: box.top, left: box.left }];
+            }),
+        );
+    }
+    JS;
+}
+
+/** Whether every element recorded by `browserRecordLayout` is still where it was. */
+function browserLayoutHeldStill(): string
+{
+    return <<<'JS'
+    (() => {
+        return Object.entries(window.__layoutBefore).every(([name, before]) => {
+            const box = document.querySelector(window.__watched[name]).getBoundingClientRect();
+
+            return Math.abs(box.top - before.top) < 0.5
+                && Math.abs(box.left - before.left) < 0.5;
+        });
+    })()
+    JS;
+}
+
+/**
+ * The team-name row sits in a section with padding below it, so the reserved
+ * gutter has somewhere to live and the message fits the 384px cell on one line.
+ * `Save` sits beside the field and is top-aligned, so it never moved; what did
+ * was everything the section pushes down — the members list below it, which the
+ * page grew by a line under someone already scrolled to it.
+ */
+test('a rejected team rename leaves the sections below it exactly where they were', function (): void {
+    ['owner' => $owner, 'team' => $team] = browserTeamForFieldErrors();
+
+    $page = signInThroughBrowser($owner)
+        ->navigate("/settings/teams/{$team->slug}")
+        ->assertSee('Team name')
+        // `login` is a reserved name (App\Rules\TeamName), so the server rejects
+        // it while the browser's own `required` check passes.
+        ->type('[data-test="team-name-input"]', 'login');
+
+    $page->script(browserRecordLayout([
+        'input' => '[data-test="team-name-input"]',
+        'save' => '[data-test="team-save-button"]',
+        'invite' => '[data-test="invite-member-button"]',
+        'members' => '[data-test="member-row"]',
+    ]));
+
+    $page->click('@team-save-button')
+        ->assertSee('This team name is reserved and cannot be used.');
+
+    $page->assertScript(browserLayoutHeldStill(), true);
+});
+
+/**
+ * The create row is the shape that cannot take the reservation: two narrow cells
+ * at the bottom edge of a card, where a wrapped message drawn out of flow would
+ * run past the card's own border. It opts out, so the card grows downward — but
+ * `Create` still must not move, in either axis. Horizontally is the new risk: an
+ * in-flow message is wider than its cell, and left to size the cell it would
+ * shove the button sideways.
+ */
+test('a rejected group create keeps the Create button still and the message inside the card', function (): void {
+    ['owner' => $owner, 'team' => $team] = browserTeamForFieldErrors();
+
+    $page = signInThroughBrowser($owner)
+        ->navigate("/settings/teams/{$team->slug}/groups")
+        ->assertSee('User groups')
+        ->type('[data-test="group-name-input"]', 'Dev Team')
+        // Rejected by the handle's regex, and long enough that the message wraps
+        // to several lines in the 192px cell.
+        ->type('[data-test="group-slug-input"]', 'NOT VALID!!');
+
+    $page->script(browserRecordLayout([
+        'create' => '[data-test="group-create-button"]',
+        'name' => '[data-test="group-name-input"]',
+        'slug' => '[data-test="group-slug-input"]',
+    ]));
+
+    $page->click('@group-create-button')
+        ->assertSee('The handle may only contain lowercase letters, numbers, and hyphens.');
+
+    $page->assertScript(browserLayoutHeldStill(), true);
+
+    // The card grew to hold the message rather than letting it escape: every
+    // line of the message is drawn inside the form's own box.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const card = document.querySelector('[data-test="group-create-form"]').getBoundingClientRect();
+        const message = [...document.querySelectorAll('[role="alert"]')]
+            .map((node) => node.getBoundingClientRect())
+            .pop();
+
+        return message.bottom <= card.bottom + 0.5 && message.right <= card.right + 0.5;
+    })()
+    JS, true);
+});
+
+/**
+ * The rename dialog keeps the reservation: the Members section below it gives a
+ * wrapped message somewhere to spill, and the whole dialog holds still — which
+ * is what stops `Save` sliding out from under the pointer.
+ */
+test('a rejected group rename leaves the editor dialog exactly where it was', function (): void {
+    ['owner' => $owner, 'team' => $team] = browserTeamForFieldErrors();
+
+    UserGroup::factory()->for($team)->slug('dev-team')->create();
+
+    $page = signInThroughBrowser($owner)
+        ->navigate("/settings/teams/{$team->slug}/groups")
+        ->click('@group-edit-dev-team')
+        ->assertPresent('[data-test="group-edit-dialog"]')
+        // The dialog fades and zooms in; a baseline recorded mid-transition
+        // measures the animation rather than the error line.
+        ->wait(0.5)
+        ->type('[data-test="group-edit-slug-input"]', 'BAD!!');
+
+    $page->script(browserRecordLayout([
+        'save' => '[data-test="group-rename-button"]',
+        'members' => '[data-test="group-members-empty"]',
+        'name' => '[data-test="group-edit-name-input"]',
+    ]));
+
+    $page->click('@group-rename-button')
+        ->assertSee('The handle may only contain lowercase letters, numbers, and hyphens.');
+
+    $page->assertScript(browserLayoutHeldStill(), true);
+});
+
+/**
+ * The integrations dialogs are plain columns, so they take the reservation as
+ * the settings modals did in #883 — the footer buttons stay put across a
+ * rejected submit.
+ */
+test('a rejected bot create leaves the dialog footer exactly where it was', function (): void {
+    ['owner' => $owner, 'team' => $team] = browserTeamForFieldErrors();
+
+    $page = signInThroughBrowser($owner)
+        ->navigate("/settings/teams/{$team->slug}/integrations")
+        ->click('@new-bot-button')
+        ->assertPresent('[data-test="new-bot-dialog"]')
+        ->wait(0.5);
+
+    $page->script(browserRecordLayout([
+        'create' => '[data-test="bot-create-button"]',
+        'input' => '[data-test="bot-name-input"]',
+    ]));
+
+    // Submitted with the name deliberately left blank.
+    $page->click('@bot-create-button')
+        ->assertSee('The name field is required.');
+
+    $page->assertScript(browserLayoutHeldStill(), true);
+});


### PR DESCRIPTION
Closes #894.

The tail of #883. That fix gave `FormField` a reserved gutter and drew `InputError` out of flow inside it, and every `FormField` consumer inherited it. Five teams pages placed `InputError` themselves, so they kept the old in-flow behaviour: their forms still grew by a line the moment the server rejected a submit.

## What changed

All 18 remaining call sites now go through one of the two sanctioned placements, so `InputError` has a single consumer pattern:

- **`FormField`** wherever there is a real label + control pair — `teams/Edit.vue` (1), `teams/Groups.vue` (4), `teams/Emojis.vue` (2), `integrations/Bot.vue` (2), `integrations/Index.vue` (6).
- **`FieldError`** for the three `<fieldset>` groups named by a `<legend>` (scopes, events, channels), where `FormField`'s `<label for>` shape is wrong. Same precedent as `Register.vue`'s consent row.

(The issue counted 23; 18 are left on `develop` today.)

**Labels stay coupled to their controls.** Six fields were named by `aria-label` and three by placeholder alone. Each now has a real `<label for>` — visually hidden via `label-class="sr-only"` where the surrounding heading already names the field, so nothing changes on screen. A placeholder disappears the moment someone types, which left those three fields unnamed exactly when someone might look for the name again. Every `data-test` selector is preserved.

## The gutter is now opt-out, because two rows genuinely could not take it

The issue flagged this as a risk and it turned out to be real, so I checked each row in the running app rather than assuming. Two shapes behave differently:

- **A field in a column** (the team-name section, the rename dialog, the integrations dialogs) has content or padding below it, so a wrapped message spills into a gap that already exists. These keep the reservation and now hold perfectly still.
- **A field in a narrow inline row at a card's bottom edge** (`Groups.vue`'s create row, `Emojis.vue`'s upload row) does not. Reserved, the three-line message these 192px cells produce was drawn straight past the card's own border, and the clean state carried 53px of dead space inside the card.

So `FieldError` gains a `reserve` prop (default `true`), forwarded by `FormField`, and those two rows opt out: the message joins the flow and the card grows to hold it. It carries `w-0 min-w-full` so an in-flow message cannot widen its cell and shove the row's submit button sideways — verified, the Create and Add buttons do not move by a pixel in either axis.

`FormField`'s own `reserve` needed an explicit `withDefaults`, since Vue casts an absent `Boolean` prop to `false` and that would have silently dropped the reservation from every field on every page.

## Keeping it from coming back

A new `local/no-standalone-input-error` ESLint rule (`error`) flags `<InputError>` placed anywhere but `FieldError.vue`, which owns the one blessed placement. It catches the kebab-case tag too.

## Testing

- `tests/Browser/TeamsFieldErrorTest.php` — four real-browser tests recording each watched element's position before a rejected submit and asserting none moved, plus one asserting the create card's message stays inside the card. Verified they discriminate: all four fail against the pre-change markup.
- `FieldError` / `FormField` Vitest specs cover both `reserve` branches; the rule has its own spec (16 cases).
- Full gate green: PHP suite at **100.0%** coverage, Pint + PHPStan + Rector clean, frontend lint (0 errors, warning count unchanged at 51) / format / types / build, Vitest 1397 passing, and the **whole browser suite 250/250** — including the axe audits for the user-groups and emoji pages.

## i18n

One new key, `Emoji name`, with its French translation. The rest reuse existing keys.

No operator-facing behaviour changed, so no docs update.

## Found along the way

#921 — renaming a team to a name written in a non-Latin script (or pure punctuation) produces an empty slug and makes the team unreachable. Pre-existing and unrelated; filed rather than fixed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787662812&installation_model_id=428379&pr_number=922&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F922&signature=2a00667008fcdd56480ea04402536b4cdf3ebfbcd49f2917c4ae68dcdc9cc053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->