### PR TITLE
fix: schedule the workspace audit-log retention sweep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,14 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # database or backup layer instead.
 # SECURITY_EVENT_RETENTION_DAYS=365
 
+# How long a workspace audit-log entry (rename, role change, member removal,
+# ownership transfer, channel lifecycle, message deletion, invitation lifecycle)
+# is kept before the daily sweep deletes it. One year by default, matching the
+# account-activity window above so both logs answer the retention question with
+# the same number. Set 0 to keep entries forever and enforce retention at the
+# database or backup layer instead.
+# AUDIT_LOG_RETENTION_DAYS=365
+
 # Single sign-on (OpenID Connect). Point these at your identity provider (Okta,
 # Microsoft Entra ID, Google Workspace, Auth0, Keycloak, …) to add a "Sign in
 # with SSO" button. The app reads the provider's discovery document at

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -126,9 +126,16 @@ CSP_ENABLED=true
 # visible; the window also caps how far back anyone can evidence an event, so
 # keep it at least as long as yours. Set 0 to keep events forever and enforce
 # retention at the database or backup layer instead. Data-export archives and
-# audit-evidence exports have a fixed 7-day window; the workspace audit log is
-# not pruned by the app.
+# audit-evidence exports have a fixed 7-day window.
 # SECURITY_EVENT_RETENTION_DAYS=365
