### PR TITLE
feat: raise the composer tray and banner controls to 44pt on touch

### DIFF
--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1453,7 +1453,7 @@ function onKeydown(event: KeyboardEvent): void {
             <div
                 v-if="props.replyTarget"
                 data-test="reply-preview"
-                class="mb-2 flex items-center gap-2 rounded-2xl border border-input bg-muted/40 px-3.5 py-2"
+                class="mb-2 flex items-center gap-2 rounded-2xl border border-input bg-muted/40 px-3.5 py-2 max-md:py-1"
             >
                 <span class="min-w-0 flex-1">
                     <MessageQuote
@@ -1468,10 +1468,10 @@ function onKeydown(event: KeyboardEvent): void {
                     type="button"
                     data-test="reply-preview-dismiss"
                     :aria-label="$t('Cancel reply')"
-                    class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    class="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground max-md:size-11"
                     @click="emit('cancelReply')"
                 >
-                    <X class="size-3.5" />
+                    <X class="size-3.5 max-md:size-4.5" />
                 </Button>
             </div>
 
@@ -1481,7 +1481,7 @@ function onKeydown(event: KeyboardEvent): void {
             <div
                 v-if="editingMessage"
                 data-test="composer-editing-banner"
-                class="mb-2 flex items-center gap-2 rounded-2xl border border-brass-border bg-brass-fill px-3.5 py-2"
+                class="mb-2 flex items-center gap-2 rounded-2xl border border-brass-border bg-brass-fill px-3.5 py-2 max-md:py-1"
             >
                 <Pencil class="size-3.5 shrink-0 text-brass" />
                 <span
@@ -1498,10 +1498,10 @@ function onKeydown(event: KeyboardEvent): void {
                     type="button"
                     data-test="composer-editing-dismiss"
                     :aria-label="$t('Cancel edit')"
-                    class="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    class="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground max-md:size-11"
                     @click="exitEditMode"
                 >
-                    <X class="size-3.5" />
+                    <X class="size-3.5 max-md:size-4.5" />
                 </Button>
             </div>
 
@@ -1523,7 +1523,13 @@ function onKeydown(event: KeyboardEvent): void {
             >
                 <!-- Pre-send attachment tray. Row order is the send order
                      (attachment_ids[]). Removing a row is immediate — the upload
-                     is pre-send, so there is nothing to undo. -->
+                     is pre-send, so there is nothing to undo.
+
+                     Every remove control here is hover-revealed from `md` up and
+                     always visible below it: there is no hover on a touch
+                     screen, so a phone had no way at all to drop a staged file
+                     (#920). Each one also carries a 44pt hit box below `md`,
+                     which the three chip shapes reach differently — see each. -->
                 <div
                     v-if="showTray"
                     data-test="composer-attachment-tray"
@@ -1535,6 +1541,7 @@ function onKeydown(event: KeyboardEvent): void {
                         <div
                             v-if="item.status === 'failed'"
                             data-test="composer-attachment"
+                            data-kind="failed"
                             data-status="failed"
                             class="relative flex h-19 min-w-50 items-center gap-2.5 rounded-xl border border-destructive/40 bg-destructive/10 px-3"
                         >
@@ -1569,19 +1576,26 @@ function onKeydown(event: KeyboardEvent): void {
                                 type="button"
                                 data-test="composer-attachment-remove"
                                 :aria-label="$t('Remove attachment')"
-                                class="shrink-0 rounded-full p-1 text-muted-foreground hover:text-foreground"
+                                class="flex shrink-0 items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11"
                                 @click="uploads.remove(item.localId)"
                             >
-                                <X class="size-3" />
+                                <X class="size-3 max-md:size-4.5" />
                             </Button>
                         </div>
 
-                        <!-- Image preview thumbnail (never SVG). -->
+                        <!-- Image preview thumbnail (never SVG). The remove
+                             control is the one chip that cannot spend 44pt on a
+                             visible button: it would bury the picture it belongs
+                             to. Below `md` the thumbnail grows instead and the
+                             painted badge keeps its corner while its hit box
+                             reaches back over the thumbnail, which has no
+                             competing tap target of its own. -->
                         <div
                             v-else-if="item.isImage"
                             data-test="composer-attachment"
+                            data-kind="image"
                             :data-status="item.status"
-                            class="group relative size-19 overflow-hidden rounded-xl border border-input bg-muted"
+                            class="group relative size-19 overflow-hidden rounded-xl border border-input bg-muted max-md:size-25"
                         >
                             <img
                                 v-if="item.previewUrl"
@@ -1608,10 +1622,15 @@ function onKeydown(event: KeyboardEvent): void {
                                 type="button"
                                 data-test="composer-attachment-remove"
                                 :aria-label="$t('Remove attachment')"
-                                class="absolute top-1 right-1 flex size-5.5 items-center justify-center rounded-full bg-foreground/80 text-background opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
+                                class="absolute top-1 right-1 flex items-center justify-center max-md:top-0 max-md:right-0 max-md:size-11 max-md:items-start max-md:justify-end max-md:p-1 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
                                 @click="uploads.remove(item.localId)"
                             >
-                                <X class="size-2.75" />
+                                <span
+                                    data-test="composer-attachment-remove-badge"
+                                    class="flex size-5.5 items-center justify-center rounded-full bg-foreground/80 text-background"
+                                >
+                                    <X class="size-2.75" />
+                                </span>
                             </Button>
                         </div>
 
@@ -1622,33 +1641,43 @@ function onKeydown(event: KeyboardEvent): void {
                         <div
                             v-else-if="item.isAudio && item.previewUrl"
                             data-test="composer-attachment"
+                            data-kind="audio"
                             :data-status="item.status"
-                            class="group relative"
+                            class="group relative flex items-center max-md:gap-1"
                         >
-                            <AudioPlayer
-                                :src="item.previewUrl"
-                                :filename="item.name"
-                                compact
-                            />
-                            <div
-                                v-if="item.status === 'uploading'"
-                                class="absolute inset-x-3 bottom-1.5 h-0.75 overflow-hidden rounded-full bg-border"
-                            >
+                            <!-- The player and its progress bar share a box of
+                                 their own so the bar keeps tracking the player
+                                 once the remove button takes a column beside
+                                 it below `md`. -->
+                            <div class="relative">
+                                <AudioPlayer
+                                    :src="item.previewUrl"
+                                    :filename="item.name"
+                                    compact
+                                />
                                 <div
-                                    class="h-full rounded-full bg-brass"
-                                    :style="{ width: `${item.progress}%` }"
-                                ></div>
+                                    v-if="item.status === 'uploading'"
+                                    class="absolute inset-x-3 bottom-1.5 h-0.75 overflow-hidden rounded-full bg-border"
+                                >
+                                    <div
+                                        class="h-full rounded-full bg-brass"
+                                        :style="{ width: `${item.progress}%` }"
+                                    ></div>
+                                </div>
                             </div>
+                            <!-- A 44pt overlay would sit on the right end of the
+                                 scrubber, so below `md` this one leaves the
+                                 corner and takes a column of its own. -->
                             <Button
                                 variant="unstyled"
                                 size="none"
                                 type="button"
                                 data-test="composer-attachment-remove"
                                 :aria-label="$t('Remove attachment')"
-                                class="absolute top-1.5 right-1.5 rounded-full p-1 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus:opacity-100"
+                                class="flex items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11 max-md:shrink-0 md:absolute md:top-1.5 md:right-1.5 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
                                 @click="uploads.remove(item.localId)"
                             >
-                                <X class="size-3" />
+                                <X class="size-3 max-md:size-4.5" />
                             </Button>
                         </div>
 
@@ -1656,6 +1685,7 @@ function onKeydown(event: KeyboardEvent): void {
                         <div
                             v-else
                             data-test="composer-attachment"
+                            data-kind="file"
                             :data-status="item.status"
                             class="group relative flex h-19 min-w-52 items-center gap-2.5 rounded-xl border border-input bg-muted px-3"
                         >
@@ -1696,10 +1726,10 @@ function onKeydown(event: KeyboardEvent): void {
                                 type="button"
                                 data-test="composer-attachment-remove"
                                 :aria-label="$t('Remove attachment')"
-                                class="shrink-0 rounded-full p-1 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:text-foreground focus:opacity-100"
+                                class="flex shrink-0 items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
                                 @click="uploads.remove(item.localId)"
                             >
-                                <X class="size-3" />
+                                <X class="size-3 max-md:size-4.5" />
                             </Button>
                         </div>
                     </template>
@@ -1995,15 +2025,20 @@ function onKeydown(event: KeyboardEvent): void {
                 </div>
             </div>
 
+            <!-- The 14px box is far too small to aim at on a phone, but growing
+                 it would make a checkbox the loudest thing under the composer.
+                 The label already wraps the text, so below `md` the whole row
+                 becomes the target instead and the box is left alone (#920). -->
             <label
                 v-if="props.allowSendToChannel && !editingMessage"
-                class="mt-2 flex w-fit cursor-pointer items-center gap-1.5 px-1.5 text-[12px] text-muted-foreground select-none"
+                data-test="send-to-channel-row"
+                class="mt-2 flex w-full cursor-pointer items-center gap-1.5 px-1.5 text-[12px] text-muted-foreground select-none max-md:min-h-11 md:w-fit"
             >
                 <input
                     v-model="sendToChannel"
                     type="checkbox"
                     data-test="send-to-channel"
-                    class="size-3.5 rounded border-input accent-primary"
+                    class="size-3.5 shrink-0 rounded border-input accent-primary"
                 />
                 {{
                     $t('Also send to #:channel', { channel: props.channelName })

--- a/tests/Browser/Helpers.php
+++ b/tests/Browser/Helpers.php
@@ -110,6 +110,39 @@ function browserChannelUrl(Team $team, Channel $channel): string
 }
 
 /**
+ * Press and hold a message row: pointer down, wait out the 500ms hold, lift.
+ *
+ * Synthesised as touch on purpose — the gesture is the touch stand-in for
+ * hover. The hold happens between two script calls so the browser's own clock
+ * drives the composable's timer.
+ */
+function longPressMessage(AwaitableWebpage $page, string $messageId): AwaitableWebpage
+{
+    $press = fn (string $type): string => <<<JS
+    (() => {
+        const row = document.getElementById('message-{$messageId}');
+        const box = row.getBoundingClientRect();
+
+        row.dispatchEvent(new PointerEvent('{$type}', {
+            pointerId: 1,
+            pointerType: 'touch',
+            isPrimary: true,
+            bubbles: true,
+            cancelable: true,
+            clientX: Math.round(box.x + 40),
+            clientY: Math.round(box.y + 8),
+        }));
+    })()
+    JS;
+
+    $page->script($press('pointerdown'));
+    $page = $page->wait(0.7);
+    $page->script($press('pointerup'));
+
+    return $page;
+}
+
+/**
  * Open the create-channel dialog at the given viewport. It is the plainest of
  * the form dialogs — a header, three fields and a pair of actions — so it stands
  * in for the whole set that shares the primitive.

--- a/tests/Browser/MobileComposerTrayTest.php
+++ b/tests/Browser/MobileComposerTrayTest.php
@@ -1,0 +1,436 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Channel;
+use App\Models\Message;
+use App\Models\User;
+use Pest\Browser\Api\AwaitableWebpage;
+
+/**
+ * The composer's tray and banner controls below `md` (#920).
+ *
+ * #889 raised the control row and the recording strip to the 44pt touch
+ * minimum; everything the composer stacks around the input was left at its
+ * desktop size. The attachment chips were worse than small: their remove button
+ * was revealed by `group-hover`, a state a touch screen cannot enter, so a
+ * staged file could not be dropped on a phone at all.
+ *
+ * Below `md` each chip therefore carries an always-visible remove control with a
+ * 44x44 hit box. The three chip shapes cannot take the same one: the file and
+ * failed chips are roomy rows whose existing right-hand button simply grows, the
+ * audio chip gives its button a column of its own (a 44px overlay would sit on
+ * the scrubber's right end), and the image chip keeps a small corner badge whose
+ * hit box reaches back into the thumbnail — the thumbnail has no competing tap
+ * target, and a 44pt *visible* button would bury the picture it belongs to.
+ *
+ * From `md` up every one of them is what it was: hover-revealed, desktop-sized.
+ */
+
+/**
+ * A JS expression building an image `File` the browser can preview and the
+ * server can thumbnail — painted on a canvas so the bytes are a genuine PNG.
+ */
+const IMAGE_FILE = <<<'JS'
+(async () => {
+    const canvas = Object.assign(document.createElement('canvas'), { width: 1200, height: 800 });
+    const context = canvas.getContext('2d');
+    context.fillStyle = '#8a6a3b';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+
+    return new File([blob], 'venue.png', { type: 'image/png' });
+})()
+JS;
+
+/** A JS expression building a short, genuinely decodable 8kHz mono WAV. */
+const AUDIO_FILE = <<<'JS'
+(() => {
+    const samples = 800;
+    const view = new DataView(new ArrayBuffer(44 + samples));
+    const ascii = (offset, text) => [...text].forEach((c, i) => view.setUint8(offset + i, c.charCodeAt(0)));
+
+    ascii(0, 'RIFF');
+    view.setUint32(4, 36 + samples, true);
+    ascii(8, 'WAVEfmt ');
+    view.setUint32(16, 16, true);
+    view.setUint16(20, 1, true);
+    view.setUint16(22, 1, true);
+    view.setUint32(24, 8000, true);
+    view.setUint32(28, 8000, true);
+    view.setUint16(32, 1, true);
+    view.setUint16(34, 8, true);
+    ascii(36, 'data');
+    view.setUint32(40, samples, true);
+
+    for (let i = 0; i < samples; i++) {
+        view.setUint8(44 + i, 128 + Math.round(120 * Math.sin(i / 6)));
+    }
+
+    return new File([view.buffer], 'standup.wav', { type: 'audio/wav' });
+})()
+JS;
+
+/** A JS expression building a plain non-image, non-audio document. */
+const DOCUMENT_FILE = <<<'JS'
+new File(['%PDF-1.4 offsite quote'], 'quote.pdf', { type: 'application/pdf' })
+JS;
+
+/**
+ * Stage a file through the composer's real file input and settle its chip.
+ *
+ * The file is handed to the input through a `DataTransfer` rather than
+ * Playwright's `setInputFiles`, which only offers the driver a local path and is
+ * refused outright by the shared Playwright server the plugin connects to. What
+ * follows is the real thing either way: the composer's own change handler runs,
+ * and the pre-upload is a genuine `multipart/form-data` round trip to the
+ * in-process server — so these chips are the ones a user gets rather than
+ * fixtures painted into the DOM.
+ */
+function stageAttachment(AwaitableWebpage $page, string $fileExpression, int $expectedChips, string $status = 'done'): AwaitableWebpage
+{
+    return $page->assertScript(<<<JS
+    (async () => {
+        const transfer = new DataTransfer();
+        transfer.items.add(await ({$fileExpression}));
+
+        const input = document.querySelector('[data-test=composer-file-input]');
+        input.files = transfer.files;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+
+        const settled = () => document.querySelectorAll(
+            '[data-test=composer-attachment][data-status={$status}]',
+        ).length === {$expectedChips};
+
+        for (let frame = 0; frame < 600 && ! settled(); frame++) {
+            await new Promise(requestAnimationFrame);
+        }
+
+        return settled();
+    })()
+    JS, true);
+}
+
+/**
+ * The shared #general with a rooted thread, so the thread panel — the one
+ * composer that offers the send-to-channel control — has something to open.
+ *
+ * @return array{owner: User, channel: Channel, root: Message}
+ */
+function trayThreadChannel(): array
+{
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $root = Message::factory()->for($channel)->for($alice)->create([
+        'body' => 'Thread root for the tray suite',
+        'created_at' => now()->subMinutes(20),
+    ]);
+
+    Message::factory()->for($channel)->inThread($root)->create([
+        'user_id' => $bob->id,
+        'body' => 'A reply so the summary renders',
+        'created_at' => now()->subMinutes(19),
+    ]);
+
+    $root->forceFill(['reply_count' => 1, 'last_reply_at' => now()->subMinutes(19)])->save();
+
+    return ['owner' => $alice, 'channel' => $channel, 'root' => $root];
+}
+
+/**
+ * Whether a control really answers a tap across its whole measured box, defined
+ * once and spliced into the measuring scripts below.
+ *
+ * The probes are the box's four edge midpoints and its centre rather than its
+ * corners: a rounded control does not hit-test its own corners (a `rounded-full`
+ * 44px button is a circle, and its corner pixels belong to whatever is behind
+ * it), so corners would report every one of these as covered. The midpoints
+ * still span the full width and height, which is the claim worth making.
+ */
+const REACHES_ACROSS_ITS_BOX = <<<'JS'
+(element, box) => [
+    [box.left + box.width / 2, box.top + box.height / 2],
+    [box.left + 1, box.top + box.height / 2],
+    [box.right - 1, box.top + box.height / 2],
+    [box.left + box.width / 2, box.top + 1],
+    [box.left + box.width / 2, box.bottom - 1],
+].every(([x, y]) => element.contains(document.elementFromPoint(x, y)))
+JS;
+
+/**
+ * Measure every remove control in the tray, keyed by the chip kind it belongs
+ * to: its hit box, whether it is visible without a hover, and whether it is
+ * really the topmost element across that box.
+ */
+function measureRemoveTargets(): string
+{
+    $reaches = REACHES_ACROSS_ITS_BOX;
+
+    return <<<JS
+    (() => {
+        const reaches = {$reaches};
+
+        return Object.fromEntries([...document.querySelectorAll('[data-test=composer-attachment]')].map((chip) => {
+            const button = chip.querySelector('[data-test=composer-attachment-remove]');
+            const box = button.getBoundingClientRect();
+
+            return [chip.dataset.kind, {
+                width: Math.round(box.width),
+                height: Math.round(box.height),
+                opacity: getComputedStyle(button).opacity,
+                hittable: reaches(button, box),
+            }];
+        }));
+    })()
+    JS;
+}
+
+/**
+ * A script asserting one banner's dismiss button clears 44x44 and is topmost
+ * across that box.
+ */
+function dismissClearsTouchMinimum(string $test): string
+{
+    $reaches = REACHES_ACROSS_ITS_BOX;
+
+    return <<<JS
+    (() => {
+        const button = document.querySelector('[data-test={$test}]');
+        const box = button.getBoundingClientRect();
+
+        return box.width >= 44 && box.height >= 44 && ({$reaches})(button, box);
+    })()
+    JS;
+}
+
+test('below md a staged image is removed by touch with no hover in the way', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertPresent('@message-composer-input');
+
+    $page = stageAttachment($page, IMAGE_FILE, 1);
+
+    // Nothing has been hovered — the mouse has not moved since the page opened —
+    // and the control is already at full opacity and hit-testable end to end.
+    $measurements = $page->script(measureRemoveTargets());
+
+    expect($measurements['image']['opacity'])->toBe('1')
+        ->and($measurements['image']['width'])->toBeGreaterThanOrEqual(44)
+        ->and($measurements['image']['height'])->toBeGreaterThanOrEqual(44)
+        ->and($measurements['image']['hittable'])->toBeTrue();
+
+    // What the user sees stays a badge: the thumbnail grows on a phone and the
+    // painted disc takes a corner of it, not the picture.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const chip = document.querySelector('[data-test=composer-attachment][data-kind=image]');
+        const thumb = chip.getBoundingClientRect();
+        const badge = chip.querySelector('[data-test=composer-attachment-remove-badge]').getBoundingClientRect();
+
+        return thumb.width >= 96
+            && badge.width <= 28
+            && badge.width * badge.height <= thumb.width * thumb.height / 8;
+    })()
+    JS, true);
+
+    $page->click('@composer-attachment-remove')
+        ->assertNotPresent('@composer-attachment');
+});
+
+test('below md every tray chip carries a 44pt remove target', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertPresent('@message-composer-input');
+
+    $page = stageAttachment($page, IMAGE_FILE, 1);
+    $page = stageAttachment($page, AUDIO_FILE, 2);
+    $page = stageAttachment($page, DOCUMENT_FILE, 3);
+
+    $measurements = $page->script(measureRemoveTargets());
+
+    expect(array_keys($measurements))->toEqualCanonicalizing(['image', 'audio', 'file']);
+
+    foreach ($measurements as $kind => $target) {
+        expect($target['opacity'])->toBe('1', "the {$kind} chip's remove button is hover-revealed")
+            ->and($target['width'])->toBeGreaterThanOrEqual(44, "the {$kind} chip's remove button is too narrow")
+            ->and($target['height'])->toBeGreaterThanOrEqual(44, "the {$kind} chip's remove button is too short")
+            ->and($target['hittable'])->toBeTrue("the {$kind} chip's remove button is covered");
+    }
+
+    // The audio chip's button took a column of its own rather than an overlay,
+    // so the scrubber it used to sit on is clear of it.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const chip = document.querySelector('[data-test=composer-attachment][data-kind=audio]');
+        const button = chip.querySelector('[data-test=composer-attachment-remove]').getBoundingClientRect();
+        const scrubber = chip.querySelector('[data-test=audio-player-scrubber]').getBoundingClientRect();
+
+        return button.left >= scrubber.right;
+    })()
+    JS, true);
+
+    // The tray still fits the phone: nothing runs off its right edge.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const tray = document.querySelector('[data-test=composer-attachment-tray]').getBoundingClientRect();
+
+        return [...document.querySelectorAll('[data-test=composer-attachment]')]
+            .every((chip) => chip.getBoundingClientRect().right <= tray.right + 1);
+    })()
+    JS, true);
+});
+
+test('below md the staged tray passes the axe audit in either theme', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertPresent('@message-composer-input');
+
+    $page = stageAttachment($page, IMAGE_FILE, 1);
+    $page = stageAttachment($page, AUDIO_FILE, 2);
+    $page = stageAttachment($page, DOCUMENT_FILE, 3);
+
+    // The badge that is now painted on every chip is new contrast on the phone:
+    // desktop only ever showed it under a hover, where no audit reached it.
+    $page->assertNoAccessibilityIssues();
+
+    switchToDarkTheme($page)->assertNoAccessibilityIssues();
+});
+
+test('below md an upload that failed can still be dropped at 44pt', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertPresent('@message-composer-input');
+
+    // Send the pre-upload somewhere unreachable so it fails as a transport
+    // error rather than a validation rejection: a 422 is definitive and drops
+    // the row, while this leaves the retryable failed chip the test is after.
+    $page->script(<<<'JS'
+    (() => {
+        const open = XMLHttpRequest.prototype.open;
+
+        XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+            const target = String(url).includes('/attachments') ? 'http://127.0.0.1:1/dropped' : url;
+
+            return open.call(this, method, target, ...rest);
+        };
+    })()
+    JS);
+
+    $page = stageAttachment($page, DOCUMENT_FILE, 1, 'failed');
+
+    $measurements = $page->script(measureRemoveTargets());
+
+    expect($measurements['failed']['width'])->toBeGreaterThanOrEqual(44)
+        ->and($measurements['failed']['height'])->toBeGreaterThanOrEqual(44)
+        ->and($measurements['failed']['hittable'])->toBeTrue();
+
+    $page->click('@composer-attachment-remove')
+        ->assertNotPresent('@composer-attachment');
+});
+
+test('below md the reply and edit banners dismiss at 44pt', function (): void {
+    ['owner' => $alice, 'member' => $bob, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $message = Message::factory()->for($channel)->for($alice)->create([
+        'body' => 'Roomy rows can just grow.',
+    ]);
+
+    $page = signInThroughBrowser($bob)
+        ->resize(390, 844)
+        ->navigate(browserChannelUrl($team, $channel))
+        ->assertPresent("#message-{$message->id}");
+
+    longPressMessage($page, $message->id)
+        ->click('@sheet-reply')
+        ->assertPresent('@reply-preview')
+        // The sheet that set the reply target is still painted over the composer
+        // for the length of its close, and it would answer the hit test below.
+        ->assertNotPresent('@message-actions-sheet')
+        ->assertScript(dismissClearsTouchMinimum('reply-preview-dismiss'), true);
+
+    $page->click('@reply-preview-dismiss')
+        ->assertNotPresent('@reply-preview');
+
+    // The editing banner is the same row shape, so it takes the same target.
+    $page
+        ->type('@message-composer-input', 'Draft to correct')
+        ->click('@message-composer-send')
+        ->assertSee('Draft to correct')
+        ->click('@message-composer-input')
+        ->keys('@message-composer-input', ['ArrowUp'])
+        ->assertPresent('@composer-editing-banner')
+        ->assertScript(dismissClearsTouchMinimum('composer-editing-dismiss'), true);
+});
+
+test('below md the send-to-channel row is toggled anywhere along it', function (): void {
+    ['owner' => $alice] = trayThreadChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->assertSee('Thread root for the tray suite');
+
+    $page->click('[data-test=thread-summary]')
+        ->assertPresent('@send-to-channel-row');
+
+    // The whole row is the target: full width, 44pt tall, and topmost at its far
+    // end, where nothing but the label's own padding reaches.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const row = document.querySelector('[data-test=send-to-channel-row]');
+        const box = row.getBoundingClientRect();
+        const parent = row.parentElement.getBoundingClientRect();
+        const farEnd = document.elementFromPoint(box.right - 2, box.top + box.height / 2);
+
+        return box.height >= 44 && box.width >= parent.width - 1 && row.contains(farEnd);
+    })()
+    JS, true);
+
+    // The box itself is left alone: the row grew, the checkbox did not.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const box = document.querySelector('[data-test=send-to-channel]').getBoundingClientRect();
+
+        return Math.round(box.width) === 14 && Math.round(box.height) === 14;
+    })()
+    JS, true);
+
+    $page->click('@send-to-channel-row')
+        ->assertChecked('@send-to-channel');
+});
+
+test('from md up the tray keeps its hover-revealed desktop buttons', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->resize(1280, 900)
+        ->assertPresent('@message-composer-input');
+
+    $page = stageAttachment($page, IMAGE_FILE, 1);
+
+    // Untouched desktop behaviour: a 76px thumbnail whose remove badge stays
+    // invisible until the chip is hovered.
+    $page->assertScript(<<<'JS'
+    (() => {
+        const chip = document.querySelector('[data-test=composer-attachment][data-kind=image]');
+        const button = chip.querySelector('[data-test=composer-attachment-remove]');
+
+        return Math.round(chip.getBoundingClientRect().width) === 76
+            && getComputedStyle(button).opacity === '0';
+    })()
+    JS, true);
+
+    $page->hover('@composer-attachment')
+        ->assertScript(<<<'JS'
+        (() => getComputedStyle(
+            document.querySelector('[data-test=composer-attachment-remove]'),
+        ).opacity === '1')()
+        JS, true);
+});

