### PR TITLE
fix: keep a client-side URL write from being swallowed by a concurrent response

### DIFF
--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -38,6 +38,7 @@ import { useUserGroups } from '@/composables/useUserGroups';
 import { formatDateTime } from '@/lib/datetime';
 import { renderMessageBody } from '@/lib/messageBody';
 import { rankPeople } from '@/lib/peopleDirectory';
+import { pinUrl } from '@/lib/pinUrl';
 import { presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
 import { urlForSearchParams } from '@/lib/searchPanel';
@@ -235,14 +236,12 @@ function selectMessage(result: MessageSearchResult): void {
 function seeAllResults(): void {
     open.value = false;
 
-    router.replace({
-        url: urlForSearchParams(
+    pinUrl(
+        urlForSearchParams(
             urlForDestination(page.url, 'search'),
             filtersToParams(parsedFilters.value),
         ),
-        preserveState: true,
-        preserveScroll: true,
-    });
+    );
 
     if (isMobile.value) {
         setOpenMobile(true);

--- a/resources/js/composables/useNavPanel.test.ts
+++ b/resources/js/composables/useNavPanel.test.ts
@@ -1,14 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { effectScope, nextTick, reactive } from 'vue';
 
-const { replace } = vi.hoisted(() => ({ replace: vi.fn() }));
+const { pinUrl } = vi.hoisted(() => ({ pinUrl: vi.fn() }));
 
 const page = reactive({ url: '/t/acme/c/general' });
 
-vi.mock('@inertiajs/vue3', () => ({
-    router: { replace },
-    usePage: () => page,
-}));
+vi.mock('@inertiajs/vue3', () => ({ usePage: () => page }));
+vi.mock('@/lib/pinUrl', () => ({ pinUrl }));
 
 import {
     destinationFromUrl,
@@ -18,7 +16,7 @@ import {
 import type { NavPanel } from '@/composables/useNavPanel';
 
 function harness(url = '/t/acme/c/general') {
-    replace.mockClear();
+    pinUrl.mockClear();
     page.url = url;
 
     const scope = effectScope();
@@ -99,11 +97,7 @@ describe('useNavPanel', () => {
         panel.openDestination('threads');
 
         expect(panel.activeDestination.value).toBe('threads');
-        expect(replace).toHaveBeenCalledWith({
-            url: '/t/acme/c/general?nav=threads',
-            preserveState: true,
-            preserveScroll: true,
-        });
+        expect(pinUrl).toHaveBeenCalledWith('/t/acme/c/general?nav=threads');
 
         scope.stop();
     });
@@ -113,7 +107,7 @@ describe('useNavPanel', () => {
 
         panel.openDestination('search');
 
-        expect(replace).not.toHaveBeenCalled();
+        expect(pinUrl).not.toHaveBeenCalled();
 
         scope.stop();
     });

--- a/resources/js/composables/useNavPanel.ts
+++ b/resources/js/composables/useNavPanel.ts
@@ -1,6 +1,7 @@
-import { router, usePage } from '@inertiajs/vue3';
+import { usePage } from '@inertiajs/vue3';
 import { ref, watch } from 'vue';
 import type { Ref } from 'vue';
+import { pinUrl } from '@/lib/pinUrl';
 
 /**
  * The dock's pinned destinations, in the order the rail and the tab bar list
@@ -75,11 +76,11 @@ export interface NavPanel {
  * that omits a destination's props cannot blank an open panel, and `?nav=` on
  * the current shell route makes it deep-linkable and reload-proof.
  *
- * Switching is a client-side visit ({@see router.replace}) rather than a server
- * round trip — the destination itself carries no props yet, and a destination
- * that needs data reloads exactly the props it needs on top of this. The
- * watcher adopts the URL's destination on history traversal, and returns the
- * panel to the conversation list when a plain channel link navigates away.
+ * Switching is a client-side visit ({@see pinUrl}) rather than a server round
+ * trip — the destination itself carries no props yet, and a destination that
+ * needs data reloads exactly the props it needs on top of this. The watcher
+ * adopts the URL's destination on history traversal, and returns the panel to
+ * the conversation list when a plain channel link navigates away.
  */
 export function useNavPanel(): NavPanel {
     const page = usePage();
@@ -92,11 +93,7 @@ export function useNavPanel(): NavPanel {
 
         activeDestination.value = destination;
 
-        router.replace({
-            url: urlForDestination(page.url, destination),
-            preserveState: true,
-            preserveScroll: true,
-        });
+        pinUrl(urlForDestination(page.url, destination));
     }
 
     function isActive(destination: NavDestination): boolean {

--- a/resources/js/lib/pinUrl.test.ts
+++ b/resources/js/lib/pinUrl.test.ts
@@ -99,12 +99,13 @@ describe('pinUrl', () => {
 
     it('gives up rather than loop when every attempt is swallowed', () => {
         pinUrl('/t/acme/c/general?nav=search');
+        settle(0, '/t/acme/c/general');
+        settle(1, '/t/acme/c/general');
 
-        for (let attempt = 0; attempt < 5; attempt++) {
-            if (replace.mock.calls.length > attempt) {
-                settle(attempt, '/t/acme/c/general');
-            }
-        }
+        // The third attempt is swallowed too, and this time nothing follows it:
+        // a write that cannot land through three windows is a symptom of
+        // something else, and looping on it would clobber whatever that is.
+        settle(2, '/t/acme/c/general');
 
         expect(replace).toHaveBeenCalledTimes(3);
     });

--- a/resources/js/lib/pinUrl.test.ts
+++ b/resources/js/lib/pinUrl.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+
+const { replace } = vi.hoisted(() => ({ replace: vi.fn() }));
+
+const page = reactive({ url: '/t/acme/c/general' });
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { replace },
+    usePage: () => page,
+}));
+
+import { pinUrl } from '@/lib/pinUrl';
+
+const SOURCE_ROOT = 'resources/js';
+
+/** The options object the nth `router.replace` was issued with. */
+function visit(index = 0): {
+    url: string;
+    preserveState: boolean;
+    preserveScroll: boolean;
+    onFinish: () => void;
+} {
+    return replace.mock.calls[index][0];
+}
+
+/**
+ * Finish the nth visit as Inertia would once its page swap settled, with `url`
+ * standing for what the page ended up on: the write's own target when it landed,
+ * the route it was issued from when a concurrent response swallowed it.
+ */
+function settle(index: number, url: string): void {
+    page.url = url;
+    visit(index).onFinish();
+    vi.runAllTimers();
+}
+
+/** Every source file under `resources/js`, tests excluded. */
+function sourceFiles(directory = SOURCE_ROOT): string[] {
+    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            return sourceFiles(path);
+        }
+
+        return /\.(ts|vue)$/.test(entry.name) &&
+            !entry.name.endsWith('.test.ts')
+            ? [path]
+            : [];
+    });
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    replace.mockClear();
+    page.url = '/t/acme/c/general';
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('pinUrl', () => {
+    it('writes the url onto the current route without a server round trip', () => {
+        pinUrl('/t/acme/c/general?nav=search');
+
+        expect(replace).toHaveBeenCalledTimes(1);
+        expect(visit()).toMatchObject({
+            url: '/t/acme/c/general?nav=search',
+            preserveState: true,
+            preserveScroll: true,
+        });
+    });
+
+    it('asks again when a concurrent response swallowed the write', () => {
+        pinUrl('/t/acme/c/general?nav=search');
+        settle(0, '/t/acme/c/general');
+
+        expect(replace).toHaveBeenCalledTimes(2);
+        expect(visit(1).url).toBe('/t/acme/c/general?nav=search');
+    });
+
+    it('stops asking once the write lands', () => {
+        pinUrl('/t/acme/c/general?nav=search');
+        settle(0, '/t/acme/c/general?nav=search');
+
+        expect(replace).toHaveBeenCalledTimes(1);
+    });
+
+    it('stands down when a real navigation moved the url meanwhile', () => {
+        pinUrl('/t/acme/c/general?nav=search');
+        settle(0, '/t/acme/c/random');
+
+        expect(replace).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up rather than loop when every attempt is swallowed', () => {
+        pinUrl('/t/acme/c/general?nav=search');
+
+        for (let attempt = 0; attempt < 5; attempt++) {
+            if (replace.mock.calls.length > attempt) {
+                settle(attempt, '/t/acme/c/general');
+            }
+        }
+
+        expect(replace).toHaveBeenCalledTimes(3);
+    });
+
+    it('issues a write that changes nothing exactly once', () => {
+        pinUrl('/t/acme/c/general');
+        settle(0, '/t/acme/c/general');
+
+        expect(replace).toHaveBeenCalledTimes(1);
+    });
+
+    it('is the only place a client-side visit is issued from', () => {
+        // A `router.replace` written by hand is a write that can be dropped in
+        // silence (#964). Route every one of them through here, so the retry is
+        // not something each call site has to remember.
+        const direct = sourceFiles()
+            .filter((path) => path !== join(SOURCE_ROOT, 'lib', 'pinUrl.ts'))
+            .filter((path) =>
+                readFileSync(path, 'utf8').includes('router.replace('),
+            )
+            .map((path) => path.slice(`${SOURCE_ROOT}/`.length));
+
+        expect(direct).toEqual([]);
+    });
+});

--- a/resources/js/lib/pinUrl.ts
+++ b/resources/js/lib/pinUrl.ts
@@ -1,0 +1,65 @@
+import { router, usePage } from '@inertiajs/vue3';
+
+/**
+ * How many times a swallowed write is re-issued before it is left alone.
+ *
+ * Losing twice over means a response landed inside two consecutive windows,
+ * which the shell's handful of first-paint visits cannot sustain. Past that,
+ * asking forever would trade a missing query param for a loop that keeps
+ * stamping over whatever else is trying to land.
+ */
+const MAX_ATTEMPTS = 3;
+
+/**
+ * Write a URL onto the current route client-side, asking again if a concurrent
+ * response swallowed it.
+ *
+ * Inertia stamps a token on the page before it awaits the component a visit
+ * resolves to, and abandons the swap if another visit stamped over that token
+ * meanwhile. A client-side visit resolves the component it is already on, so the
+ * await buys it nothing — but it still opens a window, and a server response
+ * landing inside that window drops the write with no error, no request and no
+ * history entry: the URL simply never changes (#964). It bites in the first
+ * moments after a login, where the shell's own fire-and-forget visits
+ * ({@see backgroundVisit}) are in flight all at once, and it took a destination
+ * opened from the page with it — the dock's rail was only spared because it
+ * flips the panel itself rather than reading the switch back off the URL.
+ *
+ * Asking again is conditional on nothing else having moved the URL: once a real
+ * navigation has landed it owns the address bar, and re-applying a write meant
+ * for the route the viewer has left would drag them back onto it.
+ */
+export function pinUrl(url: string): void {
+    const from = usePage().url;
+
+    // A write that changes nothing has nothing observable to be swallowed, so
+    // there is no second attempt to tell apart from a first one that worked.
+    issue(url, from, url === from ? 1 : MAX_ATTEMPTS);
+}
+
+/** Issue one client-side visit, and judge whether it survived. */
+function issue(url: string, from: string, attemptsLeft: number): void {
+    router.replace({
+        url,
+        preserveState: true,
+        preserveScroll: true,
+        onFinish: () => {
+            if (attemptsLeft <= 1) {
+                return;
+            }
+
+            // Yield first. The response that beat us to the token is itself a
+            // tick from applying, and asking again on top of it right now would
+            // stamp over that one in turn — trading our dropped write for its.
+            setTimeout(() => {
+                // Any URL other than the one we started from means this write
+                // has had its say: it landed, or the viewer went elsewhere.
+                if (usePage().url !== from) {
+                    return;
+                }
+
+                issue(url, from, attemptsLeft - 1);
+            }, 0);
+        },
+    });
+}

--- a/tests/Browser/A11ySearchTest.php
+++ b/tests/Browser/A11ySearchTest.php
@@ -38,9 +38,8 @@ function searchPanelWithMatches(): array
 
 /**
  * Sign in and open the Search destination from the rail. Opening it this way is a
- * client-side panel swap, so the browser session survives (a full `navigate()`
- * would drop it), and the rail flips the panel itself rather than waiting on the
- * URL — which is what makes it the steady way in straight after a login (#964).
+ * client-side panel swap, so the browser session survives — a full `navigate()`
+ * would drop it.
  */
 function openSearchPanel(User $user): AwaitableWebpage
 {
@@ -94,11 +93,11 @@ test('the search panel highlights matches, groups them by date, and has no serio
 test('the masthead glyph opens the search destination beside the channel it was pressed from', function (): void {
     ['owner' => $alice, 'team' => $team, 'channel' => $channel] = searchPanelWithMatches();
 
-    // The dock's own trigger for search from inside a conversation. It reaches
-    // the panel through the URL rather than flipping it directly, so it needs
-    // the shell to have finished its first-paint visits — see #964.
+    // The dock's own trigger for search from inside a conversation, pressed the
+    // instant the post-login redirect lands: it reaches the panel through the
+    // URL, and that write used to be swallowed outright by the shell's own
+    // first-paint visits (#964).
     signInThroughBrowser($alice)
-        ->wait(0.5)
         ->click('@masthead-search')
         ->assertPresent('[data-test="destination-panel-search"]')
         // The panel took the dock's column; the conversation it was pressed from

--- a/tests/Browser/DatePickerTest.php
+++ b/tests/Browser/DatePickerTest.php
@@ -82,9 +82,6 @@ test('the search panel custom range picks its bounds from a calendar', function 
         'body' => 'the quokka danced at dawn today',
     ]);
 
-    // Opened from the rail rather than the masthead: the rail flips the panel
-    // itself instead of going through the URL, which is the steady way in this
-    // soon after a login (#964).
     signInThroughBrowser($alice)
         ->click('@rail-destination-search')
         ->assertPresent('[data-test="destination-panel-search"]')

--- a/tests/Browser/MobileQuickSwitcherTest.php
+++ b/tests/Browser/MobileQuickSwitcherTest.php
@@ -198,10 +198,7 @@ test('from md up the search icon opens the dock panel and the palette stays a ce
         ->keys('@quick-switcher-input', ['Escape'])
         ->assertNotPresent('@quick-switcher-input')
         // The masthead icon keeps its desktop meaning, which is now the dock's
-        // Search destination rather than a page of its own. Reaching it from a
-        // page-level control needs the shell's first-paint visits to have
-        // settled, or the click is swallowed outright — see #964.
-        ->wait(0.5)
+        // Search destination rather than a page of its own.
         ->click('@masthead-search')
         ->assertPresent('[data-test="destination-panel-search"]')
         ->assertPathIs(browserChannelUrl($team, $channel));


### PR DESCRIPTION
Closes #964.

## The mechanism

The handler **does** run. The issue ruled that out because no `history.replaceState` landed, but instrumenting `openSearch` / `openDestination` shows both firing on every swallowed click. What never lands is the client-side visit they issue.

`Inertia.Page.set()` stamps a token on itself, then *awaits* the component the visit resolves to, and abandons the swap if the token changed meanwhile:

```js
this.componentId = {}
const componentId = this.componentId

return this.resolve(page.component, page).then((component) => {
  if (componentId !== this.componentId) {
    // Component has changed since we started resolving this component, bail
    return
  }
  ...
})
```

A **client-side** visit (`router.replace({ url })`) resolves the component it is already on, so that await buys it nothing — but it is asynchronous, because the page component is a dynamic `import()`. Any server response landing inside that window stamps its own token, and our visit bails: no history write, no request, no error, no `page.url` change. Silent.

Patched trace of a failing click (ms since page load):

```
3246.9  openSearch / openDestination  active=channels  pageUrl=/t/acme/c/general
3247.8  page.set:begin      <- our ?nav=search client visit
3266.6  page.set:begin      <- the /settings/timezone background POST's response
3278.6  page.set:resolved   bail=true   <- ours, discarded
3278.9  page.set:resolved   bail=false  <- the background response wins
```

That is why the window is "the first moments after the post-login redirect": it is exactly when the shell's own fire-and-forget visits (`pendingInvitations`, the timezone persist, the mark-read POST) are all in flight. And it is why the rail was immune — it shares the layout's `useNavPanel()` instance and flips `activeDestination` synchronously, so it never depended on the URL write landing at all.

## The fix

`resources/js/lib/pinUrl.ts` — a client-side URL write that notices it was swallowed and asks again. Asking again is conditional on nothing else having moved the URL in between: once a real navigation has landed it owns the address bar, and re-applying a write meant for the route the viewer has left would drag them back onto it. Bounded at three attempts, and it yields a tick before re-issuing so the response that beat us to the token gets to apply first, rather than trading our dropped write for its.

Both places that write a URL client-side go through it — `useNavPanel.openDestination` and `QuickSwitcher.seeAllResults`, which had the identical exposure — and a source-scanning test keeps it that way, mirroring how `backgroundVisit.test.ts` guards `router.reload`.

## Testing

`tests/Browser/A11ySearchTest.php` presses the masthead glyph the instant the post-login redirect lands, with the `wait(0.5)` gone. Measured over 20 runs each:

| | failures |
|---|---|
| before | 9 / 20 |
| after | 0 / 20 |

`resources/js/lib/pinUrl.test.ts` covers the retry deterministically: the write is re-issued when the URL did not move, left alone once it lands, stood down when a real navigation moved it, and bounded rather than looping.

The `wait(0.5)` calls and the "open it from the rail instead" comments #941 added are removed (`A11ySearchTest`, `DatePickerTest`, `MobileQuickSwitcherTest`).

Backend gate green at 100% coverage; frontend lint / format / types / vitest / build green.

No user-facing copy and no operator-facing settings, so no i18n or docs changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787777017&installation_model_id=428379&pr_number=997&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F997&signature=c195bcc4a1f2bbd1a302ae630fd5cad457ce83e1ba9cc87bb0eaece196efe69b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->