+
+# How long a workspace audit-log entry (rename, role change, member removal,
+# ownership transfer, channel lifecycle, message deletion, invitation lifecycle)
+# is kept before the scheduler's daily sweep deletes it. One year by default,
+# matching the account-activity window above so both logs answer the retention
+# question with the same number. Set 0 to keep entries forever and enforce
+# retention at the database or backup layer instead.
+# AUDIT_LOG_RETENTION_DAYS=365
 
 # --- Single sign-on (OpenID Connect) -----------------------------------------
 # SSO_OIDC_ISSUER=https://your-idp.example.com

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -15,9 +15,19 @@ return [
 
     /*
      * When the clean command is executed, all recording activities older than
-     * the number of days specified here will be deleted.
+     * the number of days specified here will be deleted. A daily scheduled sweep
+     * runs that command, so the workspace audit log is disposed of on a schedule
+     * rather than growing without bound.
+     *
+     * One year is the default because assessment periods are annual, and because
+     * it matches the account-activity window (SECURITY_EVENT_RETENTION_DAYS), so
+     * one control family answers "how long do you keep it" with one number.
+     *
+     * Set 0 (or lower) to keep entries forever — an explicit "no window", for a
+     * deployment that enforces retention at the database or backup layer instead.
+     * The sweep is skipped entirely in that case.
      */
-    'clean_after_days' => 365,
+    'clean_after_days' => (int) env('AUDIT_LOG_RETENTION_DAYS', 365),
 
     /*
      * If no log name is passed to the activity() helper

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -205,6 +205,7 @@ deployment where the `scheduler` container is running.
 | Variable                        | Default | Notes                                                                                              |
 | ------------------------------- | ------- | -------------------------------------------------------------------------------------------------- |
 | `SECURITY_EVENT_RETENTION_DAYS` | `365`   | Days a per-user security event (sign-in, credential change, session revocation, data-export activity) is kept before a daily sweep deletes it. One year covers an annual assessment period. Set `0` to keep events forever. |
+| `AUDIT_LOG_RETENTION_DAYS`      | `365`   | Days a workspace audit-log entry (rename, role change, member removal, ownership transfer, channel lifecycle, message deletion, invitation lifecycle) is kept before a daily sweep deletes it. Matches the window above so both logs answer the retention question with the same number. Set `0` to keep entries forever. |
 
 Two more windows are set elsewhere, and are listed here so the whole picture is in
 one place:
@@ -215,7 +216,8 @@ one place:
 - **Uploaded-but-never-sent attachments** are swept after
   `ATTACHMENT_PENDING_TTL_HOURS` (see [Attachments](#attachments)).
 
-The workspace audit log is not pruned by the app. See
+Setting either retention variable to `0` turns its sweep off and keeps that log
+forever, which makes disposal your responsibility. See
 [Security & compliance](/reference/security-and-compliance/) for what that means
 for an assessment.
 

--- a/docs/src/content/docs/reference/security-and-compliance.md
+++ b/docs/src/content/docs/reference/security-and-compliance.md
@@ -41,7 +41,7 @@ criterion in the context of your whole system.
 | **Provisioning and deprovisioning (SSO / SCIM)** | SSO logins just-in-time provision accounts. SCIM 2.0 lets your IdP push lifecycle changes: removing someone from the directory deactivates their account here, revoking access and ending all their sessions immediately, while retaining history. Reactivation is a later `active: true`. | CC6.1, CC6.2, CC6.3 | A.5.16, A.5.18 |
 | **Data export (portability)** | A user can request a self-service export of their own data: a ZIP of JSON files (profile, teams, messages, and their security events), delivered by email and downloadable for 7 days. | (Privacy) P5 | A.5.34, A.8.11 |
 | **Account deletion and erasure** | Deleting an account removes the user record and reassigns their authored messages to a shared "Deleted User" tombstone, so conversations stay coherent while personal attribution is removed. The user's personal teams are deleted. | (Privacy) P4 | A.8.10, A.5.34 |
-| **Retention windows** | Account-activity (security) events are deleted after `SECURITY_EVENT_RETENTION_DAYS` (default 365, so an annual assessment period stays fully visible; `0` keeps them forever). Uploaded-but-unsent attachments are swept after `ATTACHMENT_PENDING_TTL_HOURS` (default 24). Data-export archives and audit-evidence export files are downloadable for a fixed 7-day window, after which a scheduled task deletes both the file and its record. Retention of the workspace audit log itself is an operator decision (see the note below). | (Privacy) P4 | A.8.10, A.5.34 |
+| **Retention windows** | Account-activity (security) events are deleted after `SECURITY_EVENT_RETENTION_DAYS` (default 365, so an annual assessment period stays fully visible; `0` keeps them forever). The workspace audit log is deleted on the same terms after `AUDIT_LOG_RETENTION_DAYS` (default 365; `0` keeps it forever). Uploaded-but-unsent attachments are swept after `ATTACHMENT_PENDING_TTL_HOURS` (default 24). Data-export archives and audit-evidence export files are downloadable for a fixed 7-day window, after which a scheduled task deletes both the file and its record. | (Privacy) P4 | A.8.10, A.5.34 |
 | **Encryption and transport posture** | The application encrypts session data and any encrypted attributes with `APP_KEY` (AES-256). Containers speak plain HTTP by design; TLS termination is delegated to your reverse proxy (see operator responsibilities). | CC6.1, CC6.7 | A.8.24, A.5.14 |
 | **Backups** | Durable state is one PostgreSQL database plus the uploaded-files volume; the search index and Redis are derived or transient. `docker/backup.sh` and `docker/restore.sh` ship with the stack and cover the dump, restore, and retention (`--keep=N`), but scheduling, testing, encrypting, and off-siting backups is an operator responsibility. | A1.2 | A.8.13 |
 
@@ -56,19 +56,18 @@ criterion in the context of your whole system.
   passkey enrollment today. The supported way to require MFA is to front all
   access with SSO (`AUTH_SSO_ONLY=true`) and enforce the factor at your identity
   provider, which is where most SOC 2 and ISO 27001 programs already manage it.
-- **The account-activity log is disposed of on a schedule; the workspace audit log
-  is not.** Security events are deleted once they pass
-  `SECURITY_EVENT_RETENTION_DAYS` (default one year) by a daily task in the
-  `scheduler` container — so on a deployment running the bundled stack, disposal
-  of that log is automatic and its window is the number you can point an assessor
-  at. Setting the variable to `0` turns that sweep off and keeps security events
-  indefinitely, which makes disposal of this log your responsibility too, exactly
-  as it already is for the audit log. The workspace audit log has no such sweep
-  and accumulates however it is set: define a
-  retention window that matches your policy and enforce it at the database or
-  backup layer. Note that both windows cap how far back you can evidence an
-  event, so keep the security-event window at least as long as your assessment
-  period.
+- **Both logs are disposed of on a schedule.** Security events are deleted once
+  they pass `SECURITY_EVENT_RETENTION_DAYS` (default one year), and workspace
+  audit-log entries once they pass `AUDIT_LOG_RETENTION_DAYS` (default one year),
+  each by a daily task in the `scheduler` container — so on a deployment running
+  the bundled stack, disposal of both logs is automatic and each window is a
+  number you can point an assessor at. Setting either variable to `0` turns that
+  sweep off and keeps the log indefinitely, which makes disposal of it your
+  responsibility: define a retention window that matches your policy and enforce
+  it at the database or backup layer instead. Note that both windows also cap how
+  far back you can evidence an event, so keep them at least as long as your
+  assessment period. Neither sweep runs at all if you do not run the `scheduler`
+  container.
 - **The password policy is enforced in production.** The full complexity and
   breach-check rules apply when the app runs in its production environment, which
   is the configuration you audit.

--- a/routes/console.php
+++ b/routes/console.php
@@ -83,6 +83,16 @@ Schedule::call(fn (PruneSecurityEvents $prune): int => $prune->handle())
     ->withoutOverlapping()
     ->description('Prune security events past the retention window');
 
+// Spatie's clean command reads `activitylog.clean_after_days` itself, so the
+// window lives in config rather than in a --days flag here. --force is required:
+// the command is confirmable, and unattended in production it would otherwise
+// cancel itself at the prompt instead of pruning.
+Schedule::command('activitylog:clean --force')
+    ->daily()
+    ->withoutOverlapping()
+    ->when(fn (): bool => (int) config('activitylog.clean_after_days') >= 1)
+    ->description('Prune workspace audit-log entries past the retention window');
+
 Schedule::call(fn (PurgeCachedProxyImages $purge): int => $purge->handle())
     ->name('purge-cached-proxy-images')
     ->daily()

--- a/tests/Feature/Console/RetentionScheduleTest.php
+++ b/tests/Feature/Console/RetentionScheduleTest.php
@@ -1,11 +1,18 @@
 <?php
 
+use App\Models\AuditActivity;
 use App\Models\DataExport;
 use App\Models\SecurityEvent;
 use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
+
+/**
+ * The description the workspace audit-log sweep is registered under, which is
+ * also how it is located in the schedule.
+ */
+const AUDIT_LOG_SWEEP_DESCRIPTION = 'Prune workspace audit-log entries past the retention window';
 
 /**
  * Find a scheduled event by its description, loading the console schedule first
@@ -58,4 +65,37 @@ test('the scheduled data-export sweep purges expired archives', function (): voi
     Storage::disk('local')->assertExists($live->path);
     $this->assertDatabaseMissing('data_exports', ['id' => $expired->id]);
     $this->assertDatabaseHas('data_exports', ['id' => $live->id]);
+});
+
+test('the audit-log sweep is scheduled daily without overlapping', function (): void {
+    $event = dailyRetentionSweep(AUDIT_LOG_SWEEP_DESCRIPTION);
+
+    expect($event->command)->toContain('activitylog:clean');
+});
+
+test('the audit-log sweep forces itself through the production confirmation prompt', function (): void {
+    expect(dailyRetentionSweep(AUDIT_LOG_SWEEP_DESCRIPTION)->command)->toContain('--force');
+});
+
+test('the audit-log sweep runs while a retention window is set', function (): void {
+    config()->set('activitylog.clean_after_days', 365);
+
+    expect(dailyRetentionSweep(AUDIT_LOG_SWEEP_DESCRIPTION)->filtersPass($this->app))->toBeTrue();
+});
+
+test('the audit-log sweep is skipped when retention is disabled', function (int $days): void {
+    config()->set('activitylog.clean_after_days', $days);
+
+    expect(dailyRetentionSweep(AUDIT_LOG_SWEEP_DESCRIPTION)->filtersPass($this->app))->toBeFalse();
+})->with([0, -1]);
+
+test('the audit-log sweep deletes entries past the configured window and keeps newer ones', function (): void {
+    config()->set('activitylog.clean_after_days', 30);
+    $stale = AuditActivity::factory()->create(['created_at' => now()->subDays(31)]);
+    $recent = AuditActivity::factory()->create(['created_at' => now()->subDays(29)]);
+
+    $this->artisan('activitylog:clean', ['--force' => true])->assertSuccessful();
+
+    $this->assertDatabaseMissing('activity_log', ['id' => $stale->id]);
+    $this->assertDatabaseHas('activity_log', ['id' => $recent->id]);
 });

--- a/tests/Unit/AuditLogRetentionDefaultTest.php
+++ b/tests/Unit/AuditLogRetentionDefaultTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The workspace audit-log retention window an operator inherits when they never
+ * set `AUDIT_LOG_RETENTION_DAYS`. One year, matching the account-activity log so
+ * one control family answers "how long do you keep it" with a single number.
+ * See issue #913.
+ */
+const DEFAULT_AUDIT_LOG_RETENTION_DAYS = 365;
+
+/**
+ * The default is stated in five places an operator can read — the config
+ * fallback, both env templates, the env-variable table, and the compliance
+ * control mapping — and a change to one of them that misses the others hands out
+ * contradictory answers about how long the log is kept.
+ */
+function statedAuditLogRetention(string $relativePath, string $pattern): ?int
+{
+    $contents = (string) file_get_contents(dirname(__DIR__, 2).'/'.$relativePath);
+
+    if (preg_match($pattern, $contents, $matches) !== 1) {
+        return null;
+    }
+
+    return (int) $matches[1];
+}
+
+test('the config fallback is one year', function (): void {
+    expect(statedAuditLogRetention('config/activitylog.php', "/env\('AUDIT_LOG_RETENTION_DAYS',\s*(\d+)\)/"))
+        ->toBe(DEFAULT_AUDIT_LOG_RETENTION_DAYS);
+});
+
+test('both env templates ship the config fallback', function (string $template): void {
+    expect(statedAuditLogRetention($template, '/^#\s*AUDIT_LOG_RETENTION_DAYS=(\d+)$/m'))
+        ->toBe(DEFAULT_AUDIT_LOG_RETENTION_DAYS);
+})->with(['.env.example', '.env.prod.example']);
+
+test('the documented default matches the shipped one', function (): void {
+    expect(statedAuditLogRetention(
+        'docs/src/content/docs/reference/environment-variables.md',
+        '/\|\s*`AUDIT_LOG_RETENTION_DAYS`\s*\|\s*`(\d+)`/',
+    ))->toBe(DEFAULT_AUDIT_LOG_RETENTION_DAYS);
+});
+
+test('the compliance control mapping states the shipped default', function (): void {
+    expect(statedAuditLogRetention(
+        'docs/src/content/docs/reference/security-and-compliance.md',
+        '/`AUDIT_LOG_RETENTION_DAYS`\s*\(default\s*(\d+)/',
+    ))->toBe(DEFAULT_AUDIT_LOG_RETENTION_DAYS);
+});


### PR DESCRIPTION
Closes #913.

## What

`config/activitylog.php` set `clean_after_days => 365`, but that value is only read by Spatie's `activitylog:clean` command and that command was never scheduled — so the workspace audit log grew without bound and the configured window was inert.

- `clean_after_days` is now `env('AUDIT_LOG_RETENTION_DAYS', 365)`, mirroring `SECURITY_EVENT_RETENTION_DAYS`. `0` or lower means "keep forever".
- `activitylog:clean --force` is scheduled `daily()` + `withoutOverlapping()` in `routes/console.php`, with a `description()` like its neighbours, and `when()`-guarded off when retention is disabled.

`--force` is deliberate: the command is confirmable, so unattended in a production container it would cancel itself at the prompt instead of pruning. The `when()` guard also keeps the command from erroring on its own "days must be a positive integer" check when the window is `0`.

The bulk delete goes through the query builder, so it does not fire the `deleting` model event `AuditActivity` uses to keep the log append-only — the same sanctioned pruning path `PruneSecurityEvents` documents.

## Why

Retention and disposal is a control auditors check. With #423 landed, security events prune automatically; leaving the audit log unswept made one control family answer the same question two different ways. Both logs now share a default of one year.

## Testing

- `tests/Feature/Console/RetentionScheduleTest.php` — the sweep is registered daily + `withoutOverlapping`, carries `--force`, passes its filter with a window set, is filtered out at `0` and `-1`, and actually deletes past the configured window while keeping newer entries.
- `tests/Unit/AuditLogRetentionDefaultTest.php` — the 365-day default is stated identically in the config fallback, both env templates, the env-variable table, and the compliance control mapping (mirrors `SecurityEventRetentionDefaultTest`).
- `./vendor/bin/sail composer test` green: Pint, PHPStan, Rector, and `Total: 100.0 %` coverage. `cd docs && npm run build` green.

## Docs

- `AUDIT_LOG_RETENTION_DAYS` added to `.env.example`, `.env.prod.example`, and the **Data retention** table in `environment-variables.md`.
- `security-and-compliance.md`: the **Retention windows** row now covers the audit log, and the auditor note "The account-activity log is disposed of on a schedule; the workspace audit log is not" is rewritten — both logs are now swept, with the `0` opt-out and the `scheduler`-container caveat called out.
- Removed the now-false "The workspace audit log is not pruned by the app" line from `environment-variables.md`.

No user-facing copy changed, so no `lang/fr.json` additions.

## Note

Local CodeRabbit was rate-limited on the free tier (26 min wait), so this PR has not had a local pass — relying on the CodeRabbit app review here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787683542&installation_model_id=428379&pr_number=934&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F934&signature=a05962d6611a538db9ae0611bbcae4753fe570b944d641d102a7dd00b075ffd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->