### PR TITLE
fix: keep a team reachable when its name slugs to nothing

### DIFF
--- a/app/Actions/Channels/CreateChannel.php
+++ b/app/Actions/Channels/CreateChannel.php
@@ -6,8 +6,8 @@ use App\Enums\ChannelVisibility;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\NameSlug;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class CreateChannel
 {
@@ -28,7 +28,7 @@ class CreateChannel
 
             $channel = $team->channels()->create([
                 'name' => $name,
-                'slug' => Str::slug($name),
+                'slug' => NameSlug::distinct($name, Channel::FALLBACK_SLUG),
                 'visibility' => $visibility,
                 'topic' => $topic,
                 'created_by' => $creator->id,

--- a/app/Concerns/GeneratesUniqueTeamSlugs.php
+++ b/app/Concerns/GeneratesUniqueTeamSlugs.php
@@ -7,11 +7,16 @@ use Illuminate\Support\Str;
 trait GeneratesUniqueTeamSlugs
 {
     /**
+     * Slug used as the base when a name carries no sluggable characters.
+     */
+    private const string FALLBACK_SLUG = 'team';
+
+    /**
      * Generate a unique slug for the team.
      */
     protected static function generateUniqueTeamSlug(string $name, ?string $excludeId = null): string
     {
-        $defaultSlug = Str::slug($name);
+        $defaultSlug = self::sluggifyTeamName($name);
 
         $query = static::withTrashed()
             ->where(function ($query) use ($defaultSlug): void {
@@ -42,5 +47,23 @@ trait GeneratesUniqueTeamSlugs
         return $existingSlugs->isEmpty()
             ? $defaultSlug
             : $defaultSlug.'-'.($maxSuffix + 1);
+    }
+
+    /**
+     * Slug a team name, falling back when the name slugs to nothing.
+     *
+     * Str::slug() transliterates what it can (Cyrillic, Greek and Arabic all
+     * survive) but strips every character it has no Latin equivalent for, so a
+     * name written entirely in e.g. Japanese, Korean or Hebrew — or in
+     * punctuation or emoji — comes back empty. An empty slug is unusable as a
+     * route key and would make the team unreachable (issue #921), so such a
+     * name gets the generic base instead and the caller's suffix machinery
+     * keeps it unique.
+     */
+    private static function sluggifyTeamName(string $name): string
+    {
+        $slug = Str::slug($name);
+
+        return $slug === '' ? self::FALLBACK_SLUG : $slug;
     }
 }

--- a/app/Concerns/GeneratesUniqueTeamSlugs.php
+++ b/app/Concerns/GeneratesUniqueTeamSlugs.php
@@ -2,7 +2,7 @@
 
 namespace App\Concerns;
 
-use Illuminate\Support\Str;
+use App\Support\NameSlug;
 
 trait GeneratesUniqueTeamSlugs
 {
@@ -52,18 +52,12 @@ trait GeneratesUniqueTeamSlugs
     /**
      * Slug a team name, falling back when the name slugs to nothing.
      *
-     * Str::slug() transliterates what it can (Cyrillic, Greek and Arabic all
-     * survive) but strips every character it has no Latin equivalent for, so a
-     * name written entirely in e.g. Japanese, Korean or Hebrew — or in
-     * punctuation or emoji — comes back empty. An empty slug is unusable as a
-     * route key and would make the team unreachable (issue #921), so such a
-     * name gets the generic base instead and the caller's suffix machinery
-     * keeps it unique.
+     * A name with no sluggable characters would otherwise leave the team with
+     * an empty slug and so unreachable (issue #921); it gets the generic base
+     * instead, and the suffix machinery above keeps that unique.
      */
     private static function sluggifyTeamName(string $name): string
     {
-        $slug = Str::slug($name);
-
-        return $slug === '' ? self::FALLBACK_SLUG : $slug;
+        return NameSlug::make($name, self::FALLBACK_SLUG);
     }
 }

--- a/app/Http/Requests/Api/V1/StoreChannelRequest.php
+++ b/app/Http/Requests/Api/V1/StoreChannelRequest.php
@@ -6,10 +6,10 @@ use App\Enums\ChannelVisibility;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Support\Integrations\ApiChannelAccess;
+use App\Support\NameSlug;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
@@ -72,7 +72,7 @@ class StoreChannelRequest extends ApiRequest
 
                 $exists = Channel::query()
                     ->where('team_id', $this->team()->id)
-                    ->where('slug', Str::slug((string) $this->input('name')))
+                    ->where('slug', NameSlug::distinct((string) $this->input('name'), Channel::FALLBACK_SLUG))
                     ->exists();
 
                 if ($exists) {

--- a/app/Http/Requests/Channels/CreateChannelRequest.php
+++ b/app/Http/Requests/Channels/CreateChannelRequest.php
@@ -5,11 +5,11 @@ namespace App\Http\Requests\Channels;
 use App\Enums\ChannelVisibility;
 use App\Models\Channel;
 use App\Models\Team;
+use App\Support\NameSlug;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
@@ -61,7 +61,7 @@ class CreateChannelRequest extends FormRequest
                     return;
                 }
 
-                $slug = Str::slug((string) $this->input('name'));
+                $slug = NameSlug::distinct((string) $this->input('name'), Channel::FALLBACK_SLUG);
 
                 $exists = Channel::query()
                     ->where('team_id', $this->team()->id)

--- a/app/Http/Requests/Teams/StoreUserGroupRequest.php
+++ b/app/Http/Requests/Teams/StoreUserGroupRequest.php
@@ -4,10 +4,10 @@ namespace App\Http\Requests\Teams;
 
 use App\Concerns\ResolvesUserGroupRoute;
 use App\Models\UserGroup;
+use App\Support\NameSlug;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class StoreUserGroupRequest extends FormRequest
@@ -36,7 +36,9 @@ class StoreUserGroupRequest extends FormRequest
     protected function prepareForValidation(): void
     {
         if (blank($this->input('slug'))) {
-            $this->merge(['slug' => Str::slug((string) $this->input('name'))]);
+            $this->merge([
+                'slug' => NameSlug::distinct((string) $this->input('name'), UserGroup::FALLBACK_SLUG),
+            ]);
         }
     }
 

--- a/app/Http/Requests/Teams/UpdateUserGroupRequest.php
+++ b/app/Http/Requests/Teams/UpdateUserGroupRequest.php
@@ -3,10 +3,11 @@
 namespace App\Http\Requests\Teams;
 
 use App\Concerns\ResolvesUserGroupRoute;
+use App\Models\UserGroup;
+use App\Support\NameSlug;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class UpdateUserGroupRequest extends FormRequest
@@ -28,7 +29,9 @@ class UpdateUserGroupRequest extends FormRequest
     protected function prepareForValidation(): void
     {
         if (blank($this->input('slug'))) {
-            $this->merge(['slug' => Str::slug((string) $this->input('name'))]);
+            $this->merge([
+                'slug' => NameSlug::distinct((string) $this->input('name'), UserGroup::FALLBACK_SLUG),
+            ]);
         }
     }
 

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\ChannelType;
 use App\Enums\ChannelVisibility;
+use App\Support\NameSlug;
 use Database\Factories\ChannelFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
@@ -49,6 +50,31 @@ class Channel extends Model
      * The reserved slug of the auto-created, undeletable channel.
      */
     public const string GENERAL_SLUG = 'general';
+
+    /**
+     * Slug base used when a channel name carries no sluggable characters.
+     */
+    public const string FALLBACK_SLUG = 'channel';
+
+    /**
+     * Keep a usable slug on the row however the channel is written.
+     *
+     * The slug is the route key ({@see getRouteKeyName()}), so a blank one
+     * leaves the channel unreachable with no UI path back to it (issue #924).
+     * The create path derives the slug itself; this is the backstop for every
+     * other writer, including a slug blanked on an existing row.
+     */
+    #[\Override]
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::saving(function (Channel $channel): void {
+            if (blank($channel->slug)) {
+                $channel->slug = NameSlug::distinct((string) $channel->name, self::FALLBACK_SLUG);
+            }
+        });
+    }
 
     /**
      * Determine whether this is the team's protected #general channel.

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -46,15 +46,21 @@ class Team extends Model
     {
         parent::boot();
 
-        static::creating(function (Team $team): void {
-            if (empty($team->slug)) {
-                $team->slug = static::generateUniqueTeamSlug($team->name);
-            }
-        });
-
-        static::updating(function (Team $team): void {
-            if ($team->isDirty('name')) {
-                $team->slug = static::generateUniqueTeamSlug($team->name, $team->id);
+        /**
+         * Keep the slug present and in step with the name on every write.
+         *
+         * The slug is the route key ({@see getRouteKeyName()}), so a blank one
+         * makes the team unreachable with no UI path back to it (issue #921).
+         * Guarding on `saving` rather than on `creating`/`updating` covers the
+         * three ways a blank slug could otherwise be persisted: a create with
+         * no slug, a rename, and a slug explicitly blanked without a rename.
+         */
+        static::saving(function (Team $team): void {
+            if (blank($team->slug) || ($team->exists && $team->isDirty('name'))) {
+                $team->slug = static::generateUniqueTeamSlug(
+                    (string) $team->name,
+                    $team->exists ? $team->id : null,
+                );
             }
         });
     }

--- a/app/Models/UserGroup.php
+++ b/app/Models/UserGroup.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\NameSlug;
 use Database\Factories\UserGroupFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
@@ -28,6 +29,30 @@ class UserGroup extends Model
 {
     /** @use HasFactory<UserGroupFactory> */
     use HasFactory, HasUuids;
+
+    /**
+     * Slug base used when a group name carries no sluggable characters.
+     */
+    public const string FALLBACK_SLUG = 'group';
+
+    /**
+     * Keep a usable handle on the row however the group is written.
+     *
+     * The handle is what people type after `@`, so a blank one makes the group
+     * unmentionable (issue #924). The form requests derive it from the name
+     * when it is left blank; this is the backstop for every other writer.
+     */
+    #[\Override]
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::saving(function (UserGroup $group): void {
+            if (blank($group->slug)) {
+                $group->slug = NameSlug::distinct($group->name, self::FALLBACK_SLUG);
+            }
+        });
+    }
 
     /**
      * Get the team this group belongs to. A group is workspace-scoped and can be

--- a/app/Support/NameSlug.php
+++ b/app/Support/NameSlug.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Support;
+
+use App\Concerns\GeneratesUniqueTeamSlugs;
+use Illuminate\Support\Str;
+
+/**
+ * Derives a usable slug from a display name.
+ *
+ * Str::slug() transliterates what it can (Cyrillic, Greek and Arabic all
+ * survive) but strips every character it has no Latin equivalent for, so a name
+ * written entirely in e.g. Japanese, Korean or Hebrew — or in punctuation or
+ * emoji — comes back empty. Slugs are route keys here, so an empty one makes
+ * the record unreachable with no UI path back to it (issues #921 and #924).
+ */
+final class NameSlug
+{
+    /**
+     * The number of fingerprint characters appended to a fallback base.
+     *
+     * Eight hex characters keep a collision between two different names far
+     * rarer than the name clash the caller already has to handle anyway, while
+     * staying short enough to read in a URL.
+     */
+    private const int FINGERPRINT_LENGTH = 8;
+
+    /**
+     * Slug a name, falling back to the given base when nothing survives.
+     *
+     * The base is shared by every unsluggable name, so this suits a caller that
+     * resolves collisions itself — {@see GeneratesUniqueTeamSlugs}
+     * keeps team slugs unique with a numeric suffix.
+     */
+    public static function make(string $name, string $fallback): string
+    {
+        $slug = Str::slug($name);
+
+        return $slug === '' ? $fallback : $slug;
+    }
+
+    /**
+     * Slug a name, falling back to a base that stays specific to that name.
+     *
+     * Unlike {@see make()}, two different unsluggable names get two different
+     * slugs, so a caller whose slugs are unique per team does not have to probe
+     * the database to avoid a clash. The fallback is derived from the name
+     * alone, which lets a validation pre-check compute exactly the slug the
+     * write path will store — the guarantee that keeps a non-Latin channel name
+     * from being rejected as already taken (issue #924).
+     */
+    public static function distinct(string $name, string $fallback): string
+    {
+        return self::make($name, $fallback.'-'.self::fingerprint($name));
+    }
+
+    /**
+     * A short, stable, slug-safe digest of a name.
+     */
+    private static function fingerprint(string $name): string
+    {
+        return substr(hash('xxh128', $name), 0, self::FINGERPRINT_LENGTH);
+    }
+}

--- a/database/migrations/2026_07_26_131207_repair_empty_team_slugs.php
+++ b/database/migrations/2026_07_26_131207_repair_empty_team_slugs.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Team;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Give a usable slug back to teams left with a blank one.
+     *
+     * Team slugs were derived with Str::slug() alone, which returns an empty
+     * string for a name it cannot transliterate (Japanese, Korean, Hebrew,
+     * punctuation, emoji). The slug is the route key, so such a team became
+     * unreachable and its owner had to repair the row by hand (issue #921).
+     * The generator now falls back to a generic base, and re-saving the row
+     * runs it: the model guard regenerates a blank slug on save. Soft-deleted
+     * teams are included so a later restore does not resurrect the problem.
+     *
+     * A no-op on any instance that never hit the bug — which is every fresh
+     * install, since the generator can no longer produce a blank slug.
+     */
+    public function up(): void
+    {
+        Team::withTrashed()
+            ->whereRaw("trim(slug) = ''")
+            ->get()
+            ->each(function (Team $team): void {
+                $team->save();
+            });
+    }
+
+    /**
+     * Irreversible: which teams held a blank slug is not recoverable, and
+     * putting one back would only make those teams unreachable again.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2026_07_26_134641_repair_empty_channel_and_group_slugs.php
+++ b/database/migrations/2026_07_26_134641_repair_empty_channel_and_group_slugs.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\UserGroup;
+use App\Support\NameSlug;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Give a usable slug back to channels and groups left with a blank one.
+     *
+     * Both derived their slug with Str::slug() alone, which returns an empty
+     * string for a name it cannot transliterate (Japanese, Korean, Hebrew,
+     * punctuation, emoji). A channel slug is the route key, so such a channel
+     * became unreachable with no UI path back to it, and a blank group handle
+     * cannot be mentioned (issue #924). Both are now derived through
+     * {@see NameSlug}, and this repairs the rows written before that.
+     *
+     * A no-op on any instance that never hit the bug — which is every fresh
+     * install, since neither slug can be blank any more.
+     */
+    public function up(): void
+    {
+        Channel::query()
+            ->whereRaw("trim(slug) = ''")
+            ->get()
+            ->each(function (Channel $channel): void {
+                $channel->slug = $this->availableSlug($channel, Channel::FALLBACK_SLUG);
+                $channel->save();
+            });
+
+        UserGroup::query()
+            ->whereRaw("trim(slug) = ''")
+            ->get()
+            ->each(function (UserGroup $group): void {
+                $group->slug = $this->availableSlug($group, UserGroup::FALLBACK_SLUG);
+                $group->save();
+            });
+    }
+
+    /**
+     * Irreversible: which rows held a blank slug is not recoverable, and
+     * restoring one would put the record back out of reach anyway.
+     */
+    public function down(): void
+    {
+        //
+    }
+
+    /**
+     * The record's derived slug, stepped past anything already using it.
+     *
+     * Both tables are unique on (team_id, slug). The derived slug is specific
+     * to the name, so a clash needs a sibling already holding exactly that
+     * slug — vanishingly unlikely, but a migration that throws would block the
+     * upgrade, so it is handled rather than assumed away.
+     */
+    private function availableSlug(Channel|UserGroup $record, string $fallback): string
+    {
+        $base = NameSlug::distinct((string) $record->name, $fallback);
+        $slug = $base;
+
+        for ($suffix = 1; $this->slugTaken($record, $slug); $suffix++) {
+            $slug = $base.'-'.$suffix;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Determine whether a sibling in the same team already holds the slug.
+     */
+    private function slugTaken(Channel|UserGroup $record, string $slug): bool
+    {
+        return $record->newQuery()
+            ->where('team_id', $record->team_id)
+            ->where('slug', $slug)
+            ->whereKeyNot($record->getKey())
+            ->exists();
+    }
+};

--- a/tests/Feature/Api/V1/ChannelApiTest.php
+++ b/tests/Feature/Api/V1/ChannelApiTest.php
@@ -96,6 +96,40 @@ it('rejects a duplicate channel name', function (): void {
     ])->assertStatus(422)->assertJsonValidationErrorFor('name');
 });
 
+it('creates two channels named in a non-Latin script without a false duplicate', function (): void {
+    Sanctum::actingAs($this->bot, ['channels:write']);
+
+    foreach (['日本語', '中文'] as $name) {
+        $this->postJson('/api/v1/channels', [
+            'name' => $name,
+            'visibility' => ChannelVisibility::Public->value,
+        ])->assertCreated();
+    }
+
+    $slugs = Channel::query()
+        ->where('team_id', $this->team->id)
+        ->whereIn('name', ['日本語', '中文'])
+        ->pluck('slug');
+
+    expect($slugs)->toHaveCount(2)
+        ->and($slugs->unique())->toHaveCount(2)
+        ->and($slugs->filter(fn (string $slug): bool => $slug === ''))->toBeEmpty();
+});
+
+it('still rejects a repeated non-Latin channel name', function (): void {
+    Sanctum::actingAs($this->bot, ['channels:write']);
+
+    $this->postJson('/api/v1/channels', [
+        'name' => '日本語',
+        'visibility' => ChannelVisibility::Public->value,
+    ])->assertCreated();
+
+    $this->postJson('/api/v1/channels', [
+        'name' => '日本語',
+        'visibility' => ChannelVisibility::Public->value,
+    ])->assertStatus(422)->assertJsonValidationErrorFor('name');
+});
+
 it('archives a channel the bot created and audits it', function (): void {
     $channel = Channel::factory()->for($this->team)->create(['created_by' => $this->bot->id]);
     $channel->channelMembers()->create(['user_id' => $this->bot->id]);

--- a/tests/Feature/Channels/ChannelModelTest.php
+++ b/tests/Feature/Channels/ChannelModelTest.php
@@ -29,3 +29,22 @@ test('channel visibility exposes a human label', function (): void {
     expect(ChannelVisibility::Public->label())->toBe('Public')
         ->and(ChannelVisibility::Private->label())->toBe('Private');
 });
+
+test('a channel cannot be saved with a blank slug', function (?string $slug): void {
+    $channel = Channel::factory()->create(['name' => '日本語', 'slug' => $slug]);
+
+    expect(trim($channel->fresh()->slug))->not->toBe('');
+})->with([
+    'empty' => [''],
+    'whitespace' => ['   '],
+    'null' => [null],
+]);
+
+test('a channel whose slug is blanked later has it regenerated on save', function (): void {
+    $channel = Channel::factory()->create(['name' => 'Marketing', 'slug' => 'marketing']);
+
+    $channel->slug = '';
+    $channel->save();
+
+    expect($channel->fresh()->slug)->toBe('marketing');
+});

--- a/tests/Feature/Channels/CreateChannelTest.php
+++ b/tests/Feature/Channels/CreateChannelTest.php
@@ -75,6 +75,72 @@ test('the same channel name may exist in different teams', function (): void {
     expect(Channel::where('team_id', $teamB->id)->where('slug', 'marketing')->exists())->toBeTrue();
 });
 
+test('a channel named in a non-Latin script stays reachable', function (string $name): void {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)
+        ->post(route('channels.store', ['team' => $team->slug]), [
+            'name' => $name,
+            'visibility' => 'public',
+        ])
+        ->assertSessionHasNoErrors();
+
+    $channel = Channel::where('team_id', $team->id)->where('name', $name)->sole();
+
+    expect($channel->slug)->not->toBe('');
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertOk();
+})->with([
+    'japanese' => ['日本語'],
+    'korean' => ['한국어'],
+    'hebrew' => ['עברית'],
+    'punctuation' => ['<<<'],
+    'emoji' => ['🎉🎉'],
+]);
+
+test('two channels named in a non-Latin script coexist in one team', function (): void {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    foreach (['日本語', '中文'] as $name) {
+        $this->actingAs($owner)
+            ->post(route('channels.store', ['team' => $team->slug]), [
+                'name' => $name,
+                'visibility' => 'public',
+            ])
+            ->assertSessionHasNoErrors();
+    }
+
+    $slugs = Channel::where('team_id', $team->id)->whereIn('name', ['日本語', '中文'])->pluck('slug');
+
+    expect($slugs)->toHaveCount(2)
+        ->and($slugs->unique())->toHaveCount(2);
+});
+
+test('a repeated non-Latin channel name is still reported as already existing', function (): void {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)
+        ->post(route('channels.store', ['team' => $team->slug]), [
+            'name' => '日本語',
+            'visibility' => 'public',
+        ])
+        ->assertSessionHasNoErrors();
+
+    $this->actingAs($owner)
+        ->post(route('channels.store', ['team' => $team->slug]), [
+            'name' => '日本語',
+            'visibility' => 'public',
+        ])
+        ->assertSessionHasErrors('name');
+
+    expect(Channel::where('team_id', $team->id)->where('name', '日本語')->count())->toBe(1);
+});
+
 test('creating a channel requires a valid visibility', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');

--- a/tests/Feature/Channels/RepairEmptySlugsMigrationTest.php
+++ b/tests/Feature/Channels/RepairEmptySlugsMigrationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\UserGroup;
+use App\Support\NameSlug;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Load the slug-repair data migration as an instance so its up() can be
+ * exercised against rows blanked behind the models' backs (RefreshDatabase has
+ * already run it once, on empty tables, during setup).
+ */
+function repairEmptyChannelAndGroupSlugsMigration(): object
+{
+    return require base_path('database/migrations/2026_07_26_134641_repair_empty_channel_and_group_slugs.php');
+}
+
+/**
+ * Blank a row's slug without going through the model guard.
+ */
+function blankSlug(string $table, string $id, string $slug = ''): void
+{
+    DB::table($table)->where('id', $id)->update(['slug' => $slug]);
+}
+
+test('the migration gives every blank-slug channel a usable slug', function (): void {
+    $team = Team::factory()->create();
+    $japanese = Channel::factory()->for($team)->create(['name' => '日本語']);
+    $punctuation = Channel::factory()->for($team)->create(['name' => '<<<']);
+
+    blankSlug('channels', $japanese->id);
+    blankSlug('channels', $punctuation->id, '  ');
+
+    repairEmptyChannelAndGroupSlugsMigration()->up();
+
+    $slugs = collect([$japanese, $punctuation])->map(fn (Channel $channel): string => $channel->fresh()->slug);
+
+    expect($slugs->filter(fn (string $slug): bool => trim($slug) === ''))->toBeEmpty()
+        ->and($slugs->unique())->toHaveCount(2);
+});
+
+test('the migration gives every blank-slug group a usable handle', function (): void {
+    $team = Team::factory()->create();
+    $group = UserGroup::factory()->for($team)->create(['name' => '日本語']);
+
+    blankSlug('user_groups', $group->id);
+
+    repairEmptyChannelAndGroupSlugsMigration()->up();
+
+    expect($group->fresh()->slug)->toMatch('/^[a-z0-9]+(?:-[a-z0-9]+)*$/');
+});
+
+test('the migration steps around a slug already taken in the team', function (): void {
+    $team = Team::factory()->create();
+    $occupied = NameSlug::distinct('日本語', Channel::FALLBACK_SLUG);
+
+    $squatter = Channel::factory()->for($team)->create(['name' => 'Squatter', 'slug' => $occupied]);
+    $blank = Channel::factory()->for($team)->create(['name' => '日本語']);
+
+    blankSlug('channels', $blank->id);
+
+    repairEmptyChannelAndGroupSlugsMigration()->up();
+
+    expect($blank->fresh()->slug)->toBe($occupied.'-1')
+        ->and($squatter->fresh()->slug)->toBe($occupied);
+});
+
+test('the migration leaves healthy slugs alone', function (): void {
+    $team = Team::factory()->create();
+    $channel = Channel::factory()->for($team)->create(['name' => 'Marketing', 'slug' => 'marketing']);
+    $group = UserGroup::factory()->for($team)->create(['name' => 'Dev Team', 'slug' => 'dev-team']);
+
+    repairEmptyChannelAndGroupSlugsMigration()->up();
+
+    expect($channel->fresh()->slug)->toBe('marketing')
+        ->and($group->fresh()->slug)->toBe('dev-team');
+});

--- a/tests/Feature/Concerns/GeneratesUniqueTeamSlugsTest.php
+++ b/tests/Feature/Concerns/GeneratesUniqueTeamSlugsTest.php
@@ -17,3 +17,51 @@ test('a fresh name keeps its bare slug', function (): void {
 
     expect($team->slug)->toBe('unique-co');
 });
+
+test('a name that slugs to nothing falls back to a usable slug', function (string $name): void {
+    $team = Team::factory()->create(['name' => $name, 'slug' => '']);
+
+    expect($team->slug)->toBe('team');
+})->with([
+    'japanese' => ['日本語'],
+    'korean' => ['팀'],
+    'hebrew' => ['צוות'],
+    'punctuation only' => ['<<<'],
+    'emoji only' => ['🎉'],
+]);
+
+test('two names that slug to nothing get distinct slugs', function (): void {
+    $first = Team::factory()->create(['name' => '日本語', 'slug' => '']);
+    $second = Team::factory()->create(['name' => '中文团队', 'slug' => '']);
+    $third = Team::factory()->create(['name' => '!!!', 'slug' => '']);
+
+    expect([$first->slug, $second->slug, $third->slug])->toBe(['team', 'team-1', 'team-2']);
+});
+
+test('renaming to a name that slugs to nothing falls back to a usable slug', function (string $name): void {
+    $team = Team::factory()->create(['name' => 'Acme', 'slug' => 'acme']);
+
+    $team->update(['name' => $name]);
+
+    expect($team->fresh()->slug)->toBe('team');
+})->with([
+    'japanese' => ['日本語'],
+    'punctuation only' => ['<<<'],
+]);
+
+test('a slug blanked without a rename is regenerated from the name', function (): void {
+    $team = Team::factory()->create(['name' => 'Acme', 'slug' => 'acme']);
+
+    $team->update(['slug' => '   ']);
+
+    expect($team->fresh()->slug)->toBe('acme');
+});
+
+test('a name transliterated by the slugger keeps its transliteration', function (string $name, string $slug): void {
+    $team = Team::factory()->create(['name' => $name, 'slug' => '']);
+
+    expect($team->slug)->toBe($slug);
+})->with([
+    'cyrillic' => ['Привет мир', 'privet-mir'],
+    'greek' => ['Ελλάδα', 'ellada'],
+]);

--- a/tests/Feature/Teams/RepairEmptyTeamSlugsMigrationTest.php
+++ b/tests/Feature/Teams/RepairEmptyTeamSlugsMigrationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\Team;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Load the slug-repair data migration as an instance so its up() can be
+ * exercised against rows blanked behind the model's back (RefreshDatabase has
+ * already run it once, on an empty table, during setup).
+ */
+function repairEmptyTeamSlugsMigration(): object
+{
+    return require base_path('database/migrations/2026_07_26_131207_repair_empty_team_slugs.php');
+}
+
+test('the migration gives every blank-slug team a usable, unique slug', function (): void {
+    $japanese = Team::factory()->create(['name' => '日本語']);
+    $punctuation = Team::factory()->create(['name' => '<<<']);
+
+    DB::table('teams')->where('id', $japanese->id)->update(['slug' => '']);
+    DB::table('teams')->where('id', $punctuation->id)->update(['slug' => '  ']);
+
+    repairEmptyTeamSlugsMigration()->up();
+
+    $repaired = collect([$japanese, $punctuation])
+        ->map(fn (Team $team): string => $team->fresh()->slug)
+        ->sort()
+        ->values()
+        ->all();
+
+    expect($repaired)->toBe(['team', 'team-1']);
+});
+
+test('the migration repairs a soft-deleted team too', function (): void {
+    $team = Team::factory()->trashed()->create(['name' => '팀']);
+
+    DB::table('teams')->where('id', $team->id)->update(['slug' => '']);
+
+    repairEmptyTeamSlugsMigration()->up();
+
+    expect(Team::withTrashed()->find($team->id)->slug)->toBe('team');
+});
+
+test('the migration leaves healthy slugs alone', function (): void {
+    $team = Team::factory()->create(['name' => 'Acme', 'slug' => 'acme']);
+
+    repairEmptyTeamSlugsMigration()->up();
+
+    expect($team->fresh()->slug)->toBe('acme');
+});

--- a/tests/Feature/Teams/TeamTest.php
+++ b/tests/Feature/Teams/TeamTest.php
@@ -65,6 +65,51 @@ test('team slug uses next available suffix', function (): void {
     ]);
 });
 
