### PR TITLE
fix: allow the vite dev server as a font source in hot mode

### DIFF
--- a/app/Support/Csp/TheDeskPolicy.php
+++ b/app/Support/Csp/TheDeskPolicy.php
@@ -123,10 +123,15 @@ final class TheDeskPolicy implements Preset
     }
 
     /**
-     * With `npm run dev` the assets, the injected styles and the HMR socket all
-     * come from the Vite dev server on a different origin. The policy stays on in
-     * development rather than being switched off: if it is absent locally, the
-     * first person to meet it is a self-hoster in production.
+     * With `npm run dev` the assets, the injected styles, the web fonts and the
+     * HMR socket all come from the Vite dev server on a different origin. The
+     * policy stays on in development rather than being switched off: if it is
+     * absent locally, the first person to meet it is a self-hoster in production.
+     *
+     * font-src is part of that list because @font-face resolves its src against
+     * the stylesheet's origin: in hot mode that is the dev server, so leaving it
+     * out silently falls the whole app back to system fonts and buries the real
+     * console errors under CSP violations.
      */
     private function allowViteDevServer(Policy $policy): void
     {
@@ -140,6 +145,7 @@ final class TheDeskPolicy implements Preset
         $policy
             ->add(Directive::SCRIPT, $origin)
             ->add(Directive::STYLE, $origin)
+            ->add(Directive::FONT, $origin)
             ->add(Directive::CONNECT, [$origin, $socket]);
     }
 

--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -220,3 +220,17 @@ test('hot mode allow-lists the vite dev server so npm run dev keeps working', fu
         ->toContain('http://localhost:5173')
         ->toContain('ws://localhost:5173');
 });
+
+test('hot mode allow-lists the vite dev server as a font source so dev renders the real typography', function (): void {
+    $hotFile = tempnam(sys_get_temp_dir(), 'vite-hot-');
+    file_put_contents($hotFile, "http://localhost:5173\n");
+    Vite::useHotFile($hotFile);
+
+    try {
+        $contents = Policy::create([TheDeskPolicy::class])->getContents();
+    } finally {
+        unlink($hotFile);
+    }
+
+    expect($contents)->toContain("font-src 'self' http://localhost:5173");
+});


### PR DESCRIPTION
Closes #814.

## What

`TheDeskPolicy::allowViteDevServer()` adds the Vite hot origin to `script-src`, `style-src` and `connect-src` — but not `font-src`. Since `@font-face` resolves its `src` against the stylesheet's origin, and in hot mode that origin is the dev server, every `npm run dev` page load blocked all nine woff2 faces:

```
Loading the font 'http://localhost:5173/__laravel_vite_plugin__/fonts/….woff2' violates
the following Content Security Policy directive: "font-src 'self'". The action has been blocked.
```

One directive added, behind the existing `Vite::isRunningHot()` guard:

```php
->add(Directive::STYLE, $origin)
->add(Directive::FONT, $origin)
->add(Directive::CONNECT, [$origin, $socket]);
```

## Why

Dev sessions rendered system fallback fonts instead of Newsreader/Instrument Sans, so visual work done against `npm run dev` was judged on the wrong typography and design-fidelity screenshots were skewed. The violation wall also buried real console errors during browser-driven testing.

## Production behaviour is unchanged

The whole branch is gated on `Vite::isRunningHot()`, which is never true in a built deployment. The policy operators receive still ships `font-src 'self'`, so the table in `docs/reference/security.md` stays accurate and needs no edit. Operators who need an external font host already have `CSP_EXTRA_FONT_SRC`.

## How tested

- **Unit/feature:** a new test pins the directive — `font-src 'self' http://localhost:5173` — written red first and confirmed failing on exactly the missing origin. All 23 tests in `ContentSecurityPolicyTest.php` pass.
- **Real browser:** drove a Playwright page against a live `npm run dev` session. **0 CSP violations**, all 9 woff2 requests 200, and `document.fonts` confirms Newsreader + Instrument Sans in `loaded` state. Reverting the single line and re-running reproduced the issue's console output verbatim, which validates the probe rather than just the fix.
- **Full gate:** Pint, PHPStan (0 errors), Rector dry-run clean, coverage `Total: 100.0 %`.
- **CodeRabbit:** local pass against `develop`, 0 findings.

No user-facing copy, so no i18n keys. No operator-facing config change, so no docs update.

## Found while doing this

#927 — the CSP suite isn't hermetic with respect to `public/hot`. With a dev server running, `Vite::isRunningHot()` is true inside the test process and two unrelated tests fail on the *pre-existing* `style-src`/`connect-src` hot additions. Filed rather than fixed inline to keep this diff to its own scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787671535&installation_model_id=428379&pr_number=929&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F929&signature=1a54f3b982b32b23eabd9f75db36294a3085e625ba3dd606066c4457672419ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->