### PR TITLE
test: fail the browser suite fast when Reverb is not running

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ to remember: the suite compares `public/build/manifest.json` against everything
 Vite bundles and stops the run with that command if the bundle is behind, rather
 than letting a stale bundle fail the tests as though the app were broken.
 
+The live Reverb server gets the same treatment. Running the PHP gate can leave
+the `reverb` container stopped, and with no WebSocket server the realtime tests
+fail one by one on the message each was waiting for, which reads as a
+broadcasting regression rather than as the absent server it is. The suite
+therefore probes the endpoint once before the first test and stops with
+`./vendor/bin/sail up -d reverb` if nothing answers.
+
 ### Local SSO providers (OIDC & LDAP)
 
 Two opt-in dev containers let you exercise the single sign-on flows against real

--- a/bin/browser-tests
+++ b/bin/browser-tests
@@ -50,6 +50,20 @@ assert_fresh_bundle() {
         "$REPO_ROOT/tests/Support/StaleBundleGuard.php" "${1:-$REPO_ROOT}"
 }
 
+# Refuse to run without a Reverb server: the realtime tests subscribe real Echo
+# clients to one, so a stopped container fails them test by test on the message
+# each was waiting for, which reads as a broadcasting regression rather than as
+# the missing WebSocket server it is (#954). Running the PHP gate is enough to
+# leave the container stopped, and nothing else reports that.
+#
+# Checked here as well as in tests/Pest.php for the same reason as the bundle
+# above: this is the entry point `composer test:browser` and CI come through,
+# and failing before the fork prints one message instead of a worker crash.
+assert_reverb_is_running() {
+    php -r 'require $argv[1]; Tests\Support\ReverbGuard::ensureReverbIsRunning($argv[2]);' \
+        "$REPO_ROOT/tests/Support/ReverbGuard.php" "${1:-$REPO_ROOT}"
+}
+
 # The number of CPUs visible to this machine or container. Falls back to 0 —
 # which worker_count floors — rather than guessing on an exotic host.
 detect_cores() {
@@ -109,6 +123,7 @@ main() {
     cd "$REPO_ROOT"
 
     assert_fresh_bundle
+    assert_reverb_is_running
 
     build_pest_command "$@"
     printf '==> %s\n' "${PEST_COMMAND[*]}" >&2

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\ReverbGuard;
 use Tests\Support\StaleBundleGuard;
 use Tests\TestCase;
 
@@ -100,6 +101,12 @@ pest()->extend(TestCase::class)->in('Unit/ReverbSecretGuidanceTest.php');
 | bundle (issue #949). StaleBundleGuard sweeps the bundled sources once per
 | process and stops the run with the rebuild command instead.
 |
+| The live Reverb server is the other half of that story: without one, every
+| realtime test fails on the message it was waiting for, which reads as a
+| broadcasting regression rather than as the stopped container it is — and
+| running the PHP gate is enough to leave one behind (issue #954). ReverbGuard
+| probes it once per process and names it.
+|
 */
 
 pest()->extend(TestCase::class)
@@ -107,6 +114,7 @@ pest()->extend(TestCase::class)
     ->group('browser')
     ->beforeEach(function (): void {
         StaleBundleGuard::ensureFreshBundle(base_path());
+        ReverbGuard::ensureReverbIsRunning(base_path());
 
         useReverbForBrowserTests();
     })

--- a/tests/Support/ReverbGuard.php
+++ b/tests/Support/ReverbGuard.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+/**
+ * Refuse to run the browser suite without a Reverb server behind it.
+ *
+ * The realtime tests subscribe real Echo clients to a live Reverb, so a stopped
+ * one fails them one by one with messages that name the product ("Expected to
+ * see text [Live hello from Alice]") rather than the missing WebSocket server.
+ * Read cold that is a broadcasting regression; it is an absent container, and
+ * running the PHP gate is enough to leave one behind (issue #954).
+ *
+ * The container exits cleanly, which reads like Reverb's own restart signal:
+ * `reverb:start` polls `laravel:reverb:restart` in the cache every five seconds
+ * and stops the loop when the value changes. It is not that. The value is read
+ * once at boot and compared for inequality, so an empty cache staying empty
+ * across a flush never trips it. `reverb:start` is a SignalableCommandInterface
+ * whose handler returns the previous exit code, and Symfony's Application then
+ * `exit()`s with it, so a plain SIGTERM produces exactly the `Exited (0)` seen
+ * here. In other words the mechanism is whatever stops the container, not the
+ * suite talking to the cache, and no amount of guarding the cache would help.
+ * Hence a preflight rather than a fix upstream: name the missing server once,
+ * up front.
+ */
+final class ReverbGuard
+{
+    /**
+     * Whether this process has already probed the server.
+     */
+    private static bool $probed = false;
+
+    /**
+     * Reverb's own defaults, used when neither the environment nor the
+     * checkout's .env names a server.
+     */
+    public const string DEFAULT_HOST = '127.0.0.1';
+
+    public const int DEFAULT_PORT = 8080;
+
+    /**
+     * Seconds to wait for the TCP handshake before calling the server absent.
+     * Long enough for a loaded Docker host, short enough that a genuinely dead
+     * endpoint reports in about the time it takes to read the message.
+     */
+    public const float CONNECT_TIMEOUT = 2.0;
+
+    /**
+     * The host and port the browser suite's Echo clients dial, resolved the way
+     * config/broadcasting.php resolves them: the process environment first (CI
+     * exports REVERB_HOST/REVERB_PORT over the .env it copied from
+     * .env.example), then the checkout's .env, then Reverb's defaults.
+     *
+     * @return array{0: string, 1: int}
+     */
+    public static function endpoint(string $basePath): array
+    {
+        return [
+            self::setting($basePath, 'REVERB_HOST') ?? self::DEFAULT_HOST,
+            (int) (self::setting($basePath, 'REVERB_PORT') ?? self::DEFAULT_PORT),
+        ];
+    }
+
+    /**
+     * Abort the run, once, when nothing is listening where the browser suite
+     * expects Reverb.
+     *
+     * Reported by writing the message and exiting rather than by throwing, for
+     * the same reason StaleBundleGuard does: a thrown exception would surface as
+     * one failure per test, which is the very shape of output this guard exists
+     * to replace.
+     */
+    public static function ensureReverbIsRunning(string $basePath): void
+    {
+        if (self::$probed) {
+            return;
+        }
+
+        self::$probed = true;
+
+        $warning = self::unreachableWarning(...self::endpoint($basePath));
+
+        if ($warning === null) {
+            return;
+        }
+
+        fwrite(STDERR, PHP_EOL.$warning.PHP_EOL.PHP_EOL);
+
+        exit(1);
+    }
+
+    /**
+     * The message to show when nothing accepts a connection at the given
+     * endpoint, or null when a server does.
+     */
+    public static function unreachableWarning(string $host, int $port): ?string
+    {
+        if (self::accepts($host, $port)) {
+            return null;
+        }
+
+        return <<<MESSAGE
+              Reverb is not accepting connections at {$host}:{$port}.
+
+              The browser suite subscribes real Echo clients to a live Reverb server, so
+              without one every realtime test fails as though broadcasting were broken.
+
+                  ./vendor/bin/sail up -d reverb
+
+              (running the PHP gate can leave that container stopped; `docker compose ps -a`
+              shows it as Exited)
+            MESSAGE;
+    }
+
+    /**
+     * Whether a TCP connection to the given endpoint completes. The connection
+     * is closed immediately: the handshake is the whole signal, and Reverb needs
+     * no handshake of its own to answer it.
+     *
+     * A refused connection is the answer this guard is looking for, not a
+     * problem, so its warning is swallowed by a handler rather than by `@` —
+     * PHPUnit's error handler reports suppressed diagnostics anyway, and would
+     * turn every negative probe into a test warning.
+     */
+    private static function accepts(string $host, int $port): bool
+    {
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            $connection = fsockopen($host, $port, $errorNumber, $errorMessage, self::CONNECT_TIMEOUT);
+        } finally {
+            restore_error_handler();
+        }
+
+        if ($connection === false) {
+            return false;
+        }
+
+        fclose($connection);
+
+        return true;
+    }
+
+    /**
+     * The value of an environment setting, preferring the process environment
+     * over the checkout's .env, or null when neither defines a non-empty one.
+     */
+    private static function setting(string $basePath, string $key): ?string
+    {
+        $value = getenv($key);
+
+        if (is_string($value) && $value !== '') {
+            return $value;
+        }
+
+        return self::fromEnvFile($basePath, $key);
+    }
+
+    /**
+     * The value the checkout's .env assigns to the given key, or null when it
+     * assigns none.
+     *
+     * Parsed here rather than through Dotenv so this file stays standalone: the
+     * runner and the tests both `require` it on its own, with no autoloader.
+     */
+    private static function fromEnvFile(string $basePath, string $key): ?string
+    {
+        $path = $basePath.'/.env';
+
+        if (! is_readable($path)) {
+            return null;
+        }
+
+        $contents = (string) file_get_contents($path);
+
+        if (preg_match('/^[ \t]*'.preg_quote($key, '/').'[ \t]*=(.*)$/m', $contents, $matches) !== 1) {
+            return null;
+        }
+
+        $value = trim($matches[1]);
+
+        if (strlen($value) >= 2 && in_array($value[0], ['"', "'"], strict: true) && $value[-1] === $value[0]) {
+            $value = substr($value, 1, -1);
+        }
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/tests/Unit/ReverbGuardTest.php
+++ b/tests/Unit/ReverbGuardTest.php
@@ -296,11 +296,12 @@ it('checks once per process rather than once per test', function (): void {
 // that script.
 it('runs from the browser suite bootstrap, whichever way the suite is started', function (): void {
     $bootstrap = (string) file_get_contents(dirname(__DIR__).'/Pest.php');
-    $browserChain = strpos($bootstrap, "->group('browser')");
 
-    expect($browserChain)->not->toBeFalse()
-        ->and(substr($bootstrap, $browserChain))
-        ->toContain('ReverbGuard::ensureReverbIsRunning(base_path())');
+    // Narrowed to the chain itself, so a guard call anywhere else in the
+    // bootstrap cannot stand in for one the browser suite actually runs.
+    $browserChain = (string) strstr((string) strstr($bootstrap, "->group('browser')"), "->in('Browser');", before_needle: true);
+
+    expect($browserChain)->toContain('ReverbGuard::ensureReverbIsRunning(base_path())');
 });
 
 // Also checked ahead of paratest, not only inside it: aborting a worker surfaces

--- a/tests/Unit/ReverbGuardTest.php
+++ b/tests/Unit/ReverbGuardTest.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+use Tests\Support\ReverbGuard;
+
+/**
+ * The browser suite subscribes real Echo clients to a live Reverb server, so a
+ * stopped one fails every realtime test with a message that names the product
+ * rather than the missing WebSocket server ("Expected to see text [Live hello
+ * from Alice]"). Running the PHP gate is enough to leave the container stopped,
+ * and nothing reports that (issue #954). These tests pin the preflight that
+ * turns those failures into one message naming the server.
+ */
+
+/**
+ * The fixture prefix, scoped to this process, for the same reason
+ * StaleBundleGuardTest scopes its own: every paratest worker shares one temp
+ * directory, and a sweep that matched them all would delete a rival worker's
+ * fixtures out from under it.
+ */
+function reverbFixturePrefix(): string
+{
+    return 'reverb-guard-'.getmypid().'-';
+}
+
+/**
+ * Build a throwaway checkout whose .env holds the given lines.
+ *
+ * @param  list<string>  $lines
+ */
+function reverbFixture(array $lines = []): string
+{
+    $base = sys_get_temp_dir().'/'.reverbFixturePrefix().bin2hex(random_bytes(8));
+
+    mkdir($base, recursive: true);
+    file_put_contents($base.'/.env', implode(PHP_EOL, $lines).PHP_EOL);
+
+    return $base;
+}
+
+/**
+ * A TCP server on a free loopback port, and that port. The socket is never
+ * accepted from: a connection completing into the listen backlog is all the
+ * guard checks for.
+ *
+ * @return array{0: resource, 1: int}
+ */
+function listeningPort(): array
+{
+    $server = stream_socket_server('tcp://127.0.0.1:0', $errno, $error);
+
+    expect($server)->not->toBeFalse($error);
+
+    /** @var resource $server */
+    $name = (string) stream_socket_get_name($server, false);
+
+    return [$server, (int) substr($name, (int) strrpos($name, ':') + 1)];
+}
+
+/**
+ * A loopback port with nothing listening on it: bound to learn a free one, then
+ * released.
+ */
+function closedPort(): int
+{
+    [$server, $port] = listeningPort();
+
+    fclose($server);
+
+    return $port;
+}
+
+/**
+ * The environment a guard subprocess runs under: the endpoint it should resolve,
+ * with both keys *removed* from the inherited environment when it names none.
+ *
+ * Removed rather than merely left unset, because the rest of the suite boots the
+ * application, and Laravel's Dotenv putenv()s this checkout's own REVERB_HOST as
+ * it goes. A child would inherit that, and a test about the .env fallback would
+ * then resolve the developer's live server instead of its fixture.
+ *
+ * @return array<string, string|false>
+ */
+function reverbEnvironment(?string $host = null, ?int $port = null): array
+{
+    return [
+        'REVERB_HOST' => $host ?? false,
+        'REVERB_PORT' => $port !== null ? (string) $port : false,
+    ];
+}
+
+/**
+ * Drive `ensureReverbIsRunning()` in its own process, so the run it aborts is
+ * not the one running this test.
+ *
+ * @param  list<string>  $basePaths  one call per base path, in order
+ */
+function runReverbGuard(array $basePaths, ?string $host = null, ?int $port = null): Process
+{
+    $calls = implode('', array_map(
+        static fn (string $basePath): string => sprintf(
+            'Tests\Support\ReverbGuard::ensureReverbIsRunning(%s);',
+            var_export($basePath, true),
+        ),
+        $basePaths,
+    ));
+
+    $process = new Process([PHP_BINARY, '-r', sprintf(
+        'require %s; %s echo "the suite ran";',
+        var_export(dirname(__DIR__).'/Support/ReverbGuard.php', true),
+        $calls,
+    )], env: reverbEnvironment($host, $port));
+    $process->run();
+
+    return $process;
+}
+
+/**
+ * The endpoint the guard resolves, as `host:port`, read in its own process so
+ * an ambient REVERB_HOST cannot leak in from a booted application.
+ */
+function resolvedEndpoint(string $basePath, ?string $host = null, ?int $port = null): string
+{
+    $process = new Process([PHP_BINARY, '-r', sprintf(
+        'require %s; printf("%%s:%%d", ...Tests\Support\ReverbGuard::endpoint(%s));',
+        var_export(dirname(__DIR__).'/Support/ReverbGuard.php', true),
+        var_export($basePath, true),
+    )], env: reverbEnvironment($host, $port));
+    $process->run();
+
+    expect($process->getExitCode())->toBe(0, $process->getErrorOutput());
+
+    return $process->getOutput();
+}
+
+/**
+ * Call the runner's Reverb check without running the suite it guards.
+ */
+function runRunnerReverbCheck(string $basePath, ?string $host = null, ?int $port = null): Process
+{
+    $environment = reverbEnvironment($host, $port);
+
+    $exported = implode('', array_map(
+        static fn (string|false $value, string $key): string => $value === false
+            ? 'unset '.$key.'; '
+            : 'export '.$key.'='.escapeshellarg($value).'; ',
+        $environment,
+        array_keys($environment),
+    ));
+
+    $process = new Process(['bash', '-c', sprintf(
+        'BROWSER_TESTS_LIB=1 . %s; %sassert_reverb_is_running %s',
+        escapeshellarg(dirname(__DIR__, 2).'/bin/browser-tests'),
+        $exported,
+        escapeshellarg($basePath),
+    )]);
+    $process->run();
+
+    return $process;
+}
+
+afterEach(function (): void {
+    $filesystem = new Filesystem;
+
+    foreach ($filesystem->glob(sys_get_temp_dir().'/'.reverbFixturePrefix().'*') ?: [] as $fixture) {
+        $filesystem->deleteDirectory($fixture);
+    }
+});
+
+it('stays quiet when Reverb is accepting connections', function (): void {
+    [$server, $port] = listeningPort();
+
+    expect(ReverbGuard::unreachableWarning('127.0.0.1', $port))->toBeNull();
+
+    fclose($server);
+});
+
+it('names the endpoint and the command that starts it when nothing is listening', function (): void {
+    $port = closedPort();
+
+    expect(ReverbGuard::unreachableWarning('127.0.0.1', $port))
+        ->toContain('not accepting connections')
+        ->toContain('127.0.0.1:'.$port)
+        ->toContain('./vendor/bin/sail up -d reverb');
+});
+
+it('says which server is missing rather than which test failed', function (): void {
+    expect(ReverbGuard::unreachableWarning('127.0.0.1', closedPort()))
+        ->toContain('Reverb')
+        ->toContain('realtime');
+});
+
+// A refused connection is this guard's whole subject, so it must not also be a
+// diagnostic: PHPUnit reports `@`-suppressed warnings, which would tag every
+// run of the suite that starts without Reverb with a warning of its own.
+it('probes a dead endpoint without raising a PHP warning', function (): void {
+    $raised = [];
+
+    set_error_handler(static function (int $type, string $message) use (&$raised): bool {
+        $raised[] = $message;
+
+        return true;
+    });
+
+    try {
+        ReverbGuard::unreachableWarning('127.0.0.1', closedPort());
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($raised)->toBeEmpty();
+});
+
+it('reads the endpoint from the process environment', function (): void {
+    expect(resolvedEndpoint(
+        reverbFixture(['REVERB_HOST=ignored', 'REVERB_PORT=9999']),
+        host: '10.0.0.1',
+        port: 9001,
+    ))->toBe('10.0.0.1:9001');
+});
+
+it('falls back to the checkout .env when the environment names no server', function (): void {
+    expect(resolvedEndpoint(reverbFixture(['APP_ENV=local', 'REVERB_HOST="reverb"', 'REVERB_PORT=8080'])))
+        ->toBe('reverb:8080');
+});
+
+it('falls back to the defaults when neither the environment nor .env names one', function (): void {
+    expect(resolvedEndpoint(reverbFixture(['APP_ENV=local'])))->toBe('127.0.0.1:8080');
+});
+
+it('ignores a commented-out or differently-suffixed .env key', function (): void {
+    expect(resolvedEndpoint(reverbFixture([
+        '# REVERB_HOST=commented',
+        'REVERB_HOST_PUBLIC=ws.example.test',
+        'REVERB_PORT_PUBLIC=443',
+    ])))->toBe('127.0.0.1:8080');
+});
+
+it('treats an empty .env value as unset', function (): void {
+    expect(resolvedEndpoint(reverbFixture(['REVERB_HOST=', 'REVERB_PORT='])))->toBe('127.0.0.1:8080');
+});
+
+it('resolves the defaults when the checkout has no .env at all', function (): void {
+    expect(resolvedEndpoint(sys_get_temp_dir().'/'.reverbFixturePrefix().'absent'))->toBe('127.0.0.1:8080');
+});
+
+it('aborts the run before a single browser test executes', function (): void {
+    $process = runReverbGuard([reverbFixture()], host: '127.0.0.1', port: closedPort());
+
+    expect($process->getExitCode())->toBe(1)
+        ->and($process->getOutput())->not->toContain('the suite ran')
+        ->and($process->getErrorOutput())
+        ->toContain('not accepting connections')
+        ->toContain('./vendor/bin/sail up -d reverb');
+});
+
+it('lets the run proceed when Reverb is up', function (): void {
+    [$server, $port] = listeningPort();
+
+    $process = runReverbGuard([reverbFixture()], host: '127.0.0.1', port: $port);
+
+    fclose($server);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toContain('the suite ran')
+        ->and($process->getErrorOutput())->toBe('');
+});
+
+// One TCP connect per test would pay a network round trip 272 times over, and
+// worse, would abort mid-suite if the server went down halfway. The memo makes
+// it a preflight: a second call against an unmistakably dead endpoint must not
+// even look.
+it('checks once per process rather than once per test', function (): void {
+    [$server, $port] = listeningPort();
+
+    // Each call reads its own checkout, so the endpoints have to live in the
+    // fixtures rather than in the environment the two share.
+    $live = reverbFixture(['REVERB_HOST=127.0.0.1', 'REVERB_PORT='.$port]);
+    $dead = reverbFixture(['REVERB_HOST=127.0.0.1', 'REVERB_PORT='.closedPort()]);
+
+    $process = runReverbGuard([$live, $dead]);
+
+    fclose($server);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toContain('the suite ran');
+});
+
+// Wired into the `->in('Browser')` chain rather than only into bin/browser-tests,
+// because the documented `sail bin pest tests/Browser` entry point never runs
+// that script.
+it('runs from the browser suite bootstrap, whichever way the suite is started', function (): void {
+    $bootstrap = (string) file_get_contents(dirname(__DIR__).'/Pest.php');
+    $browserChain = strpos($bootstrap, "->group('browser')");
+
+    expect($browserChain)->not->toBeFalse()
+        ->and(substr($bootstrap, $browserChain))
+        ->toContain('ReverbGuard::ensureReverbIsRunning(base_path())');
+});
+
+// Also checked ahead of paratest, not only inside it: aborting a worker surfaces
+// the message wrapped in a WorkerCrashedException and followed by paratest's own
+// usage dump, whereas failing before the fork prints the message and nothing
+// else. `composer test:browser` and CI both come through here.
+it('stops the runner before it forks any worker', function (): void {
+    $process = runRunnerReverbCheck(reverbFixture(), host: '127.0.0.1', port: closedPort());
+
+    expect($process->getExitCode())->toBe(1)
+        ->and($process->getErrorOutput())
+        ->toContain('not accepting connections')
+        ->toContain('./vendor/bin/sail up -d reverb');
+});
+
+it('lets the runner through when Reverb is up', function (): void {
+    [$server, $port] = listeningPort();
+
+    $process = runRunnerReverbCheck(reverbFixture(), host: '127.0.0.1', port: $port);
+
+    fclose($server);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getErrorOutput())->toBe('');
+});

--- a/tests/Unit/ReverbGuardTest.php
+++ b/tests/Unit/ReverbGuardTest.php
@@ -61,16 +61,18 @@ function listeningPort(): array
 }
 
 /**
- * A loopback port with nothing listening on it: bound to learn a free one, then
- * released.
+ * A loopback port nothing can be listening on.
+ *
+ * Fixed rather than allocated and released, which is the obvious way to find a
+ * free port and is racy under paratest: between the release and the probe,
+ * another worker's `listeningPort()` can be handed the very same ephemeral port
+ * and start listening on it, and a test that needs no server then finds one.
+ * Port 1 is privileged, so no worker can bind it, and the connection is refused
+ * outright rather than left to time out.
  */
-function closedPort(): int
+function refusedPort(): int
 {
-    [$server, $port] = listeningPort();
-
-    fclose($server);
-
-    return $port;
+    return 1;
 }
 
 /**
@@ -179,7 +181,7 @@ it('stays quiet when Reverb is accepting connections', function (): void {
 });
 
 it('names the endpoint and the command that starts it when nothing is listening', function (): void {
-    $port = closedPort();
+    $port = refusedPort();
 
     expect(ReverbGuard::unreachableWarning('127.0.0.1', $port))
         ->toContain('not accepting connections')
@@ -188,7 +190,7 @@ it('names the endpoint and the command that starts it when nothing is listening'
 });
 
 it('says which server is missing rather than which test failed', function (): void {
-    expect(ReverbGuard::unreachableWarning('127.0.0.1', closedPort()))
+    expect(ReverbGuard::unreachableWarning('127.0.0.1', refusedPort()))
         ->toContain('Reverb')
         ->toContain('realtime');
 });
@@ -206,7 +208,7 @@ it('probes a dead endpoint without raising a PHP warning', function (): void {
     });
 
     try {
-        ReverbGuard::unreachableWarning('127.0.0.1', closedPort());
+        ReverbGuard::unreachableWarning('127.0.0.1', refusedPort());
     } finally {
         restore_error_handler();
     }
@@ -248,7 +250,7 @@ it('resolves the defaults when the checkout has no .env at all', function (): vo
 });
 
 it('aborts the run before a single browser test executes', function (): void {
-    $process = runReverbGuard([reverbFixture()], host: '127.0.0.1', port: closedPort());
+    $process = runReverbGuard([reverbFixture()], host: '127.0.0.1', port: refusedPort());
 
     expect($process->getExitCode())->toBe(1)
         ->and($process->getOutput())->not->toContain('the suite ran')
@@ -279,7 +281,7 @@ it('checks once per process rather than once per test', function (): void {
     // Each call reads its own checkout, so the endpoints have to live in the
     // fixtures rather than in the environment the two share.
     $live = reverbFixture(['REVERB_HOST=127.0.0.1', 'REVERB_PORT='.$port]);
-    $dead = reverbFixture(['REVERB_HOST=127.0.0.1', 'REVERB_PORT='.closedPort()]);
+    $dead = reverbFixture(['REVERB_HOST=127.0.0.1', 'REVERB_PORT='.refusedPort()]);
 
     $process = runReverbGuard([$live, $dead]);
 
@@ -306,7 +308,7 @@ it('runs from the browser suite bootstrap, whichever way the suite is started', 
 // usage dump, whereas failing before the fork prints the message and nothing
 // else. `composer test:browser` and CI both come through here.
 it('stops the runner before it forks any worker', function (): void {
-    $process = runRunnerReverbCheck(reverbFixture(), host: '127.0.0.1', port: closedPort());
+    $process = runRunnerReverbCheck(reverbFixture(), host: '127.0.0.1', port: refusedPort());
 
     expect($process->getExitCode())->toBe(1)
         ->and($process->getErrorOutput())


### PR DESCRIPTION
Closes #954.

## What

The realtime browser tests subscribe real Echo clients to a live Reverb server, so a stopped one fails them test by test on the message each was waiting for ("Expected to see text [Live hello from Alice]"). Read cold that is a broadcasting regression; it is an absent WebSocket server, and running the PHP gate is enough to leave the container behind.

`Tests\Support\ReverbGuard` probes the endpoint once per process and stops the run with one message naming the server and the command that starts it, instead of letting the suite fail test by test:

```
  Reverb is not accepting connections at reverb:8080.

  The browser suite subscribes real Echo clients to a live Reverb server, so
  without one every realtime test fails as though broadcasting were broken.

      ./vendor/bin/sail up -d reverb

  (running the PHP gate can leave that container stopped; `docker compose ps -a`
  shows it as Exited)
```

It is wired into both entry points the same way `StaleBundleGuard` is, and for the same reasons:

- `tests/Pest.php`, in the `->group('browser')` chain, so the documented `sail bin pest tests/Browser` path is covered.
- `bin/browser-tests`, ahead of the paratest fork, so `composer test:browser` and CI print the one message rather than a `WorkerCrashedException` wrapped in paratest's usage dump.

The endpoint is resolved the way `config/broadcasting.php` resolves it: the process environment first (CI exports `REVERB_HOST`/`REVERB_PORT` over the `.env` it copies from `.env.example`), then the checkout's `.env`, then Reverb's own defaults.

## On the cache-flush theory

The issue's third acceptance criterion was conditional on confirming it. It does not hold, so nothing was changed upstream:

- `reverb:start` reads `laravel:reverb:restart` once at boot and compares it for **inequality** every five seconds. An empty cache staying empty across a flush is `null === null`, so a flush cannot trip the restart path.
- `reverb:start` is a `SignalableCommandInterface` whose handler returns the previous exit code, and Symfony's `Application` then `exit()`s with it (`vendor/symfony/console/Application.php:1112`). A plain SIGTERM therefore produces exactly the `Exited (0)` reported. The mechanism is whatever stops the container, not the suite talking to the cache.

Three full `composer test` runs in an isolated worktree did not reproduce the exit, so the trigger stays unknown. That is what makes the preflight the right shape of fix: it names the missing server whatever stopped it.

## Testing

- New `tests/Unit/ReverbGuardTest.php` (16 tests) covers the message, the endpoint resolution (environment, `.env`, defaults, quoted values, absent file), the once-per-process memo, and both entry points.
- Verified end to end in the worktree: with `reverb` stopped, `bin/browser-tests` and `sail bin pest tests/Browser/RealtimeTypingTest.php` both stop on the message; with it up, `RealtimeTypingTest` passes.
- `./vendor/bin/sail composer test` green at `Total: 100.0 %` (Pint, PHPStan, Rector clean); `npm run format:check` green. No frontend sources changed.

## Docs

README's browser-suite section gains the paragraph describing the preflight, alongside the stale-bundle one it mirrors. No operator-facing config changed, so `docs/` is untouched.

## CodeRabbit

Applied: the refused-connection probes now use a port no paratest worker can bind, instead of allocating an ephemeral port and releasing it (a released port can be re-bound by a sibling worker before the probe, which would have been a genuine flake); the bootstrap assertion is scoped to the browser chain itself rather than to everything after it.

Declined: replacing the runner test's library-mode call with a real `bin/browser-tests` invocation. `main()` runs the stale-bundle check first, so that test would fail with the bundle message whenever `public/build` is behind, coupling the backend gate (and CI's `ci` job, which builds no assets) to a fresh Vite build. Library mode is what `tests/Unit/BrowserSuiteParallelTest.php` already uses for this script.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787762071&installation_model_id=428379&pr_number=969&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F969&signature=3de7bc49f2e9133de5e8697aebae5869db874f6cd01cb877a110c908faeae255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->