### PR TITLE
fix: reject private and reserved hosts as web push endpoints

### DIFF
--- a/app/Http/Requests/Settings/StorePushSubscriptionRequest.php
+++ b/app/Http/Requests/Settings/StorePushSubscriptionRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Settings;
 
+use App\Rules\PublicWebhookUrl;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -18,17 +19,25 @@ class StorePushSubscriptionRequest extends FormRequest
      * services issue long URLs, and a longer one would fail at insert rather
      * than at validation.
      *
-     * HTTPS only. This value decides where the server itself posts every push,
-     * so a plaintext endpoint would put the delivery on the wire in the clear
-     * and let a signed-in user aim the instance's own requests wherever they
-     * like. Real push services are HTTPS without exception.
+     * HTTPS only, and public only. This value decides where the server itself
+     * posts every push, from a queue worker inside the instance's own network:
+     * a plaintext endpoint would put the delivery on the wire in the clear, and
+     * a private or reserved host would turn the subscription into a blind
+     * request forger aimed at whatever the app container can reach. Real push
+     * services are public HTTPS without exception, so the guard costs nothing.
      *
      * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
         return [
-            'endpoint' => ['required', 'string', 'url:https', 'max:500'],
+            'endpoint' => [
+                'required',
+                'string',
+                'url:https',
+                'max:500',
+                new PublicWebhookUrl(__('The push endpoint must be a public HTTPS address.')),
+            ],
             'keys.p256dh' => ['required', 'string', 'max:255'],
             'keys.auth' => ['required', 'string', 'max:255'],
             // Firefox's older endpoints negotiate `aesgcm`; everything current

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,7 @@ use App\Enums\TimeFormat;
 use App\Enums\UserType;
 use App\Observers\UserObserver;
 use App\Support\Gravatar;
+use App\Support\Http\OutboundUrlGuard;
 use App\Support\Images\ImageProxy;
 use App\Support\PresenceRegistry;
 use Carbon\CarbonInterface;
@@ -166,6 +167,27 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
         }
 
         return $this->status_expires_at === null || $this->status_expires_at->isFuture();
+    }
+
+    /**
+     * The subscribed devices a push may actually be delivered to.
+     *
+     * The store request already refuses a non-public endpoint at the door, so
+     * this re-check is the delivery-time half — the same belt-and-braces the
+     * webhook delivery job applies to a subscription's URL before it connects.
+     * It catches the rows the door never saw: subscriptions stored before the
+     * endpoint was validated, and hostnames repointed at a private address
+     * after the fact. The check is {@see OutboundUrlGuard::isPublic()}, which
+     * does no DNS lookup, because the push package owns the connection and
+     * leaves us nothing to pin a resolved IP to.
+     *
+     * @return Collection<int, PushSubscription>
+     */
+    public function routeNotificationForWebPush(): Collection
+    {
+        return $this->pushSubscriptions
+            ->filter(static fn (PushSubscription $subscription): bool => OutboundUrlGuard::isPublic($subscription->endpoint))
+            ->values();
     }
 
     /**

--- a/app/Rules/PublicWebhookUrl.php
+++ b/app/Rules/PublicWebhookUrl.php
@@ -9,13 +9,24 @@ use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 
 /**
- * Validation rule rejecting webhook destination URLs that aren't public
- * http/https addresses — the request-time half of the SSRF guard (see
+ * Validation rule rejecting member-supplied outbound destinations that aren't
+ * public http/https addresses — the request-time half of the SSRF guard (see
  * {@see OutboundUrlGuard}). Loopback, private, link-local, and cloud-metadata
- * targets fail here before a subscription is ever stored.
+ * targets fail here before the destination is ever stored.
+ *
+ * The rule kept its webhook-era name, but it guards every destination the
+ * server later opens a connection to on a member's say-so: webhook
+ * subscriptions and web push endpoints alike. Those surfaces call the URL
+ * different things, so the failure message is overridable.
  */
 class PublicWebhookUrl implements ValidationRule
 {
+    /**
+     * @param  string|null  $message  the failure message, when the surface calls
+     *                                the destination something other than a webhook URL
+     */
+    public function __construct(private readonly ?string $message = null) {}
+
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! is_string($value)) {
@@ -23,7 +34,7 @@ class PublicWebhookUrl implements ValidationRule
         }
 
         if (! OutboundUrlGuard::isPublic($value)) {
-            $fail(__('The webhook URL must be a public HTTP or HTTPS address.'));
+            $fail($this->message ?? __('The webhook URL must be a public HTTP or HTTPS address.'));
         }
     }
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -737,6 +737,7 @@
   "The team owner cannot be removed.": "Le propriétaire de l’équipe ne peut pas être retiré.",
   "The version this instance is running.": "La version exécutée par cette instance.",
   "The webhook URL must be a public HTTP or HTTPS address.": "L’URL du webhook doit être une adresse HTTP ou HTTPS publique.",
