### PR TITLE
feat: workspace sheet, + New menu, and cross-workspace unread on the rail

### DIFF
--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -143,10 +143,8 @@ trait HasTeams
 
         return $this->teams()
             ->get()
-            ->map(fn (Team $team) => ! $includeCurrent && $this->isCurrentTeam($team)
-                ? null
-                : $this->toUserTeam($team, $unread[$team->id] ?? null))
-            ->filter()
+            ->reject(fn (Team $team): bool => ! $includeCurrent && $this->isCurrentTeam($team))
+            ->map(fn (Team $team): UserTeam => $this->toUserTeam($team, $unread[$team->id] ?? null))
             ->values();
     }
 

--- a/app/Concerns/HasTeams.php
+++ b/app/Concerns/HasTeams.php
@@ -8,6 +8,7 @@ use App\Enums\TeamPermission;
 use App\Enums\TeamRole;
 use App\Models\Membership;
 use App\Models\Team;
+use App\Support\WorkspaceUnread;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -135,17 +136,26 @@ trait HasTeams
      */
     public function toUserTeams(bool $includeCurrent = false): Collection
     {
+        // One grouped query answers every membership's unread standing, so the
+        // workspace list stays a fixed query cost however many workspaces the
+        // user belongs to ({@see WorkspaceUnread}).
+        $unread = WorkspaceUnread::forUser($this);
+
         return $this->teams()
             ->get()
-            ->map(fn (Team $team) => ! $includeCurrent && $this->isCurrentTeam($team) ? null : $this->toUserTeam($team))
+            ->map(fn (Team $team) => ! $includeCurrent && $this->isCurrentTeam($team)
+                ? null
+                : $this->toUserTeam($team, $unread[$team->id] ?? null))
             ->filter()
             ->values();
     }
 
     /**
      * Get the user's team as a UserTeam object.
+     *
+     * @param  array{unread: int, mention: int}|null  $unread  This workspace's unread standing, when the caller has already resolved it.
      */
-    public function toUserTeam(Team $team): UserTeam
+    public function toUserTeam(Team $team, ?array $unread = null): UserTeam
     {
         $role = $this->teamRole($team);
 
@@ -158,6 +168,8 @@ trait HasTeams
             roleLabel: $role?->label(),
             membersCount: $team->members()->count(),
             isCurrent: $this->isCurrentTeam($team),
+            unreadCount: $unread['unread'] ?? 0,
+            mentionCount: $unread['mention'] ?? 0,
         );
     }
 

--- a/app/Data/UserTeam.php
+++ b/app/Data/UserTeam.php
@@ -15,6 +15,10 @@ readonly class UserTeam
         public ?string $roleLabel,
         public int $membersCount = 0,
         public ?bool $isCurrent = null,
+        /** Ordinary unread messages waiting in this workspace, muting applied. */
+        public int $unreadCount = 0,
+        /** Unread @mentions waiting in this workspace, muting applied. */
+        public int $mentionCount = 0,
     ) {
         //
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -186,6 +186,13 @@ class HandleInertiaRequests extends Middleware
             'canInviteToCurrentTeam' => fn () => $user?->currentTeam
                 ? $user->toTeamPermissions($user->currentTeam)->canCreateInvitation
                 : false,
+            // The workspace sheet offers "Workspace settings" only to someone who
+            // can actually change the workspace. The page-scoped permission set
+            // is not in reach from the shell, so the one flag the sheet needs
+            // rides along like its siblings below.
+            'canUpdateCurrentTeam' => fn (): bool => $user?->currentTeam
+                ? $user->toTeamPermissions($user->currentTeam)->canUpdateTeam
+                : false,
             // The settings sidebar surfaces a team-admin "evidence" group (Audit
             // log, Security log, Exports) gated by the same permissions as the
             // Team-settings cards, so an admin can jump straight to those surfaces

--- a/app/Support/WorkspaceUnread.php
+++ b/app/Support/WorkspaceUnread.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Data\ChannelData;
+use App\Enums\MessageType;
+use App\Enums\NotificationLevel;
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Query\JoinClause;
+
+/**
+ * The viewer's unread standing in every workspace they belong to, driving the
+ * rail's workspace dots and the workspace sheet's per-workspace badges.
+ *
+ * One grouped query answers every membership at once: the rail draws N tiles,
+ * and a per-team loop would put N queries on the shell's critical path for a
+ * signal that is decoration. Muting and the notification level are applied in
+ * SQL exactly as {@see ChannelData::fromChannel()} applies them per
+ * channel, so a workspace badge can never contradict the channel rows the
+ * viewer would find inside it.
+ */
+class WorkspaceUnread
+{
+    /**
+     * Unread and mention counts per team id, for the teams that have any. A team
+     * with nothing new is simply absent, so callers default it to zero.
+     *
+     * @return array<string, array{unread: int, mention: int}>
+     */
+    public static function forUser(User $user): array
+    {
+        return self::query($user)
+            ->get()
+            ->mapWithKeys(fn (object $row): array => [
+                (string) $row->team_id => [
+                    'unread' => (int) $row->unread_count,
+                    'mention' => (int) $row->mention_count,
+                ],
+            ])
+            ->all();
+    }
+
+    /**
+     * The grouped query behind {@see self::forUser()}.
+     *
+     * Rides `Message::query()` rather than the query builder so the model's
+     * soft-delete scope applies — a deleted message must stop counting — then
+     * drops to the base builder because the rows are aggregates, not messages.
+     */
+    protected static function query(User $user): QueryBuilder
+    {
+        return Message::query()
+            ->join('channels', 'channels.id', '=', 'messages.channel_id')
+            ->join('channel_members', function (JoinClause $join) use ($user): void {
+                $join->on('channel_members.channel_id', '=', 'channels.id')
+                    ->where('channel_members.user_id', '=', $user->id);
+            })
+            // A mention is a row in the pivot for *this* viewer; the left join
+            // keeps ordinary messages in the aggregate with a null side.
+            ->leftJoin('mentions', function (JoinClause $join) use ($user): void {
+                $join->on('mentions.message_id', '=', 'messages.id')
+                    ->where('mentions.mentioned_user_id', '=', $user->id);
+            })
+            ->whereNull('channels.archived_at')
+            ->where('messages.user_id', '!=', $user->id)
+            // System notices (member joined / left) are ambient: they never
+            // badge a channel, so they never badge a workspace either.
+            ->whereNotIn('messages.type', MessageType::systemValues())
+            ->where(fn ($query) => $query
+                ->whereNull('channel_members.last_read_message_id')
+                ->orWhereColumn('messages.id', '>', 'channel_members.last_read_message_id'))
+            // A muted channel — or one set to "nothing" — is silent on both
+            // counts, so it is excluded outright rather than case-by-case.
+            ->where('channel_members.muted', false)
+            ->where('channel_members.notification_level', '!=', NotificationLevel::Nothing->value)
+            ->groupBy('channels.team_id')
+            ->select('channels.team_id')
+            // Thread-only replies live in the thread view and stay out of the
+            // plain unread count, and the "mentions" level silences it entirely.
+            ->selectRaw(
+                'sum(case when channel_members.notification_level = ? and (messages.thread_root_id is null or messages.sent_to_channel = ?) then 1 else 0 end) as unread_count',
+                [NotificationLevel::All->value, true],
+            )
+            ->selectRaw('sum(case when mentions.message_id is not null then 1 else 0 end) as mention_count')
+            ->toBase();
+    }
+}

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1370,5 +1370,16 @@
   "File": "Fichier",
   "Choose :action": "Choisissez :action",
   "Click :action to finish": "Cliquez sur :action pour terminer",
-  "Got it": "C’est compris"
+  "Got it": "C’est compris",
+  "Workspaces": "Espaces de travail",
+  "Switch workspace, or manage this one.": "Changez d’espace de travail, ou gérez celui-ci.",
+  "Workspace settings": "Réglages de l’espace",
+  "Create a workspace": "Créer un espace",
+  "Join a workspace": "Rejoindre un espace",
+  "Workspace: :name": "Espace de travail : :name",
+  "Switch to :name": "Basculer vers :name",
+  "New": "Nouveau",
+  "New channel": "Nouveau canal",
+  "Start a channel, a message, or a section.": "Démarrez un canal, un message ou une section.",
+  "Open the workspace menu to invite teammates, switch workspace, or manage this one.": "Ouvrez le menu de l’espace pour inviter des coéquipiers, changer d’espace ou gérer celui-ci."
 }

--- a/resources/js/components/PendingInvitationsModal.vue
+++ b/resources/js/components/PendingInvitationsModal.vue
@@ -18,7 +18,13 @@ type Props = {
 
 const props = defineProps<Props>();
 
-const open = ref(true);
+/**
+ * Presented as soon as the invitations land, and re-openable from the workspace
+ * sheet's "Join a workspace" row — invitations are the only way into a
+ * workspace, so dismissing the prompt must not be the end of the road.
+ */
+const open = defineModel<boolean>('open', { default: true });
+
 const processingCode = ref<string | null>(null);
 
 const acceptInvitation = (invitation: DashboardInvitation) => {

--- a/resources/js/components/navigation/NavigationRail.test.ts
+++ b/resources/js/components/navigation/NavigationRail.test.ts
@@ -22,6 +22,25 @@ vi.mock('@/components/CreateTeamModal.vue', () => ({
     }),
 }));
 
