### PR TITLE
test: hoist the eslint config resolution out of the first v-html policy test

### DIFF
--- a/eslint-rules/no-v-html-policy.test.ts
+++ b/eslint-rules/no-v-html-policy.test.ts
@@ -1,5 +1,5 @@
 import { ESLint } from 'eslint';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 /**
  * Guards the wiring rather than a rule implementation: `vue/no-v-html` is what
@@ -11,43 +11,60 @@ import { describe, expect, it } from 'vitest';
  */
 const eslint = new ESLint();
 
-async function severityFor(
-    filePath: string,
-    rule = 'vue/no-v-html',
-): Promise<unknown> {
-    const config = await eslint.calculateConfigForFile(filePath);
+const ORDINARY_COMPONENT = 'resources/js/components/Probe.vue';
+const ORDINARY_PAGE = 'resources/js/pages/channels/Probe.vue';
+const SAFE_HTML = 'resources/js/components/SafeHtml.vue';
+
+const PROBE_PATHS = [ORDINARY_COMPONENT, ORDINARY_PAGE, SAFE_HTML];
+
+/** Resolved flat config per probe path, populated once before the assertions. */
+const configs = new Map<string, { rules?: Record<string, unknown[]> }>();
+
+/**
+ * Building the flat config and its vue parser pipeline costs a second or two,
+ * and it is paid entirely by whichever resolution happens to run first — so
+ * charging it to the first test made this file cross vitest's 5s per-test
+ * timeout under full-suite load (#804). Resolving every probe path here moves
+ * that cost onto a hook with a budget big enough for it, and leaves the tests
+ * as pure assertions over the already-resolved configs.
+ */
+beforeAll(async () => {
+    for (const filePath of PROBE_PATHS) {
+        configs.set(filePath, await eslint.calculateConfigForFile(filePath));
+    }
+}, 60_000);
+
+function severityFor(filePath: string, rule = 'vue/no-v-html'): unknown {
+    const config = configs.get(filePath);
+
+    if (!config) {
+        throw new Error(`No config was resolved for ${filePath}.`);
+    }
 
     return config.rules?.[rule]?.[0];
 }
 
 describe('the v-html policy', () => {
-    it('errors on v-html in an ordinary component', async () => {
-        expect(await severityFor('resources/js/components/Probe.vue')).toBe(2);
+    it('errors on v-html in an ordinary component', () => {
+        expect(severityFor(ORDINARY_COMPONENT)).toBe(2);
     });
 
-    it('errors on v-html in a page', async () => {
-        expect(await severityFor('resources/js/pages/channels/Probe.vue')).toBe(
-            2,
-        );
+    it('errors on v-html in a page', () => {
+        expect(severityFor(ORDINARY_PAGE)).toBe(2);
     });
 
-    it('allows v-html in the SafeHtml primitive that owns the trust boundary', async () => {
-        expect(await severityFor('resources/js/components/SafeHtml.vue')).toBe(
-            0,
-        );
+    it('allows v-html in the SafeHtml primitive that owns the trust boundary', () => {
+        expect(severityFor(SAFE_HTML)).toBe(0);
     });
 
-    it('also clears the on-component variant for SafeHtml, whose directive sits on a dynamic <component>', async () => {
+    it('also clears the on-component variant for SafeHtml, whose directive sits on a dynamic <component>', () => {
         expect(
-            await severityFor(
-                'resources/js/components/SafeHtml.vue',
-                'vue/no-v-text-v-html-on-component',
-            ),
+            severityFor(SAFE_HTML, 'vue/no-v-text-v-html-on-component'),
         ).toBe(0);
 
         expect(
-            await severityFor(
-                'resources/js/components/Probe.vue',
+            severityFor(
+                ORDINARY_COMPONENT,
                 'vue/no-v-text-v-html-on-component',
             ),
         ).toBe(2);


### PR DESCRIPTION
Closes #804.

## What

`eslint-rules/no-v-html-policy.test.ts` resolved the project's flat ESLint config lazily, inside whichever assertion ran first. Building that config plus the vue parser pipeline is a one-off cost, so the first test paid it and the other three ran off ESLint's warm internal cache.

Measured on `develop`, under full-suite load:

```
✓ errors on v-html in an ordinary component                     1554ms
✓ errors on v-html in a page                                       1ms
✓ allows v-html in the SafeHtml primitive ...                     18ms
✓ also clears the on-component variant for SafeHtml ...            0ms
```

1554ms is comfortably under vitest's 5s default, but it is load-dependent — on a busier machine it crossed the wall and failed at 6017ms, then passed in isolation.

## How

Resolve all three probe paths once in a `beforeAll` with an explicit 60s hook timeout, and keep the resolved configs in a map. The setup cost now lands on a hook with a budget sized for it, and the tests are pure assertions over already-resolved configs.

`severityFor` throws if asked for a path that was not preloaded, so adding a probe path without registering it in `PROBE_PATHS` fails loudly instead of quietly asserting against `undefined`.

Chose hoisting over the alternative the issue also offered (a per-file `testTimeout` bump): a bump keeps a 1.5s-and-growing test in the suite and just moves the goalposts, whereas hoisting takes the cost out of test attribution entirely.

## Testing

After the change, across three consecutive full runs:

```
✓ errors on v-html in an ordinary component                      1ms
✓ errors on v-html in a page                                     0ms
✓ allows v-html in the SafeHtml primitive ...                    0ms
✓ also clears the on-component variant for SafeHtml ...          0ms

Test Files  144 passed (144)
     Tests  1422 passed (1422)
```

- `npm run test:js` — 3/3 green, timings above
- `composer test` — green, Total: 100.0 % coverage
- `npm run lint:check` / `format:check` / `types:check` / `build` — green

No timing assertion was added as a regression guard: a wall-clock assertion introduced to cure a wall-clock flake would just relocate the flakiness. The guard is the empirical one the issue asks for — repeated green full-suite runs.

Nothing else in the suite is near the 5s wall; the slowest remaining individual tests are component mounts at ~1-2s (`PasskeyManagement` 2016ms, `PasskeyPromptDialog` 1694ms), unrelated and passing.

## i18n / docs

None — test-only change, no user-facing copy and nothing operator-facing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787681327&installation_model_id=428379&pr_number=932&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F932&signature=88c5872990ad9cfea1aa3d496d9feacab48ce9561213a8aed0153ec1d9f21b2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->