+  "The push endpoint must be a public HTTPS address.": "Le point de terminaison push doit être une adresse HTTPS publique.",
   "Theme": "Thème",
   "There are no public channels left to join.": "Il ne reste aucun canal public à rejoindre.",
   "This account cannot reset its password.": "Ce compte ne peut pas réinitialiser son mot de passe.",

--- a/tests/Feature/Settings/PushSubscriptionTest.php
+++ b/tests/Feature/Settings/PushSubscriptionTest.php
@@ -159,10 +159,42 @@ test('the subscription payload is validated', function (array $payload, string $
     // The server posts to this endpoint itself, so a plaintext one is both a
     // push payload sent in the clear and a destination an operator never chose.
     'a plaintext endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'http://push.example.test/device']), 'endpoint'],
+    // Nothing about a push endpoint is fetched by the browser: the instance
+    // posts to it from inside its own network, so a private or reserved host
+    // turns the subscription into a request forger pointed at whatever the app
+    // container can reach.
+    'a loopback endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'https://127.0.0.1:9200/_search']), 'endpoint'],
+    'a private-range endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'https://10.0.0.5/push']), 'endpoint'],
+    'a cloud-metadata endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'https://169.254.169.254/latest/meta-data/']), 'endpoint'],
+    'a localhost endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'https://localhost/push']), 'endpoint'],
+    'an internal-suffix endpoint' => [fn (): array => pushSubscriptionPayload(['endpoint' => 'https://internal-admin.internal/push']), 'endpoint'],
     'a missing public key' => [fn (): array => pushSubscriptionPayload(['keys' => ['auth' => 'auth-only']]), 'keys.p256dh'],
     'a missing auth token' => [fn (): array => pushSubscriptionPayload(['keys' => ['p256dh' => 'key-only']]), 'keys.auth'],
     'an unknown content encoding' => [fn (): array => pushSubscriptionPayload(['contentEncoding' => 'rot13']), 'contentEncoding'],
 ]);
