### PR TITLE
fix: make the search facet pickers proper comboboxes

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1005,6 +1005,8 @@
   "Filter people…": "Filtrer les personnes…",
   "Filter channels": "Filtrer les salons",
   "Filter channels…": "Filtrer les salons…",
+  "No people match": "Aucune personne ne correspond",
+  "No channels match": "Aucun canal ne correspond",
   "Remove author filter": "Retirer le filtre d’auteur",
   "Remove channel filter": "Retirer le filtre de salon",
   "Remove date filter": "Retirer le filtre de date",

--- a/resources/js/components/ui/combobox/Combobox.test.ts
+++ b/resources/js/components/ui/combobox/Combobox.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import { Combobox, ComboboxItem } from '.';
+
+/**
+ * Mounts a real `<Combobox>` — reka's popover and listbox included — so the
+ * tests read the ARIA wiring exactly where axe audits it: a `combobox` input
+ * pointing at a sibling `listbox` of `option`s, never a filter buried inside a
+ * menu (#451).
+ */
+let app: App | null = null;
+
+const PEOPLE = [
+    { id: 'alice', name: 'Alice Brown' },
+    { id: 'bob', name: 'Bob Smith' },
+];
+
+function mount(onSelect: (id: string) => void = () => {}): void {
+    app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(
+                    Combobox,
+                    {
+                        fieldLabel: 'Filter people',
+                        listLabel: 'People',
+                        placeholder: 'Filter people…',
+                        emptyText: 'No people found',
+                    },
+                    {
+                        trigger: () =>
+                            h(
+                                'button',
+                                { type: 'button', 'data-test': 'picker' },
+                                'Author',
+                            ),
+                        default: () =>
+                            PEOPLE.map((person) =>
+                                h(
+                                    ComboboxItem,
+                                    {
+                                        key: person.id,
+                                        value: person.id,
+                                        onSelect: () => onSelect(person.id),
+                                    },
+                                    () => person.name,
+                                ),
+                            ),
+                    },
+                ),
+        }),
+    );
+    app.mount(document.body.appendChild(document.createElement('div')));
+}
+
+function query<T extends HTMLElement>(selector: string): T | null {
+    return document.querySelector<T>(selector);
+}
+
+async function open(): Promise<void> {
+    query<HTMLButtonElement>('[data-test="picker"]')?.click();
+    await nextTick();
+    await nextTick();
+}
+
+async function type(value: string): Promise<void> {
+    const input = query<HTMLInputElement>('[role="combobox"]');
+
+    if (input === null) {
+        throw new Error('The combobox input was not rendered.');
+    }
+
+    input.value = value;
+    input.dispatchEvent(new Event('input'));
+    await nextTick();
+    await nextTick();
+}
+
+/** What the trigger reports to assistive tech: whether the popup is showing. */
+function isExpanded(): string | null | undefined {
+    return query('[data-test="picker"]')?.getAttribute('aria-expanded');
+}
+
+async function press(key: string): Promise<void> {
+    query('[role="combobox"]')?.dispatchEvent(
+        new KeyboardEvent('keydown', { key, bubbles: true }),
+    );
+    await nextTick();
+    await nextTick();
+}
+
+beforeAll(() => {
+    // Roving the highlight scrolls the option into view, which jsdom has no
+    // layout to do.
+    Element.prototype.scrollIntoView = () => {};
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('Combobox', () => {
+    it('opens a combobox input wired to a sibling listbox of options', async () => {
+        mount();
+        await open();
+
+        const input = query<HTMLInputElement>('[role="combobox"]');
+        const listbox = query('[role="listbox"]');
+
+        expect(input).not.toBeNull();
+        expect(listbox).not.toBeNull();
+        expect(input?.getAttribute('aria-expanded')).toBe('true');
+        expect(input?.getAttribute('aria-autocomplete')).toBe('list');
+        expect(input?.getAttribute('aria-label')).toBe('Filter people');
+        expect(input?.getAttribute('aria-controls')).toBe(listbox?.id);
+        expect(listbox?.getAttribute('aria-label')).toBe('People');
+        // The filter is a sibling of the list, never a text field owned by it.
+        expect(listbox?.contains(input as Node)).toBe(false);
+        expect(document.querySelectorAll('[role="option"]')).toHaveLength(2);
+    });
+
+    it('narrows the options as the filter is typed, then says nothing matched', async () => {
+        mount();
+        await open();
+        await type('bob');
+
+        const options = document.querySelectorAll('[role="option"]');
+
+        expect(options).toHaveLength(1);
+        expect(options[0]?.textContent).toContain('Bob Smith');
+
+        await type('zzz');
+
+        expect(document.querySelectorAll('[role="option"]')).toHaveLength(0);
+        expect(document.body.textContent).toContain('No people found');
+    });
+
+    it('stops naming an active option once the filter matches nothing', async () => {
+        mount();
+        await open();
+        await press('ArrowDown');
+
+        expect(
+            query('[role="combobox"]')?.getAttribute('aria-activedescendant'),
+        ).not.toBeNull();
+
+        await type('zzz');
+
+        // The highlighted option is gone from the DOM, so keeping its id here
+        // would leave the field pointing at nothing (axe: aria-valid-attr-value).
+        expect(
+            query('[role="combobox"]')?.getAttribute('aria-activedescendant'),
+        ).toBeNull();
+    });
+
+    it('reports the clicked option and dismisses the popup', async () => {
+        const picked: string[] = [];
+
+        mount((id) => picked.push(id));
+        await open();
+
+        document.querySelectorAll<HTMLElement>('[role="option"]')[1]?.click();
+        await nextTick();
+        await nextTick();
+
+        expect(picked).toEqual(['bob']);
+        expect(isExpanded()).toBe('false');
+    });
+
+    it('roves the highlight with the arrow keys and selects with Enter', async () => {
+        const picked: string[] = [];
+
+        mount((id) => picked.push(id));
+        await open();
+        await press('ArrowDown');
+
+        const input = query('[role="combobox"]');
+        const highlighted = query('[data-highlighted]');
+
+        expect(highlighted?.getAttribute('role')).toBe('option');
+        expect(input?.getAttribute('aria-activedescendant')).toBe(
+            highlighted?.id,
+        );
+
+        await press('ArrowDown');
+        await press('Enter');
+
+        expect(picked).toEqual(['bob']);
+        expect(isExpanded()).toBe('false');
+    });
+});

--- a/resources/js/components/ui/combobox/Combobox.vue
+++ b/resources/js/components/ui/combobox/Combobox.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue';
+import { useId } from 'vue';
+import {
+    Command,
+    CommandEmpty,
+    CommandList,
+    provideCommandGroupContext,
+} from '@/components/ui/command';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import ComboboxFilter from './ComboboxFilter.vue';
+import { provideComboboxContext } from '.';
+
+/**
+ * A filterable single-select popup built as a real combobox: a `combobox` text
+ * field that types-to-filter, beside — never inside — a `listbox` of `option`s
+ * the arrow keys rove through. Its trigger is a slot, so a call site keeps
+ * whatever affordance it already draws (a facet pill, a field, a button).
+ */
+const props = defineProps<{
+    /**
+     * Accessible name for the filter field and the popup around it. Required:
+     * the popup shows no visible label, so this is the only thing that says
+     * which list is being filtered.
+     */
+    fieldLabel: string;
+    /** Accessible name for the listbox, saying what the options are. */
+    listLabel: string;
+    /** Placeholder for the filter field. */
+    placeholder: string;
+    /** Shown in place of the list once the filter matches nothing. */
+    emptyText: string;
+    /** Extra classes for the popup surface, e.g. its width. */
+    class?: HTMLAttributes['class'];
+}>();
+
+defineOptions({
+    // The trigger is the call site's own element, so fallthrough attributes go
+    // to the one element this component owns and a caller may need to reach:
+    // the filter field.
+    inheritAttrs: false,
+});
+
+const open = defineModel<boolean>('open', { default: false });
+
+const listboxId = useId();
+
+provideComboboxContext({
+    close: () => {
+        open.value = false;
+    },
+});
+
+/**
+ * A single flat list needs no `<CommandGroup>` — and rendering one would leave
+ * a `group` whose `aria-labelledby` points at a heading that was never drawn.
+ * Standing in for it keeps `<CommandItem>`'s required group context satisfied
+ * while the listbox owns its options directly.
+ */
+provideCommandGroupContext({});
+</script>
+
+<template>
+    <Popover v-model:open="open">
+        <PopoverTrigger as-child>
+            <slot name="trigger" />
+        </PopoverTrigger>
+        <PopoverContent
+            align="start"
+            :aria-label="props.fieldLabel"
+            :class="cn('w-56 p-1.5', props.class)"
+        >
+            <Command>
+                <ComboboxFilter
+                    :field-label="props.fieldLabel"
+                    :listbox-id="listboxId"
+                    :placeholder="props.placeholder"
+                    v-bind="$attrs"
+                />
+                <CommandList
+                    :id="listboxId"
+                    :ariaLabel="props.listLabel"
+                    class="max-h-56"
+                >
+                    <slot />
+                </CommandList>
+                <CommandEmpty class="py-3 text-[13px] text-muted-foreground">
+                    {{ props.emptyText }}
+                </CommandEmpty>
+            </Command>
+        </PopoverContent>
+    </Popover>
+</template>

--- a/resources/js/components/ui/combobox/ComboboxFilter.vue
+++ b/resources/js/components/ui/combobox/ComboboxFilter.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { injectListboxRootContext, ListboxFilter } from 'reka-ui';
+import { watch } from 'vue';
+import { useCommand } from '@/components/ui/command';
+
+/**
+ * The combobox's text field. It writes straight into the surrounding
+ * `<Command>`'s filter state, so the listbox below narrows as it is typed, and
+ * reka's `ListboxFilter` keeps the roving `aria-activedescendant` pointed at
+ * the highlighted option while the arrow keys move through the list.
+ */
+const props = defineProps<{
+    /**
+     * Accessible name for the field. Required: the popup carries no visible
+     * label, so this is the only thing that says which facet is being filtered.
+     */
+    fieldLabel: string;
+    /** Id of the listbox this field controls, for `aria-controls`. */
+    listboxId: string;
+    placeholder: string;
+}>();
+
+const { filterState } = useCommand();
+
+const listbox = injectListboxRootContext();
+
+/**
+ * reka keeps the roving highlight on the option it last pointed at, even once
+ * the filter has taken that option out of the DOM — leaving
+ * `aria-activedescendant` naming an element that no longer exists, which axe
+ * reports as a critical `aria-valid-attr-value` violation. Re-checking once the
+ * list has re-rendered drops such a highlight; reka highlights the first
+ * surviving option by itself, so this only bites when nothing matched at all.
+ */
+watch(
+    () => filterState.search,
+    () => {
+        const highlighted = listbox.highlightedElement.value;
+
+        if (highlighted !== null && !highlighted.isConnected) {
+            listbox.highlightedElement.value = null;
+        }
+    },
+    { flush: 'post' },
+);
+</script>
+
+<template>
+    <!--
+        The field only ever renders inside an open popup, so the list it
+        controls is showing whenever the field exists: `aria-expanded` is true
+        by construction rather than tracking a second piece of state.
+    -->
+    <ListboxFilter
+        v-model="filterState.search"
+        auto-focus
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded="true"
+        :aria-controls="props.listboxId"
+        :aria-label="props.fieldLabel"
+        :placeholder="props.placeholder"
+        data-slot="combobox-filter"
+        class="border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 mb-1 h-8 w-full min-w-0 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs outline-none focus-visible:ring-[3px] max-md:h-11 md:text-xs"
+    />
+</template>

--- a/resources/js/components/ui/combobox/ComboboxItem.vue
+++ b/resources/js/components/ui/combobox/ComboboxItem.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import type { ListboxItemEmits, ListboxItemProps } from 'reka-ui';
+import type { HTMLAttributes } from 'vue';
+import { reactiveOmit } from '@vueuse/core';
+import { CommandItem } from '@/components/ui/command';
+import { cn } from '@/lib/utils';
+import { useCombobox } from '.';
+
+/**
+ * One `role="option"` row of a `<Combobox>`. Selecting it — by click, by Enter
+ * on the highlighted row — reports the choice and dismisses the popup, so a
+ * call site never has to drive the open state itself.
+ */
+const props = defineProps<
+    ListboxItemProps & { class?: HTMLAttributes['class'] }
+>();
+
+const emits = defineEmits<ListboxItemEmits>();
+
+const delegatedProps = reactiveOmit(props, 'class');
+
+const { close } = useCombobox();
+
+/** The payload reka hands a `select` listener: the choice, and the event behind it. */
+type SelectEvent = ListboxItemEmits['select'][0];
+
+function select(event: SelectEvent): void {
+    emits('select', event);
+    close();
+}
+</script>
+
+<template>
+    <CommandItem
+        v-bind="delegatedProps"
+        :class="
+            cn(
+                'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] max-md:min-h-11',
+                props.class,
+            )
+        "
+        @select="select"
+    >
+        <slot />
+    </CommandItem>
+</template>

--- a/resources/js/components/ui/combobox/index.ts
+++ b/resources/js/components/ui/combobox/index.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'reka-ui';
+
+export { default as Combobox } from './Combobox.vue';
+export { default as ComboboxFilter } from './ComboboxFilter.vue';
+export { default as ComboboxItem } from './ComboboxItem.vue';
+
+/**
+ * Lets an item dismiss the popup its `<Combobox>` owns, so a call site only
+ * says what a selection *means* and never has to hold the open state itself.
+ */
+export const [useCombobox, provideComboboxContext] = createContext<{
+    close: () => void;
+}>('Combobox');

--- a/resources/js/pages/channels/Search.vue
+++ b/resources/js/pages/channels/Search.vue
@@ -16,12 +16,8 @@ import {
 import { index as search } from '@/actions/App/Http/Controllers/Channels/SearchController';
 import SafeHtml from '@/components/SafeHtml.vue';
 import { Button } from '@/components/ui/button';
+import { Combobox, ComboboxItem } from '@/components/ui/combobox';
 import { DatePicker } from '@/components/ui/date-picker';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import {
     Popover,
@@ -289,27 +285,6 @@ function searchAllChannels(): void {
     reload();
 }
 
-/** Facet-picker filter inputs. */
-const channelFilter = ref('');
-const authorFilter = ref('');
-
-const filteredChannels = computed(() => {
-    const needle = channelFilter.value.trim().toLowerCase();
-
-    return channelOptions.value.filter(
-        (channel) =>
-            needle === '' || channel.name.toLowerCase().includes(needle),
-    );
-});
-
-const filteredMembers = computed(() => {
-    const needle = authorFilter.value.trim().toLowerCase();
-
-    return members.value.filter(
-        (member) => needle === '' || member.name.toLowerCase().includes(needle),
-    );
-});
-
 // Date presets set the same before/after bounds a custom range would; the chip
 // then renders from the bounds, so presets need no remembered identity.
 function isoDay(date: Date): string {
@@ -521,8 +496,15 @@ function jumpHref(result: MessageSearchResult): string {
                         <X class="size-3" aria-hidden="true" />
                     </Button>
                 </span>
-                <DropdownMenu v-else>
-                    <DropdownMenuTrigger as-child>
+                <Combobox
+                    v-else
+                    :field-label="$t('Filter people')"
+                    :list-label="$t('People')"
+                    :placeholder="$t('Filter people…')"
+                    :empty-text="$t('No people match')"
+                    data-test="facet-author-filter"
+                >
+                    <template #trigger>
                         <Button
                             variant="unstyled"
                             size="none"
@@ -533,37 +515,22 @@ function jumpHref(result: MessageSearchResult): string {
                             {{ $t('Author') }}
                             <ChevronDown class="size-3" aria-hidden="true" />
                         </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" class="w-56 p-1.5">
-                        <Input
-                            v-model="authorFilter"
-                            :placeholder="$t('Filter people…')"
-                            :aria-label="$t('Filter people')"
-                            data-test="facet-author-filter"
-                            class="mb-1 h-8 text-base max-md:h-11 md:text-xs"
-                            @keydown.stop
-                        />
-                        <div class="max-h-56 overflow-y-auto">
-                            <Button
-                                variant="unstyled"
-                                size="none"
-                                v-for="member in filteredMembers"
-                                :key="member.id"
-                                type="button"
-                                class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent max-md:min-h-11"
-                                data-test="facet-author-option"
-                                @click="setAuthor(member.id)"
-                            >
-                                <span
-                                    class="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[8px] font-semibold text-primary"
-                                    aria-hidden="true"
-                                    >{{ getInitials(member.name) }}</span
-                                >
-                                <span class="truncate">{{ member.name }}</span>
-                            </Button>
-                        </div>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                    </template>
+                    <ComboboxItem
+                        v-for="member in members"
+                        :key="member.id"
+                        :value="member.id"
+                        data-test="facet-author-option"
+                        @select="setAuthor(member.id)"
+                    >
+                        <span
+                            class="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[8px] font-semibold text-primary"
+                            aria-hidden="true"
+                            >{{ getInitials(member.name) }}</span
+                        >
+                        <span class="truncate">{{ member.name }}</span>
+                    </ComboboxItem>
+                </Combobox>
 
                 <!-- channel facet -->
                 <span
@@ -584,8 +551,15 @@ function jumpHref(result: MessageSearchResult): string {
                         <X class="size-3" aria-hidden="true" />
                     </Button>
                 </span>
-                <DropdownMenu v-else>
-                    <DropdownMenuTrigger as-child>
+                <Combobox
+                    v-else
+                    :field-label="$t('Filter channels')"
+                    :list-label="$t('Channels')"
+                    :placeholder="$t('Filter channels…')"
+                    :empty-text="$t('No channels match')"
+                    data-test="facet-channel-filter"
+                >
+                    <template #trigger>
                         <Button
                             variant="unstyled"
                             size="none"
@@ -600,47 +574,30 @@ function jumpHref(result: MessageSearchResult): string {
                             >{{ $t('Channel') }}
                             <ChevronDown class="size-3" aria-hidden="true" />
                         </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" class="w-56 p-1.5">
-                        <Input
-                            v-model="channelFilter"
-                            :placeholder="$t('Filter channels…')"
-                            :aria-label="$t('Filter channels')"
-                            class="mb-1 h-8 text-base max-md:h-11 md:text-xs"
-                            @keydown.stop
+                    </template>
+                    <ComboboxItem
+                        v-for="channel in channelOptions"
+                        :key="channel.id"
+                        :value="channel.id"
+                        data-test="facet-channel-option"
+                        @select="setChannel(channel.id)"
+                    >
+                        <Lock
+                            v-if="channel.isPrivate"
+                            class="size-3 shrink-0 text-muted-foreground"
+                            aria-hidden="true"
                         />
-                        <div class="max-h-56 overflow-y-auto">
-                            <Button
-                                v-for="channel in filteredChannels"
-                                :key="channel.id"
-                                variant="unstyled"
-                                size="none"
-                                type="button"
-                                class="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] hover:bg-accent max-md:min-h-11"
-                                data-test="facet-channel-option"
-                                @click="setChannel(channel.id)"
-                            >
-                                <Lock
-                                    v-if="channel.isPrivate"
-                                    class="size-3 shrink-0 text-muted-foreground"
-                                    aria-hidden="true"
-                                />
-                                <span
-                                    v-else
-                                    aria-hidden="true"
-                                    class="text-brass"
-                                    >#</span
-                                >
-                                <span class="truncate">{{ channel.name }}</span>
-                                <span
-                                    v-if="channel.teamName !== null"
-                                    class="ml-auto shrink-0 text-[10px] text-muted-foreground"
-                                    >{{ channel.teamName }}</span
-                                >
-                            </Button>
-                        </div>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                        <span v-else aria-hidden="true" class="text-brass"
+                            >#</span
+                        >
+                        <span class="truncate">{{ channel.name }}</span>
+                        <span
+                            v-if="channel.teamName !== null"
+                            class="ml-auto shrink-0 text-[10px] text-muted-foreground"
+                            >{{ channel.teamName }}</span
+                        >
+                    </ComboboxItem>
+                </Combobox>
 
                 <!-- date facet -->
                 <span

--- a/tests/Browser/A11ySearchTest.php
+++ b/tests/Browser/A11ySearchTest.php
@@ -186,6 +186,97 @@ test('the author facet applies and removes, and a date preset applies', function
         ->assertPresent('[data-test="facet-date"]');
 });
 
+test('the facet pickers are comboboxes that keep the open popup accessible in both themes', function (): void {
+    ['owner' => $alice] = searchPageWithMatches();
+
+    $page = signInThroughBrowser($alice)
+        ->click('@masthead-search')
+        ->assertPathContains('/search')
+        ->type('@search-input', 'quokka')
+        ->wait(0.8)
+        ->assertPresent('[data-test="search-result"]')
+        // The pill opens a real combobox: a filter field beside a listbox of
+        // options, never a text input buried inside a menu (#451).
+        ->click('@facet-author-picker')
+        ->wait(0.3)
+        ->assertPresent('[data-test="facet-author-filter"][role="combobox"]')
+        ->assertPresent(
+            '[role="listbox"] [data-test="facet-author-option"][role="option"]',
+        )
+        ->assertNoAccessibilityIssues();
+
+    // The field names the list it controls, and the arrow keys rove the
+    // highlight through that list without focus ever leaving the field.
+    $wiring = $page->keys('@facet-author-filter', ['ArrowDown'])->script(<<<'JS'
+    () => {
+        const input = document.querySelector('[data-test="facet-author-filter"]');
+        const listbox = document.querySelector('[role="listbox"]');
+        const active = document.getElementById(
+            input.getAttribute('aria-activedescendant') ?? '',
+        );
+
+        return {
+            controlsTheList: input.getAttribute('aria-controls') === listbox.id,
+            expanded: input.getAttribute('aria-expanded'),
+            keepsFocus: document.activeElement === input,
+            activeRole: active?.getAttribute('role') ?? null,
+            activeIsHighlighted: active?.hasAttribute('data-highlighted') ?? false,
+        };
+    }
+    JS);
+
+    expect($wiring)->toBe([
+        'controlsTheList' => true,
+        'expanded' => 'true',
+        'keepsFocus' => true,
+        'activeRole' => 'option',
+        'activeIsHighlighted' => true,
+    ]);
+
+    // A filter that matches nothing empties the listbox and says so — audited
+    // too, since an empty list is the state a picker is easiest to break in.
+    $page->type('@facet-author-filter', 'zzzznobodyzzzz')
+        ->wait(0.3)
+        ->assertMissing('[data-test="facet-author-option"]')
+        ->assertSee('No people match')
+        ->assertNoAccessibilityIssues();
+
+    // Type to filter, then Enter applies the highlighted option as a chip.
+    $page->type('@facet-author-filter', 'Bob')
+        ->wait(0.3)
+        ->keys('@facet-author-filter', ['Enter'])
+        ->wait(0.8)
+        ->assertPresent('[data-test="facet-author"]')
+        ->assertMissing('[data-test="facet-author-filter"]');
+
+    // Escape dismisses a picker without applying anything.
+    $page->click('@facet-channel-picker')
+        ->wait(0.3)
+        ->assertPresent('[data-test="facet-channel-filter"][role="combobox"]')
+        ->keys('@facet-channel-filter', ['Escape'])
+        ->wait(0.5)
+        ->assertMissing('[data-test="facet-channel-filter"]')
+        ->assertMissing('[data-test="facet-channel"]');
+
+    // Re-audit the open picker against the dark palette (localStorage before
+    // the class, so the appearance controller doesn't re-resolve to light
+    // mid-audit) — the popup carries its own surface and border tokens.
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)
+        ->assertPresent('html.dark')
+        ->click('@facet-channel-picker')
+        ->wait(0.3)
+        ->assertPresent('[data-test="facet-channel-option"]')
+        ->assertNoAccessibilityIssues();
+});
+
 test('the zero-result state names the active filters and offers both escapes', function (): void {
     ['owner' => $alice] = searchPageWithMatches();
 

--- a/tests/Browser/Helpers.php
+++ b/tests/Browser/Helpers.php
@@ -169,10 +169,19 @@ function ensureStylesheetsLoaded(AwaitableWebpage $page): AwaitableWebpage
         await Promise.all(dropped.map((link) => new Promise((resolve) => {
             const retry = document.createElement('link');
 
+            // A repair, not an assertion: a retry that errors — or that never
+            // fires either event — settles anyway, so the caller's own
+            // assertion reports what is wrong instead of this timing out.
+            const settle = () => {
+                clearTimeout(deadline);
+                resolve();
+            };
+            const deadline = setTimeout(resolve, 5000);
+
             retry.rel = 'stylesheet';
             retry.href = link.href;
-            retry.onload = resolve;
-            retry.onerror = resolve;
+            retry.onload = settle;
+            retry.onerror = settle;
 
             document.head.appendChild(retry);
         })));

--- a/tests/Browser/Helpers.php
+++ b/tests/Browser/Helpers.php
@@ -143,3 +143,43 @@ function signInThroughBrowser(User $user, string $password = 'password'): Awaita
         // to /login. assertPathIsNot retries within the browser timeout.
         ->assertPathIsNot('/login');
 }
+
+/**
+ * Re-request any stylesheet the page ended up without, and hand the page back.
+ *
+ * The plugin serves the app in-process and streams static assets straight off
+ * disk while the same event loop drives the browser protocol; on a second full
+ * `navigate()` it sometimes never delivers the largest of them. The browser
+ * records that request with status 0 and no bytes and — unlike a script — never
+ * retries a stylesheet, so the page renders completely unstyled. Fetching the
+ * same URL a moment later always succeeds, and which asset loses is decided by
+ * the shape of the built bundle, so any chunking change can move it (#944).
+ *
+ * Call this after a `navigate()` whose assertions read rendered geometry: an
+ * unstyled page reports every box at its content height, which reads as a real
+ * layout regression.
+ */
+function ensureStylesheetsLoaded(AwaitableWebpage $page): AwaitableWebpage
+{
+    $page->script(<<<'JS'
+    async () => {
+        const dropped = [...document.querySelectorAll('link[rel="stylesheet"]')]
+            .filter((link) => link.sheet === null);
+
+        await Promise.all(dropped.map((link) => new Promise((resolve) => {
+            const retry = document.createElement('link');
+
+            retry.rel = 'stylesheet';
+            retry.href = link.href;
+            retry.onload = resolve;
+            retry.onerror = resolve;
+
+            document.head.appendChild(retry);
+        })));
+
+        return dropped.length;
+    }
+    JS);
+
+    return $page;
+}

--- a/tests/Browser/MobileUndrawnScreensTest.php
+++ b/tests/Browser/MobileUndrawnScreensTest.php
@@ -132,9 +132,13 @@ test('the browse-channels heading survives a phone width untruncated', function 
         'slug' => 'design-reviews',
     ]);
 
-    signInThroughBrowser($alice)
+    $page = signInThroughBrowser($alice)
         ->resize(360, 740)
-        ->navigate("/t/{$team->slug}/channels/browse")
+        ->navigate("/t/{$team->slug}/channels/browse");
+
+    // Both assertions below measure rendered boxes, so they need the stylesheet
+    // the in-process server sometimes drops on this second document (#944).
+    ensureStylesheetsLoaded($page)
         ->assertScript(rendersFullTextInsideViewport('h1'), true)
         ->assertScript(offersPhoneTouchTargets('button[type="submit"]'), true);
 });


### PR DESCRIPTION
Closes #451.

## What

The author and channel facet pickers on the search page were a `DropdownMenu` with a filter `<Input>` inside it — a text field owned by a `menu`, with `@keydown.stop` blocking the arrow keys so nothing roved between the field and the option rows.

Both now use a new shared `ui/combobox` primitive:

- the pill stays a plain popover trigger, so the facet bar looks exactly as it did;
- the popup holds a `role="combobox"` field (`aria-expanded`, `aria-controls`, `aria-autocomplete="list"`) **beside** — never inside — a `role="listbox"` of `role="option"` rows;
- the field keeps a roving `aria-activedescendant` while the arrow keys move through the list, so focus never leaves the input;
- open → type to filter → arrow to navigate → Enter to select → Escape to dismiss all work, and a filter that matches nothing says so instead of showing an empty box.

Built on the existing `command` (reka `Listbox`) primitives, which also lets the page drop its own filter refs and computed lists.

Two ARIA defects were found by the new audit and fixed in the primitive: reka keeps the highlight on an option the filter has just removed from the DOM (leaving `aria-activedescendant` pointing at nothing — a critical `aria-valid-attr-value` violation), and a headingless `CommandGroup` renders `aria-labelledby` for a label that is never drawn.

## Testing

- `resources/js/components/ui/combobox/Combobox.test.ts` — 5 jsdom specs over the real primitive: the ARIA wiring, filtering and the empty state, the dropped highlight, click-to-select, and arrow + Enter.
- `A11ySearchTest` — a new browser test drives the whole keyboard flow and runs **axe against the open picker** in light and dark themes, including the no-matches state.
- Full gate green: backend `Total: 100.0 %` (Pint + PHPStan + Rector), `lint:check` / `format:check` / `types:check` / `test:js` / `build`, and the full browser suite.
- All existing `data-test` hooks are preserved, so `A11ySearchTest`, `DatePickerTest` and `MobileUndrawnScreensTest` keep passing unchanged.

## Found along the way

#944 — the browser suite's in-process server sometimes never delivers the Tailwind stylesheet on a second full `navigate()`, leaving the page unstyled; which asset loses is decided by the bundle's chunk graph, so this change moved the victim onto `MobileUndrawnScreensTest`. `ensureStylesheetsLoaded()` (in `tests/Browser/Helpers.php`) re-requests a dropped stylesheet, and that one test calls it; the helper goes away when #944 is fixed.

## i18n

`No people match` / `No channels match` added to `lang/fr.json`. No operator-facing change, so no docs update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787688468&installation_model_id=428379&pr_number=945&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F945&signature=052356d8ee826214738ccac0acd3ceb48e8c4bad897d8d0ece2af8336aafb61a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->