### PR TITLE
test: pin the vite hot state so the csp suite ignores npm run dev

### DIFF
--- a/tests/Feature/Middleware/ContentSecurityPolicyTest.php
+++ b/tests/Feature/Middleware/ContentSecurityPolicyTest.php
@@ -19,6 +19,14 @@ function cspNonceFrom(string $header): string
 }
 
 beforeEach(function (): void {
+    // Vite reads public/hot off the filesystem, so a `npm run dev` left running
+    // in another terminal would put the whole file in hot mode and splice the
+    // dev-server origin into the directives asserted below. Pin the hot state
+    // the way the posture below is pinned: point Vite at a hot file that does
+    // not exist — unique per test, so nothing can create it underneath us — and
+    // let the hot-mode test opt back in explicitly.
+    Vite::useHotFile(sys_get_temp_dir().'/'.uniqid('the-desk-vite-not-hot-', true));
+
     // .env.example turns report-only on for local development, so every test
     // states the posture it is asserting rather than inheriting the ambient one.
     config([
@@ -202,6 +210,28 @@ test('an extra frame source replaces the none placeholder rather than sitting be
 
     expect($header)->toContain('frame-src https://embed.example.test')
         ->not->toContain("frame-src 'none'");
+});
+
+test('an ambient vite dev server does not leak into the policy', function (): void {
+    // `npm run dev` writes public/hot, which Vite reads straight off the
+    // filesystem — so without the pin in beforeEach a dev server running in
+    // another terminal splices its origin into script-src/style-src/connect-src
+    // for every test in this file, breaking the ones that assert an exact
+    // directive. Swap in a public path that carries a hot file to stand in for
+    // that dev server, rather than writing to the real one it owns.
+    $publicPath = sys_get_temp_dir().'/'.uniqid('the-desk-csp-public-', true);
+    mkdir($publicPath);
+    file_put_contents($publicPath.'/hot', "http://localhost:5173\n");
+    $this->app->usePublicPath($publicPath);
+
+    try {
+        $contents = Policy::create([TheDeskPolicy::class])->getContents();
+    } finally {
+        unlink($publicPath.'/hot');
+        rmdir($publicPath);
+    }
+
+    expect($contents)->not->toContain('localhost:5173');
 });
 
 test('hot mode allow-lists the vite dev server so npm run dev keeps working', function (): void {


### PR DESCRIPTION
Closes #927.

## What

`tests/Feature/Middleware/ContentSecurityPolicyTest.php` inherited the ambient Vite hot state: with `npm run dev` running, `public/hot` exists, so `Vite::isRunningHot()` is true inside the test process and `TheDeskPolicy::allowViteDevServer()` splices the dev-server origin into `script-src` / `style-src` / `connect-src` for every test in the file. Two assertions that pin an exact directive prefix then failed, blaming code that had not changed.

`beforeEach` now pins the hot state the same way it already pins `csp.enabled` / `csp.report_only` / `csp.extra`: Vite is pointed at a hot file that does not exist (unique per test, so nothing can create it underneath us). The one test that deliberately exercises hot mode still opts in explicitly with its own hot file.

## Why

`composer test` is the gate everyone runs before pushing, and it is most often run mid-feature with a dev server up in another terminal. It should not depend on that.

## How tested

- New regression test `an ambient vite dev server does not leak into the policy` swaps in a public path carrying a `hot` file to stand in for a running dev server (rather than writing to the real `public/hot`, which the dev server owns) and asserts the policy stays clean. It fails without the pin and passes with it.
- Verified both ways against a real dev server: with `sail npm run dev` running, the pre-change file reproduces exactly the two documented failures (`connect-src falls back to self…`, `allow-listing an external font pairing…`); the changed file is 23/23 green both with the dev server up and with it stopped.
- Full gate green: Pint, PHPStan, Rector, and `php artisan test --parallel --coverage --min=100` at `Total: 100.0 %`.

No i18n or docs impact (test-only change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787680694&installation_model_id=428379&pr_number=930&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F930&signature=030af0572ff4cf9b202eb66423368ec11cff06fe0a588a750921e8e84906efe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->