### PR TITLE
test: settle the thread-card count and the panel before auditing

### DIFF
--- a/tests/Browser/Helpers.php
+++ b/tests/Browser/Helpers.php
@@ -200,22 +200,50 @@ function navParamSettles(?string $destination): string
 }
 
 /**
- * Repaint a live page in the dark palette, settled enough for an axe audit.
+ * A script resolving once exactly `$count` elements match `$selector`.
  *
- * Persisting to localStorage first keeps the appearance controller from
- * re-resolving `system` back to light. The injected stylesheet is the part that
- * makes the audit trustworthy: swapping the palette re-tints every element
- * carrying `transition-colors`, and axe reads `getComputedStyle` off whatever
- * frame it lands on, so a tween in flight is reported as if it were the shipped
- * colour. That is what #946 chased — four "contrast misses" in the mobile
- * drawer that were each an interpolation between the light and dark values of
- * `--muted-foreground`, one of them measured against a background matching no
- * token in the palette at all. The ratios moved run to run, which no real token
- * pair can do. Killing transitions and animations outright pins the audit to the
- * settled palette, which is the only thing worth asserting; it also removes the
- * fade-settle that the dialog audits needed for the same reason (#775).
+ * `assertScript` is a one-shot evaluation with no retry, the same trap
+ * `queryParamSettles()` covers on the URL side. A dock panel opens on a
+ * client-side switch and then fetches its own props with `reset:`, so between
+ * its first row appearing (which `assertPresent` waits for) and the list
+ * settling there is a window where the merged page is being replaced and the
+ * list is momentarily empty. On a loaded parallel runner the one-shot read
+ * lands inside that window and sees 0 (#965).
+ *
+ * Polling stops at the first frame the count matches, which is the settled
+ * value in practice: the transient the panel passes through is the empty list,
+ * never a different non-zero total.
  */
