### PR TITLE
feat: focus the notification rail with F6

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -334,6 +334,7 @@
   "Failed to update the reaction": "Échec de la mise à jour de la réaction",
   "Failed to update the scheduled message": "Échec de la mise à jour du message programmé",
   "Finish": "Terminer",
+  "Focus notifications": "Aller aux notifications",
   "Forgot password": "Mot de passe oublié",
   "Forgot password?": "Mot de passe oublié ?",
   "Flip the table": "Retourner la table",

--- a/resources/js/composables/keyboardShortcuts.test.ts
+++ b/resources/js/composables/keyboardShortcuts.test.ts
@@ -201,6 +201,28 @@ describe('dispatchKeydown', () => {
         expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
+    it('fires the notification-rail shortcut on F6', () => {
+        const event = keydown({ key: 'F6' });
+        const run = vi.fn();
+
+        expect(dispatchKeydown(event, SHORTCUTS, run)).toBe(true);
+        expect(run).toHaveBeenCalledWith('focus-notifications');
+        expect(event.preventDefault).toHaveBeenCalledOnce();
+    });
+
+    it('still reaches the notification rail while typing in a field', () => {
+        // A failed send raises its toast while the composer still has focus, so
+        // a shortcut suppressed there could never reach the action it offers.
+        const event = keydown({
+            key: 'F6',
+            target: { tagName: 'TEXTAREA' } as unknown as EventTarget,
+        });
+        const run = vi.fn();
+
+        expect(dispatchKeydown(event, SHORTCUTS, run)).toBe(true);
+        expect(run).toHaveBeenCalledWith('focus-notifications');
+    });
+
     it('still fires command-key shortcuts while typing in a field', () => {
         const event = keydown({
             key: 'k',
@@ -250,7 +272,17 @@ describe('shortcutsByCategory', () => {
             'quick-switcher',
             'previous-channel',
             'next-channel',
+            'focus-notifications',
         ]);
+    });
+
+    it('lists the notification rail in the help modal, keyed on F6', () => {
+        const shortcut = SHORTCUTS.find(
+            (candidate) => candidate.id === 'focus-notifications',
+        );
+
+        expect(shortcut?.keys).toEqual(['F6']);
+        expect(shortcut?.displayOnly).toBeUndefined();
     });
 
     it('lists the composer-local edit shortcut for discoverability', () => {

--- a/resources/js/composables/keyboardShortcuts.ts
+++ b/resources/js/composables/keyboardShortcuts.ts
@@ -7,6 +7,7 @@ export type ShortcutId =
     | 'quick-switcher'
     | 'previous-channel'
     | 'next-channel'
+    | 'focus-notifications'
     | 'edit-last-message'
     | 'show-shortcuts';
 
@@ -37,6 +38,14 @@ export interface ShortcutDefinition {
      * dispatcher must not claim the bare keypress.
      */
     displayOnly?: boolean;
+    /**
+     * Whether the shortcut still fires while the user is typing in a field.
+     * Non-modifier shortcuts are otherwise suppressed there so they never hijack
+     * a keystroke mid-word — which a function key cannot do, and which F6 in
+     * particular must not be: the composer is exactly where the user is standing
+     * when a send fails, and the toast offering Retry is the thing F6 reaches.
+     */
+    firesWhileTyping?: boolean;
 }
 
 /**
@@ -69,6 +78,14 @@ export const SHORTCUTS: readonly ShortcutDefinition[] = [
         description: 'Next channel',
         keys: ['⌥', '↓'],
         match: { key: 'ArrowDown', alt: true },
+    },
+    {
+        id: 'focus-notifications',
+        category: 'Navigation',
+        description: 'Focus notifications',
+        keys: ['F6'],
+        match: { key: 'F6' },
+        firesWhileTyping: true,
     },
     {
         id: 'edit-last-message',
@@ -174,7 +191,11 @@ export function dispatchKeydown(
         return false;
     }
 
-    if (isEditableTarget(event.target) && !shortcut.match.mod) {
+    if (
+        isEditableTarget(event.target) &&
+        !shortcut.match.mod &&
+        !shortcut.firesWhileTyping
+    ) {
         return false;
     }
 

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -67,7 +67,7 @@ import { useSidebarBadges } from '@/composables/useSidebarBadges';
 import { useSidebarPosition } from '@/composables/useSidebarPosition';
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useTimezone } from '@/composables/useTimezone';
-import { useToast } from '@/composables/useToast';
+import { useToast, useToastCount } from '@/composables/useToast';
 import { useToastZoneHeight } from '@/composables/useToastZoneHeight';
 import { useTranslations } from '@/composables/useTranslations';
 import { useUserStatusDialog } from '@/composables/useUserStatusDialog';
@@ -88,6 +88,28 @@ const reminderUndo = useReminderUndo();
  * around, hence the measurement (#978).
  */
 const toastZoneHeight = useToastZoneHeight();
+
+/** How many toasts are up, so F6 only claims focus for a rail that has cards. */
+const toastCount = useToastCount();
+
+/**
+ * sonner's stock hotkey, which it keeps whenever the rail has no toasts on it.
+ * Restoring it there rather than leaving F6 bound is the point: sonner's handler
+ * focuses its list unconditionally, and an F6 that pulled the caret out of the
+ * composer into an empty corner would be worse than no shortcut at all.
+ */
+const SONNER_DEFAULT_HOTKEY = ['altKey', 'KeyT'];
+
+/**
+ * F6 is sonner's hotkey while it has something to show. Its handler expands the
+ * stack — which is what holds every dismiss timer — and focuses the list, and
+ * neither is reachable from outside the component, so the shortcut is handed
+ * over rather than reimplemented against its internals. The registry entry
+ * remains the single source of truth for what F6 does and how it is documented.
+ */
+const toasterHotkey = computed<string[]>(() =>
+    toastCount.value > 0 ? ['F6'] : SONNER_DEFAULT_HOTKEY,
+);
 
 /**
  * 16px in from the pane's right edge and 16px above its composer, per the
@@ -314,10 +336,30 @@ function moveChannel(delta: number): void {
     }
 }
 
+/**
+ * Move focus to the bottom-right rail, so a card's action is reachable before
+ * its timer runs out. The rail is one surface with two zones, and F6 goes to
+ * whichever cards are on it — but only one of the zones is ours.
+ *
+ * The toast zone belongs to sonner, and {@link toasterHotkey} hands F6 to it:
+ * its own handler expands the stack, which is what *pauses* the dismiss timers,
+ * and none of that is reachable from out here (focusing the list is not enough —
+ * sonner counts only a pointer press as interaction). So this handler owns the
+ * zone sonner knows nothing about, and takes precedence when both are occupied:
+ * the nudges are the upper zone and the persistent cards, and sonner's handler
+ * has already run by the time this one does.
+ */
+function focusNotificationRail(): void {
+    document
+        .querySelector<HTMLElement>('[data-test="reminder-nudges"]')
+        ?.focus();
+}
+
 useKeyboardShortcuts({
     'quick-switcher': () => toggleQuickSwitcher(),
     'previous-channel': () => moveChannel(-1),
     'next-channel': () => moveChannel(1),
+    'focus-notifications': () => focusNotificationRail(),
     'show-shortcuts': () => toggleShortcuts(),
 });
 
@@ -675,6 +717,9 @@ onMounted(() => {
         <div
             v-if="firedReminders.length > 0"
             data-test="reminder-nudges"
+            role="region"
+            :aria-label="$t('Reminders')"
+            tabindex="-1"
             class="pointer-events-none fixed z-50 flex flex-col gap-2.5"
             :style="{
                 right: 'calc(1rem + var(--rail-right-inset, 0px))',
@@ -701,6 +746,10 @@ onMounted(() => {
 
         <OnboardingTour />
 
-        <Toaster :offset="toastOffset" :mobile-offset="toastMobileOffset" />
+        <Toaster
+            :offset="toastOffset"
+            :mobile-offset="toastMobileOffset"
+            :hotkey="toasterHotkey"
+        />
     </SidebarProvider>
 </template>

--- a/tests/Browser/NotificationRailFocusTest.php
+++ b/tests/Browser/NotificationRailFocusTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Message;
+use App\Models\MessageReminder;
+use App\Models\User;
+
+// A toast's action has to be reachable before its timer runs out, and reaching
+// for the mouse is not a way to reach it. F6 takes focus to the bottom-right
+// rail — to whichever cards are on it, since the rail is one surface shared by
+// the toasts and the reminder nudges (#979).
+
+/**
+ * Press F6 on whatever holds focus, so it bubbles the way a real keystroke does
+ * — past sonner's listener on `document` and on to the app's own on `window`.
+ * `code` as well as `key`, since the two listeners read different fields.
+ */
+function browserPressF6(): string
+{
+    return <<<'JS'
+    () => {
+        (document.activeElement ?? document.body).dispatchEvent(
+            new KeyboardEvent('keydown', {
+                key: 'F6',
+                code: 'F6',
+                bubbles: true,
+            }),
+        );
+    }
+    JS;
+}
+
+/** The `data-test` of whatever currently holds focus, or the empty string. */
+function browserFocusedTestId(): string
+{
+    return <<<'JS'
+    (() => document.activeElement?.closest('[data-test]')?.dataset.test ?? '')()
+    JS;
+}
+
+test('F6 focuses the toast region and holds its timer there', function (): void {
+    $alice = User::factory()->create();
+
+    // Saving the profile flashes a success toast from the server, which is the
+    // plainest way to get a real one on the rail.
+    $page = signInThroughBrowser($alice)
+        ->navigate('/settings/profile')
+        ->assertSee('Profile')
+        ->click('[data-test="update-profile-button"]')
+        ->assertPresent('[data-test=toast]');
+
+    $page->script(browserPressF6());
+
+    // Asserted in one read: sonner's list takes the focus, and the drain holds
+    // where it is. The drain is driven by the same expansion that pauses the
+    // dismiss timer, so a toast reached this way waits to be acted on. Both are
+    // read at once because a retry loop here outlives the toast it is asking
+    // about.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const focused = document.activeElement?.hasAttribute('data-sonner-toaster') ?? false;
+        const drain = document.querySelector('[data-test=toast-drain] > span');
+
+        return `${focused}|${drain?.style.animationPlayState ?? 'missing'}`;
+    })()
+    JS, 'true|paused');
+});
+
+test('F6 leaves focus alone when the rail is empty', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->assertPresent('@message-composer-input')
+        ->click('@message-composer-input')
+        ->type('@message-composer-input', 'still typing');
+
+    $page->script(browserPressF6());
+
+    // Nothing is on the rail, so the composer keeps the caret rather than
+    // losing it to an empty corner.
+    $page->assertScript(browserFocusedTestId(), 'message-composer-input');
+});
+
+test('F6 goes to the reminder nudges when one is on the rail', function (): void {
+    ['owner' => $alice, 'channel' => $channel] = browserTeamWithChannel();
+
+    $message = Message::factory()->for($channel)->for($alice, 'user')->create([
+        'body' => 'The message being reminded about',
+    ]);
+    MessageReminder::factory()->fired()->create([
+        'user_id' => $alice->id,
+        'message_id' => $message->id,
+        'remind_at' => now()->subMinute(),
+    ]);
+
+    $page = signInThroughBrowser($alice)
+        ->assertPresent('[data-test=reminder-nudges]');
+
+    // From inside the composer: a shortcut suppressed while typing could never
+    // reach a card raised by the send the user just made.
+    $page->click('@message-composer-input')
+        ->type('@message-composer-input', 'mid-sentence')
+        ->script(browserPressF6());
+
+    $page->assertScript(browserFocusedTestId(), 'reminder-nudges');
+
+    // A named region, so landing there announces what it is rather than
+    // dropping a screen-reader user into an unlabelled box — and a name on a
+    // role that can carry one, which a bare div could not.
+    //
+    // An axe audit belongs here too, but the nudge card already carries a
+    // serious contrast failure of its own (#1009) and would fail it on arrival.
+    $page->assertAttribute('[data-test=reminder-nudges]', 'role', 'region')
+        ->assertAttribute('[data-test=reminder-nudges]', 'aria-label', 'Reminders');
+});


### PR DESCRIPTION
Item 4 of #979, the last of the three. Item 1 is #1007, item 2 is #1008; item 3 was split out to #1006.

## What

A toast's action has to be reachable before its timer runs out, and reaching for the mouse is not a way to reach it. F6 now takes focus to the bottom-right rail.

The rail is one surface with two zones — the toasts at the foot, the reminder nudges above — and only one of them is ours, which shapes the implementation:

- **The toast zone is sonner's.** Its own hotkey handler expands the stack *and* focuses the list, and the expansion is what holds every dismiss timer. Focus alone does not do it: sonner counts only a pointer press as interaction (`interacting` is set in `onPointerDown`, nowhere else), so focusing the list from outside would look right and drain anyway. So F6 is handed to sonner rather than reimplemented against its internals — but only while it has toasts up, since its handler focuses the list unconditionally and an F6 that pulled the caret out of the composer into an empty corner would be worse than no shortcut.
- **The nudge zone is ours.** It becomes a named `role="region"` with `tabindex="-1"`, and the registry's handler focuses it. It takes precedence when both zones are occupied: it is the upper zone and holds the persistent cards, and sonner's `document` listener has already run by the time the app's `window` one does.

`SHORTCUTS` stays the single source of truth: `focus-notifications` is a real entry, so it appears in the shortcuts modal, translated, and the registry's tests cover it.

### F6 fires while typing

`dispatchKeydown` suppresses non-modifier shortcuts inside a field so they never hijack a keystroke mid-word. A function key cannot, and F6 in particular must not be suppressed: the composer is exactly where the user is standing when a send fails, and the toast offering Retry is the thing F6 is for. Hence the new opt-in `firesWhileTyping` on a shortcut definition — opt-in rather than derived, so no existing shortcut's behaviour moves.

## Found on the way

`ReminderNudge.vue`'s muted text misses the contrast floor (4.43:1, serious). It is pre-existing and unrelated, so it is filed as #1009 rather than fixed here — but it is why this PR's browser test asserts the region's role and name directly instead of running a full axe audit, which would fail on arrival. #1009 asks for the audit to be added back with the fix.

## Testing

- `keyboardShortcuts.test.ts`: F6 dispatches `focus-notifications`, still fires from inside a text field, and appears in the help modal's Navigation group keyed on `F6`.
- `tests/Browser/NotificationRailFocusTest.php`: F6 focuses sonner's list and holds the drain where it is; F6 leaves the caret in the composer when the rail is empty; and F6 goes to the nudges, from inside the composer, when one is up — with the region's role and accessible name pinned.
- Full gate green: `composer test` at `Total: 100.0 %` with a clean Rector dry-run, plus `lint:check`, `format:check`, `types:check`, `test:js` and `build`. `ToastPositionTest` and `A11yShellTest` still pass unmodified.

## i18n

`Focus notifications` added with its French translation. `Reminders` already existed.

No operator-facing change, so no docs update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787827549&installation_model_id=428379&pr_number=1010&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1010&signature=f249ce2317daa02f7df8fe6b3e0528f499ed03a113e9696de7e1e5da20e359c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->