+test('a team created with a name that slugs to nothing stays reachable', function (): void {
+    $user = User::factory()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->post(route('teams.store'), [
+            'name' => '日本語',
+        ]);
+
+    $team = Team::query()->where('name', '日本語')->sole();
+
+    expect($team->slug)->not->toBe('');
+
+    $response->assertRedirect(route('teams.edit', $team));
+
+    $this
+        ->actingAs($user)
+        ->get(route('teams.edit', $team))
+        ->assertOk();
+});
+
+test('a team renamed to a name that slugs to nothing stays reachable', function (): void {
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['name' => 'Original Name']);
+
+    $team->members()->attach($user, ['role' => TeamRole::Owner->value]);
+
+    $response = $this
+        ->actingAs($user)
+        ->patch(route('teams.update', $team), [
+            'name' => '<<<',
+        ]);
+
+    $renamed = $team->fresh();
+
+    expect($renamed->slug)->not->toBe('');
+
+    $response->assertRedirect(route('teams.edit', $renamed));
+
+    $this
+        ->actingAs($user)
+        ->get(route('teams.edit', $renamed))
+        ->assertOk();
+});
+
 test('the team edit page can be rendered', function (): void {
     $user = User::factory()->create();
     $team = Team::factory()->create();

--- a/tests/Feature/Teams/UserGroupTest.php
+++ b/tests/Feature/Teams/UserGroupTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
+use App\Http\Requests\Teams\StoreUserGroupRequest;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\UserGroup;
@@ -81,12 +82,43 @@ test('a handle that is not lowercase kebab-case is rejected', function (string $
         ->assertSessionHasErrors('slug');
 })->with(['Dev Team', 'dev_team', 'DevTeam', '-devs', 'devs-', 'dev--team', 'dév']);
 
-test('a name that derives to an empty handle is rejected', function (): void {
+test('a name that slugs to nothing still derives a usable handle', function (string $name): void {
     [$owner, $team] = userGroupTeam();
 
     $this->actingAs($owner)
-        ->post(route('teams.groups.store', $team), ['name' => '!!!'])
-        ->assertSessionHasErrors('slug');
+        ->post(route('teams.groups.store', $team), ['name' => $name])
+        ->assertSessionHasNoErrors();
+
+    expect(UserGroup::sole()->slug)->toMatch(StoreUserGroupRequest::SLUG_PATTERN);
+})->with([
+    'japanese' => ['日本語'],
+    'korean' => ['한국어'],
+    'hebrew' => ['עברית'],
+    'punctuation' => ['!!!'],
+    'emoji' => ['🎉🎉'],
+]);
+
+test('two groups whose names slug to nothing get distinct handles', function (): void {
+    [$owner, $team] = userGroupTeam();
+
+    foreach (['日本語', '中文'] as $name) {
+        $this->actingAs($owner)
+            ->post(route('teams.groups.store', $team), ['name' => $name])
+            ->assertSessionHasNoErrors();
+    }
+
+    expect(UserGroup::pluck('slug')->unique())->toHaveCount(2);
+});
+
+test('renaming a group to a name that slugs to nothing keeps a usable handle', function (): void {
+    [$owner, $team] = userGroupTeam();
+    $group = UserGroup::factory()->for($team)->slug('dev-team')->create();
+
+    $this->actingAs($owner)
+        ->patch(route('teams.groups.update', [$team, $group]), ['name' => '日本語'])
+        ->assertSessionHasNoErrors();
+
+    expect($group->fresh()->slug)->toMatch(StoreUserGroupRequest::SLUG_PATTERN);
 });
 
 test('an admin manages groups but a plain member may not', function (): void {
@@ -275,3 +307,13 @@ test('leaving the workspace drops you from its groups', function (): void {
 
     expect($group->members()->count())->toBe(0);
 });
+
+test('a group cannot be saved with a blank handle', function (?string $slug): void {
+    $group = UserGroup::factory()->create(['name' => '日本語', 'slug' => $slug]);
+
+    expect($group->fresh()->slug)->toMatch(StoreUserGroupRequest::SLUG_PATTERN);
+})->with([
+    'empty' => [''],
+    'whitespace' => ['   '],
+    'null' => [null],
+]);

--- a/tests/Unit/Support/NameSlugTest.php
+++ b/tests/Unit/Support/NameSlugTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\NameSlug;
+
+test('a name that slugs to something keeps its slug', function (string $name, string $expected): void {
+    expect(NameSlug::make($name, 'thing'))->toBe($expected)
+        ->and(NameSlug::distinct($name, 'thing'))->toBe($expected);
+})->with([
+    'latin' => ['Marketing', 'marketing'],
+    'mixed case and spaces' => ['Dev Team', 'dev-team'],
+    'cyrillic transliterates' => ['Привет', 'privet'],
+    'greek transliterates' => ['Ελλάδα', 'ellada'],
+    'latin survives alongside emoji' => ['Launch 🎉', 'launch'],
+]);
+
+test('a name that slugs to nothing falls back to the given base', function (string $name): void {
+    expect(NameSlug::make($name, 'thing'))->toBe('thing');
+})->with([
+    'japanese' => ['日本語'],
+    'korean' => ['한국어'],
+    'hebrew' => ['עברית'],
+    'punctuation' => ['<<<'],
+    'emoji' => ['🎉🎉'],
+]);
+
+test('distinct keeps two unsluggable names apart', function (): void {
+    $japanese = NameSlug::distinct('日本語', 'channel');
+    $chinese = NameSlug::distinct('中文', 'channel');
+
+    expect($japanese)->not->toBe($chinese)
+        ->and($japanese)->toStartWith('channel-')
+        ->and($chinese)->toStartWith('channel-');
+});
+
+test('distinct is stable for the same name, so a pre-check can reproduce it', function (): void {
+    expect(NameSlug::distinct('日本語', 'channel'))->toBe(NameSlug::distinct('日本語', 'channel'));
+});
+
+test('a fallback slug is usable as a route key and as a group handle', function (string $name): void {
+    expect(NameSlug::distinct($name, 'group'))->toMatch('/^[a-z0-9]+(?:-[a-z0-9]+)*$/');
+})->with([
+    'japanese' => ['日本語'],
+    'punctuation' => ['<<<'],
+    'emoji' => ['🎉🎉'],
+]);


### PR DESCRIPTION
Closes #921.

## What

`Team::generateUniqueTeamSlug()` derived the slug with a bare `Str::slug()`, which strips every character it has no Latin equivalent for. A team named entirely in Japanese, Korean or Hebrew (or in punctuation or emoji) got `slug = ''`, and since the slug is the route key the team became unreachable: `/settings/teams/` 404s and there is no UI path back to it, so the owner had to repair the row by hand. It hit creation as well as rename.

## How

- **Fallback base.** `Str::slug()` already transliterates what it can (Cyrillic, Greek and Arabic survive, and there are now tests pinning that), so only the empty result is redirected: it falls back to the generic base `team`, and the existing suffix machinery keeps it unique (`team`, `team-1`, …).
- **One guard on `saving`.** The `creating` + `updating` hooks collapse into a single `saving` hook, so the three ways a blank slug could be persisted through the model are all covered: a create with no slug, a rename, and a slug explicitly blanked without a rename. Externally the behaviour is unchanged: an explicitly supplied slug is still respected, and a rename still re-slugs.
- **Repair migration** for instances that already hit the bug, since the affected owner is locked out today. It re-saves every blank-slug row (soft-deleted ones included, so a later restore doesn't resurrect the problem) and lets the model guard regenerate the slug. A no-op on a fresh install.

Note this also fixes a second facet: `teams.slug` is unique, so with one empty-slug team already present, creating a second non-Latin team failed on the unique index.

## Testing

- `tests/Feature/Concerns/GeneratesUniqueTeamSlugsTest.php`: fallback on create for Japanese/Korean/Hebrew/punctuation/emoji names, distinct slugs for three such names, fallback on rename, regeneration of a blanked slug, and transliteration kept for Cyrillic/Greek.
- `tests/Feature/Teams/TeamTest.php`: the reported symptom at the HTTP seam — create and rename with such a name, then the redirect target and `teams.edit` both resolve. Both were verified red against the unfixed generator.
- `tests/Feature/Teams/RepairEmptyTeamSlugsMigrationTest.php`: the migration repairs blank and whitespace-only slugs (including a soft-deleted team) and leaves healthy slugs alone.
- Full gate green: `composer test` at `Total: 100.0 %` with Pint, PHPStan and Rector clean, plus `lint:check` / `format:check` / `types:check`.

No new user-facing copy, so no `lang/fr.json` change; nothing operator-facing, so no `docs/` change.

## Found while implementing

#924 — channels (`CreateChannel`) and user-group handles derive their slug the same way and hit the same failure. Left out of scope here; channels are the worse case, since an empty channel slug is also a lockout and the second such channel is rejected as "already exists".

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787664526&installation_model_id=428379&pr_number=925&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F925&signature=7ec0d9776850778a9b548ee469894bdec2043ce2669f3daf3ef652d8a51c3a2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->