### PR TITLE
fix: patch the OS packages the published image inherits from its base

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,4 +46,6 @@ bootstrap/cache/*.php
 tests
 compose.yaml
 docker-compose.prod.yml
+# Read from the checkout by the two scan workflows, never from inside the image.
+.trivyignore.yaml
 *.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,10 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - '.github/workflows/docker.yml'
+      # Not a build input, but it decides what the scan below reports — so a
+      # change to it has to be seen against a real image rather than merged on
+      # the strength of the diff alone.
+      - '.trivyignore.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -103,6 +107,12 @@ jobs:
       # to ignore the check. `ignore-unfixed` keeps the report to what a rebuild
       # or a pin can actually resolve. Tighten to a failing CRITICAL gate once
       # the baseline is clean.
+      #
+      # `trivyignores` is the same file image-scan.yml reads, so this scan and
+      # the weekly one cannot disagree about what counts as a finding: a CVE in
+      # an upstream binary this repository cannot patch is documented and dated
+      # there rather than silently accepted in one place and reported in the
+      # other. See .trivyignore.yaml for what may go on it.
       - name: Scan the built image for known vulnerabilities
         if: env.PUBLISH != 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -112,6 +122,7 @@ jobs:
           output: trivy-results.sarif
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
           exit-code: '0'
 
       # The code-scanning tab is what gives the findings history and dedup: the
@@ -141,6 +152,7 @@ jobs:
           output: trivy-report.txt
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
           exit-code: '0'
           skip-setup-trivy: true
 

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -27,6 +27,15 @@ jobs:
       issues: write
 
     steps:
+      # Only for .trivyignore.yaml: the scan itself talks to a registry and
+      # needs nothing from the tree. Without the checkout this scan would count
+      # findings the per-build scan in docker.yml has already suppressed, and
+      # reopen an issue about them every week.
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Log in to GHCR
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -42,9 +51,10 @@ jobs:
       - name: Scan each published tag and report
         env:
           GH_TOKEN: ${{ github.token }}
-          # This job never checks the repository out — it only talks to a
-          # registry — so `gh` has no remote to infer the repository from and
-          # every issue command below would fail without this.
+          # Explicit rather than inferred from the checkout's remote: the
+          # checkout above exists only to bring .trivyignore.yaml in, and an
+          # issue command that silently depends on it would break the day the
+          # ignore file is no longer needed and the step is dropped.
           GH_REPO: ${{ github.repository }}
           IMAGE: ghcr.io/${{ github.repository }}
           TITLE: "fix: patch the vulnerabilities found in the published image"
@@ -68,9 +78,15 @@ jobs:
 
             # --ignore-unfixed: an unfixed upstream CVE is not something this
             # repository can act on, and an issue nobody can close is noise.
+            # --ignorefile: for the same reason, one step further — a CVE that
+            # *is* fixed upstream but only in a build nobody has published yet
+            # is equally unactionable here. Those are enumerated, justified and
+            # dated in .trivyignore.yaml, and reported again the moment an entry
+            # expires.
             trivy image \
               --severity CRITICAL,HIGH \
               --ignore-unfixed \
+              --ignorefile .trivyignore.yaml \
               --format json \
               --output "scan-${tag}.json" \
               "$reference"

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,47 @@
+# Findings the image scans report against an artifact this repository consumes
+# as a prebuilt binary, and therefore cannot patch.
+#
+# Both scans read this one file, so a finding is suppressed in both places or in
+# neither: the per-build scan in .github/workflows/docker.yml and the weekly scan
+# of the published tags in .github/workflows/image-scan.yml.
+#
+# An entry belongs here only when the fix is genuinely out of reach — the CVE is
+# fixed upstream but no published build of the artifact carries it yet. Anything
+# a Dockerfile change can reach is patched there instead; `apk upgrade` in the
+# runtime stage covers the OS packages, which is what most base-image findings
+# turn out to be.
+#
+# Every entry is scoped to the artifact it was assessed against, says why in a
+# sentence someone can check, and expires. Trivy reports an expired entry again,
+# which reopens the rolling issue image-scan.yml keeps: that is the point of the
+# date. A suppression is a reminder to re-check, never a way to make a finding
+# go away. tests/Unit/ImageSupplyChainTest.php holds those three rules.
+vulnerabilities:
+  # Both of these are compiled into the FrankenPHP binary the runtime stage
+  # inherits from `dunglas/frankenphp:1-php8.5-alpine`: they are Caddy's
+  # dependency graph, not this application's, and nothing in the Dockerfile can
+  # move them. v1.12.6 (Caddy 2.11.4) is the newest upstream release and still
+  # carries both, so rebuilding on a current base does not clear them either;
+  # only a FrankenPHP rebuild will. The expiry falls on a Monday so the scheduled
+  # scan is what re-reports them (#962).
+  - id: GHSA-r277-6w6q-xmqw
+    paths:
+      - usr/local/bin/frankenphp
+    statement: >-
+      kin-openapi fail-open authentication bypass in ValidationHandler.Load(),
+      fixed in kin-openapi 0.144.0. It reaches this image only through Caddy
+      inside the upstream FrankenPHP binary, which ships no build carrying the
+      fix as of v1.12.6. The Caddyfile this image runs enables php_server alone
+      (Vulcain, the module that pulls in OpenAPI request validation, is left
+      commented out upstream), so no OpenAPI validation handler is loaded.
+    expired_at: 2026-10-26
+  - id: GHSA-hrxh-6v49-42gf
+    paths:
+      - usr/local/bin/frankenphp
+    statement: >-
+      gRPC-Go xDS RBAC and HTTP/2 vulnerabilities, fixed in grpc-go 1.82.1. It
+      reaches this image only through Caddy inside the upstream FrankenPHP
+      binary, which ships no build carrying the fix as of v1.12.6. This image
+      serves HTTP/1.1 and HTTP/2 from Caddy's own stack and exposes neither a
+      gRPC listener nor an xDS control plane.
+    expired_at: 2026-10-26

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,16 @@ ARG PHPREDIS_VERSION=6.3.0
 #
 # phpredis is cloned rather than fetched as an archive: the codeload tarball
 # omits the liblzf submodule and the build fails on the missing sources.
+#
+# `apk upgrade` comes first, before anything is installed on top of it. A base
+# image carries the package snapshot it was built against, and Alpine publishes
+# security updates to the branch repository continuously — so an OS package goes
+# stale in the published image without a single commit landing in this
+# repository, and the weekly scan of the published tags is what finds out (#962,
+# where the base shipped c-ares 1.34.6-r0 against a 1.34.8-r0 fix already in
+# v3.24/main). Only the runtime stage needs it: the vendor and assets stages
+# contribute no packages to the image that ships. PHP and FrankenPHP are not apk
+# packages in this base, so nothing the app is pinned to moves underneath it.
 RUN set -eu; \
     max_attempts=5; \
     retry_delay=10; \
@@ -137,6 +147,7 @@ RUN set -eu; \
             attempt=$((attempt + 1)); \
         done; \
     }; \
+    retry apk upgrade --no-cache; \
     retry apk add --no-cache --virtual .phpredis-source git; \
     retry git clone \
             --depth 1 \

--- a/tests/Unit/ImageSupplyChainTest.php
+++ b/tests/Unit/ImageSupplyChainTest.php
@@ -223,7 +223,14 @@ test('the build-only path scans the image it just built', function (): void {
 
 test('the runtime stage patches the base image OS packages at build time', function (): void {
     $dockerfile = supplyChainDockerfile();
-    $runtime = substr($dockerfile, (int) strpos($dockerfile, 'AS runtime'));
+    $runtimeStart = strpos($dockerfile, 'AS runtime');
+
+    // Without this the stage marker could be renamed and `substr` would fall
+    // back to offset 0, quietly widening every assertion below to the whole
+    // file — so an `apk upgrade` in a build stage that ships nothing would pass.
+    expect($runtimeStart)->not->toBeFalse('the runtime stage is what ships, and it can no longer be located');
+
+    $runtime = substr($dockerfile, (int) $runtimeStart);
 
     // A base image carries the apk snapshot it was built against, and Alpine
     // publishes security updates to the branch repository continuously — so an
@@ -251,7 +258,13 @@ test('every suppressed vulnerability is justified, scoped, and expires', functio
 
         // Scoped to the artifact it was assessed against, so the same CVE
         // surfacing in something this repository does control is still reported.
-        expect($entry['paths'] ?? [])->not->toBeEmpty();
+        // A bare scalar reads like a scope but is not one Trivy accepts, so the
+        // shape is asserted rather than just the emptiness.
+        expect($entry['paths'] ?? null)->toBeArray()->not->toBeEmpty();
+
+        foreach ($entry['paths'] as $path) {
+            expect($path)->toBeString()->not->toBeEmpty();
+        }
 
         // And never permanent: Trivy reports an expired entry again, which
         // reopens the rolling issue rather than letting the finding disappear.
@@ -274,11 +287,20 @@ test('both scans read the same checked-in suppression list', function (): void {
     }
 
     // The weekly scan only ever talked to a registry, so the file it now has to
-    // read has to be fetched first.
-    expect(supplyChainStepUsing('image-scan', 'scan-published-images', 'actions/checkout@'))
-        ->not->toBeNull('the weekly scan cannot read the ignore file without checking the repository out');
+    // read has to be fetched first — and fetched *before* the scan runs, which
+    // is the half of it a "the step exists" assertion would miss.
+    $steps = supplyChainSteps('image-scan', 'scan-published-images');
+    $checkout = $steps->search(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), 'actions/checkout@'));
+    $scan = $steps->search(static fn (array $step): bool => str_contains((string) ($step['run'] ?? ''), 'trivy image'));
 
-    expect(supplyChainRunScripts('image-scan', 'scan-published-images'))->toContain('--ignorefile');
+    expect($checkout)->not->toBeFalse('the weekly scan cannot read the ignore file without checking the repository out')
+        ->and($scan)->not->toBeFalse()
+        ->and($checkout)->toBeLessThan($scan);
+
+    // The path too, not just the flag: pointed at a file that is not there,
+    // Trivy scans on with no suppressions and the rolling issue never closes.
+    expect(supplyChainRunScripts('image-scan', 'scan-published-images'))
+        ->toContain('--ignorefile .trivyignore.yaml');
 
     // Editing the list changes what the build scan reports, so a pull request
     // that touches it has to rebuild and re-scan rather than merge on the

--- a/tests/Unit/ImageSupplyChainTest.php
+++ b/tests/Unit/ImageSupplyChainTest.php
@@ -70,6 +70,34 @@ function supplyChainRunScripts(string $workflow, string $job): string
     return supplyChainSteps($workflow, $job)->pluck('run')->filter()->implode("\n");
 }
 
+/**
+ * The production Dockerfile as text. Whatever the base image ships, this file is
+ * the only place this repository gets to patch it.
+ */
+function supplyChainDockerfile(): string
+{
+    return (string) file_get_contents(dirname(__DIR__, 2).'/Dockerfile');
+}
+
+/**
+ * Path to the Trivy ignore file both scans read.
+ */
+function supplyChainIgnoreFile(): string
+{
+    return dirname(__DIR__, 2).'/.trivyignore.yaml';
+}
+
+/**
+ * Every suppressed finding, with `expired_at` kept as a date rather than folded
+ * to a Unix timestamp (which is what the parser does without the flag).
+ *
+ * @return list<array<string, mixed>>
+ */
+function supplyChainSuppressions(): array
+{
+    return Yaml::parseFile(supplyChainIgnoreFile(), Yaml::PARSE_DATETIME)['vulnerabilities'] ?? [];
+}
+
 test('the composite action can attach provenance and an SBOM to what it pushes', function (): void {
     $action = supplyChainBuildAction();
 
@@ -191,6 +219,72 @@ test('the build-only path scans the image it just built', function (): void {
     // Readable on the run itself, not only behind the Security tab, which most
     // reviewers never open on a PR.
     expect(supplyChainRunScripts('docker', 'build'))->toContain('GITHUB_STEP_SUMMARY');
+});
+
+test('the runtime stage patches the base image OS packages at build time', function (): void {
+    $dockerfile = supplyChainDockerfile();
+    $runtime = substr($dockerfile, (int) strpos($dockerfile, 'AS runtime'));
+
+    // A base image carries the apk snapshot it was built against, and Alpine
+    // publishes security updates to the branch repository continuously — so an
+    // OS package goes stale in the published image without a single commit
+    // landing here (#962, c-ares CVE-2026-33630, fixed upstream but not yet in
+    // any FrankenPHP build). Upgrading at build time is what closes that window.
+    // In the runtime stage specifically: the vendor and assets stages contribute
+    // no packages to the image that ships.
+    expect($runtime)->toContain('apk upgrade --no-cache');
+
+    // Under the same bounded retry as every other apk call in the stage, since
+    // it reaches the network exactly the same way (#626, #641).
+    expect($runtime)->toContain('retry apk upgrade --no-cache');
+});
+
+test('every suppressed vulnerability is justified, scoped, and expires', function (): void {
+    // The list is allowed to be empty — nothing suppressed is strictly better —
+    // but an entry that is on it has to earn its place.
+    foreach (supplyChainSuppressions() as $entry) {
+        expect($entry['id'] ?? '')->toBeString()->not->toBeEmpty();
+
+        // A suppression nobody can read back is indistinguishable from one added
+        // to turn a red scan green.
+        expect($entry['statement'] ?? '')->toBeString()->not->toBeEmpty();
+
+        // Scoped to the artifact it was assessed against, so the same CVE
+        // surfacing in something this repository does control is still reported.
+        expect($entry['paths'] ?? [])->not->toBeEmpty();
+
+        // And never permanent: Trivy reports an expired entry again, which
+        // reopens the rolling issue rather than letting the finding disappear.
+        expect($entry['expired_at'] ?? null)->toBeInstanceOf(DateTimeInterface::class);
+    }
+});
+
+test('both scans read the same checked-in suppression list', function (): void {
+    expect(supplyChainIgnoreFile())->toBeFile();
+
+    // Every trivy-action call on the build path, or the per-build scan and the
+    // weekly one disagree about what counts as a finding.
+    $scans = supplyChainSteps('docker', 'build')
+        ->filter(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), 'aquasecurity/trivy-action@'));
+
+    expect($scans)->not->toBeEmpty();
+
+    foreach ($scans as $scan) {
+        expect($scan['with']['trivyignores'] ?? null)->toBe('.trivyignore.yaml');
+    }
+
+    // The weekly scan only ever talked to a registry, so the file it now has to
+    // read has to be fetched first.
+    expect(supplyChainStepUsing('image-scan', 'scan-published-images', 'actions/checkout@'))
+        ->not->toBeNull('the weekly scan cannot read the ignore file without checking the repository out');
+
+    expect(supplyChainRunScripts('image-scan', 'scan-published-images'))->toContain('--ignorefile');
+
+    // Editing the list changes what the build scan reports, so a pull request
+    // that touches it has to rebuild and re-scan rather than merge on the
+    // strength of the diff.
+    expect(supplyChainTriggers(supplyChainWorkflow('docker'))['pull_request']['paths'] ?? [])
+        ->toContain('.trivyignore.yaml');
 });
 
 test('the build job publishes the digest of the image it pushed', function (): void {


### PR DESCRIPTION
Closes #962.

## What the scan actually found

All three findings come from `dunglas/frankenphp:1-php8.5-alpine` itself, not from anything this repository installs. I scanned the current base directly before changing anything, so the issue's stock line ("rebuilding the image on a current base usually clears them") does not hold here: a rebuild today reproduces all three.

| Finding | Where it lives | Actionable here? |
| --- | --- | --- |
| `CVE-2026-33630` (c-ares, HIGH) | Alpine package, base ships `1.34.6-r0` | **Yes.** `1.34.8-r0` is already in `v3.24/main` |
| `GHSA-r277-6w6q-xmqw` (kin-openapi, CRITICAL) | compiled into `/usr/local/bin/frankenphp` | No |
| `GHSA-hrxh-6v49-42gf` (grpc, HIGH) | compiled into `/usr/local/bin/frankenphp` | No |

FrankenPHP v1.12.6 (Caddy 2.11.4) is the newest upstream release and carries both Go findings, so no published base clears them and nothing in the `Dockerfile` can move them.

## What this changes

**The runtime stage runs `apk upgrade` before installing anything on top of it**, under the same bounded retry as its other network calls. A base image only carries the apk snapshot it was built against, and Alpine publishes security updates to the branch repository continuously, so its OS packages go stale in the published image without a commit landing here. Only the runtime stage needs it: the vendor and assets stages contribute no packages to the image that ships, and PHP/FrankenPHP are not apk packages in this base, so nothing the app is pinned to moves underneath it.

**The two upstream-only findings are recorded in a checked-in `.trivyignore.yaml`**, each scoped to the binary it was assessed against, with the reason it is unactionable and an expiry. Trivy reports an expired entry again, which reopens the rolling issue rather than letting a finding disappear quietly. Both scans read that one file, so the per-build scan in `docker.yml` and the weekly one in `image-scan.yml` cannot disagree about what counts as a finding; the weekly job gains a checkout to reach it, and `.trivyignore.yaml` joins the `docker.yml` PR path filter so a change to it is seen against a real image.

The expiry is 2026-10-26, a Monday, so the scheduled scan is what re-reports them.

## How it was tested

Beyond the guard tests, I built the production image locally and scanned it:

- **Without** the ignore file: the alpine target goes from 1 finding to **0** (`Upgrading c-ares (1.34.6-r0 -> 1.34.8-r0)` in the build log), leaving only the two FrankenPHP findings.
- **With** it, using the same flags `image-scan.yml` uses: the count that job computes is **0**, which is the condition that closes the rolling issue.

I also verified the mechanics rather than assuming them: a past `expired_at` puts both findings back (3 again), and `paths` scoping confirms the suppression only applies to the FrankenPHP binary.

New assertions in `tests/Unit/ImageSupplyChainTest.php` cover the runtime-stage upgrade, the three rules every suppression must satisfy (justified, scoped, expiring), and the wiring of both scans to the one file. Each was mutation-checked to confirm it fails when the invariant is broken.

No user-facing copy, so no i18n keys; nothing operator-facing changed, so no docs update.

## Note

Operators running `latest` receive this at the next stable release, since moving tags are only republished when a `v*` tag is pushed. That is by design.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787771569&installation_model_id=428379&pr_number=973&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F973&signature=e87e55ae73feaca038c769b007479d5b298484def253c986f06a8debdf107b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->