### PR TITLE
fix: keep channels and groups usable when their name slugs to nothing

### DIFF
--- a/app/Actions/Channels/CreateChannel.php
+++ b/app/Actions/Channels/CreateChannel.php
@@ -6,8 +6,8 @@ use App\Enums\ChannelVisibility;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\NameSlug;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class CreateChannel
 {
@@ -28,7 +28,7 @@ class CreateChannel
 
             $channel = $team->channels()->create([
                 'name' => $name,
-                'slug' => Str::slug($name),
+                'slug' => NameSlug::distinct($name, Channel::FALLBACK_SLUG),
                 'visibility' => $visibility,
                 'topic' => $topic,
                 'created_by' => $creator->id,

--- a/app/Concerns/GeneratesUniqueTeamSlugs.php
+++ b/app/Concerns/GeneratesUniqueTeamSlugs.php
@@ -2,7 +2,7 @@
 
 namespace App\Concerns;
 
-use Illuminate\Support\Str;
+use App\Support\NameSlug;
 
 trait GeneratesUniqueTeamSlugs
 {
@@ -52,18 +52,12 @@ trait GeneratesUniqueTeamSlugs
     /**
      * Slug a team name, falling back when the name slugs to nothing.
      *
-     * Str::slug() transliterates what it can (Cyrillic, Greek and Arabic all
-     * survive) but strips every character it has no Latin equivalent for, so a
-     * name written entirely in e.g. Japanese, Korean or Hebrew — or in
-     * punctuation or emoji — comes back empty. An empty slug is unusable as a
-     * route key and would make the team unreachable (issue #921), so such a
-     * name gets the generic base instead and the caller's suffix machinery
-     * keeps it unique.
+     * A name with no sluggable characters would otherwise leave the team with
+     * an empty slug and so unreachable (issue #921); it gets the generic base
+     * instead, and the suffix machinery above keeps that unique.
      */
     private static function sluggifyTeamName(string $name): string
     {
-        $slug = Str::slug($name);
-
-        return $slug === '' ? self::FALLBACK_SLUG : $slug;
+        return NameSlug::make($name, self::FALLBACK_SLUG);
     }
 }

--- a/app/Http/Requests/Api/V1/StoreChannelRequest.php
+++ b/app/Http/Requests/Api/V1/StoreChannelRequest.php
@@ -6,10 +6,10 @@ use App\Enums\ChannelVisibility;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Support\Integrations\ApiChannelAccess;
+use App\Support\NameSlug;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
@@ -72,7 +72,7 @@ class StoreChannelRequest extends ApiRequest
 
                 $exists = Channel::query()
                     ->where('team_id', $this->team()->id)
-                    ->where('slug', Str::slug((string) $this->input('name')))
+                    ->where('slug', NameSlug::distinct((string) $this->input('name'), Channel::FALLBACK_SLUG))
                     ->exists();
 
                 if ($exists) {

--- a/app/Http/Requests/Channels/CreateChannelRequest.php
+++ b/app/Http/Requests/Channels/CreateChannelRequest.php
@@ -5,11 +5,11 @@ namespace App\Http\Requests\Channels;
 use App\Enums\ChannelVisibility;
 use App\Models\Channel;
 use App\Models\Team;
+use App\Support\NameSlug;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
@@ -61,7 +61,7 @@ class CreateChannelRequest extends FormRequest
                     return;
                 }
 
-                $slug = Str::slug((string) $this->input('name'));
+                $slug = NameSlug::distinct((string) $this->input('name'), Channel::FALLBACK_SLUG);
 
                 $exists = Channel::query()
                     ->where('team_id', $this->team()->id)

--- a/app/Http/Requests/Teams/StoreUserGroupRequest.php
+++ b/app/Http/Requests/Teams/StoreUserGroupRequest.php
@@ -4,10 +4,10 @@ namespace App\Http\Requests\Teams;
 
 use App\Concerns\ResolvesUserGroupRoute;
 use App\Models\UserGroup;
+use App\Support\NameSlug;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class StoreUserGroupRequest extends FormRequest
@@ -36,7 +36,9 @@ class StoreUserGroupRequest extends FormRequest
     protected function prepareForValidation(): void
     {
         if (blank($this->input('slug'))) {
-            $this->merge(['slug' => Str::slug((string) $this->input('name'))]);
+            $this->merge([
+                'slug' => NameSlug::distinct((string) $this->input('name'), UserGroup::FALLBACK_SLUG),
+            ]);
         }
     }
 

--- a/app/Http/Requests/Teams/UpdateUserGroupRequest.php
+++ b/app/Http/Requests/Teams/UpdateUserGroupRequest.php
@@ -3,10 +3,11 @@
 namespace App\Http\Requests\Teams;
 
 use App\Concerns\ResolvesUserGroupRoute;
+use App\Models\UserGroup;
+use App\Support\NameSlug;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class UpdateUserGroupRequest extends FormRequest
@@ -28,7 +29,9 @@ class UpdateUserGroupRequest extends FormRequest
     protected function prepareForValidation(): void
     {
         if (blank($this->input('slug'))) {
-            $this->merge(['slug' => Str::slug((string) $this->input('name'))]);
+            $this->merge([
+                'slug' => NameSlug::distinct((string) $this->input('name'), UserGroup::FALLBACK_SLUG),
+            ]);
         }
     }
 

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\ChannelType;
 use App\Enums\ChannelVisibility;
+use App\Support\NameSlug;
 use Database\Factories\ChannelFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
@@ -49,6 +50,31 @@ class Channel extends Model
      * The reserved slug of the auto-created, undeletable channel.
      */
     public const string GENERAL_SLUG = 'general';
+
+    /**
+     * Slug base used when a channel name carries no sluggable characters.
+     */
+    public const string FALLBACK_SLUG = 'channel';
+
+    /**
+     * Keep a usable slug on the row however the channel is written.
+     *
+     * The slug is the route key ({@see getRouteKeyName()}), so a blank one
+     * leaves the channel unreachable with no UI path back to it (issue #924).
+     * The create path derives the slug itself; this is the backstop for every
+     * other writer, including a slug blanked on an existing row.
+     */
+    #[\Override]
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::saving(function (Channel $channel): void {
+            if (blank($channel->slug)) {
+                $channel->slug = NameSlug::distinct((string) $channel->name, self::FALLBACK_SLUG);
+            }
+        });
+    }
 
     /**
      * Determine whether this is the team's protected #general channel.

--- a/app/Models/UserGroup.php
+++ b/app/Models/UserGroup.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Support\NameSlug;
 use Database\Factories\UserGroupFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
@@ -28,6 +29,30 @@ class UserGroup extends Model
 {
     /** @use HasFactory<UserGroupFactory> */
     use HasFactory, HasUuids;
+
+    /**
+     * Slug base used when a group name carries no sluggable characters.
+     */
+    public const string FALLBACK_SLUG = 'group';
+
+    /**
+     * Keep a usable handle on the row however the group is written.
+     *
+     * The handle is what people type after `@`, so a blank one makes the group
+     * unmentionable (issue #924). The form requests derive it from the name
+     * when it is left blank; this is the backstop for every other writer.
+     */
+    #[\Override]
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::saving(function (UserGroup $group): void {
+            if (blank($group->slug)) {
+                $group->slug = NameSlug::distinct($group->name, self::FALLBACK_SLUG);
+            }
+        });
+    }
 
     /**
      * Get the team this group belongs to. A group is workspace-scoped and can be

--- a/app/Support/NameSlug.php
+++ b/app/Support/NameSlug.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Support;
+
+use App\Concerns\GeneratesUniqueTeamSlugs;
+use Illuminate\Support\Str;
+
+/**
+ * Derives a usable slug from a display name.
+ *
+ * Str::slug() transliterates what it can (Cyrillic, Greek and Arabic all
+ * survive) but strips every character it has no Latin equivalent for, so a name
+ * written entirely in e.g. Japanese, Korean or Hebrew — or in punctuation or
+ * emoji — comes back empty. Slugs are route keys here, so an empty one makes
+ * the record unreachable with no UI path back to it (issues #921 and #924).
+ */
+final class NameSlug
+{
+    /**
+     * The number of fingerprint characters appended to a fallback base.
+     *
+     * Eight hex characters keep a collision between two different names far
+     * rarer than the name clash the caller already has to handle anyway, while
+     * staying short enough to read in a URL.
+     */
+    private const int FINGERPRINT_LENGTH = 8;
+
+    /**
+     * Slug a name, falling back to the given base when nothing survives.
+     *
+     * The base is shared by every unsluggable name, so this suits a caller that
+     * resolves collisions itself — {@see GeneratesUniqueTeamSlugs}
+     * keeps team slugs unique with a numeric suffix.
+     */
+    public static function make(string $name, string $fallback): string
+    {
+        $slug = Str::slug($name);
+
+        return $slug === '' ? $fallback : $slug;
+    }
+
+    /**
+     * Slug a name, falling back to a base that stays specific to that name.
+     *
+     * Unlike {@see make()}, two different unsluggable names get two different
+     * slugs, so a caller whose slugs are unique per team does not have to probe
+     * the database to avoid a clash. The fallback is derived from the name
+     * alone, which lets a validation pre-check compute exactly the slug the
+     * write path will store — the guarantee that keeps a non-Latin channel name
+     * from being rejected as already taken (issue #924).
+     */
+    public static function distinct(string $name, string $fallback): string
+    {
+        return self::make($name, $fallback.'-'.self::fingerprint($name));
+    }
+
+    /**
+     * A short, stable, slug-safe digest of a name.
+     */
+    private static function fingerprint(string $name): string
+    {
+        return substr(hash('xxh128', $name), 0, self::FINGERPRINT_LENGTH);
+    }
+}

--- a/database/migrations/2026_07_26_134641_repair_empty_channel_and_group_slugs.php
+++ b/database/migrations/2026_07_26_134641_repair_empty_channel_and_group_slugs.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\UserGroup;
+use App\Support\NameSlug;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Give a usable slug back to channels and groups left with a blank one.
+     *
+     * Both derived their slug with Str::slug() alone, which returns an empty
+     * string for a name it cannot transliterate (Japanese, Korean, Hebrew,
+     * punctuation, emoji). A channel slug is the route key, so such a channel
+     * became unreachable with no UI path back to it, and a blank group handle
+     * cannot be mentioned (issue #924). Both are now derived through
+     * {@see NameSlug}, and this repairs the rows written before that.
+     *
+     * A no-op on any instance that never hit the bug — which is every fresh
+     * install, since neither slug can be blank any more.
+     */
+    public function up(): void
+    {
+        Channel::query()
+            ->whereRaw("trim(slug) = ''")
+            ->get()
+            ->each(function (Channel $channel): void {
+                $channel->slug = $this->availableSlug($channel, Channel::FALLBACK_SLUG);
+                $channel->save();
+            });
+
+        UserGroup::query()
+            ->whereRaw("trim(slug) = ''")
+            ->get()
+            ->each(function (UserGroup $group): void {
+                $group->slug = $this->availableSlug($group, UserGroup::FALLBACK_SLUG);
+                $group->save();
+            });
+    }
+
+    /**
+     * Irreversible: which rows held a blank slug is not recoverable, and
+     * restoring one would put the record back out of reach anyway.
+     */
+    public function down(): void
+    {
+        //
+    }
+
+    /**
+     * The record's derived slug, stepped past anything already using it.
+     *
+     * Both tables are unique on (team_id, slug). The derived slug is specific
+     * to the name, so a clash needs a sibling already holding exactly that
+     * slug — vanishingly unlikely, but a migration that throws would block the
+     * upgrade, so it is handled rather than assumed away.
+     */
+    private function availableSlug(Channel|UserGroup $record, string $fallback): string
+    {
+        $base = NameSlug::distinct((string) $record->name, $fallback);
+        $slug = $base;
+
+        for ($suffix = 1; $this->slugTaken($record, $slug); $suffix++) {
+            $slug = $base.'-'.$suffix;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Determine whether a sibling in the same team already holds the slug.
+     */
+    private function slugTaken(Channel|UserGroup $record, string $slug): bool
+    {
+        return $record->newQuery()
+            ->where('team_id', $record->team_id)
+            ->where('slug', $slug)
+            ->whereKeyNot($record->getKey())
+            ->exists();
+    }
+};

--- a/tests/Feature/Api/V1/ChannelApiTest.php
+++ b/tests/Feature/Api/V1/ChannelApiTest.php
@@ -96,6 +96,40 @@ it('rejects a duplicate channel name', function (): void {
     ])->assertStatus(422)->assertJsonValidationErrorFor('name');
 });
 
+it('creates two channels named in a non-Latin script without a false duplicate', function (): void {
+    Sanctum::actingAs($this->bot, ['channels:write']);
+
+    foreach (['日本語', '中文'] as $name) {
+        $this->postJson('/api/v1/channels', [
+            'name' => $name,
+            'visibility' => ChannelVisibility::Public->value,
+        ])->assertCreated();
+    }
+
+    $slugs = Channel::query()
+        ->where('team_id', $this->team->id)
+        ->whereIn('name', ['日本語', '中文'])
+        ->pluck('slug');
+
+    expect($slugs)->toHaveCount(2)
+        ->and($slugs->unique())->toHaveCount(2)
+        ->and($slugs->filter(fn (string $slug): bool => $slug === ''))->toBeEmpty();
+});
+
+it('still rejects a repeated non-Latin channel name', function (): void {
+    Sanctum::actingAs($this->bot, ['channels:write']);
+
+    $this->postJson('/api/v1/channels', [
+        'name' => '日本語',
+        'visibility' => ChannelVisibility::Public->value,
+    ])->assertCreated();
+
+    $this->postJson('/api/v1/channels', [
+        'name' => '日本語',
+        'visibility' => ChannelVisibility::Public->value,
+    ])->assertStatus(422)->assertJsonValidationErrorFor('name');
+});
+
 it('archives a channel the bot created and audits it', function (): void {
     $channel = Channel::factory()->for($this->team)->create(['created_by' => $this->bot->id]);
     $channel->channelMembers()->create(['user_id' => $this->bot->id]);

--- a/tests/Feature/Channels/ChannelModelTest.php
+++ b/tests/Feature/Channels/ChannelModelTest.php
@@ -29,3 +29,22 @@ test('channel visibility exposes a human label', function (): void {
     expect(ChannelVisibility::Public->label())->toBe('Public')
         ->and(ChannelVisibility::Private->label())->toBe('Private');
 });
+
+test('a channel cannot be saved with a blank slug', function (?string $slug): void {
+    $channel = Channel::factory()->create(['name' => '日本語', 'slug' => $slug]);
+
+    expect($channel->fresh()->slug)->not->toBe('');
+})->with([
+    'empty' => [''],
+    'whitespace' => ['   '],
+    'null' => [null],
+]);
+
+test('a channel whose slug is blanked later has it regenerated on save', function (): void {
+    $channel = Channel::factory()->create(['name' => 'Marketing', 'slug' => 'marketing']);
+
+    $channel->slug = '';
+    $channel->save();
+
+    expect($channel->fresh()->slug)->toBe('marketing');
+});

--- a/tests/Feature/Channels/ChannelModelTest.php
+++ b/tests/Feature/Channels/ChannelModelTest.php
@@ -33,7 +33,7 @@ test('channel visibility exposes a human label', function (): void {
 test('a channel cannot be saved with a blank slug', function (?string $slug): void {
     $channel = Channel::factory()->create(['name' => '日本語', 'slug' => $slug]);
 
-    expect($channel->fresh()->slug)->not->toBe('');
+    expect(trim($channel->fresh()->slug))->not->toBe('');
 })->with([
     'empty' => [''],
     'whitespace' => ['   '],

--- a/tests/Feature/Channels/CreateChannelTest.php
+++ b/tests/Feature/Channels/CreateChannelTest.php
@@ -75,6 +75,72 @@ test('the same channel name may exist in different teams', function (): void {
     expect(Channel::where('team_id', $teamB->id)->where('slug', 'marketing')->exists())->toBeTrue();
 });
 
+test('a channel named in a non-Latin script stays reachable', function (string $name): void {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)
+        ->post(route('channels.store', ['team' => $team->slug]), [
+            'name' => $name,
+            'visibility' => 'public',
+        ])
+        ->assertSessionHasNoErrors();
+
+    $channel = Channel::where('team_id', $team->id)->where('name', $name)->sole();
+
+    expect($channel->slug)->not->toBe('');
+
+    $this->actingAs($owner)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertOk();
+})->with([
+    'japanese' => ['日本語'],
+    'korean' => ['한국어'],
+    'hebrew' => ['עברית'],
+    'punctuation' => ['<<<'],
+    'emoji' => ['🎉🎉'],
+]);
+
+test('two channels named in a non-Latin script coexist in one team', function (): void {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    foreach (['日本語', '中文'] as $name) {
+        $this->actingAs($owner)
+            ->post(route('channels.store', ['team' => $team->slug]), [
+                'name' => $name,
+                'visibility' => 'public',
+            ])
+            ->assertSessionHasNoErrors();
+    }
+
+    $slugs = Channel::where('team_id', $team->id)->whereIn('name', ['日本語', '中文'])->pluck('slug');
+
+    expect($slugs)->toHaveCount(2)
+        ->and($slugs->unique())->toHaveCount(2);
+});
+
+test('a repeated non-Latin channel name is still reported as already existing', function (): void {
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+
+    $this->actingAs($owner)
+        ->post(route('channels.store', ['team' => $team->slug]), [
+            'name' => '日本語',
+            'visibility' => 'public',
+        ])
+        ->assertSessionHasNoErrors();
+
+    $this->actingAs($owner)
+        ->post(route('channels.store', ['team' => $team->slug]), [
+            'name' => '日本語',
+            'visibility' => 'public',
+        ])
+        ->assertSessionHasErrors('name');
+
+    expect(Channel::where('team_id', $team->id)->where('name', '日本語')->count())->toBe(1);
+});
+
 test('creating a channel requires a valid visibility', function (): void {
     $owner = User::factory()->create();
     $team = app(CreateTeam::class)->handle($owner, 'Acme');

--- a/tests/Feature/Channels/RepairEmptySlugsMigrationTest.php
+++ b/tests/Feature/Channels/RepairEmptySlugsMigrationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\UserGroup;
+use App\Support\NameSlug;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Load the slug-repair data migration as an instance so its up() can be
+ * exercised against rows blanked behind the models' backs (RefreshDatabase has
+ * already run it once, on empty tables, during setup).
+ */
+function repairEmptyChannelAndGroupSlugsMigration(): object
+{
+    return require base_path('database/migrations/2026_07_26_134641_repair_empty_channel_and_group_slugs.php');
+}
+
+/**
+ * Blank a row's slug without going through the model guard.
+ */
+function blankSlug(string $table, string $id, string $slug = ''): void
+{
+    DB::table($table)->where('id', $id)->update(['slug' => $slug]);
+}
+
+test('the migration gives every blank-slug channel a usable slug', function (): void {
+    $team = Team::factory()->create();
+    $japanese = Channel::factory()->for($team)->create(['name' => '日本語']);
+    $punctuation = Channel::factory()->for($team)->create(['name' => '<<<']);
+
+    blankSlug('channels', $japanese->id);
+    blankSlug('channels', $punctuation->id, '  ');
+
+    repairEmptyChannelAndGroupSlugsMigration()->up();
+
+    $slugs = collect([$japanese, $punctuation])->map(fn (Channel $channel): string => $channel->fresh()->slug);
+
+    expect($slugs->filter(fn (string $slug): bool => trim($slug) === ''))->toBeEmpty()
+        ->and($slugs->unique())->toHaveCount(2);
+});
+
+test('the migration gives every blank-slug group a usable handle', function (): void {
+    $team = Team::factory()->create();
+    $group = UserGroup::factory()->for($team)->create(['name' => '日本語']);
+
+    blankSlug('user_groups', $group->id);
+
+    repairEmptyChannelAndGroupSlugsMigration()->up();
+
+    expect($group->fresh()->slug)->toMatch('/^[a-z0-9]+(?:-[a-z0-9]+)*$/');
+});
+
+test('the migration steps around a slug already taken in the team', function (): void {
+    $team = Team::factory()->create();
+    $occupied = NameSlug::distinct('日本語', Channel::FALLBACK_SLUG);
+
+    $squatter = Channel::factory()->for($team)->create(['name' => 'Squatter', 'slug' => $occupied]);
+    $blank = Channel::factory()->for($team)->create(['name' => '日本語']);
+
+    blankSlug('channels', $blank->id);
+
+    repairEmptyChannelAndGroupSlugsMigration()->up();
+
+    expect($blank->fresh()->slug)->toBe($occupied.'-1')
+        ->and($squatter->fresh()->slug)->toBe($occupied);
+});
+
+test('the migration leaves healthy slugs alone', function (): void {
+    $team = Team::factory()->create();
+    $channel = Channel::factory()->for($team)->create(['name' => 'Marketing', 'slug' => 'marketing']);
+    $group = UserGroup::factory()->for($team)->create(['name' => 'Dev Team', 'slug' => 'dev-team']);
+
+    repairEmptyChannelAndGroupSlugsMigration()->up();
+
+    expect($channel->fresh()->slug)->toBe('marketing')
+        ->and($group->fresh()->slug)->toBe('dev-team');
+});

--- a/tests/Feature/Teams/UserGroupTest.php
+++ b/tests/Feature/Teams/UserGroupTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
+use App\Http\Requests\Teams\StoreUserGroupRequest;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\UserGroup;
@@ -81,12 +82,43 @@ test('a handle that is not lowercase kebab-case is rejected', function (string $
         ->assertSessionHasErrors('slug');
 })->with(['Dev Team', 'dev_team', 'DevTeam', '-devs', 'devs-', 'dev--team', 'dév']);
 
-test('a name that derives to an empty handle is rejected', function (): void {
+test('a name that slugs to nothing still derives a usable handle', function (string $name): void {
     [$owner, $team] = userGroupTeam();
 
     $this->actingAs($owner)
-        ->post(route('teams.groups.store', $team), ['name' => '!!!'])
-        ->assertSessionHasErrors('slug');
+        ->post(route('teams.groups.store', $team), ['name' => $name])
+        ->assertSessionHasNoErrors();
+
+    expect(UserGroup::sole()->slug)->toMatch(StoreUserGroupRequest::SLUG_PATTERN);
+})->with([
+    'japanese' => ['日本語'],
+    'korean' => ['한국어'],
+    'hebrew' => ['עברית'],
+    'punctuation' => ['!!!'],
+    'emoji' => ['🎉🎉'],
+]);
+
+test('two groups whose names slug to nothing get distinct handles', function (): void {
+    [$owner, $team] = userGroupTeam();
+
+    foreach (['日本語', '中文'] as $name) {
+        $this->actingAs($owner)
+            ->post(route('teams.groups.store', $team), ['name' => $name])
+            ->assertSessionHasNoErrors();
+    }
+
+    expect(UserGroup::pluck('slug')->unique())->toHaveCount(2);
+});
+
+test('renaming a group to a name that slugs to nothing keeps a usable handle', function (): void {
+    [$owner, $team] = userGroupTeam();
+    $group = UserGroup::factory()->for($team)->slug('dev-team')->create();
+
+    $this->actingAs($owner)
+        ->patch(route('teams.groups.update', [$team, $group]), ['name' => '日本語'])
+        ->assertSessionHasNoErrors();
+
+    expect($group->fresh()->slug)->toMatch(StoreUserGroupRequest::SLUG_PATTERN);
 });
 
 test('an admin manages groups but a plain member may not', function (): void {
@@ -275,3 +307,13 @@ test('leaving the workspace drops you from its groups', function (): void {
 
     expect($group->members()->count())->toBe(0);
 });
+
+test('a group cannot be saved with a blank handle', function (?string $slug): void {
+    $group = UserGroup::factory()->create(['name' => '日本語', 'slug' => $slug]);
+
+    expect($group->fresh()->slug)->toMatch(StoreUserGroupRequest::SLUG_PATTERN);
+})->with([
+    'empty' => [''],
+    'whitespace' => ['   '],
+    'null' => [null],
+]);

--- a/tests/Unit/Support/NameSlugTest.php
+++ b/tests/Unit/Support/NameSlugTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Support\NameSlug;
 
 test('a name that slugs to something keeps its slug', function (string $name, string $expected): void {

--- a/tests/Unit/Support/NameSlugTest.php
+++ b/tests/Unit/Support/NameSlugTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Support\NameSlug;
+
+test('a name that slugs to something keeps its slug', function (string $name, string $expected): void {
+    expect(NameSlug::make($name, 'thing'))->toBe($expected)
+        ->and(NameSlug::distinct($name, 'thing'))->toBe($expected);
+})->with([
+    'latin' => ['Marketing', 'marketing'],
+    'mixed case and spaces' => ['Dev Team', 'dev-team'],
+    'cyrillic transliterates' => ['Привет', 'privet'],
+    'greek transliterates' => ['Ελλάδα', 'ellada'],
+    'latin survives alongside emoji' => ['Launch 🎉', 'launch'],
+]);
+
+test('a name that slugs to nothing falls back to the given base', function (string $name): void {
+    expect(NameSlug::make($name, 'thing'))->toBe('thing');
+})->with([
+    'japanese' => ['日本語'],
+    'korean' => ['한국어'],
+    'hebrew' => ['עברית'],
+    'punctuation' => ['<<<'],
+    'emoji' => ['🎉🎉'],
+]);
+
+test('distinct keeps two unsluggable names apart', function (): void {
+    $japanese = NameSlug::distinct('日本語', 'channel');
+    $chinese = NameSlug::distinct('中文', 'channel');
+
+    expect($japanese)->not->toBe($chinese)
+        ->and($japanese)->toStartWith('channel-')
+        ->and($chinese)->toStartWith('channel-');
+});
+
+test('distinct is stable for the same name, so a pre-check can reproduce it', function (): void {
+    expect(NameSlug::distinct('日本語', 'channel'))->toBe(NameSlug::distinct('日本語', 'channel'));
+});
+
+test('a fallback slug is usable as a route key and as a group handle', function (string $name): void {
+    expect(NameSlug::distinct($name, 'group'))->toMatch('/^[a-z0-9]+(?:-[a-z0-9]+)*$/');
+})->with([
+    'japanese' => ['日本語'],
+    'punctuation' => ['<<<'],
+    'emoji' => ['🎉🎉'],
+]);


### PR DESCRIPTION
Closes #924.

Stacked on #925 (issue #921), which this branch forks from and targets — it needs that fix's fallback rule to hoist rather than copy. Merge #925 first; the diff here is only the channel and group half.

## What

`Str::slug()` strips every character it has no Latin equivalent for, so a name written entirely in Japanese, Korean or Hebrew — or in punctuation or emoji — comes back empty. Three models derived a slug that way; #925 fixed teams, this fixes the other two.

- **Channels were a lockout.** `CreateChannel` stored `slug = ''`, and since the slug is the route key every URL naming the channel 404'd, with no UI path back to it. `channels` is unique on `(team_id, slug)`, so the *second* such channel in a workspace was rejected as "A channel with this name already exists." — naming a channel that did not exist.
- **User-group handles were a dead end.** Both form requests derived the handle with `Str::slug()` when the operator left it blank, producing `''` against a `required` rule: an error on a field the user never filled and could not obviously fix.

## How

- **One shared rule, per the issue's note.** New `App\Support\NameSlug` holds the blank-slug fallback that #925 introduced. `GeneratesUniqueTeamSlugs` now delegates to it, so teams stop carrying their own copy — behaviour and tests there are unchanged.
- **Two entry points, because the callers need different guarantees.** `make()` returns a shared generic base and suits a caller that resolves collisions itself (teams, via the existing numeric-suffix machinery). `distinct()` appends a short fingerprint of the name, so two different unsluggable names never collide.
- **`distinct()` is what makes the false "already exists" impossible rather than merely unlikely.** The fallback is derived from the name alone, so `CreateChannelRequest` and `Api\V1\StoreChannelRequest` compute exactly the slug `CreateChannel` will store. A genuinely repeated name still collides and still reports "already exists", which is now truthful.
- **Model guards.** `Channel` and `UserGroup` guard on `saving` (mirroring `Team`'s in #925) so no writer can persist a blank slug.
- **Repair migration** for instances already holding broken rows, since an affected channel is unreachable today. It steps past an occupied slug rather than throwing, because a migration that throws blocks the upgrade. A no-op on a fresh install.

## Notes for review

- **One existing test's expectation is reversed.** `tests/Feature/Teams/UserGroupTest.php` had `a name that derives to an empty handle is rejected`, which pinned the bug. Acceptance criterion 3 explicitly reverses it, so it is now `a name that slugs to nothing still derives a usable handle`.
- **There is no channel-rename path in the app today** (no route updates a channel's name), so the criterion's "on any rename path" is vacuous. The `saving` guard covers it if one is added.

## Testing

- `tests/Unit/Support/NameSlugTest.php`: fallback for Japanese/Korean/Hebrew/punctuation/emoji, transliteration kept for Cyrillic/Greek, and the two properties the pre-check depends on — `distinct()` separates different names and is stable for the same one.
- `tests/Feature/Channels/CreateChannelTest.php`: the reported symptom at the HTTP seam — a non-Latin channel is created and its URL resolves, two of them coexist, and a repeated one is still rejected. Verified red first: the redirect failed with `Missing required parameter [channel]` and the second create reported the false duplicate.
- `tests/Feature/Api/V1/ChannelApiTest.php`: same two guarantees on the public API path. Verified red (422 on the second create).
- `tests/Feature/Teams/UserGroupTest.php`: handle derived for such names, distinct across two of them, kept on rename, plus the model guard.
- `tests/Feature/Channels/ChannelModelTest.php`: blank, whitespace-only and null slugs all regenerate.
- `tests/Feature/Channels/RepairEmptySlugsMigrationTest.php`: repairs channels and groups, steps around an occupied slug, leaves healthy slugs alone.
- Full gate green: `composer test` at `Total: 100.0 %` with Pint, PHPStan and Rector clean, plus `lint:check` / `format:check` / `types:check` / `test:js` / `build`.

No new user-facing copy, so no `lang/fr.json` change; nothing operator-facing, so no `docs/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787669746&installation_model_id=428379&pr_number=928&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F928&signature=092c035b7c87d6f764043c7ba1dc8ae8d862103e4f15e65fdc132cdc82d18712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->