### PR TITLE
test: settle the theme flip before auditing the dark palette

### DIFF
--- a/tests/Browser/A11yAuditTest.php
+++ b/tests/Browser/A11yAuditTest.php
@@ -36,19 +36,7 @@ test('the authenticated channel page has no serious accessibility violations in 
         ->assertPresent('#mention-listbox')
         ->assertNoAccessibilityIssues();
 
-    // Re-audit against the dark palette. Persist 'dark' to localStorage — the
-    // source of truth `useAppearance` reads — before applying the `.dark` class,
-    // otherwise the appearance controller re-resolves 'system' → light and
-    // reverts the toggle mid-audit. The settle lets that recompute finish.
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });
 
@@ -121,17 +109,7 @@ test('the unread jump-to-unread pill has no serious accessibility violations in 
         ->assertPresent('[data-test="jump-to-unread"]')
         ->assertNoAccessibilityIssues();
 
-    // Re-audit the pill against the dark palette (see the sibling test for why the
-    // localStorage write must precede the `.dark` class).
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertPresent('[data-test="jump-to-unread"]')
         ->assertNoAccessibilityIssues();
 });

--- a/tests/Browser/A11yDestructiveTextTest.php
+++ b/tests/Browser/A11yDestructiveTextTest.php
@@ -43,14 +43,6 @@ test('destructive status text passes the axe audit in either theme', function ()
         ->assertPresent('[data-test="auto-disable-banner"]')
         ->assertNoAccessibilityIssues();
 
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });

--- a/tests/Browser/A11yEmojiSettingsTest.php
+++ b/tests/Browser/A11yEmojiSettingsTest.php
@@ -37,14 +37,6 @@ test('the custom emoji settings page passes the axe audit in either theme', func
         ->assertPresent('[data-test="emoji-remove-party-parrot"]')
         ->assertNoAccessibilityIssues();
 
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });

--- a/tests/Browser/A11yMarketingTest.php
+++ b/tests/Browser/A11yMarketingTest.php
@@ -12,18 +12,6 @@ test('the public marketing page has no serious accessibility violations in eithe
         ->wait(0.9)
         ->assertNoAccessibilityIssues();
 
-    // Re-audit against the dark palette. Persist 'dark' to localStorage — the
-    // source of truth `useAppearance` reads — before applying the `.dark` class,
-    // otherwise the appearance controller re-resolves 'system' → light and reverts
-    // the toggle mid-audit. The settle lets that recompute finish.
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });

--- a/tests/Browser/A11yQuickReactionsTest.php
+++ b/tests/Browser/A11yQuickReactionsTest.php
@@ -67,17 +67,8 @@ test('the quick cluster and frequently-used strip pass the axe audit in either t
         ->assertPresent('[data-test="frequent-emoji-strip"]')
         ->assertNoAccessibilityIssues();
 
-    // Re-audit against the dark palette, where the pressed shortcut swaps to the
-    // brass-tint fill. Persist the choice before applying the class so the
-    // appearance controller doesn't re-resolve 'system' back to light.
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    // Worth auditing twice: the pressed shortcut swaps to the brass-tint fill in
+    // dark, a pairing the light pass never exercises.
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });

--- a/tests/Browser/A11ySearchTest.php
+++ b/tests/Browser/A11ySearchTest.php
@@ -85,17 +85,7 @@ test('the search panel highlights matches, groups them by date, and has no serio
 
     expect($highlight)->toBe(['fontWeight' => '600', 'borderRadius' => '3px']);
 
-    // Re-audit the results against the dark palette (localStorage before the
-    // class, so the appearance controller doesn't re-resolve to light mid-audit).
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertPresent('[data-test="search-result"] mark')
         ->assertNoAccessibilityIssues();
 });
@@ -302,18 +292,8 @@ test('the facet pickers are comboboxes that keep the open popup accessible in bo
         ->assertMissing('[data-test="facet-channel-filter"]')
         ->assertMissing('[data-test="facet-channel"]');
 
-    // Re-audit the open picker against the dark palette (localStorage before
-    // the class, so the appearance controller doesn't re-resolve to light
-    // mid-audit) — the popup carries its own surface and border tokens.
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    // Worth auditing twice: the popup carries its own surface and border tokens.
+    switchToDarkTheme($page)
         ->assertPresent('html.dark')
         ->click('@facet-channel-picker')
         ->wait(0.3)

--- a/tests/Browser/A11yShellTest.php
+++ b/tests/Browser/A11yShellTest.php
@@ -39,17 +39,7 @@ test('the New Direct Message palette has no serious accessibility violations, li
         ->wait(0.5)
         ->assertNoAccessibilityIssues();
 
-    // Re-audit against the dark palette; persisting to localStorage first keeps
-    // the appearance controller from re-resolving 'system' back to light.
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });
 