+vi.mock('@/components/navigation/WorkspaceSheet.vue', () => ({
+    default: defineComponent({
+        setup:
+            (_, { slots }) =>
+            () =>
+                h(
+                    'div',
+                    { 'data-test': 'workspace-sheet-anchor' },
+                    slots.default?.(),
+                ),
+    }),
+}));
+
+const switchTeam = vi.hoisted(() => vi.fn());
+
+vi.mock('@/composables/useTeamSwitch', () => ({
+    useTeamSwitch: () => ({ switchTeam }),
+}));
+
 vi.mock('@/components/ui/avatar', () => ({
     Avatar: defineComponent({
         setup:
@@ -50,7 +69,19 @@ const viewer: User = {
     avatar: null,
 } as unknown as User;
 
-const team: Team = { id: 't-1', name: 'Acme Corp', slug: 'acme' } as Team;
+function makeTeam(overrides: Partial<Team> = {}): Team {
+    return {
+        id: 't-1',
+        name: 'Acme Corp',
+        slug: 'acme',
+        isPersonal: false,
+        membersCount: 7,
+        isCurrent: true,
+        unreadCount: 0,
+        mentionCount: 0,
+        ...overrides,
+    };
+}
 
 let app: App | null = null;
 
@@ -58,13 +89,14 @@ afterEach(() => {
     app?.unmount();
     app = null;
     document.body.innerHTML = '';
+    switchTeam.mockClear();
 });
 
 function mountRail(
     overrides: {
         active?: NavDestination;
         hasUnreadThreads?: boolean;
-        currentTeam?: Team | null;
+        teams?: Team[];
         avatar?: string;
     } = {},
 ) {
@@ -78,20 +110,35 @@ function mountRail(
             h(NavigationRail, {
                 active: overrides.active ?? 'channels',
                 user: { ...viewer, avatar: overrides.avatar },
-                currentTeam:
-                    overrides.currentTeam === undefined
-                        ? team
-                        : overrides.currentTeam,
+                teams: overrides.teams ?? [makeTeam()],
                 presence: 'active',
                 isDnd: false,
                 hasUnreadThreads: overrides.hasUnreadThreads ?? false,
                 onSelect: select,
             }),
     });
-    app.config.globalProperties.$t = (key: string) => key;
+    app.config.globalProperties.$t = (
+        key: string,
+        replacements?: Record<string, unknown>,
+    ) =>
+        replacements
+            ? Object.entries(replacements).reduce(
+                  (line, [token, value]) =>
+                      line.replaceAll(`:${token}`, String(value)),
+                  key,
+              )
+            : key;
     app.mount(host);
 
     return { host, select };
+}
+
+function tiles(host: HTMLElement): HTMLElement[] {
+    return [
+        ...host.querySelectorAll<HTMLElement>(
+            '[data-test="rail-workspace-tile"]',
+        ),
+    ];
 }
 
 function glyph(host: HTMLElement, destination: NavDestination): HTMLElement {
@@ -168,19 +215,96 @@ it('flags unread threads on the threads glyph only while there are any', () => {
     ).toBeNull();
 });
 
-it('tiles the current workspace above the destinations', () => {
-    const { host } = mountRail();
+it('tiles every workspace above the destinations', () => {
+    const { host } = mountRail({
+        teams: [
+            makeTeam(),
+            makeTeam({ id: 't-2', name: 'Nord Bureau', isCurrent: false }),
+        ],
+    });
 
-    const tile = host.querySelector('[data-test="rail-workspace-tile"]');
-
-    expect(tile).not.toBeNull();
-    expect(tile!.textContent).toContain('AC');
+    expect(tiles(host)).toHaveLength(2);
+    expect(tiles(host)[0].textContent).toContain('AC');
+    expect(tiles(host)[1].textContent).toContain('NB');
 });
 
-it('drops the workspace tile when the viewer is not in a workspace', () => {
-    const { host } = mountRail({ currentTeam: null });
+it('drops the workspace tiles when the viewer is not in a workspace', () => {
+    const { host } = mountRail({ teams: [] });
 
-    expect(host.querySelector('[data-test="rail-workspace-tile"]')).toBeNull();
+    expect(tiles(host)).toHaveLength(0);
+});
+
+it('opens the workspace sheet from the open workspace tile, and switches from the others', () => {
+    const { host } = mountRail({
+        teams: [
+            makeTeam(),
+            makeTeam({
+                id: 't-2',
+                name: 'Nord',
+                slug: 'nord',
+                isCurrent: false,
+            }),
+        ],
+    });
+
+    // The open tile is the sheet's anchor, so it is wrapped rather than wired
+    // to a switch of its own.
+    expect(
+        tiles(host)[0].closest('[data-test="workspace-sheet-anchor"]'),
+    ).not.toBeNull();
+    expect(tiles(host)[0].getAttribute('data-current')).toBe('true');
+
+    tiles(host)[0].click();
+
+    expect(switchTeam).not.toHaveBeenCalled();
+
+    tiles(host)[1].click();
+
+    expect(switchTeam).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: 'nord' }),
+    );
+});
+
+it('dots a workspace holding anything unread, and only that one', () => {
+    const { host } = mountRail({
+        teams: [
+            makeTeam(),
+            makeTeam({
+                id: 't-2',
+                name: 'Nord',
+                isCurrent: false,
+                unreadCount: 4,
+            }),
+            makeTeam({ id: 't-3', name: 'Sud', isCurrent: false }),
+        ],
+    });
+
+    expect(
+        host.querySelectorAll('[data-test="rail-workspace-unread-dot"]'),
+    ).toHaveLength(1);
+});
+
+it('dots a workspace whose only news is a mention', () => {
+    const { host } = mountRail({
+        teams: [
+            makeTeam({
+                id: 't-2',
+                name: 'Nord',
+                isCurrent: false,
+                mentionCount: 2,
+            }),
+        ],
+    });
+
+    expect(
+        host.querySelectorAll('[data-test="rail-workspace-unread-dot"]'),
+    ).toHaveLength(1);
+});
+
+it('keeps a way to create a workspace at the foot of the tiles', () => {
+    const { host } = mountRail();
+
+    expect(host.querySelector('[data-test="new-team-trigger"]')).not.toBeNull();
 });
 
 it('draws an uploaded avatar in place of the initials fallback', () => {

--- a/resources/js/components/navigation/NavigationRail.vue
+++ b/resources/js/components/navigation/NavigationRail.vue
@@ -3,11 +3,13 @@ import { Plus } from '@lucide/vue';
 import { computed } from 'vue';
 import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import { NAV_DESTINATION_GLYPHS } from '@/components/navigation/destinations';
+import WorkspaceSheet from '@/components/navigation/WorkspaceSheet.vue';
 import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { useInitials } from '@/composables/useInitials';
 import type { NavDestination } from '@/composables/useNavPanel';
+import { useTeamSwitch } from '@/composables/useTeamSwitch';
 import type { RenderedPresence } from '@/lib/presence';
 import type { Team, User } from '@/types';
 
@@ -26,8 +28,8 @@ const props = defineProps<{
     active: NavDestination;
     /** The viewer, whose avatar is the "You" destination. */
     user: User;
-    /** The open workspace, tiled at the top; absent off a workspace. */
-    currentTeam: Team | null;
+    /** Every workspace the viewer belongs to, one tile each; empty off a workspace. */
+    teams: Team[];
     /** The viewer's own effective presence, for the avatar's corner dot. */
     presence: RenderedPresence;
     /** Whether the viewer is in do-not-disturb, drawn as the dot's crescent. */
@@ -36,9 +38,16 @@ const props = defineProps<{
     hasUnreadThreads: boolean;
 }>();
 
-const emit = defineEmits<{ select: [destination: NavDestination] }>();
+const emit = defineEmits<{
+    select: [destination: NavDestination];
+    /** Raised by the workspace sheet the current tile opens. */
+    invite: [];
+    /** Raised by the workspace sheet the current tile opens. */
+    join: [];
+}>();
 
 const { getInitials } = useInitials();
+const { switchTeam } = useTeamSwitch();
 
 const hasAvatar = computed(
     () => !!props.user.avatar && props.user.avatar !== '',
@@ -53,6 +62,15 @@ const hasAvatar = computed(
  * each other, so an accent press is invisible in the light theme even though
  * it reads fine in the dark one.
  */
+/**
+ * Whether a workspace has anything waiting. The tile draws a plain dot either
+ * way: the exact count belongs to the workspace sheet's rows, where there is
+ * room to read it.
+ */
+function hasUnread(team: Team): boolean {
+    return team.unreadCount > 0 || team.mentionCount > 0;
+}
+
 function glyphClass(destination: NavDestination): string {
     return props.active === destination
         ? 'bg-sidebar text-sidebar-foreground shadow-sm'
@@ -66,25 +84,71 @@ function glyphClass(destination: NavDestination): string {
         :aria-label="$t('Destinations')"
         class="flex w-14 shrink-0 flex-col items-center gap-1.5 border-sidebar-border bg-sidebar-rail py-3"
     >
-        <!-- Workspace identity, not a control: the switcher lives in the panel
-             header beside it, so the tile would only repeat a name assistive
-             technology already reached. Child #2 turns it into the workspace
-             sheet's third anchor. -->
-        <span
-            v-if="currentTeam"
-            data-test="rail-workspace-tile"
-            aria-hidden="true"
-            :title="currentTeam.name"
-            class="flex size-8.5 shrink-0 items-center justify-center rounded-[10px] bg-sidebar-primary text-[11px] font-semibold text-sidebar-primary-foreground"
-            >{{ getInitials(currentTeam.name) }}</span
+        <!-- One tile per workspace, in their own scroller: a viewer in many
+             workspaces must never push the destination glyphs below the fold.
+             Tapping another workspace switches straight to it; tapping the open
+             one opens the workspace sheet — the rail's anchor onto the surface
+             the two headers also carry. -->
+        <div
+            v-if="teams.length > 0"
+            class="flex min-h-0 w-full shrink flex-col items-center gap-2 overflow-y-auto overscroll-contain py-1"
         >
+            <template v-for="team in teams" :key="team.id">
+                <WorkspaceSheet
+                    v-if="team.isCurrent"
+                    side="right"
+                    @invite="emit('invite')"
+                    @join="emit('join')"
+                >
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        data-test="rail-workspace-tile"
+                        data-current="true"
+                        :title="team.name"
+                        class="size-8.5 shrink-0 rounded-[10px] bg-sidebar-primary text-[11px] font-semibold text-sidebar-primary-foreground ring-2 ring-brass ring-offset-2 ring-offset-sidebar-rail hover:bg-sidebar-primary"
+                    >
+                        <span aria-hidden="true">{{
+                            getInitials(team.name)
+                        }}</span>
+                        <span class="sr-only">{{
+                            $t('Workspace: :name', { name: team.name })
+                        }}</span>
+                    </Button>
+                </WorkspaceSheet>
+                <Button
+                    v-else
+                    variant="ghost"
+                    size="icon"
+                    data-test="rail-workspace-tile"
+                    :title="team.name"
+                    class="relative size-8.5 shrink-0 rounded-[10px] bg-sidebar text-[11px] font-semibold text-sidebar-foreground/80 transition-colors hover:text-sidebar-foreground"
+                    @click="switchTeam(team)"
+                >
+                    <span aria-hidden="true">{{ getInitials(team.name) }}</span>
+                    <span class="sr-only">{{
+                        $t('Switch to :name', { name: team.name })
+                    }}</span>
+                    <template v-if="hasUnread(team)">
+                        <span
+                            data-test="rail-workspace-unread-dot"
+                            aria-hidden="true"
+                            class="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-brass ring-2 ring-sidebar-rail"
+                        />
+                        <!-- The dot is decorative; the state is named for
+                             assistive tech in the tile's own label. -->
+                        <span class="sr-only">{{ $t('Unread') }}</span>
+                    </template>
+                </Button>
+            </template>
+        </div>
         <CreateTeamModal>
             <Button
                 variant="ghost"
                 size="icon"
                 :title="$t('New team')"
-                data-test="rail-new-team-trigger"
-                class="size-8.5 rounded-[10px] border border-dashed border-sidebar-border text-sidebar-foreground/70 transition-colors hover:bg-sidebar hover:text-sidebar-foreground"
+                data-test="new-team-trigger"
+                class="size-8.5 shrink-0 rounded-[10px] border border-dashed border-sidebar-border text-sidebar-foreground/70 transition-colors hover:bg-sidebar hover:text-sidebar-foreground"
             >
                 <Plus class="size-3.75" />
                 <span class="sr-only">{{ $t('New team') }}</span>

--- a/resources/js/components/navigation/NewMenu.test.ts
+++ b/resources/js/components/navigation/NewMenu.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+
+/** Drives the mocked breakpoint flag, which has to stay a real ref. */
+const viewport = vi.hoisted(() => ({
+    setMobile: null as null | ((mobile: boolean) => void),
+}));
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { ref } = await import('vue');
+    const isMobile = ref(false);
+
+    viewport.setMobile = (mobile: boolean) => {
+        isMobile.value = mobile;
+    };
+
+    return { useIsMobile: () => isMobile };
+});
+
+vi.mock('@lucide/vue', () => ({
+    FolderPlus: { render: () => h('svg') },
+    Hash: { render: () => h('svg') },
+    MessageSquare: { render: () => h('svg') },
+}));
+
+const channelModalTeamSlug = vi.hoisted(() => ({ value: '' }));
+
+vi.mock('@/components/CreateChannelModal.vue', () => ({
+    default: defineComponent({
+        props: { teamSlug: { type: String, default: '' } },
+        setup(modalProps, { slots }) {
+            channelModalTeamSlug.value = modalProps.teamSlug;
+
+            return () => h('div', slots.default?.());
+        },
+    }),
+}));
+
+/** Renders its slot and forwards a click as the `select` menu rows are wired to. */
+function passthrough(tag = 'div') {
+    return defineComponent({
+        inheritAttrs: false,
+        emits: ['select', 'update:open'],
+        setup:
+            (_, { slots, emit, attrs }) =>
+            () =>
+                h(
+                    tag,
+                    { ...attrs, onClick: () => emit('select', new Event('x')) },
+                    slots.default?.(),
+                ),
+    });
+}
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: passthrough(),
+    DropdownMenuTrigger: passthrough(),
+    DropdownMenuContent: passthrough(),
+    DropdownMenuItem: passthrough('button'),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: passthrough(),
+    DialogTrigger: passthrough(),
+    DialogContent: passthrough(),
+    DialogTitle: passthrough(),
+    DialogDescription: passthrough(),
+}));
+
+import NewMenu from './NewMenu.vue';
+
+let app: App | null = null;
+
+beforeEach(() => {
+    viewport.setMobile?.(false);
+    channelModalTeamSlug.value = '';
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+function mountMenu() {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    const messaged = vi.fn();
+    const sectioned = vi.fn();
+
+    app = createApp({
+        render: () =>
+            h(
+                NewMenu,
+                { teamSlug: 'acme', onMessage: messaged, onSection: sectioned },
+                {
+                    default: () =>
+                        h('button', { 'data-test': 'new-menu-trigger' }),
+                },
+            ),
+    });
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(host);
+
+    return { host, messaged, sectioned };
+}
+
+function row(host: HTMLElement, name: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${name}"]`);
+}
+
+it('offers exactly three ways to start something', () => {
+    const { host } = mountMenu();
+
+    expect(
+        host.querySelectorAll('[data-test="new-menu"] > *').length,
+    ).toBeGreaterThan(0);
+    expect(row(host, 'new-menu-channel')).not.toBeNull();
+    expect(row(host, 'new-menu-message')).not.toBeNull();
+    expect(row(host, 'create-section-trigger')).not.toBeNull();
+});
+
+it('never carries an invite row — membership is the workspace sheet job', () => {
+    const { host } = mountMenu();
+
+    expect(row(host, 'new-menu')!.textContent).not.toContain('Invite');
+    expect(row(host, 'invite-member-trigger')).toBeNull();
+});
+
+it('keeps the trigger the caller supplied', () => {
+    const { host } = mountMenu();
+
+    expect(row(host, 'new-menu-trigger')).not.toBeNull();
+});
+
+it('points the channel modal at the open workspace', () => {
+    mountMenu();
+
+    expect(channelModalTeamSlug.value).toBe('acme');
+});
+
+it('hands the direct message over to its host', () => {
+    const { host, messaged } = mountMenu();
+
+    row(host, 'new-menu-message')!.click();
+
+    expect(messaged).toHaveBeenCalledTimes(1);
+});
+
+it('hands the new section over to its host', () => {
+    const { host, sectioned } = mountMenu();
+
+    row(host, 'create-section-trigger')!.click();
+
+    expect(sectioned).toHaveBeenCalledTimes(1);
+});
+
+it('presents the same three rows as a bottom sheet below the breakpoint', () => {
+    viewport.setMobile?.(true);
+
+    const { host, messaged, sectioned } = mountMenu();
+
+    expect(row(host, 'new-menu-trigger')).not.toBeNull();
+    expect(row(host, 'new-menu-channel')).not.toBeNull();
+
+    row(host, 'new-menu-message')!.click();
+    row(host, 'create-section-trigger')!.click();
+
+    expect(messaged).toHaveBeenCalledTimes(1);
+    expect(sectioned).toHaveBeenCalledTimes(1);
+});

--- a/resources/js/components/navigation/NewMenu.test.ts
+++ b/resources/js/components/navigation/NewMenu.test.ts
@@ -141,12 +141,14 @@ function row(host: HTMLElement, name: string): HTMLElement | null {
 it('offers exactly three ways to start something', () => {
     const { host } = mountMenu();
 
-    expect(
-        host.querySelectorAll('[data-test="new-menu"] > *').length,
-    ).toBeGreaterThan(0);
     expect(row(host, 'new-menu-channel')).not.toBeNull();
     expect(row(host, 'new-menu-message')).not.toBeNull();
     expect(row(host, 'create-section-trigger')).not.toBeNull();
+    // And nothing else: the menu is a fixed three, not a drawer for whatever
+    // else needs a home.
+    expect(
+        host.querySelectorAll('[data-test="new-menu"] [data-test]'),
+    ).toHaveLength(3);
 });
 
 it('never carries an invite row — membership is the workspace sheet job', () => {

--- a/resources/js/components/navigation/NewMenu.test.ts
+++ b/resources/js/components/navigation/NewMenu.test.ts
@@ -27,6 +27,9 @@ vi.mock('@lucide/vue', () => ({
 
 const channelModalTeamSlug = vi.hoisted(() => ({ value: '' }));
 
+/** Lets a test replay the moment the menu finishes closing. */
+const menu = vi.hoisted(() => ({ replayClose: null as null | (() => Event) }));
+
 vi.mock('@/components/CreateChannelModal.vue', () => ({
     default: defineComponent({
         props: { teamSlug: { type: String, default: '' } },
@@ -54,10 +57,32 @@ function passthrough(tag = 'div') {
     });
 }
 
+/**
+ * The menu body, which additionally exposes its `close-auto-focus` — the moment
+ * the real menu is done with focus, and the one the "New section" row is
+ * announced from. `replayClose` lets a test drive that moment.
+ */
+function menuContent() {
+    return defineComponent({
+        inheritAttrs: false,
+        emits: ['closeAutoFocus'],
+        setup(_, { slots, emit, attrs }) {
+            menu.replayClose = () => {
+                const event = new Event('closeautofocus', { cancelable: true });
+                emit('closeAutoFocus', event);
+
+                return event;
+            };
+
+            return () => h('div', { ...attrs }, slots.default?.());
+        },
+    });
+}
+
 vi.mock('@/components/ui/dropdown-menu', () => ({
     DropdownMenu: passthrough(),
     DropdownMenuTrigger: passthrough(),
-    DropdownMenuContent: passthrough(),
+    DropdownMenuContent: menuContent(),
     DropdownMenuItem: passthrough('button'),
 }));
 
@@ -76,6 +101,7 @@ let app: App | null = null;
 beforeEach(() => {
     viewport.setMobile?.(false);
     channelModalTeamSlug.value = '';
+    menu.replayClose = null;
 });
 
 afterEach(() => {
@@ -150,12 +176,31 @@ it('hands the direct message over to its host', () => {
     expect(messaged).toHaveBeenCalledTimes(1);
 });
 
-it('hands the new section over to its host', () => {
+it('hands the new section over once the menu is done with focus', () => {
     const { host, sectioned } = mountMenu();
 
     row(host, 'create-section-trigger')!.click();
 
+    // Announcing on `select` would race the menu's own teardown for the caret,
+    // so the row waits for the close.
+    expect(sectioned).not.toHaveBeenCalled();
+
+    const event = menu.replayClose!();
+
     expect(sectioned).toHaveBeenCalledTimes(1);
+    // And the menu gives up its restore, since focus is going to the field.
+    expect(event.defaultPrevented).toBe(true);
+});
+
+it('leaves the focus restore alone when the menu closes on anything else', () => {
+    const { host, sectioned } = mountMenu();
+
+    row(host, 'new-menu-message')!.click();
+
+    const event = menu.replayClose!();
+
+    expect(sectioned).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
 });
 
 it('presents the same three rows as a bottom sheet below the breakpoint', () => {

--- a/resources/js/components/navigation/NewMenu.vue
+++ b/resources/js/components/navigation/NewMenu.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { FolderPlus, Hash, MessageSquare } from '@lucide/vue';
+import { ref, watch } from 'vue';
+import CreateChannelModal from '@/components/CreateChannelModal.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useIsMobile } from '@/composables/useIsMobile';
+
+/**
+ * The dock header's "+ New" menu: exactly three ways to start something —
+ * a channel, a direct message, a section — and nothing else.
+ *
+ * Inviting people is deliberately absent: it is an act of membership, not of
+ * creation, and lives in the workspace sheet. The group headers keep their own
+ * "+" shortcuts, which this menu duplicates rather than replaces.
+ *
+ * Like the workspace sheet, the trigger is the default slot and the surface
+ * presents as a bottom sheet below `md`.
+ */
+defineProps<{
+    /** The workspace the new channel would belong to. */
+    teamSlug: string;
+}>();
+
+const emit = defineEmits<{
+    /** Start a direct message; the host owns the people picker. */
+    message: [];
+    /** Start a section; the host owns the inline name field. */
+    section: [];
+}>();
+
+const isSheetViewport = useIsMobile();
+
+const open = ref(false);
+
+watch(isSheetViewport, () => {
+    open.value = false;
+});
+
+function requestMessage(): void {
+    open.value = false;
+    emit('message');
+}
+
+function requestSection(): void {
+    open.value = false;
+    emit('section');
+}
+
+/** The shared look of one 52px sheet row. */
+const sheetRowClass =
+    'flex h-13 w-full items-center gap-3.25 rounded-[13px] px-3 text-left text-base font-normal text-foreground transition-colors hover:bg-muted/50 active:bg-muted';
+</script>
+
+<template>
+    <Dialog v-if="isSheetViewport" :open="open" @update:open="open = $event">
+        <DialogTrigger as-child>
+            <slot />
+        </DialogTrigger>
+        <DialogContent
+            data-test="new-menu"
+            :show-close-button="false"
+            class="gap-0 p-2"
+        >
+            <DialogTitle class="sr-only">{{ $t('New') }}</DialogTitle>
+            <DialogDescription class="sr-only">
+                {{ $t('Start a channel, a message, or a section.') }}
+            </DialogDescription>
+
+            <CreateChannelModal :team-slug="teamSlug">
+                <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    data-test="new-menu-channel"
+                    :class="sheetRowClass"
+                >
+                    <Hash class="size-5 text-muted-foreground" />
+                    <span class="min-w-0 flex-1 truncate">{{
+                        $t('New channel')
+                    }}</span>
+                </Button>
+            </CreateChannelModal>
+            <Button
+                variant="unstyled"
+                size="none"
+                type="button"
+                data-test="new-menu-message"
+                :class="sheetRowClass"
+                @click="requestMessage"
+            >
+                <MessageSquare class="size-5 text-muted-foreground" />
+                <span class="min-w-0 flex-1 truncate">{{
+                    $t('New message')
+                }}</span>
+            </Button>
+            <Button
+                variant="unstyled"
+                size="none"
+                type="button"
+                data-test="create-section-trigger"
+                :class="sheetRowClass"
+                @click="requestSection"
+            >
+                <FolderPlus class="size-5 text-muted-foreground" />
+                <span class="min-w-0 flex-1 truncate">{{
+                    $t('New section')
+                }}</span>
+            </Button>
+        </DialogContent>
+    </Dialog>
+
+    <DropdownMenu v-else :open="open" @update:open="open = $event">
+        <DropdownMenuTrigger as-child>
+            <slot />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+            data-test="new-menu"
+            align="end"
+            class="w-53.5 rounded-[14px] p-1.5"
+        >
+            <CreateChannelModal :team-slug="teamSlug">
+                <DropdownMenuItem
+                    data-test="new-menu-channel"
+                    class="h-8.5 cursor-pointer gap-2.25"
+                    @select.prevent
+                >
+                    <Hash class="size-3.75 text-muted-foreground" />
+                    {{ $t('New channel') }}
+                </DropdownMenuItem>
+            </CreateChannelModal>
+            <DropdownMenuItem
+                data-test="new-menu-message"
+                class="h-8.5 cursor-pointer gap-2.25"
+                @select="requestMessage"
+            >
+                <MessageSquare class="size-3.75 text-muted-foreground" />
+                {{ $t('New message') }}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+                data-test="create-section-trigger"
+                class="h-8.5 cursor-pointer gap-2.25"
+                @select="requestSection"
+            >
+                <FolderPlus class="size-3.75 text-muted-foreground" />
+                {{ $t('New section') }}
+            </DropdownMenuItem>
+        </DropdownMenuContent>
+    </DropdownMenu>
+</template>

--- a/resources/js/components/navigation/NewMenu.vue
+++ b/resources/js/components/navigation/NewMenu.vue
@@ -54,8 +54,35 @@ function requestMessage(): void {
     emit('message');
 }
 
+/** The bottom sheet has no focus scope to outlive, so it announces at once. */
 function requestSection(): void {
     open.value = false;
+    emit('section');
+}
+
+/** Set between picking "New section" and the menu finishing its close. */
+const sectionPending = ref(false);
+
+function requestSectionFromMenu(): void {
+    sectionPending.value = true;
+    open.value = false;
+}
+
+/**
+ * "New section" opens an inline field at the foot of the list and puts the
+ * caret in it, so the menu announces it from its own close rather than from
+ * `select`: this is the moment it is done with focus. Announcing earlier means
+ * racing the menu's teardown, which traps focus while it runs and then drops it
+ * on the body — leaving the field open but unfocused. The restore to the
+ * trigger is suppressed for the same reason: the field is where focus is going.
+ */
+function onCloseAutoFocus(event: Event): void {
+    if (!sectionPending.value) {
+        return;
+    }
+
+    sectionPending.value = false;
+    event.preventDefault();
     emit('section');
 }
 
@@ -130,6 +157,7 @@ const sheetRowClass =
             data-test="new-menu"
             align="end"
             class="w-53.5 rounded-[14px] p-1.5"
+            @close-auto-focus="onCloseAutoFocus"
         >
             <CreateChannelModal :team-slug="teamSlug">
                 <DropdownMenuItem
@@ -152,7 +180,7 @@ const sheetRowClass =
             <DropdownMenuItem
                 data-test="create-section-trigger"
                 class="h-8.5 cursor-pointer gap-2.25"
-                @select="requestSection"
+                @select="requestSectionFromMenu"
             >
                 <FolderPlus class="size-3.75 text-muted-foreground" />
                 {{ $t('New section') }}

--- a/resources/js/components/navigation/WorkspaceSheet.test.ts
+++ b/resources/js/components/navigation/WorkspaceSheet.test.ts
@@ -1,0 +1,351 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import type { Team } from '@/types';
+
+/** Mutable stand-in for the shared workspace props. */
+const props = vi.hoisted(() => ({
+    currentTeam: null as Team | null,
+    teams: [] as Team[],
+    canInviteToCurrentTeam: false,
+    canUpdateCurrentTeam: false,
+    pendingInvitations: [] as unknown[],
+}));
+
+const switchTeam = vi.hoisted(() => vi.fn());
+
+/** Drives the mocked breakpoint flag, which has to stay a real ref. */
+const viewport = vi.hoisted(() => ({
+    setMobile: null as null | ((mobile: boolean) => void),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props }),
+    Link: defineComponent({
+        props: { href: { type: String, default: '' } },
+        setup:
+            (linkProps, { slots }) =>
+            () =>
+                h('a', { href: linkProps.href }, slots.default?.()),
+    }),
+}));
+
+vi.mock('@/composables/useTeamSwitch', () => ({
+    useTeamSwitch: () => ({ switchTeam }),
+}));
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { ref } = await import('vue');
+    const isMobile = ref(false);
+
+    viewport.setMobile = (mobile: boolean) => {
+        isMobile.value = mobile;
+    };
+
+    return { useIsMobile: () => isMobile };
+});
+
+vi.mock('@/routes/teams', () => ({
+    edit: (slug: string) => ({ url: `/settings/teams/${slug}` }),
+}));
+
+vi.mock('@lucide/vue', () => ({
+    Check: { render: () => h('svg') },
+    LogIn: { render: () => h('svg') },
+    Plus: { render: () => h('svg') },
+    Settings: { render: () => h('svg') },
+    UserPlus: { render: () => h('svg') },
+    Users: { render: () => h('svg') },
+}));
+
+vi.mock('@/components/CreateTeamModal.vue', () => ({
+    default: defineComponent({
+        setup:
+            (_, { slots }) =>
+            () =>
+                h('div', slots.default?.()),
+    }),
+}));
+
+/**
+ * A stand-in for one menu/dialog primitive: it always renders its slot (so the
+ * closed-surface machinery stays out of the assertions) and forwards a click as
+ * the `select` the menu rows are wired to.
+ */
+function passthrough(tag = 'div') {
+    return defineComponent({
+        inheritAttrs: false,
+        emits: ['select', 'update:open'],
+        setup:
+            (_, { slots, emit, attrs }) =>
+            () =>
+                h(
+                    tag,
+                    { ...attrs, onClick: () => emit('select', new Event('x')) },
+                    slots.default?.(),
+                ),
+    });
+}
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: passthrough(),
+    DropdownMenuTrigger: passthrough(),
+    DropdownMenuContent: passthrough(),
+    DropdownMenuItem: passthrough('button'),
+    DropdownMenuLabel: passthrough(),
+    DropdownMenuSeparator: passthrough('hr'),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: passthrough(),
+    DialogTrigger: passthrough(),
+    DialogContent: passthrough(),
+    DialogTitle: passthrough(),
+    DialogDescription: passthrough(),
+}));
+
+import WorkspaceSheet from './WorkspaceSheet.vue';
+
+function team(overrides: Partial<Team> = {}): Team {
+    return {
+        id: 't-1',
+        name: 'Acme Corp',
+        slug: 'acme',
+        isPersonal: false,
+        membersCount: 7,
+        isCurrent: true,
+        unreadCount: 0,
+        mentionCount: 0,
+        ...overrides,
+    };
+}
+
+let app: App | null = null;
+
+beforeEach(() => {
+    props.currentTeam = team();
+    props.teams = [team()];
+    props.canInviteToCurrentTeam = true;
+    props.canUpdateCurrentTeam = true;
+    props.pendingInvitations = [];
+    viewport.setMobile?.(false);
+    switchTeam.mockClear();
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+function mountSheet() {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    const invited = vi.fn();
+    const joined = vi.fn();
+
+    app = createApp({
+        render: () =>
+            h(
+                WorkspaceSheet,
+                { onInvite: invited, onJoin: joined },
+                {
+                    default: () =>
+                        h('button', { 'data-test': 'workspace-switcher' }),
+                },
+            ),
+    });
+    app.config.globalProperties.$t = (
+        key: string,
+        replacements?: Record<string, unknown>,
+    ) =>
+        replacements
+            ? Object.entries(replacements).reduce(
+                  (line, [token, value]) =>
+                      line.replaceAll(`:${token}`, String(value)),
+                  key,
+              )
+            : key;
+    app.mount(host);
+
+    return { host, invited, joined };
+}
+
+function row(host: HTMLElement, name: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${name}"]`);
+}
+
+it('names the current workspace and its member count', () => {
+    const { host } = mountSheet();
+
+    const sheet = row(host, 'workspace-sheet');
+
+    expect(sheet).not.toBeNull();
+    expect(sheet!.textContent).toContain('Acme Corp');
+    expect(sheet!.textContent).toContain('7 members');
+});
+
+it('keeps the trigger the caller supplied', () => {
+    const { host } = mountSheet();
+
+    expect(row(host, 'workspace-switcher')).not.toBeNull();
+});
+
+it('offers members, invite and settings to an admin', () => {
+    const { host } = mountSheet();
+
+    expect(row(host, 'workspace-members-link')).not.toBeNull();
+    expect(row(host, 'invite-member-trigger')).not.toBeNull();
+    expect(row(host, 'workspace-settings-link')).not.toBeNull();
+});
+
+it('leaves a plain member with the members row alone', () => {
+    props.canInviteToCurrentTeam = false;
+    props.canUpdateCurrentTeam = false;
+
+    const { host } = mountSheet();
+
+    expect(row(host, 'workspace-members-link')).not.toBeNull();
+    expect(row(host, 'invite-member-trigger')).toBeNull();
+    expect(row(host, 'workspace-settings-link')).toBeNull();
+});
+
+it('anchors the members row on the roster section of the settings page', () => {
+    const { host } = mountSheet();
+
+    expect(row(host, 'workspace-members-link')!.getAttribute('href')).toBe(
+        '/settings/teams/acme#members',
+    );
+    expect(row(host, 'workspace-settings-link')!.getAttribute('href')).toBe(
+        '/settings/teams/acme',
+    );
+});
+
+it('hands the invite request to its host', () => {
+    const { host, invited } = mountSheet();
+
+    row(host, 'invite-member-trigger')!.click();
+
+    expect(invited).toHaveBeenCalledTimes(1);
+});
+
+it('hides the join row until an invitation is pending', () => {
+    const { host } = mountSheet();
+
+    expect(row(host, 'join-workspace-trigger')).toBeNull();
+});
+
+it('carries the pending invitation count on the join row', () => {
+    props.pendingInvitations = [{}, {}];
+
+    const { host, joined } = mountSheet();
+
+    expect(row(host, 'join-workspace-count')!.textContent).toContain('2');
+
+    row(host, 'join-workspace-trigger')!.click();
+
+    expect(joined).toHaveBeenCalledTimes(1);
+});
+
+it('marks the current workspace and never switches to it', () => {
+    const { host } = mountSheet();
+
+    const current = row(host, 'team-switcher-item')!;
+
+    expect(current.getAttribute('aria-current')).toBe('true');
+
+    current.click();
+
+    expect(switchTeam).not.toHaveBeenCalled();
+});
+
+it('switches straight to another workspace', () => {
+    props.teams = [
+        team(),
+        team({ id: 't-2', name: 'Nord', slug: 'nord', isCurrent: false }),
+    ];
+
+    const { host } = mountSheet();
+
+    host.querySelectorAll<HTMLElement>(
+        '[data-test="team-switcher-item"]',
+    )[1].click();
+
+    expect(switchTeam).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: 'nord' }),
+    );
+});
+
+it('badges a workspace with its mention count, and dots a merely unread one', () => {
+    props.teams = [
+        team({ id: 't-2', name: 'Nord', isCurrent: false, mentionCount: 3 }),
+        team({ id: 't-3', name: 'Sud', isCurrent: false, unreadCount: 5 }),
+    ];
+
+    const { host } = mountSheet();
+
+    const badges = host.querySelectorAll(
+        '[data-test="workspace-mention-badge"]',
+    );
+
+    expect(badges).toHaveLength(1);
+    expect(badges[0].textContent).toContain('3');
+    expect(
+        host.querySelectorAll('[data-test="workspace-unread-dot"]'),
+    ).toHaveLength(1);
+});
+
+it('shows no unread cue on a workspace with nothing waiting', () => {
+    props.teams = [team({ isCurrent: false })];
+
+    const { host } = mountSheet();
+
+    expect(row(host, 'workspace-mention-badge')).toBeNull();
+    expect(row(host, 'workspace-unread-dot')).toBeNull();
+});
+
+it('presents the same rows as a bottom sheet below the breakpoint', () => {
+    viewport.setMobile?.(true);
+    props.pendingInvitations = [{}];
+
+    const { host } = mountSheet();
+
+    expect(row(host, 'workspace-sheet')).not.toBeNull();
+    expect(row(host, 'workspace-switcher')).not.toBeNull();
+    expect(row(host, 'workspace-members-link')).not.toBeNull();
+    expect(row(host, 'invite-member-trigger')).not.toBeNull();
+    expect(row(host, 'workspace-settings-link')).not.toBeNull();
+    expect(row(host, 'team-switcher-item')).not.toBeNull();
+    expect(row(host, 'team-switcher-new-team')).not.toBeNull();
+    expect(row(host, 'join-workspace-trigger')).not.toBeNull();
+});
+
+it('hands the invite request over from the bottom sheet too', () => {
+    viewport.setMobile?.(true);
+
+    const { host, invited } = mountSheet();
+
+    row(host, 'invite-member-trigger')!.click();
+
+    expect(invited).toHaveBeenCalledTimes(1);
+});
+
+it('switches workspace from the bottom sheet', () => {
+    viewport.setMobile?.(true);
+    props.teams = [
+        team(),
+        team({ id: 't-2', name: 'Nord', slug: 'nord', isCurrent: false }),
+    ];
+
+    const { host } = mountSheet();
+
+    host.querySelectorAll<HTMLElement>(
+        '[data-test="team-switcher-item"]',
+    )[1].click();
+
+    expect(switchTeam).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: 'nord' }),
+    );
+});

--- a/resources/js/components/navigation/WorkspaceSheet.vue
+++ b/resources/js/components/navigation/WorkspaceSheet.vue
@@ -22,6 +22,7 @@ import {
 import { useInitials } from '@/composables/useInitials';
 import { useIsMobile } from '@/composables/useIsMobile';
 import { useTeamSwitch } from '@/composables/useTeamSwitch';
+import { useTranslations } from '@/composables/useTranslations';
 import { edit as teamEdit } from '@/routes/teams';
 import type { Team } from '@/types';
 
@@ -61,6 +62,7 @@ const emit = defineEmits<{
 }>();
 
 const page = usePage();
+const { t } = useTranslations();
 const { getInitials } = useInitials();
 const { switchTeam } = useTeamSwitch();
 
@@ -117,9 +119,17 @@ function chooseTeam(team: Team): void {
     }
 }
 
-/** How many members a workspace has, as the one line both surfaces render. */
-function memberCountLabel(team: Team | null): string {
-    return (team?.membersCount ?? 0) === 1 ? 'member' : 'members';
+/**
+ * How many members a workspace has, as the one line both surfaces render. The
+ * count is interpolated rather than concatenated, so a locale is free to put it
+ * anywhere in the phrase.
+ */
+function memberCountLine(team: Team | null): string {
+    const count = team?.membersCount ?? 0;
+
+    return count === 1
+        ? t(':count member', { count })
+        : t(':count members', { count });
 }
 
 /** The shared look of one 52px sheet row. */
@@ -152,10 +162,9 @@ const sheetRowClass =
                     <span class="block truncate text-base font-semibold">{{
                         currentTeam?.name ?? $t('Select team')
                     }}</span>
-                    <span class="block text-xs text-muted-foreground"
-                        >{{ currentTeam?.membersCount ?? 0 }}
-                        {{ $t(memberCountLabel(currentTeam)) }}</span
-                    >
+                    <span class="block text-xs text-muted-foreground">{{
+                        memberCountLine(currentTeam)
+                    }}</span>
                 </span>
             </div>
 
@@ -229,10 +238,9 @@ const sheetRowClass =
                     <span class="block truncate text-[15px]">{{
                         team.name
                     }}</span>
-                    <span class="block text-xs text-muted-foreground"
-                        >{{ team.membersCount }}
-                        {{ $t(memberCountLabel(team)) }}</span
-                    >
+                    <span class="block text-xs text-muted-foreground">{{
+                        memberCountLine(team)
+                    }}</span>
                 </span>
                 <Check
                     v-if="team.isCurrent"
@@ -320,10 +328,9 @@ const sheetRowClass =
                         class="block truncate text-[13.5px] font-semibold text-foreground"
                         >{{ currentTeam?.name ?? $t('Select team') }}</span
                     >
-                    <span class="block text-[11px] text-muted-foreground"
-                        >{{ currentTeam?.membersCount ?? 0 }}
-                        {{ $t(memberCountLabel(currentTeam)) }}</span
-                    >
+                    <span class="block text-[11px] text-muted-foreground">{{
+                        memberCountLine(currentTeam)
+                    }}</span>
                 </span>
             </div>
 
@@ -391,10 +398,9 @@ const sheetRowClass =
                         :class="team.isCurrent ? 'font-semibold' : ''"
                         >{{ team.name }}</span
                     >
-                    <span class="block text-[11px] text-muted-foreground"
-                        >{{ team.membersCount }}
-                        {{ $t(memberCountLabel(team)) }}</span
-                    >
+                    <span class="block text-[11px] text-muted-foreground">{{
+                        memberCountLine(team)
+                    }}</span>
                 </span>
                 <Check
                     v-if="team.isCurrent"

--- a/resources/js/components/navigation/WorkspaceSheet.vue
+++ b/resources/js/components/navigation/WorkspaceSheet.vue
@@ -1,0 +1,454 @@
+<script setup lang="ts">
+import { Link, usePage } from '@inertiajs/vue3';
+import { Check, LogIn, Plus, Settings, UserPlus, Users } from '@lucide/vue';
+import { computed, ref, watch } from 'vue';
+import CreateTeamModal from '@/components/CreateTeamModal.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useInitials } from '@/composables/useInitials';
+import { useIsMobile } from '@/composables/useIsMobile';
+import { useTeamSwitch } from '@/composables/useTeamSwitch';
+import { edit as teamEdit } from '@/routes/teams';
+import type { Team } from '@/types';
+
+/**
+ * The workspace sheet: one surface behind three anchors — the desktop panel
+ * header, the mobile drawer header, and the rail's current-workspace tile.
+ *
+ * It carries the workspace's own actions (Members, Invite people, Workspace
+ * settings), the list of workspaces with their unread standing, and the two
+ * ways in and out of a workspace. Membership actions live here rather than in
+ * "+ New", which is strictly about creating conversations.
+ *
+ * The trigger is this component's default slot, so each anchor keeps its own
+ * markup and selector while the surface stays a single implementation. Below
+ * `md` it presents as a bottom sheet for the same reason the user menu does: a
+ * dropdown anchored inside an off-canvas drawer is neither reachable nor
+ * sizeable on a phone.
+ */
+withDefaults(
+    defineProps<{
+        /**
+         * Which edge the desktop popover leaves its anchor from: the headers
+         * drop it downwards, the rail's tile pushes it out sideways so it lands
+         * beside the rail rather than over the panel. Ignored below `md`, where
+         * the surface is a bottom sheet.
+         */
+        side?: 'bottom' | 'right';
+    }>(),
+    { side: 'bottom' },
+);
+
+const emit = defineEmits<{
+    /** The viewer asked to invite people; the host owns the invite modal. */
+    invite: [];
+    /** The viewer asked to review their pending invitations. */
+    join: [];
+}>();
+
+const page = usePage();
+const { getInitials } = useInitials();
+const { switchTeam } = useTeamSwitch();
+
+const currentTeam = computed<Team | null>(() => page.props.currentTeam);
+const teams = computed<Team[]>(() => page.props.teams ?? []);
+const canInvite = computed(() => page.props.canInviteToCurrentTeam ?? false);
+const canUpdate = computed(() => page.props.canUpdateCurrentTeam ?? false);
+const pendingInvitationCount = computed(
+    () => (page.props.pendingInvitations ?? []).length,
+);
+
+/**
+ * Where the two settings rows land. "Members" anchors on the roster section of
+ * the workspace settings page rather than opening a surface of its own — the
+ * page already holds the member list, the invite button and the role controls.
+ */
+const settingsHref = computed(() =>
+    currentTeam.value ? teamEdit(currentTeam.value.slug).url : '',
+);
+const membersHref = computed(() =>
+    settingsHref.value === '' ? '' : `${settingsHref.value}#members`,
+);
+
+const isSheetViewport = useIsMobile();
+
+const open = ref(false);
+
+// A breakpoint crossing while the surface is open resets it, so the sheet
+// cannot reappear stale on the way back down (as the user menu does).
+watch(isSheetViewport, () => {
+    open.value = false;
+});
+
+/** Leave the surface before anything else happens: it must never outlive a navigation. */
+function close(): void {
+    open.value = false;
+}
+
+function requestInvite(): void {
+    close();
+    emit('invite');
+}
+
+function requestJoin(): void {
+    close();
+    emit('join');
+}
+
+function chooseTeam(team: Team): void {
+    close();
+
+    if (team.id !== currentTeam.value?.id) {
+        switchTeam(team);
+    }
+}
+
+/** How many members a workspace has, as the one line both surfaces render. */
+function memberCountLabel(team: Team | null): string {
+    return (team?.membersCount ?? 0) === 1 ? 'member' : 'members';
+}
+
+/** The shared look of one 52px sheet row. */
+const sheetRowClass =
+    'flex h-13 w-full items-center gap-3 rounded-[13px] px-3 text-left text-base font-normal text-foreground transition-colors hover:bg-muted/50 active:bg-muted';
+</script>
+
+<template>
+    <Dialog v-if="isSheetViewport" :open="open" @update:open="open = $event">
+        <DialogTrigger as-child>
+            <slot />
+        </DialogTrigger>
+        <DialogContent
+            data-test="workspace-sheet"
+            :show-close-button="false"
+            class="gap-0 p-2"
+        >
+            <DialogTitle class="sr-only">{{ $t('Workspaces') }}</DialogTitle>
+            <DialogDescription class="sr-only">
+                {{ $t('Switch workspace, or manage this one.') }}
+            </DialogDescription>
+
+            <div class="flex items-center gap-3 px-3 pt-2 pb-3">
+                <span
+                    aria-hidden="true"
+                    class="flex size-10 shrink-0 items-center justify-center rounded-[11px] bg-sidebar-primary text-[13px] font-semibold text-sidebar-primary-foreground"
+                    >{{ getInitials(currentTeam?.name ?? '') }}</span
+                >
+                <span class="min-w-0 flex-1">
+                    <span class="block truncate text-base font-semibold">{{
+                        currentTeam?.name ?? $t('Select team')
+                    }}</span>
+                    <span class="block text-xs text-muted-foreground"
+                        >{{ currentTeam?.membersCount ?? 0 }}
+                        {{ $t(memberCountLabel(currentTeam)) }}</span
+                    >
+                </span>
+            </div>
+
+            <Link
+                v-if="currentTeam"
+                :href="membersHref"
+                data-test="workspace-members-link"
+                :class="sheetRowClass"
+                @click="close"
+            >
+                <Users class="size-5 text-muted-foreground" />
+                <span class="min-w-0 flex-1 truncate">{{ $t('Members') }}</span>
+            </Link>
+            <Button
+                v-if="canInvite"
+                variant="unstyled"
+                size="none"
+                type="button"
+                data-test="invite-member-trigger"
+                :class="sheetRowClass"
+                @click="requestInvite"
+            >
+                <UserPlus class="size-5 text-muted-foreground" />
+                <span class="min-w-0 flex-1 truncate">{{
+                    $t('Invite people')
+                }}</span>
+            </Button>
+            <Link
+                v-if="canUpdate && currentTeam"
+                :href="settingsHref"
+                data-test="workspace-settings-link"
+                :class="sheetRowClass"
+                @click="close"
+            >
+                <Settings class="size-5 text-muted-foreground" />
+                <span class="min-w-0 flex-1 truncate">{{
+                    $t('Workspace settings')
+                }}</span>
+            </Link>
+
+            <div aria-hidden="true" class="mx-3 my-2 h-px bg-border" />
+
+            <div
+                class="px-3 pb-1.5 text-[10px] font-semibold tracking-[0.12em] text-muted-foreground uppercase"
+            >
+                {{ $t('Workspaces') }}
+            </div>
+            <Button
+                v-for="team in teams"
+                :key="team.id"
+                variant="unstyled"
+                size="none"
+                type="button"
+                data-test="team-switcher-item"
+                :data-current="team.isCurrent ? 'true' : undefined"
+                :aria-current="team.isCurrent ? 'true' : undefined"
+                :class="[sheetRowClass, team.isCurrent ? 'bg-muted' : '']"
+                @click="chooseTeam(team)"
+            >
+                <span
+                    aria-hidden="true"
+                    class="flex size-8 shrink-0 items-center justify-center rounded-[9px] text-[11px] font-semibold"
+                    :class="
+                        team.isCurrent
+                            ? 'bg-sidebar-primary text-sidebar-primary-foreground'
+                            : 'bg-secondary text-secondary-foreground'
+                    "
+                    >{{ getInitials(team.name) }}</span
+                >
+                <span class="min-w-0 flex-1">
+                    <span class="block truncate text-[15px]">{{
+                        team.name
+                    }}</span>
+                    <span class="block text-xs text-muted-foreground"
+                        >{{ team.membersCount }}
+                        {{ $t(memberCountLabel(team)) }}</span
+                    >
+                </span>
+                <Check
+                    v-if="team.isCurrent"
+                    class="size-4 shrink-0 text-brass"
+                />
+                <template v-else>
+                    <span
+                        v-if="team.mentionCount > 0"
+                        data-test="workspace-mention-badge"
+                        class="flex h-4.5 min-w-4.5 shrink-0 items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums"
+                        :aria-label="
+                            $t(':count unread mentions', {
+                                count: team.mentionCount,
+                            })
+                        "
+                        >{{ team.mentionCount }}</span
+                    >
+                    <template v-else-if="team.unreadCount > 0">
+                        <span
+                            aria-hidden="true"
+                            data-test="workspace-unread-dot"
+                            class="size-1.5 shrink-0 rounded-full bg-brass"
+                        />
+                        <span class="sr-only">{{ $t('Unread') }}</span>
+                    </template>
+                </template>
+            </Button>
+
+            <div aria-hidden="true" class="mx-3 my-2 h-px bg-border" />
+
+            <CreateTeamModal>
+                <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    data-test="team-switcher-new-team"
+                    :class="sheetRowClass"
+                >
+                    <Plus class="size-5 text-muted-foreground" />
+                    <span class="min-w-0 flex-1 truncate">{{
+                        $t('Create a workspace')
+                    }}</span>
+                </Button>
+            </CreateTeamModal>
+            <Button
+                v-if="pendingInvitationCount > 0"
+                variant="unstyled"
+                size="none"
+                type="button"
+                data-test="join-workspace-trigger"
+                :class="sheetRowClass"
+                @click="requestJoin"
+            >
+                <LogIn class="size-5 text-muted-foreground" />
+                <span class="min-w-0 flex-1 truncate">{{
+                    $t('Join a workspace')
+                }}</span>
+                <span
+                    data-test="join-workspace-count"
+                    class="flex h-4.5 min-w-4.5 shrink-0 items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums"
+                    >{{ pendingInvitationCount }}</span
+                >
+            </Button>
+        </DialogContent>
+    </Dialog>
+
+    <DropdownMenu v-else :open="open" @update:open="open = $event">
+        <DropdownMenuTrigger as-child>
+            <slot />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+            data-test="workspace-sheet"
+            align="start"
+            :side="side"
+            class="w-59 rounded-[14px] p-1.5"
+        >
+            <div class="flex items-center gap-2.5 px-2.5 pt-2 pb-2">
+                <span
+                    aria-hidden="true"
+                    class="flex size-8 shrink-0 items-center justify-center rounded-[9px] bg-sidebar-primary text-[11.5px] font-semibold text-sidebar-primary-foreground"
+                    >{{ getInitials(currentTeam?.name ?? '') }}</span
+                >
+                <span class="min-w-0 flex-1">
+                    <span
+                        class="block truncate text-[13.5px] font-semibold text-foreground"
+                        >{{ currentTeam?.name ?? $t('Select team') }}</span
+                    >
+                    <span class="block text-[11px] text-muted-foreground"
+                        >{{ currentTeam?.membersCount ?? 0 }}
+                        {{ $t(memberCountLabel(currentTeam)) }}</span
+                    >
+                </span>
+            </div>
+
+            <DropdownMenuItem v-if="currentTeam" as-child>
+                <Link
+                    :href="membersHref"
+                    data-test="workspace-members-link"
+                    class="cursor-pointer gap-2.25"
+                    @click="close"
+                >
+                    <Users class="size-3.75 text-muted-foreground" />
+                    {{ $t('Members') }}
+                </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+                v-if="canInvite"
+                data-test="invite-member-trigger"
+                class="cursor-pointer gap-2.25"
+                @select="requestInvite"
+            >
+                <UserPlus class="size-3.75 text-muted-foreground" />
+                {{ $t('Invite people') }}
+            </DropdownMenuItem>
+            <DropdownMenuItem v-if="canUpdate && currentTeam" as-child>
+                <Link
+                    :href="settingsHref"
+                    data-test="workspace-settings-link"
+                    class="cursor-pointer gap-2.25"
+                    @click="close"
+                >
+                    <Settings class="size-3.75 text-muted-foreground" />
+                    {{ $t('Workspace settings') }}
+                </Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator />
+
+            <DropdownMenuLabel
+                class="px-2.5 pb-1 text-[10px] font-semibold tracking-[0.1em] text-muted-foreground uppercase"
+            >
+                {{ $t('Workspaces') }}
+            </DropdownMenuLabel>
+            <DropdownMenuItem
+                v-for="team in teams"
+                :key="team.id"
+                data-test="team-switcher-item"
+                :data-current="team.isCurrent ? 'true' : undefined"
+                :aria-current="team.isCurrent ? 'true' : undefined"
+                class="cursor-pointer gap-2.5 rounded-[10px] px-2.5 py-1.75 data-[current=true]:bg-secondary"
+                @select="chooseTeam(team)"
+            >
+                <span
+                    aria-hidden="true"
+                    class="flex size-6.5 shrink-0 items-center justify-center rounded-[8px] text-[10px] font-semibold"
+                    :class="
+                        team.isCurrent
+                            ? 'bg-sidebar-primary text-sidebar-primary-foreground'
+                            : 'bg-secondary text-secondary-foreground'
+                    "
+                    >{{ getInitials(team.name) }}</span
+                >
+                <span class="min-w-0 flex-1">
+                    <span
+                        class="block truncate text-[13px]"
+                        :class="team.isCurrent ? 'font-semibold' : ''"
+                        >{{ team.name }}</span
+                    >
+                    <span class="block text-[11px] text-muted-foreground"
+                        >{{ team.membersCount }}
+                        {{ $t(memberCountLabel(team)) }}</span
+                    >
+                </span>
+                <Check
+                    v-if="team.isCurrent"
+                    class="size-3.5 shrink-0 text-brass"
+                />
+                <template v-else>
+                    <span
+                        v-if="team.mentionCount > 0"
+                        data-test="workspace-mention-badge"
+                        class="flex h-4.25 min-w-4.5 shrink-0 items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums"
+                        :aria-label="
+                            $t(':count unread mentions', {
+                                count: team.mentionCount,
+                            })
+                        "
+                        >{{ team.mentionCount }}</span
+                    >
+                    <template v-else-if="team.unreadCount > 0">
+                        <span
+                            aria-hidden="true"
+                            data-test="workspace-unread-dot"
+                            class="size-1.5 shrink-0 rounded-full bg-brass"
+                        />
+                        <span class="sr-only">{{ $t('Unread') }}</span>
+                    </template>
+                </template>
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator />
+
+            <CreateTeamModal>
+                <DropdownMenuItem
+                    data-test="team-switcher-new-team"
+                    class="cursor-pointer gap-2.25"
+                    @select.prevent
+                >
+                    <Plus class="size-3.75 text-muted-foreground" />
+                    {{ $t('Create a workspace') }}
+                </DropdownMenuItem>
+            </CreateTeamModal>
+            <DropdownMenuItem
+                v-if="pendingInvitationCount > 0"
+                data-test="join-workspace-trigger"
+                class="cursor-pointer gap-2.25"
+                @select="requestJoin"
+            >
+                <LogIn class="size-3.75 text-muted-foreground" />
+                {{ $t('Join a workspace') }}
+                <span
+                    data-test="join-workspace-count"
+                    class="ml-auto flex h-4.25 min-w-4.5 items-center justify-center rounded-full bg-brass px-1.5 text-[10px] font-bold text-brass-foreground tabular-nums"
+                    >{{ pendingInvitationCount }}</span
+                >
+            </DropdownMenuItem>
+        </DropdownMenuContent>
+    </DropdownMenu>
+</template>

--- a/resources/js/composables/useOnboardingTour.ts
+++ b/resources/js/composables/useOnboardingTour.ts
@@ -18,7 +18,13 @@ export type TourStep = {
 /**
  * The first-run tour: three coachmarks pointing at the key actions a new user
  * takes. The `target` values match `data-tour` attributes placed on the composer
- * (Show.vue) and the sidebar create-channel / invite affordances (MainLayout).
+ * (Show.vue) and, in MainLayout, the sidebar's create-channel shortcut and the
+ * workspace-sheet trigger.
+ *
+ * The last step spotlights the trigger rather than the invite row itself: the
+ * row now lives inside the workspace sheet, and a `data-tour` anchor inside a
+ * closed surface resolves to nothing, leaving the spotlight with no rect to cut
+ * ({@see OnboardingTour.vue}).
  */
 export const tourSteps: TourStep[] = [
     {
@@ -34,7 +40,7 @@ export const tourSteps: TourStep[] = [
     {
         target: 'invite',
         title: 'Invite your teammates',
-        body: 'A workspace comes alive with people. Invite a few teammates to get the conversation going.',
+        body: 'Open the workspace menu to invite teammates, switch workspace, or manage this one.',
     },
 ];
 

--- a/resources/js/composables/useSidebarBadges.test.ts
+++ b/resources/js/composables/useSidebarBadges.test.ts
@@ -106,7 +106,11 @@ describe('useSidebarBadges cross-device read sync', () => {
 
         expect(reload).toHaveBeenCalledTimes(1);
         expect(reload).toHaveBeenCalledWith(
-            expect.objectContaining({ only: ['channels', 'hasUnreadThreads'] }),
+            expect.objectContaining({
+                // `teams` rides along so the cross-workspace dots refresh on
+                // the same debounced reload the channel badges already use.
+                only: ['channels', 'hasUnreadThreads', 'teams'],
+            }),
         );
     });
 

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -38,8 +38,13 @@ export function useSidebarBadges(): void {
     );
 
     // reload defaults to preserving scroll and page state; it re-evaluates the
-    // shared `channels` prop to recompute every badge count, plus the aggregate
-    // `hasUnreadThreads` flag behind the sidebar's Threads dot. A teammate's
+    // shared `channels` prop to recompute every badge count, the aggregate
+    // `hasUnreadThreads` flag behind the sidebar's Threads dot, and `teams` —
+    // whose per-workspace counts are the cross-workspace dots on the rail. The
+    // last one rides along rather than getting its own signal: no per-member
+    // fanout of MessageSent exists, so a workspace the viewer is not in
+    // refreshes on the next trigger any of their own channels raises. A
+    // teammate's
     // message — or another of the viewer's own devices — decides when it fires,
     // so it runs as a background visit ({@see backgroundVisit}); otherwise an
     // arrival landing mid-navigation cancels the visit the user actually asked
@@ -48,7 +53,7 @@ export function useSidebarBadges(): void {
         () =>
             router.reload({
                 ...backgroundVisit,
-                only: ['channels', 'hasUnreadThreads'],
+                only: ['channels', 'hasUnreadThreads', 'teams'],
             }),
         { delay: REFRESH_DEBOUNCE_MS },
     );

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -870,13 +870,16 @@ onMounted(() => {
                                         <span
                                             class="block text-[11px] text-muted-foreground max-md:text-[12.5px]"
                                             >{{
-                                                currentTeam?.membersCount ?? 0
-                                            }}
-                                            {{
                                                 (currentTeam?.membersCount ??
                                                     0) === 1
-                                                    ? $t('member')
-                                                    : $t('members')
+                                                    ? $t(':count member', {
+                                                          count: 1,
+                                                      })
+                                                    : $t(':count members', {
+                                                          count:
+                                                              currentTeam?.membersCount ??
+                                                              0,
+                                                      })
                                             }}</span
                                         >
                                     </span>

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { Link, router, usePage } from '@inertiajs/vue3';
 import {
-    Check,
+    ChevronDown,
     ChevronRight,
-    FolderPlus,
     GripVertical,
     MoreHorizontal,
     MoreVertical,
@@ -11,7 +10,6 @@ import {
     Plus,
     Search,
     Trash2,
-    UserPlus,
     X,
 } from '@lucide/vue';
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
@@ -37,7 +35,6 @@ import { update as updateSidebarSections } from '@/actions/App/Http/Controllers/
 import PasskeyPromptDialog from '@/components/auth/PasskeyPromptDialog.vue';
 import ChannelListItem from '@/components/ChannelListItem.vue';
 import CreateChannelModal from '@/components/CreateChannelModal.vue';
-import CreateTeamModal from '@/components/CreateTeamModal.vue';
 import DemoBanner from '@/components/DemoBanner.vue';
 import DirectMessageListItem from '@/components/DirectMessageListItem.vue';
 import DndPauseDialog from '@/components/DndPauseDialog.vue';
@@ -48,6 +45,8 @@ import KeyboardShortcutsModal from '@/components/KeyboardShortcutsModal.vue';
 import DestinationPanel from '@/components/navigation/DestinationPanel.vue';
 import NavigationRail from '@/components/navigation/NavigationRail.vue';
 import NavigationTabBar from '@/components/navigation/NavigationTabBar.vue';
+import NewMenu from '@/components/navigation/NewMenu.vue';
+import WorkspaceSheet from '@/components/navigation/WorkspaceSheet.vue';
 import NavUser from '@/components/NavUser.vue';
 import NewDirectMessageModal from '@/components/NewDirectMessageModal.vue';
 import OnboardingTour from '@/components/OnboardingTour.vue';
@@ -61,8 +60,6 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
@@ -103,7 +100,6 @@ import { useQuickSwitcher } from '@/composables/useQuickSwitcher';
 import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
 import { useTeamPresence } from '@/composables/useTeamPresence';
-import { useTeamSwitch } from '@/composables/useTeamSwitch';
 import { useTimezone } from '@/composables/useTimezone';
 import { useTranslations } from '@/composables/useTranslations';
 import { useUserStatusDialog } from '@/composables/useUserStatusDialog';
@@ -174,8 +170,8 @@ const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
 const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
 
 /**
- * The dock header's "invite people" mini-button reuses the member-invite modal;
- * the permission and assignable roles ride along on the shared workspace props.
+ * The workspace sheet's "invite people" row reuses the member-invite modal; the
+ * permission and assignable roles ride along on the shared workspace props.
  */
 const canInviteToCurrentTeam = computed(
     () => page.props.canInviteToCurrentTeam ?? false,
@@ -184,6 +180,13 @@ const invitableRoles = computed<RoleOption[]>(
     () => page.props.invitableRoles ?? [],
 );
 const inviteOpen = ref(false);
+
+/**
+ * Whether the pending-invitations modal is presented. It opens itself the moment
+ * the (lazily shared) invitations land, and the workspace sheet's "Join a
+ * workspace" row reopens it once the viewer has dismissed it.
+ */
+const invitationsOpen = ref(true);
 
 /**
  * The user's custom sidebar sections for the current team, kept in their
@@ -379,7 +382,11 @@ const newSectionName = ref('');
 async function openSectionForm(): Promise<void> {
     sectionFormOpen.value = true;
     await nextTick();
-    focusSidebarInput('create-section-input');
+
+    // The "+ New" surface this row now lives on returns focus to its trigger as
+    // it closes, and that lands after this tick — so the field is taken on the
+    // following frame, or the caret would end up back on the "+" instead.
+    requestAnimationFrame(() => focusSidebarInput('create-section-input'));
 }
 
 function cancelSectionForm(): void {
@@ -562,7 +569,6 @@ function toggleSection(section: SidebarSectionKey): void {
 }
 
 const { getInitials } = useInitials();
-const { switchTeam } = useTeamSwitch();
 const { start: startOnboardingTour } = useOnboardingTour();
 
 const { isOpen: quickSwitcherOpen, toggle: toggleQuickSwitcher } =
@@ -810,11 +816,13 @@ onMounted(() => {
                     "
                     :active="activeDestination"
                     :user="page.props.auth.user"
-                    :current-team="currentTeam"
+                    :teams="teams"
                     :presence="ownPresence"
                     :is-dnd="ownDnd"
                     :has-unread-threads="hasUnreadThreads"
                     @select="openDestination"
+                    @invite="inviteOpen = true"
+                    @join="invitationsOpen = true"
                 />
 
                 <div class="flex min-h-0 min-w-0 flex-1 flex-col">
@@ -822,119 +830,89 @@ onMounted(() => {
                         class="gap-0 border-b border-sidebar-border p-3.5 pb-2.5"
                     >
                         <div class="flex items-center gap-2">
-                            <DropdownMenu>
-                                <DropdownMenuTrigger as-child>
-                                    <Button
-                                        variant="ghost"
-                                        data-test="workspace-switcher"
-                                        class="-m-1 flex h-auto min-w-0 flex-1 items-center justify-start gap-2 rounded-[9px] p-1 text-left transition-colors hover:bg-sidebar-accent"
+                            <!-- The whole identity zone is the workspace sheet's
+                                 trigger. Desktop drops the workspace avatar —
+                                 the rail already carries it — while the drawer,
+                                 which has no rail, keeps it. -->
+                            <WorkspaceSheet
+                                @invite="inviteOpen = true"
+                                @join="invitationsOpen = true"
+                            >
+                                <Button
+                                    variant="ghost"
+                                    data-test="workspace-switcher"
+                                    data-tour="invite"
+                                    class="-m-1 flex h-auto min-w-0 flex-1 items-center justify-start gap-2.5 rounded-[9px] p-1 text-left transition-colors hover:bg-sidebar-accent"
+                                >
+                                    <span
+                                        v-if="isMobileViewport"
+                                        aria-hidden="true"
+                                        class="flex size-10 shrink-0 items-center justify-center rounded-[11px] bg-sidebar-primary text-[13px] font-semibold text-sidebar-primary-foreground"
+                                        >{{
+                                            getInitials(currentTeam?.name ?? '')
+                                        }}</span
                                     >
+                                    <span class="min-w-0 flex-1">
                                         <span
-                                            class="flex size-8 shrink-0 items-center justify-center rounded-[9px] bg-sidebar-primary text-[11px] font-semibold text-sidebar-primary-foreground"
-                                            >{{
-                                                getInitials(
-                                                    currentTeam?.name ?? '',
-                                                )
-                                            }}</span
+                                            class="flex items-center gap-1.25"
                                         >
-                                        <span class="min-w-0 flex-1">
                                             <span
-                                                class="block truncate text-sm font-semibold text-sidebar-foreground"
+                                                class="truncate text-sm font-semibold text-sidebar-foreground max-md:text-base"
                                                 >{{
                                                     currentTeam?.name ??
                                                     $t('Select team')
                                                 }}</span
                                             >
-                                            <span
-                                                class="block text-[11px] text-muted-foreground"
-                                                >{{
-                                                    currentTeam?.membersCount ??
-                                                    0
-                                                }}
-                                                {{
-                                                    (currentTeam?.membersCount ??
-                                                        0) === 1
-                                                        ? $t('member')
-                                                        : $t('members')
-                                                }}</span
-                                            >
+                                            <ChevronDown
+                                                class="size-3 shrink-0 text-muted-foreground"
+                                            />
                                         </span>
-                                    </Button>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent align="start" class="w-56">
-                                    <DropdownMenuLabel
-                                        class="text-xs text-muted-foreground"
-                                    >
-                                        {{ $t('Teams') }}
-                                    </DropdownMenuLabel>
-                                    <DropdownMenuItem
-                                        v-for="team in teams"
-                                        :key="team.id"
-                                        data-test="team-switcher-item"
-                                        class="cursor-pointer gap-2"
-                                        @click="switchTeam(team)"
-                                    >
-                                        {{ team.name }}
-                                        <Check
-                                            v-if="team.id === currentTeam?.id"
-                                            class="ml-auto size-4"
-                                        />
-                                    </DropdownMenuItem>
-                                    <DropdownMenuSeparator />
-                                    <CreateTeamModal>
-                                        <DropdownMenuItem
-                                            data-test="team-switcher-new-team"
-                                            class="cursor-pointer gap-2"
-                                            @select.prevent
+                                        <span
+                                            class="block text-[11px] text-muted-foreground max-md:text-[12.5px]"
+                                            >{{
+                                                currentTeam?.membersCount ?? 0
+                                            }}
+                                            {{
+                                                (currentTeam?.membersCount ??
+                                                    0) === 1
+                                                    ? $t('member')
+                                                    : $t('members')
+                                            }}</span
                                         >
-                                            <Plus class="size-4" />
-                                            <span
-                                                class="text-muted-foreground"
-                                                >{{ $t('New team') }}</span
-                                            >
-                                        </DropdownMenuItem>
-                                    </CreateTeamModal>
-                                </DropdownMenuContent>
-                            </DropdownMenu>
-                            <div class="flex shrink-0 items-center gap-1">
-                                <Button
-                                    v-if="canInviteToCurrentTeam"
-                                    variant="ghost"
-                                    size="icon"
-                                    :title="$t('Invite people')"
-                                    data-test="invite-member-trigger"
-                                    data-tour="invite"
-                                    class="size-6 rounded-[7px] border border-sidebar-border text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
-                                    @click="inviteOpen = true"
-                                >
-                                    <UserPlus class="size-3" />
-                                    <span class="sr-only">{{
-                                        $t('Invite people')
-                                    }}</span>
+                                    </span>
                                 </Button>
-                                <CreateTeamModal>
+                            </WorkspaceSheet>
+                            <div class="flex shrink-0 items-center gap-1">
+                                <NewMenu
+                                    v-if="currentTeam"
+                                    :team-slug="currentTeam.slug"
+                                    @message="newDmOpen = true"
+                                    @section="openSectionForm"
+                                >
                                     <Button
                                         variant="ghost"
                                         size="icon"
-                                        :title="$t('New team')"
-                                        data-test="new-team-trigger"
-                                        class="size-6 rounded-[7px] border border-dashed border-sidebar-border text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                                        :title="$t('New')"
+                                        data-test="new-menu-trigger"
+                                        class="size-7 rounded-[9px] bg-sidebar-accent text-sidebar-foreground transition-colors hover:bg-sidebar-accent/70 data-[state=open]:bg-brass data-[state=open]:text-brass-foreground max-md:size-11 max-md:rounded-[12px]"
                                     >
-                                        <Plus class="size-3" />
+                                        <Plus
+                                            class="size-3.75 max-md:size-5.25"
+                                        />
                                         <span class="sr-only">{{
-                                            $t('New team')
+                                            $t('New')
                                         }}</span>
                                     </Button>
-                                </CreateTeamModal>
+                                </NewMenu>
                                 <SheetClose v-if="isMobileViewport" as-child>
                                     <Button
                                         variant="ghost"
                                         size="icon"
                                         :title="$t('Close')"
                                         data-test="dock-close"
-                                        class="size-9 rounded-[10px] text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                                        class="size-11 rounded-[12px] text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
                                     >
-                                        <X class="size-4" />
+                                        <X class="size-5" />
                                         <span class="sr-only">{{
                                             $t('Close')
                                         }}</span>
@@ -1474,10 +1452,13 @@ onMounted(() => {
                                 </SidebarGroupContent>
                             </SidebarGroup>
 
-                            <!-- Create a new custom section. -->
-                            <SidebarGroup class="py-0">
+                            <!-- Naming a new custom section. The row that used to
+                                 stand here is now the third row of "+ New"; only
+                                 the field it opens still belongs at the foot of
+                                 the list, where the section will appear. -->
+                            <SidebarGroup v-if="sectionFormOpen" class="py-0">
                                 <SidebarGroupContent>
-                                    <div v-if="sectionFormOpen" class="px-2">
+                                    <div class="px-2">
                                         <Input
                                             v-model="newSectionName"
                                             data-test="create-section-input"
@@ -1494,16 +1475,6 @@ onMounted(() => {
                                             @blur="createSection"
                                         />
                                     </div>
-                                    <Button
-                                        v-else
-                                        variant="ghost"
-                                        data-test="create-section-trigger"
-                                        class="flex h-7 w-full items-center justify-start gap-1.5 rounded-md px-2 text-[12px] font-normal text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
-                                        @click="openSectionForm"
-                                    >
-                                        <FolderPlus class="size-3.5" />
-                                        {{ $t('New section') }}
-                                    </Button>
                                 </SidebarGroupContent>
                             </SidebarGroup>
                         </nav>
@@ -1570,6 +1541,7 @@ onMounted(() => {
 
         <PendingInvitationsModal
             v-if="pendingInvitations.length > 0"
+            v-model:open="invitationsOpen"
             :invitations="pendingInvitations"
         />
 

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -276,8 +276,10 @@ const confirmTransferOwnership = (member: TeamMember) => {
             </Form>
         </section>
 
-        <!-- Team members -->
-        <section class="border-b border-border py-6">
+        <!-- Team members. The id is the anchor the dock's workspace sheet links
+             its "Members" row at, so that row lands on the roster rather than at
+             the top of the page. -->
+        <section id="members" class="border-b border-border py-6">
             <div class="mb-4 flex flex-wrap items-start gap-3">
                 <div class="min-w-0">
                     <h2 class="font-serif text-lg font-semibold">

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -54,6 +54,7 @@ declare module '@inertiajs/core' {
             currentTeam: Team | null;
             teams: Team[];
             canInviteToCurrentTeam: boolean;
+            canUpdateCurrentTeam: boolean;
             canViewCurrentTeamAudit: boolean;
             canViewCurrentTeamSecurityLog: boolean;
             canManageCurrentTeamIntegrations: boolean;

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -9,6 +9,14 @@ export type Team = {
     roleLabel?: string;
     membersCount: number;
     isCurrent?: boolean;
+    /**
+     * Ordinary unread messages waiting in this workspace, muting and the
+     * per-channel notification level already applied server-side. Drives the
+     * rail tile's dot and the workspace sheet's row cue.
+     */
+    unreadCount: number;
+    /** Unread @mentions waiting in this workspace, drawn as a numeric badge. */
+    mentionCount: number;
 };
 
 export type TeamMember = {

--- a/tests/Browser/SidebarControlsTest.php
+++ b/tests/Browser/SidebarControlsTest.php
@@ -7,10 +7,12 @@ use App\Models\ChannelSection;
 test('a section can be created through the inline shadcn input', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 
-    // Opening the inline form focuses the shadcn <Input> (resolved by data-test,
-    // not a component ref); typing a name and pressing Enter blurs it, which
+    // "New section" now lives in the dock header's "+ New" menu; opening the
+    // inline form still focuses the shadcn <Input> (resolved by data-test, not
+    // a component ref), and typing a name then pressing Enter blurs it, which
     // commits the section.
     signInThroughBrowser($alice)
+        ->click('@new-menu-trigger')
         ->click('@create-section-trigger')
         ->type('@create-section-input', 'Projects')
         ->keys('@create-section-input', ['Enter'])

--- a/tests/Browser/WorkspaceSheetTest.php
+++ b/tests/Browser/WorkspaceSheetTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\TeamInvitation;
+use App\Models\User;
+
+/**
+ * The workspace sheet, the "+ New" menu, and the rail's workspace tiles.
+ *
+ * The sheet is one surface behind three anchors, so what these guard is that
+ * each anchor reaches the same rows, that a plain member never finds an action
+ * they cannot take, and that the two membership rows (invite, join) are present
+ * exactly when they lead somewhere.
+ */
+
+/** Give the viewer a second workspace holding an unread message. */
+function browserSecondWorkspace(User $viewer, string $name = 'Nord Bureau'): void
+{
+    $author = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($author, $name);
+    $general = Channel::where('team_id', $team->id)
+        ->where('slug', Channel::GENERAL_SLUG)
+        ->firstOrFail();
+
+    $team->memberships()->create(['user_id' => $viewer->id, 'role' => TeamRole::Member]);
+    $general->channelMembers()->firstOrCreate(['user_id' => $viewer->id]);
+
+    Message::factory()->for($general)->for($author)->create(['body' => 'Hello over here']);
+}
+
+test('the header chevron and the rail tile open the same workspace sheet', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@workspace-switcher')
+        ->assertPresent('@workspace-sheet')
+        ->assertSee('Workspaces')
+        ->assertPresent('@workspace-members-link')
+        ->assertPresent('@invite-member-trigger')
+        ->assertPresent('@workspace-settings-link')
+        ->assertPresent('@team-switcher-new-team')
+        ->keys('@workspace-sheet', ['Escape'])
+        ->assertNotPresent('@workspace-sheet');
+
+    // The rail's own tile is the third anchor onto the very same surface.
+    $page->click('@rail-workspace-tile')
+        ->assertPresent('@workspace-sheet')
+        ->assertPresent('@workspace-members-link');
+});
+
+test('a plain member finds neither invite nor workspace settings on the sheet', function (): void {
+    ['member' => $bob, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($bob)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@workspace-switcher')
+        ->assertPresent('@workspace-sheet')
+        ->assertPresent('@workspace-members-link')
+        ->assertNotPresent('@invite-member-trigger')
+        ->assertNotPresent('@workspace-settings-link');
+});
+
+test('the sheet closes on its way to the members roster', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@workspace-switcher')
+        ->click('@workspace-members-link')
+        // The roster the row anchors on, with the sheet gone behind it.
+        ->assertPresent('@member-row')
+        ->assertNotPresent('@workspace-sheet');
+});
+
+test('the invite row opens the invite modal without leaving the channel', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@workspace-switcher')
+        ->click('@invite-member-trigger')
+        ->assertPresent('@invite-submit')
+        ->assertPathIs(browserChannelUrl($team, $channel));
+});
+
+test('the join row appears only while an invitation is pending, carrying its count', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@workspace-switcher')
+        ->assertNotPresent('@join-workspace-trigger');
+
+    $inviter = User::factory()->create();
+    $other = app(CreateTeam::class)->handle($inviter, 'Sud');
+    TeamInvitation::factory()->create([
+        'team_id' => $other->id,
+        'email' => $alice->email,
+        'invited_by' => $inviter->id,
+    ]);
+
+    $page->navigate(browserChannelUrl($team, $channel))
+        // The invitations prompt shows itself first; dismissing it is what makes
+        // the join row the way back to it.
+        ->assertPresent('@pending-invitations-modal')
+        ->keys('@pending-invitations-modal', ['Escape'])
+        ->click('@workspace-switcher')
+        ->assertPresent('@join-workspace-trigger')
+        ->assertSeeIn('@join-workspace-count', '1')
+        ->click('@join-workspace-trigger')
+        ->assertPresent('@pending-invitations-modal');
+});
+
+test('the rail tiles every workspace, dots the unread one, and switches on a tap', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+    browserSecondWorkspace($alice);
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertScript(<<<'JS'
+        (() => document.querySelectorAll('[data-test="rail-workspace-tile"]').length)()
+        JS, 2)
+        // The workspace the viewer is not reading carries the brass dot.
+        ->assertScript(<<<'JS'
+        (() => document.querySelectorAll('[data-test="rail-workspace-unread-dot"]').length)()
+        JS, 1)
+        ->assertPresent('@new-team-trigger');
+});
+
+test('the plus menu offers exactly three ways to start something', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@new-menu-trigger')
+        ->assertPresent('@new-menu')
+        ->assertPresent('@new-menu-channel')
+        ->assertPresent('@new-menu-message')
+        ->assertPresent('@create-section-trigger')
+        // Membership is the workspace sheet's business, never the + menu's.
+        ->assertNotPresent('@invite-member-trigger')
+        ->assertScript(<<<'JS'
+        (() => document.querySelectorAll('[data-test="new-menu"] [role="menuitem"]').length)()
+        JS, 3);
+});
+
+test('the open workspace sheet has no serious accessibility violations, light or dark', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+    browserSecondWorkspace($alice);
+
+    // The settle lets the popover's fade finish: axe blends the mid-animation
+    // opacity into its contrast arithmetic otherwise (#775).
+    $page = signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@workspace-switcher')
+        ->assertVisible('@workspace-sheet')
+        ->wait(0.5)
+        ->assertNoAccessibilityIssues();
+
+    $page->script(<<<'JS'
+    () => {
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    $page->wait(0.5)->assertNoAccessibilityIssues();
+});
+
+test('the workspace sheet and the plus menu are keyboard-operable', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    // Both anchors are real buttons, so Tab reaches them and Enter opens them.
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertPresent('button[data-test="workspace-switcher"]')
+        ->assertPresent('button[data-test="new-menu-trigger"]')
+        ->keys('@new-menu-trigger', 'Enter')
+        ->assertPresent('@new-menu');
+});
+
+test('the mobile drawer header carries the workspace, the plus and the close', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->click('@sidebar-toggle')
+        ->assertPresent('@workspace-switcher')
+        ->assertPresent('@new-menu-trigger')
+        ->assertPresent('@dock-close')
+        ->click('@workspace-switcher')
+        ->assertPresent('@workspace-sheet')
+        ->assertPresent('@workspace-members-link');
+});
+
+test('the onboarding tour completes with the invite step spotlighting the workspace sheet', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+    $alice->update(['onboarding_completed_at' => null]);
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertPresent('@onboarding-tour')
+        ->click('@onboarding-next')
+        ->click('@onboarding-next')
+        ->assertSee('Invite your teammates')
+        // The last step's anchor has to resolve, or the spotlight cuts no hole.
+        ->assertScript(<<<'JS'
+        (() => {
+            const anchor = document.querySelector('[data-tour="invite"]');
+
+            if (anchor === null) {
+                return false;
+            }
+
+            const rect = anchor.getBoundingClientRect();
+
+            return rect.width > 0 && rect.height > 0;
+        })()
+        JS, true)
+        ->click('@onboarding-next')
+        ->assertNotPresent('@onboarding-tour');
+});

--- a/tests/Browser/WorkspaceSheetTest.php
+++ b/tests/Browser/WorkspaceSheetTest.php
@@ -138,7 +138,11 @@ test('the rail tiles every workspace, dots the unread one, and switches on a tap
         ->assertScript(<<<'JS'
         (() => document.querySelectorAll('[data-test="rail-workspace-unread-dot"]').length)()
         JS, 1)
-        ->assertPresent('@new-team-trigger');
+        ->assertPresent('@new-team-trigger')
+        // And tapping the dotted tile goes straight there, no sheet in between.
+        ->click('[data-test="rail-workspace-unread-dot"]')
+        ->assertNotPresent('@workspace-sheet')
+        ->assertSee('Nord Bureau');
 });
 
 test('the plus menu offers exactly three ways to start something', function (): void {
@@ -193,6 +197,10 @@ test('the workspace sheet and the plus menu are keyboard-operable', function ():
         ->navigate(browserChannelUrl($team, $channel))
         ->assertPresent('button[data-test="workspace-switcher"]')
         ->assertPresent('button[data-test="new-menu-trigger"]')
+        ->keys('@workspace-switcher', 'Enter')
+        ->assertPresent('@workspace-sheet')
+        ->keys('@workspace-sheet', ['Escape'])
+        ->assertNotPresent('@workspace-sheet')
         ->keys('@new-menu-trigger', 'Enter')
         ->assertPresent('@new-menu');
 });

--- a/tests/Browser/WorkspaceSheetTest.php
+++ b/tests/Browser/WorkspaceSheetTest.php
@@ -49,8 +49,9 @@ test('the header chevron and the rail tile open the same workspace sheet', funct
         ->keys('@workspace-sheet', ['Escape'])
         ->assertNotPresent('@workspace-sheet');
 
-    // The rail's own tile is the third anchor onto the very same surface.
-    $page->click('@rail-workspace-tile')
+    // The rail's own tile is the third anchor onto the very same surface — the
+    // *open* workspace's tile, since the others switch instead of opening.
+    $page->click('[data-test="rail-workspace-tile"][data-current="true"]')
         ->assertPresent('@workspace-sheet')
         ->assertPresent('@workspace-members-link');
 });
@@ -129,9 +130,10 @@ test('the rail tiles every workspace, dots the unread one, and switches on a tap
     signInThroughBrowser($alice)
         ->resize(1280, 900)
         ->navigate(browserChannelUrl($team, $channel))
+        // Alice's own personal workspace, the shared Acme one, and Nord Bureau.
         ->assertScript(<<<'JS'
         (() => document.querySelectorAll('[data-test="rail-workspace-tile"]').length)()
-        JS, 2)
+        JS, 3)
         // The workspace the viewer is not reading carries the brass dot.
         ->assertScript(<<<'JS'
         (() => document.querySelectorAll('[data-test="rail-workspace-unread-dot"]').length)()

--- a/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
+++ b/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
@@ -1,0 +1,208 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Data\UserTeam;
+use App\Enums\MessageType;
+use App\Enums\NotificationLevel;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * The `teams` shared prop entry for the given team, as the acting user sees it
+ * from inside their current workspace.
+ *
+ * @return array{unreadCount: int, mentionCount: int}
+ */
+function workspaceBadge(User $user, Team $team): array
+{
+    $response = test()->actingAs($user)->get(route('channels.show', [
+        'team' => $user->currentTeam->slug,
+        'channel' => Channel::GENERAL_SLUG,
+    ]))->assertOk();
+
+    $entry = collect($response->viewData('page')['props']['teams'])->firstWhere('id', $team->id);
+
+    expect($entry)->toBeInstanceOf(UserTeam::class);
+
+    return ['unreadCount' => $entry->unreadCount, 'mentionCount' => $entry->mentionCount];
+}
+
+/**
+ * Give the viewer a second workspace they share with an author, and return both
+ * the workspace and its #general channel.
+ *
+ * @return array{0: Team, 1: Channel, 2: User}
+ */
+function otherWorkspace(User $viewer): array
+{
+    $author = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($author, 'Nord & Bureau');
+    $general = Channel::where('team_id', $team->id)->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+
+    $team->memberships()->create(['user_id' => $viewer->id, 'role' => TeamRole::Member]);
+    $general->channelMembers()->firstOrCreate(['user_id' => $viewer->id]);
+
+    return [$team, $general, $author];
+}
+
+/** Post a message in the channel, optionally mentioning the viewer. */
+function crossWorkspacePost(Channel $channel, User $author, ?User $mention = null, array $attributes = []): Message
+{
+    $message = Message::factory()->for($channel)->for($author)->create($attributes);
+
+    if ($mention instanceof User) {
+        $message->mentionedUsers()->attach($mention->id);
+    }
+
+    return $message;
+}
+
+test('a workspace the viewer is not reading carries its unread and mention counts', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $author);
+    crossWorkspacePost($general, $author);
+    crossWorkspacePost($general, $author, $viewer);
+
+    expect(workspaceBadge($viewer, $team))
+        ->toMatchArray(['unreadCount' => 3, 'mentionCount' => 1]);
+});
+
+test('a workspace with nothing new reports zero', function (): void {
+    $viewer = User::factory()->create();
+    [$team] = otherWorkspace($viewer);
+
+    expect(workspaceBadge($viewer, $team))
+        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+});
+
+test('messages already read do not count', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $author);
+    $last = crossWorkspacePost($general, $author);
+    crossWorkspacePost($general, $author);
+
+    $viewer->channels()->updateExistingPivot($general->id, ['last_read_message_id' => $last->id]);
+
+    expect(workspaceBadge($viewer, $team)['unreadCount'])->toBe(1);
+});
+
+test('the viewer own messages and system notices never count', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $viewer);
+    crossWorkspacePost($general, $author, attributes: ['type' => MessageType::MemberJoined]);
+
+    expect(workspaceBadge($viewer, $team))
+        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+});
+
+test('a muted channel contributes neither unread nor mentions', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $author);
+    crossWorkspacePost($general, $author, $viewer);
+
+    $viewer->channels()->updateExistingPivot($general->id, ['muted' => true]);
+
+    expect(workspaceBadge($viewer, $team))
+        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+});
+
+test('the mentions-only level keeps the mention count and silences ordinary unread', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $author);
+    crossWorkspacePost($general, $author, $viewer);
+
+    $viewer->channels()->updateExistingPivot($general->id, [
+        'notification_level' => NotificationLevel::Mentions->value,
+    ]);
+
+    expect(workspaceBadge($viewer, $team))
+        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 1]);
+});
+
+test('the nothing level silences the workspace entirely', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $author);
+    crossWorkspacePost($general, $author, $viewer);
+
+    $viewer->channels()->updateExistingPivot($general->id, [
+        'notification_level' => NotificationLevel::Nothing->value,
+    ]);
+
+    expect(workspaceBadge($viewer, $team))
+        ->toMatchArray(['unreadCount' => 0, 'mentionCount' => 0]);
+});
+
+test('a thread-only reply stays out of the unread count but its mention still counts', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    $root = crossWorkspacePost($general, $author);
+    crossWorkspacePost($general, $author, $viewer, [
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => false,
+    ]);
+
+    expect(workspaceBadge($viewer, $team))
+        ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 1]);
+});
+
+test('an archived channel drops out of the workspace counts', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $author);
+    $general->update(['archived_at' => now()]);
+
+    expect(workspaceBadge($viewer, $team)['unreadCount'])->toBe(0);
+});
+
+test('a deleted message stops counting', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    crossWorkspacePost($general, $author)->delete();
+
+    expect(workspaceBadge($viewer, $team)['unreadCount'])->toBe(0);
+});
+
+test('counts are grouped per workspace rather than pooled', function (): void {
+    $viewer = User::factory()->create();
+    [$first, $firstGeneral, $firstAuthor] = otherWorkspace($viewer);
+    [$second, $secondGeneral, $secondAuthor] = otherWorkspace($viewer);
+
+    crossWorkspacePost($firstGeneral, $firstAuthor);
+    crossWorkspacePost($secondGeneral, $secondAuthor);
+    crossWorkspacePost($secondGeneral, $secondAuthor, $viewer);
+
+    expect(workspaceBadge($viewer, $first))->toMatchArray(['unreadCount' => 1, 'mentionCount' => 0]);
+    expect(workspaceBadge($viewer, $second))->toMatchArray(['unreadCount' => 2, 'mentionCount' => 1]);
+});
+
+test('another member unread traffic never leaks into the viewer counts', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    $bystander = User::factory()->create();
+    $team->memberships()->create(['user_id' => $bystander->id, 'role' => TeamRole::Member]);
+    $general->channelMembers()->firstOrCreate(['user_id' => $bystander->id]);
+
+    crossWorkspacePost($general, $author, $bystander);
+
+    expect(workspaceBadge($viewer, $team))
+        ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 0]);
+});

