### PR TITLE
refactor: route every toast through a useToast composable

### DIFF
--- a/eslint-rules/vue-sonner-policy.test.ts
+++ b/eslint-rules/vue-sonner-policy.test.ts
@@ -1,0 +1,66 @@
+import { ESLint } from 'eslint';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Guards the wiring rather than a rule implementation: `useToast` is only the
+ * single entry point for toasts if nothing else can reach `vue-sonner`, and
+ * that holds only while `no-restricted-imports` names the package everywhere
+ * except the two files that own the boundary. Resolving the project config per
+ * file path is what proves both halves — a config typo, a stray `files` glob,
+ * or someone dropping the restriction would fail here.
+ */
+const eslint = new ESLint();
+
+const ORDINARY_COMPOSABLE = 'resources/js/composables/useProbe.ts';
+const ORDINARY_COMPONENT = 'resources/js/components/Probe.vue';
+const USE_TOAST = 'resources/js/composables/useToast.ts';
+
+const PROBE_PATHS = [ORDINARY_COMPOSABLE, ORDINARY_COMPONENT, USE_TOAST];
+
+/** Resolved flat config per probe path, populated once before the assertions. */
+const configs = new Map<string, { rules?: Record<string, unknown[]> }>();
+
+/**
+ * Building the flat config and its vue parser pipeline costs a second or two,
+ * and charging it to whichever test runs first has crossed vitest's per-test
+ * timeout under full-suite load before (#804). Resolve every probe path on a
+ * hook with a budget big enough for it.
+ */
+beforeAll(async () => {
+    for (const filePath of PROBE_PATHS) {
+        configs.set(filePath, await eslint.calculateConfigForFile(filePath));
+    }
+}, 60_000);
+
+/** The paths `no-restricted-imports` forbids for a given file. */
+function restrictedPathsFor(filePath: string): string[] {
+    const config = configs.get(filePath);
+
+    if (!config) {
+        throw new Error(`No config was resolved for ${filePath}.`);
+    }
+
+    const entry = config.rules?.['no-restricted-imports'];
+
+    if (!entry || entry[0] === 0 || entry[0] === 'off') {
+        return [];
+    }
+
+    const options = entry[1] as { paths?: { name: string }[] } | undefined;
+
+    return (options?.paths ?? []).map((path) => path.name);
+}
+
+describe('the vue-sonner policy', () => {
+    it('forbids reaching for vue-sonner from an ordinary composable', () => {
+        expect(restrictedPathsFor(ORDINARY_COMPOSABLE)).toContain('vue-sonner');
+    });
+
+    it('forbids reaching for vue-sonner from an ordinary component', () => {
+        expect(restrictedPathsFor(ORDINARY_COMPONENT)).toContain('vue-sonner');
+    });
+
+    it('allows it in useToast, the composable that owns the boundary', () => {
+        expect(restrictedPathsFor(USE_TOAST)).not.toContain('vue-sonner');
+    });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -120,6 +120,25 @@ export default defineConfigWithVueTs(
                 'error',
                 { max: 400, skipBlankLines: true, skipComments: true },
             ],
+            // Every toast in the app goes through `useToast()`, which is where
+            // the duration policy, the merge key and the action slot live. A
+            // call site reaching for `vue-sonner` directly would bypass all
+            // three, which is how the app ended up with no place to put them
+            // (#978). Exempted just below for `useToast` itself — the one
+            // module allowed to see the package (`components/ui/` is not
+            // linted at all, so `sonner/Sonner.vue` needs no entry).
+            'no-restricted-imports': [
+                'error',
+                {
+                    paths: [
+                        {
+                            name: 'vue-sonner',
+                            message:
+                                'Raise toasts through useToast() from @/composables/useToast instead.',
+                        },
+                    ],
+                },
+            ],
             // XSS trust boundary. Every run of HTML the client renders as markup
             // must go through `<SafeHtml>`, which sanitizes it with DOMPurify
             // against a named allowlist; a raw `v-html` anywhere else would
@@ -127,6 +146,15 @@ export default defineConfigWithVueTs(
             // `SafeHtml.vue` itself just below — the one place the directive is
             // allowed to appear.
             'vue/no-v-html': 'error',
+        },
+    },
+    {
+        // `useToast` is the app's toast boundary: it wraps `vue-sonner` so no
+        // other module has to, which is precisely what the restriction above
+        // exists to guarantee everywhere else.
+        files: ['resources/js/composables/useToast.ts'],
+        rules: {
+            'no-restricted-imports': 'off',
         },
     },
     {

--- a/resources/js/components/AddDirectMessagePeopleModal.vue
+++ b/resources/js/components/AddDirectMessagePeopleModal.vue
@@ -2,7 +2,6 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { Info, Search, X } from '@lucide/vue';
 import { computed, ref, watch } from 'vue';
-import { toast } from 'vue-sonner';
 import { store as addPeople } from '@/actions/App/Http/Controllers/Channels/DirectMessagePeopleController';
 import { Button } from '@/components/ui/button';
 import {
@@ -13,6 +12,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import { useInitials } from '@/composables/useInitials';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { findMatchingDirectMessage, groupDmMastheadName } from '@/lib/groupDm';
 import { rankPeople } from '@/lib/peopleDirectory';
@@ -30,6 +30,7 @@ const open = defineModel<boolean>('open', { default: false });
 const page = usePage();
 const { getInitials } = useInitials();
 const { t } = useTranslations();
+const toast = useToast();
 
 // How many ranked candidates to offer at once.
 const MAX_CANDIDATES = 6;

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -2,7 +2,6 @@
 import { Link, router } from '@inertiajs/vue3';
 import { GripVertical, MoreVertical, Pencil, Star } from '@lucide/vue';
 import { computed, ref } from 'vue';
-import { toast } from 'vue-sonner';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
 import { Button } from '@/components/ui/button';
@@ -20,6 +19,7 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { notificationIndicator } from '@/lib/notificationIndicator';
 import type { Channel, ChannelSection } from '@/types/channels';
@@ -48,6 +48,7 @@ const emit = defineEmits<{
 const menuOpen = ref(false);
 
 const { t } = useTranslations();
+const toast = useToast();
 
 // The mute / notification-level cue for this row, matching the conversation
 // masthead; null (and so no icon) for an unmuted channel at the default level.

--- a/resources/js/components/DirectMessageListItem.test.ts
+++ b/resources/js/components/DirectMessageListItem.test.ts
@@ -28,7 +28,16 @@ vi.mock('@inertiajs/vue3', () => ({
     router: { post: vi.fn() },
     usePage: () => ({ props: { auth: { user: { avatar: null } } } }),
 }));
-vi.mock('vue-sonner', () => ({ toast: { error: vi.fn() } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 vi.mock('@/actions/App/Http/Controllers/Channels/ChannelController', () => ({
     show: () => ({ url: '/team/general' }),
 }));

--- a/resources/js/components/DirectMessageListItem.vue
+++ b/resources/js/components/DirectMessageListItem.vue
@@ -2,7 +2,6 @@
 import { Link, router, usePage } from '@inertiajs/vue3';
 import { X } from '@lucide/vue';
 import { computed } from 'vue';
-import { toast } from 'vue-sonner';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { store as hideDirectMessage } from '@/actions/App/Http/Controllers/Channels/HideDirectMessageController';
 import AvatarStack from '@/components/AvatarStack.vue';
@@ -17,6 +16,7 @@ import {
 } from '@/components/ui/tooltip';
 import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
 import { useInitials } from '@/composables/useInitials';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { groupDmSidebarName } from '@/lib/groupDm';
 import { notificationIndicator } from '@/lib/notificationIndicator';
@@ -38,6 +38,7 @@ const props = defineProps<{
 
 const { getInitials } = useInitials();
 const { t } = useTranslations();
+const toast = useToast();
 
 // How many participant avatars a group row stacks before a "+N" overflow chip.
 const MAX_ROW_AVATARS = 3;

--- a/resources/js/components/DndPauseDialog.vue
+++ b/resources/js/components/DndPauseDialog.vue
@@ -4,7 +4,6 @@ import { CalendarDate, today } from '@internationalized/date';
 import { Clock } from '@lucide/vue';
 import type { DateValue } from 'reka-ui';
 import { computed, ref, watch } from 'vue';
-import { toast } from 'vue-sonner';
 import { update as updateDndPause } from '@/actions/App/Http/Controllers/Settings/DndController';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
@@ -22,6 +21,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import {
     to12Hour,
@@ -34,6 +34,7 @@ const open = defineModel<boolean>('open', { default: false });
 
 const page = usePage();
 const { t } = useTranslations();
+const toast = useToast();
 
 const effectiveZone = computed(
     () =>

--- a/resources/js/components/GifPickerPanel.test.ts
+++ b/resources/js/components/GifPickerPanel.test.ts
@@ -4,7 +4,16 @@ import type { App, Component } from 'vue';
 import { createApp, defineComponent, h, nextTick } from 'vue';
 import GifPickerPanel from './GifPickerPanel.vue';
 
-vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 vi.mock('@/components/ui/button', async () => {
     const { defineComponent, h } = await import('vue');

--- a/resources/js/components/GifPickerPanel.vue
+++ b/resources/js/components/GifPickerPanel.vue
@@ -8,12 +8,12 @@ import {
     ref,
     watch,
 } from 'vue';
-import { toast } from 'vue-sonner';
 import {
     search as searchRoute,
     store as storeRoute,
 } from '@/actions/App/Http/Controllers/Channels/GiphyController';
 import { Button } from '@/components/ui/button';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { attachGiphyGif, fetchGiphyPage } from '@/lib/giphy';
 import type { AttachmentData } from '@/types/attachments';
@@ -50,6 +50,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useTranslations();
+const toast = useToast();
 
 const query = ref(props.initialQuery);
 const results = ref<App.Data.GiphyGifData[]>([]);

--- a/resources/js/components/MessageActionsSheet.test.ts
+++ b/resources/js/components/MessageActionsSheet.test.ts
@@ -15,7 +15,18 @@ vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({ props }),
 }));
 
-vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 // The sheet rides the app's dialog primitive; its portal/focus behaviour is the
 // primitive's own tested concern, so render it down to a passthrough.
@@ -262,7 +273,6 @@ describe('MessageActionsSheet action rows', () => {
     });
 
     it('reports a copy that could not reach the clipboard and still dismisses', async () => {
-        const { toast } = await import('vue-sonner');
         const writeText = vi.fn().mockRejectedValue(new Error('denied'));
         Object.defineProperty(navigator, 'clipboard', {
             value: { writeText },
@@ -275,7 +285,7 @@ describe('MessageActionsSheet action rows', () => {
         await Promise.resolve();
         await Promise.resolve();
 
-        expect(toast.error).toHaveBeenCalledExactlyOnceWith(
+        expect(toastError).toHaveBeenCalledExactlyOnceWith(
             'The message text could not be copied.',
         );
         expect(emitted['update:open']).toEqual([[false]]);

--- a/resources/js/components/MessageActionsSheet.vue
+++ b/resources/js/components/MessageActionsSheet.vue
@@ -11,7 +11,6 @@ import {
     Trash2,
 } from '@lucide/vue';
 import { computed, watch } from 'vue';
-import { toast } from 'vue-sonner';
 import EmojiPickerPopover from '@/components/EmojiPickerPopover.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -24,6 +23,7 @@ import {
 import { useCustomEmojis } from '@/composables/useCustomEmojis';
 import { useFrequentEmojis } from '@/composables/useFrequentEmojis';
 import { useInitials } from '@/composables/useInitials';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatTimeOfDay } from '@/lib/datetime';
 import {
@@ -76,6 +76,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useTranslations();
+const toast = useToast();
 const { getInitials } = useInitials();
 const { parseToken } = useCustomEmojis();
 const { list: frequentEmojis } = useFrequentEmojis();

--- a/resources/js/components/UserStatusDialog.vue
+++ b/resources/js/components/UserStatusDialog.vue
@@ -4,7 +4,6 @@ import { CalendarDate, today } from '@internationalized/date';
 import { Clock, Smile } from '@lucide/vue';
 import type { DateValue } from 'reka-ui';
 import { computed, ref, watch } from 'vue';
-import { toast } from 'vue-sonner';
 import {
     destroy as destroyStatus,
     update as updateStatus,
@@ -28,6 +27,7 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import {
     to12Hour,
@@ -52,6 +52,7 @@ const open = defineModel<boolean>('open', { default: false });
 
 const page = usePage();
 const { t } = useTranslations();
+const toast = useToast();
 
 const status = computed(() => page.props.auth.user.status ?? null);
 const isEditing = computed(() => status.value !== null);

--- a/resources/js/components/navigation/ChannelsPanel.test.ts
+++ b/resources/js/components/navigation/ChannelsPanel.test.ts
@@ -12,7 +12,16 @@ vi.mock('@inertiajs/vue3', () => ({
     usePage: () => page,
 }));
 
-vi.mock('vue-sonner', () => ({ toast: { error: vi.fn() } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 vi.mock('@lucide/vue', () => ({
     ChevronRight: { render: () => h('svg') },

--- a/resources/js/components/navigation/UserPanel.test.ts
+++ b/resources/js/components/navigation/UserPanel.test.ts
@@ -44,7 +44,16 @@ vi.mock('@inertiajs/vue3', () => ({
     }),
 }));
 
-vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: vi.fn(),
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 // The workspace sheet is a surface of its own with its own specs; here it is
 // only the wrapper the "Switch workspace" row triggers, so the stub keeps that

--- a/resources/js/composables/useAttachmentUploads.test.ts
+++ b/resources/js/composables/useAttachmentUploads.test.ts
@@ -4,9 +4,16 @@ import type { EffectScope } from 'vue';
 
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 
-vi.mock('vue-sonner', () => ({
-    toast: { error: toastError, success: vi.fn() },
-}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
 import type { AttachmentUploads } from '@/composables/useAttachmentUploads';

--- a/resources/js/composables/useAttachmentUploads.ts
+++ b/resources/js/composables/useAttachmentUploads.ts
@@ -1,6 +1,6 @@
 import { computed, onScopeDispose, ref } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
-import { toast } from 'vue-sonner';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatFileSize, isImageMime } from '@/lib/attachments';
 import { isPlayableAudio } from '@/lib/audio';
@@ -141,6 +141,7 @@ export function useAttachmentUploads(
     options: AttachmentUploadsOptions,
 ): AttachmentUploads {
     const { t } = useTranslations();
+    const toast = useToast();
     const upload = options.uploader ?? xhrUpload;
     const createObjectUrl = options.createObjectUrl ?? defaultCreateObjectUrl;
     const revokeObjectUrl = options.revokeObjectUrl ?? defaultRevokeObjectUrl;

--- a/resources/js/composables/useChannelPlacement.test.ts
+++ b/resources/js/composables/useChannelPlacement.test.ts
@@ -9,7 +9,16 @@ const { patch, toastError } = vi.hoisted(() => ({
 const page = reactive<{ props: Record<string, unknown> }>({ props: {} });
 
 vi.mock('@inertiajs/vue3', () => ({ router: { patch }, usePage: () => page }));
-vi.mock('vue-sonner', () => ({ toast: { error: toastError } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 import { useChannelPlacement } from '@/composables/useChannelPlacement';
 import type { ChannelPlacement } from '@/composables/useChannelPlacement';

--- a/resources/js/composables/useChannelPlacement.ts
+++ b/resources/js/composables/useChannelPlacement.ts
@@ -1,9 +1,9 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { computed, ref, watch } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
-import { toast } from 'vue-sonner';
 import { update as updateChannelPlacement } from '@/actions/App/Http/Controllers/Channels/ChannelPlacementController';
 import { reorder as reorderSections } from '@/actions/App/Http/Controllers/Channels/ChannelSectionController';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { partitionChannels } from '@/lib/channelSections';
 import type { ChannelSectionGroup } from '@/lib/channelSections';
@@ -58,6 +58,7 @@ export interface ChannelPlacement {
 export function useChannelPlacement(): ChannelPlacement {
     const page = usePage();
     const { t } = useTranslations();
+    const toast = useToast();
 
     const currentTeam = computed(() => page.props.currentTeam);
     const channels = computed(() => page.props.channels ?? []);

--- a/resources/js/composables/useChannelPreferences.test.ts
+++ b/resources/js/composables/useChannelPreferences.test.ts
@@ -8,7 +8,16 @@ const { patch, toastError } = vi.hoisted(() => ({
 }));
 
 vi.mock('@inertiajs/vue3', () => ({ router: { patch } }));
-vi.mock('vue-sonner', () => ({ toast: { error: toastError } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 import { useChannelPreferences } from '@/composables/useChannelPreferences';
 import type { ChannelPreferences } from '@/composables/useChannelPreferences';

--- a/resources/js/composables/useChannelPreferences.ts
+++ b/resources/js/composables/useChannelPreferences.ts
@@ -2,9 +2,9 @@ import { router } from '@inertiajs/vue3';
 import type { AcceptableValue } from 'reka-ui';
 import { computed, ref, watch } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
-import { toast } from 'vue-sonner';
 import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
 import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
+import { useToast } from '@/composables/useToast';
 import { backgroundVisit } from '@/lib/backgroundVisit';
 import { notificationIndicator } from '@/lib/notificationIndicator';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
@@ -55,6 +55,7 @@ export interface ChannelPreferences {
 export function useChannelPreferences(
     options: ChannelPreferencesOptions,
 ): ChannelPreferences {
+    const toast = useToast();
     const notificationLevel = ref<NotificationLevel>(
         options.channel().notificationLevel,
     );

--- a/resources/js/composables/useChannelSections.test.ts
+++ b/resources/js/composables/useChannelSections.test.ts
@@ -16,7 +16,16 @@ vi.mock('@inertiajs/vue3', () => ({
     router: { delete: destroy, patch, post },
     usePage: () => page,
 }));
-vi.mock('vue-sonner', () => ({ toast: { error: toastError } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 import { useChannelSections } from '@/composables/useChannelSections';
 import type { ChannelSectionGroup } from '@/lib/channelSections';

--- a/resources/js/composables/useChannelSections.ts
+++ b/resources/js/composables/useChannelSections.ts
@@ -1,12 +1,12 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
 import type { Ref } from 'vue';
-import { toast } from 'vue-sonner';
 import {
     destroy as destroySection,
     store as storeSection,
     update as updateSection,
 } from '@/actions/App/Http/Controllers/Channels/ChannelSectionController';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import type { ChannelSectionGroup } from '@/lib/channelSections';
 import type { ChannelSection } from '@/types/channels';
@@ -69,6 +69,7 @@ export interface ChannelSections {
 export function useChannelSections(): ChannelSections {
     const page = usePage();
     const { t } = useTranslations();
+    const toast = useToast();
 
     const teamSlug = computed(() => page.props.currentTeam?.slug ?? '');
 

--- a/resources/js/composables/useCollapsedSections.test.ts
+++ b/resources/js/composables/useCollapsedSections.test.ts
@@ -9,7 +9,16 @@ const { patch, toastError } = vi.hoisted(() => ({
 const page = reactive<{ props: Record<string, unknown> }>({ props: {} });
 
 vi.mock('@inertiajs/vue3', () => ({ router: { patch }, usePage: () => page }));
-vi.mock('vue-sonner', () => ({ toast: { error: toastError } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 import { useCollapsedSections } from '@/composables/useCollapsedSections';
 import type { CollapsedSections } from '@/composables/useCollapsedSections';

--- a/resources/js/composables/useCollapsedSections.ts
+++ b/resources/js/composables/useCollapsedSections.ts
@@ -1,7 +1,7 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { ref, watch } from 'vue';
-import { toast } from 'vue-sonner';
 import { update as updateSidebarSections } from '@/actions/App/Http/Controllers/SidebarSectionController';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { toggleCollapsedSection } from '@/lib/channelSections';
 import type { SidebarSectionKey } from '@/lib/channelSections';
@@ -25,6 +25,7 @@ export interface CollapsedSections {
 export function useCollapsedSections(): CollapsedSections {
     const page = usePage();
     const { t } = useTranslations();
+    const toast = useToast();
 
     const collapsedSections = ref<string[]>([
         ...(page.props.collapsedChannelSections ?? []),

--- a/resources/js/composables/useMessageActions.test.ts
+++ b/resources/js/composables/useMessageActions.test.ts
@@ -13,9 +13,16 @@ const { post, patch, destroy, toastError, toastSuccess } = vi.hoisted(() => ({
 vi.mock('@inertiajs/vue3', () => ({
     router: { post, patch, delete: destroy },
 }));
-vi.mock('vue-sonner', () => ({
-    toast: { error: toastError, success: toastSuccess },
-}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: toastSuccess,
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 import { useMessageActions } from '@/composables/useMessageActions';
 import type { MessageActions } from '@/composables/useMessageActions';

--- a/resources/js/composables/useMessageActions.ts
+++ b/resources/js/composables/useMessageActions.ts
@@ -1,7 +1,6 @@
 import { router } from '@inertiajs/vue3';
 import { nextTick } from 'vue';
 import type { Ref } from 'vue';
-import { toast } from 'vue-sonner';
 import { store as forwardMessageAction } from '@/actions/App/Http/Controllers/Channels/ForwardMessageController';
 import {
     destroy as destroyMessage,
@@ -26,6 +25,7 @@ import {
 import { store as storeCommand } from '@/actions/App/Http/Controllers/Channels/SlashCommandController';
 import type { useMessageStream } from '@/composables/useMessageStream';
 import { optimisticMessage } from '@/composables/useMessageStream';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { planForward } from '@/lib/forwardPlacement';
 import type { Outbox } from '@/lib/outbox';
@@ -191,6 +191,7 @@ export function useMessageActions(
     options: MessageActionsOptions,
 ): MessageActions {
     const { t } = useTranslations();
+    const toast = useToast();
 
     /** Add an optimistic row to the main timeline, honouring the pin-to-bottom rule. */
     function appendPendingMain(message: Message): void {

--- a/resources/js/composables/useOpenDirectMessage.ts
+++ b/resources/js/composables/useOpenDirectMessage.ts
@@ -1,6 +1,6 @@
 import { router } from '@inertiajs/vue3';
-import { toast } from 'vue-sonner';
 import { store as openDm } from '@/actions/App/Http/Controllers/Channels/DirectMessageController';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 
 /**
@@ -11,6 +11,7 @@ import { useTranslations } from '@/composables/useTranslations';
  */
 export function useOpenDirectMessage(teamSlug: () => string) {
     const { t } = useTranslations();
+    const toast = useToast();
 
     function openDirectMessage(userId: string): void {
         router.post(

--- a/resources/js/composables/useToast.test.ts
+++ b/resources/js/composables/useToast.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { sonner } = vi.hoisted(() => ({
+    sonner: {
+        success: vi.fn(),
+        error: vi.fn(),
+        warning: vi.fn(),
+        loading: vi.fn(),
+    },
+}));
+
+vi.mock('vue-sonner', () => ({ toast: sonner }));
+
+import { useToast } from '@/composables/useToast';
+
+/** The options bag the composable handed to vue-sonner. */
+function optionsOf(spy: {
+    mock: { calls: unknown[][] };
+}): Record<string, unknown> {
+    return spy.mock.calls[0][1] as Record<string, unknown>;
+}
+
+describe('useToast', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('tones', () => {
+        it('speaks each tone through the matching sonner variant', () => {
+            const toast = useToast();
+
+            toast.success('Reminder set');
+            toast.error('Could not save your status');
+            toast.warning('Your connection is unstable');
+            toast.progress('Uploading');
+
+            expect(sonner.success).toHaveBeenCalledWith(
+                'Reminder set',
+                expect.anything(),
+            );
+            expect(sonner.error).toHaveBeenCalledWith(
+                'Could not save your status',
+                expect.anything(),
+            );
+            expect(sonner.warning).toHaveBeenCalledWith(
+                'Your connection is unstable',
+                expect.anything(),
+            );
+            expect(sonner.loading).toHaveBeenCalledWith(
+                'Uploading',
+                expect.anything(),
+            );
+        });
+    });
+
+    describe('the duration policy', () => {
+        it('holds a bare confirmation for four seconds', () => {
+            useToast().success('Reminder set');
+
+            expect(optionsOf(sonner.success).duration).toBe(4_000);
+        });
+
+        it('holds a confirmation carrying an action for seven, so it can be taken', () => {
+            useToast().success('Reminder set', {
+                action: { label: 'Undo', run: vi.fn() },
+            });
+
+            expect(optionsOf(sonner.success).duration).toBe(7_000);
+        });
+
+        it('leaves an error up until it is dismissed, action or not', () => {
+            const toast = useToast();
+
+            toast.error('Message failed to send');
+            toast.error('Message failed to send', {
+                action: { label: 'Retry', run: vi.fn() },
+            });
+
+            expect(optionsOf(sonner.error).duration).toBe(Infinity);
+            expect(
+                (sonner.error.mock.calls[1][1] as { duration: number })
+                    .duration,
+            ).toBe(Infinity);
+        });
+
+        it('leaves work in progress up until it resolves', () => {
+            useToast().progress('Uploading');
+
+            expect(optionsOf(sonner.loading).duration).toBe(Infinity);
+        });
+
+        it('lets a call site override the policy', () => {
+            useToast().success('Reminder set', { duration: 1_000 });
+
+            expect(optionsOf(sonner.success).duration).toBe(1_000);
+        });
+    });
+
+    describe('options', () => {
+        it('renders the value that was set as the detail line', () => {
+            useToast().success('Reminder set', { detail: 'Tomorrow, 9:00 AM' });
+
+            expect(optionsOf(sonner.success).description).toBe(
+                'Tomorrow, 9:00 AM',
+            );
+        });
+
+        it('merges repeats under a key instead of queueing them', () => {
+            const toast = useToast();
+
+            toast.error('That file type is not allowed', { key: 'upload' });
+            toast.error('That file type is not allowed', { key: 'upload' });
+
+            expect(optionsOf(sonner.error).id).toBe('upload');
+            expect((sonner.error.mock.calls[1][1] as { id: string }).id).toBe(
+                'upload',
+            );
+        });
+
+        it('leaves an unkeyed toast to queue on its own', () => {
+            useToast().success('Reminder set');
+
+            expect(optionsOf(sonner.success).id).toBeUndefined();
+        });
+
+        it('wires the action so taking it runs the call site handler', () => {
+            const run = vi.fn();
+
+            useToast().success('Reminder set', {
+                action: { label: 'Undo', run },
+            });
+
+            const action = optionsOf(sonner.success).action as {
+                label: string;
+                onClick: () => void;
+            };
+
+            expect(action.label).toBe('Undo');
+
+            action.onClick();
+
+            expect(run).toHaveBeenCalledOnce();
+        });
+
+        it('omits the action slot when the toast carries none', () => {
+            useToast().success('Reminder set');
+
+            expect(optionsOf(sonner.success).action).toBeUndefined();
+        });
+    });
+});

--- a/resources/js/composables/useToast.ts
+++ b/resources/js/composables/useToast.ts
@@ -1,0 +1,103 @@
+import { toast as sonner } from 'vue-sonner';
+
+/**
+ * The single action a toast may carry. One only — when several would apply the
+ * precedence is Undo, then Retry, then View.
+ */
+export type ToastAction = {
+    /** Already-translated label, e.g. `t('Undo')`. */
+    label: string;
+    run: () => void;
+};
+
+export type ToastOptions = {
+    /**
+     * The value that was just set, rendered under the title: "Reminder set"
+     * carries "Tomorrow, 9:00 AM".
+     */
+    detail?: string;
+    action?: ToastAction;
+    /**
+     * Merge identity. A repeat under the same key replaces the toast on screen
+     * instead of queueing behind it, so ten failing uploads are one toast.
+     */
+    key?: string;
+    /** Overrides the duration policy below. Only pass one with a reason. */
+    duration?: number;
+};
+
+/** A confirmation the user does not have to act on. */
+const CONFIRMATION_MS = 4_000;
+
+/** Long enough to read the outcome and still reach for Undo, Retry or View. */
+const ACTIONABLE_MS = 7_000;
+
+/** Errors and work in progress stay up until they are dismissed or resolve. */
+const UNTIL_DISMISSED = Infinity;
+
+type ToastTone = 'success' | 'error' | 'warning' | 'progress';
+
+/**
+ * The design's vocabulary, mapped onto sonner's. `progress` is sonner's
+ * `loading`; the other three line up by name.
+ */
+const SONNER_VARIANT: Record<
+    ToastTone,
+    (message: string, options: Record<string, unknown>) => unknown
+> = {
+    success: sonner.success,
+    error: sonner.error,
+    warning: sonner.warning,
+    progress: sonner.loading,
+};
+
+/**
+ * The duration policy lives here rather than at the call sites, so a toast's
+ * lifetime follows from what it is rather than from who raised it. Tone wins
+ * over the action: an error carrying Retry is still an error, and a Retry the
+ * user never saw is worse than no Retry at all.
+ */
+function durationFor(tone: ToastTone, options: ToastOptions): number {
+    if (options.duration !== undefined) {
+        return options.duration;
+    }
+
+    if (tone === 'error' || tone === 'progress') {
+        return UNTIL_DISMISSED;
+    }
+
+    return options.action ? ACTIONABLE_MS : CONFIRMATION_MS;
+}
+
+function notify(tone: ToastTone, title: string, options: ToastOptions): void {
+    SONNER_VARIANT[tone](title, {
+        id: options.key,
+        description: options.detail,
+        duration: durationFor(tone, options),
+        action: options.action
+            ? { label: options.action.label, onClick: options.action.run }
+            : undefined,
+    });
+}
+
+/**
+ * The single entry point for every toast in the app: nothing outside
+ * `components/ui/sonner/` may reach for `vue-sonner` directly (enforced by
+ * `no-restricted-imports`, see `eslint-rules/vue-sonner-policy.test.ts`).
+ * Routing every call site through here is what gives the duration policy, the
+ * merge key and the action slot one place to live.
+ *
+ * Copy stays with the caller: titles and details arrive already translated.
+ */
+export function useToast() {
+    return {
+        success: (title: string, options: ToastOptions = {}): void =>
+            notify('success', title, options),
+        error: (title: string, options: ToastOptions = {}): void =>
+            notify('error', title, options),
+        warning: (title: string, options: ToastOptions = {}): void =>
+            notify('warning', title, options),
+        progress: (title: string, options: ToastOptions = {}): void =>
+            notify('progress', title, options),
+    };
+}

--- a/resources/js/composables/useUserMenu.ts
+++ b/resources/js/composables/useUserMenu.ts
@@ -1,7 +1,6 @@
 import { router, usePage } from '@inertiajs/vue3';
 import type { ComputedRef } from 'vue';
 import { computed } from 'vue';
-import { toast } from 'vue-sonner';
 import {
     destroy as destroyDndPause,
     update as updateDndPause,
@@ -9,6 +8,7 @@ import {
 import { update as snoozeDndSchedule } from '@/actions/App/Http/Controllers/Settings/DndScheduleSnoozeController';
 import { update as updatePresence } from '@/actions/App/Http/Controllers/Settings/PresenceController';
 import { destroy as destroyStatus } from '@/actions/App/Http/Controllers/Settings/StatusController';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatTimeOfDay } from '@/lib/datetime';
 import { isDndActiveNow, quietHoursEndsAt } from '@/lib/dnd';
@@ -48,6 +48,7 @@ export type UseUserMenuReturn = {
 export function useUserMenu(): UseUserMenuReturn {
     const page = usePage();
     const { t } = useTranslations();
+    const toast = useToast();
 
     const currentTeam = computed(() => page.props.currentTeam as Team | null);
 

--- a/resources/js/composables/useVoiceRecorder.test.ts
+++ b/resources/js/composables/useVoiceRecorder.test.ts
@@ -4,9 +4,16 @@ import type { EffectScope } from 'vue';
 
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 
-vi.mock('vue-sonner', () => ({
-    toast: { error: toastError, success: vi.fn() },
-}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 import { useVoiceRecorder } from '@/composables/useVoiceRecorder';
 import type {
@@ -235,8 +242,7 @@ describe('useVoiceRecorder', () => {
         expect(toastError).toHaveBeenCalledWith(
             'Microphone unavailable',
             expect.objectContaining({
-                description:
-                    'Allow microphone access in your browser to record a voice message.',
+                detail: 'Allow microphone access in your browser to record a voice message.',
             }),
         );
         scope.stop();

--- a/resources/js/composables/useVoiceRecorder.ts
+++ b/resources/js/composables/useVoiceRecorder.ts
@@ -1,6 +1,6 @@
 import { computed, onScopeDispose, ref } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
-import { toast } from 'vue-sonner';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import {
     VOICE_MAX_DURATION_SECONDS,
@@ -133,6 +133,7 @@ function defaultCreateLevelMeter(stream: MediaStream): VoiceLevelMeter | null {
  */
 export function useVoiceRecorder(options: VoiceRecorderOptions): VoiceRecorder {
     const { t } = useTranslations();
+    const toast = useToast();
     const requestStream = options.requestStream ?? defaultRequestStream;
     const createRecording = options.createRecording ?? defaultCreateRecording;
     const createLevelMeter =
@@ -234,7 +235,7 @@ export function useVoiceRecorder(options: VoiceRecorderOptions): VoiceRecorder {
             // Denied permission, no input device, or a hardware failure — all
             // read the same to the user, and nothing is staged either way.
             toast.error(t('Microphone unavailable'), {
-                description: t(
+                detail: t(
                     'Allow microphone access in your browser to record a voice message.',
                 ),
             });
@@ -264,7 +265,7 @@ export function useVoiceRecorder(options: VoiceRecorderOptions): VoiceRecorder {
             chunks = [];
             teardown();
             toast.error(t('Microphone unavailable'), {
-                description: t(
+                detail: t(
                     'Allow microphone access in your browser to record a voice message.',
                 ),
             });

--- a/resources/js/composables/useWebPush.ts
+++ b/resources/js/composables/useWebPush.ts
@@ -1,7 +1,7 @@
 import { usePage } from '@inertiajs/vue3';
 import { computed, onMounted, ref } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
-import { toast } from 'vue-sonner';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import {
     currentSubscription,
@@ -40,6 +40,7 @@ export interface WebPush {
 export function useWebPush(): WebPush {
     const page = usePage();
     const { t } = useTranslations();
+    const toast = useToast();
 
     const supported = ref(false);
     const subscribed = ref(false);

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -2,7 +2,6 @@
 import { router, usePage } from '@inertiajs/vue3';
 import { ChevronDown, Plus, X } from '@lucide/vue';
 import { computed, onMounted, ref } from 'vue';
-import { toast } from 'vue-sonner';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import {
     destroy as destroyReminder,
@@ -67,6 +66,7 @@ import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTimezone } from '@/composables/useTimezone';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { useUserStatusDialog } from '@/composables/useUserStatusDialog';
 import { backgroundVisit } from '@/lib/backgroundVisit';
@@ -76,6 +76,7 @@ import type { RoleOption } from '@/types/teams';
 const page = usePage();
 
 const { t } = useTranslations();
+const toast = useToast();
 
 /**
  * The same workspace shell wraps the settings/teams section, but its sidebar

--- a/resources/js/lib/flashToast.test.ts
+++ b/resources/js/lib/flashToast.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { on, success, error, warning } = vi.hoisted(() => ({
+    on: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({ router: { on } }));
+vi.mock('@/composables/useToast', () => {
+    const toast = { success, error, warning, progress: vi.fn() };
+
+    return { useToast: () => toast };
+});
+
+import { initializeFlashToast } from '@/lib/flashToast';
+
+/** Fire the `flash` event the way Inertia does, with the given payload. */
+function flash(toast: unknown): void {
+    initializeFlashToast();
+
+    const handler = on.mock.calls.at(-1)?.[1] as (event: unknown) => void;
+
+    handler({ detail: { flash: { toast } } });
+}
+
+describe('initializeFlashToast', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('raises a flashed success through the toast composable', () => {
+        flash({ type: 'success', message: 'Photo updated everywhere.' });
+
+        expect(success).toHaveBeenCalledWith('Photo updated everywhere.');
+    });
+
+    it('raises a flashed error through the toast composable', () => {
+        flash({ type: 'error', message: 'An export is already generating' });
+
+        expect(error).toHaveBeenCalledWith('An export is already generating');
+    });
+
+    it('raises a flashed warning through the toast composable', () => {
+        flash({ type: 'warning', message: 'Your seat expires tomorrow' });
+
+        expect(warning).toHaveBeenCalledWith('Your seat expires tomorrow');
+    });
+
+    it('stays quiet when the response carries no toast', () => {
+        flash(undefined);
+
+        expect(success).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        expect(warning).not.toHaveBeenCalled();
+    });
+
+    it('ignores a tone it cannot speak rather than throwing at the user', () => {
+        expect(() =>
+            flash({ type: 'info', message: 'Heads up' }),
+        ).not.toThrow();
+
+        expect(success).not.toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+        expect(warning).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/lib/flashToast.test.ts
+++ b/resources/js/lib/flashToast.test.ts
@@ -65,4 +65,11 @@ describe('initializeFlashToast', () => {
         expect(error).not.toHaveBeenCalled();
         expect(warning).not.toHaveBeenCalled();
     });
+
+    it.each(['constructor', 'toString', '__proto__'])(
+        'ignores %s rather than reaching a tone it inherited from Object',
+        (type) => {
+            expect(() => flash({ type, message: 'Heads up' })).not.toThrow();
+        },
+    );
 });

--- a/resources/js/lib/flashToast.ts
+++ b/resources/js/lib/flashToast.ts
@@ -24,6 +24,13 @@ export function initializeFlashToast(): void {
             return;
         }
 
-        tones[data.type]?.(data.message);
+        // Own-property check, not a bare lookup: `data.type` arrives over the
+        // wire, and `tones.constructor` / `tones.toString` are callable members
+        // `tones` inherits from `Object.prototype`.
+        if (!Object.hasOwn(tones, data.type)) {
+            return;
+        }
+
+        tones[data.type](data.message);
     });
 }

--- a/resources/js/lib/flashToast.ts
+++ b/resources/js/lib/flashToast.ts
@@ -1,8 +1,21 @@
 import { router } from '@inertiajs/vue3';
-import { toast } from 'vue-sonner';
+import { useToast } from '@/composables/useToast';
 import type { FlashToast } from '@/types/ui';
 
 export function initializeFlashToast(): void {
+    const toast = useToast();
+
+    /**
+     * The tones a server flash may ask for. Deliberately a lookup rather than
+     * `toast[data.type]`: the payload crosses the wire, so a tone the client
+     * cannot speak has to be ignorable rather than a call on `undefined`.
+     */
+    const tones: Record<FlashToast['type'], (message: string) => void> = {
+        success: toast.success,
+        error: toast.error,
+        warning: toast.warning,
+    };
+
     router.on('flash', (event) => {
         const flash = (event as CustomEvent).detail?.flash;
         const data = flash?.toast as FlashToast | undefined;
@@ -11,6 +24,6 @@ export function initializeFlashToast(): void {
             return;
         }
 
-        toast[data.type](data.message);
+        tones[data.type]?.(data.message);
     });
 }

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -10,7 +10,6 @@ import {
     ref,
     watch,
 } from 'vue';
-import { toast } from 'vue-sonner';
 import {
     archive as archiveChannel,
     read as markChannelRead,
@@ -57,6 +56,7 @@ import { useSendFailureAnnouncer } from '@/composables/useSendFailureAnnouncer';
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useThreadPanel } from '@/composables/useThreadPanel';
 import { useTimezone } from '@/composables/useTimezone';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { useTypingIndicator } from '@/composables/useTypingIndicator';
 import { useUnreadDivider } from '@/composables/useUnreadDivider';
@@ -149,6 +149,7 @@ const props = defineProps<{
 const page = usePage();
 
 const { t } = useTranslations();
+const toast = useToast();
 
 const currentUser = computed(() => ({
     id: String(page.props.auth.user.id),

--- a/resources/js/pages/settings/Appearance.vue
+++ b/resources/js/pages/settings/Appearance.vue
@@ -2,7 +2,6 @@
 import { Head, router, usePage } from '@inertiajs/vue3';
 import { Moon, Play } from '@lucide/vue';
 import { computed, ref, watch } from 'vue';
-import { toast } from 'vue-sonner';
 import { update as updateDndSchedule } from '@/actions/App/Http/Controllers/Settings/DndScheduleController';
 import AppearanceTabs from '@/components/AppearanceTabs.vue';
 import SettingsPane from '@/components/SettingsPane.vue';
@@ -19,6 +18,7 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { useChimes } from '@/composables/useChimes';
 import { useReadReceipts } from '@/composables/useReadReceipts';
+import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { useWebPush } from '@/composables/useWebPush';
 import { formatWallTime } from '@/lib/datetime';
@@ -73,6 +73,7 @@ const {
 
 const page = usePage();
 const { t } = useTranslations();
+const toast = useToast();
 
 /**
  * The stored quiet-hours schedule, from the viewer's own `auth.user` prop. The

--- a/resources/js/types/ui.ts
+++ b/resources/js/types/ui.ts
@@ -1,7 +1,13 @@
 export type Appearance = 'light' | 'dark' | 'system';
 export type ResolvedAppearance = 'light' | 'dark';
 
+/**
+ * A toast flashed by the server through `Inertia::flash('toast', …)`. The tones
+ * are the ones `useToast` speaks: `progress` is unreachable from a completed
+ * request, and there is no `info` tone in the design's vocabulary (nothing has
+ * ever flashed one).
+ */
 export type FlashToast = {
-    type: 'success' | 'info' | 'warning' | 'error';
+    type: 'success' | 'warning' | 'error';
     message: string;
 };


### PR DESCRIPTION
Refs #978. This is **PR1 of 3** for the toast redesign; it is the logic extraction, with zero visual change.

## Why

Every call site imported `toast` from `vue-sonner` directly — 20 modules, 54 calls — so there was nowhere to put a duration policy, a merge key or an Undo action. The redesign in PR2 needs all three.

## What

`resources/js/composables/useToast.ts` is now the single entry point, shaped around the design's vocabulary rather than sonner's:

- `success` / `error` / `warning` / `progress`, each taking `(title, options?)`.
- `options`: `detail` (the value that was just set), `action` (`{ label, run }`), `key` (merge identity), `duration` (override).
- **The duration policy lives here, not at the call sites.** A bare confirmation holds 4s; one carrying Undo/Retry/View holds 7s; an error or work in progress stays until dismissed. Tone wins over the action — an error carrying Retry is still an error, and a Retry the user never saw is worse than none.
- `key` becomes sonner's `id`, so ten failing uploads merge into one toast instead of queueing.
- Copy stays with the caller: titles and details arrive already translated.

Nothing else may import `vue-sonner`. `no-restricted-imports` names the package everywhere except `useToast.ts` (`components/ui/` is not linted at all, so `sonner/Sonner.vue` needs no entry), and `eslint-rules/vue-sonner-policy.test.ts` resolves the flat config per probe path so a typo, a stray `files` glob or someone dropping the restriction fails a test rather than passing silently.

`lib/flashToast.ts` moves off the dynamic `toast[data.type]` onto an explicit tone lookup. That dispatch is now guarded with `Object.hasOwn`: `data.type` arrives over the wire, and `tones.constructor` / `tones.toString` are callable members inherited from `Object.prototype` — `constructor` was reachable and `__proto__` threw. `FlashToast['type']` narrows to the tones the composable speaks (`info` was declared but nothing has ever flashed one).

## Testing

- New: `useToast.test.ts` (11 specs — tone routing, the full duration policy, key merge, action wiring, detail line) and `flashToast.test.ts` (8 specs, including the prototype-chain cases).
- All 12 suites that mocked `vue-sonner` re-pointed onto `@/composables/useToast`, each returning one stable object so spy assertions keep holding.
- `test:js` 1717 passed; `composer test` `Total: 100.0 %` with a clean Rector dry-run; `lint:check` / `format:check` / `types:check` / `build` green.
- **The whole browser suite passes unmodified — 310 tests, `ToastPositionTest` and `A11yShellTest` included.** That is the bar for this PR: no rendered pixel moves.

## Notes for the reviewer

- Errors now stay up until dismissed, per the policy. Between this PR and PR2 they are dismissible by swipe only; PR2 adds the close control the error variant is specified to carry.
- CodeRabbit flagged two hardcoded English toast strings in `useChannelPreferences.ts` (pre-existing — one of them *already* has a French translation in `lang/fr.json` that the code never reaches, so French users see English). Left here deliberately: PR3 is the toast copy pass and renames these keys, so fixing them here would touch the same lines twice.

No i18n keys added and no operator-facing change, so `lang/fr.json` and `docs/` are untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787780025&installation_model_id=428379&pr_number=1000&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1000&signature=e4ac01427090368b81ab21bfe3659765176a4a07c7881a0803d996e41cff1874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->