### PR TITLE
fix: return focus to the control that opened a dialog when it closes

### DIFF
--- a/resources/js/components/ui/dialog/DialogContent.vue
+++ b/resources/js/components/ui/dialog/DialogContent.vue
@@ -11,6 +11,7 @@ import {
   useForwardPropsEmits,
 } from "reka-ui"
 import { computed } from "vue"
+import { useDialogFocusRestore } from "@/composables/useDialogFocusRestore"
 import { useIsMobile } from "@/composables/useIsMobile"
 import { useKeyboardInset } from "@/composables/useKeyboardInset"
 import { useSheetDrag } from "@/composables/useSheetDrag"
@@ -66,6 +67,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
 const isMobile = useIsMobile()
 const keyboardInset = useKeyboardInset()
 const rootContext = injectDialogRootContext()
+const { restoreFocusOnClose } = useDialogFocusRestore()
 
 /** Whether this dialog is presenting as a bottom sheet at the current width. */
 const asSheet = computed(() =>
@@ -151,6 +153,7 @@ const contentStyle = computed<CSSProperties | undefined>(() => {
       v-bind="{ ...$attrs, ...forwarded }"
       :class="contentClass"
       :style="contentStyle"
+      @close-auto-focus="restoreFocusOnClose"
     >
       <!-- The sheet's sticky strip carries both top affordances: the grab
            handle, and the close button — which must live here rather than

--- a/resources/js/composables/useDialogFocusRestore.test.ts
+++ b/resources/js/composables/useDialogFocusRestore.test.ts
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { App, VNodeChild } from 'vue';
+import { createApp, defineComponent, h, nextTick, ref } from 'vue';
+
+import {
+    Dialog,
+    DialogContent,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { initializeOverlayInert } from '@/lib/overlayInert';
+
+/**
+ * The restore has to survive the `inert` the app mirrors over the page behind an
+ * open dialog, so these render a real `<Dialog>` with that mirror running rather
+ * than stubbing either half.
+ */
+let app: App | null = null;
+let disposeOverlayInert: (() => void) | null = null;
+
+/** jsdom has no `matchMedia`; the dialog primitive asks it for the breakpoint. */
+function standAt(width: number): void {
+    window.matchMedia = ((query: string) => {
+        const limit = Number(/max-width:\s*([\d.]+)px/.exec(query)?.[1] ?? NaN);
+
+        return {
+            matches: Number.isNaN(limit) ? false : width <= limit,
+            media: query,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            addListener: () => {},
+            removeListener: () => {},
+            onchange: null,
+            dispatchEvent: () => false,
+        };
+    }) as typeof window.matchMedia;
+}
+
+const nativeFocus = HTMLElement.prototype.focus;
+
+/**
+ * jsdom implements `focus()` without the platform's `inert` rule: it will focus
+ * an element inside an inert subtree, which a browser silently refuses to do.
+ * That refusal *is* the defect under test (#784), so the rule is put back here —
+ * without it a restore that fires too early would look like it had worked.
+ */
+function enforceInertFocusRule(): void {
+    HTMLElement.prototype.focus = function focus(
+        this: HTMLElement,
+        options?: FocusOptions,
+    ): void {
+        if (this.closest('[inert]')) {
+            return;
+        }
+
+        nativeFocus.call(this, options);
+    };
+}
+
+/**
+ * Let Vue, the overlay-inert `MutationObserver` (a microtask) and the deferred
+ * restore (a task) all land before anything is read.
+ */
+async function settle(): Promise<void> {
+    for (let round = 0; round < 4; round += 1) {
+        await nextTick();
+        await new Promise((resolve) => setTimeout(resolve));
+    }
+}
+
+/**
+ * Mount `tree`, open the dialog by clicking the control it marked `@opener`, and
+ * hand both that control and a way to close back to the test.
+ */
+async function openDialog(
+    tree: (open: boolean, onUpdate: (value: boolean) => void) => VNodeChild,
+): Promise<{ opener: HTMLElement; close: () => void }> {
+    const open = ref(false);
+
+    app = createApp(
+        defineComponent({
+            setup: () => () =>
+                tree(open.value, (value: boolean) => {
+                    open.value = value;
+                }),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+
+    const host = document.createElement('div');
+    document.body.append(host);
+    app.mount(host);
+    await nextTick();
+
+    const opener = document.querySelector<HTMLElement>('[data-test="opener"]');
+
+    expect(opener).not.toBeNull();
+
+    opener!.focus();
+    opener!.click();
+    await settle();
+
+    return {
+        opener: opener as HTMLElement,
+        close: () => {
+            open.value = false;
+        },
+    };
+}
+
+/** The dialog's own half of the tree, shared by every shape of opener. */
+const content = (): VNodeChild =>
+    h(DialogContent, null, () => [h(DialogTitle, () => 'Create a channel')]);
+
+beforeEach(() => {
+    standAt(1280);
+    enforceInertFocusRule();
+    disposeOverlayInert = initializeOverlayInert();
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    disposeOverlayInert?.();
+    disposeOverlayInert = null;
+    HTMLElement.prototype.focus = nativeFocus;
+    document.body.innerHTML = '';
+});
+
+describe('closing a dialog', () => {
+    it('returns focus to the button that opened it', async () => {
+        // An ordinary button driving `v-model:open` — how nearly every dialog
+        // in this app is opened, and the shape reka's own restore misses.
+        const { opener, close } = await openDialog((open, onUpdate) => [
+            h(
+                'button',
+                {
+                    type: 'button',
+                    'data-test': 'opener',
+                    onClick: () => onUpdate(true),
+                },
+                'Open',
+            ),
+            h(Dialog, { open, 'onUpdate:open': onUpdate }, content),
+        ]);
+
+        // The page behind the dialog is inert while it is open — the state the
+        // restore has to outlive.
+        expect(opener.closest('[inert]')).not.toBeNull();
+
+        close();
+        await settle();
+
+        expect(document.activeElement).toBe(opener);
+    });
+
+    it('returns focus to a real DialogTrigger too', async () => {
+        const { opener, close } = await openDialog((open, onUpdate) =>
+            h(Dialog, { open, 'onUpdate:open': onUpdate }, () => [
+                h(DialogTrigger, { asChild: true }, () => [
+                    h(
+                        'button',
+                        { type: 'button', 'data-test': 'opener' },
+                        'Open',
+                    ),
+                ]),
+                content(),
+            ]),
+        );
+
+        close();
+        await settle();
+
+        expect(document.activeElement).toBe(opener);
+    });
+
+    it('leaves a call site that names its own destination alone', async () => {
+        const elsewhere = document.createElement('button');
+        document.body.append(elsewhere);
+
+        const { close } = await openDialog((open, onUpdate) => [
+            h(
+                'button',
+                {
+                    type: 'button',
+                    'data-test': 'opener',
+                    onClick: () => onUpdate(true),
+                },
+                'Open',
+            ),
+            h(Dialog, { open, 'onUpdate:open': onUpdate }, () => [
+                h(
+                    DialogContent,
+                    {
+                        onCloseAutoFocus: (event: Event) => {
+                            event.preventDefault();
+                            setTimeout(() => elsewhere.focus());
+                        },
+                    },
+                    () => [h(DialogTitle, () => 'Create a channel')],
+                ),
+            ]),
+        ]);
+
+        close();
+        await settle();
+
+        expect(document.activeElement).toBe(elsewhere);
+    });
+});

--- a/resources/js/composables/useDialogFocusRestore.ts
+++ b/resources/js/composables/useDialogFocusRestore.ts
@@ -1,0 +1,67 @@
+import { injectDialogRootContext } from 'reka-ui';
+import { watch } from 'vue';
+
+import { focusAfterOverlayInert } from '@/lib/overlayInert';
+
+/**
+ * Give a reka dialog surface the focus restore WCAG 2.4.3 asks for: closing it
+ * hands focus back to the control that opened it, instead of dropping a keyboard
+ * or screen-reader user at the top of the document (#784).
+ *
+ * reka already tries. `DialogContentModal` cancels the browser's own restore and
+ * focuses the trigger itself, synchronously, from inside `closeAutoFocus` — but
+ * at that moment the page behind the surface is still `inert`, because the
+ * mirror that makes it so is torn down a microtask later (see
+ * `@/lib/overlayInert`). Focusing into an inert subtree does nothing, and reka's
+ * own deferred fallback has already been cancelled, so focus lands nowhere.
+ * Waiting for the mirror to lift is the whole fix.
+ */
+export function useDialogFocusRestore(): {
+    restoreFocusOnClose: (event: Event) => void;
+} {
+    const rootContext = injectDialogRootContext();
+
+    /**
+     * Whatever held focus the instant before the surface opened. reka's own
+     * `triggerElement` only covers surfaces opened through a `<DialogTrigger>`;
+     * most here are driven straight from `v-model:open`, and some open from a
+     * keyboard shortcut, where the right destination is the control the user
+     * actually left — not a trigger at all.
+     */
+    let opener: HTMLElement | null = null;
+
+    watch(
+        () => rootContext.open.value,
+        (open) => {
+            if (!open) {
+                return;
+            }
+
+            const active = document.activeElement;
+
+            opener =
+                active instanceof HTMLElement && active !== document.body
+                    ? active
+                    : null;
+        },
+        { immediate: true },
+    );
+
+    function restoreFocusOnClose(event: Event): void {
+        // A call site that named its own destination has already prevented this
+        // — the mobile sidebar hands focus to the destination pane, because the
+        // row that opened it navigated away with the sheet.
+        if (event.defaultPrevented) {
+            return;
+        }
+
+        // Cancels reka's restore, which cannot land while the page is inert.
+        event.preventDefault();
+
+        focusAfterOverlayInert(
+            opener ?? rootContext.triggerElement.value ?? null,
+        );
+    }
+
+    return { restoreFocusOnClose };
+}

--- a/resources/js/lib/overlayInert.ts
+++ b/resources/js/lib/overlayInert.ts
@@ -45,6 +45,28 @@ function syncOverlayInert(): void {
 }
 
 /**
+ * Move focus to `element` once the mirror above has been lifted.
+ *
+ * `syncOverlayInert` runs from a `MutationObserver` callback, which the platform
+ * delivers as a microtask — so anything that focuses as an overlay closes is
+ * still aiming into an inert subtree, and the platform answers a focus call
+ * there by focusing nothing at all. That is how closing a dialog stranded focus
+ * on `<body>` (#784). A task runs after that microtask, so by then the page is
+ * focusable again.
+ */
+export function focusAfterOverlayInert(element: HTMLElement | null): void {
+    if (element === null) {
+        return;
+    }
+
+    setTimeout(() => {
+        if (element.isConnected) {
+            element.focus();
+        }
+    });
+}
+
+/**
  * Start mirroring `inert` onto the region reka hides behind an open overlay.
  * Runs for the lifetime of the app; the returned disposer exists for tests.
  */

--- a/tests/Browser/DialogFocusRestoreTest.php
+++ b/tests/Browser/DialogFocusRestoreTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Focus restore when a dialog closes (#784).
+ *
+ * WCAG 2.4.3 (Focus Order): a keyboard or screen-reader user who opens a dialog
+ * and closes it belongs back at the control they opened it from, not at the top
+ * of the document with the whole page to tab through again.
+ *
+ * The defect was a timing one, and needs a real browser to see: reka restores
+ * focus synchronously as the dialog tears down, while the page behind it is
+ * still `inert` (the app mirrors `inert` onto whatever reka hides — see
+ * `resources/js/lib/overlayInert.ts`). A browser answers a focus call into an
+ * inert subtree by focusing nothing at all, so focus landed on `<body>`. jsdom
+ * has no such rule, which is why this half of the cover lives here.
+ */
+
+/**
+ * Whether focus has come home to the given `data-test` control. Read after the
+ * dialog is gone, so it also proves the restore outlived the teardown.
+ */
+function focusIsOn(string $test): string
+{
+    return <<<JS
+    (() => document.activeElement === document.querySelector('[data-test="{$test}"]'))()
+    JS;
+}
+
+test('closing a dialog with Escape returns focus to the control that opened it', function (int $width, int $height): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        $width,
+        $height,
+        browserChannelUrl($team, $channel),
+    )
+        ->keys('@create-channel-name', ['Escape'])
+        ->assertNotPresent('@create-channel-submit')
+        ->assertScript(focusIsOn('create-channel-trigger'), true);
+})->with([
+    // Not a mobile defect: it held at both ends of the range, so both are read.
+    'phone' => [390, 844],
+    'desktop' => [1280, 800],
+]);
+
+test('closing a dialog with its close button returns focus too', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        1280,
+        800,
+        browserChannelUrl($team, $channel),
+    )
+        ->click('@dialog-close-button')
+        ->assertNotPresent('@create-channel-submit')
+        ->assertScript(focusIsOn('create-channel-trigger'), true);
+});
+
+test('dismissing a dialog by its scrim returns focus too', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $page = openCreateChannelDialog(
+        signInThroughBrowser($alice),
+        390,
+        844,
+        browserChannelUrl($team, $channel),
+    );
+
+    // Dispatched at whatever a hit test says is under that point, not at the
+    // overlay element: while a dialog is open the whole page is
+    // `pointer-events: none`, so a tap above the sheet resolves to the document
+    // and is answered by a document-level listener.
+    $page->script(<<<'JS'
+    (() => {
+        const sheet = document.querySelector('[data-slot="dialog-content"]').getBoundingClientRect();
+        const point = {
+            bubbles: true,
+            cancelable: true,
+            clientX: Math.round(window.innerWidth / 2),
+            clientY: Math.round(sheet.top / 2),
+        };
+        const target = document.elementFromPoint(point.clientX, point.clientY);
+        const pointer = { ...point, pointerId: 1, pointerType: 'mouse', isPrimary: true, button: 0 };
+
+        target.dispatchEvent(new PointerEvent('pointerdown', pointer));
+        target.dispatchEvent(new PointerEvent('pointerup', pointer));
+        target.dispatchEvent(new MouseEvent('click', { ...point, button: 0 }));
+    })()
+    JS);
+
+    $page->assertNotPresent('@create-channel-submit')
+        ->assertScript(focusIsOn('create-channel-trigger'), true);
+});
+
+test('a dialog opened from a dropdown menu returns focus to the menu item', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // The one opener that is not a plain button: a menu item that keeps its menu
+    // open while the dialog it triggers takes over.
+    signInThroughBrowser($alice)
+        ->resize(1280, 800)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@workspace-switcher')
+        ->click('@team-switcher-new-team')
+        ->assertPresent('@create-team-submit')
+        ->keys('@create-team-name', ['Escape'])
+        ->assertNotPresent('@create-team-submit')
+        ->assertScript(focusIsOn('team-switcher-new-team'), true);
+});

--- a/tests/Browser/Helpers.php
+++ b/tests/Browser/Helpers.php
@@ -110,6 +110,24 @@ function browserChannelUrl(Team $team, Channel $channel): string
 }
 
 /**
+ * Open the create-channel dialog at the given viewport. It is the plainest of
+ * the form dialogs — a header, three fields and a pair of actions — so it stands
+ * in for the whole set that shares the primitive.
+ */
+function openCreateChannelDialog(AwaitableWebpage $page, int $width, int $height, string $url): AwaitableWebpage
+{
+    $page = $page->resize($width, $height)->navigate($url);
+
+    // Below the breakpoint the dock is a Sheet, so its rows only exist once it
+    // is opened; from `md` up the rail is always mounted.
+    if ($width < 768) {
+        $page = $page->click('@sidebar-toggle');
+    }
+
+    return $page->click('@create-channel-trigger')->assertPresent('@create-channel-submit');
+}
+
+/**
  * Sign a user in through the real login form, returning the page so the caller
  * can continue driving it. Each `visit()` gets its own browser context (isolated
  * cookie jar), so two calls yield two independently authenticated clients.

--- a/tests/Browser/MobileSheetsTest.php
+++ b/tests/Browser/MobileSheetsTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use App\Enums\AppLocale;
-use Pest\Browser\Api\AwaitableWebpage;
 
 /**
  * Dialogs below the `md` breakpoint (#772).
@@ -60,24 +59,6 @@ function openSurfaceIsACentredDialog(): string
             && box.width < window.innerWidth;
     })()
     JS;
-}
-
-/**
- * Open the create-channel dialog from the dock. It is the plainest of the form
- * dialogs — a header, three fields and a pair of actions — so it stands in for
- * the whole set that shares the primitive.
- */
-function openCreateChannelDialog(AwaitableWebpage $page, int $width, int $height, string $url): AwaitableWebpage
-{
-    $page = $page->resize($width, $height)->navigate($url);
-
-    // Below the breakpoint the dock is a Sheet, so its rows only exist once it
-    // is opened; from `md` up the rail is always mounted.
-    if ($width < 768) {
-        $page = $page->click('@sidebar-toggle');
-    }
-
-    return $page->click('@create-channel-trigger')->assertPresent('@create-channel-submit');
 }
 
 test('a dialog is a bottom sheet on a phone and a centred dialog from md up', function (int $width, int $height, bool $expectSheet): void {


### PR DESCRIPTION
Closes #784.

## Root cause — not the one the issue's comment guessed

`rootContext.triggerElement` *is* populated: reka's `DialogContentImpl` captures `document.activeElement` on mount even when there is no `<DialogTrigger>`. Instrumenting a real browser showed `focus()` firing on the still-connected trigger with no `focusin` following it.

The culprit is our own `resources/js/lib/overlayInert.ts` — the `inert` mirror added in #730 to fix `aria-hidden-focus`. It is driven by a `MutationObserver`, so it is torn down a microtask later, while reka's `DialogContentModal` restores focus *synchronously* inside `closeAutoFocus`. At that instant the opener's ancestor still carries `inert`, and the platform answers a focus call into an inert subtree by focusing nothing at all — with reka's own deferred fallback already cancelled by its `preventDefault()`. Focus lands on `<body>`.

## What changed

- `focusAfterOverlayInert()` in `overlayInert.ts` — the module that knows why the wait is needed — defers a focus by a task, past the observer's microtask.
- `useDialogFocusRestore()` resolves the destination (whatever held focus the instant before the dialog opened, falling back to reka's `triggerElement`) and hands it to that helper on `closeAutoFocus`. Wired into `ui/dialog/DialogContent.vue`, so all ~40 call sites are covered at once.
- A call site that names its own destination still wins — the mobile sidebar's `#main` handler prevents default first, and the composable stands down.

Two things measured and deliberately left alone: `SheetContent.vue` shares the primitive, but its only consumer (`Sidebar.vue`) always overrides `close-auto-focus`, so there is no reachable defect there; and `#main` sits outside the region reka hides, so the sidebar's own synchronous restore was never broken.

## How it was tested

- `resources/js/composables/useDialogFocusRestore.test.ts` — 3 cases running a real `<Dialog>` with the inert mirror live. They also put back the platform's inert focus rule, which jsdom does not implement: without it a too-early restore looks like it worked, and the defect is invisible.
- `tests/Browser/DialogFocusRestoreTest.php` — 5 cases: Escape at 390x844 and 1280x800, the close button, the scrim, and a dialog opened from a dropdown menu item.
- All 8 verified red without the fix and green with it.
- `openCreateChannelDialog` moved from `MobileSheetsTest.php` to `Browser/Helpers.php` so both suites share it; `MobileSheetsTest` re-run green (20 passed).
- Full gate green: `composer test` at `Total: 100.0 %`, plus `lint:check`, `format:check`, `types:check`, `build`, and the 1425-test vitest suite.

No user-facing copy and no operator-facing settings changed, so there are no i18n or docs updates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787686418&installation_model_id=428379&pr_number=935&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F935&signature=13d4735fae6c608e5aba265c36e3cb13184c0f46ee046a982cc5213a793d9979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->