--- a/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
+++ b/tests/Feature/Channels/CrossWorkspaceUnreadTest.php
@@ -161,6 +161,19 @@ test('a thread-only reply stays out of the unread count but its mention still co
         ->toMatchArray(['unreadCount' => 1, 'mentionCount' => 1]);
 });
 
+test('a thread reply also sent to the channel counts like any other message', function (): void {
+    $viewer = User::factory()->create();
+    [$team, $general, $author] = otherWorkspace($viewer);
+
+    $root = crossWorkspacePost($general, $author);
+    crossWorkspacePost($general, $author, attributes: [
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => true,
+    ]);
+
+    expect(workspaceBadge($viewer, $team)['unreadCount'])->toBe(2);
+});
+
 test('an archived channel drops out of the workspace counts', function (): void {
     $viewer = User::factory()->create();
     [$team, $general, $author] = otherWorkspace($viewer);

--- a/tests/Feature/Channels/WorkspaceShellTest.php
+++ b/tests/Feature/Channels/WorkspaceShellTest.php
@@ -74,9 +74,37 @@ test('the workspace shell shares the dock header affordances', function (): void
         ->assertInertia(fn (Assert $page): Assert => $page
             ->where('currentTeam.membersCount', 1)
             ->where('canInviteToCurrentTeam', true)
+            ->where('canUpdateCurrentTeam', true)
             ->has('invitableRoles')
             ->where('invitableRoles.0.value', 'admin')
         );
+});
+
+test('a plain member cannot reach the workspace settings row from the shell', function (): void {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $member = User::factory()->create();
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+    $member->switchTeam($team);
+
+    $this->actingAs($member)
+        ->get(route('channels.show', [
+            'team' => $team->slug,
+            'channel' => Channel::GENERAL_SLUG,
+        ]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('canUpdateCurrentTeam', false)
+            ->where('canInviteToCurrentTeam', false)
+        );
+});
+
+test('the workspace update permission is false for a guest with no workspace', function (): void {
+    $this->get(route('login'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page->where('canUpdateCurrentTeam', false));
 });
 
 test('login to workspace smoke: land in #general, create a channel, then browse', function (): void {


### PR DESCRIPTION
Closes #938. Part of the navigation epic #936, on top of the rail/tab-bar foundation that landed in #947.

## What

**One workspace sheet behind three anchors.** The desktop panel header chevron, the mobile drawer header chevron and the rail's current-workspace tile all open the same surface: current workspace → Members · Invite people · Workspace settings → the workspace list with its unread standing → Create / Join. It presents as a dropdown from `md` up and as a bottom sheet below, the same split the user menu already uses — a dropdown anchored inside an off-canvas drawer is neither reachable nor sizeable on a phone. The sheet closes before it navigates.

- **Members** and **Workspace settings** both reuse `teams.edit` (the roster section gained an `id="members"` anchor), so no new detail surface was built. **Invite people** opens the existing `InviteMemberModal` in place.
- **Member variant:** a plain member sees the header, Members, the workspace list and Create a workspace. Invite and Workspace settings are absent, gated on the new `canUpdateCurrentTeam` / existing `canInviteToCurrentTeam` props.
- **Join a workspace** renders only when an invitation is actually pending, carrying the count, and reopens `PendingInvitationsModal` (which gained a `v-model:open` so the row can bring it back after a dismissal). Invitations are the only join path, so a permanent row would be a dead end.

**`+ New` is exactly three rows** — New channel, New message, New section — and nothing else. Inviting is an act of membership, not of creation, so it lives in the workspace sheet. The menu absorbs `create-section-trigger`, whose row leaves the bottom of the list; only the inline name field it opens stays there. The group-header `+` shortcuts stay where they are and are duplicated here.

**Rail tiles.** One tile per workspace inside its own scroller, so a viewer in many workspaces can never push the destination glyphs below the fold. The open one is ringed and opens the sheet; the others switch straight over. A brass dot marks any workspace holding something unread.

## Cross-workspace unread

`UserTeam` gains `unreadCount` and `mentionCount`, filled by **one grouped query** across every membership (`App\Support\WorkspaceUnread`) rather than a loop over teams. Muting and the per-channel notification level are applied in SQL exactly as `ChannelData::fromChannel()` applies them per channel, so a workspace badge can never contradict the channel rows found inside it. Semantics are borrowed verbatim from `ChannelListItem`: a number for mentions, a dot for ordinary unread, nothing otherwise.

Liveness is request-time and piggybacked: `useSidebarBadges` adds `teams` to its existing debounced reload, so every trigger that already refreshes the channel badges refreshes the cross-workspace state too. **A per-member fanout of `MessageSent` is deliberately out of scope** (N events per message on the send path) — a message landing in a workspace the viewer is not in shows up on their next navigation. If that proves annoying it gets its own issue, with the fanout benchmarked.

## Selectors

Preserved: `workspace-switcher` (now the whole identity zone, and the `data-tour="invite"` anchor), `team-switcher-item`, `team-switcher-new-team`, `invite-member-trigger` (now the sheet's row), `create-section-trigger` (now the `+ New` row), `dock-close`, `create-channel-trigger`, `new-dm-trigger`. `new-team-trigger` moved onto the rail's dashed `+` (replacing the interim `rail-new-team-trigger` from #947). `SidebarControlsTest` opens `+ New` first, in lockstep.

The tour's invite step was reworded to point at the workspace sheet and now spotlights its trigger: a `data-tour` anchor inside a closed surface resolves to nothing and the spotlight silently renders no rect.

## Testing

- 13 feature tests for the cross-workspace counts: read/unread, own messages, system notices, muted, mentions-only, nothing, thread-only vs channel-sent replies, archived, soft-deleted, per-workspace grouping, no cross-viewer leakage.
- Feature tests for `canUpdateCurrentTeam` across owner, plain member and guest.
- 15 + 8 vitest cases for `WorkspaceSheet` and `NewMenu` (both viewports), plus the rail's tiles, dots and switching.
- 11 browser tests: the three anchors, the member variant, closing before navigation, the join row's presence and count, the rail, the `+ New` menu, the mobile drawer header, the tour completing on a resolvable anchor, and axe audits of the open sheet in both themes.
- `sail composer test` green with Pint, PHPStan and Rector clean; frontend gate (`lint:check`, `format:check`, `types:check`, `test:js`, `build`) green. `lang/fr.json` updated.

The member-count line moved to the repo's interpolated `:count member` / `:count members` pair rather than concatenating a number onto a bare word, so a locale can place the count where it belongs.

## Note

The full browser sweep runs 284 tests; two parallel runs each came back 283/284 with a *different* geometry test failing (`MobileSheetsTest`, then `MobileDemoBannerTest`), both passing serially and neither in a file this branch touches. That is the CPU-starvation flake class from #786 / #948.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787707001&installation_model_id=428379&pr_number=958&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F958&signature=22790016c20ea70a97615cb72978c26768f05b63902f5d8cb667f403fb266f0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->