--- a/tests/Browser/MobileMessageActionsSheetTest.php
+++ b/tests/Browser/MobileMessageActionsSheetTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use App\Enums\AppLocale;
 use App\Models\Message;
-use Pest\Browser\Api\AwaitableWebpage;
 
 /**
  * Long-press message actions below the `md` breakpoint (#774).
@@ -13,41 +12,10 @@ use Pest\Browser\Api\AwaitableWebpage;
  * a phone. Long-pressing a message lifts it onto a scrim and opens a bottom
  * sheet carrying the same actions, gated by the same guards — nothing the
  * toolbar hides may appear in the sheet.
- */
-
-/**
- * Press and hold a message row: pointer down, wait out the 500ms hold, lift.
  *
- * Synthesised as touch on purpose — the gesture is the touch stand-in for
- * hover. The hold happens between two script calls so the browser's own clock
- * drives the composable's timer.
+ * The gesture itself lives in `Helpers.php` as `longPressMessage()`: the mobile
+ * composer suite needs it too, to reach a reply target on a phone (#920).
  */
-function longPressMessage(AwaitableWebpage $page, string $messageId): AwaitableWebpage
-{
-    $press = fn (string $type): string => <<<JS
-    (() => {
-        const row = document.getElementById('message-{$messageId}');
-        const box = row.getBoundingClientRect();
-
-        row.dispatchEvent(new PointerEvent('{$type}', {
-            pointerId: 1,
-            pointerType: 'touch',
-            isPrimary: true,
-            bubbles: true,
-            cancelable: true,
-            clientX: Math.round(box.x + 40),
-            clientY: Math.round(box.y + 8),
-        }));
-    })()
-    JS;
-
-    $page->script($press('pointerdown'));
-    $page = $page->wait(0.7);
-    $page->script($press('pointerup'));
-
-    return $page;
-}
-
 test('a long-press on a peer message opens the sheet without the author-only actions', function (): void {
     ['owner' => $alice, 'member' => $bob, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
 

--- a/tests/Browser/Support/LaravelHttpServer.php
+++ b/tests/Browser/Support/LaravelHttpServer.php
@@ -18,6 +18,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Foundation\Testing\Concerns\WithoutExceptionHandlingHandler;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Uri;
 use Pest\Browser\Contracts\HttpServer;
@@ -46,7 +47,7 @@ use Throwable;
  * and every assertion that reads a rendered box reports a bogus layout
  * regression instead (issue #944).
  *
- * There are two behavioural changes, and everything else is a verbatim copy:
+ * There are three behavioural changes, and everything else is a verbatim copy:
  *
  * 1. `start()` raises the connection and stream timeouts past any plausible
  *    test duration, so the server never closes a connection the browser still
@@ -57,10 +58,18 @@ use Throwable;
  *    never observes — and no browser retries a stylesheet on its own. The
  *    retry is automatic rather than opt-in per test, which is what issue #944
  *    asks for.
+ * 3. `parseMultipartBody()` fills in the request bag the vendor class leaves
+ *    empty behind a `@TODO files...`. It parses only urlencoded bodies, and
+ *    calls `Request::create()` with no files at all, so `$request->file(...)`
+ *    is null for every upload a browser makes: the pre-upload 422s, the chip
+ *    vanishes, and no attachment behaviour can be covered in a browser test at
+ *    all (that is what retired `ComposerAttachmentTest` in #483). #920 needs a
+ *    real staged attachment on a phone viewport to prove its remove target, so
+ *    the shadow parses the multipart body into `UploadedFile`s.
  *
  * Remove this shadow (and its `require` in `tests/Pest.php`) once the plugin
- * fixes asset delivery upstream; `tests/Unit/BrowserAssetDeliveryTest.php` pins
- * the shadow until then.
+ * fixes asset delivery and uploads upstream; `tests/Unit/BrowserAssetDeliveryTest.php`
+ * and `tests/Unit/BrowserUploadDeliveryTest.php` pin the shadow until then.
  *
  * @internal
  *
@@ -292,8 +301,12 @@ final class LaravelHttpServer implements HttpServer
         $method = mb_strtoupper($request->getMethod());
         $rawBody = (string) $request->getBody();
         $parameters = [];
+        $files = [];
         if ($method !== 'GET' && str_starts_with(mb_strtolower($contentType), 'application/x-www-form-urlencoded')) {
             parse_str($rawBody, $parameters);
+        }
+        if ($method !== 'GET' && str_starts_with(mb_strtolower($contentType), 'multipart/form-data')) {
+            [$parameters, $files] = $this->parseMultipartBody($rawBody, $contentType);
         }
         $cookies = array_map(fn (RequestCookie $cookie): string => urldecode($cookie->getValue()), $request->getCookies());
         $cookies = array_merge($cookies, test()->prepareCookiesForRequest()); // @phpstan-ignore-line
@@ -305,7 +318,7 @@ final class LaravelHttpServer implements HttpServer
             $method,
             $parameters,
             $cookies,
-            [], // @TODO files...
+            $files,
             $serverVariables,
             $rawBody
         );
@@ -338,6 +351,8 @@ final class LaravelHttpServer implements HttpServer
 
         $kernel->terminate($laravelRequest, $response);
 
+        $this->discardTemporaryUploads($files);
+
         if (property_exists($response, 'exception') && $response->exception !== null) {
             assert($response->exception instanceof Throwable);
 
@@ -361,6 +376,149 @@ final class LaravelHttpServer implements HttpServer
             $response->headers->all(), // @phpstan-ignore-line
             $this->withStylesheetRepair((string) $content, (string) $response->headers->get('Content-Type')),
         );
+    }
+
+    /**
+     * Split a `multipart/form-data` body into request parameters and uploads.
+     *
+     * The vendor class parses urlencoded bodies only, so every file a browser
+     * posts arrives as nothing at all. Each part is read here into either a
+     * scalar field or a temporary file wrapped in an `UploadedFile` marked as a
+     * test upload — `is_uploaded_file()` is false for anything this process
+     * wrote itself, and without that flag Laravel's `file` rule rejects it.
+     *
+     * Field names go back through `parse_str`, so `tags[]` and `filters[type]`
+     * keep the shape PHP would have given them; file names are walked by hand
+     * for the same reason, since `parse_str` cannot carry an object.
+     *
+     * @return array{0: array<string, mixed>, 1: array<string, mixed>}
+     */
+    private function parseMultipartBody(string $body, string $contentType): array
+    {
+        if (preg_match('/boundary="?([^";,]+)"?/i', $contentType, $matches) !== 1) {
+            return [[], []];
+        }
+
+        $fields = [];
+        $files = [];
+        $segments = explode('--'.$matches[1], $body);
+
+        // The first segment is the preamble before the opening boundary and the
+        // last is the epilogue after the closing one; neither is a part.
+        foreach (array_slice($segments, 1, -1) as $segment) {
+            // Byte functions throughout: a part's content is arbitrary binary,
+            // and the `mb_` family this class otherwise uses would rewrite any
+            // byte that is not valid UTF-8 into a replacement character.
+            $split = explode("\r\n\r\n", ltrim($segment, "\r\n"), 2);
+
+            if (count($split) !== 2) {
+                continue;
+            }
+
+            [$rawHeaders, $content] = $split;
+            $content = (string) preg_replace('/\r\n$/', '', $content);
+            $name = $this->headerParameter($rawHeaders, 'name');
+
+            if ($name === null) {
+                continue;
+            }
+
+            $filename = $this->headerParameter($rawHeaders, 'filename');
+
+            if ($filename === null) {
+                $fields[] = urlencode($name).'='.urlencode($content);
+
+                continue;
+            }
+
+            $this->assignFile($files, $name, $this->temporaryUpload($content, $filename, $rawHeaders));
+        }
+
+        parse_str(implode('&', $fields), $parameters);
+
+        return [$parameters, $files];
+    }
+
+    /**
+     * Read one `Content-Disposition` parameter (`name`, `filename`) off a part's
+     * headers, quoted or bare.
+     */
+    private function headerParameter(string $rawHeaders, string $parameter): ?string
+    {
+        $pattern = sprintf('/;\s*%s="([^"]*)"/i', preg_quote($parameter, '/'));
+
+        return preg_match($pattern, $rawHeaders, $matches) === 1 ? $matches[1] : null;
+    }
+
+    /**
+     * Spill one part's bytes to a temporary file and wrap them as an upload.
+     */
+    private function temporaryUpload(string $content, string $filename, string $rawHeaders): UploadedFile
+    {
+        $path = (string) tempnam(sys_get_temp_dir(), 'pest-upload-');
+        file_put_contents($path, $content);
+
+        $mimeType = preg_match('/^content-type:\s*(\S+)/im', $rawHeaders, $matches) === 1
+            ? $matches[1]
+            : null;
+
+        return new UploadedFile($path, $filename, $mimeType, null, true);
+    }
+
+    /**
+     * Place an upload in the file bag under the bracket path its field name
+     * spells out: `file`, `photos[]` and `docs[cover]` all land where PHP would
+     * have put them.
+     *
+     * @param  array<string, mixed>  $files
+     */
+    private function assignFile(array &$files, string $name, UploadedFile $file): void
+    {
+        if (preg_match('/^([^\[\]]+)((?:\[[^\[\]]*\])*)$/', $name, $matches) !== 1) {
+            return;
+        }
+
+        preg_match_all('/\[([^\[\]]*)\]/', $matches[2], $brackets);
+
+        $keys = array_merge([$matches[1]], $brackets[1]);
+        $cursor = &$files;
+
+        foreach ($keys as $depth => $key) {
+            $isLeaf = $depth === count($keys) - 1;
+
+            if ($key === '') {
+                $cursor[] = $isLeaf ? $file : [];
+                $key = array_key_last($cursor);
+            } elseif ($isLeaf) {
+                $cursor[$key] = $file;
+            } elseif (! isset($cursor[$key]) || ! is_array($cursor[$key])) {
+                $cursor[$key] = [];
+            }
+
+            if ($isLeaf) {
+                return;
+            }
+
+            $cursor = &$cursor[$key];
+        }
+    }
+
+    /**
+     * Delete the temporary files of any upload the application did not move.
+     *
+     * A request that stores its upload has already moved the file away; one that
+     * fails validation leaves it behind, and the browser suite posts enough of
+     * them to matter over a full run.
+     *
+     * @param  array<string, mixed>  $files
+     */
+    private function discardTemporaryUploads(array $files): void
+    {
+        array_walk_recursive($files, function (mixed $file): void {
+            if ($file instanceof UploadedFile && is_file($file->getPathname())) {
+                @unlink($file->getPathname());
+            }
+        });
     }
 
     /**

--- a/tests/Browser/Support/LaravelHttpServer.php
+++ b/tests/Browser/Support/LaravelHttpServer.php
@@ -59,8 +59,8 @@ use Throwable;
  *    retry is automatic rather than opt-in per test, which is what issue #944
  *    asks for.
  * 3. `parseMultipartBody()` fills in the request bag the vendor class leaves
- *    empty behind a `@TODO files...`. It parses only urlencoded bodies, and
- *    calls `Request::create()` with no files at all, so `$request->file(...)`
+ *    empty behind a `@TODO files...`. That class parses urlencoded bodies only
+ *    and calls `Request::create()` with no files at all, so `$request->file(...)`
  *    is null for every upload a browser makes: the pre-upload 422s, the chip
  *    vanishes, and no attachment behaviour can be covered in a browser test at
  *    all (that is what retired `ComposerAttachmentTest` in #483). #920 needs a
@@ -441,7 +441,8 @@ final class LaravelHttpServer implements HttpServer
 
     /**
      * Read one `Content-Disposition` parameter (`name`, `filename`) off a part's
-     * headers, quoted or bare.
+     * headers. Only the quoted form is matched, which is the only one a browser
+     * or an HTTP client this suite drives emits.
      */
     private function headerParameter(string $rawHeaders, string $parameter): ?string
     {
@@ -458,7 +459,9 @@ final class LaravelHttpServer implements HttpServer
         $path = (string) tempnam(sys_get_temp_dir(), 'pest-upload-');
         file_put_contents($path, $content);
 
-        $mimeType = preg_match('/^content-type:\s*(\S+)/im', $rawHeaders, $matches) === 1
+        // Stop at the parameter separator: `text/plain; charset=utf-8` is a
+        // client mime type of `text/plain`, not `text/plain;`.
+        $mimeType = preg_match('/^content-type:\s*([^;\s]+)/im', $rawHeaders, $matches) === 1
             ? $matches[1]
             : null;
 

--- a/tests/Unit/BrowserUploadDeliveryTest.php
+++ b/tests/Unit/BrowserUploadDeliveryTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\UploadedFile;
+use Pest\Browser\Drivers\LaravelHttpServer;
+
+/**
+ * pest-plugin-browser v4.3.1 serves the app in-process from a server that reads
+ * `application/x-www-form-urlencoded` bodies and nothing else, and hands
+ * `Request::create()` an empty file bag behind a `@TODO files...`. Every upload
+ * a browser makes therefore reaches the application as no file at all: the
+ * composer's attachment pre-upload 422s on `file` being required, the staged
+ * chip is dropped, and no attachment behaviour is coverable in a browser test —
+ * which is why `ComposerAttachmentTest` was retired in #483 rather than fixed.
+ *
+ * `tests/Browser/Support/LaravelHttpServer.php` shadows the vendor class (see
+ * `tests/Unit/BrowserAssetDeliveryTest.php` for the rest of what it patches) and
+ * parses the multipart body itself, so #920's mobile tray suite can stage a real
+ * attachment. These tests pin that parsing.
+ */
+it('reads a file part into an uploaded file Laravel will accept', function (): void {
+    [$parameters, $files] = parseMultipart([
+        ['name' => 'file', 'filename' => 'venue.png', 'type' => 'image/png', 'content' => "\x89PNG\r\n\x1a\nbytes"],
+    ]);
+
+    expect($parameters)->toBe([])
+        ->and($files['file'])->toBeInstanceOf(UploadedFile::class);
+
+    $file = $files['file'];
+    assert($file instanceof UploadedFile);
+
+    expect($file->getClientOriginalName())->toBe('venue.png')
+        ->and($file->getClientMimeType())->toBe('image/png')
+        // Binary content survives the split verbatim: the trailing CRLF that
+        // belongs to the boundary comes off, nothing inside the part does.
+        ->and(file_get_contents($file->getPathname()))->toBe("\x89PNG\r\n\x1a\nbytes")
+        // `is_uploaded_file()` is false for a file this process wrote, so
+        // without the test flag the `file` validation rule rejects every upload.
+        ->and($file->isValid())->toBeTrue();
+});
+
+it('reads scalar fields alongside the files, with PHP array shapes intact', function (): void {
+    [$parameters, $files] = parseMultipart([
+        ['name' => '_method', 'content' => 'PUT'],
+        ['name' => 'tags[]', 'content' => 'offsite'],
+        ['name' => 'tags[]', 'content' => 'venue'],
+        ['name' => 'filters[type]', 'content' => 'image'],
+        ['name' => 'file', 'filename' => 'quote.pdf', 'type' => 'application/pdf', 'content' => 'pdf'],
+    ]);
+
+    expect($parameters)->toBe([
+        '_method' => 'PUT',
+        'tags' => ['offsite', 'venue'],
+        'filters' => ['type' => 'image'],
+    ])->and($files)->toHaveKey('file');
+});
+
+it('places bracketed file fields where PHP would have put them', function (): void {
+    [, $files] = parseMultipart([
+        ['name' => 'photos[]', 'filename' => 'one.png', 'content' => 'a'],
+        ['name' => 'photos[]', 'filename' => 'two.png', 'content' => 'b'],
+        ['name' => 'docs[cover]', 'filename' => 'cover.pdf', 'content' => 'c'],
+    ]);
+
+    expect($files['photos'])->toHaveCount(2)
+        ->and($files['photos'][0]->getClientOriginalName())->toBe('one.png')
+        ->and($files['photos'][1]->getClientOriginalName())->toBe('two.png')
+        ->and($files['docs']['cover']->getClientOriginalName())->toBe('cover.pdf');
+});
+
+it('leaves a body with no boundary to split on alone', function (): void {
+    $server = new LaravelHttpServer('127.0.0.1', 1);
+
+    $parsed = new ReflectionMethod($server, 'parseMultipartBody')
+        ->invoke($server, 'whatever', 'multipart/form-data');
+
+    expect($parsed)->toBe([[], []]);
+});
+
+it('skips a part carrying no headers or no name', function (): void {
+    [$parameters, $files] = parseMultipart([
+        ['name' => 'kept', 'content' => 'yes'],
+        ['raw' => "Content-Disposition: form-data\r\n\r\nnameless"],
+        ['raw' => 'no blank line so no body'],
+    ]);
+
+    expect($parameters)->toBe(['kept' => 'yes'])
+        ->and($files)->toBe([]);
+});
+
+it('discards the temporary file of an upload the application never moved', function (): void {
+    [, $files] = parseMultipart([
+        ['name' => 'file', 'filename' => 'venue.png', 'content' => 'bytes'],
+    ]);
+
+    $file = $files['file'];
+    assert($file instanceof UploadedFile);
+    $path = $file->getPathname();
+
+    expect($path)->toBeFile();
+
+    new ReflectionMethod(new LaravelHttpServer('127.0.0.1', 1), 'discardTemporaryUploads')
+        ->invoke(new LaravelHttpServer('127.0.0.1', 1), $files);
+
+    expect(file_exists($path))->toBeFalse();
+});
+
+/**
+ * Build a multipart body out of the given parts and run it through the shadow's
+ * parser.
+ *
+ * A part is either `raw` (spliced in verbatim, for the malformed cases) or a
+ * `name` with optional `filename`, `type` and `content`.
+ *
+ * @param  array<int, array<string, string>>  $parts
+ * @return array{0: array<string, mixed>, 1: array<string, mixed>}
+ */
+function parseMultipart(array $parts): array
+{
+    $boundary = '----PestBoundary1234';
+
+    $body = '';
+
+    foreach ($parts as $part) {
+        $body .= "--{$boundary}\r\n";
+
+        if (isset($part['raw'])) {
+            $body .= $part['raw']."\r\n";
+
+            continue;
+        }
+
+        $disposition = "Content-Disposition: form-data; name=\"{$part['name']}\"";
+
+        if (isset($part['filename'])) {
+            $disposition .= "; filename=\"{$part['filename']}\"";
+        }
+
+        $body .= $disposition."\r\n";
+
+        if (isset($part['type'])) {
+            $body .= "Content-Type: {$part['type']}\r\n";
+        }
+
+        $body .= "\r\n".($part['content'] ?? '')."\r\n";
+    }
+
+    $body .= "--{$boundary}--\r\n";
+
+    $parsed = new ReflectionMethod(new LaravelHttpServer('127.0.0.1', 1), 'parseMultipartBody')
+        ->invoke(new LaravelHttpServer('127.0.0.1', 1), $body, "multipart/form-data; boundary={$boundary}");
+
+    assert(is_array($parsed));
+
+    return $parsed;
+}

--- a/tests/Unit/BrowserUploadDeliveryTest.php
+++ b/tests/Unit/BrowserUploadDeliveryTest.php
@@ -89,22 +89,59 @@ it('skips a part carrying no headers or no name', function (): void {
         ->and($files)->toBe([]);
 });
 
-it('discards the temporary file of an upload the application never moved', function (): void {
+it('reads a mime type without the parameters that follow it', function (): void {
     [, $files] = parseMultipart([
-        ['name' => 'file', 'filename' => 'venue.png', 'content' => 'bytes'],
+        ['name' => 'file', 'filename' => 'notes.txt', 'type' => 'text/plain; charset=utf-8', 'content' => 'hi'],
     ]);
 
     $file = $files['file'];
     assert($file instanceof UploadedFile);
-    $path = $file->getPathname();
 
-    expect($path)->toBeFile();
-
-    new ReflectionMethod(new LaravelHttpServer('127.0.0.1', 1), 'discardTemporaryUploads')
-        ->invoke(new LaravelHttpServer('127.0.0.1', 1), $files);
-
-    expect(file_exists($path))->toBeFalse();
+    expect($file->getClientMimeType())->toBe('text/plain');
 });
+
+it('discards the temporary file of every upload the application never moved', function (): void {
+    // Nested as well as flat: the bag is walked recursively, and a `photos[]`
+    // left behind leaks just as readily as a `file` does.
+    [, $files] = parseMultipart([
+        ['name' => 'file', 'filename' => 'venue.png', 'content' => 'bytes'],
+        ['name' => 'photos[]', 'filename' => 'one.png', 'content' => 'a'],
+        ['name' => 'docs[cover]', 'filename' => 'cover.pdf', 'content' => 'c'],
+    ]);
+
+    $paths = [
+        $files['file']->getPathname(),
+        $files['photos'][0]->getPathname(),
+        $files['docs']['cover']->getPathname(),
+    ];
+
+    expect($paths)->each->toBeFile();
+
+    discardUploads($files);
+
+    expect(array_filter($paths, file_exists(...)))->toBe([]);
+});
+
+// Every test here spills temporary files the parser is not asked to clean up,
+// and a failing assertion would strand them. Nothing else in the suite writes
+// this prefix — only the shadow does, and only for a browser test.
+afterEach(function (): void {
+    foreach (glob(sys_get_temp_dir().'/pest-upload-*') ?: [] as $path) {
+        @unlink($path);
+    }
+});
+
+/**
+ * Run a file bag through the shadow's temporary-file cleanup.
+ *
+ * @param  array<string, mixed>  $files
+ */
+function discardUploads(array $files): void
+{
+    $server = new LaravelHttpServer('127.0.0.1', 1);
+
+    new ReflectionMethod($server, 'discardTemporaryUploads')->invoke($server, $files);
+}
 
 /**
  * Build a multipart body out of the given parts and run it through the shadow's
@@ -148,8 +185,10 @@ function parseMultipart(array $parts): array
 
     $body .= "--{$boundary}--\r\n";
 
-    $parsed = new ReflectionMethod(new LaravelHttpServer('127.0.0.1', 1), 'parseMultipartBody')
-        ->invoke(new LaravelHttpServer('127.0.0.1', 1), $body, "multipart/form-data; boundary={$boundary}");
+    $server = new LaravelHttpServer('127.0.0.1', 1);
+
+    $parsed = new ReflectionMethod($server, 'parseMultipartBody')
+        ->invoke($server, $body, "multipart/form-data; boundary={$boundary}");
 
     assert(is_array($parsed));
 


### PR DESCRIPTION
Closes #920.

## What

Every composer control outside the #889 control row was left at its desktop size on a phone, and the attachment chips were worse than small: their remove button was revealed by `group-hover`, a state a touch screen cannot enter. Picking the wrong photo left no way to drop it short of sending or clearing the composer.

Below `md` each chip now carries an always-visible remove control with a 44x44 hit box. The three chip shapes cannot take the same one, so each gets the one that fits it:

- **Image chip** — the thumbnail grows from 76px to 100px and the painted badge keeps its corner while its hit box reaches back over the thumbnail. A 44pt *visible* button would bury the picture it belongs to, and the thumbnail has no competing tap target of its own.
- **Audio chip** — the button leaves its overlay and takes a column of its own beside the player. A 44px overlay at the top-right would sit on the right end of the scrubber.
- **File and failed chips** — roomy rows, so their existing right-hand button simply grows.

`reply-preview-dismiss` and `composer-editing-dismiss` grow to 44pt (their banners tighten their vertical padding below `md` to absorb it), and the `send-to-channel` control is toggled by its whole label row, with the 14px box left exactly as it was.

From `md` up every one of them is byte-for-byte what it was: hover-revealed, desktop-sized. Verified by screenshot in both viewports.

## Testing

`tests/Browser/MobileComposerTrayTest.php` stages real attachments at 390x844 and measures every target with `getBoundingClientRect`, checking each is topmost across its own box via `elementFromPoint`. It also removes a chip with no hover anywhere in the run, covers the failed-upload chip by pointing its pre-upload somewhere unreachable, and runs an axe audit over the staged tray in both themes — the badge is new contrast on the phone, since desktop only ever showed it under a hover where no audit reached it.

That needed uploads to work in a browser test, which they did not: the pest-plugin-browser in-process server parses urlencoded bodies only and hands `Request::create()` an empty file bag behind a `// @TODO files...`, so `$request->file('file')` was always null and the staged chip vanished on a 422. That is what retired `ComposerAttachmentTest` in #483. We already shadow that class for the #944 stylesheet fix, so the shadow now parses `multipart/form-data` itself — pinned by `tests/Unit/BrowserUploadDeliveryTest.php`, and useful beyond this PR (#890's camera work will want it).

`longPressMessage()` moved from `MobileMessageActionsSheetTest.php` to `Helpers.php`, since reaching a reply target on a phone needs the same gesture.

Backend gate green at 100% coverage (Pint, PHPStan, Rector clean); frontend lint/format/types/vitest/build green; full browser suite 326/326. No new user-facing copy, so no catalog changes, and nothing operator-facing, so no docs changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787831549&installation_model_id=428379&pr_number=1011&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1011&signature=d318d5e6b8de510a786774a84cb5a876d2f94bc891d2aef7210f840f39c49455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->