### PR TITLE
build: cap file size with a max-lines eslint rule and a shrinking grandfather list

### DIFF
--- a/eslint-rules/max-lines-policy.test.ts
+++ b/eslint-rules/max-lines-policy.test.ts
@@ -1,0 +1,176 @@
+import { existsSync } from 'node:fs';
+import { ESLint } from 'eslint';
+import { parser as tsParser } from 'typescript-eslint';
+import { beforeAll, describe, expect, it } from 'vitest';
+import vueParser from 'vue-eslint-parser';
+import config from '../eslint.config.js';
+
+/**
+ * Guards the file-size ratchet rather than a rule implementation: `max-lines`
+ * is a built-in ESLint rule, and what needs protecting is its wiring — the
+ * threshold applying to every ordinary file, and the grandfather list of
+ * today's offenders being able to shrink but never grow.
+ *
+ * The list ossifies without this test: a file that gets split keeps its
+ * exemption, and the next author regrows it for free. Asserting that every
+ * exempt path still exists *and* still breaches the threshold makes an entry
+ * that is no longer earned fail the suite until it is deleted (#957).
+ */
+const eslint = new ESLint();
+
+/** A path that does not exist, standing in for a file someone adds tomorrow. */
+const NEW_COMPONENT = 'resources/js/components/Probe.vue';
+const NEW_COMPOSABLE = 'resources/js/composables/useProbe.ts';
+
+type MaxLinesOptions = {
+    max: number;
+    skipBlankLines: boolean;
+    skipComments: boolean;
+};
+
+/**
+ * A rule entry is either a bare severity or a `[severity, ...options]` tuple;
+ * `calculateConfigForFile` always hands back the tuple, a config block may use
+ * either.
+ */
+function severityOf(entry: unknown): unknown {
+    return Array.isArray(entry) ? entry[0] : entry;
+}
+
+/**
+ * The paths the `files:` override block exempts, read back out of the resolved
+ * flat config so the assertions follow the config instead of a second copy of
+ * the list that could drift from it.
+ */
+const grandfathered = config
+    .filter((entry) => {
+        const severity = severityOf(entry.rules?.['max-lines']);
+
+        return severity === 'off' || severity === 0;
+    })
+    .flatMap((entry) => (entry.files ?? []) as string[]);
+
+/** Options the rule is configured with, resolved once for the whole file. */
+let options: MaxLinesOptions;
+
+/** Lint results for the grandfathered paths, with the exemption forced off. */
+let breaches: Map<string, boolean>;
+
+/** Grandfathered paths the probe could not parse, and so could not count. */
+let unparsed: string[];
+
+/**
+ * Counts a file the way the project config does, but with nothing else loaded:
+ * the same parsers, `max-lines` alone, and no plugin rule running over what are
+ * by definition the largest files in the tree. Re-linting them under the full
+ * config instead cost the whole vitest suite an order of magnitude in wall
+ * clock, and starved its worker pool into unrelated failures.
+ */
+function countingProbe(maxLines: MaxLinesOptions): ESLint {
+    return new ESLint({
+        overrideConfigFile: true,
+        overrideConfig: [
+            {
+                files: ['**/*.vue'],
+                languageOptions: {
+                    parser: vueParser,
+                    // The SFCs here all use `<script setup lang="ts">`, which
+                    // vue-eslint-parser hands to this inner parser; without it
+                    // every one of them dies on the first type annotation, and
+                    // a file that cannot be parsed reports no breach at all.
+                    parserOptions: { parser: tsParser },
+                },
+            },
+            { files: ['**/*.ts'], languageOptions: { parser: tsParser } },
+            {
+                languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+                rules: { 'max-lines': ['error', maxLines] },
+            },
+        ],
+    });
+}
+
+/**
+ * Resolving the flat config and counting the largest files in the tree costs a
+ * second or two, and charging it to the first test would push that test past
+ * vitest's per-test timeout under full-suite load (as it did in #804). Both
+ * happen here instead, on a hook with a budget that fits.
+ */
+beforeAll(async () => {
+    const resolved = await eslint.calculateConfigForFile(NEW_COMPONENT);
+
+    options = (resolved.rules?.['max-lines'] as [unknown, MaxLinesOptions])[1];
+
+    const probe = countingProbe(options);
+    const existing = grandfathered.filter((path) => existsSync(path));
+    // `lintFiles([])` falls back to linting the whole project, which would
+    // turn an empty list into hundreds of unrelated failures.
+    const results = existing.length > 0 ? await probe.lintFiles(existing) : [];
+
+    breaches = new Map(
+        results.map((result) => [
+            result.filePath,
+            result.messages.some((message) => message.ruleId === 'max-lines'),
+        ]),
+    );
+
+    unparsed = results
+        .filter((result) => result.messages.some((message) => message.fatal))
+        .map((result) => result.filePath);
+}, 60_000);
+
+async function severityFor(filePath: string): Promise<unknown> {
+    const resolved = await eslint.calculateConfigForFile(filePath);
+
+    return (resolved.rules?.['max-lines'] as unknown[] | undefined)?.at(0);
+}
+
+describe('the max-lines policy', () => {
+    it('caps a new component at the configured threshold', async () => {
+        expect(await severityFor(NEW_COMPONENT)).toBe(2);
+    });
+
+    it('caps a new composable at the configured threshold', async () => {
+        expect(await severityFor(NEW_COMPOSABLE)).toBe(2);
+    });
+
+    it('skips blank lines and comments, so documenting a declaration is free', () => {
+        expect(options).toEqual({
+            max: 400,
+            skipBlankLines: true,
+            skipComments: true,
+        });
+    });
+
+    it('grandfathers today’s offenders', () => {
+        expect(grandfathered.length).toBeGreaterThan(0);
+    });
+
+    it('exempts every grandfathered path by name, never by a glob that would also cover new files', () => {
+        expect(grandfathered.filter((path) => /[*?[\]{}]/.test(path))).toEqual(
+            [],
+        );
+    });
+
+    it('exempts the files it lists', async () => {
+        for (const path of grandfathered) {
+            expect(await severityFor(path)).toBe(0);
+        }
+    });
+
+    it('lists only files that still exist', () => {
+        expect(grandfathered.filter((path) => !existsSync(path))).toEqual([]);
+    });
+
+    it('counts every grandfathered file, since one it cannot parse would read as under the cap', () => {
+        expect(unparsed).toEqual([]);
+    });
+
+    it('lists only files that still breach the threshold, so the list can only shrink', () => {
+        const undeserved = [...breaches.entries()]
+            .filter(([, breached]) => !breached)
+            .map(([filePath]) => filePath);
+
+        expect(undeserved).toEqual([]);
+    });
+});

