### PR TITLE
fix: keep the paused card readable when its pill label runs long

### DIFF
--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -369,7 +369,7 @@ const installRowIsNew = useInstallRowBadge();
             </DropdownMenuItem>
             <DropdownMenuItem
                 :as-child="true"
-                class="min-w-0 rounded-full p-0 focus:bg-transparent"
+                class="shrink-0 rounded-full p-0 focus:bg-transparent"
                 data-test="clear-status-menu-item"
                 @select="clearStatus"
             >

--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -241,14 +241,26 @@ const installRowIsNew = useInstallRowBadge();
         <!-- While in DND the section leads with the paused card: crescent,
              when it lifts in italic serif, and a one-tap pill — Resume for a
              manual pause, Snooze for quiet hours (lifts tonight's window and
-             lets the standing schedule resume on its own). -->
+             lets the standing schedule resume on its own).
+
+             Unlike the label rows below, the card sets two siblings against
+             each other rather than a label against the row height, so
+             ellipsising alone would not save it: with the pill unshrinkable the
+             zero-basis label column was the only thing that could give, and the
+             French snooze label starved the readout to nothing (#762). The row
+             therefore wraps, and the label keeps a floor wide enough to stay
+             worth reading — so a pill that cannot fit beside the readout drops
+             under it with both still legible, in any locale. -->
         <div
             v-if="isDnd"
             data-test="dnd-paused-card"
-            class="mb-1 flex min-h-11 items-center gap-2.5 rounded-[10px] border border-border bg-muted px-2.5 py-1.5"
+            class="mb-1 flex min-h-11 flex-wrap items-center gap-2.5 rounded-[10px] border border-border bg-muted px-2.5 py-1.5"
         >
             <Moon class="size-4 shrink-0 text-muted-foreground" />
-            <span class="flex min-w-0 flex-1 flex-col">
+            <span
+                data-test="dnd-paused-label"
+                class="flex min-w-20 flex-1 flex-col"
+            >
                 <span
                     class="truncate text-[13px] font-semibold text-foreground"
                     >{{ $t('Paused') }}</span
@@ -273,7 +285,7 @@ const installRowIsNew = useInstallRowBadge();
             <DropdownMenuItem
                 v-if="pausedUntil"
                 :as-child="true"
-                class="shrink-0 rounded-full p-0 focus:bg-transparent"
+                class="min-w-0 rounded-full p-0 focus:bg-transparent"
                 data-test="dnd-resume-menu-item"
                 @select="resumeNotifications"
             >
@@ -283,13 +295,13 @@ const installRowIsNew = useInstallRowBadge();
                     type="button"
                     class="inline-flex h-6.5 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
                 >
-                    {{ $t('Resume') }}
+                    <span class="truncate">{{ $t('Resume') }}</span>
                 </Button>
             </DropdownMenuItem>
             <DropdownMenuItem
                 v-else-if="quietHoursUntil"
                 :as-child="true"
-                class="shrink-0 rounded-full p-0 focus:bg-transparent"
+                class="min-w-0 rounded-full p-0 focus:bg-transparent"
                 data-test="dnd-snooze-menu-item"
                 @select="snoozeSchedule"
             >
@@ -299,7 +311,9 @@ const installRowIsNew = useInstallRowBadge();
                     type="button"
                     class="inline-flex h-6.5 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
                 >
-                    {{ $t('Snooze schedule today') }}
+                    <span class="truncate">{{
+                        $t('Snooze schedule today')
+                    }}</span>
                 </Button>
             </DropdownMenuItem>
         </div>
@@ -355,7 +369,7 @@ const installRowIsNew = useInstallRowBadge();
             </DropdownMenuItem>
             <DropdownMenuItem
                 :as-child="true"
-                class="shrink-0 rounded-full p-0 focus:bg-transparent"
+                class="min-w-0 rounded-full p-0 focus:bg-transparent"
                 data-test="clear-status-menu-item"
                 @select="clearStatus"
             >

--- a/resources/js/components/UserMenuSheet.vue
+++ b/resources/js/components/UserMenuSheet.vue
@@ -265,13 +265,20 @@ const footerStyle = {
                  whose presets open as a second sheet. -->
             <div class="px-2 pt-3 pb-1">
                 <div :class="sectionLabelClass">{{ $t('Status') }}</div>
+                <!-- The desktop card's twin, wrapping for the same reason: the
+                     pill and the readout are siblings competing for one row, so
+                     a locale whose pill label outruns the sheet would otherwise
+                     squeeze the readout away entirely (#762). -->
                 <div
                     v-if="isDnd"
                     data-test="dnd-paused-card"
-                    class="mb-1 flex min-h-12 items-center gap-2.5 rounded-[11px] border border-border bg-muted px-2.5 py-1.5"
+                    class="mb-1 flex min-h-12 flex-wrap items-center gap-2.5 rounded-[11px] border border-border bg-muted px-2.5 py-1.5"
                 >
                     <Moon class="size-4 shrink-0 text-muted-foreground" />
-                    <span class="flex min-w-0 flex-1 flex-col">
+                    <span
+                        data-test="dnd-paused-label"
+                        class="flex min-w-20 flex-1 flex-col"
+                    >
                         <span
                             class="truncate text-[13px] font-semibold text-foreground"
                             >{{ $t('Paused') }}</span
@@ -301,10 +308,10 @@ const footerStyle = {
                         size="none"
                         type="button"
                         data-test="dnd-resume-menu-item"
-                        class="inline-flex h-7 shrink-0 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
+                        class="inline-flex h-7 min-w-0 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
                         @click="resumeNotifications()"
                     >
-                        {{ $t('Resume') }}
+                        <span class="truncate">{{ $t('Resume') }}</span>
                     </Button>
                     <Button
                         v-else-if="quietHoursUntil"
@@ -312,10 +319,12 @@ const footerStyle = {
                         size="none"
                         type="button"
                         data-test="dnd-snooze-menu-item"
-                        class="inline-flex h-7 shrink-0 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
+                        class="inline-flex h-7 min-w-0 cursor-pointer items-center rounded-full border border-border px-3 text-[11.5px] font-semibold text-muted-foreground hover:text-foreground"
                         @click="snoozeSchedule()"
                     >
-                        {{ $t('Snooze schedule today') }}
+                        <span class="truncate">{{
+                            $t('Snooze schedule today')
+                        }}</span>
                     </Button>
                 </div>
                 <Button

--- a/tests/Browser/UserMenuLongLabelTest.php
+++ b/tests/Browser/UserMenuLongLabelTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\AppLocale;
+use App\Models\User;
 
 /**
  * The user menu is only ever as wide as the dock it hangs off (its content
@@ -144,6 +145,126 @@ test('the presence menu renders at its narrowest supported width', function (): 
                 .closest('[data-slot="dropdown-menu-content"]');
 
             return Math.round(menu.getBoundingClientRect().width) === 256;
+        })()
+        JS, true);
+});
+
+/**
+ * The paused card is the one row where two siblings compete for the width
+ * rather than a label competing with the row height: its label column carries
+ * the state readout, and a one-tap pill sits beside it. The pill used to be
+ * unshrinkable, so the label — a flex child with a zero basis — was the only
+ * thing that could give, and in French "Suspendre l'horaire aujourd'hui"
+ * squeezed it to nothing while the card overflowed its own box (#762).
+ */
+
+/**
+ * A script asserting the paused card still reads: the label column holds a real
+ * width, neither of its two lines is clipped, and the card itself does not
+ * overflow.
+ */
+function pausedCardStillReads(): string
+{
+    return <<<'JS'
+    (() => {
+        const card = document.querySelector('[data-test="dnd-paused-card"]');
+        const label = document.querySelector('[data-test="dnd-paused-label"]');
+        const lines = [...label.children];
+
+        return card.scrollWidth <= card.clientWidth
+            && label.getBoundingClientRect().width > 0
+            && lines.length === 2
+            && lines.every(line => line.scrollWidth <= line.clientWidth);
+    })()
+    JS;
+}
+
+/**
+ * Put the viewer inside a quiet-hours window straddling this very minute, so
+ * the paused card is showing whenever the suite happens to run — near midnight
+ * the bounds wrap, which the evaluator reads as an overnight window.
+ */
+function insideQuietHours(User $user): void
+{
+    $now = now('UTC');
+
+    $user->forceFill([
+        'timezone' => 'UTC',
+        'dnd_schedule_enabled' => true,
+        'dnd_starts_at' => $now->subMinutes(10)->format('H:i'),
+        'dnd_ends_at' => $now->addMinutes(10)->format('H:i'),
+    ])->save();
+}
+
+test('the paused card keeps its quiet-hours readout legible in French', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+    $alice->update(['locale' => AppLocale::French]);
+    insideQuietHours($alice);
+
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@dnd-paused-card')
+        ->wait(0.5)
+        // The state the card exists to show is on screen, not squeezed out by
+        // the pill standing next to it...
+        ->assertSee('En pause')
+        ->assertSee('heures calmes')
+        ->assertSee("Suspendre l'horaire aujourd'hui")
+        ->assertScript(pausedCardStillReads(), true);
+});
+
+test('the paused card holds up against a pill label no locale would exceed', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+    insideQuietHours($alice);
+
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@dnd-snooze-menu-item')
+        ->wait(0.5)
+        // The English pill left the readout 14px to live in, which was already
+        // too little to read even before the French one erased it outright.
+        ->assertScript(pausedCardStillReads(), true)
+        ->assertScript(<<<'JS'
+        (() => {
+            const pill = document.querySelector('[data-test="dnd-snooze-menu-item"] span');
+            pill.textContent = 'Heutigen Zeitplan für ruhige Stunden vorübergehend aussetzen';
+
+            return true;
+        })()
+        JS, true)
+        ->assertScript(pausedCardStillReads(), true)
+        // A pill wider than the card itself is clipped to an ellipsis rather
+        // than allowed to push the card open.
+        ->assertScript(<<<'JS'
+        (() => {
+            const pill = document.querySelector('[data-test="dnd-snooze-menu-item"] span');
+
+            return pill.scrollWidth > pill.clientWidth
+                && getComputedStyle(pill).textOverflow === 'ellipsis';
+        })()
+        JS, true);
+});
+
+test('the paused card leaves the manual-pause variant on one line', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+    $alice->update(['locale' => AppLocale::French]);
+    $alice->forceFill(['dnd_until' => now()->addMinutes(30)])->save();
+
+    // "Reprendre" is short enough to sit beside the label, so the manual pause
+    // keeps the single-row card it always had — the wrapping guard below only
+    // bites when the pill genuinely cannot fit.
+    signInThroughBrowser($alice)
+        ->click('@sidebar-menu-button')
+        ->assertPresent('@dnd-resume-menu-item')
+        ->wait(0.5)
+        ->assertSee('Reprendre')
+        ->assertScript(pausedCardStillReads(), true)
+        ->assertScript(<<<'JS'
+        (() => {
+            const label = document.querySelector('[data-test="dnd-paused-label"]');
+            const pill = document.querySelector('[data-test="dnd-resume-menu-item"]');
+
+            return pill.getBoundingClientRect().top < label.getBoundingClientRect().bottom;
         })()
         JS, true);
 });

--- a/tests/Browser/UserMenuLongLabelTest.php
+++ b/tests/Browser/UserMenuLongLabelTest.php
@@ -191,8 +191,8 @@ function insideQuietHours(User $user): void
     $user->forceFill([
         'timezone' => 'UTC',
         'dnd_schedule_enabled' => true,
-        'dnd_starts_at' => $now->subMinutes(10)->format('H:i'),
-        'dnd_ends_at' => $now->addMinutes(10)->format('H:i'),
+        'dnd_starts_at' => $now->copy()->subMinutes(10)->format('H:i'),
+        'dnd_ends_at' => $now->copy()->addMinutes(10)->format('H:i'),
     ])->save();
 }
 
@@ -261,10 +261,17 @@ test('the paused card leaves the manual-pause variant on one line', function ():
         ->assertScript(pausedCardStillReads(), true)
         ->assertScript(<<<'JS'
         (() => {
-            const label = document.querySelector('[data-test="dnd-paused-label"]');
-            const pill = document.querySelector('[data-test="dnd-resume-menu-item"]');
+            const label = document.querySelector('[data-test="dnd-paused-label"]')
+                .getBoundingClientRect();
+            const pill = document.querySelector('[data-test="dnd-resume-menu-item"]')
+                .getBoundingClientRect();
 
-            return pill.getBoundingClientRect().top < label.getBoundingClientRect().bottom;
+            // The card centres its row, and the label column is its tallest
+            // item, so sharing a centre line is sharing a row — a wrapped pill
+            // would sit a whole line below.
+            return Math.abs(
+                (pill.top + pill.height / 2) - (label.top + label.height / 2),
+            ) <= 1;
         })()
         JS, true);
 });


