### PR TITLE
test: fail the browser suite fast when the compiled bundle is stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ browsers, PHP servers and Playwright then compete for the same cores, which
 makes the suite both slower and flakier. Pin a different count with
 `BROWSER_TEST_PROCESSES=N` to measure another setting.
 
-Rebuild the frontend (`npm run build`) after changing any Vue component the
-tests touch, since the in-process server serves the compiled Vite assets — and
-after pulling someone else's, for the same reason. You don't have to remember:
-the suite compares `public/build/manifest.json` against everything Vite bundles
-and stops the run with that command if the bundle is behind, rather than letting
-a stale bundle fail the tests as though the app were broken.
+Rebuild the frontend (`./vendor/bin/sail npm run build`) after changing any Vue
+component the tests touch, since the in-process server serves the compiled Vite
+assets — and after pulling someone else's, for the same reason. You don't have
+to remember: the suite compares `public/build/manifest.json` against everything
+Vite bundles and stops the run with that command if the bundle is behind, rather
+than letting a stale bundle fail the tests as though the app were broken.
 
 ### Local SSO providers (OIDC & LDAP)
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,11 @@ makes the suite both slower and flakier. Pin a different count with
 `BROWSER_TEST_PROCESSES=N` to measure another setting.
 
 Rebuild the frontend (`npm run build`) after changing any Vue component the
-tests touch, since the in-process server serves the compiled Vite assets.
+tests touch, since the in-process server serves the compiled Vite assets — and
+after pulling someone else's, for the same reason. You don't have to remember:
+the suite compares `public/build/manifest.json` against everything Vite bundles
+and stops the run with that command if the bundle is behind, rather than letting
+a stale bundle fail the tests as though the app were broken.
 
 ### Local SSO providers (OIDC & LDAP)
 

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -32,6 +32,24 @@
 
 set -euo pipefail
 