+
+test('a stored endpoint that is not public is skipped at delivery time', function (): void {
+    $user = User::factory()->create();
+
+    // Straight to the model, the way a row stored before the endpoint was
+    // validated looks — or one whose hostname has since been repointed at a
+    // private address.
+    $user->updatePushSubscription('https://127.0.0.1:9200/_search', 'private-key', 'private-auth');
+    $user->updatePushSubscription('https://fcm.googleapis.com/fcm/send/device-one', 'public-key', 'public-auth');
+
+    expect($user->routeNotificationForWebPush()->pluck('endpoint')->all())
+        ->toBe(['https://fcm.googleapis.com/fcm/send/device-one']);
+});
+
+test('an instance that deliberately allows private endpoints still delivers to them', function (): void {
+    config(['integrations.webhooks.block_private_urls' => false]);
+
+    $user = User::factory()->create();
+
+    $user->updatePushSubscription('https://push.internal/device-one', 'public-key', 'public-auth');
+
+    expect($user->routeNotificationForWebPush())->toHaveCount(1);
+});
 
 test('the revoke payload requires an endpoint', function (): void {
     $this->actingAs(User::factory()->create())

--- a/tests/Feature/Support/OutboundUrlGuardTest.php
+++ b/tests/Feature/Support/OutboundUrlGuardTest.php
@@ -116,6 +116,16 @@ it('drives the PublicWebhookUrl validation rule', function (): void {
         ->and($fails->errors()->first('url'))->toBe('The webhook URL must be a public HTTP or HTTPS address.');
 });
 
+it('lets a surface name the destination in its own words', function (): void {
+    $fails = Validator::make(
+        ['endpoint' => 'https://127.0.0.1:9200/_search'],
+        ['endpoint' => new PublicWebhookUrl('The push endpoint must be a public HTTPS address.')],
+    );
+
+    expect($fails->fails())->toBeTrue()
+        ->and($fails->errors()->first('endpoint'))->toBe('The push endpoint must be a public HTTPS address.');
+});
+
 it('ignores a non-string value in the rule, leaving type validation to other rules', function (): void {
     $validator = Validator::make(['url' => ['array']], ['url' => new PublicWebhookUrl]);
 


### PR DESCRIPTION
Closes #904.

## What

A signed-in user could register any HTTPS URL as their web push endpoint, and the instance would then POST an encrypted push payload to it from a queue worker inside its own network — `https://127.0.0.1:9200/_search`, `https://169.254.169.254/latest/meta-data/`, `https://internal-admin.lan/whatever`. #905 closed the plaintext half with `url:https`; this closes the host half.

## How

**At the door.** `StorePushSubscriptionRequest` now runs `PublicWebhookUrl` on `endpoint` alongside `url:https`. Loopback, private ranges, link-local/cloud-metadata, `localhost`, and the `.local` / `.internal` / `.localhost` suffixes fail validation on `endpoint`.

The rule is reused rather than reimplemented, as the issue asked. It gained one optional constructor argument — the failure message — so the push surface can say "The push endpoint must be a public HTTPS address." instead of talking about a webhook URL. The check underneath is the same `OutboundUrlGuard::isPublic()`.

**At delivery.** The issue left open whether a subscription that was valid at registration but later resolves somewhere private should be dropped at send time too. `DeliverWebhook` already answers this for webhooks — it re-runs the guard before every connect — so `User::routeNotificationForWebPush()` now filters non-public endpoints out of the routed collection. That covers the rows the door never saw: subscriptions stored before this rule existed, and hostnames repointed at a private address afterwards. It uses the literal, no-DNS check only: unlike the webhook job, the push package owns the Guzzle client, so there is no connection to pin a resolved IP to.

An instance that deliberately targets internal endpoints is unaffected — `integrations.webhooks.block_private_urls=false` passes everything, at both halves.

## Note on the issue's test concern

The issue warned that applying the guard would make `PushSubscriptionTest` depend on name resolution. That is no longer true: `isPublic()` has since been split from `resolveDeliveryIp()` and does no DNS lookup. The existing `fcm.googleapis.com` and `push.example.test` fixtures needed no change.

## Testing

- Five new validation cases in `PushSubscriptionTest` (loopback, private range, cloud metadata, `localhost`, `.internal`), plus two covering the delivery-time filter and the guard-disabled escape hatch.
- One new case in `OutboundUrlGuardTest` covering the overridable failure message.
- `./vendor/bin/sail composer test` — Pint, PHPStan, Rector and the parallel suite green at `Total: 100.0 %`.
- Local CodeRabbit pass against `develop`: 0 findings.

## i18n / docs

`lang/fr.json` gains the new key. Nothing operator-facing changed, so no `docs/` update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787665113&installation_model_id=428379&pr_number=926&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F926&signature=0ffd52b51376eb4e803a959f2e34c33abb84cc23ae3a8ed29a09166159bd417f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->