@@ -217,34 +207,28 @@ test('an open destination panel has no serious accessibility violations, light o
         ->wait(0.5)
         ->assertNoAccessibilityIssues();
 
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });
 
-test('the mobile tab bar has no serious accessibility violations', function (): void {
+test('the mobile tab bar has no serious accessibility violations, light or dark', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 
-    // Light theme only, deliberately: this is the first audit of the drawer, and
-    // it turned up four *pre-existing* dark-theme contrast misses on rows that
-    // predate the tab bar (the jump-to field and the section toggles, all
-    // `--muted-foreground` under 4.5:1). Fixing those means moving the dark
-    // palette's token — see #946, which owns that sweep and re-enables the dark
-    // half here. The tab bar's own labels dodge the token entirely, so they
-    // clear AA on both themes today.
-    signInThroughBrowser($alice)
+    $page = signInThroughBrowser($alice)
         ->resize(390, 844)
         ->click('@sidebar-toggle')
         ->assertPresent('@navigation-tab-bar')
         ->assertAttribute('nav[data-test="navigation-tab-bar"]', 'aria-label', 'Destinations')
         ->assertAttribute('[data-test="tab-destination-channels"]', 'aria-current', 'true')
+        // The `--muted-foreground` rows the drawer inherited from the desktop
+        // sidebar, pinned visible so the audit below provably reaches them —
+        // they are what #946 was opened over.
+        ->assertVisible('@quick-switcher-trigger')
+        ->assertVisible('@section-toggle-channels')
+        ->assertVisible('@section-toggle-direct')
         ->wait(0.5)
+        ->assertNoAccessibilityIssues();
+
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });

--- a/tests/Browser/A11yUserGroupsTest.php
+++ b/tests/Browser/A11yUserGroupsTest.php
@@ -46,15 +46,7 @@ test('a rendered group mention pill passes the axe audit in either theme', funct
         ->assertPresent('[data-test="mention-option-group-count"]')
         ->assertNoAccessibilityIssues();
 
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });
 
@@ -75,14 +67,6 @@ test('the user groups settings page passes the axe audit in either theme', funct
         ->wait(0.5)
         ->assertNoAccessibilityIssues();
 
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
-
-    $page->wait(0.5)
+    switchToDarkTheme($page)
         ->assertNoAccessibilityIssues();
 });