--- a/eslint-rules/max-lines-policy.test.ts
+++ b/eslint-rules/max-lines-policy.test.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { ESLint } from 'eslint';
 import { parser as tsParser } from 'typescript-eslint';
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -53,7 +54,15 @@ const grandfathered = config
 /** Options the rule is configured with, resolved once for the whole file. */
 let options: MaxLinesOptions;
 
-/** Lint results for the grandfathered paths, with the exemption forced off. */
+/** Resolved `max-lines` severity per probed path. */
+let severities: Map<string, unknown>;
+
+/**
+ * Whether each grandfathered path still breaches the threshold, keyed by
+ * absolute path. Seeded from the list rather than from the lint results: a
+ * path the probe silently returned nothing for would otherwise be absent from
+ * the map, and an entry nobody counted would clear the shrink test by default.
+ */
 let breaches: Map<string, boolean>;
 
 /** Grandfathered paths the probe could not parse, and so could not count. */
@@ -107,31 +116,42 @@ beforeAll(async () => {
     // turn an empty list into hundreds of unrelated failures.
     const results = existing.length > 0 ? await probe.lintFiles(existing) : [];
 
-    breaches = new Map(
-        results.map((result) => [
+    breaches = new Map(existing.map((path) => [resolve(path), false]));
+
+    for (const result of results) {
+        breaches.set(
             result.filePath,
             result.messages.some((message) => message.ruleId === 'max-lines'),
-        ]),
-    );
+        );
+    }
 
     unparsed = results
         .filter((result) => result.messages.some((message) => message.fatal))
         .map((result) => result.filePath);
+
+    severities = new Map(
+        await Promise.all(
+            [NEW_COMPONENT, NEW_COMPOSABLE, ...grandfathered].map(
+                async (path): Promise<[string, unknown]> => {
+                    const config = await eslint.calculateConfigForFile(path);
+                    const rule = config.rules?.['max-lines'] as
+                        | unknown[]
+                        | undefined;
+
+                    return [path, rule?.at(0)];
+                },
+            ),
+        ),
+    );
 }, 60_000);
 