-function switchToDarkTheme(AwaitableWebpage $page): AwaitableWebpage
+function elementCountSettles(string $selector, int $count): string
+{
+    $needle = json_encode($selector, JSON_THROW_ON_ERROR);
+
+    return <<<JS
+    (async () => {
+        const settled = () => document.querySelectorAll({$needle}).length === {$count};
+
+        for (let frame = 0; frame < 120 && ! settled(); frame++) {
+            await new Promise(requestAnimationFrame);
+        }
+
+        return settled();
+    })()
+    JS;
+}
+
+/**
+ * Pin a live page to its settled styles by killing transitions and animations.
+ *
+ * axe reads `getComputedStyle` off whatever frame it lands on, so a tween in
+ * flight is reported as if it were the shipped colour — a "contrast miss"
+ * between two states that each pass, against a blended background matching no
+ * token in the palette. #946 chased that through the theme flip; the same trap
+ * catches any audit that follows a control changing state, such as the threads
+ * filter pills swapping foreground and background on `aria-pressed` (#965).
+ * Applying `transition: none` also cancels whatever is already running, so the
+ * elements snap to their target styles rather than finishing the tween.
+ */
+function suppressTransitions(AwaitableWebpage $page): AwaitableWebpage
 {
     $page->script(<<<'JS'
     () => {
@@ -223,7 +251,32 @@ function switchToDarkTheme(AwaitableWebpage $page): AwaitableWebpage
         settled.textContent =
             '*, *::before, *::after { transition: none !important; animation: none !important; }';
         document.head.appendChild(settled);
+    }
+    JS);
 
+    return $page;
+}
+
+/**
+ * Repaint a live page in the dark palette, settled enough for an axe audit.
+ *
+ * Persisting to localStorage first keeps the appearance controller from
+ * re-resolving `system` back to light. Suppressing transitions first is the part
+ * that makes the audit trustworthy: swapping the palette re-tints every element
+ * carrying `transition-colors`, and #946 was four "contrast misses" in the
+ * mobile drawer that were each an interpolation between the light and dark
+ * values of `--muted-foreground`, one of them measured against a background
+ * matching no token in the palette at all. The ratios moved run to run, which no
+ * real token pair can do. Pinning the audit to the settled palette is the only
+ * thing worth asserting; it also removes the fade-settle that the dialog audits
+ * needed for the same reason (#775). See suppressTransitions().
+ */
+function switchToDarkTheme(AwaitableWebpage $page): AwaitableWebpage
+{
+    $page = suppressTransitions($page);
+
+    $page->script(<<<'JS'
+    () => {
         localStorage.setItem('appearance', 'dark');
         document.documentElement.classList.add('dark');
         document.documentElement.style.colorScheme = 'dark';

--- a/tests/Browser/ThreadsDestinationTest.php
+++ b/tests/Browser/ThreadsDestinationTest.php
@@ -53,12 +53,17 @@ function threadsPanelInbox(): array
     ];
 }
 
-/** How many thread cards the panel is currently rendering. */
-function threadCardCount(): string
+/**
+ * A script resolving once the panel is rendering exactly `$count` thread cards.
+ *
+ * Polled rather than read once: the panel fetches its own props with
+ * `reset: ['threads']`, so the list is momentarily empty between the first card
+ * appearing and the fresh page merging in, and a one-shot read on a loaded
+ * parallel runner lands inside that window (#965).
+ */
+function threadCardsSettle(int $count): string
 {
-    return <<<'JS'
-    (() => document.querySelectorAll('[data-test="thread-inbox-item"]').length)()
-    JS;
+    return elementCountSettles('[data-test="thread-inbox-item"]', $count);
 }
 
 /**
@@ -87,7 +92,11 @@ test('the rail opens the inbox in the panel, filtered to what is unread', functi
         ->assertPresent('@thread-inbox-item')
         // The panel fetched its own props: the unread thread is here with the
         // count of what is new, and the caught-up one is filtered out.
-        ->assertScript(threadCardCount(), 1)
+        ->assertScript(threadCardsSettle(1), true)
+        // Negative control: the poll is a real assertion, not one that reports
+        // true for anything. Pointed at a total the inbox never reaches it runs
+        // out of frames and says so.
+        ->assertScript(threadCardsSettle(99), false)
         ->assertScript(threadsPanelShows('Shall we move Thursday to 3pm?'), true)
         ->assertScript(threadsPanelShows('Thanks everyone for the release push.'), false)
         ->assertScript(threadsPanelShows('1 new reply'), true)
@@ -96,20 +105,12 @@ test('the rail opens the inbox in the panel, filtered to what is unread', functi
     // The default filter stays off the URL, so the everyday address is the plain
     // pinned destination.
     $page->assertScript(queryParamSettles('nav', 'threads'), true)
-        ->assertQueryStringMissing('filter')
-        ->assertNoAccessibilityIssues();
+        ->assertQueryStringMissing('filter');
 
-    // Re-audit against the dark palette; persisting to localStorage first keeps
-    // the choice through any re-render the audit triggers.
-    $page->script(<<<'JS'
-    () => {
-        localStorage.setItem('appearance', 'dark');
-        document.documentElement.classList.add('dark');
-        document.documentElement.style.colorScheme = 'dark';
-    }
-    JS);
+    suppressTransitions($page)->assertNoAccessibilityIssues();
 
-    $page->wait(0.5)->assertNoAccessibilityIssues();
+    // Re-audit against the dark palette.
+    switchToDarkTheme($page)->assertNoAccessibilityIssues();
 });
 
 test('the All pill brings back the caught-up threads, server-side and shareable', function (): void {
@@ -123,16 +124,18 @@ test('the All pill brings back the caught-up threads, server-side and shareable'
         // Two cards now, which only a fresh server page can produce: the read
         // thread was never in the client's list to un-filter.
         ->assertScript(threadsPanelShows('Thanks everyone for the release push.'), true)
-        ->assertScript(threadCardCount(), 2);
+        ->assertScript(threadCardsSettle(2), true);
 
     $page->assertScript(queryParamSettles('filter', 'all'), true)
         ->assertQueryStringHas('filter', 'all')
         // The caught-up card shows the thread's whole length, not a new-reply count.
-        ->assertScript(threadsPanelShows('1 reply'), true)
-        // Audited here as well as on the unread view: the caught-up card is a
-        // different treatment (plain outline, dimmer copy) and carries its own
-        // contrast risk.
-        ->assertNoAccessibilityIssues();
+        ->assertScript(threadsPanelShows('1 reply'), true);
+
+    // Audited here as well as on the unread view: the caught-up card is a
+    // different treatment (plain outline, dimmer copy) and carries its own
+    // contrast risk. The pills swap foreground and background on `aria-pressed`,
+    // so the audit has to wait out that tween like the theme flip does (#965).
+    suppressTransitions($page)->assertNoAccessibilityIssues();
 });
 
 test('a filter deep link renders the panel on a cold load, with no client fetch', function (): void {
@@ -142,7 +145,7 @@ test('a filter deep link renders the panel on a cold load, with no client fetch'
         ->resize(1280, 900)
         ->navigate(browserChannelUrl($team, $channel).'?nav=threads&filter=all')
         ->assertPresent('@thread-inbox-item')
-        ->assertScript(threadCardCount(), 2)
+        ->assertScript(threadCardsSettle(2), true)
         ->assertScript(
             '(() => document.querySelector(\'[data-test="threads-filter-all"]\').getAttribute("aria-pressed"))()',
             'true',
@@ -163,7 +166,7 @@ test('mark all read empties the inbox and drops the rail dot', function (): void
         // The redirect back re-renders the route, so the emptied inbox, the zeroed
         // tally and the dropped dot all arrive as fresh props.
         ->assertPresent('@threads-empty')
-        ->assertScript(threadCardCount(), 0)
+        ->assertScript(threadCardsSettle(0), true)
         ->assertNotPresent('@rail-threads-unread-dot')
         ->assertNotPresent('@threads-unread-count');
 });


### PR DESCRIPTION
Closes #965.

## What

`tests/Browser/ThreadsDestinationTest.php` reported two intermittent failures under parallel load — a thread-card count reading 0, and an axe contrast violation on the filter pills. Both are the same defect: the assertion runs before the panel has settled.

- `elementCountSettles($selector, $count)` joins `queryParamSettles()` in `tests/Browser/Helpers.php` — a polled script in the same shape, hoisted so the other destinations can use it. All four `threadCardCount()` reads become `threadCardsSettle()`.
- `suppressTransitions($page)` is extracted out of `switchToDarkTheme()` (which now calls it), so an audit can pin a page to its settled styles without flipping the palette. Both light audits in this suite go through it.
- The suite's hand-rolled dark flip is replaced by `switchToDarkTheme()` — it was the last copy #968 missed, and it carried the same latent flake.

## Why

**The card count.** `assertScript` is a one-shot evaluation with no retry, the same trap the `?nav=` URL races hit in #947. `ThreadsPanel.vue` opens on a client-side switch and then fetches its own props with `reset: ['threads']`, so between the first card appearing (which `assertPresent` waits for) and the fresh page merging in there is a window where the list is momentarily empty. On a loaded runner the one-shot read lands inside it and sees 0.

**The contrast violation.** The reported colours were the tell: `#615e5a`/`#b7b5b2` are blended greys matching no token pair, and the two pills reported near-mirror-image values. Probing the live page confirms it — read immediately after the click, the pills still report their *pre-click* state:

```
IMMEDIATELY AFTER CLICK:  threads-filter-unread fg=rgb(251,250,247) bg=rgb(29,26,21) | threads-filter-all fg=rgb(29,26,21) bg=rgba(0,0,0,0)
AFTER suppressTransitions: threads-filter-unread fg=rgb(29,26,21) bg=rgba(0,0,0,0) | threads-filter-all fg=rgb(251,250,247) bg=rgb(29,26,21)
```

The pills swap foreground and background on `aria-pressed` through a transition, and axe reads `getComputedStyle` off whatever frame it lands on. Every intermediate is a blend of two states that each pass — which is why the ratios moved run to run. Suppressing transitions cancels what is running and snaps the elements to their target styles, pinning the audit to the shipped tokens. Exactly the #946 root cause, on a control's state change rather than the theme flip.

## How tested

- **Negative control**: `->assertScript(threadCardsSettle(99), false)` — pointed at a total the inbox never reaches, the poll runs out of frames and reports false, so the helper is a real assertion rather than one that is true for anything.
- `tests/Browser/ThreadsDestinationTest.php` green 4/4 in isolation.
- Three full `tests/Browser --parallel --processes=6` sweeps — the configuration both symptoms were reported under — **327 passed, 3/3 green**.
- `composer test` reports `Total: 100.0 %` with Pint, PHPStan and Rector clean; `lint:check`, `format:check`, `types:check` and `build` green; `test:js` 1770 passed.

## i18n / docs

None — test-only, no user-facing copy and nothing operator-facing.

## Note on the type

`test:` rather than `fix:`: the diff touches only `tests/Browser/`, and no shipped behaviour changes, so a **Bug Fixes** entry would claim a repair to the application that never happened. Same call as #968 for the same class of flake.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787847244&installation_model_id=428379&pr_number=1015&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1015&signature=fc542d6e23f25479232e3530a47ea1371dc6d27c15540c0673696ef3da29d285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->