--- a/tests/Browser/Helpers.php
+++ b/tests/Browser/Helpers.php
@@ -167,6 +167,40 @@ function navParamSettles(?string $destination): string
 }
 
 /**
+ * Repaint a live page in the dark palette, settled enough for an axe audit.
+ *
+ * Persisting to localStorage first keeps the appearance controller from
+ * re-resolving `system` back to light. The injected stylesheet is the part that
+ * makes the audit trustworthy: swapping the palette re-tints every element
+ * carrying `transition-colors`, and axe reads `getComputedStyle` off whatever
+ * frame it lands on, so a tween in flight is reported as if it were the shipped
+ * colour. That is what #946 chased — four "contrast misses" in the mobile
+ * drawer that were each an interpolation between the light and dark values of
+ * `--muted-foreground`, one of them measured against a background matching no
+ * token in the palette at all. The ratios moved run to run, which no real token
+ * pair can do. Killing transitions and animations outright pins the audit to the
+ * settled palette, which is the only thing worth asserting; it also removes the
+ * fade-settle that the dialog audits needed for the same reason (#775).
+ */
+function switchToDarkTheme(AwaitableWebpage $page): AwaitableWebpage
+{
+    $page->script(<<<'JS'
+    () => {
+        const settled = document.createElement('style');
+        settled.textContent =
+            '*, *::before, *::after { transition: none !important; animation: none !important; }';
+        document.head.appendChild(settled);
+
+        localStorage.setItem('appearance', 'dark');
+        document.documentElement.classList.add('dark');
+        document.documentElement.style.colorScheme = 'dark';
+    }
+    JS);
+
+    return $page->wait(0.5);
+}
+
+/**
  * Sign a user in through the real login form, returning the page so the caller
  * can continue driving it. Each `visit()` gets its own browser context (isolated
  * cookie jar), so two calls yield two independently authenticated clients.

--- a/tests/Browser/MobileQuickSwitcherTest.php
+++ b/tests/Browser/MobileQuickSwitcherTest.php
@@ -198,7 +198,10 @@ test('from md up the search icon opens the dock panel and the palette stays a ce
         ->keys('@quick-switcher-input', ['Escape'])
         ->assertNotPresent('@quick-switcher-input')
         // The masthead icon keeps its desktop meaning, which is now the dock's
-        // Search destination rather than a page of its own.
+        // Search destination rather than a page of its own. Reaching it from a
+        // page-level control needs the shell's first-paint visits to have
+        // settled, or the click is swallowed outright — see #964.
+        ->wait(0.5)
         ->click('@masthead-search')
         ->assertPresent('[data-test="destination-panel-search"]')
         ->assertPathIs(browserChannelUrl($team, $channel));


### PR DESCRIPTION
Closes #946.

## What

Adds `switchToDarkTheme()` to `tests/Browser/Helpers.php` and routes every `A11y*` browser audit's dark half through it, so axe measures the shipped palette instead of a frame of the crossfade. Re-enables the dark half of the mobile drawer audit on top of it.

`resources/css/app.css` is untouched.

## Why

#946 reported four rows in the mobile navigation drawer missing WCAG AA on `--muted-foreground` in dark, and asked for a sweep of the dark palette. That premise does not hold - the rows were never failing:

- The settled computed colour of `[data-test="quick-switcher-trigger"]` is `rgb(157, 148, 126)` = `#9d947e` (the shipped `--muted-foreground`) on `#2a271f` (`--muted`) - **4.95:1**, an AA pass, with `opacity: 1` on every ancestor.
- `axe.run()` called from inside the page at that moment returns **zero** `color-contrast` violations. Only `assertNoAccessibilityIssues()` fails, and it reports a different foreground each run - `#89816e`, `#8b826f`, `#8d8571` - each an exact interpolation between the light token `#6b6355` and the dark token `#9d947e` (63%, 68%). No real token pair moves run to run.
- The giveaway is in the issue's own table: the background `#1f1c16` matches no token in the palette. It is `--sidebar-background` 99.6% through its tween from the light `#fbfaf7` to the dark `#1e1b15`.

So the audit was sampling a `transition-colors` tween still in flight after the theme flip. That also rules out the fix the issue proposed: the tween starts at the *light* `--muted-foreground`, ~1.9:1 on a dark surface, so lightening the dark endpoint cannot remove the failing intermediates - it would keep flaking at a different progress point.

Suppressing transitions and animations before the swap pins the audit to the settled tokens, which is the only thing worth asserting. It subsumes the fade-settles that the dialog audits needed for the same reason (#775), and `A11yUserGroupsTest` already carried a comment describing the symptom without naming the cause.

The 13 hand-rolled flips across the `A11y*` suites were all latent flakes of this kind, so they move onto the helper too - which also retires four copies of the same paragraph explaining why the `localStorage` write has to precede the `.dark` class.

## How tested

- The drawer audit is red before the change (2/2 runs) and green after (3/3 runs), with the three `--muted-foreground` rows pinned visible via `assertVisible` so the dark pass provably reaches them.
- All 44 `A11y*` browser tests pass - the suppression unmasks no previously hidden violation.
- `composer test` reports `Total: 100.0 %` with Pint, PHPStan and Rector clean; `lint:check`, `format:check`, `types:check`, `build` green; `test:js` 1590 passed.

## i18n / docs

None - test-only, no user-facing copy and nothing operator-facing.

## Note on the type

`test:` rather than `fix:`: the diff is test-only and no shipped behaviour changes, so a **Bug Fixes** entry would claim a contrast repair that never happened. The `#269` guard in `resources/js/theme/contrast.test.ts` already covers every surface `--muted-foreground` reaches, and `--muted-foreground` deliberately never paints on `--sidebar-rail`, so no palette sweep remains.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787759470&installation_model_id=428379&pr_number=968&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F968&signature=030237cb33044026bb91a80f578eb91e7c9565eabc35da83e087a0a54be16b38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->