### PR DESCRIPTION
Closes #762.

## What was wrong

The DND paused card sets its state readout against a one-tap pill in a single row. The pill was `shrink-0` and the label column was `min-w-0 flex-1` (a zero flex basis), so the label was the only thing that could give. Measured in the running app at the menu's narrow end (236px card, 216px of content):

| | label column | card |
| --- | --- | --- |
| French, quiet hours | **0px** | scrollWidth 256 > clientWidth 236 (overflows) |
| English, quiet hours | **14px** | fits, but the readout is clipped to nothing |
| French, manual pause ("Reprendre") | 89px | fits |

So "En pause" and "heures calmes · jusqu'à 8:00" were erased outright in French, and English was already down to an unreadable 14px.

## The fix

- The card row wraps, and the label column keeps an `min-w-20` (80px) floor. A pill that cannot fit beside the readout drops onto its own line with both still legible — no locale-specific string, and no shortened French translation.
- The pill can now shrink and clips to an ellipsis (`min-w-0` + a truncating span) rather than pushing the card open, so even a pill wider than the card itself cannot cause an overflow.
- Same change in `UserMenuSheet.vue`, which carries the same card on mobile and had the same competition (a 27px label in French).
- The status card's clear (x) control keeps `shrink-0` — it is a fixed-size icon button, not a label.

After: the French and English snooze variants show a two-row card with the full readout and full pill label; the manual-pause variant is pixel-identical (label 89px, card 50px tall, single row).

## How it was tested

Three Pest browser tests in `tests/Browser/UserMenuLongLabelTest.php`, alongside the #760 ones on the same surface:

- French + quiet hours: the readout is on screen, neither line is clipped, and `scrollWidth <= clientWidth`.
- Locale-agnostic: with the pill label swapped for a string no translation would exceed, the card still holds and the pill ellipsises instead of overflowing.
- Manual pause in French: "Reprendre" still shares the label's centre line, i.e. the card stays one row.

Full gate green — `composer test` at `Total: 100.0 %` with clean Pint/PHPStan/Rector, plus `lint:check`, `format:check`, `types:check`, `test:js` and `build`.

## i18n / docs

No new or changed strings, so no catalog updates. Nothing operator-facing, so no `docs/` changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787682933&installation_model_id=428379&pr_number=933&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F933&signature=218823c7e63cbc210e46cb229a458f129090c7d78c2dd54f09471470fa95bf98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->