### PR TITLE
test: cover section delete, collapse persistence and move-to-section

### DIFF
--- a/tests/Browser/SidebarControlsTest.php
+++ b/tests/Browser/SidebarControlsTest.php
@@ -4,6 +4,41 @@ declare(strict_types=1);
 
 use App\Models\ChannelSection;
 
+/**
+ * A script resolving once the given selector has reached the wanted visibility —
+ * `false` covering both "hidden" and "gone from the DOM", since a collapsed
+ * group is kept mounted by `v-show` while a deleted section is removed outright.
+ *
+ * Every element assertion the browser plugin offers is a one-shot read
+ * (`assertPresent` counts, `assertMissing` reads `isVisible()`), and what these
+ * tests watch for lands after a server round-trip. Polling one animation frame
+ * at a time settles that without pinning a sleep to whatever a loaded CI runner
+ * happens to take, the same way the destinations suite polls the URL.
+ */
+function sidebarSelectorSettles(string $selector, bool $visible): string
+{
+    $wanted = $visible ? 'true' : 'false';
+
+    return <<<JS
+    (async () => {
+        const settled = () =>
+            (document.querySelector('{$selector}')?.checkVisibility() ?? false) === {$wanted};
+
+        for (let frame = 0; frame < 300 && ! settled(); frame++) {
+            await new Promise(requestAnimationFrame);
+        }
+
+        return settled();
+    })()
+    JS;
+}
+
+/** The selector for a channel's row inside one sidebar group. */
+function sidebarChannelRow(string $group, string $slug): string
+{
+    return '[data-test="'.$group.'"] a[href$="/'.$slug.'"]';
+}
+
 test('a section can be created through the inline shadcn input', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 
@@ -43,4 +78,83 @@ test('a section can be renamed through the inline shadcn input', function (): vo
         ->keys("@section-rename-input-{$section->id}", ['Enter'])
         ->assertSee('New name')
         ->assertDontSee('Old name');
+});
+
+test('deleting a section returns its channels to the default group', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    $section = ChannelSection::factory()->for($alice)->for($team)->create([
+        'name' => 'Projects',
+    ]);
+    $alice->channels()->updateExistingPivot($general->id, ['section_id' => $section->id]);
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $general))
+        ->assertScript(
+            sidebarSelectorSettles(sidebarChannelRow("section-content-custom-{$section->id}", 'general'), true),
+            true,
+        )
+        ->click("@section-menu-{$section->id}")
+        // Let the dropdown settle past its open/pointer-grace window, otherwise
+        // the "Delete" click is swallowed and the section survives.
+        ->wait(0.5)
+        ->click("@section-delete-{$section->id}")
+        // Deleting a section only unfiles its channels: #general falls back to
+        // the default group rather than leaving the sidebar with the section.
+        ->assertScript(sidebarSelectorSettles("[data-test=\"section-custom-{$section->id}\"]", false), true)
+        ->assertScript(sidebarSelectorSettles(sidebarChannelRow('section-content-channels', 'general'), true), true);
+});
+
+test('a collapsed built-in section and a collapsed custom section both survive a reload', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    $section = ChannelSection::factory()->for($alice)->for($team)->create([
+        'name' => 'Projects',
+    ]);
+
+    $page = signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $general))
+        ->assertScript(sidebarSelectorSettles('[data-test="section-content-channels"]', true), true)
+        // The two mechanisms are separate: the built-in set lives on the user,
+        // the custom flag on the section itself.
+        ->click('@section-toggle-channels')
+        ->click("@section-toggle-custom-{$section->id}")
+        ->assertScript(sidebarSelectorSettles('[data-test="section-content-channels"]', false), true)
+        ->assertScript(sidebarSelectorSettles("[data-test=\"section-content-custom-{$section->id}\"]", false), true);
+
+    // Both toggles are optimistic, so a reload proves nothing until their
+    // PATCHes have landed. Poll for that rather than sleeping through it.
+    retry(30, function () use ($alice, $section): void {
+        expect($alice->refresh()->collapsed_channel_sections)->toContain('channels');
+        expect($section->refresh()->collapsed)->toBeTrue();
+    }, 100);
+
+    $page->navigate(browserChannelUrl($team, $general))
+        ->assertScript(sidebarSelectorSettles('[data-test="section-toggle-channels"]', true), true)
+        ->assertScript(sidebarSelectorSettles('[data-test="section-content-channels"]', false), true)
+        ->assertScript(sidebarSelectorSettles("[data-test=\"section-content-custom-{$section->id}\"]", false), true);
+});
+
+test('a channel is filed under a section from its kebab menu', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $general] = browserTeamWithChannel();
+
+    $section = ChannelSection::factory()->for($alice)->for($team)->create([
+        'name' => 'Projects',
+    ]);
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->navigate(browserChannelUrl($team, $general))
+        ->assertScript(sidebarSelectorSettles(sidebarChannelRow('section-content-channels', 'general'), true), true)
+        // The row's kebab only carries "Move to" once a section exists to move into.
+        ->click('@channel-menu-general')
+        ->wait(0.5)
+        ->click("@move-to-{$section->id}")
+        ->assertScript(
+            sidebarSelectorSettles(sidebarChannelRow("section-content-custom-{$section->id}", 'general'), true),
+            true,
+        )
+        ->assertScript(sidebarSelectorSettles(sidebarChannelRow('section-content-channels', 'general'), false), true);
 });


### PR DESCRIPTION
Part A of #956.

The conversation-list region of `MainLayout.vue` is about to be extracted into four components and three composables. Its current browser coverage is two paths (create a section, rename one), which is not enough for the move to be provably behaviour-preserving. These three tests are written against the *current* markup precisely so that their staying green across the extraction is itself the parity proof.

## What is covered

- **Deleting a section returns its channels to the default group.** A channel filed under a section, deleted from the section's kebab, has to fall back into `section-content-channels` rather than leaving the sidebar with the section.
- **Both collapse mechanisms survive a reload.** They are separate stores — the built-in set lives on the user (`collapsed_channel_sections`), the custom flag on the section row — so one test collapses one of each and reloads.
- **A channel is filed under a section from its row kebab.** The `move` emit path out of `ChannelListItem`, which nothing covered.

All three are click-driven. No drag test: `vuedraggable`/Sortable under Playwright is a known flake source, and the drag handlers get deterministic vitest coverage at the composable level in part B, which is only possible *because* of the extraction.

## Notes

- `sidebarSelectorSettles()` polls `checkVisibility()` a frame at a time, the same way the destinations suite polls the URL. Every element assertion the plugin offers is a one-shot read (`assertPresent` counts, `assertMissing` reads `isVisible()`), and what these assertions watch for lands after a server round-trip. It also covers "hidden" and "gone from the DOM" in one helper, which the two cases here need: `v-show` keeps a collapsed group mounted, a deleted section is removed outright.
- The collapse test polls the database for the two optimistic PATCHes before reloading rather than sleeping through them — the hide is instant and local, so a reload proves nothing until they have actually persisted.

## Testing

`sail bin pest tests/Browser/SidebarControlsTest.php` — 5 passed, run four times over to check for flakiness. No app code changed, so the PHP gate is unaffected.

No new user-facing copy, so `lang/fr.json` is untouched. Nothing operator-facing, so no docs change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787773261&installation_model_id=428379&pr_number=976&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F976&signature=9e76e3eedc108cbf7e1ff415d10810119b69ecf8367d306aedc5cdc9d4c3c86d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->