+# This checkout, resolved at source time so the helpers below hold no matter
+# which directory they are called from.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Refuse to run against a bundle older than the sources it was built from: the
+# suite serves public/build, so a stale bundle fails every test as though the
+# app were broken, aimed squarely at whatever landed most recently (#949).
+#
+# tests/Pest.php runs the same guard in-process, which is what covers the
+# documented `pest tests/Browser` entry point. Repeating it here is about the
+# output: a guard that aborts a paratest worker reads as a
+# WorkerCrashedException followed by paratest's own usage dump, while failing
+# before the fork prints the one message and nothing else.
+assert_fresh_bundle() {
+    php -r 'require $argv[1]; Tests\Support\StaleBundleGuard::ensureFreshBundle($argv[2]);' \
+        "$REPO_ROOT/tests/Support/StaleBundleGuard.php" "${1:-$REPO_ROOT}"
+}
+
 # The number of CPUs visible to this machine or container. Falls back to 0 —
 # which worker_count floors — rather than guessing on an exotic host.
 detect_cores() {
@@ -88,7 +106,9 @@ pest_command() {
 }
 
 main() {
-    cd "$(dirname "${BASH_SOURCE[0]}")/.."
+    cd "$REPO_ROOT"
+
+    assert_fresh_bundle
 
     build_pest_command "$@"
     printf '==> %s\n' "${PEST_COMMAND[*]}" >&2

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\StaleBundleGuard;
 use Tests\TestCase;
 
 /*
@@ -73,12 +74,21 @@ pest()->extend(TestCase::class)->in('Unit/ReverbSecretGuidanceTest.php');
 | live Reverb server. They are tagged `browser` and excluded from the default
 | coverage gate; run them with `composer test:browser` (see README).
 |
+| That in-process server hands the browser the *compiled* assets under
+| `public/build`, so a bundle older than the working tree fails these tests as
+| though the application were broken — and it fails them on whatever landed most
+| recently, which reads as a regression in those very PRs rather than as a stale
+| bundle (issue #949). StaleBundleGuard sweeps the bundled sources once per
+| process and stops the run with the rebuild command instead.
+|
 */
 
 pest()->extend(TestCase::class)
     ->use(RefreshDatabase::class)
     ->group('browser')
     ->beforeEach(function (): void {
+        StaleBundleGuard::ensureFreshBundle(base_path());
+
         useReverbForBrowserTests();
     })
     ->in('Browser');

--- a/tests/Support/StaleBundleGuard.php
+++ b/tests/Support/StaleBundleGuard.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+final class StaleBundleGuard
+{
+    /**
+     * Whether this process has already swept the sources.
+     */
+    private static bool $swept = false;
+
+    /**
+     * The Vite manifest, relative to the project root. Its mtime is the moment
+     * the current bundle was written.
+     */
+    public const string MANIFEST = 'public/build/manifest.json';
+
+    /**
+     * The source trees Vite bundles, relative to the project root.
+     */
+    public const array WATCHED_DIRECTORIES = [
+        'resources/js',
+        'resources/css',
+        'resources/pwa',
+    ];
+
+    /**
+     * Individual files outside the source trees that change what Vite emits,
+     * relative to the project root.
+     */
+    public const array WATCHED_FILES = [
+        'vite.config.ts',
+        'package.json',
+        'package-lock.json',
+    ];
+
+    /**
+     * Trees under a watched directory that the guard must not stat, relative to
+     * the project root.
+     *
+     * All four are git-ignored generator output. `actions`, `routes` and
+     * `wayfinder` are rewritten by the Vite build itself, and `generated` holds
+     * the ambient `App.*` types `artisan typescript:transform` writes — types
+     * only, erased before anything reaches the bundle. Watching them would trip
+     * the guard for changes that cannot make the bundle stale.
+     */
+    public const array IGNORED_DIRECTORIES = [
+        'resources/js/actions',
+        'resources/js/routes',
+        'resources/js/wayfinder',
+        'resources/js/generated',
+    ];
+
+    /**
+     * The newest bundled source's mtime and path, relative to the project root.
+     *
+     * @return array{0: int, 1: string}
+     */
+    private static function newestSource(string $basePath): array
+    {
+        $newestMtime = 0;
+        $newestPath = '';
+
+        $sources = self::WATCHED_FILES;
+
+        foreach (self::WATCHED_DIRECTORIES as $directory) {
+            $sources = [...$sources, ...self::filesIn($basePath, $directory)];
+        }
+
+        foreach ($sources as $relative) {
+            $mtime = (int) @filemtime($basePath.'/'.$relative);
+
+            if ($mtime > $newestMtime) {
+                $newestMtime = $mtime;
+                $newestPath = $relative;
+            }
+        }
+
+        return [$newestMtime, $newestPath];
+    }
+
+    /**
+     * Every file under the given directory, recursively, as paths relative to
+     * the project root — minus the trees the guard ignores.
+     *
+     * @return list<string>
+     */
+    private static function filesIn(string $basePath, string $directory): array
+    {
+        if (in_array($directory, self::IGNORED_DIRECTORIES, strict: true) || ! is_dir($basePath.'/'.$directory)) {
+            return [];
+        }
+
+        $files = [];
+
+        foreach (array_diff(scandir($basePath.'/'.$directory) ?: [], ['.', '..']) as $entry) {
+            $relative = $directory.'/'.$entry;
+
+            if (is_dir($basePath.'/'.$relative)) {
+                $files = [...$files, ...self::filesIn($basePath, $relative)];
+
+                continue;
+            }
+
+            $files[] = $relative;
+        }
+
+        return $files;
+    }
+
+    /**
+     * Abort the run, once, if the browser suite is about to drive a bundle
+     * older than the sources it was built from.
+     *
+     * Reported by writing the message and exiting rather than by throwing: a
+     * thrown exception would surface as one failure per test, which is the very
+     * shape of output this guard exists to replace.
+     */
+    public static function ensureFreshBundle(string $basePath): void
+    {
+        if (self::$swept) {
+            return;
+        }
+
+        self::$swept = true;
+
+        $warning = self::staleBundleWarning($basePath);
+
+        if ($warning === null) {
+            return;
+        }
+
+        fwrite(STDERR, PHP_EOL.$warning.PHP_EOL.PHP_EOL);
+
+        exit(1);
+    }
+
+    /**
+     * The message to show when the compiled bundle is older than its sources,
+     * or null when the bundle is current.
+     */
+    public static function staleBundleWarning(string $basePath): ?string
+    {
+        [$newestMtime, $newestPath] = self::newestSource($basePath);
+
+        $manifestMtime = (int) @filemtime($basePath.'/'.self::MANIFEST);
+
+        if ($newestMtime <= $manifestMtime) {
+            return null;
+        }
+
+        return <<<MESSAGE
+              Your compiled assets are older than your sources.
+
+              The browser suite serves public/build, so these tests would run against a
+              stale bundle and fail as if the app were broken.
+
+                  ./vendor/bin/sail npm run build
+
+              (newest source: {$newestPath})
+            MESSAGE;
+    }
+}

--- a/tests/Unit/StaleBundleGuardTest.php
+++ b/tests/Unit/StaleBundleGuardTest.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use Tests\Support\StaleBundleGuard;
+
+/**
+ * The browser suite serves `public/build`, not `resources/` — the in-process
+ * HTTP server hands Playwright the compiled Vite assets. A bundle older than
+ * the working tree therefore fails the suite as though the application were
+ * broken, and the failures land on whatever shipped most recently, so the
+ * natural reading is "the last few PRs regressed" (issue #949). These tests pin
+ * the guard that turns that into one message naming the rebuild command.
+ */
+const FIXTURE_PREFIX = 'stale-bundle-guard-';
+
+/**
+ * Build a throwaway checkout whose files carry the given mtimes.
+ *
+ * @param  array<string, int>  $files  relative path => mtime
+ */
+function bundleFixture(array $files): string
+{
+    $base = sys_get_temp_dir().'/'.FIXTURE_PREFIX.bin2hex(random_bytes(8));
+
+    foreach ($files as $relative => $mtime) {
+        $path = $base.'/'.$relative;
+
+        if (! is_dir(dirname($path))) {
+            mkdir(dirname($path), recursive: true);
+        }
+
+        file_put_contents($path, '');
+        touch($path, $mtime);
+    }
+
+    return $base;
+}
+
+/**
+ * Drive `ensureFreshBundle()` in its own process, so the run it aborts is not
+ * the one running this test.
+ *
+ * @param  list<string>  $basePaths  one call per base path, in order
+ */
+function runBundleGuard(array $basePaths): Process
+{
+    $calls = implode('', array_map(
+        static fn (string $basePath): string => sprintf(
+            'Tests\Support\StaleBundleGuard::ensureFreshBundle(%s);',
+            var_export($basePath, true),
+        ),
+        $basePaths,
+    ));
+
+    $process = new Process([PHP_BINARY, '-r', sprintf(
+        'require %s; %s echo "the suite ran";',
+        var_export(dirname(__DIR__).'/Support/StaleBundleGuard.php', true),
+        $calls,
+    )]);
+    $process->run();
+
+    return $process;
+}
+
+afterEach(function (): void {
+    $filesystem = new Filesystem;
+
+    foreach ($filesystem->glob(sys_get_temp_dir().'/'.FIXTURE_PREFIX.'*') ?: [] as $fixture) {
+        $filesystem->deleteDirectory($fixture);
+    }
+});
+
+it('stays quiet when the manifest is newer than every bundled source', function (): void {
+    $base = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_000,
+        'resources/css/app.css' => 1_700_000_000,
+        'resources/pwa/service-worker.ts' => 1_700_000_000,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    expect(StaleBundleGuard::staleBundleWarning($base))->toBeNull();
+});
+
+it('names the rebuild command and the newest source when the bundle is stale', function (): void {
+    $base = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_000,
+        'resources/js/pages/Search.vue' => 1_700_000_200,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    expect(StaleBundleGuard::staleBundleWarning($base))
+        ->toContain('older than your sources')
+        ->toContain('public/build')
+        ->toContain('./vendor/bin/sail npm run build')
+        ->toContain('resources/js/pages/Search.vue');
+});
+
+it('gives the same message when no manifest has ever been built', function (): void {
+    $base = bundleFixture(['resources/js/app.ts' => 1_700_000_000]);
+
+    expect(StaleBundleGuard::staleBundleWarning($base))
+        ->toContain('older than your sources')
+        ->toContain('./vendor/bin/sail npm run build');
+});
+
+it('ignores the git-ignored trees the build writes itself', function (string $generated): void {
+    $base = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_000,
+        $generated => 1_700_000_200,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    expect(StaleBundleGuard::staleBundleWarning($base))->toBeNull();
+})->with([
+    'resources/js/actions/App/Http/Controllers/SearchController.ts',
+    'resources/js/routes/index.ts',
+    'resources/js/wayfinder/index.ts',
+    'resources/js/generated/generated.d.ts',
+]);
+
+it('watches the root files that change what the build emits', function (string $file): void {
+    $base = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_000,
+        $file => 1_700_000_200,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    expect(StaleBundleGuard::staleBundleWarning($base))->toContain($file);
+})->with([
+    'vite.config.ts',
+    'package.json',
+    'package-lock.json',
+]);
+
+it('leaves Blade out of it, since views are rendered at runtime rather than bundled', function (): void {
+    $base = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_000,
+        'resources/views/app.blade.php' => 1_700_000_200,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    expect(StaleBundleGuard::staleBundleWarning($base))->toBeNull();
+});
+
+// The build reads its sources before it writes the manifest, so a source saved
+// during the build shares its second on a one-second-resolution stat. Treating
+// that tie as fresh keeps the guard from firing on a bundle that is current.
+it('treats a source saved in the same second as the manifest as current', function (): void {
+    $base = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_100,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    expect(StaleBundleGuard::staleBundleWarning($base))->toBeNull();
+});
+
+it('aborts the run before a single browser test executes', function (): void {
+    $base = bundleFixture([
+        'resources/js/pages/Search.vue' => 1_700_000_200,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    $process = runBundleGuard([$base]);
+
+    expect($process->getExitCode())->toBe(1)
+        ->and($process->getOutput())->not->toContain('the suite ran')
+        ->and($process->getErrorOutput())
+        ->toContain('older than your sources')
+        ->toContain('./vendor/bin/sail npm run build')
+        ->toContain('resources/js/pages/Search.vue');
+});
+
+it('lets the run proceed when the bundle is current', function (): void {
+    $base = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_000,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    $process = runBundleGuard([$base]);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toContain('the suite ran')
+        ->and($process->getErrorOutput())->toBe('');
+});
+
+// The sweep stats every bundled source, so running it per test would pay that
+// cost 272 times over. The memo is what makes it once per suite — a second call
+// against an unmistakably stale checkout must not even look.
+it('sweeps once per process rather than once per test', function (): void {
+    $fresh = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_000,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+    $stale = bundleFixture(['resources/js/app.ts' => 1_700_000_200]);
+
+    $process = runBundleGuard([$fresh, $stale]);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toContain('the suite ran');
+});
+
+// Wired into the `->in('Browser')` chain rather than into bin/browser-tests,
+// because the documented `sail bin pest tests/Browser` entry point never runs
+// that script.
+it('runs from the browser suite bootstrap, whichever way the suite is started', function (): void {
+    $bootstrap = (string) file_get_contents(dirname(__DIR__).'/Pest.php');
+    $browserChain = substr($bootstrap, (int) strpos($bootstrap, "->group('browser')"));
+
+    expect($browserChain)->toContain('StaleBundleGuard::ensureFreshBundle(base_path())');
+});
+
+/**
+ * Call the runner's bundle check against the given checkout, without running
+ * the suite it guards.
+ */
+function runRunnerBundleCheck(string $basePath): Process
+{
+    $process = new Process(['bash', '-c', sprintf(
+        'BROWSER_TESTS_LIB=1 . %s; assert_fresh_bundle %s',
+        escapeshellarg(dirname(__DIR__, 2).'/bin/browser-tests'),
+        escapeshellarg($basePath),
+    )]);
+    $process->run();
+
+    return $process;
+}
+
+// Also checked ahead of paratest, not only inside it: aborting a worker
+// surfaces the message wrapped in a WorkerCrashedException and followed by
+// paratest's own usage dump, whereas failing before the fork prints the message
+// and nothing else. `composer test:browser` and CI both come through here.
+it('stops the runner before it forks any worker', function (): void {
+    $base = bundleFixture([
+        'resources/js/pages/Search.vue' => 1_700_000_200,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    $process = runRunnerBundleCheck($base);
+
+    expect($process->getExitCode())->toBe(1)
+        ->and($process->getErrorOutput())
+        ->toContain('older than your sources')
+        ->toContain('./vendor/bin/sail npm run build');
+});
+
+it('lets the runner through when the bundle is current', function (): void {
+    $base = bundleFixture([
+        'resources/js/app.ts' => 1_700_000_000,
+        'public/build/manifest.json' => 1_700_000_100,
+    ]);
+
+    $process = runRunnerBundleCheck($base);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getErrorOutput())->toBe('');
+});

--- a/tests/Unit/StaleBundleGuardTest.php
+++ b/tests/Unit/StaleBundleGuardTest.php
@@ -14,7 +14,15 @@ use Tests\Support\StaleBundleGuard;
  * natural reading is "the last few PRs regressed" (issue #949). These tests pin
  * the guard that turns that into one message naming the rebuild command.
  */
-const FIXTURE_PREFIX = 'stale-bundle-guard-';
+/**
+ * The fixture prefix, scoped to this process — every paratest worker shares one
+ * temp directory, and a sweep that matched them all would delete a rival
+ * worker's checkout out from under it.
+ */
+function fixturePrefix(): string
+{
+    return 'stale-bundle-guard-'.getmypid().'-';
+}
 
 /**
  * Build a throwaway checkout whose files carry the given mtimes.
@@ -23,7 +31,7 @@ const FIXTURE_PREFIX = 'stale-bundle-guard-';
  */
 function bundleFixture(array $files): string
 {
-    $base = sys_get_temp_dir().'/'.FIXTURE_PREFIX.bin2hex(random_bytes(8));
+    $base = sys_get_temp_dir().'/'.fixturePrefix().bin2hex(random_bytes(8));
 
     foreach ($files as $relative => $mtime) {
         $path = $base.'/'.$relative;
@@ -68,7 +76,7 @@ function runBundleGuard(array $basePaths): Process
 afterEach(function (): void {
     $filesystem = new Filesystem;
 
-    foreach ($filesystem->glob(sys_get_temp_dir().'/'.FIXTURE_PREFIX.'*') ?: [] as $fixture) {
+    foreach ($filesystem->glob(sys_get_temp_dir().'/'.fixturePrefix().'*') ?: [] as $fixture) {
         $filesystem->deleteDirectory($fixture);
     }
 });
@@ -207,9 +215,11 @@ it('sweeps once per process rather than once per test', function (): void {
 // that script.
 it('runs from the browser suite bootstrap, whichever way the suite is started', function (): void {
     $bootstrap = (string) file_get_contents(dirname(__DIR__).'/Pest.php');
-    $browserChain = substr($bootstrap, (int) strpos($bootstrap, "->group('browser')"));
+    $browserChain = strpos($bootstrap, "->group('browser')");
 
-    expect($browserChain)->toContain('StaleBundleGuard::ensureFreshBundle(base_path())');
+    expect($browserChain)->not->toBeFalse()
+        ->and(substr($bootstrap, $browserChain))
+        ->toContain('StaleBundleGuard::ensureFreshBundle(base_path())');
 });
 
 /**


### PR DESCRIPTION
Closes #949.

## What

The browser suite serves `public/build`, not `resources/` — the in-process test server hands Playwright the compiled Vite assets. A bundle older than the working tree therefore fails the suite as though the application were broken, and it fails it on whatever landed most recently, so the natural reading is "the last few PRs regressed" rather than "my bundle is stale". Measured on a `develop` checkout with a bundle a few days old: 17 failures, all aimed at the last four merged PRs, all green after one `npm run build`.

`Tests\Support\StaleBundleGuard` now compares the newest mtime among the files Vite actually bundles against `public/build/manifest.json`, and stops the run with one message:

```
  Your compiled assets are older than your sources.

  The browser suite serves public/build, so these tests would run against a
  stale bundle and fail as if the app were broken.

      ./vendor/bin/sail npm run build

  (newest source: resources/js/pages/search/Index.vue)
```

## How

- **Watched:** `resources/js`, `resources/css`, `resources/pwa`, plus `vite.config.ts`, `package.json`, `package-lock.json`.
- **Ignored:** the git-ignored generated trees under `resources/js` (`actions/`, `routes/`, `wayfinder/`, `generated/`). The first three are rewritten by the build itself; `generated/generated.d.ts` is types-only and is regenerated by `artisan typescript:transform` independently, so watching it would trip the guard for a change that cannot affect the bundle. Verified quiet immediately after a real `npm run build`.
- **Not watched:** `resources/views` — Blade is rendered at runtime, not bundled.
- A missing `public/build/manifest.json` gives the same message (mtime 0), instead of a confusing 500 from the Vite manifest exception.
- Equal mtimes count as fresh: the build reads its sources before it writes the manifest, so a source saved during the build shares its second on a one-second-resolution stat.

**Two call sites, one guard.** `tests/Pest.php`'s `->in('Browser')` chain calls it, memoised behind a static so the sweep happens once per process rather than 272 times — that covers the documented `sail bin pest tests/Browser` entry point. `bin/browser-tests` calls the same class before it forks, because a guard that aborts a paratest worker surfaces as a `WorkerCrashedException` wrapped in paratest's own usage dump, whereas failing before the fork prints the message and nothing else. That path is what `composer test:browser` and CI use.

**Decisions the issue left open:**
- *Escape hatch* — deliberately declined. Testing an older bundle on purpose is not a real workflow, and an override is one more way to reintroduce the exact failure the guard exists to prevent.
- *Reported by exiting, not throwing* — a thrown exception would surface as one failure per test, which is the very shape of output this guard replaces.
- *CI* — the `browser` job checks out (setting mtimes to checkout time) and then runs `npm run build`, so the manifest ends up newest and the guard is a no-op. Unchanged in this PR; confirmed by this run.

## Testing

`tests/Unit/StaleBundleGuardTest.php` covers every acceptance criterion: fresh bundle stays quiet, a newer source names itself and the rebuild command, a missing manifest gives the same message, each git-ignored generated tree is ignored, each watched root file is honoured, Blade is left out, and same-second ties count as fresh. The fail-fast behaviour and the memo are driven in subprocesses, so the run being aborted is not the one asserting on it — including the runner's pre-flight, sourced from `bin/browser-tests` with `BROWSER_TESTS_LIB=1`.

Verified end to end by hand as well: with a deliberately stale bundle, `bin/browser-tests` exits 1 printing only that message, and `sail bin pest tests/Browser/ClockStyleTest.php` aborts with it; after `sail npm run build` the same test passes.

Full gate green — Pint, PHPStan, Rector, and `artisan test --parallel --coverage --min=100` at `Total: 100.0 %` — plus `lint:check`, `format:check`, `types:check` and `build`.

No user-facing copy, so no i18n keys; no operator-facing behaviour, so no `docs/` change. `README.md`'s browser-test section is updated, since its rebuild reminder is exactly the prose this guard replaces with enforcement.

## Noted while working

`npm run test:js` timed out on ~15 component tests under full-suite load on this machine, and passed 150/150 at `--maxWorkers=3`. That is #804 (flaky vitest exceeding 5s under full-suite load), not a regression here — this PR touches no frontend files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787701123&installation_model_id=428379&pr_number=952&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F952&signature=1c74633c5bfd02313b7b06b49684c5eb5a76301c2cb5282d331bd96d7f157e23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->