-async function severityFor(filePath: string): Promise<unknown> {
-    const resolved = await eslint.calculateConfigForFile(filePath);
-
-    return (resolved.rules?.['max-lines'] as unknown[] | undefined)?.at(0);
-}
-
 describe('the max-lines policy', () => {
-    it('caps a new component at the configured threshold', async () => {
-        expect(await severityFor(NEW_COMPONENT)).toBe(2);
+    it('caps a new component at the configured threshold', () => {
+        expect(severities.get(NEW_COMPONENT)).toBe(2);
     });
 
-    it('caps a new composable at the configured threshold', async () => {
-        expect(await severityFor(NEW_COMPOSABLE)).toBe(2);
+    it('caps a new composable at the configured threshold', () => {
+        expect(severities.get(NEW_COMPOSABLE)).toBe(2);
     });
 
     it('skips blank lines and comments, so documenting a declaration is free', () => {
@@ -152,10 +172,12 @@ describe('the max-lines policy', () => {
         );
     });
 
-    it('exempts the files it lists', async () => {
-        for (const path of grandfathered) {
-            expect(await severityFor(path)).toBe(0);
-        }
+    it('exempts the files it lists', () => {
+        const unexempted = grandfathered.filter(
+            (path) => severities.get(path) !== 0,
+        );
+
+        expect(unexempted).toEqual([]);
     });
 
     it('lists only files that still exist', () => {
@@ -172,5 +194,11 @@ describe('the max-lines policy', () => {
             .map(([filePath]) => filePath);
 
         expect(undeserved).toEqual([]);
+    });
+
+    it('counts every grandfathered file it could find, rather than passing on an absent result', () => {
+        expect(breaches.size).toBe(
+            grandfathered.filter((path) => existsSync(path)).length,
+        );
     });
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,6 +104,22 @@ export default defineConfigWithVueTs(
             // on (#894). `error` because every occurrence was converted, so a
             // new fork cannot land silently.
             'local/no-standalone-input-error': 'error',
+            // Cap how large a single file may grow, so the shell's biggest
+            // components can only shrink. Several grew past a thousand lines
+            // with nothing to stop them — `MainLayout.vue` reached 1643 raw
+            // lines before anyone called it (#956) — and `max-lines` counts
+            // the whole `.vue` file, template included, not just the
+            // `<script>` block. `error` rather than `warn` because a warning
+            // leaves `lint:check` green and a new 900-line file lands anyway.
+            // Blank lines and comments are skipped: the conventions here ask
+            // for JSDoc on declarations and for *why* comments, and charging
+            // those against the budget would punish exactly the behaviour the
+            // conventions require. Today's offenders are grandfathered by
+            // explicit path further down (#957).
+            'max-lines': [
+                'error',
+                { max: 400, skipBlankLines: true, skipComments: true },
+            ],
             // XSS trust boundary. Every run of HTML the client renders as markup
             // must go through `<SafeHtml>`, which sanitizes it with DOMPurify
             // against a named allowlist; a raw `v-html` anywhere else would
@@ -195,6 +211,45 @@ export default defineConfigWithVueTs(
         },
     },
     {
+        // Every file that already breached the `max-lines` cap when it was
+        // introduced (#957), listed by explicit path: a glob would hand new
+        // files the same free pass, which is the one thing the rule exists to
+        // prevent. The counts come from running the rule itself, not `wc -l`
+        // — six files over 400 raw lines fall under it once blanks and
+        // comments are skipped, and are deliberately absent here rather than
+        // being granted another 60 lines of room.
+        //
+        // This is a burn-down list, not a settlement: each entry is a file
+        // waiting to be split (#956 takes the first, `MainLayout.vue`).
+        // `eslint-rules/max-lines-policy.test.ts` fails as soon as an entry
+        // stops breaching the threshold, so the list can only shrink.
+        files: [
+            'resources/js/components/ChannelMasthead.vue',
+            'resources/js/components/MessageComposer.vue',
+            'resources/js/components/MessageList.vue',
+            'resources/js/components/QuickSwitcher.vue',
+            'resources/js/components/UserMenuContent.vue',
+            'resources/js/components/UserMenuSheet.vue',
+            'resources/js/components/UserStatusDialog.vue',
+            'resources/js/composables/useAttachmentUploads.test.ts',
+            'resources/js/composables/useMessageActions.test.ts',
+            'resources/js/composables/useMessageActions.ts',
+            'resources/js/layouts/MainLayout.vue',
+            'resources/js/pages/Welcome.vue',
+            'resources/js/pages/channels/Search.vue',
+            'resources/js/pages/channels/Show.vue',
+            'resources/js/pages/teams/Analytics.vue',
+            'resources/js/pages/teams/AuditExports.vue',
+            'resources/js/pages/teams/Edit.vue',
+            'resources/js/pages/teams/Groups.vue',
+            'resources/js/pages/teams/integrations/Bot.vue',
+            'resources/js/pages/teams/integrations/Index.vue',
+        ],
+        rules: {
+            'max-lines': 'off',
+        },
+    },
+    {
         ignores: [
             '.claude',
             'vendor',
@@ -207,6 +262,13 @@ export default defineConfigWithVueTs(
             'vitest.config.ts',
             'resources/js/actions/**',
             'resources/js/components/ui/*',
+            // Ambient types transformed out of the PHP `Data` classes and
+            // enums. Like the Wayfinder output above and below it, it is
+            // git-ignored build output nobody hand-writes, and it is absent
+            // in CI's lint job (which never runs `typescript:transform`) — so
+            // linting it can only ever fail locally, on a file whose shape is
+            // not ours to change.
+            'resources/js/generated/**',
             'resources/js/routes/**',
             'resources/js/wayfinder/**',
         ],


### PR DESCRIPTION
Closes #957.

## What

Installs the file-size ratchet: `max-lines` at `error` with `{ max: 400, skipBlankLines: true, skipComments: true }`, today's offenders grandfathered by explicit path, and a vitest guard that lets that list shrink but never grow.

`max-lines` is a built-in ESLint rule and it counts the whole `.vue` file (template included), so no local rule was needed — this is a config change plus its guard.

## Why

Nothing stopped a Vue file growing without bound, and several did. `MainLayout.vue` reached 1643 raw lines before anyone called it (#956). `error` rather than `warn` because a warning leaves `lint:check` green and a new 900-line file lands anyway; blank lines and comments are skipped because the conventions here ask for JSDoc on declarations and *why* comments, and charging those against the budget would punish exactly that.

## The baseline

Regenerated by running the rule against this tree, not pasted from the issue and not `wc -l`. **20 files** breach the counted threshold — the issue's 18 plus `useMessageActions.test.ts` (489) and `useAttachmentUploads.test.ts` (427), which have crossed since it was written. The six files that are over 400 *raw* lines but under 400 counted (`MessageActionsSheet.vue` 398, `MessageActions.vue` 352, `ThreadPanel.vue` 337, `settings/Appearance.vue` 358, `lib/messageBody.ts` 259, `useAttachmentUploads.ts` 283) are deliberately absent, so they get no free rein to grow.

`resources/js/generated/**` is added to `ignores` rather than grandfathered: it is git-ignored `typescript:transform` output, like the Wayfinder directories already listed beside it, and it is absent from CI's lint job — so linting it could only ever fail locally, on a file whose shape is not ours to change.

## The guard

`eslint-rules/max-lines-policy.test.ts` reads the exemption list back out of the resolved flat config (no second copy to drift) and asserts every entry still exists, is a literal path rather than a glob, and still breaches the threshold. Split a file and leave its entry behind, and the suite fails until the entry goes.

It counts with a minimal ESLint instance — same parsers, `max-lines` alone. Re-linting the 20 largest files in the tree under the full config took the vitest suite from 12s to 161s and starved its worker pool into unrelated failures. Counts were verified identical between the two.

## How tested

- Guard test drives both directions: a fresh 427-line component fails `lint:check` (`402:1 error File has too many lines (427)`), and adding an under-threshold or non-existent path to the list fails the guard.
- `lint:check` 0 errors, 51 warnings — unchanged from `develop`.
- `format:check`, `types:check`, `build`, and `test:js` (151 files, 1476 tests) all green.

No user-facing copy, so no i18n keys; nothing operator-facing, so no `docs/` change.

## Note for #942

The list is generated from the current tree, so files the nav epic *grows* stay exempt, but files it *creates* do not. #942 merges `UserMenuContent` (591 counted) and `UserMenuSheet` (575) into one shared component — that new component will have to come in under 400.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787707046&installation_model_id=428379&pr_number=959&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F959&signature=68fadfe880fea9edae0c479121cfd7c6266f03ed3e5e361062152e03140cc7b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a file-size lint rule that flags files over 400 lines, excluding blank lines and comments.
  * Introduced path-based exemptions for specific already-oversized files to support gradual reduction.
  * Updated linting to ignore generated JavaScript resources.

* **Tests**
  * Added a config-driven regression test to verify the rule threshold, exemption coverage, parsing behavior, and that the exemption list can only shrink over time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->