### PR TITLE
refactor: extract the composer's surfaces out of MessageComposer.vue

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -253,7 +253,6 @@ export default defineConfigWithVueTs(
         // stops breaching the threshold, so the list can only shrink.
         files: [
             'resources/js/components/ChannelMasthead.vue',
-            'resources/js/components/MessageComposer.vue',
             'resources/js/components/MessageList.vue',
             'resources/js/components/QuickSwitcher.vue',
             'resources/js/components/UserStatusDialog.vue',

--- a/resources/js/components/MessageComposer.editMode.test.ts
+++ b/resources/js/components/MessageComposer.editMode.test.ts
@@ -1,0 +1,308 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import type { Message } from '@/types';
+import MessageComposer from './MessageComposer.vue';
+
+/**
+ * Covers the composer's inline edit mode: the ArrowUp recall, the banner and
+ * the save/cancel controls it swaps in, the `edit`/`editingChange` emits, and
+ * the rule that an edit in progress never persists as a channel draft.
+ *
+ * The browser suite already walks the happy path end to end; this pins the
+ * emits and the guards around them at the layer that holds them deterministically.
+ */
+
+vi.mock('@/actions/App/Http/Controllers/Channels/AttachmentController', () => ({
+    store: () => ({ url: '/t/acme/c/general/attachments' }),
+}));
+
+vi.mock('@/components/ui/button', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        Button: defineComponent({
+            name: 'ButtonStub',
+            inheritAttrs: false,
+            setup:
+                (_props, { attrs, slots }) =>
+                () =>
+                    h('button', attrs, slots.default?.()),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { defineComponent, h } = await import('vue');
+    const slot = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        Tooltip: slot('TooltipStub'),
+        TooltipContent: slot('TooltipContentStub'),
+        TooltipProvider: slot('TooltipProviderStub'),
+        TooltipTrigger: slot('TooltipTriggerStub'),
+    };
+});
+
+const VIEWER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+/** A message carrying just the fields the edit path reads. */
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'first draft',
+        type: 'standard',
+        user: { id: VIEWER_ID, name: 'Ada Lovelace' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    };
+}
+
+type Edit = { message: Message; body: string };
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+function mountComposer(props: Record<string, unknown> = {}) {
+    const edits: Edit[] = [];
+    const editing: Array<string | null> = [];
+    const drafts: string[] = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(MessageComposer as Component, {
+                    channelName: 'general',
+                    members: [],
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                    currentUserId: VIEWER_ID,
+                    messages: [message()],
+                    onEdit: (target: Message, body: string) =>
+                        edits.push({ message: target, body }),
+                    onEditingChange: (messageId: string | null) =>
+                        editing.push(messageId),
+                    onDraftChange: (body: string) => drafts.push(body),
+                    ...props,
+                }),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(container);
+    active.push({ app, container });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+        '[data-test="message-composer-input"]',
+    )!;
+
+    return { container, drafts, editing, edits, textarea };
+}
+
+function type(textarea: HTMLTextAreaElement, value: string): Promise<void> {
+    textarea.value = value;
+    textarea.setSelectionRange(value.length, value.length);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+    return nextTick();
+}
+
+function press(textarea: HTMLTextAreaElement, key: string): Promise<void> {
+    textarea.dispatchEvent(
+        new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }),
+    );
+
+    return nextTick();
+}
+
+function click(container: HTMLElement, test: string): void {
+    container
+        .querySelector<HTMLButtonElement>(`[data-test="${test}"]`)!
+        .click();
+}
+
+function banner(container: HTMLElement): HTMLElement | null {
+    return container.querySelector('[data-test="composer-editing-banner"]');
+}
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+});
+
+describe('MessageComposer edit mode', () => {
+    it('recalls the last editable message on ArrowUp in an empty composer', async () => {
+        const { container, editing, textarea } = mountComposer();
+
+        await press(textarea, 'ArrowUp');
+
+        expect(textarea.value).toBe('first draft');
+        expect(banner(container)).not.toBeNull();
+        expect(editing).toEqual(['m1']);
+    });
+
+    it('leaves a composer with text alone', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, 'still typing');
+        await press(textarea, 'ArrowUp');
+
+        expect(banner(container)).toBeNull();
+        expect(textarea.value).toBe('still typing');
+    });
+
+    it('stays out of edit mode when the viewer has nothing editable', async () => {
+        const { container, editing, textarea } = mountComposer({
+            messages: [message({ isDeleted: true })],
+        });
+
+        await press(textarea, 'ArrowUp');
+
+        expect(banner(container)).toBeNull();
+        expect(editing).toEqual([]);
+    });
+
+    it('skips an in-flight optimistic send when resolving the target', async () => {
+        const { container, textarea } = mountComposer({
+            messages: [message(), message({ id: 'm2', clientUuid: 'uuid-2' })],
+            pendingUuids: ['uuid-2'],
+        });
+
+        await press(textarea, 'ArrowUp');
+
+        expect(textarea.value).toBe('first draft');
+        expect(banner(container)).not.toBeNull();
+    });
+
+    it('saves the correction on Enter and returns to composing', async () => {
+        const { container, editing, edits, textarea } = mountComposer();
+
+        await press(textarea, 'ArrowUp');
+        await type(textarea, 'second draft');
+        await press(textarea, 'Enter');
+
+        expect(edits).toHaveLength(1);
+        expect(edits[0].message.id).toBe('m1');
+        expect(edits[0].body).toBe('second draft');
+        expect(textarea.value).toBe('');
+        expect(banner(container)).toBeNull();
+        expect(editing).toEqual(['m1', null]);
+    });
+
+    it('saves from the explicit save control', async () => {
+        const { container, edits, textarea } = mountComposer();
+
+        await press(textarea, 'ArrowUp');
+        await type(textarea, 'second draft');
+        click(container, 'message-composer-edit-save');
+        await nextTick();
+
+        expect(edits[0].body).toBe('second draft');
+    });
+
+    it('leaves an unchanged or emptied body unsaved', async () => {
+        const unchanged = mountComposer();
+        await press(unchanged.textarea, 'ArrowUp');
+        await press(unchanged.textarea, 'Enter');
+        expect(unchanged.edits).toEqual([]);
+        expect(banner(unchanged.container)).toBeNull();
+
+        const emptied = mountComposer();
+        await press(emptied.textarea, 'ArrowUp');
+        await type(emptied.textarea, '   ');
+        await press(emptied.textarea, 'Enter');
+        expect(emptied.edits).toEqual([]);
+    });
+
+    it('abandons the edit on Escape', async () => {
+        const { container, editing, edits, textarea } = mountComposer();
+
+        await press(textarea, 'ArrowUp');
+        await type(textarea, 'second draft');
+        await press(textarea, 'Escape');
+
+        expect(edits).toEqual([]);
+        expect(textarea.value).toBe('');
+        expect(banner(container)).toBeNull();
+        expect(editing).toEqual(['m1', null]);
+    });
+
+    it('abandons the edit from the banner’s dismiss control', async () => {
+        const { container, edits, textarea } = mountComposer();
+
+        await press(textarea, 'ArrowUp');
+        click(container, 'composer-editing-dismiss');
+        await nextTick();
+
+        expect(edits).toEqual([]);
+        expect(banner(container)).toBeNull();
+    });
+
+    it('never persists an in-progress edit as a channel draft', async () => {
+        const { drafts, textarea } = mountComposer();
+
+        await press(textarea, 'ArrowUp');
+        await type(textarea, 'second draft');
+        await press(textarea, 'Enter');
+
+        // Neither the recalled body, the correction, nor the wipe that leaves
+        // edit mode is a new-message draft.
+        expect(drafts).toEqual([]);
+    });
+
+    it('keeps typing a draft again once the edit is over', async () => {
+        const { drafts, textarea } = mountComposer();
+
+        await press(textarea, 'ArrowUp');
+        await press(textarea, 'Escape');
+        await type(textarea, 'a fresh message');
+
+        expect(drafts).toEqual(['a fresh message']);
+    });
+
+    it('hides the also-send-to-channel row while editing', async () => {
+        const { container, textarea } = mountComposer({
+            allowSendToChannel: true,
+        });
+
+        expect(
+            container.querySelector('[data-test="send-to-channel-row"]'),
+        ).not.toBeNull();
+
+        await press(textarea, 'ArrowUp');
+
+        expect(
+            container.querySelector('[data-test="send-to-channel-row"]'),
+        ).toBeNull();
+    });
+});

--- a/resources/js/components/MessageComposer.format.test.ts
+++ b/resources/js/components/MessageComposer.format.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import MessageComposer from './MessageComposer.vue';
+
+/**
+ * Covers the composer's inline-format cluster: the four toolbar controls, the
+ * keyboard shortcuts that mirror them, and the selection they leave behind.
+ * `toggleInlineMark` is unit-tested on its own — what is watched here is the
+ * wiring around it, which is what moves when the composer is split.
+ */
+
+vi.mock('@/actions/App/Http/Controllers/Channels/AttachmentController', () => ({
+    store: () => ({ url: '/t/acme/c/general/attachments' }),
+}));
+
+vi.mock('@/components/ui/button', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        Button: defineComponent({
+            name: 'ButtonStub',
+            inheritAttrs: false,
+            setup:
+                (_props, { attrs, slots }) =>
+                () =>
+                    h('button', attrs, slots.default?.()),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { defineComponent, h } = await import('vue');
+    const slot = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        Tooltip: slot('TooltipStub'),
+        TooltipContent: slot('TooltipContentStub'),
+        TooltipProvider: slot('TooltipProviderStub'),
+        TooltipTrigger: slot('TooltipTriggerStub'),
+    };
+});
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+function mountComposer() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(MessageComposer as Component, {
+                    channelName: 'general',
+                    members: [],
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                }),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(container);
+    active.push({ app, container });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+        '[data-test="message-composer-input"]',
+    )!;
+
+    return { container, textarea };
+}
+
+/** Seed the field's text, then select the given range. */
+async function select(
+    textarea: HTMLTextAreaElement,
+    value: string,
+    start: number,
+    end: number,
+): Promise<void> {
+    textarea.value = value;
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    await nextTick();
+    textarea.setSelectionRange(start, end);
+}
+
+/** Click a format control and let the composer restore the selection. */
+async function clickFormat(
+    container: HTMLElement,
+    marker: string,
+): Promise<void> {
+    container
+        .querySelector<HTMLButtonElement>(
+            `[data-test="message-composer-format-${marker}"]`,
+        )!
+        .click();
+    await nextTick();
+    await nextTick();
+}
+
+function shortcut(
+    textarea: HTMLTextAreaElement,
+    key: string,
+    modifiers: { shiftKey?: boolean; altKey?: boolean } = {},
+): KeyboardEvent {
+    const event = new KeyboardEvent('keydown', {
+        key,
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+        ...modifiers,
+    });
+    textarea.dispatchEvent(event);
+
+    return event;
+}
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+});
+
+describe('MessageComposer inline formatting', () => {
+    it('offers a control per Markdown marker', () => {
+        const { container } = mountComposer();
+
+        const markers = Array.from(
+            container.querySelectorAll<HTMLElement>(
+                '[data-test="composer-format-cluster"] [data-test^="message-composer-format-"]',
+            ),
+        ).map((node) =>
+            node
+                .getAttribute('data-test')
+                ?.replace('message-composer-format-', ''),
+        );
+
+        expect(markers).toEqual(['**', '*', '~~', '`']);
+    });
+
+    it('wraps the selection from each control and keeps the inner text selected', async () => {
+        const cases: Array<[string, string]> = [
+            ['**', 'say **hello** now'],
+            ['*', 'say *hello* now'],
+            ['~~', 'say ~~hello~~ now'],
+            ['`', 'say `hello` now'],
+        ];
+
+        for (const [marker, expected] of cases) {
+            const { container, textarea } = mountComposer();
+
+            await select(textarea, 'say hello now', 4, 9);
+            await clickFormat(container, marker);
+
+            expect(textarea.value).toBe(expected);
+            expect([textarea.selectionStart, textarea.selectionEnd]).toEqual([
+                4 + marker.length,
+                9 + marker.length,
+            ]);
+        }
+    });
+
+    it('unwraps a selection already carrying the marker', async () => {
+        const { container, textarea } = mountComposer();
+
+        await select(textarea, 'say **hello** now', 6, 11);
+        await clickFormat(container, '**');
+
+        expect(textarea.value).toBe('say hello now');
+    });
+
+    it('inserts an empty pair with the caret between the markers', async () => {
+        const { container, textarea } = mountComposer();
+
+        await select(textarea, 'say ', 4, 4);
+        await clickFormat(container, '`');
+
+        expect(textarea.value).toBe('say ``');
+        expect(textarea.selectionStart).toBe(5);
+    });
+
+    it('applies the same markers from the keyboard', async () => {
+        const cases: Array<[string, { shiftKey?: boolean }, string]> = [
+            ['b', {}, 'say **hello** now'],
+            ['i', {}, 'say *hello* now'],
+            ['e', {}, 'say `hello` now'],
+            ['x', { shiftKey: true }, 'say ~~hello~~ now'],
+        ];
+
+        for (const [key, modifiers, expected] of cases) {
+            const { textarea } = mountComposer();
+
+            await select(textarea, 'say hello now', 4, 9);
+            const event = shortcut(textarea, key, modifiers);
+            await nextTick();
+
+            expect(textarea.value).toBe(expected);
+            expect(event.defaultPrevented).toBe(true);
+        }
+    });
+
+    it('keeps a format shortcut from reaching the window-level shortcuts', async () => {
+        const { textarea } = mountComposer();
+        const onWindowKey = vi.fn();
+        window.addEventListener('keydown', onWindowKey);
+
+        await select(textarea, 'say hello now', 4, 9);
+        shortcut(textarea, 'b');
+        await nextTick();
+
+        window.removeEventListener('keydown', onWindowKey);
+        // ⌘/Ctrl+B also toggles the sidebar, so formatting must claim the key.
+        expect(onWindowKey).not.toHaveBeenCalled();
+    });
+
+    it('leaves a modified combination that is not a format shortcut alone', async () => {
+        const { textarea } = mountComposer();
+
+        await select(textarea, 'say hello now', 4, 9);
+        // Alt disqualifies the combination, as does an unmapped key.
+        shortcut(textarea, 'b', { altKey: true });
+        shortcut(textarea, 'k');
+        await nextTick();
+
+        expect(textarea.value).toBe('say hello now');
+    });
+
+    it('names each control and its shortcut hint', () => {
+        const { container } = mountComposer();
+        const cluster = container.querySelector<HTMLElement>(
+            '[data-test="composer-format-cluster"]',
+        )!;
+
+        expect(
+            container
+                .querySelector('[data-test="message-composer-format-**"]')
+                ?.getAttribute('aria-label'),
+        ).toBe('Bold');
+        expect(cluster.textContent).toContain('Ctrl+B');
+        expect(cluster.textContent).toContain('Ctrl+Shift+X');
+    });
+});

--- a/resources/js/components/MessageComposer.mentions.test.ts
+++ b/resources/js/components/MessageComposer.mentions.test.ts
@@ -1,0 +1,380 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick, ref } from 'vue';
+import type { Mention } from '@/types';
+import MessageComposer from './MessageComposer.vue';
+
+/**
+ * Covers the composer's `@` autocomplete: which rows the menu offers (people
+ * first, with reserved tail slots for user groups), how a chosen row completes
+ * into a mention token, the keyboard model, and which mentions a send carries.
+ *
+ * Written against the live `<MessageComposer>` rather than a helper so it keeps
+ * watching the same behaviour once the mention surface moves out of the file.
+ */
+
+vi.mock('@/actions/App/Http/Controllers/Channels/AttachmentController', () => ({
+    store: () => ({ url: '/t/acme/c/general/attachments' }),
+}));
+
+// The workspace's mentionable groups ride on the Inertia page in the app; here
+// they are handed straight to the composable the menu reads them through.
+const groups: App.Data.UserGroupData[] = [
+    {
+        id: 'g1111111-1111-4111-8111-111111111111',
+        name: 'Design',
+        slug: 'design',
+        membersCount: 4,
+        members: [],
+    },
+    {
+        id: 'g2222222-2222-4222-8222-222222222222',
+        name: 'Platform',
+        slug: 'platform',
+        membersCount: 1,
+        members: [],
+    },
+    {
+        id: 'g3333333-3333-4333-8333-333333333333',
+        name: 'Support',
+        slug: 'support',
+        membersCount: 7,
+        members: [],
+    },
+    {
+        id: 'g4444444-4444-4444-8444-444444444444',
+        name: 'Growth',
+        slug: 'growth',
+        membersCount: 2,
+        members: [],
+    },
+];
+
+vi.mock('@/composables/useUserGroups', () => ({
+    useUserGroups: () => ({
+        groups: { value: groups },
+        search: (query: string) =>
+            query === ''
+                ? groups
+                : groups.filter(
+                      (group) =>
+                          group.slug.includes(query) ||
+                          group.name.toLowerCase().includes(query),
+                  ),
+    }),
+}));
+
+vi.mock('@/components/ui/button', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        Button: defineComponent({
+            name: 'ButtonStub',
+            inheritAttrs: false,
+            setup:
+                (_props, { attrs, slots }) =>
+                () =>
+                    h('button', attrs, slots.default?.()),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { defineComponent, h } = await import('vue');
+    const slot = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        Tooltip: slot('TooltipStub'),
+        TooltipContent: slot('TooltipContentStub'),
+        TooltipProvider: slot('TooltipProviderStub'),
+        TooltipTrigger: slot('TooltipTriggerStub'),
+    };
+});
+
+const ADA = {
+    id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    name: 'Ada Lovelace',
+};
+const GRACE = {
+    id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    name: 'Grace Hopper',
+};
+
+/** Ten members, so the eight-row cap and the group slots both bite. */
+const MANY_MEMBERS: Mention[] = Array.from({ length: 10 }, (_, index) => ({
+    id: `cccccccc-cccc-4ccc-8ccc-cccccccccc${String(index).padStart(2, '0')}`,
+    name: `Person ${index}`,
+}));
+
+type SentMessage = { body: string; mentions: Mention[] };
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+function mountComposer(props: Record<string, unknown> = {}) {
+    const sent: SentMessage[] = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const composer = ref<{ insertMention: (member: Mention) => void } | null>(
+        null,
+    );
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(MessageComposer as Component, {
+                    ref: composer,
+                    channelName: 'general',
+                    members: [ADA, GRACE],
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                    onSend: (body: string, mentions: Mention[]) =>
+                        sent.push({ body, mentions }),
+                    ...props,
+                }),
+        }),
+    );
+    // Interpolating stub: the group rows read their member count through a
+    // `:count` placeholder, which a key-only stub would swallow.
+    app.config.globalProperties.$t = (
+        key: string,
+        replacements: Record<string, string | number> = {},
+    ) =>
+        Object.entries(replacements).reduce(
+            (text, [token, value]) => text.replace(`:${token}`, String(value)),
+            key,
+        );
+    app.mount(container);
+    active.push({ app, container });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+        '[data-test="message-composer-input"]',
+    )!;
+
+    return { composer, container, sent, textarea };
+}
+
+/** Set the field's value + caret and fire the composer's `input` handler. */
+function type(textarea: HTMLTextAreaElement, value: string): Promise<void> {
+    textarea.value = value;
+    textarea.setSelectionRange(value.length, value.length);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+    return nextTick();
+}
+
+function press(textarea: HTMLTextAreaElement, key: string): Promise<void> {
+    textarea.dispatchEvent(
+        new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }),
+    );
+
+    return nextTick();
+}
+
+function options(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+        container.querySelectorAll<HTMLElement>('[data-test="mention-option"]'),
+    );
+}
+
+/**
+ * A row's label, past the leading initials/icon badge every row opens with.
+ */
+function labelOf(row: HTMLElement): string {
+    return row.querySelectorAll('span')[1].textContent?.trim() ?? '';
+}
+
+function send(container: HTMLElement): void {
+    container
+        .querySelector<HTMLButtonElement>(
+            '[data-test="message-composer-send"]',
+        )!
+        .click();
+}
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+});
+
+describe('MessageComposer mention autocomplete', () => {
+    it('opens the menu on @ and filters people by name', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, '@');
+        expect(
+            container.querySelector('[data-test="mention-menu"]'),
+        ).not.toBeNull();
+
+        await type(textarea, '@grace');
+        const rows = options(container);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].textContent).toContain('Grace Hopper');
+    });
+
+    it('closes the menu when the caret leaves a mention context', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, '@ada');
+        expect(
+            container.querySelector('[data-test="mention-menu"]'),
+        ).not.toBeNull();
+
+        await type(textarea, 'hello there');
+        expect(
+            container.querySelector('[data-test="mention-menu"]'),
+        ).toBeNull();
+    });
+
+    it('reserves the tail slots for groups so a match is never crowded out', async () => {
+        const { container, textarea } = mountComposer({
+            members: MANY_MEMBERS,
+        });
+
+        await type(textarea, '@');
+        const labels = options(container).map(labelOf);
+
+        // Five people, then three of the four groups: a flat slice would have
+        // spent all eight slots on names and hidden every group.
+        expect(labels).toEqual([
+            'Person 0',
+            'Person 1',
+            'Person 2',
+            'Person 3',
+            'Person 4',
+            'design',
+            'platform',
+            'support',
+        ]);
+    });
+
+    it('names how far a group mention reaches', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, '@p');
+        const counts = Array.from(
+            container.querySelectorAll<HTMLElement>(
+                '[data-test="mention-option-group-count"]',
+            ),
+        ).map((node) => node.textContent?.trim());
+
+        expect(counts).toEqual(['1 member', '7 members']);
+    });
+
+    it('completes a person into a mention token', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, 'hi @ad');
+        options(container)[0].dispatchEvent(
+            new MouseEvent('mousedown', { bubbles: true, cancelable: true }),
+        );
+        await nextTick();
+
+        expect(textarea.value).toBe(`hi @[Ada Lovelace](${ADA.id}) `);
+        expect(
+            container.querySelector('[data-test="mention-menu"]'),
+        ).toBeNull();
+    });
+
+    it('completes a group into a group token', async () => {
+        const { textarea } = mountComposer();
+
+        await type(textarea, '@design');
+        await press(textarea, 'Enter');
+
+        expect(textarea.value).toBe(`@[design](group:${groups[0].id}) `);
+    });
+
+    it('navigates with the arrow keys and closes on Escape', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, '@');
+        await press(textarea, 'ArrowDown');
+        expect(options(container)[1].getAttribute('aria-selected')).toBe(
+            'true',
+        );
+
+        await press(textarea, 'ArrowUp');
+        expect(options(container)[0].getAttribute('aria-selected')).toBe(
+            'true',
+        );
+
+        await press(textarea, 'Escape');
+        expect(
+            container.querySelector('[data-test="mention-menu"]'),
+        ).toBeNull();
+    });
+
+    it('completes the highlighted row on Tab', async () => {
+        const { textarea } = mountComposer();
+
+        await type(textarea, '@gr');
+        await press(textarea, 'Tab');
+
+        expect(textarea.value).toBe(`@[Grace Hopper](${GRACE.id}) `);
+    });
+
+    it('sends the distinct people named in the body', async () => {
+        const { container, sent, textarea } = mountComposer();
+
+        await type(
+            textarea,
+            `@[Ada Lovelace](${ADA.id}) @[Ada Lovelace](${ADA.id}) @[Grace Hopper](${GRACE.id}) ship it`,
+        );
+        send(container);
+        await nextTick();
+
+        expect(sent[0].mentions).toEqual([
+            { id: ADA.id, name: ADA.name },
+            { id: GRACE.id, name: GRACE.name },
+        ]);
+    });
+
+    it('leaves a group token out of the optimistic mention list', async () => {
+        const { container, sent, textarea } = mountComposer();
+
+        await type(textarea, `@[design](group:${groups[0].id}) heads up`);
+        send(container);
+        await nextTick();
+
+        // The fan-out is resolved server-side at post time, so the optimistic
+        // row lists only the people it can already name.
+        expect(sent[0].mentions).toEqual([]);
+    });
+
+    it('explains missing bots only in a channel that has one', async () => {
+        const withoutBots = mountComposer();
+        await type(withoutBots.textarea, '@');
+        expect(
+            withoutBots.container.querySelector(
+                '[data-test="mention-bot-hint"]',
+            ),
+        ).toBeNull();
+
+        const withBots = mountComposer({ hasBots: true });
+        await type(withBots.textarea, '@');
+        expect(
+            withBots.container.querySelector('[data-test="mention-bot-hint"]'),
+        ).not.toBeNull();
+    });
+
+    it('drops a mention in at the caret from outside the composer', async () => {
+        const { composer, textarea } = mountComposer();
+
+        await type(textarea, 'ping');
+        composer.value!.insertMention(GRACE);
+        await nextTick();
+
+        expect(textarea.value).toBe(`ping @[Grace Hopper](${GRACE.id}) `);
+    });
+});

--- a/resources/js/components/MessageComposer.tray.test.ts
+++ b/resources/js/components/MessageComposer.tray.test.ts
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import type { UploadHandle } from '@/lib/uploadAttachment';
+import MessageComposer from './MessageComposer.vue';
+
+/**
+ * Covers the pre-send attachment tray's chips: which shape each staged row
+ * renders as (image, file, failed), the progress it reports while uploading,
+ * and the remove/retry controls on it. `useAttachmentUploads` is unit-tested on
+ * its own; what is watched here is the markup the composer wraps it in.
+ */
+
+type PendingUpload = {
+    resolve: (value: unknown) => void;
+    reject: (reason: unknown) => void;
+    progress: (percent: number) => void;
+};
+
+/** Control the upload transport so a staged file settles on demand. */
+const uploads = vi.hoisted(() => [] as PendingUpload[]);
+
+vi.mock('@/lib/uploadAttachment', () => ({
+    xhrUpload: (
+        _endpoint: string,
+        _file: File,
+        onProgress: (percent: number) => void,
+    ): UploadHandle => {
+        let resolve!: (value: unknown) => void;
+        let reject!: (reason: unknown) => void;
+        const promise = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        uploads.push({ resolve, reject, progress: onProgress });
+
+        return { promise: promise as Promise<never>, abort: vi.fn() };
+    },
+}));
+
+vi.mock('@/actions/App/Http/Controllers/Channels/AttachmentController', () => ({
+    store: () => ({ url: '/t/acme/c/general/attachments' }),
+}));
+
+vi.mock('@/components/ui/button', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        Button: defineComponent({
+            name: 'ButtonStub',
+            inheritAttrs: false,
+            setup:
+                (_props, { attrs, slots }) =>
+                () =>
+                    h('button', attrs, slots.default?.()),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { defineComponent, h } = await import('vue');
+    const slot = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        Tooltip: slot('TooltipStub'),
+        TooltipContent: slot('TooltipContentStub'),
+        TooltipProvider: slot('TooltipProviderStub'),
+        TooltipTrigger: slot('TooltipTriggerStub'),
+    };
+});
+
+const PREVIEW_URL = 'blob:preview-1';
+
+beforeEach(() => {
+    URL.createObjectURL = vi.fn(() => PREVIEW_URL);
+    URL.revokeObjectURL = vi.fn();
+});
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+function mountComposer(props: Record<string, unknown> = {}) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(MessageComposer as Component, {
+                    channelName: 'general',
+                    members: [],
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                    maxAttachmentSizeMb: 25,
+                    maxAttachmentsPerMessage: 10,
+                    ...props,
+                }),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(container);
+    active.push({ app, container });
+
+    return { container };
+}
+
+/** Set the hidden input's `files` (read-only in jsdom) and fire `change`. */
+async function stage(container: HTMLElement, file: File): Promise<void> {
+    const input = container.querySelector<HTMLInputElement>(
+        '[data-test="composer-file-input"]',
+    )!;
+    const list = {
+        0: file,
+        length: 1,
+        item: (index: number) => (index === 0 ? file : null),
+    };
+    Object.defineProperty(input, 'files', { value: list, configurable: true });
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+
+    await nextTick();
+}
+
+function chips(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+        container.querySelectorAll<HTMLElement>(
+            '[data-test="composer-attachment"]',
+        ),
+    );
+}
+
+function textFile(): File {
+    return new File(['x'.repeat(2048)], 'launch-checklist.txt', {
+        type: 'text/plain',
+    });
+}
+
+function imageFile(): File {
+    return new File(['png'], 'diagram.png', { type: 'image/png' });
+}
+
+/** Settle the mocked upload promise's `.then` handlers. */
+async function settle(): Promise<void> {
+    await Promise.resolve();
+    await nextTick();
+}
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+    uploads.length = 0;
+});
+
+describe('MessageComposer attachment tray', () => {
+    it('stays out of the way until something is staged', () => {
+        const { container } = mountComposer();
+
+        expect(
+            container.querySelector('[data-test="composer-attachment-tray"]'),
+        ).toBeNull();
+    });
+
+    it('offers no attachments where the composer does not know its channel', () => {
+        const { container } = mountComposer({ channelSlug: undefined });
+
+        expect(
+            container
+                .querySelector('[data-test="message-composer-attach"]')
+                ?.hasAttribute('disabled'),
+        ).toBe(true);
+    });
+
+    it('reports a file’s name, size and progress while it uploads', async () => {
+        const { container } = mountComposer();
+
+        await stage(container, textFile());
+        uploads[0].progress(40);
+        await nextTick();
+
+        const [chip] = chips(container);
+        expect(chip.getAttribute('data-kind')).toBe('file');
+        expect(chip.getAttribute('data-status')).toBe('uploading');
+        expect(chip.textContent).toContain('launch-checklist.txt');
+        expect(chip.textContent).toContain('2 KB');
+        expect(chip.textContent).toContain('40%');
+    });
+
+    it('settles a finished upload into a plain chip', async () => {
+        const { container } = mountComposer();
+
+        await stage(container, textFile());
+        uploads[0].resolve({ id: 'att-1' });
+        await settle();
+
+        const [chip] = chips(container);
+        expect(chip.getAttribute('data-status')).toBe('done');
+        expect(chip.textContent).not.toContain('%');
+    });
+
+    it('previews a staged image as a thumbnail', async () => {
+        const { container } = mountComposer();
+
+        await stage(container, imageFile());
+
+        const [chip] = chips(container);
+        expect(chip.getAttribute('data-kind')).toBe('image');
+        expect(chip.querySelector('img')?.getAttribute('src')).toBe(
+            PREVIEW_URL,
+        );
+        // The thumbnail's remove control is a painted badge rather than a
+        // visible button, so the picture it belongs to stays readable.
+        expect(
+            chip.querySelector(
+                '[data-test="composer-attachment-remove-badge"]',
+            ),
+        ).not.toBeNull();
+    });
+
+    it('offers a retry on a transport failure', async () => {
+        const { container } = mountComposer();
+
+        await stage(container, textFile());
+        uploads[0].reject({ aborted: false, message: null, status: 500 });
+        await settle();
+
+        const [failed] = chips(container);
+        expect(failed.getAttribute('data-kind')).toBe('failed');
+        expect(failed.textContent).toContain('Upload failed');
+
+        failed
+            .querySelector<HTMLButtonElement>(
+                '[data-test="composer-attachment-retry"]',
+            )!
+            .click();
+        await nextTick();
+
+        expect(chips(container)[0].getAttribute('data-status')).toBe(
+            'uploading',
+        );
+        expect(uploads).toHaveLength(2);
+    });
+
+    it('drops a staged row from its remove control', async () => {
+        const { container } = mountComposer();
+
+        await stage(container, textFile());
+        chips(container)[0]
+            .querySelector<HTMLButtonElement>(
+                '[data-test="composer-attachment-remove"]',
+            )!
+            .click();
+        await nextTick();
+
+        expect(chips(container)).toHaveLength(0);
+        expect(
+            container.querySelector('[data-test="composer-attachment-tray"]'),
+        ).toBeNull();
+    });
+
+    it('blocks the send while a row is still uploading or failed', async () => {
+        const { container } = mountComposer();
+        const send = container.querySelector<HTMLButtonElement>(
+            '[data-test="message-composer-send"]',
+        )!;
+
+        await stage(container, textFile());
+        expect(send.hasAttribute('disabled')).toBe(true);
+
+        uploads[0].resolve({ id: 'att-1' });
+        await settle();
+        expect(send.hasAttribute('disabled')).toBe(false);
+    });
+});

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -1,60 +1,32 @@
 <script setup lang="ts">
-import {
-    ArrowUp,
-    Bold,
-    Bot,
-    CircleAlert,
-    Code,
-    FileText,
-    Italic,
-    Mic,
-    Pencil,
-    Plus,
-    Square,
-    Strikethrough,
-    Users,
-    X,
-} from '@lucide/vue';
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
-import { store as storeAttachment } from '@/actions/App/Http/Controllers/Channels/AttachmentController';
-import AudioPlayer from '@/components/AudioPlayer.vue';
-import ComposerSendButton from '@/components/ComposerSendButton.vue';
+import AttachmentTray from '@/components/composer/AttachmentTray.vue';
+import ComposerInputRow from '@/components/composer/ComposerInputRow.vue';
+import EditingBanner from '@/components/composer/EditingBanner.vue';
+import MentionMenu from '@/components/composer/MentionMenu.vue';
+import RecordingStrip from '@/components/composer/RecordingStrip.vue';
+import ReplyPreview from '@/components/composer/ReplyPreview.vue';
+import SlashCommandMenu from '@/components/composer/SlashCommandMenu.vue';
 import GifPickerPanel from '@/components/GifPickerPanel.vue';
-import MessageQuote from '@/components/MessageQuote.vue';
 import PollComposerPanel from '@/components/PollComposerPanel.vue';
 import ScheduleMessageDialog from '@/components/ScheduleMessageDialog.vue';
-import { Button } from '@/components/ui/button';
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipProvider,
-    TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
+import { useComposerAttachments } from '@/composables/useComposerAttachments';
+import { useComposerEditMode } from '@/composables/useComposerEditMode';
+import { useComposerField } from '@/composables/useComposerField';
+import { useComposerFormat } from '@/composables/useComposerFormat';
+import { useComposerKeyboard } from '@/composables/useComposerKeyboard';
+import { useComposerMentions } from '@/composables/useComposerMentions';
+import { useComposerSend } from '@/composables/useComposerSend';
+import { useComposerSlashCommands } from '@/composables/useComposerSlashCommands';
 import { useEllipsizedText } from '@/composables/useEllipsizedText';
-import { useInitials } from '@/composables/useInitials';
 import { useKeyboardInset } from '@/composables/useKeyboardInset';
 import type {
     CommandCallbacks,
     SendCallbacks,
 } from '@/composables/useMessageActions';
 import { useTranslations } from '@/composables/useTranslations';
-import { useUserGroups } from '@/composables/useUserGroups';
-import { useVoiceRecorder } from '@/composables/useVoiceRecorder';
-import { formatFileSize } from '@/lib/attachments';
-import {
-    VOICE_MAX_DURATION_SECONDS,
-    formatClock,
-    isVoiceRecordingSupported,
-} from '@/lib/audio';
-import {
-    isComposerEditTrigger,
-    resolveComposerEditTarget,
-} from '@/lib/composerEdit';
 import { isInteractiveComposerTarget } from '@/lib/composerFocus';
-import { toggleInlineMark } from '@/lib/composerFormat';
 import type { Mention, Message } from '@/types';
-import type { AttachmentData } from '@/types/attachments';
 
 const props = defineProps<{
     channelName: string;
@@ -162,172 +134,42 @@ const emit = defineEmits<{
     editingChange: [messageId: string | null];
 }>();
 
-const { getInitials } = useInitials();
-const { search: searchGroups } = useUserGroups();
 const { t } = useTranslations();
 
-const body = ref(props.initialBody ?? '');
-const textarea = ref<HTMLTextAreaElement | null>(null);
+const field = useComposerField(props.initialBody ?? '');
+const { body, textarea, focus, resize } = field;
 
-/**
- * The message the composer is editing in place, or null in normal compose mode.
- * Set by the ArrowUp "edit last message" shortcut; while non-null the body is
- * scoped to that message, not a new-message draft.
- */
-const editingMessage = ref<Message | null>(null);
-
-/**
- * When true, the next body change is a programmatic clear-on-send (or the wipe
- * that leaves edit mode), not a user edit, so it must not emit a draft change:
- * sending already clears the draft server-side, and re-emitting would fire a
- * redundant save.
- */
-let clearingAfterSend = false;
-
-// Surface every body change so the parent can persist (or clear) the draft.
-// Seeding `body` above happens before this watch is registered, so restoring a
-// draft doesn't echo back as a change.
-watch(body, (value) => {
-    if (clearingAfterSend) {
-        clearingAfterSend = false;
-
-        return;
-    }
-
-    // A body change while editing an existing message is scoped to that
-    // message, not a new-message draft, so it must never persist as a draft.
-    if (editingMessage.value) {
-        return;
-    }
-
-    emit('draftChange', value);
+const attachments = useComposerAttachments({
+    teamSlug: () => props.teamSlug,
+    channelSlug: () => props.channelSlug,
+    maxSizeMb: () => props.maxAttachmentSizeMb,
+    maxPerMessage: () => props.maxAttachmentsPerMessage,
 });
+const {
+    attachmentsEnabled,
+    canRecord,
+    onPaste,
+    recorder,
+    showTray,
+    trayItems,
+    uploads,
+} = attachments;
 
-/** In a thread composer, whether the reply is also surfaced in the main timeline. */
-const sendToChannel = ref(false);
-
-/**
- * Attachments are enabled only when the composer knows its channel: files
- * pre-upload to that channel's endpoint. The thread composer omits the slug, so
- * its "Add attachment" button stays disabled (thread attachments are a separate
- * epic child).
- */
-const attachmentsEnabled = computed(
-    () => Boolean(props.teamSlug) && Boolean(props.channelSlug),
-);
-
-/**
- * The pre-send attachment tray: files upload immediately on pick/paste/drop,
- * each row tracking its own progress; the send later claims the finished ids.
- */
-const uploads = useAttachmentUploads({
-    endpoint: () =>
-        storeAttachment({
-            team: props.teamSlug ?? '',
-            channel: props.channelSlug ?? '',
-        }).url,
-    maxSizeMb: () => props.maxAttachmentSizeMb ?? 25,
-    maxPerMessage: () => props.maxAttachmentsPerMessage ?? 10,
-});
-
-const trayItems = computed(() => uploads.items.value);
-const showTray = computed(
-    () => attachmentsEnabled.value && trayItems.value.length > 0,
-);
-
-/**
- * A send is allowed once nothing is mid-upload or failed and there is something
- * to send (body text or at least one finished attachment). Body is optional
- * when the tray carries a ready attachment.
- */
-const canSubmit = computed(() => {
-    if (uploads.isUploading.value || uploads.hasFailed.value) {
-        return false;
-    }
-
-    return body.value.trim() !== '' || uploads.attachmentIds.value.length > 0;
-});
-
-/**
- * A voice clip is nothing but an audio attachment, so recording rides the tray
- * above: the finished clip is staged exactly like a dropped file and uploads
- * through the same endpoint. Capability is read once — `MediaRecorder` and a
- * secure-context `getUserMedia` don't appear mid-session — and where either is
- * missing the mic slot is absent rather than present-and-broken.
- */
-const voiceRecordingSupported = isVoiceRecordingSupported();
-const canRecord = computed(
-    () => attachmentsEnabled.value && voiceRecordingSupported,
-);
-
-const recorder = useVoiceRecorder({
-    onRecorded: (clip) => uploads.addFiles([clip]),
-});
-
-/** The recording strip's `elapsed / 5:00` ceiling. */
-const recordingLimit = formatClock(VOICE_MAX_DURATION_SECONDS);
-
-/**
- * The live input-level meter's bars (design 1b). Purely ephemeral chrome: the
- * levels are read from the mic in real time and nothing is kept with the clip.
- */
-const LEVEL_BARS = 10;
-const levelBars = computed(() =>
-    Array.from({ length: LEVEL_BARS }, (_, index) => {
-        // Stagger the bars around the current level so the meter reads as a
-        // moving waveform rather than a single block rising and falling.
-        const offset = ((index % 3) + 1) / 4;
-
-        return Math.min(
-            Math.max(recorder.level.value * (0.5 + offset), 0.1),
-            1,
-        );
-    }),
-);
-
-/** The hidden native file input the "Add attachment" button proxies to. */
-const fileInput = ref<HTMLInputElement | null>(null);
-
-function openFilePicker(): void {
-    fileInput.value?.click();
+/** Take the field element the input row mounts, which the composer drives. */
+function registerField(element: HTMLTextAreaElement | null): void {
+    textarea.value = element;
 }
 
-function onFilesPicked(event: Event): void {
-    const input = event.target as HTMLInputElement;
-
-    if (input.files) {
-        uploads.addFiles(input.files);
-    }
-
-    // Reset so re-picking the same file fires `change` again.
-    input.value = '';
+function onFieldInput(): void {
+    resize();
+    refreshSuggestions();
+    refreshSlashSuggestions();
+    emit('typing');
 }
 
-/**
- * Pasting image data (a screenshot) or files into the composer stages them in
- * the tray instead of dropping raw bytes into the text.
- */
-function onPaste(event: ClipboardEvent): void {
-    if (!attachmentsEnabled.value) {
-        return;
-    }
-
-    const files = Array.from(event.clipboardData?.files ?? []);
-
-    if (files.length > 0) {
-        event.preventDefault();
-        uploads.addFiles(files);
-    }
-}
-
-/**
- * Stage externally-provided files (the channel pane's drag-and-drop overlay
- * forwards its drop here). Exposed below.
- */
-function addFiles(files: FileList | File[]): void {
-    if (attachmentsEnabled.value) {
-        uploads.addFiles(files);
-    }
+function onFieldClick(): void {
+    refreshSuggestions();
+    refreshSlashSuggestions();
 }
 
 const composerPlaceholder = computed(
@@ -362,52 +204,131 @@ watch(
     () => props.replyTarget,
     (target) => {
         if (target) {
-            nextTick(() => textarea.value?.focus());
+            focus();
         }
     },
 );
 
-/**
- * Well-formed *person* mention token: `@[Display Name](user-id)`. The parser on
- * the server resolves the id; here it lets us collect the mentions being sent
- * and recognise a completed token so it never re-triggers the autocomplete. A
- * group token carries a `group:` prefix, so it deliberately does not match —
- * the optimistic row lists people, and the group's fan-out is resolved
- * server-side at post time.
- */
-const MENTION_TOKEN = /@\[[^\]]+\]\(([0-9a-fA-F-]{36})\)/g;
+const mentions = useComposerMentions({
+    field,
+    members: () => props.members,
+});
+const {
+    activeIndex,
+    insertMention,
+    refreshSuggestions,
+    selectSuggestion,
+    showMenu,
+    suggestions,
+} = mentions;
 
 /**
- * A fresh `@query` at the caret: an `@` at the start or after whitespace,
- * followed by run of non-space characters that isn't already a token.
+ * When true, the next body change is a programmatic clear-on-send (or the wipe
+ * that leaves edit mode), not a user edit, so it must not emit a draft change:
+ * sending already clears the draft server-side, and re-emitting would fire a
+ * redundant save.
  */
-const MENTION_QUERY = /(?:^|\s)@([^\s@[\]()]*)$/;
+let clearingAfterSend = false;
 
-const MAX_SUGGESTIONS = 8;
+function suppressNextDraftChange(suppress: boolean): void {
+    clearingAfterSend = suppress;
+}
 
-/**
- * How many of those slots user groups may claim. Capped so the menu stays a
- * people-picker first, but never so low that a matching group is crowded out.
- */
-const MAX_GROUP_SUGGESTIONS = 3;
+const editing = useComposerEditMode({
+    field,
+    messages: () => props.messages ?? [],
+    currentUserId: () => props.currentUserId ?? '',
+    pendingUuids: () => props.pendingUuids,
+    closeMenu: mentions.closeMenu,
+    suppressNextDraftChange,
+    onEditingChange: (messageId) => emit('editingChange', messageId),
+    onSave: (message, edited) => emit('edit', message, edited),
+});
+const { editingMessage, exitEditMode, saveEdit } = editing;
 
-/**
- * One row of the `@` menu: a person, or a user group that fans the mention out
- * to everyone in it. Both live in one list so the keyboard model, the active
- * index, and the ARIA wiring stay single-source.
- */
-type MentionSuggestion =
-    | { kind: 'user'; id: string; label: string; member: Mention }
-    | {
-          kind: 'group';
-          id: string;
-          label: string;
-          group: App.Data.UserGroupData;
-      };
+// Surface every body change so the parent can persist (or clear) the draft.
+// Seeding `body` above happens before this watch is registered, so restoring a
+// draft doesn't echo back as a change.
+watch(body, (value) => {
+    if (clearingAfterSend) {
+        clearingAfterSend = false;
 
-const suggestions = ref<MentionSuggestion[]>([]);
-const activeIndex = ref(0);
-const menuOpen = ref(false);
+        return;
+    }
+
+    // A body change while editing an existing message is scoped to that
+    // message, not a new-message draft, so it must never persist as a draft.
+    if (editingMessage.value) {
+        return;
+    }
+
+    emit('draftChange', value);
+});
+
+const slash = useComposerSlashCommands({
+    field,
+    commands: () => props.slashCommands,
+    gifPickerEnabled: () => Boolean(props.gifPickerEnabled),
+    pollsEnabled: () => Boolean(props.pollsEnabled),
+    attachmentsEnabled: () => attachmentsEnabled.value,
+    teamSlug: () => props.teamSlug,
+    channelSlug: () => props.channelSlug,
+    isEditing: () => editingMessage.value !== null,
+    stageRemote: (attachment) => uploads.addRemote(attachment),
+});
+const {
+    closeGifPicker,
+    closePollComposer,
+    gifPickerAvailable,
+    gifPickerOpen,
+    gifPickerQuery,
+    onGifSelected,
+    pollComposerAvailable,
+    pollComposerOpen,
+    refreshSlashSuggestions,
+    selectSlashCommand,
+    showSlashMenu,
+    slashActiveIndex,
+    slashSuggestions,
+} = slash;
+
+const format = useComposerFormat({ field });
+const { applyFormat, formatActions } = format;
+
+const send = useComposerSend({
+    field,
+    attachments,
+    mentions,
+    slash,
+    suppressNextDraftChange,
+    onSend: (text, sentMentions, toChannel, attachmentIds, callbacks) =>
+        emit('send', text, sentMentions, toChannel, attachmentIds, callbacks),
+    onCommand: (rawBody, callbacks) => emit('command', rawBody, callbacks),
+    onSchedule: (text, sentMentions, sendAt) =>
+        emit('schedule', text, sentMentions, sendAt),
+    onDraftChange: (value) => emit('draftChange', value),
+});
+const {
+    canSchedule,
+    canSubmit,
+    commandPending,
+    onScheduleConfirm,
+    openSchedule,
+    scheduling,
+    sendToChannel,
+    submit,
+} = send;
+
+const { onKeydown } = useComposerKeyboard({
+    field,
+    mentions,
+    slash,
+    format,
+    editing,
+    replyTarget: () => props.replyTarget,
+    onCancelReply: () => emit('cancelReply'),
+    onSubmit: submit,
+});
 
 /**
  * Whether the compose tools are disclosed. Only consulted below the breakpoint,
@@ -422,511 +343,6 @@ const toolsOpen = ref(false);
  */
 const keyboardInsetPx = useKeyboardInset();
 
-const showMenu = computed(() => menuOpen.value && suggestions.value.length > 0);
-
-/**
- * The active `@query` immediately before the caret, or null when the caret is
- * not in a mention context.
- */
-function activeQuery(): { query: string; start: number } | null {
-    const el = textarea.value;
-    const caret = el ? el.selectionStart : body.value.length;
-    const upToCaret = body.value.slice(0, caret);
-    const match = upToCaret.match(MENTION_QUERY);
-
-    if (!match) {
-        return null;
-    }
-
-    return { query: match[1], start: caret - match[1].length - 1 };
-}
-
-function refreshSuggestions(): void {
-    const active = activeQuery();
-
-    if (!active) {
-        menuOpen.value = false;
-        suggestions.value = [];
-
-        return;
-    }
-
-    const needle = active.query.toLowerCase();
-
-    // People first, then groups: naming an individual is the far more common
-    // intent, and a group reaching several people should never be the row the
-    // caret lands on by default.
-    const people: MentionSuggestion[] = props.members
-        .filter((member) => member.name.toLowerCase().includes(needle))
-        .map((member) => ({
-            kind: 'user',
-            id: member.id,
-            label: member.name,
-            member,
-        }));
-
-    const groups: MentionSuggestion[] = searchGroups(needle).map((group) => ({
-        kind: 'group',
-        id: group.id,
-        label: group.slug,
-        group,
-    }));
-
-    // Groups get reserved slots at the tail rather than whatever the people list
-    // leaves over: a plain `[...people, ...groups].slice(MAX)` would hide a
-    // matching group entirely behind eight matching names, making it
-    // unreachable from the menu.
-    const groupSlots = Math.min(groups.length, MAX_GROUP_SUGGESTIONS);
-
-    suggestions.value = [
-        ...people.slice(0, MAX_SUGGESTIONS - groupSlots),
-        ...groups.slice(0, groupSlots),
-    ];
-    activeIndex.value = 0;
-    menuOpen.value = suggestions.value.length > 0;
-}
-
-function moveActive(delta: number): void {
-    const count = suggestions.value.length;
-    activeIndex.value = (activeIndex.value + delta + count) % count;
-}
-
-function selectSuggestion(suggestion: MentionSuggestion): void {
-    const el = textarea.value;
-    const caret = el ? el.selectionStart : body.value.length;
-    const active = activeQuery();
-
-    if (!active) {
-        return;
-    }
-
-    const before = body.value.slice(0, active.start);
-    const after = body.value.slice(caret);
-    // The `group:` prefix is what tells the server (and the renderer) to expand
-    // the token to a whole group rather than resolve one person.
-    const token =
-        suggestion.kind === 'group'
-            ? `@[${suggestion.label}](group:${suggestion.id}) `
-            : `@[${suggestion.label}](${suggestion.id}) `;
-
-    body.value = before + token + after;
-    menuOpen.value = false;
-
-    const nextCaret = before.length + token.length;
-
-    nextTick(() => {
-        const field = textarea.value;
-
-        if (field) {
-            field.focus();
-            field.setSelectionRange(nextCaret, nextCaret);
-        }
-
-        resize();
-    });
-}
-
-function selectActive(): void {
-    const suggestion = suggestions.value[activeIndex.value];
-
-    if (suggestion) {
-        selectSuggestion(suggestion);
-    }
-}
-
-/**
- * A slash command occupies the whole body up to the caret: a leading `/`
- * followed by word characters and nothing else. The menu therefore triggers
- * only at composer position 0 and closes the instant a space is typed (which
- * breaks the match), matching the server's `^/(name)(\s|$)` interception rule.
- */
-const SLASH_QUERY = /^\/(\w*)$/;
-
-const slashSuggestions = ref<App.Data.SlashCommandData[]>([]);
-const slashActiveIndex = ref(0);
-const slashMenuOpen = ref(false);
-
-const showSlashMenu = computed(
-    () => slashMenuOpen.value && slashSuggestions.value.length > 0,
-);
-
-/**
- * True while a command send awaits the server. Unlike a normal (optimistic)
- * send, a command keeps its text and blocks re-submits until the outcome lands.
- */
-const commandPending = ref(false);
-
-function refreshSlashSuggestions(): void {
-    const commands = props.slashCommands ?? [];
-
-    if (commands.length === 0) {
-        slashMenuOpen.value = false;
-        slashSuggestions.value = [];
-
-        return;
-    }
-
-    const el = textarea.value;
-    const caret = el ? el.selectionStart : body.value.length;
-    const match = body.value.slice(0, caret).match(SLASH_QUERY);
-
-    if (!match) {
-        slashMenuOpen.value = false;
-        slashSuggestions.value = [];
-
-        return;
-    }
-
-    const needle = match[1].toLowerCase();
-
-    slashSuggestions.value = commands
-        .filter((command) => command.name.toLowerCase().startsWith(needle))
-        .slice(0, MAX_SUGGESTIONS);
-    slashActiveIndex.value = 0;
-    slashMenuOpen.value = slashSuggestions.value.length > 0;
-}
-
-function slashMoveActive(delta: number): void {
-    const count = slashSuggestions.value.length;
-    slashActiveIndex.value = (slashActiveIndex.value + delta + count) % count;
-}
-
-/**
- * The one picker-backed command: `/gif` opens the Giphy picker instead of
- * completing to text and posting through the command endpoint.
- */
-const GIF_COMMAND_NAME = 'gif';
-
-/** The GIF picker's open state and the search term it opens on (from `/gif cats`). */
-const gifPickerOpen = ref(false);
-const gifPickerQuery = ref('');
-
-/**
- * The picker is usable only when configured, when the composer knows its
- * channel (a picked GIF is staged as an attachment on that channel), and while
- * composing a new message — not editing an existing one (an inline edit saves
- * text only and cannot carry an attachment).
- */
-const gifPickerAvailable = computed(
-    () =>
-        Boolean(props.gifPickerEnabled) &&
-        attachmentsEnabled.value &&
-        !editingMessage.value,
-);
-
-/**
- * The search term if `text` is the `/gif` command (`/gif` or `/gif <query>`) and
- * the picker is available, else null. Used to divert `/gif` away from the text
- * command path and into the picker.
- */
-function gifCommandQuery(text: string): string | null {
-    if (!gifPickerAvailable.value) {
-        return null;
-    }
-
-    const match = text.match(/^\/gif(?:\s+(.*))?$/i);
-
-    return match ? (match[1]?.trim() ?? '') : null;
-}
-
-/** Open the GIF picker on the given search term, clearing the `/gif` text. */
-function openGifPicker(query: string): void {
-    slashMenuOpen.value = false;
-    gifPickerQuery.value = query;
-    gifPickerOpen.value = true;
-    body.value = '';
-}
-
-function closeGifPicker(): void {
-    gifPickerOpen.value = false;
-    nextTick(() => textarea.value?.focus());
-}
-
-/**
- * A picked GIF joins the tray as a remote attachment; the picker closes only if
- * it was accepted, so a full tray keeps the picker open with its toast shown.
- */
-function onGifSelected(attachment: AttachmentData): void {
-    if (uploads.addRemote(attachment)) {
-        closeGifPicker();
-    }
-}
-
-/**
- * The other picker-backed command: `/poll` opens the poll builder instead of
- * completing to text and posting through the command endpoint.
- */
-const POLL_COMMAND_NAME = 'poll';
-
-/** The poll builder's open state. */
-const pollComposerOpen = ref(false);
-
-/**
- * The builder is usable only when polls are enabled, when the composer knows its
- * channel (the poll is posted to that channel), and while composing a new
- * message — not editing an existing one.
- */
-const pollComposerAvailable = computed(
-    () =>
-        Boolean(props.pollsEnabled) &&
-        Boolean(props.teamSlug) &&
-        Boolean(props.channelSlug) &&
-        !editingMessage.value,
-);
-
-/** Whether `text` is the `/poll` command and the builder is available. */
-function isPollCommand(text: string): boolean {
-    return pollComposerAvailable.value && /^\/poll(?:\s+.*)?$/i.test(text);
-}
-
-/** Open the poll builder, closing the slash menu and clearing the `/poll` text. */
-function openPollComposer(): void {
-    slashMenuOpen.value = false;
-    pollComposerOpen.value = true;
-    body.value = '';
-}
-
-function closePollComposer(): void {
-    pollComposerOpen.value = false;
-    nextTick(() => textarea.value?.focus());
-}
-
-function selectSlashCommand(command: App.Data.SlashCommandData): void {
-    if (command.name === GIF_COMMAND_NAME && gifPickerAvailable.value) {
-        openGifPicker('');
-
-        return;
-    }
-
-    if (command.name === POLL_COMMAND_NAME && pollComposerAvailable.value) {
-        openPollComposer();
-
-        return;
-    }
-
-    body.value = `/${command.name} `;
-    slashMenuOpen.value = false;
-
-    const nextCaret = body.value.length;
-
-    nextTick(() => {
-        const field = textarea.value;
-
-        if (field) {
-            field.focus();
-            field.setSelectionRange(nextCaret, nextCaret);
-        }
-
-        resize();
-    });
-}
-
-function selectSlashActive(): void {
-    const command = slashSuggestions.value[slashActiveIndex.value];
-
-    if (command) {
-        selectSlashCommand(command);
-    }
-}
-
-/**
- * Whether the trimmed body is a send-ready command the server will intercept: a
- * leading `/name` (name followed by a space or the end) matching a registered
- * command. Only advisory — it decides which endpoint the composer posts to; the
- * server re-parses authoritatively.
- */
-function looksLikeCommand(text: string): boolean {
-    const match = text.match(/^\/(\S+)(?:\s|$)/);
-
-    if (!match) {
-        return false;
-    }
-
-    return (props.slashCommands ?? []).some(
-        (command) => command.name === match[1],
-    );
-}
-
-/**
- * Collect the distinct, resolvable mentions present in the body so the
- * optimistic row can highlight them before the server echo arrives.
- */
-function collectMentions(text: string): Mention[] {
-    const seen = new Set<string>();
-    const mentions: Mention[] = [];
-
-    for (const match of text.matchAll(MENTION_TOKEN)) {
-        const id = match[1];
-        const member = props.members.find((candidate) => candidate.id === id);
-
-        if (member && !seen.has(id)) {
-            seen.add(id);
-            mentions.push({ id: member.id, name: member.name });
-        }
-    }
-
-    return mentions;
-}
-
-function resize(): void {
-    const el = textarea.value;
-
-    if (!el) {
-        return;
-    }
-
-    el.style.height = 'auto';
-    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
-}
-
-/**
- * The platform's primary modifier, for the format tooltips' shortcut hints.
- * Falls back to Ctrl off-Mac (and during SSR, where `navigator` is absent).
- */
-const isMac =
-    typeof navigator !== 'undefined' &&
-    /Mac|iPhone|iPad/.test(navigator.platform);
-const modLabel = isMac ? '⌘' : 'Ctrl+';
-const shiftLabel = isMac ? '⇧' : 'Shift+';
-
-/**
- * The four inline-format controls, each pairing its Markdown marker with the
- * icon, accessible label, and shortcut hint shown in its tooltip. Driven by the
- * toolbar buttons and the keyboard shortcuts alike.
- */
-const formatActions = computed(() => [
-    { marker: '**', icon: Bold, label: t('Bold'), shortcut: `${modLabel}B` },
-    { marker: '*', icon: Italic, label: t('Italic'), shortcut: `${modLabel}I` },
-    {
-        marker: '~~',
-        icon: Strikethrough,
-        label: t('Strikethrough'),
-        shortcut: `${modLabel}${shiftLabel}X`,
-    },
-    {
-        marker: '`',
-        icon: Code,
-        label: t('Inline code'),
-        shortcut: `${modLabel}E`,
-    },
-]);
-
-/**
- * Wrap (or unwrap) the current textarea selection in a Markdown marker, then
- * restore focus and the resulting selection so the field stays ready to type.
- * Shared by the toolbar buttons and the keyboard shortcuts.
- */
-function applyFormat(marker: string): void {
-    const el = textarea.value;
-
-    if (!el) {
-        return;
-    }
-
-    const result = toggleInlineMark(
-        body.value,
-        el.selectionStart,
-        el.selectionEnd,
-        marker,
-    );
-
-    body.value = result.value;
-
-    nextTick(() => {
-        const field = textarea.value;
-
-        if (field) {
-            field.focus();
-            field.setSelectionRange(result.selectionStart, result.selectionEnd);
-        }
-
-        resize();
-    });
-}
-
-/**
- * Handle the format keyboard shortcuts (⌘/Ctrl+B/I/E and ⌘/Ctrl+Shift+X),
- * returning true when one fired so the caller stops further key handling. The
- * chosen keys avoid every existing composer binding.
- */
-function tryFormatShortcut(event: KeyboardEvent): boolean {
-    if (!(event.metaKey || event.ctrlKey) || event.altKey) {
-        return false;
-    }
-
-    const key = event.key.toLowerCase();
-
-    const marker =
-        key === 'b' && !event.shiftKey
-            ? '**'
-            : key === 'i' && !event.shiftKey
-              ? '*'
-              : key === 'e' && !event.shiftKey
-                ? '`'
-                : key === 'x' && event.shiftKey
-                  ? '~~'
-                  : null;
-
-    if (marker === null) {
-        return false;
-    }
-
-    event.preventDefault();
-    // Claim the key before it bubbles to window-level shortcuts (⌘/Ctrl+B also
-    // toggles the sidebar), so formatting in the composer never fires those too.
-    event.stopPropagation();
-    applyFormat(marker);
-
-    return true;
-}
-
-/**
- * Insert a mention token at the caret (or the end), keeping a space separator
- * from preceding text. Exposed so a profile hover card can drop a mention into
- * the composer from elsewhere in the page.
- */
-function insertMention(member: Mention): void {
-    const el = textarea.value;
-    const caret = el ? el.selectionStart : body.value.length;
-    const before = body.value.slice(0, caret);
-    const after = body.value.slice(caret);
-
-    const separator = before.length > 0 && !before.endsWith(' ') ? ' ' : '';
-    const token = `${separator}@[${member.name}](${member.id}) `;
-
-    body.value = before + token + after;
-
-    const nextCaret = before.length + token.length;
-
-    nextTick(() => {
-        const field = textarea.value;
-
-        if (field) {
-            field.focus();
-            field.setSelectionRange(nextCaret, nextCaret);
-        }
-
-        resize();
-    });
-}
-
-/**
- * Focus the input field, e.g. from the brand-new-workspace welcome's "Post your
- * first message" action.
- */
-function focus(): void {
-    nextTick(() => textarea.value?.focus());
-}
-
-/**
- * The whole card reads as "the message box", so a click anywhere in its chrome —
- * the padding, the whitespace around the single line of text — should activate
- * the input. Clicks that land on a control (send/attachment/schedule buttons) or
- * on the textarea itself carry their own behaviour and are left untouched; only
- * clicks on the non-interactive chrome fall through here to focus the field with
- * the caret at the end. `mousedown` is preventable before focus shifts, so the
- * redirect happens without a flicker of the card losing then regaining focus.
- */
 function focusFromCard(event: MouseEvent): void {
     const el = textarea.value;
 
@@ -947,359 +363,7 @@ function focusFromCard(event: MouseEvent): void {
     el.setSelectionRange(end, end);
 }
 
-defineExpose({ insertMention, focus, addFiles });
-
-/**
- * Clear the composer after the text has been handed off (an immediate send or a
- * scheduled one), flagging the wipe so it doesn't re-persist as a draft.
- */
-function clearAfterHandoff(): void {
-    clearingAfterSend = true;
-    body.value = '';
-    sendToChannel.value = false;
-    menuOpen.value = false;
-    slashMenuOpen.value = false;
-    nextTick(resize);
-}
-
-/**
- * Send a slash command. Non-optimistic: the composer keeps the typed text in a
- * pending state, clears it once the server confirms the command ran, and keeps
- * it if the command failed so the user can correct and resend.
- *
- * The field stays editable while the send is in flight, so both outcomes guard
- * against clobbering a fresh edit: success clears only if the body is still the
- * one that was sent, and failure re-emits the draft (the command send cancels
- * the debounced save, so the retained text must reschedule its persistence).
- */
-function submitCommand(rawBody: string): void {
-    const submittedBody = body.value;
-    commandPending.value = true;
-    slashMenuOpen.value = false;
-
-    emit('command', rawBody, {
-        onSuccess: () => {
-            commandPending.value = false;
-
-            if (body.value === submittedBody) {
-                clearAfterHandoff();
-            }
-        },
-        onError: () => {
-            commandPending.value = false;
-            emit('draftChange', body.value);
-        },
-    });
-}
-
-function submit(): void {
-    if (!canSubmit.value || commandPending.value) {
-        return;
-    }
-
-    const trimmed = body.value.trim();
-
-    // A slash command forks off the optimistic message path onto a dedicated,
-    // non-optimistic send. Only when the tray is empty — a command carries no
-    // attachments, so a command-looking body with staged files posts as text.
-    if (uploads.attachmentIds.value.length === 0 && looksLikeCommand(trimmed)) {
-        // `/gif [query]` opens the picker rather than posting text; the chosen
-        // GIF is then sent as an attachment through the ordinary path.
-        const gifQuery = gifCommandQuery(trimmed);
-
-        if (gifQuery !== null) {
-            openGifPicker(gifQuery);
-
-            return;
-        }
-
-        // `/poll` opens the builder rather than posting text; the composed poll
-        // is then posted as a first-class poll message through its own endpoint.
-        if (isPollCommand(trimmed)) {
-            openPollComposer();
-
-            return;
-        }
-
-        submitCommand(trimmed);
-
-        return;
-    }
-
-    // Snapshot the composer state before the optimistic wipe: the send is
-    // fire-and-forget, so if an online send fails, the staged attachments (and
-    // the typed body) are handed back through the outcome hooks below, letting
-    // the user retry without re-picking every file. A successful (or queued)
-    // send disposes the snapshot instead. `detach` empties the tray but keeps the
-    // rows' previews alive until the outcome lands.
-    const stagedBody = body.value;
-    const attachmentIds = uploads.attachmentIds.value;
-    const snapshot = uploads.detach();
-
-    emit(
-        'send',
-        trimmed,
-        collectMentions(trimmed),
-        sendToChannel.value,
-        attachmentIds,
-        {
-            onAccepted: () => snapshot.dispose(),
-            onRejected: () => {
-                snapshot.restore();
-                body.value = stagedBody;
-            },
-        },
-    );
-    clearAfterHandoff();
-}
-
-/** Whether the caret sits at the very start of the field (nothing selected). */
-function caretAtStart(): boolean {
-    const el = textarea.value;
-
-    if (!el) {
-        return true;
-    }
-
-    return el.selectionStart === 0 && el.selectionEnd === 0;
-}
-
-/**
- * Load a message's body into the composer and switch to edit mode, placing the
- * caret at the end so the just-recalled text is ready to correct. The body is
- * restored verbatim (mention tokens included) so it round-trips faithfully.
- */
-function enterEditMode(message: Message): void {
-    editingMessage.value = message;
-    body.value = message.body;
-    menuOpen.value = false;
-    emit('editingChange', message.id);
-
-    nextTick(() => {
-        const field = textarea.value;
-
-        if (field) {
-            field.focus();
-
-            const end = field.value.length;
-            field.setSelectionRange(end, end);
-        }
-
-        resize();
-    });
-}
-
-/**
- * Leave edit mode and reset the composer to its prior (empty) state. The wipe is
- * flagged so it isn't persisted as a channel draft (entry required an empty
- * composer, so there is nothing to restore).
- */
-function exitEditMode(): void {
-    // Suppress the draft echo from the wipe only when there is text to clear;
-    // clearing an already-empty field fires no watcher, which would otherwise
-    // leave the guard armed for the next genuine keystroke.
-    clearingAfterSend = body.value !== '';
-    body.value = '';
-    editingMessage.value = null;
-    menuOpen.value = false;
-    emit('editingChange', null);
-    nextTick(resize);
-}
-
-/**
- * Resolve the viewer's most recent editable message on this surface and enter
- * edit mode for it. A no-op (falling through to the default ArrowUp behaviour)
- * when there is none.
- */
-function tryEditLastMessage(): boolean {
-    const target = resolveComposerEditTarget(
-        props.messages ?? [],
-        props.currentUserId ?? '',
-        props.pendingUuids,
-    );
-
-    if (!target) {
-        return false;
-    }
-
-    enterEditMode(target);
-
-    return true;
-}
-
-/**
- * Save the in-progress composer edit through the shared edit/PATCH path. An
- * empty or unchanged draft is a no-op, matching the inline editor; either way
- * the composer returns to its normal empty state.
- */
-function saveEdit(): void {
-    const target = editingMessage.value;
-
-    if (!target) {
-        return;
-    }
-
-    const trimmed = body.value.trim();
-
-    if (trimmed !== '' && trimmed !== target.body) {
-        emit('edit', target, trimmed);
-    }
-
-    exitEditMode();
-}
-
-/**
- * Whether the schedule picker is open. Opening requires some text — an empty
- * composer has nothing to schedule.
- */
-const scheduling = ref(false);
-
-/**
- * Scheduling never carries attachments, so the "Send later" affordances gate on
- * body text alone, matching the old schedule button's guard.
- */
-const canSchedule = computed(() => body.value.trim() !== '');
-
-function openSchedule(): void {
-    if (!canSchedule.value) {
-        return;
-    }
-
-    scheduling.value = true;
-}
-
-function onScheduleConfirm(sendAt: string): void {
-    const trimmed = body.value.trim();
-
-    if (trimmed === '') {
-        return;
-    }
-
-    emit('schedule', trimmed, collectMentions(trimmed), sendAt);
-    clearAfterHandoff();
-}
-
-function onKeydown(event: KeyboardEvent): void {
-    if (showMenu.value) {
-        if (event.key === 'ArrowDown') {
-            event.preventDefault();
-            moveActive(1);
-
-            return;
-        }
-
-        if (event.key === 'ArrowUp') {
-            event.preventDefault();
-            moveActive(-1);
-
-            return;
-        }
-
-        if (event.key === 'Enter' || event.key === 'Tab') {
-            event.preventDefault();
-            selectActive();
-
-            return;
-        }
-
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            menuOpen.value = false;
-
-            return;
-        }
-    }
-
-    // The slash-command menu mirrors the mention menu's navigation. The two are
-    // mutually exclusive (a `/…` body never matches an `@query`), so this runs
-    // only when the slash menu is the open one.
-    if (showSlashMenu.value) {
-        if (event.key === 'ArrowDown') {
-            event.preventDefault();
-            slashMoveActive(1);
-
-            return;
-        }
-
-        if (event.key === 'ArrowUp') {
-            event.preventDefault();
-            slashMoveActive(-1);
-
-            return;
-        }
-
-        if (event.key === 'Enter' || event.key === 'Tab') {
-            event.preventDefault();
-            selectSlashActive();
-
-            return;
-        }
-
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            slashMenuOpen.value = false;
-
-            return;
-        }
-    }
-
-    // Format shortcuts wrap the selection. Placed after the mention menu's key
-    // handling so its arrow/Enter/Escape keep priority while it is open; the
-    // chosen keys (B/I/E, ⇧X) never collide with it or Enter-to-send.
-    if (tryFormatShortcut(event)) {
-        return;
-    }
-
-    // With the mention menu closed, Escape leaves edit mode (restoring the empty
-    // composer) or, failing that, dismisses the active reply context.
-    if (event.key === 'Escape' && editingMessage.value) {
-        event.preventDefault();
-        exitEditMode();
-
-        return;
-    }
-
-    if (event.key === 'Escape' && props.replyTarget) {
-        event.preventDefault();
-        emit('cancelReply');
-
-        return;
-    }
-
-    // ArrowUp on an empty composer recalls the viewer's last editable message
-    // into edit mode ("↑ to edit last message"). The gate keeps it clear of the
-    // mention menu, `⌥↑` channel nav, and an in-progress reply.
-    if (
-        isComposerEditTrigger({
-            key: event.key,
-            altKey: event.altKey,
-            ctrlKey: event.ctrlKey,
-            metaKey: event.metaKey,
-            shiftKey: event.shiftKey,
-            menuOpen: showMenu.value || showSlashMenu.value,
-            editing: editingMessage.value !== null,
-            hasReplyTarget: props.replyTarget != null,
-            isEmpty: body.value.trim() === '',
-            caretAtStart: caretAtStart(),
-        })
-    ) {
-        if (tryEditLastMessage()) {
-            event.preventDefault();
-        }
-
-        return;
-    }
-
-    if (event.key === 'Enter' && !event.shiftKey) {
-        event.preventDefault();
-
-        if (editingMessage.value) {
-            saveEdit();
-        } else {
-            submit();
-        }
-    }
-}
+defineExpose({ insertMention, focus, addFiles: attachments.addFiles });
 </script>
 
 <template>
@@ -1314,122 +378,22 @@ function onKeydown(event: KeyboardEvent): void {
         }"
     >
         <div class="relative">
-            <ul
+            <MentionMenu
                 v-if="showMenu"
-                id="mention-listbox"
-                data-test="mention-menu"
-                role="listbox"
-                :aria-label="$t('Mention a teammate')"
-                class="absolute bottom-full left-0 z-10 mb-2 max-h-60 w-64 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md"
-            >
-                <li
-                    v-for="(suggestion, index) in suggestions"
-                    :id="`mention-option-${index}`"
-                    :key="`${suggestion.kind}-${suggestion.id}`"
-                    data-test="mention-option"
-                    role="option"
-                    tabindex="-1"
-                    :aria-selected="index === activeIndex"
-                    class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-popover-foreground"
-                    :class="
-                        index === activeIndex
-                            ? 'bg-accent text-accent-foreground'
-                            : 'hover:bg-accent/60'
-                    "
-                    @mousedown.prevent="selectSuggestion(suggestion)"
-                    @mouseenter="activeIndex = index"
-                >
-                    <span
-                        v-if="suggestion.kind === 'group'"
-                        class="flex size-6 shrink-0 items-center justify-center rounded-md bg-violet-500/10 text-violet-700 select-none dark:bg-violet-400/15 dark:text-violet-300"
-                        aria-hidden="true"
-                    >
-                        <Users class="size-3.5" />
-                    </span>
-                    <span
-                        v-else
-                        class="flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-semibold text-primary select-none"
-                        aria-hidden="true"
-                    >
-                        {{ getInitials(suggestion.label) }}
-                    </span>
-                    <span class="truncate">{{ suggestion.label }}</span>
-                    <!-- The member count is what tells a reader how far this one
-                         mention reaches before they send it. -->
-                    <span
-                        v-if="suggestion.kind === 'group'"
-                        data-test="mention-option-group-count"
-                        class="ml-auto shrink-0 text-[11px] text-muted-foreground"
-                    >
-                        {{
-                            suggestion.group.membersCount === 1
-                                ? $t(':count member', {
-                                      count: suggestion.group.membersCount,
-                                  })
-                                : $t(':count members', {
-                                      count: suggestion.group.membersCount,
-                                  })
-                        }}
-                    </span>
-                </li>
-                <!-- A quiet footnote explaining why bots never appear here — shown
-                     only in a channel that actually has a bot. Presentational, so
-                     it is not announced as a selectable option. -->
-                <li
-                    v-if="props.hasBots"
-                    role="presentation"
-                    data-test="mention-bot-hint"
-                    class="mt-1 flex items-center gap-2 border-t border-border px-2 pt-2 pb-1 text-[11px] text-muted-foreground italic"
-                >
-                    <Bot class="size-3 shrink-0" aria-hidden="true" />
-                    <span>{{
-                        $t('Bots can’t be mentioned — they don’t read messages')
-                    }}</span>
-                </li>
-            </ul>
+                :suggestions="suggestions"
+                :active-index="activeIndex"
+                :has-bots="props.hasBots"
+                @select="selectSuggestion"
+                @activate="activeIndex = $event"
+            />
 
-            <!-- Slash-command autocomplete. Mirrors the mention menu's listbox
-                 ARIA and keyboard model, but triggers only at composer position
-                 0. Each row shows name · argument hint · description. -->
-            <ul
+            <SlashCommandMenu
                 v-if="showSlashMenu"
-                id="slash-listbox"
-                data-test="slash-menu"
-                role="listbox"
-                :aria-label="$t('Slash commands')"
-                class="absolute bottom-full left-0 z-10 mb-2 max-h-60 w-80 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md"
-            >
-                <li
-                    v-for="(command, index) in slashSuggestions"
-                    :id="`slash-option-${index}`"
-                    :key="command.name"
-                    data-test="slash-option"
-                    role="option"
-                    tabindex="-1"
-                    :aria-selected="index === slashActiveIndex"
-                    class="flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-1.5 text-left text-sm text-popover-foreground"
-                    :class="
-                        index === slashActiveIndex
-                            ? 'bg-accent text-accent-foreground'
-                            : 'hover:bg-accent/60'
-                    "
-                    @mousedown.prevent="selectSlashCommand(command)"
-                    @mouseenter="slashActiveIndex = index"
-                >
-                    <span class="flex items-baseline gap-1.5">
-                        <span class="font-semibold">/{{ command.name }}</span>
-                        <span
-                            v-if="command.argumentHint"
-                            class="text-[11px] text-muted-foreground"
-                        >
-                            {{ command.argumentHint }}
-                        </span>
-                    </span>
-                    <span class="truncate text-[12px] text-muted-foreground">
-                        {{ command.description }}
-                    </span>
-                </li>
-            </ul>
+                :commands="slashSuggestions"
+                :active-index="slashActiveIndex"
+                @select="selectSlashCommand"
+                @activate="slashActiveIndex = $event"
+            />
 
             <!-- The Giphy picker, opened by `/gif`. Sits in the same anchored
                  position as the autocomplete menus; picking a GIF stages it in
@@ -1450,60 +414,13 @@ function onKeydown(event: KeyboardEvent): void {
                 @close="closePollComposer"
             />
 
-            <div
+            <ReplyPreview
                 v-if="props.replyTarget"
-                data-test="reply-preview"
-                class="mb-2 flex items-center gap-2 rounded-2xl border border-input bg-muted/40 px-3.5 py-2 max-md:py-1"
-            >
-                <span class="min-w-0 flex-1">
-                    <MessageQuote
-                        :author-name="props.replyTarget.user.name"
-                        :body="props.replyTarget.body"
-                        :is-deleted="props.replyTarget.isDeleted"
-                    />
-                </span>
-                <Button
-                    variant="unstyled"
-                    size="none"
-                    type="button"
-                    data-test="reply-preview-dismiss"
-                    :aria-label="$t('Cancel reply')"
-                    class="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground max-md:size-11"
-                    @click="emit('cancelReply')"
-                >
-                    <X class="size-3.5 max-md:size-4.5" />
-                </Button>
-            </div>
+                :target="props.replyTarget"
+                @cancel="emit('cancelReply')"
+            />
 
-            <!-- Edit-mode banner: brass-tinted so the composer unmistakably
-                 reads as editing an existing message rather than composing a new
-                 one, naming how to save or cancel. -->
-            <div
-                v-if="editingMessage"
-                data-test="composer-editing-banner"
-                class="mb-2 flex items-center gap-2 rounded-2xl border border-brass-border bg-brass-fill px-3.5 py-2 max-md:py-1"
-            >
-                <Pencil class="size-3.5 shrink-0 text-brass" />
-                <span
-                    class="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-brass-fill-foreground"
-                >
-                    {{ $t('Editing your message') }}
-                </span>
-                <span class="shrink-0 text-[11.5px] text-muted-foreground">
-                    {{ $t('Enter to save · Esc to cancel') }}
-                </span>
-                <Button
-                    variant="unstyled"
-                    size="none"
-                    type="button"
-                    data-test="composer-editing-dismiss"
-                    :aria-label="$t('Cancel edit')"
-                    class="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground max-md:size-11"
-                    @click="exitEditMode"
-                >
-                    <X class="size-3.5 max-md:size-4.5" />
-                </Button>
-            </div>
+            <EditingBanner v-if="editingMessage" @cancel="exitEditMode" />
 
             <!-- Floating pill: input on the left, ghost tool icons and the ink
                  send circle tucked to the right. Grows upward as the textarea
@@ -1521,508 +438,55 @@ function onKeydown(event: KeyboardEvent): void {
                 "
                 @mousedown="focusFromCard"
             >
-                <!-- Pre-send attachment tray. Row order is the send order
-                     (attachment_ids[]). Removing a row is immediate — the upload
-                     is pre-send, so there is nothing to undo.
-
-                     Every remove control here is hover-revealed from `md` up and
-                     always visible below it: there is no hover on a touch
-                     screen, so a phone had no way at all to drop a staged file
-                     (#920). Each one also carries a 44pt hit box below `md`,
-                     which the three chip shapes reach differently — see each. -->
-                <div
+                <AttachmentTray
                     v-if="showTray"
-                    data-test="composer-attachment-tray"
-                    class="flex flex-wrap gap-2.5 px-4 pt-3.5 pb-1"
-                >
-                    <template v-for="item in trayItems" :key="item.localId">
-                        <!-- Failed upload: a retryable chip. Nothing was
-                             persisted; it blocks send until retried or removed. -->
-                        <div
-                            v-if="item.status === 'failed'"
-                            data-test="composer-attachment"
-                            data-kind="failed"
-                            data-status="failed"
-                            class="relative flex h-19 min-w-50 items-center gap-2.5 rounded-xl border border-destructive/40 bg-destructive/10 px-3"
-                        >
-                            <span
-                                class="flex size-9.5 shrink-0 items-center justify-center rounded-[10px] bg-destructive/15 text-destructive-text"
-                            >
-                                <CircleAlert class="size-4.5" />
-                            </span>
-                            <span class="flex min-w-0 flex-1 flex-col gap-0.5">
-                                <span
-                                    class="truncate text-[12.5px] font-semibold text-foreground"
-                                >
-                                    {{ item.name }}
-                                </span>
-                                <span class="text-[11px] text-destructive-text">
-                                    {{ $t('Upload failed') }} ·
-                                    <Button
-                                        variant="unstyled"
-                                        size="none"
-                                        type="button"
-                                        data-test="composer-attachment-retry"
-                                        class="underline hover:no-underline"
-                                        @click="uploads.retry(item.localId)"
-                                    >
-                                        {{ $t('Retry') }}
-                                    </Button>
-                                </span>
-                            </span>
-                            <Button
-                                variant="unstyled"
-                                size="none"
-                                type="button"
-                                data-test="composer-attachment-remove"
-                                :aria-label="$t('Remove attachment')"
-                                class="flex shrink-0 items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11"
-                                @click="uploads.remove(item.localId)"
-                            >
-                                <X class="size-3 max-md:size-4.5" />
-                            </Button>
-                        </div>
+                    :items="trayItems"
+                    @remove="uploads.remove"
+                    @retry="uploads.retry"
+                />
 
-                        <!-- Image preview thumbnail (never SVG). The remove
-                             control is the one chip that cannot spend 44pt on a
-                             visible button: it would bury the picture it belongs
-                             to. Below `md` the thumbnail grows instead and the
-                             painted badge keeps its corner while its hit box
-                             reaches back over the thumbnail, which has no
-                             competing tap target of its own. -->
-                        <div
-                            v-else-if="item.isImage"
-                            data-test="composer-attachment"
-                            data-kind="image"
-                            :data-status="item.status"
-                            class="group relative size-19 overflow-hidden rounded-xl border border-input bg-muted max-md:size-25"
-                        >
-                            <img
-                                v-if="item.previewUrl"
-                                :src="item.previewUrl"
-                                alt=""
-                                class="size-full object-cover"
-                            />
-                            <div
-                                v-if="item.status === 'uploading'"
-                                class="absolute inset-0 bg-foreground/25"
-                            ></div>
-                            <div
-                                v-if="item.status === 'uploading'"
-                                class="absolute inset-x-1.5 bottom-1.5 h-0.75 overflow-hidden rounded-full bg-background/40"
-                            >
-                                <div
-                                    class="h-full rounded-full bg-brass"
-                                    :style="{ width: `${item.progress}%` }"
-                                ></div>
-                            </div>
-                            <Button
-                                variant="unstyled"
-                                size="none"
-                                type="button"
-                                data-test="composer-attachment-remove"
-                                :aria-label="$t('Remove attachment')"
-                                class="absolute top-1 right-1 flex items-center justify-center max-md:top-0 max-md:right-0 max-md:size-11 max-md:items-start max-md:justify-end max-md:p-1 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
-                                @click="uploads.remove(item.localId)"
-                            >
-                                <span
-                                    data-test="composer-attachment-remove-badge"
-                                    class="flex size-5.5 items-center justify-center rounded-full bg-foreground/80 text-background"
-                                >
-                                    <X class="size-2.75" />
-                                </span>
-                            </Button>
-                        </div>
-
-                        <!-- Audio chip: the same inline player the timeline
-                             uses, previewing the local blob before send. A
-                             recorded clip drops its filename line inside the
-                             player, so the tray reads as "a voice message". -->
-                        <div
-                            v-else-if="item.isAudio && item.previewUrl"
-                            data-test="composer-attachment"
-                            data-kind="audio"
-                            :data-status="item.status"
-                            class="group relative flex items-center max-md:gap-1"
-                        >
-                            <!-- The player and its progress bar share a box of
-                                 their own so the bar keeps tracking the player
-                                 once the remove button takes a column beside
-                                 it below `md`. -->
-                            <div class="relative">
-                                <AudioPlayer
-                                    :src="item.previewUrl"
-                                    :filename="item.name"
-                                    compact
-                                />
-                                <div
-                                    v-if="item.status === 'uploading'"
-                                    class="absolute inset-x-3 bottom-1.5 h-0.75 overflow-hidden rounded-full bg-border"
-                                >
-                                    <div
-                                        class="h-full rounded-full bg-brass"
-                                        :style="{ width: `${item.progress}%` }"
-                                    ></div>
-                                </div>
-                            </div>
-                            <!-- A 44pt overlay would sit on the right end of the
-                                 scrubber, so below `md` this one leaves the
-                                 corner and takes a column of its own. -->
-                            <Button
-                                variant="unstyled"
-                                size="none"
-                                type="button"
-                                data-test="composer-attachment-remove"
-                                :aria-label="$t('Remove attachment')"
-                                class="flex items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11 max-md:shrink-0 md:absolute md:top-1.5 md:right-1.5 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
-                                @click="uploads.remove(item.localId)"
-                            >
-                                <X class="size-3 max-md:size-4.5" />
-                            </Button>
-                        </div>
-
-                        <!-- Non-image file chip (uploading or done). -->
-                        <div
-                            v-else
-                            data-test="composer-attachment"
-                            data-kind="file"
-                            :data-status="item.status"
-                            class="group relative flex h-19 min-w-52 items-center gap-2.5 rounded-xl border border-input bg-muted px-3"
-                        >
-                            <span
-                                class="flex size-9.5 shrink-0 items-center justify-center rounded-[10px] bg-background text-muted-foreground"
-                            >
-                                <FileText class="size-4.5" />
-                            </span>
-                            <span class="flex min-w-0 flex-1 flex-col gap-1">
-                                <span
-                                    class="truncate text-[12.5px] font-semibold text-foreground"
-                                >
-                                    {{ item.name }}
-                                </span>
-                                <span
-                                    class="text-[11px] text-muted-foreground tabular-nums"
-                                >
-                                    {{ formatFileSize(item.sizeBytes)
-                                    }}<template
-                                        v-if="item.status === 'uploading'"
-                                    >
-                                        · {{ item.progress }}%</template
-                                    >
-                                </span>
-                                <div
-                                    v-if="item.status === 'uploading'"
-                                    class="h-0.75 overflow-hidden rounded-full bg-border"
-                                >
-                                    <div
-                                        class="h-full rounded-full bg-brass"
-                                        :style="{ width: `${item.progress}%` }"
-                                    ></div>
-                                </div>
-                            </span>
-                            <Button
-                                variant="unstyled"
-                                size="none"
-                                type="button"
-                                data-test="composer-attachment-remove"
-                                :aria-label="$t('Remove attachment')"
-                                class="flex shrink-0 items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
-                                @click="uploads.remove(item.localId)"
-                            >
-                                <X class="size-3 max-md:size-4.5" />
-                            </Button>
-                        </div>
-                    </template>
-                </div>
-
-                <!-- Recording strip: while the mic is open the input row gives
-                     way to a live readout — a pulsing record dot, the elapsed
-                     time against the five-minute cap, an ephemeral input-level
-                     meter, and discard/stage controls. -->
-                <div
+                <RecordingStrip
                     v-if="recorder.isRecording.value"
-                    data-test="composer-recording"
-                    class="flex h-13 items-center gap-2.5 py-2 pr-2 pl-4.5"
-                >
-                    <span
-                        class="size-2.5 shrink-0 animate-pulse rounded-full bg-destructive"
-                        aria-hidden="true"
-                    ></span>
-                    <span
-                        data-test="composer-recording-elapsed"
-                        :data-warning="
-                            recorder.isNearingLimit.value ? 'true' : 'false'
-                        "
-                        class="text-sm font-semibold tabular-nums"
-                        :class="
-                            recorder.isNearingLimit.value
-                                ? 'text-destructive-text'
-                                : 'text-foreground'
-                        "
-                        aria-live="off"
-                    >
-                        {{ formatClock(recorder.elapsedSeconds.value) }}
-                    </span>
-                    <span
-                        class="text-[12.5px] text-muted-foreground tabular-nums"
-                    >
-                        / {{ recordingLimit }}
-                    </span>
-                    <div
-                        class="flex min-w-0 flex-1 items-center gap-0.75 px-1.5"
-                        aria-hidden="true"
-                    >
-                        <span
-                            v-for="(bar, index) in levelBars"
-                            :key="index"
-                            class="w-0.75 rounded-full bg-destructive/60"
-                            :style="{ height: `${bar * 20}px` }"
-                        ></span>
-                    </div>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        data-test="composer-recording-cancel"
-                        class="size-8.5 shrink-0 rounded-full text-muted-foreground"
-                        :aria-label="$t('Discard recording')"
-                        @click="recorder.cancel"
-                    >
-                        <X class="size-3.75" />
-                    </Button>
-                    <Button
-                        size="icon"
-                        data-test="composer-recording-stop"
-                        class="size-8.5 shrink-0 rounded-full bg-primary text-brass hover:bg-primary/90"
-                        :aria-label="$t('Stop recording')"
-                        @click="recorder.stop"
-                    >
-                        <Square class="size-3" fill="currentColor" />
-                    </Button>
-                </div>
+                    :elapsed-seconds="recorder.elapsedSeconds.value"
+                    :is-nearing-limit="recorder.isNearingLimit.value"
+                    :level="recorder.level.value"
+                    @cancel="recorder.cancel"
+                    @stop="recorder.stop"
+                />
 
-                <!-- Input row. Below the breakpoint this is the pill from the
-                     mobile design: just the field and Send, with the compose
-                     tools folded away behind the toggle beside them. Opening
-                     them wraps them onto a second line inside the same pill
-                     rather than squeezing the field, which is what used to
-                     collapse it to zero width on a phone. -->
-                <div
+                <ComposerInputRow
                     v-else
-                    class="flex flex-wrap items-end gap-2.5 py-2 pr-2 pl-4.5 @lg:flex-nowrap"
-                >
-                    <textarea
-                        ref="textarea"
-                        v-model="body"
-                        rows="1"
-                        :placeholder="visiblePlaceholder"
-                        :aria-label="composerPlaceholder"
-                        data-test="message-composer-input"
-                        role="combobox"
-                        aria-autocomplete="list"
-                        :aria-expanded="showMenu || showSlashMenu"
-                        :aria-controls="
-                            showMenu
-                                ? 'mention-listbox'
-                                : showSlashMenu
-                                  ? 'slash-listbox'
-                                  : undefined
-                        "
-                        :aria-activedescendant="
-                            showMenu
-                                ? `mention-option-${activeIndex}`
-                                : showSlashMenu
-                                  ? `slash-option-${slashActiveIndex}`
-                                  : undefined
-                        "
-                        autocomplete="off"
-                        autocorrect="off"
-                        autocapitalize="sentences"
-                        spellcheck="true"
-                        data-1p-ignore
-                        data-lpignore="true"
-                        data-bwignore
-                        data-form-type="other"
-                        class="max-h-[200px] min-w-0 flex-1 resize-none self-center bg-transparent py-1 text-base text-foreground outline-none placeholder:text-muted-foreground md:text-sm"
-                        @input="
-                            (resize(),
-                            refreshSuggestions(),
-                            refreshSlashSuggestions(),
-                            emit('typing'))
-                        "
-                        @paste="onPaste"
-                        @click="
-                            (refreshSuggestions(), refreshSlashSuggestions())
-                        "
-                        @keydown="onKeydown"
-                    ></textarea>
-                    <!-- Edit mode swaps the compose tools for explicit
-                         save/cancel actions; Enter/Esc still drive them from the
-                         keyboard. -->
-                    <template v-if="editingMessage">
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            data-test="message-composer-edit-cancel"
-                            class="h-8.5 shrink-0 rounded-full px-3.5 text-[12.5px] font-semibold text-muted-foreground"
-                            @click="exitEditMode"
-                        >
-                            {{ $t('Cancel') }}
-                        </Button>
-                        <Button
-                            size="sm"
-                            data-test="message-composer-edit-save"
-                            class="h-8.5 shrink-0 rounded-full px-4 text-[12.5px] font-semibold"
-                            @click="saveEdit"
-                        >
-                            {{ $t('Save edit') }}
-                        </Button>
-                    </template>
-                    <template v-else>
-                        <input
-                            ref="fileInput"
-                            type="file"
-                            multiple
-                            class="hidden"
-                            data-test="composer-file-input"
-                            @change="onFilesPicked"
-                        />
-                        <!-- The compose tools. One instance, placed by CSS: in
-                             line with the field from `md` up, on their own row
-                             under it once disclosed on a phone. -->
-                        <div
-                            class="shrink-0 items-end gap-2.5"
-                            :class="
-                                toolsOpen
-                                    ? 'order-last flex w-full pt-1 @lg:order-none @lg:w-auto @lg:pt-0'
-                                    : 'hidden @lg:flex'
-                            "
-                            data-test="composer-tools"
-                        >
-                            <!-- Inline-format cluster: wraps the current selection in
-                             Markdown markers, mirrored by the keyboard shortcuts.
-                             mousedown is prevented so the textarea keeps focus and
-                             its selection survives the click. -->
-                            <TooltipProvider
-                                :delay-duration="300"
-                                :skip-delay-duration="150"
-                            >
-                                <div
-                                    class="flex shrink-0 items-center gap-0.5"
-                                    data-test="composer-format-cluster"
-                                >
-                                    <Tooltip
-                                        v-for="action in formatActions"
-                                        :key="action.marker"
-                                    >
-                                        <TooltipTrigger as-child>
-                                            <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                :data-test="`message-composer-format-${action.marker}`"
-                                                class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
-                                                :aria-label="action.label"
-                                                @mousedown.prevent
-                                                @click="
-                                                    applyFormat(action.marker)
-                                                "
-                                            >
-                                                <component
-                                                    :is="action.icon"
-                                                    class="size-3.5"
-                                                />
-                                            </Button>
-                                        </TooltipTrigger>
-                                        <TooltipContent
-                                            side="top"
-                                            :side-offset="6"
-                                            class="flex items-center gap-2"
-                                        >
-                                            {{ action.label }}
-                                            <span
-                                                class="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
-                                                >{{ action.shortcut }}</span
-                                            >
-                                        </TooltipContent>
-                                    </Tooltip>
-                                </div>
-                            </TooltipProvider>
-                            <span
-                                class="mx-0.5 h-5 w-px shrink-0 self-center bg-border"
-                                aria-hidden="true"
-                            ></span>
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                :disabled="!attachmentsEnabled"
-                                data-test="message-composer-attach"
-                                class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
-                                :aria-label="$t('Add attachment')"
-                                @click="openFilePicker"
-                            >
-                                <Plus class="size-3.5" />
-                            </Button>
-                            <!-- The mic sits last before send, and only where the
-                             browser can actually record (MediaRecorder +
-                             getUserMedia in a secure context). -->
-                            <Button
-                                v-if="canRecord"
-                                variant="ghost"
-                                size="icon"
-                                data-test="message-composer-record"
-                                class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
-                                :aria-label="$t('Record a voice message')"
-                                @click="recorder.start"
-                            >
-                                <Mic class="size-3.5" />
-                            </Button>
-                        </div>
-                        <!-- Discloses the tools above on a phone, where they
-                             have no room beside the field. Hidden from `md` up,
-                             where they are always in line. -->
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            data-test="composer-tools-toggle"
-                            class="size-8.5 shrink-0 rounded-full text-muted-foreground max-md:size-11 @lg:hidden"
-                            :aria-expanded="toolsOpen"
-                            :aria-label="
-                                toolsOpen
-                                    ? $t('Hide compose tools')
-                                    : $t('Show compose tools')
-                            "
-                            @click="toolsOpen = !toolsOpen"
-                        >
-                            <Plus
-                                class="size-4 transition-transform"
-                                :class="toolsOpen ? 'rotate-45' : ''"
-                            />
-                        </Button>
-                        <!-- Split send button: a primary Send plus a caret
-                             opening the "Send later" menu (quick presets +
-                             custom time). Falls back to a plain send circle in
-                             surfaces without scheduling (the thread composer). -->
-                        <ComposerSendButton
-                            v-if="props.allowSchedule"
-                            :can-submit="canSubmit && !commandPending"
-                            :can-schedule="canSchedule"
-                            :timezone="props.timezone ?? null"
-                            @send="submit"
-                            @schedule-at="onScheduleConfirm"
-                            @custom-time="openSchedule"
-                        />
-                        <Button
-                            v-else
-                            size="icon"
-                            :disabled="!canSubmit || commandPending"
-                            data-test="message-composer-send"
-                            class="size-8.5 shrink-0 rounded-full bg-primary text-brass hover:bg-primary/90"
-                            :aria-label="$t('Send message')"
-                            @click="submit"
-                        >
-                            <ArrowUp class="size-3.75" :stroke-width="2.2" />
-                        </Button>
-                    </template>
-                </div>
+                    v-model="body"
+                    :placeholder="visiblePlaceholder"
+                    :field-label="composerPlaceholder"
+                    :show-mention-menu="showMenu"
+                    :show-slash-menu="showSlashMenu"
+                    :mention-active-index="activeIndex"
+                    :slash-active-index="slashActiveIndex"
+                    :editing="editingMessage !== null"
+                    :format-actions="formatActions"
+                    :attachments-enabled="attachmentsEnabled"
+                    :can-record="canRecord"
+                    :tools-open="toolsOpen"
+                    :can-submit="canSubmit && !commandPending"
+                    :can-schedule="canSchedule"
+                    :allow-schedule="Boolean(props.allowSchedule)"
+                    :timezone="props.timezone ?? null"
+                    :register="registerField"
+                    @input="onFieldInput"
+                    @paste="onPaste"
+                    @click="onFieldClick"
+                    @keydown="onKeydown"
+                    @files="uploads.addFiles"
+                    @format="applyFormat"
+                    @record="recorder.start"
+                    @toggle-tools="toolsOpen = !toolsOpen"
+                    @send="submit"
+                    @schedule-at="onScheduleConfirm"
+                    @custom-time="openSchedule"
+                    @save-edit="saveEdit"
+                    @cancel-edit="exitEditMode"
+                />
             </div>
 
             <!-- The 14px box is far too small to aim at on a phone, but growing

--- a/resources/js/components/composer/AttachmentTray.vue
+++ b/resources/js/components/composer/AttachmentTray.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { CircleAlert, FileText, X } from '@lucide/vue';
+import AudioPlayer from '@/components/AudioPlayer.vue';
+import { Button } from '@/components/ui/button';
+import type { PendingAttachment } from '@/composables/useAttachmentUploads';
+import { formatFileSize } from '@/lib/attachments';
+
+defineProps<{
+    /** The staged rows, in send order (`attachment_ids[]`). */
+    items: PendingAttachment[];
+}>();
+
+defineEmits<{
+    /** Drop a staged row. Immediate — the upload is pre-send, so there is nothing to undo. */
+    remove: [localId: string];
+    /** Re-fire a failed row's upload. */
+    retry: [localId: string];
+}>();
+</script>
+
+<template>
+    <!-- Pre-send attachment tray. Row order is the send order
+         (attachment_ids[]).
+
+         Every remove control here is hover-revealed from `md` up and
+         always visible below it: there is no hover on a touch
+         screen, so a phone had no way at all to drop a staged file
+         (#920). Each one also carries a 44pt hit box below `md`,
+         which the three chip shapes reach differently — see each. -->
+    <div
+        data-test="composer-attachment-tray"
+        class="flex flex-wrap gap-2.5 px-4 pt-3.5 pb-1"
+    >
+        <template v-for="item in items" :key="item.localId">
+            <!-- Failed upload: a retryable chip. Nothing was
+                 persisted; it blocks send until retried or removed. -->
+            <div
+                v-if="item.status === 'failed'"
+                data-test="composer-attachment"
+                data-kind="failed"
+                data-status="failed"
+                class="relative flex h-19 min-w-50 items-center gap-2.5 rounded-xl border border-destructive/40 bg-destructive/10 px-3"
+            >
+                <span
+                    class="flex size-9.5 shrink-0 items-center justify-center rounded-[10px] bg-destructive/15 text-destructive-text"
+                >
+                    <CircleAlert class="size-4.5" />
+                </span>
+                <span class="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span
+                        class="truncate text-[12.5px] font-semibold text-foreground"
+                    >
+                        {{ item.name }}
+                    </span>
+                    <span class="text-[11px] text-destructive-text">
+                        {{ $t('Upload failed') }} ·
+                        <Button
+                            variant="unstyled"
+                            size="none"
+                            type="button"
+                            data-test="composer-attachment-retry"
+                            class="underline hover:no-underline"
+                            @click="$emit('retry', item.localId)"
+                        >
+                            {{ $t('Retry') }}
+                        </Button>
+                    </span>
+                </span>
+                <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    data-test="composer-attachment-remove"
+                    :aria-label="$t('Remove attachment')"
+                    class="flex shrink-0 items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11"
+                    @click="$emit('remove', item.localId)"
+                >
+                    <X class="size-3 max-md:size-4.5" />
+                </Button>
+            </div>
+
+            <!-- Image preview thumbnail (never SVG). The remove
+                 control is the one chip that cannot spend 44pt on a
+                 visible button: it would bury the picture it belongs
+                 to. Below `md` the thumbnail grows instead and the
+                 painted badge keeps its corner while its hit box
+                 reaches back over the thumbnail, which has no
+                 competing tap target of its own. -->
+            <div
+                v-else-if="item.isImage"
+                data-test="composer-attachment"
+                data-kind="image"
+                :data-status="item.status"
+                class="group relative size-19 overflow-hidden rounded-xl border border-input bg-muted max-md:size-25"
+            >
+                <img
+                    v-if="item.previewUrl"
+                    :src="item.previewUrl"
+                    alt=""
+                    class="size-full object-cover"
+                />
+                <div
+                    v-if="item.status === 'uploading'"
+                    class="absolute inset-0 bg-foreground/25"
+                ></div>
+                <div
+                    v-if="item.status === 'uploading'"
+                    class="absolute inset-x-1.5 bottom-1.5 h-0.75 overflow-hidden rounded-full bg-background/40"
+                >
+                    <div
+                        class="h-full rounded-full bg-brass"
+                        :style="{ width: `${item.progress}%` }"
+                    ></div>
+                </div>
+                <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    data-test="composer-attachment-remove"
+                    :aria-label="$t('Remove attachment')"
+                    class="absolute top-1 right-1 flex items-center justify-center max-md:top-0 max-md:right-0 max-md:size-11 max-md:items-start max-md:justify-end max-md:p-1 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
+                    @click="$emit('remove', item.localId)"
+                >
+                    <span
+                        data-test="composer-attachment-remove-badge"
+                        class="flex size-5.5 items-center justify-center rounded-full bg-foreground/80 text-background"
+                    >
+                        <X class="size-2.75" />
+                    </span>
+                </Button>
+            </div>
+
+            <!-- Audio chip: the same inline player the timeline
+                 uses, previewing the local blob before send. A
+                 recorded clip drops its filename line inside the
+                 player, so the tray reads as "a voice message". -->
+            <div
+                v-else-if="item.isAudio && item.previewUrl"
+                data-test="composer-attachment"
+                data-kind="audio"
+                :data-status="item.status"
+                class="group relative flex items-center max-md:gap-1"
+            >
+                <!-- The player and its progress bar share a box of
+                     their own so the bar keeps tracking the player
+                     once the remove button takes a column beside
+                     it below `md`. -->
+                <div class="relative">
+                    <AudioPlayer
+                        :src="item.previewUrl"
+                        :filename="item.name"
+                        compact
+                    />
+                    <div
+                        v-if="item.status === 'uploading'"
+                        class="absolute inset-x-3 bottom-1.5 h-0.75 overflow-hidden rounded-full bg-border"
+                    >
+                        <div
+                            class="h-full rounded-full bg-brass"
+                            :style="{ width: `${item.progress}%` }"
+                        ></div>
+                    </div>
+                </div>
+                <!-- A 44pt overlay would sit on the right end of the
+                     scrubber, so below `md` this one leaves the
+                     corner and takes a column of its own. -->
+                <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    data-test="composer-attachment-remove"
+                    :aria-label="$t('Remove attachment')"
+                    class="flex items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11 max-md:shrink-0 md:absolute md:top-1.5 md:right-1.5 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
+                    @click="$emit('remove', item.localId)"
+                >
+                    <X class="size-3 max-md:size-4.5" />
+                </Button>
+            </div>
+
+            <!-- Non-image file chip (uploading or done). -->
+            <div
+                v-else
+                data-test="composer-attachment"
+                data-kind="file"
+                :data-status="item.status"
+                class="group relative flex h-19 min-w-52 items-center gap-2.5 rounded-xl border border-input bg-muted px-3"
+            >
+                <span
+                    class="flex size-9.5 shrink-0 items-center justify-center rounded-[10px] bg-background text-muted-foreground"
+                >
+                    <FileText class="size-4.5" />
+                </span>
+                <span class="flex min-w-0 flex-1 flex-col gap-1">
+                    <span
+                        class="truncate text-[12.5px] font-semibold text-foreground"
+                    >
+                        {{ item.name }}
+                    </span>
+                    <span
+                        class="text-[11px] text-muted-foreground tabular-nums"
+                    >
+                        {{ formatFileSize(item.sizeBytes)
+                        }}<template v-if="item.status === 'uploading'">
+                            · {{ item.progress }}%</template
+                        >
+                    </span>
+                    <div
+                        v-if="item.status === 'uploading'"
+                        class="h-0.75 overflow-hidden rounded-full bg-border"
+                    >
+                        <div
+                            class="h-full rounded-full bg-brass"
+                            :style="{ width: `${item.progress}%` }"
+                        ></div>
+                    </div>
+                </span>
+                <Button
+                    variant="unstyled"
+                    size="none"
+                    type="button"
+                    data-test="composer-attachment-remove"
+                    :aria-label="$t('Remove attachment')"
+                    class="flex shrink-0 items-center justify-center rounded-full p-1 text-muted-foreground hover:text-foreground max-md:size-11 md:opacity-0 md:transition-opacity md:group-hover:opacity-100 md:focus:opacity-100"
+                    @click="$emit('remove', item.localId)"
+                >
+                    <X class="size-3 max-md:size-4.5" />
+                </Button>
+            </div>
+        </template>
+    </div>
+</template>

--- a/resources/js/components/composer/ComposerInputRow.vue
+++ b/resources/js/components/composer/ComposerInputRow.vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import { ArrowUp, Plus } from '@lucide/vue';
+import { ref } from 'vue';
+import ComposerTools from '@/components/composer/ComposerTools.vue';
+import ComposerSendButton from '@/components/ComposerSendButton.vue';
+import { Button } from '@/components/ui/button';
+import type { FormatAction } from '@/composables/useComposerFormat';
+
+const props = defineProps<{
+    /** The rendered (ellipsized) placeholder, with the full one on the label below. */
+    placeholder: string;
+    fieldLabel: string;
+    /** Which autocomplete, if either, the field's combobox ARIA currently points at. */
+    showMentionMenu: boolean;
+    showSlashMenu: boolean;
+    mentionActiveIndex: number;
+    slashActiveIndex: number;
+    /** Whether the composer is correcting an existing message rather than composing. */
+    editing: boolean;
+    formatActions: FormatAction[];
+    attachmentsEnabled: boolean;
+    canRecord: boolean;
+    /** Whether the compose tools are disclosed (only consulted below the breakpoint). */
+    toolsOpen: boolean;
+    canSubmit: boolean;
+    canSchedule: boolean;
+    /** Whether to offer the "schedule for later" affordance (main channel composer only). */
+    allowSchedule: boolean;
+    timezone: string | null;
+    /**
+     * Hand the field element back to the composer, which drives its caret,
+     * height and focus through it.
+     */
+    register: (element: HTMLTextAreaElement | null) => void;
+}>();
+
+const body = defineModel<string>({ required: true });
+
+const emit = defineEmits<{
+    /** The field's own events, forwarded verbatim to the composer. */
+    input: [];
+    paste: [event: ClipboardEvent];
+    click: [];
+    keydown: [event: KeyboardEvent];
+    /** Files were picked from the hidden native input. */
+    files: [files: FileList];
+    /** Wrap the current selection in a Markdown marker. */
+    format: [marker: string];
+    /** Open the mic. */
+    record: [];
+    /** Disclose or fold away the compose tools. */
+    toggleTools: [];
+    /** Send the composed message now, or at the chosen instant. */
+    send: [];
+    scheduleAt: [sendAt: string];
+    /** Open the custom "send later" picker. */
+    customTime: [];
+    /** Save or abandon the in-progress edit. */
+    saveEdit: [];
+    cancelEdit: [];
+}>();
+
+/** The hidden native file input the "Add attachment" button proxies to. */
+const fileInput = ref<HTMLInputElement | null>(null);
+
+function openFilePicker(): void {
+    fileInput.value?.click();
+}
+
+function onFilesPicked(event: Event): void {
+    const input = event.target as HTMLInputElement;
+
+    if (input.files) {
+        emit('files', input.files);
+    }
+
+    // Reset so re-picking the same file fires `change` again.
+    input.value = '';
+}
+</script>
+
+<template>
+    <!-- Below the breakpoint this is the pill from the mobile design: just the
+         field and Send, with the compose tools folded away behind the toggle
+         beside them. Opening them wraps them onto a second line inside the same
+         pill rather than squeezing the field, which is what used to collapse it
+         to zero width on a phone. -->
+    <div
+        class="flex flex-wrap items-end gap-2.5 py-2 pr-2 pl-4.5 @lg:flex-nowrap"
+    >
+        <textarea
+            :ref="(element) => props.register(element as HTMLTextAreaElement)"
+            v-model="body"
+            rows="1"
+            :placeholder="placeholder"
+            :aria-label="fieldLabel"
+            data-test="message-composer-input"
+            role="combobox"
+            aria-autocomplete="list"
+            :aria-expanded="showMentionMenu || showSlashMenu"
+            :aria-controls="
+                showMentionMenu
+                    ? 'mention-listbox'
+                    : showSlashMenu
+                      ? 'slash-listbox'
+                      : undefined
+            "
+            :aria-activedescendant="
+                showMentionMenu
+                    ? `mention-option-${mentionActiveIndex}`
+                    : showSlashMenu
+                      ? `slash-option-${slashActiveIndex}`
+                      : undefined
+            "
+            autocomplete="off"
+            autocorrect="off"
+            autocapitalize="sentences"
+            spellcheck="true"
+            data-1p-ignore
+            data-lpignore="true"
+            data-bwignore
+            data-form-type="other"
+            class="max-h-[200px] min-w-0 flex-1 resize-none self-center bg-transparent py-1 text-base text-foreground outline-none placeholder:text-muted-foreground md:text-sm"
+            @input="emit('input')"
+            @paste="emit('paste', $event)"
+            @click="emit('click')"
+            @keydown="emit('keydown', $event)"
+        ></textarea>
+        <!-- Edit mode swaps the compose tools for explicit save/cancel actions;
+             Enter/Esc still drive them from the keyboard. -->
+        <template v-if="editing">
+            <Button
+                variant="ghost"
+                size="sm"
+                data-test="message-composer-edit-cancel"
+                class="h-8.5 shrink-0 rounded-full px-3.5 text-[12.5px] font-semibold text-muted-foreground"
+                @click="emit('cancelEdit')"
+            >
+                {{ $t('Cancel') }}
+            </Button>
+            <Button
+                size="sm"
+                data-test="message-composer-edit-save"
+                class="h-8.5 shrink-0 rounded-full px-4 text-[12.5px] font-semibold"
+                @click="emit('saveEdit')"
+            >
+                {{ $t('Save edit') }}
+            </Button>
+        </template>
+        <template v-else>
+            <input
+                ref="fileInput"
+                type="file"
+                multiple
+                class="hidden"
+                data-test="composer-file-input"
+                @change="onFilesPicked"
+            />
+            <ComposerTools
+                :format-actions="formatActions"
+                :attachments-enabled="attachmentsEnabled"
+                :can-record="canRecord"
+                :open="toolsOpen"
+                @format="emit('format', $event)"
+                @attach="openFilePicker"
+                @record="emit('record')"
+            />
+            <!-- Discloses the tools above on a phone, where they have no room
+                 beside the field. Hidden from `md` up, where they are always in
+                 line. -->
+            <Button
+                variant="ghost"
+                size="icon"
+                data-test="composer-tools-toggle"
+                class="size-8.5 shrink-0 rounded-full text-muted-foreground max-md:size-11 @lg:hidden"
+                :aria-expanded="toolsOpen"
+                :aria-label="
+                    toolsOpen
+                        ? $t('Hide compose tools')
+                        : $t('Show compose tools')
+                "
+                @click="emit('toggleTools')"
+            >
+                <Plus
+                    class="size-4 transition-transform"
+                    :class="toolsOpen ? 'rotate-45' : ''"
+                />
+            </Button>
+            <!-- Split send button: a primary Send plus a caret opening the
+                 "Send later" menu (quick presets + custom time). Falls back to a
+                 plain send circle in surfaces without scheduling (the thread
+                 composer). -->
+            <ComposerSendButton
+                v-if="allowSchedule"
+                :can-submit="canSubmit"
+                :can-schedule="canSchedule"
+                :timezone="timezone"
+                @send="emit('send')"
+                @schedule-at="emit('scheduleAt', $event)"
+                @custom-time="emit('customTime')"
+            />
+            <Button
+                v-else
+                size="icon"
+                :disabled="!canSubmit"
+                data-test="message-composer-send"
+                class="size-8.5 shrink-0 rounded-full bg-primary text-brass hover:bg-primary/90"
+                :aria-label="$t('Send message')"
+                @click="emit('send')"
+            >
+                <ArrowUp class="size-3.75" :stroke-width="2.2" />
+            </Button>
+        </template>
+    </div>
+</template>

--- a/resources/js/components/composer/ComposerTools.vue
+++ b/resources/js/components/composer/ComposerTools.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { Mic, Plus } from '@lucide/vue';
+import { Button } from '@/components/ui/button';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import type { FormatAction } from '@/composables/useComposerFormat';
+
+defineProps<{
+    /** The inline-format controls, each with its icon, label and shortcut hint. */
+    formatActions: FormatAction[];
+    /** Whether the composer knows its channel, which is what attachments need. */
+    attachmentsEnabled: boolean;
+    /** Whether this browser can record (MediaRecorder + a secure-context getUserMedia). */
+    canRecord: boolean;
+    /**
+     * Whether the tools are disclosed. Only consulted below the breakpoint,
+     * where they fold away behind a toggle so the field keeps the pill's width;
+     * from `md` up they are always in line and this is ignored.
+     */
+    open: boolean;
+}>();
+
+defineEmits<{
+    /** Wrap the current selection in a Markdown marker. */
+    format: [marker: string];
+    /** Open the native file picker. */
+    attach: [];
+    /** Open the mic. */
+    record: [];
+}>();
+</script>
+
+<template>
+    <!-- One instance, placed by CSS: in line with the field from `md` up, on
+         their own row under it once disclosed on a phone. -->
+    <div
+        class="shrink-0 items-end gap-2.5"
+        :class="
+            open
+                ? 'order-last flex w-full pt-1 @lg:order-none @lg:w-auto @lg:pt-0'
+                : 'hidden @lg:flex'
+        "
+        data-test="composer-tools"
+    >
+        <!-- Inline-format cluster: wraps the current selection in
+             Markdown markers, mirrored by the keyboard shortcuts.
+             mousedown is prevented so the textarea keeps focus and
+             its selection survives the click. -->
+        <TooltipProvider :delay-duration="300" :skip-delay-duration="150">
+            <div
+                class="flex shrink-0 items-center gap-0.5"
+                data-test="composer-format-cluster"
+            >
+                <Tooltip v-for="action in formatActions" :key="action.marker">
+                    <TooltipTrigger as-child>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            :data-test="`message-composer-format-${action.marker}`"
+                            class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
+                            :aria-label="action.label"
+                            @mousedown.prevent
+                            @click="$emit('format', action.marker)"
+                        >
+                            <component :is="action.icon" class="size-3.5" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent
+                        side="top"
+                        :side-offset="6"
+                        class="flex items-center gap-2"
+                    >
+                        {{ action.label }}
+                        <span
+                            class="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                            >{{ action.shortcut }}</span
+                        >
+                    </TooltipContent>
+                </Tooltip>
+            </div>
+        </TooltipProvider>
+        <span
+            class="mx-0.5 h-5 w-px shrink-0 self-center bg-border"
+            aria-hidden="true"
+        ></span>
+        <Button
+            variant="ghost"
+            size="icon"
+            :disabled="!attachmentsEnabled"
+            data-test="message-composer-attach"
+            class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
+            :aria-label="$t('Add attachment')"
+            @click="$emit('attach')"
+        >
+            <Plus class="size-3.5" />
+        </Button>
+        <!-- The mic sits last before send, and only where the
+             browser can actually record (MediaRecorder +
+             getUserMedia in a secure context). -->
+        <Button
+            v-if="canRecord"
+            variant="ghost"
+            size="icon"
+            data-test="message-composer-record"
+            class="size-7 shrink-0 rounded-full text-muted-foreground max-md:size-11"
+            :aria-label="$t('Record a voice message')"
+            @click="$emit('record')"
+        >
+            <Mic class="size-3.5" />
+        </Button>
+    </div>
+</template>

--- a/resources/js/components/composer/EditingBanner.vue
+++ b/resources/js/components/composer/EditingBanner.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { Pencil, X } from '@lucide/vue';
+import { Button } from '@/components/ui/button';
+
+defineEmits<{
+    /** Abandon the edit and return to composing. */
+    cancel: [];
+}>();
+</script>
+
+<template>
+    <!-- Brass-tinted so the composer unmistakably reads as editing an existing
+         message rather than composing a new one, naming how to save or cancel. -->
+    <div
+        data-test="composer-editing-banner"
+        class="mb-2 flex items-center gap-2 rounded-2xl border border-brass-border bg-brass-fill px-3.5 py-2 max-md:py-1"
+    >
+        <Pencil class="size-3.5 shrink-0 text-brass" />
+        <span
+            class="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-brass-fill-foreground"
+        >
+            {{ $t('Editing your message') }}
+        </span>
+        <span class="shrink-0 text-[11.5px] text-muted-foreground">
+            {{ $t('Enter to save · Esc to cancel') }}
+        </span>
+        <Button
+            variant="unstyled"
+            size="none"
+            type="button"
+            data-test="composer-editing-dismiss"
+            :aria-label="$t('Cancel edit')"
+            class="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground max-md:size-11"
+            @click="$emit('cancel')"
+        >
+            <X class="size-3.5 max-md:size-4.5" />
+        </Button>
+    </div>
+</template>

--- a/resources/js/components/composer/MentionMenu.vue
+++ b/resources/js/components/composer/MentionMenu.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { Bot, Users } from '@lucide/vue';
+import type { MentionSuggestion } from '@/composables/useComposerMentions';
+import { useInitials } from '@/composables/useInitials';
+
+defineProps<{
+    /** The rows to offer, people first and user groups in the reserved tail slots. */
+    suggestions: MentionSuggestion[];
+    /** Which row the keyboard is on. */
+    activeIndex: number;
+    /**
+     * Whether this channel has any bot members. Bots are excluded from the
+     * suggestions (they can't be mentioned), so the menu explains their absence
+     * with a quiet footnote only when at least one is present.
+     */
+    hasBots?: boolean;
+}>();
+
+defineEmits<{
+    /** A row was chosen (clicked). */
+    select: [suggestion: MentionSuggestion];
+    /** The pointer moved onto a row, which becomes the active one. */
+    activate: [index: number];
+}>();
+
+const { getInitials } = useInitials();
+</script>
+
+<template>
+    <ul
+        id="mention-listbox"
+        data-test="mention-menu"
+        role="listbox"
+        :aria-label="$t('Mention a teammate')"
+        class="absolute bottom-full left-0 z-10 mb-2 max-h-60 w-64 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md"
+    >
+        <li
+            v-for="(suggestion, index) in suggestions"
+            :id="`mention-option-${index}`"
+            :key="`${suggestion.kind}-${suggestion.id}`"
+            data-test="mention-option"
+            role="option"
+            tabindex="-1"
+            :aria-selected="index === activeIndex"
+            class="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-popover-foreground"
+            :class="
+                index === activeIndex
+                    ? 'bg-accent text-accent-foreground'
+                    : 'hover:bg-accent/60'
+            "
+            @mousedown.prevent="$emit('select', suggestion)"
+            @mouseenter="$emit('activate', index)"
+        >
+            <span
+                v-if="suggestion.kind === 'group'"
+                class="flex size-6 shrink-0 items-center justify-center rounded-md bg-violet-500/10 text-violet-700 select-none dark:bg-violet-400/15 dark:text-violet-300"
+                aria-hidden="true"
+            >
+                <Users class="size-3.5" />
+            </span>
+            <span
+                v-else
+                class="flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-semibold text-primary select-none"
+                aria-hidden="true"
+            >
+                {{ getInitials(suggestion.label) }}
+            </span>
+            <span class="truncate">{{ suggestion.label }}</span>
+            <!-- The member count is what tells a reader how far this one
+                 mention reaches before they send it. -->
+            <span
+                v-if="suggestion.kind === 'group'"
+                data-test="mention-option-group-count"
+                class="ml-auto shrink-0 text-[11px] text-muted-foreground"
+            >
+                {{
+                    suggestion.group.membersCount === 1
+                        ? $t(':count member', {
+                              count: suggestion.group.membersCount,
+                          })
+                        : $t(':count members', {
+                              count: suggestion.group.membersCount,
+                          })
+                }}
+            </span>
+        </li>
+        <!-- A quiet footnote explaining why bots never appear here — shown
+             only in a channel that actually has a bot. Presentational, so
+             it is not announced as a selectable option. -->
+        <li
+            v-if="hasBots"
+            role="presentation"
+            data-test="mention-bot-hint"
+            class="mt-1 flex items-center gap-2 border-t border-border px-2 pt-2 pb-1 text-[11px] text-muted-foreground italic"
+        >
+            <Bot class="size-3 shrink-0" aria-hidden="true" />
+            <span>{{
+                $t('Bots can’t be mentioned — they don’t read messages')
+            }}</span>
+        </li>
+    </ul>
+</template>

--- a/resources/js/components/composer/RecordingStrip.vue
+++ b/resources/js/components/composer/RecordingStrip.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { Square, X } from '@lucide/vue';
+import { computed } from 'vue';
+import { Button } from '@/components/ui/button';
+import { VOICE_MAX_DURATION_SECONDS, formatClock } from '@/lib/audio';
+
+const props = defineProps<{
+    /** How long the mic has been open, in seconds. */
+    elapsedSeconds: number;
+    /** Whether the clip is inside the final thirty seconds of its budget. */
+    isNearingLimit: boolean;
+    /** The live input level, 0–1, driving the meter. */
+    level: number;
+}>();
+
+defineEmits<{
+    /** Throw the recording away. */
+    cancel: [];
+    /** Stop the mic and stage the clip in the tray. */
+    stop: [];
+}>();
+
+/** The strip's `elapsed / 5:00` ceiling. */
+const recordingLimit = formatClock(VOICE_MAX_DURATION_SECONDS);
+
+/**
+ * The live input-level meter's bars (design 1b). Purely ephemeral chrome: the
+ * levels are read from the mic in real time and nothing is kept with the clip.
+ */
+const LEVEL_BARS = 10;
+const levelBars = computed(() =>
+    Array.from({ length: LEVEL_BARS }, (_, index) => {
+        // Stagger the bars around the current level so the meter reads as a
+        // moving waveform rather than a single block rising and falling.
+        const offset = ((index % 3) + 1) / 4;
+
+        return Math.min(Math.max(props.level * (0.5 + offset), 0.1), 1);
+    }),
+);
+</script>
+
+<template>
+    <!-- While the mic is open the input row gives way to a live readout — a
+         pulsing record dot, the elapsed time against the five-minute cap, an
+         ephemeral input-level meter, and discard/stage controls. -->
+    <div
+        data-test="composer-recording"
+        class="flex h-13 items-center gap-2.5 py-2 pr-2 pl-4.5"
+    >
+        <span
+            class="size-2.5 shrink-0 animate-pulse rounded-full bg-destructive"
+            aria-hidden="true"
+        ></span>
+        <span
+            data-test="composer-recording-elapsed"
+            :data-warning="isNearingLimit ? 'true' : 'false'"
+            class="text-sm font-semibold tabular-nums"
+            :class="
+                isNearingLimit ? 'text-destructive-text' : 'text-foreground'
+            "
+            aria-live="off"
+        >
+            {{ formatClock(elapsedSeconds) }}
+        </span>
+        <span class="text-[12.5px] text-muted-foreground tabular-nums">
+            / {{ recordingLimit }}
+        </span>
+        <div
+            class="flex min-w-0 flex-1 items-center gap-0.75 px-1.5"
+            aria-hidden="true"
+        >
+            <span
+                v-for="(bar, index) in levelBars"
+                :key="index"
+                class="w-0.75 rounded-full bg-destructive/60"
+                :style="{ height: `${bar * 20}px` }"
+            ></span>
+        </div>
+        <Button
+            variant="ghost"
+            size="icon"
+            data-test="composer-recording-cancel"
+            class="size-8.5 shrink-0 rounded-full text-muted-foreground"
+            :aria-label="$t('Discard recording')"
+            @click="$emit('cancel')"
+        >
+            <X class="size-3.75" />
+        </Button>
+        <Button
+            size="icon"
+            data-test="composer-recording-stop"
+            class="size-8.5 shrink-0 rounded-full bg-primary text-brass hover:bg-primary/90"
+            :aria-label="$t('Stop recording')"
+            @click="$emit('stop')"
+        >
+            <Square class="size-3" fill="currentColor" />
+        </Button>
+    </div>
+</template>

--- a/resources/js/components/composer/ReplyPreview.vue
+++ b/resources/js/components/composer/ReplyPreview.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { X } from '@lucide/vue';
+import MessageQuote from '@/components/MessageQuote.vue';
+import { Button } from '@/components/ui/button';
+import type { Message } from '@/types';
+
+defineProps<{
+    /** The message being answered. */
+    target: Message;
+}>();
+
+defineEmits<{
+    /** Drop the reply context and compose a plain message instead. */
+    cancel: [];
+}>();
+</script>
+
+<template>
+    <div
+        data-test="reply-preview"
+        class="mb-2 flex items-center gap-2 rounded-2xl border border-input bg-muted/40 px-3.5 py-2 max-md:py-1"
+    >
+        <span class="min-w-0 flex-1">
+            <MessageQuote
+                :author-name="target.user.name"
+                :body="target.body"
+                :is-deleted="target.isDeleted"
+            />
+        </span>
+        <Button
+            variant="unstyled"
+            size="none"
+            type="button"
+            data-test="reply-preview-dismiss"
+            :aria-label="$t('Cancel reply')"
+            class="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground max-md:size-11"
+            @click="$emit('cancel')"
+        >
+            <X class="size-3.5 max-md:size-4.5" />
+        </Button>
+    </div>
+</template>

--- a/resources/js/components/composer/SlashCommandMenu.vue
+++ b/resources/js/components/composer/SlashCommandMenu.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+defineProps<{
+    /** The commands to offer, already filtered against what has been typed. */
+    commands: App.Data.SlashCommandData[];
+    /** Which row the keyboard is on. */
+    activeIndex: number;
+}>();
+
+defineEmits<{
+    /** A command was chosen (clicked). */
+    select: [command: App.Data.SlashCommandData];
+    /** The pointer moved onto a row, which becomes the active one. */
+    activate: [index: number];
+}>();
+</script>
+
+<template>
+    <!-- Mirrors the mention menu's listbox ARIA and keyboard model, but
+         triggers only at composer position 0. Each row shows
+         name · argument hint · description. -->
+    <ul
+        id="slash-listbox"
+        data-test="slash-menu"
+        role="listbox"
+        :aria-label="$t('Slash commands')"
+        class="absolute bottom-full left-0 z-10 mb-2 max-h-60 w-80 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-md"
+    >
+        <li
+            v-for="(command, index) in commands"
+            :id="`slash-option-${index}`"
+            :key="command.name"
+            data-test="slash-option"
+            role="option"
+            tabindex="-1"
+            :aria-selected="index === activeIndex"
+            class="flex w-full cursor-pointer flex-col gap-0.5 rounded-md px-2 py-1.5 text-left text-sm text-popover-foreground"
+            :class="
+                index === activeIndex
+                    ? 'bg-accent text-accent-foreground'
+                    : 'hover:bg-accent/60'
+            "
+            @mousedown.prevent="$emit('select', command)"
+            @mouseenter="$emit('activate', index)"
+        >
+            <span class="flex items-baseline gap-1.5">
+                <span class="font-semibold">/{{ command.name }}</span>
+                <span
+                    v-if="command.argumentHint"
+                    class="text-[11px] text-muted-foreground"
+                >
+                    {{ command.argumentHint }}
+                </span>
+            </span>
+            <span class="truncate text-[12px] text-muted-foreground">
+                {{ command.description }}
+            </span>
+        </li>
+    </ul>
+</template>

--- a/resources/js/composables/useComposerAttachments.ts
+++ b/resources/js/composables/useComposerAttachments.ts
@@ -1,0 +1,116 @@
+import { computed } from 'vue';
+import type { ComputedRef } from 'vue';
+import { store as storeAttachment } from '@/actions/App/Http/Controllers/Channels/AttachmentController';
+import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
+import type {
+    AttachmentUploads,
+    PendingAttachment,
+} from '@/composables/useAttachmentUploads';
+import { useVoiceRecorder } from '@/composables/useVoiceRecorder';
+import type { VoiceRecorder } from '@/composables/useVoiceRecorder';
+import { isVoiceRecordingSupported } from '@/lib/audio';
+
+export type ComposerAttachments = {
+    /** Whether the composer knows its channel, which is what attachments need. */
+    attachmentsEnabled: ComputedRef<boolean>;
+    /** The pre-send tray itself: staging, progress, removal, and the claimable ids. */
+    uploads: AttachmentUploads;
+    trayItems: ComputedRef<PendingAttachment[]>;
+    showTray: ComputedRef<boolean>;
+    /** Whether the mic slot applies at all in this browser and this channel. */
+    canRecord: ComputedRef<boolean>;
+    recorder: VoiceRecorder;
+    /** Stage pasted image data or files instead of dropping raw bytes into the text. */
+    onPaste: (event: ClipboardEvent) => void;
+    /** Stage externally-provided files (the channel pane's drag-and-drop overlay). */
+    addFiles: (files: FileList | File[]) => void;
+};
+
+/**
+ * Everything the composer stages before a send: the pre-send attachment tray,
+ * the paths files reach it by (pick, paste, drop), and voice recording — which
+ * is nothing but an audio attachment, so it rides the same tray and endpoint.
+ */
+export function useComposerAttachments(options: {
+    teamSlug: () => string | undefined;
+    channelSlug: () => string | undefined;
+    /** The per-file size cap in megabytes, defaulting to the server's own. */
+    maxSizeMb: () => number | undefined;
+    /** The per-message file-count cap, defaulting to the server's own. */
+    maxPerMessage: () => number | undefined;
+}): ComposerAttachments {
+    /**
+     * Attachments are enabled only when the composer knows its channel: files
+     * pre-upload to that channel's endpoint. The thread composer omits the slug, so
+     * its "Add attachment" button stays disabled (thread attachments are a separate
+     * epic child).
+     */
+    const attachmentsEnabled = computed(
+        () => Boolean(options.teamSlug()) && Boolean(options.channelSlug()),
+    );
+
+    /**
+     * The pre-send attachment tray: files upload immediately on pick/paste/drop,
+     * each row tracking its own progress; the send later claims the finished ids.
+     */
+    const uploads = useAttachmentUploads({
+        endpoint: () =>
+            storeAttachment({
+                team: options.teamSlug() ?? '',
+                channel: options.channelSlug() ?? '',
+            }).url,
+        maxSizeMb: () => options.maxSizeMb() ?? 25,
+        maxPerMessage: () => options.maxPerMessage() ?? 10,
+    });
+
+    const trayItems = computed(() => uploads.items.value);
+    const showTray = computed(
+        () => attachmentsEnabled.value && trayItems.value.length > 0,
+    );
+
+    /**
+     * A voice clip is nothing but an audio attachment, so recording rides the tray
+     * above: the finished clip is staged exactly like a dropped file and uploads
+     * through the same endpoint. Capability is read once — `MediaRecorder` and a
+     * secure-context `getUserMedia` don't appear mid-session — and where either is
+     * missing the mic slot is absent rather than present-and-broken.
+     */
+    const voiceRecordingSupported = isVoiceRecordingSupported();
+    const canRecord = computed(
+        () => attachmentsEnabled.value && voiceRecordingSupported,
+    );
+
+    const recorder = useVoiceRecorder({
+        onRecorded: (clip) => uploads.addFiles([clip]),
+    });
+
+    function onPaste(event: ClipboardEvent): void {
+        if (!attachmentsEnabled.value) {
+            return;
+        }
+
+        const files = Array.from(event.clipboardData?.files ?? []);
+
+        if (files.length > 0) {
+            event.preventDefault();
+            uploads.addFiles(files);
+        }
+    }
+
+    function addFiles(files: FileList | File[]): void {
+        if (attachmentsEnabled.value) {
+            uploads.addFiles(files);
+        }
+    }
+
+    return {
+        attachmentsEnabled,
+        uploads,
+        trayItems,
+        showTray,
+        canRecord,
+        recorder,
+        onPaste,
+        addFiles,
+    };
+}

--- a/resources/js/composables/useComposerEditMode.ts
+++ b/resources/js/composables/useComposerEditMode.ts
@@ -1,0 +1,129 @@
+import { nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+import type { ComposerField } from '@/composables/useComposerField';
+import { resolveComposerEditTarget } from '@/lib/composerEdit';
+import type { Message } from '@/types';
+
+export type ComposerEditMode = {
+    editingMessage: Ref<Message | null>;
+    enterEditMode: (message: Message) => void;
+    exitEditMode: () => void;
+    tryEditLastMessage: () => boolean;
+    saveEdit: () => void;
+};
+
+/**
+ * The composer's inline edit mode: recalling the viewer's last editable message
+ * into the field ("↑ to edit last message"), saving the correction through the
+ * shared PATCH path, and leaving again. While it is on, the body is scoped to
+ * that message rather than being a new-message draft.
+ */
+export function useComposerEditMode(options: {
+    field: ComposerField;
+    /** The surface's messages, oldest first, the recall resolves against. */
+    messages: () => Message[];
+    /** The viewer's id, deciding which of `messages` they may edit. */
+    currentUserId: () => string;
+    /** Client uuids of in-flight optimistic sends, skipped when resolving. */
+    pendingUuids: () => string[] | undefined;
+    /** Close the mention menu, which never survives an entry or an exit. */
+    closeMenu: () => void;
+    /**
+     * Flag the next body change as programmatic, so the wipe that leaves edit
+     * mode is not persisted as a channel draft.
+     */
+    suppressNextDraftChange: (suppress: boolean) => void;
+    /** Announce that the composer entered (message id) or left (null) edit mode. */
+    onEditingChange: (messageId: string | null) => void;
+    /** Save the correction through the same PATCH path the inline editor uses. */
+    onSave: (message: Message, body: string) => void;
+}): ComposerEditMode {
+    const { body, focusEnd, resize } = options.field;
+
+    /**
+     * The message the composer is editing in place, or null in normal compose
+     * mode. Set by the ArrowUp "edit last message" shortcut.
+     */
+    const editingMessage = ref<Message | null>(null);
+
+    /**
+     * Load a message's body into the composer and switch to edit mode, placing the
+     * caret at the end so the just-recalled text is ready to correct. The body is
+     * restored verbatim (mention tokens included) so it round-trips faithfully.
+     */
+    function enterEditMode(message: Message): void {
+        editingMessage.value = message;
+        body.value = message.body;
+        options.closeMenu();
+        options.onEditingChange(message.id);
+
+        focusEnd();
+    }
+
+    /**
+     * Leave edit mode and reset the composer to its prior (empty) state. The wipe is
+     * flagged so it isn't persisted as a channel draft (entry required an empty
+     * composer, so there is nothing to restore).
+     */
+    function exitEditMode(): void {
+        // Suppress the draft echo from the wipe only when there is text to clear;
+        // clearing an already-empty field fires no watcher, which would otherwise
+        // leave the guard armed for the next genuine keystroke.
+        options.suppressNextDraftChange(body.value !== '');
+        body.value = '';
+        editingMessage.value = null;
+        options.closeMenu();
+        options.onEditingChange(null);
+        nextTick(resize);
+    }
+
+    /**
+     * Resolve the viewer's most recent editable message on this surface and enter
+     * edit mode for it. A no-op (falling through to the default ArrowUp behaviour)
+     * when there is none.
+     */
+    function tryEditLastMessage(): boolean {
+        const target = resolveComposerEditTarget(
+            options.messages(),
+            options.currentUserId(),
+            options.pendingUuids(),
+        );
+
+        if (!target) {
+            return false;
+        }
+
+        enterEditMode(target);
+
+        return true;
+    }
+
+    /**
+     * Save the in-progress composer edit through the shared edit/PATCH path. An
+     * empty or unchanged draft is a no-op, matching the inline editor; either way
+     * the composer returns to its normal empty state.
+     */
+    function saveEdit(): void {
+        const target = editingMessage.value;
+
+        if (!target) {
+            return;
+        }
+
+        const trimmed = body.value.trim();
+
+        if (trimmed !== '' && trimmed !== target.body) {
+            options.onSave(target, trimmed);
+        }
+
+        exitEditMode();
+    }
+
+    return {
+        editingMessage,
+        enterEditMode,
+        exitEditMode,
+        tryEditLastMessage,
+        saveEdit,
+    };
+}

--- a/resources/js/composables/useComposerField.ts
+++ b/resources/js/composables/useComposerField.ts
@@ -1,0 +1,101 @@
+import { nextTick, ref } from 'vue';
+import type { Ref } from 'vue';
+
+/**
+ * The composer's text field: the body being typed, the textarea behind it, and
+ * the caret/auto-grow helpers every surface built on it — mentions, slash
+ * commands, inline formatting, edit mode — drives it through. One owner for the
+ * "write the body, then put the caret back and re-measure" dance those four
+ * would otherwise each repeat.
+ */
+export type ComposerField = {
+    body: Ref<string>;
+    textarea: Ref<HTMLTextAreaElement | null>;
+    /** Grow (or shrink) the field to its content, up to the scroll ceiling. */
+    resize: () => void;
+    /** Focus the field without moving the caret. */
+    focus: () => void;
+    /** Focus the field and restore a selection, then re-measure its height. */
+    focusRange: (start: number, end?: number) => void;
+    /** Focus the field with the caret past the last character. */
+    focusEnd: () => void;
+    /** Whether the caret sits at the very start of the field (nothing selected). */
+    caretAtStart: () => boolean;
+    /** The caret offset, falling back to the end of the body before mount. */
+    caretPosition: () => number;
+};
+
+export function useComposerField(initialBody: string): ComposerField {
+    const body = ref(initialBody);
+    const textarea = ref<HTMLTextAreaElement | null>(null);
+
+    function resize(): void {
+        const el = textarea.value;
+
+        if (!el) {
+            return;
+        }
+
+        el.style.height = 'auto';
+        el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+    }
+
+    function focus(): void {
+        nextTick(() => textarea.value?.focus());
+    }
+
+    function focusRange(start: number, end: number = start): void {
+        nextTick(() => {
+            const field = textarea.value;
+
+            if (field) {
+                field.focus();
+                field.setSelectionRange(start, end);
+            }
+
+            resize();
+        });
+    }
+
+    function focusEnd(): void {
+        nextTick(() => {
+            const field = textarea.value;
+
+            if (field) {
+                field.focus();
+
+                const end = field.value.length;
+                field.setSelectionRange(end, end);
+            }
+
+            resize();
+        });
+    }
+
+    function caretAtStart(): boolean {
+        const el = textarea.value;
+
+        if (!el) {
+            return true;
+        }
+
+        return el.selectionStart === 0 && el.selectionEnd === 0;
+    }
+
+    function caretPosition(): number {
+        const el = textarea.value;
+
+        return el ? el.selectionStart : body.value.length;
+    }
+
+    return {
+        body,
+        textarea,
+        resize,
+        focus,
+        focusRange,
+        focusEnd,
+        caretAtStart,
+        caretPosition,
+    };
+}

--- a/resources/js/composables/useComposerFormat.ts
+++ b/resources/js/composables/useComposerFormat.ts
@@ -1,0 +1,138 @@
+import { Bold, Code, Italic, Strikethrough } from '@lucide/vue';
+import { computed } from 'vue';
+import type { ComputedRef, FunctionalComponent } from 'vue';
+import type { ComposerField } from '@/composables/useComposerField';
+import { useTranslations } from '@/composables/useTranslations';
+import { toggleInlineMark } from '@/lib/composerFormat';
+
+/**
+ * One inline-format control: its Markdown marker paired with the icon,
+ * accessible label, and shortcut hint its tooltip shows.
+ */
+export type FormatAction = {
+    marker: string;
+    icon: FunctionalComponent;
+    label: string;
+    shortcut: string;
+};
+
+/**
+ * The platform's primary modifier, for the format tooltips' shortcut hints.
+ * Falls back to Ctrl off-Mac (and during SSR, where `navigator` is absent).
+ */
+const isMac =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad/.test(navigator.platform);
+const modLabel = isMac ? '⌘' : 'Ctrl+';
+const shiftLabel = isMac ? '⇧' : 'Shift+';
+
+export type ComposerFormat = {
+    formatActions: ComputedRef<FormatAction[]>;
+    applyFormat: (marker: string) => void;
+    tryFormatShortcut: (event: KeyboardEvent) => boolean;
+};
+
+/**
+ * The composer's inline formatting: the four toolbar controls and the keyboard
+ * shortcuts that mirror them, both wrapping (or unwrapping) the current
+ * selection in a Markdown marker.
+ */
+export function useComposerFormat(options: {
+    field: ComposerField;
+}): ComposerFormat {
+    const { body, textarea, focusRange } = options.field;
+    const { t } = useTranslations();
+
+    /**
+     * The four inline-format controls. Driven by the toolbar buttons and the
+     * keyboard shortcuts alike.
+     */
+    const formatActions = computed<FormatAction[]>(() => [
+        {
+            marker: '**',
+            icon: Bold,
+            label: t('Bold'),
+            shortcut: `${modLabel}B`,
+        },
+        {
+            marker: '*',
+            icon: Italic,
+            label: t('Italic'),
+            shortcut: `${modLabel}I`,
+        },
+        {
+            marker: '~~',
+            icon: Strikethrough,
+            label: t('Strikethrough'),
+            shortcut: `${modLabel}${shiftLabel}X`,
+        },
+        {
+            marker: '`',
+            icon: Code,
+            label: t('Inline code'),
+            shortcut: `${modLabel}E`,
+        },
+    ]);
+
+    /**
+     * Wrap (or unwrap) the current textarea selection in a Markdown marker, then
+     * restore focus and the resulting selection so the field stays ready to type.
+     * Shared by the toolbar buttons and the keyboard shortcuts.
+     */
+    function applyFormat(marker: string): void {
+        const el = textarea.value;
+
+        if (!el) {
+            return;
+        }
+
+        const result = toggleInlineMark(
+            body.value,
+            el.selectionStart,
+            el.selectionEnd,
+            marker,
+        );
+
+        body.value = result.value;
+
+        focusRange(result.selectionStart, result.selectionEnd);
+    }
+
+    /**
+     * Handle the format keyboard shortcuts (⌘/Ctrl+B/I/E and ⌘/Ctrl+Shift+X),
+     * returning true when one fired so the caller stops further key handling. The
+     * chosen keys avoid every existing composer binding.
+     */
+    function tryFormatShortcut(event: KeyboardEvent): boolean {
+        if (!(event.metaKey || event.ctrlKey) || event.altKey) {
+            return false;
+        }
+
+        const key = event.key.toLowerCase();
+
+        const marker =
+            key === 'b' && !event.shiftKey
+                ? '**'
+                : key === 'i' && !event.shiftKey
+                  ? '*'
+                  : key === 'e' && !event.shiftKey
+                    ? '`'
+                    : key === 'x' && event.shiftKey
+                      ? '~~'
+                      : null;
+
+        if (marker === null) {
+            return false;
+        }
+
+        event.preventDefault();
+        // Claim the key before it bubbles to window-level shortcuts (⌘/Ctrl+B also
+        // toggles the sidebar), so formatting in the composer never fires those too.
+        event.stopPropagation();
+        applyFormat(marker);
+
+        return true;
+    }
+
+    return { formatActions, applyFormat, tryFormatShortcut };
+}

--- a/resources/js/composables/useComposerKeyboard.ts
+++ b/resources/js/composables/useComposerKeyboard.ts
@@ -1,0 +1,151 @@
+import type { ComposerEditMode } from '@/composables/useComposerEditMode';
+import type { ComposerField } from '@/composables/useComposerField';
+import type { ComposerFormat } from '@/composables/useComposerFormat';
+import type { ComposerMentions } from '@/composables/useComposerMentions';
+import type { ComposerSlashCommands } from '@/composables/useComposerSlashCommands';
+import { isComposerEditTrigger } from '@/lib/composerEdit';
+import type { Message } from '@/types';
+
+/**
+ * The composer's keydown model, in priority order: whichever autocomplete menu
+ * is open owns the arrows, Enter/Tab and Escape; then the format shortcuts;
+ * then Escape's fallbacks (leave edit mode, else drop the reply); then ArrowUp's
+ * "edit last message" recall; and finally Enter to send or save.
+ */
+export function useComposerKeyboard(options: {
+    field: ComposerField;
+    mentions: ComposerMentions;
+    slash: ComposerSlashCommands;
+    format: ComposerFormat;
+    editing: ComposerEditMode;
+    replyTarget: () => Message | null | undefined;
+    onCancelReply: () => void;
+    onSubmit: () => void;
+}): { onKeydown: (event: KeyboardEvent) => void } {
+    const { body, caretAtStart } = options.field;
+    const { mentions, slash, editing } = options;
+
+    function onKeydown(event: KeyboardEvent): void {
+        if (mentions.showMenu.value) {
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                mentions.moveActive(1);
+
+                return;
+            }
+
+            if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                mentions.moveActive(-1);
+
+                return;
+            }
+
+            if (event.key === 'Enter' || event.key === 'Tab') {
+                event.preventDefault();
+                mentions.selectActive();
+
+                return;
+            }
+
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                mentions.closeMenu();
+
+                return;
+            }
+        }
+
+        // The slash-command menu mirrors the mention menu's navigation. The two are
+        // mutually exclusive (a `/…` body never matches an `@query`), so this runs
+        // only when the slash menu is the open one.
+        if (slash.showSlashMenu.value) {
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                slash.slashMoveActive(1);
+
+                return;
+            }
+
+            if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                slash.slashMoveActive(-1);
+
+                return;
+            }
+
+            if (event.key === 'Enter' || event.key === 'Tab') {
+                event.preventDefault();
+                slash.selectSlashActive();
+
+                return;
+            }
+
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                slash.closeSlashMenu();
+
+                return;
+            }
+        }
+
+        // Format shortcuts wrap the selection. Placed after the mention menu's key
+        // handling so its arrow/Enter/Escape keep priority while it is open; the
+        // chosen keys (B/I/E, ⇧X) never collide with it or Enter-to-send.
+        if (options.format.tryFormatShortcut(event)) {
+            return;
+        }
+
+        // With the mention menu closed, Escape leaves edit mode (restoring the empty
+        // composer) or, failing that, dismisses the active reply context.
+        if (event.key === 'Escape' && editing.editingMessage.value) {
+            event.preventDefault();
+            editing.exitEditMode();
+
+            return;
+        }
+
+        if (event.key === 'Escape' && options.replyTarget()) {
+            event.preventDefault();
+            options.onCancelReply();
+
+            return;
+        }
+
+        // ArrowUp on an empty composer recalls the viewer's last editable message
+        // into edit mode ("↑ to edit last message"). The gate keeps it clear of the
+        // mention menu, `⌥↑` channel nav, and an in-progress reply.
+        if (
+            isComposerEditTrigger({
+                key: event.key,
+                altKey: event.altKey,
+                ctrlKey: event.ctrlKey,
+                metaKey: event.metaKey,
+                shiftKey: event.shiftKey,
+                menuOpen: mentions.showMenu.value || slash.showSlashMenu.value,
+                editing: editing.editingMessage.value !== null,
+                hasReplyTarget: options.replyTarget() != null,
+                isEmpty: body.value.trim() === '',
+                caretAtStart: caretAtStart(),
+            })
+        ) {
+            if (editing.tryEditLastMessage()) {
+                event.preventDefault();
+            }
+
+            return;
+        }
+
+        if (event.key === 'Enter' && !event.shiftKey) {
+            event.preventDefault();
+
+            if (editing.editingMessage.value) {
+                editing.saveEdit();
+            } else {
+                options.onSubmit();
+            }
+        }
+    }
+
+    return { onKeydown };
+}

--- a/resources/js/composables/useComposerMentions.ts
+++ b/resources/js/composables/useComposerMentions.ts
@@ -1,0 +1,238 @@
+import { computed, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { ComposerField } from '@/composables/useComposerField';
+import { useUserGroups } from '@/composables/useUserGroups';
+import type { Mention } from '@/types';
+
+/**
+ * Well-formed *person* mention token: `@[Display Name](user-id)`. The parser on
+ * the server resolves the id; here it lets us collect the mentions being sent
+ * and recognise a completed token so it never re-triggers the autocomplete. A
+ * group token carries a `group:` prefix, so it deliberately does not match —
+ * the optimistic row lists people, and the group's fan-out is resolved
+ * server-side at post time.
+ */
+const MENTION_TOKEN = /@\[[^\]]+\]\(([0-9a-fA-F-]{36})\)/g;
+
+/**
+ * A fresh `@query` at the caret: an `@` at the start or after whitespace,
+ * followed by run of non-space characters that isn't already a token.
+ */
+const MENTION_QUERY = /(?:^|\s)@([^\s@[\]()]*)$/;
+
+const MAX_SUGGESTIONS = 8;
+
+/**
+ * How many of those slots user groups may claim. Capped so the menu stays a
+ * people-picker first, but never so low that a matching group is crowded out.
+ */
+const MAX_GROUP_SUGGESTIONS = 3;
+
+/**
+ * One row of the `@` menu: a person, or a user group that fans the mention out
+ * to everyone in it. Both live in one list so the keyboard model, the active
+ * index, and the ARIA wiring stay single-source.
+ */
+export type MentionSuggestion =
+    | { kind: 'user'; id: string; label: string; member: Mention }
+    | {
+          kind: 'group';
+          id: string;
+          label: string;
+          group: App.Data.UserGroupData;
+      };
+
+export type ComposerMentions = {
+    suggestions: Ref<MentionSuggestion[]>;
+    activeIndex: Ref<number>;
+    menuOpen: Ref<boolean>;
+    showMenu: ComputedRef<boolean>;
+    refreshSuggestions: () => void;
+    moveActive: (delta: number) => void;
+    selectSuggestion: (suggestion: MentionSuggestion) => void;
+    selectActive: () => void;
+    closeMenu: () => void;
+    collectMentions: (text: string) => Mention[];
+    insertMention: (member: Mention) => void;
+};
+
+/**
+ * The composer's `@` autocomplete: which rows the menu offers for the query at
+ * the caret, how a chosen row completes into a mention token, and which people
+ * a body's tokens resolve to when it is sent.
+ */
+export function useComposerMentions(options: {
+    field: ComposerField;
+    /** The channel's mentionable members (bots excluded upstream). */
+    members: () => Mention[];
+}): ComposerMentions {
+    const { body, caretPosition, focusRange } = options.field;
+    const { search: searchGroups } = useUserGroups();
+
+    const suggestions = ref<MentionSuggestion[]>([]);
+    const activeIndex = ref(0);
+    const menuOpen = ref(false);
+
+    const showMenu = computed(
+        () => menuOpen.value && suggestions.value.length > 0,
+    );
+
+    /**
+     * The active `@query` immediately before the caret, or null when the caret is
+     * not in a mention context.
+     */
+    function activeQuery(): { query: string; start: number } | null {
+        const caret = caretPosition();
+        const upToCaret = body.value.slice(0, caret);
+        const match = upToCaret.match(MENTION_QUERY);
+
+        if (!match) {
+            return null;
+        }
+
+        return { query: match[1], start: caret - match[1].length - 1 };
+    }
+
+    function refreshSuggestions(): void {
+        const active = activeQuery();
+
+        if (!active) {
+            menuOpen.value = false;
+            suggestions.value = [];
+
+            return;
+        }
+
+        const needle = active.query.toLowerCase();
+
+        // People first, then groups: naming an individual is the far more common
+        // intent, and a group reaching several people should never be the row the
+        // caret lands on by default.
+        const people: MentionSuggestion[] = options
+            .members()
+            .filter((member) => member.name.toLowerCase().includes(needle))
+            .map((member) => ({
+                kind: 'user',
+                id: member.id,
+                label: member.name,
+                member,
+            }));
+
+        const groups: MentionSuggestion[] = searchGroups(needle).map(
+            (group) => ({
+                kind: 'group',
+                id: group.id,
+                label: group.slug,
+                group,
+            }),
+        );
+
+        // Groups get reserved slots at the tail rather than whatever the people list
+        // leaves over: a plain `[...people, ...groups].slice(MAX)` would hide a
+        // matching group entirely behind eight matching names, making it
+        // unreachable from the menu.
+        const groupSlots = Math.min(groups.length, MAX_GROUP_SUGGESTIONS);
+
+        suggestions.value = [
+            ...people.slice(0, MAX_SUGGESTIONS - groupSlots),
+            ...groups.slice(0, groupSlots),
+        ];
+        activeIndex.value = 0;
+        menuOpen.value = suggestions.value.length > 0;
+    }
+
+    function moveActive(delta: number): void {
+        const count = suggestions.value.length;
+        activeIndex.value = (activeIndex.value + delta + count) % count;
+    }
+
+    function selectSuggestion(suggestion: MentionSuggestion): void {
+        const caret = caretPosition();
+        const active = activeQuery();
+
+        if (!active) {
+            return;
+        }
+
+        const before = body.value.slice(0, active.start);
+        const after = body.value.slice(caret);
+        // The `group:` prefix is what tells the server (and the renderer) to expand
+        // the token to a whole group rather than resolve one person.
+        const token =
+            suggestion.kind === 'group'
+                ? `@[${suggestion.label}](group:${suggestion.id}) `
+                : `@[${suggestion.label}](${suggestion.id}) `;
+
+        body.value = before + token + after;
+        menuOpen.value = false;
+
+        focusRange(before.length + token.length);
+    }
+
+    function selectActive(): void {
+        const suggestion = suggestions.value[activeIndex.value];
+
+        if (suggestion) {
+            selectSuggestion(suggestion);
+        }
+    }
+
+    function closeMenu(): void {
+        menuOpen.value = false;
+    }
+
+    /**
+     * Collect the distinct, resolvable mentions present in the body so the
+     * optimistic row can highlight them before the server echo arrives.
+     */
+    function collectMentions(text: string): Mention[] {
+        const seen = new Set<string>();
+        const mentions: Mention[] = [];
+
+        for (const match of text.matchAll(MENTION_TOKEN)) {
+            const id = match[1];
+            const member = options
+                .members()
+                .find((candidate) => candidate.id === id);
+
+            if (member && !seen.has(id)) {
+                seen.add(id);
+                mentions.push({ id: member.id, name: member.name });
+            }
+        }
+
+        return mentions;
+    }
+
+    /**
+     * Insert a mention token at the caret (or the end), keeping a space separator
+     * from preceding text. Exposed so a profile hover card can drop a mention into
+     * the composer from elsewhere in the page.
+     */
+    function insertMention(member: Mention): void {
+        const caret = caretPosition();
+        const before = body.value.slice(0, caret);
+        const after = body.value.slice(caret);
+
+        const separator = before.length > 0 && !before.endsWith(' ') ? ' ' : '';
+        const token = `${separator}@[${member.name}](${member.id}) `;
+
+        body.value = before + token + after;
+
+        focusRange(before.length + token.length);
+    }
+
+    return {
+        suggestions,
+        activeIndex,
+        menuOpen,
+        showMenu,
+        refreshSuggestions,
+        moveActive,
+        selectSuggestion,
+        selectActive,
+        closeMenu,
+        collectMentions,
+        insertMention,
+    };
+}

--- a/resources/js/composables/useComposerSend.ts
+++ b/resources/js/composables/useComposerSend.ts
@@ -1,0 +1,229 @@
+import { computed, nextTick, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { ComposerAttachments } from '@/composables/useComposerAttachments';
+import type { ComposerField } from '@/composables/useComposerField';
+import type { ComposerMentions } from '@/composables/useComposerMentions';
+import type { ComposerSlashCommands } from '@/composables/useComposerSlashCommands';
+import type {
+    CommandCallbacks,
+    SendCallbacks,
+} from '@/composables/useMessageActions';
+import type { Mention } from '@/types';
+
+export type ComposerSend = {
+    /** In a thread composer, whether the reply is also surfaced in the main timeline. */
+    sendToChannel: Ref<boolean>;
+    /** Whether there is something to send and nothing blocking it. */
+    canSubmit: ComputedRef<boolean>;
+    /** True while a command send awaits the server, blocking re-submits. */
+    commandPending: Ref<boolean>;
+    /** Whether the schedule picker is open. */
+    scheduling: Ref<boolean>;
+    /** Whether there is text to schedule (scheduling never carries attachments). */
+    canSchedule: ComputedRef<boolean>;
+    submit: () => void;
+    openSchedule: () => void;
+    onScheduleConfirm: (sendAt: string) => void;
+};
+
+/**
+ * Where the composed text leaves the composer: the choice between the
+ * optimistic message path, the non-optimistic slash-command path, and the two
+ * commands that open a picker instead — plus scheduling it for later, and the
+ * clear-down each of those ends in.
+ */
+export function useComposerSend(options: {
+    field: ComposerField;
+    attachments: ComposerAttachments;
+    mentions: ComposerMentions;
+    slash: ComposerSlashCommands;
+    /**
+     * Flag the next body change as programmatic, so a clear-on-send is not
+     * re-persisted as a draft (the send already cleared it server-side).
+     */
+    suppressNextDraftChange: (suppress: boolean) => void;
+    onSend: (
+        body: string,
+        mentions: Mention[],
+        sendToChannel: boolean,
+        attachmentIds: string[],
+        callbacks: SendCallbacks,
+    ) => void;
+    onCommand: (body: string, callbacks: CommandCallbacks) => void;
+    onSchedule: (body: string, mentions: Mention[], sendAt: string) => void;
+    /** Re-persist the retained text after a command send failed. */
+    onDraftChange: (body: string) => void;
+}): ComposerSend {
+    const { body, resize } = options.field;
+    const { uploads } = options.attachments;
+
+    const sendToChannel = ref(false);
+    const commandPending = ref(false);
+
+    /**
+     * A send is allowed once nothing is mid-upload or failed and there is something
+     * to send (body text or at least one finished attachment). Body is optional
+     * when the tray carries a ready attachment.
+     */
+    const canSubmit = computed(() => {
+        if (uploads.isUploading.value || uploads.hasFailed.value) {
+            return false;
+        }
+
+        return (
+            body.value.trim() !== '' || uploads.attachmentIds.value.length > 0
+        );
+    });
+
+    /**
+     * Clear the composer after the text has been handed off (an immediate send or a
+     * scheduled one), flagging the wipe so it doesn't re-persist as a draft.
+     */
+    function clearAfterHandoff(): void {
+        options.suppressNextDraftChange(true);
+        body.value = '';
+        sendToChannel.value = false;
+        options.mentions.closeMenu();
+        options.slash.closeSlashMenu();
+        nextTick(resize);
+    }
+
+    /**
+     * Send a slash command. Non-optimistic: the composer keeps the typed text in a
+     * pending state, clears it once the server confirms the command ran, and keeps
+     * it if the command failed so the user can correct and resend.
+     *
+     * The field stays editable while the send is in flight, so both outcomes guard
+     * against clobbering a fresh edit: success clears only if the body is still the
+     * one that was sent, and failure re-emits the draft (the command send cancels
+     * the debounced save, so the retained text must reschedule its persistence).
+     */
+    function submitCommand(rawBody: string): void {
+        const submittedBody = body.value;
+        commandPending.value = true;
+        options.slash.closeSlashMenu();
+
+        options.onCommand(rawBody, {
+            onSuccess: () => {
+                commandPending.value = false;
+
+                if (body.value === submittedBody) {
+                    clearAfterHandoff();
+                }
+            },
+            onError: () => {
+                commandPending.value = false;
+                options.onDraftChange(body.value);
+            },
+        });
+    }
+
+    function submit(): void {
+        if (!canSubmit.value || commandPending.value) {
+            return;
+        }
+
+        const trimmed = body.value.trim();
+
+        // A slash command forks off the optimistic message path onto a dedicated,
+        // non-optimistic send. Only when the tray is empty — a command carries no
+        // attachments, so a command-looking body with staged files posts as text.
+        if (
+            uploads.attachmentIds.value.length === 0 &&
+            options.slash.looksLikeCommand(trimmed)
+        ) {
+            // `/gif [query]` opens the picker rather than posting text; the chosen
+            // GIF is then sent as an attachment through the ordinary path.
+            const gifQuery = options.slash.gifCommandQuery(trimmed);
+
+            if (gifQuery !== null) {
+                options.slash.openGifPicker(gifQuery);
+
+                return;
+            }
+
+            // `/poll` opens the builder rather than posting text; the composed poll
+            // is then posted as a first-class poll message through its own endpoint.
+            if (options.slash.isPollCommand(trimmed)) {
+                options.slash.openPollComposer();
+
+                return;
+            }
+
+            submitCommand(trimmed);
+
+            return;
+        }
+
+        // Snapshot the composer state before the optimistic wipe: the send is
+        // fire-and-forget, so if an online send fails, the staged attachments (and
+        // the typed body) are handed back through the outcome hooks below, letting
+        // the user retry without re-picking every file. A successful (or queued)
+        // send disposes the snapshot instead. `detach` empties the tray but keeps the
+        // rows' previews alive until the outcome lands.
+        const stagedBody = body.value;
+        const attachmentIds = uploads.attachmentIds.value;
+        const snapshot = uploads.detach();
+
+        options.onSend(
+            trimmed,
+            options.mentions.collectMentions(trimmed),
+            sendToChannel.value,
+            attachmentIds,
+            {
+                onAccepted: () => snapshot.dispose(),
+                onRejected: () => {
+                    snapshot.restore();
+                    body.value = stagedBody;
+                },
+            },
+        );
+        clearAfterHandoff();
+    }
+
+    /**
+     * Whether the schedule picker is open. Opening requires some text — an empty
+     * composer has nothing to schedule.
+     */
+    const scheduling = ref(false);
+
+    /**
+     * Scheduling never carries attachments, so the "Send later" affordances gate on
+     * body text alone, matching the old schedule button's guard.
+     */
+    const canSchedule = computed(() => body.value.trim() !== '');
+
+    function openSchedule(): void {
+        if (!canSchedule.value) {
+            return;
+        }
+
+        scheduling.value = true;
+    }
+
+    function onScheduleConfirm(sendAt: string): void {
+        const trimmed = body.value.trim();
+
+        if (trimmed === '') {
+            return;
+        }
+
+        options.onSchedule(
+            trimmed,
+            options.mentions.collectMentions(trimmed),
+            sendAt,
+        );
+        clearAfterHandoff();
+    }
+
+    return {
+        sendToChannel,
+        canSubmit,
+        commandPending,
+        scheduling,
+        canSchedule,
+        submit,
+        openSchedule,
+        onScheduleConfirm,
+    };
+}

--- a/resources/js/composables/useComposerSlashCommands.ts
+++ b/resources/js/composables/useComposerSlashCommands.ts
@@ -1,0 +1,280 @@
+import { computed, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { ComposerField } from '@/composables/useComposerField';
+import type { AttachmentData } from '@/types/attachments';
+
+/**
+ * A slash command occupies the whole body up to the caret: a leading `/`
+ * followed by word characters and nothing else. The menu therefore triggers
+ * only at composer position 0 and closes the instant a space is typed (which
+ * breaks the match), matching the server's `^/(name)(\s|$)` interception rule.
+ */
+const SLASH_QUERY = /^\/(\w*)$/;
+
+const MAX_SUGGESTIONS = 8;
+
+/**
+ * The one picker-backed command: `/gif` opens the Giphy picker instead of
+ * completing to text and posting through the command endpoint.
+ */
+const GIF_COMMAND_NAME = 'gif';
+
+/**
+ * The other picker-backed command: `/poll` opens the poll builder instead of
+ * completing to text and posting through the command endpoint.
+ */
+const POLL_COMMAND_NAME = 'poll';
+
+export type ComposerSlashCommands = {
+    slashSuggestions: Ref<App.Data.SlashCommandData[]>;
+    slashActiveIndex: Ref<number>;
+    slashMenuOpen: Ref<boolean>;
+    showSlashMenu: ComputedRef<boolean>;
+    refreshSlashSuggestions: () => void;
+    slashMoveActive: (delta: number) => void;
+    selectSlashCommand: (command: App.Data.SlashCommandData) => void;
+    selectSlashActive: () => void;
+    closeSlashMenu: () => void;
+    looksLikeCommand: (text: string) => boolean;
+    gifPickerOpen: Ref<boolean>;
+    gifPickerQuery: Ref<string>;
+    gifPickerAvailable: ComputedRef<boolean>;
+    gifCommandQuery: (text: string) => string | null;
+    openGifPicker: (query: string) => void;
+    closeGifPicker: () => void;
+    onGifSelected: (attachment: AttachmentData) => void;
+    pollComposerOpen: Ref<boolean>;
+    pollComposerAvailable: ComputedRef<boolean>;
+    isPollCommand: (text: string) => boolean;
+    openPollComposer: () => void;
+    closePollComposer: () => void;
+};
+
+/**
+ * The composer's slash-command surface: the autocomplete menu, the advisory
+ * "is this a command?" check that decides which endpoint a send posts to, and
+ * the two commands that open a picker rather than posting text at all.
+ */
+export function useComposerSlashCommands(options: {
+    field: ComposerField;
+    /** The server's autocomplete manifest; empty or absent disables all slash handling. */
+    commands: () => App.Data.SlashCommandData[] | undefined;
+    /** Whether the Giphy picker is configured for this instance. */
+    gifPickerEnabled: () => boolean;
+    /** Whether the poll builder is enabled for this instance. */
+    pollsEnabled: () => boolean;
+    /** Whether the composer knows its channel, so a picked GIF can be staged. */
+    attachmentsEnabled: () => boolean;
+    teamSlug: () => string | undefined;
+    channelSlug: () => string | undefined;
+    /** Whether an existing message is being edited (neither picker applies then). */
+    isEditing: () => boolean;
+    /** Stage a picked GIF in the attachment tray; false when the tray refused it. */
+    stageRemote: (attachment: AttachmentData) => boolean;
+}): ComposerSlashCommands {
+    const { body, caretPosition, focus, focusRange } = options.field;
+
+    const slashSuggestions = ref<App.Data.SlashCommandData[]>([]);
+    const slashActiveIndex = ref(0);
+    const slashMenuOpen = ref(false);
+
+    const showSlashMenu = computed(
+        () => slashMenuOpen.value && slashSuggestions.value.length > 0,
+    );
+
+    /** The GIF picker's open state and the search term it opens on (from `/gif cats`). */
+    const gifPickerOpen = ref(false);
+    const gifPickerQuery = ref('');
+
+    /** The poll builder's open state. */
+    const pollComposerOpen = ref(false);
+
+    function refreshSlashSuggestions(): void {
+        const commands = options.commands() ?? [];
+
+        if (commands.length === 0) {
+            slashMenuOpen.value = false;
+            slashSuggestions.value = [];
+
+            return;
+        }
+
+        const match = body.value.slice(0, caretPosition()).match(SLASH_QUERY);
+
+        if (!match) {
+            slashMenuOpen.value = false;
+            slashSuggestions.value = [];
+
+            return;
+        }
+
+        const needle = match[1].toLowerCase();
+
+        slashSuggestions.value = commands
+            .filter((command) => command.name.toLowerCase().startsWith(needle))
+            .slice(0, MAX_SUGGESTIONS);
+        slashActiveIndex.value = 0;
+        slashMenuOpen.value = slashSuggestions.value.length > 0;
+    }
+
+    function slashMoveActive(delta: number): void {
+        const count = slashSuggestions.value.length;
+        slashActiveIndex.value =
+            (slashActiveIndex.value + delta + count) % count;
+    }
+
+    function closeSlashMenu(): void {
+        slashMenuOpen.value = false;
+    }
+
+    /**
+     * The picker is usable only when configured, when the composer knows its
+     * channel (a picked GIF is staged as an attachment on that channel), and while
+     * composing a new message — not editing an existing one (an inline edit saves
+     * text only and cannot carry an attachment).
+     */
+    const gifPickerAvailable = computed(
+        () =>
+            options.gifPickerEnabled() &&
+            options.attachmentsEnabled() &&
+            !options.isEditing(),
+    );
+
+    /**
+     * The search term if `text` is the `/gif` command (`/gif` or `/gif <query>`) and
+     * the picker is available, else null. Used to divert `/gif` away from the text
+     * command path and into the picker.
+     */
+    function gifCommandQuery(text: string): string | null {
+        if (!gifPickerAvailable.value) {
+            return null;
+        }
+
+        const match = text.match(/^\/gif(?:\s+(.*))?$/i);
+
+        return match ? (match[1]?.trim() ?? '') : null;
+    }
+
+    /** Open the GIF picker on the given search term, clearing the `/gif` text. */
+    function openGifPicker(query: string): void {
+        slashMenuOpen.value = false;
+        gifPickerQuery.value = query;
+        gifPickerOpen.value = true;
+        body.value = '';
+    }
+
+    function closeGifPicker(): void {
+        gifPickerOpen.value = false;
+        focus();
+    }
+
+    /**
+     * A picked GIF joins the tray as a remote attachment; the picker closes only if
+     * it was accepted, so a full tray keeps the picker open with its toast shown.
+     */
+    function onGifSelected(attachment: AttachmentData): void {
+        if (options.stageRemote(attachment)) {
+            closeGifPicker();
+        }
+    }
+
+    /**
+     * The builder is usable only when polls are enabled, when the composer knows its
+     * channel (the poll is posted to that channel), and while composing a new
+     * message — not editing an existing one.
+     */
+    const pollComposerAvailable = computed(
+        () =>
+            options.pollsEnabled() &&
+            Boolean(options.teamSlug()) &&
+            Boolean(options.channelSlug()) &&
+            !options.isEditing(),
+    );
+
+    /** Whether `text` is the `/poll` command and the builder is available. */
+    function isPollCommand(text: string): boolean {
+        return pollComposerAvailable.value && /^\/poll(?:\s+.*)?$/i.test(text);
+    }
+
+    /** Open the poll builder, closing the slash menu and clearing the `/poll` text. */
+    function openPollComposer(): void {
+        slashMenuOpen.value = false;
+        pollComposerOpen.value = true;
+        body.value = '';
+    }
+
+    function closePollComposer(): void {
+        pollComposerOpen.value = false;
+        focus();
+    }
+
+    function selectSlashCommand(command: App.Data.SlashCommandData): void {
+        if (command.name === GIF_COMMAND_NAME && gifPickerAvailable.value) {
+            openGifPicker('');
+
+            return;
+        }
+
+        if (command.name === POLL_COMMAND_NAME && pollComposerAvailable.value) {
+            openPollComposer();
+
+            return;
+        }
+
+        body.value = `/${command.name} `;
+        slashMenuOpen.value = false;
+
+        focusRange(body.value.length);
+    }
+
+    function selectSlashActive(): void {
+        const command = slashSuggestions.value[slashActiveIndex.value];
+
+        if (command) {
+            selectSlashCommand(command);
+        }
+    }
+
+    /**
+     * Whether the trimmed body is a send-ready command the server will intercept: a
+     * leading `/name` (name followed by a space or the end) matching a registered
+     * command. Only advisory — it decides which endpoint the composer posts to; the
+     * server re-parses authoritatively.
+     */
+    function looksLikeCommand(text: string): boolean {
+        const match = text.match(/^\/(\S+)(?:\s|$)/);
+
+        if (!match) {
+            return false;
+        }
+
+        return (options.commands() ?? []).some(
+            (command) => command.name === match[1],
+        );
+    }
+
+    return {
+        slashSuggestions,
+        slashActiveIndex,
+        slashMenuOpen,
+        showSlashMenu,
+        refreshSlashSuggestions,
+        slashMoveActive,
+        selectSlashCommand,
+        selectSlashActive,
+        closeSlashMenu,
+        looksLikeCommand,
+        gifPickerOpen,
+        gifPickerQuery,
+        gifPickerAvailable,
+        gifCommandQuery,
+        openGifPicker,
+        closeGifPicker,
+        onGifSelected,
+        pollComposerOpen,
+        pollComposerAvailable,
+        isPollCommand,
+        openPollComposer,
+        closePollComposer,
+    };
+}


### PR DESCRIPTION
Closes #981. First child of #980.

`MessageComposer.vue` goes from **2021 to 512 raw lines** — **1462 to 380** as
`max-lines` counts them, against the 400 cap. Its entry is gone from the
exemption block in `eslint.config.js`, so `max-lines-policy.test.ts` now holds
the file to the cap like any other.

Everything the composer had grown — attachments, mentions, formatting, slash
commands, drafts, editing, polls, voice — lived in one scope. It moves out along
the seams that were already there, script half first (this was a
composable-extraction job before it was a component-extraction one).

## What moved

| New file | Lines | What it holds |
| --- | ---: | --- |
| `composables/useComposerSlashCommands.ts` | 181 | The `/` menu, `looksLikeCommand`, and the two picker-backed commands (`/gif`, `/poll`) |
| `composables/useComposerMentions.ts` | 151 | The `@` menu: the query at the caret, people-before-groups ordering, token completion, `collectMentions` |
| `composables/useComposerSend.ts` | 145 | Where the text leaves: optimistic send vs. command vs. picker, the snapshot/restore, scheduling, clear-down |
| `composables/useComposerKeyboard.ts` | 107 | The keydown priority model, menus first and Enter-to-send last |
| `composables/useComposerFormat.ts` | 92 | The four inline-format controls and the shortcuts mirroring them |
| `composables/useComposerAttachments.ts` | 76 | The pre-send tray, the paths files reach it by, and voice (an audio attachment) |
| `composables/useComposerEditMode.ts` | 70 | The ArrowUp recall, save, and leaving again |
| `composables/useComposerField.ts` | 69 | The body, the textarea, and the caret/auto-grow dance the other five repeated |
| `components/composer/AttachmentTray.vue` | 221 | The four chip shapes and their remove/retry controls |
| `components/composer/ComposerInputRow.vue` | 187 | The field and the trailing controls, edit-mode and compose alike |
| `components/composer/ComposerTools.vue` | 102 | The format cluster, attach and mic |
| `components/composer/MentionMenu.vue` | 89 | The `@` listbox |
| `components/composer/RecordingStrip.vue` | 81 | The live readout while the mic is open, meter included |
| `components/composer/SlashCommandMenu.vue` | 53 | The `/` listbox |
| `components/composer/ReplyPreview.vue` | 37 | The reply context banner |
| `components/composer/EditingBanner.vue` | 36 | The brass edit banner |

The composables take their inputs as getters, matching `useAttachmentUploads`'
existing shape; each returns a named type so the ones that compose
(`useComposerKeyboard`, `useComposerSend`) take the others whole rather than
twenty loose callbacks. The one structural note: `ComposerInputRow` owns the
`<textarea>` and hands the element back through a `register` callback, so
`useComposerField` still drives the caret, height and focus.

## The move is provably a move

The first commit is **tests only, written against the untouched component**, so
their staying green across the second commit is the parity proof. Coverage was
thin exactly where the largest pieces were about to move — the mention menu had
only the a11y audits, formatting only the mobile hit-box geometry, and the
draft-emission rules almost nothing.

40 new cases across four files: `MessageComposer.mentions.test.ts` (12),
`MessageComposer.editMode.test.ts` (12), `MessageComposer.format.test.ts` (8),
`MessageComposer.tray.test.ts` (8). Every `data-test` selector, string, route
and key list is preserved verbatim, and `lang/fr.json` is untouched.

## Testing

- `sail composer test` — `Total: 100.0 %`, clean Pint/PHPStan/Rector.
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — clean.
- `sail npm run test:js` — 1810 passed.
- 80 browser assertions re-run against the split component: `MobileComposerTrayTest`,
  `MobileShellTest`, `ComposerEditLastMessageTest`, `ComposerPlaceholderTest`,
  `A11yTimelineTest`, `A11yUserGroupsTest`, `PollComposerPanelTest`,
  `MobileThreadPanelTest`, `MobileUndrawnScreensTest`, `RealtimeTyping/Messaging/EditDelete`,
  `OfflineQueueRetryTest`, `ForwardUndoTest` — all green, axe audits included.

## Found on the way

A local CodeRabbit pass raised five findings. **None are applied here** — each
one is byte-identical on `develop`, so it predates the split, and fixing them
inline would cost the reviewer the "if it moved, it did not change" assumption
this PR is built on. The four genuine defects are filed as #1016 (draft
suppression sticking after an attachment-only send; no IME `isComposing` guard,
so Enter sends mid-composition for CJK input; slash completion discarding text
after the caret; `sendToChannel` not restored on a rejected send). The fifth,
giving tray thumbnails `alt="{filename}"`, is a judgement call rather than a
defect and is noted there too.

No user-facing copy, config, or operator-facing behaviour changes, so no docs or
i18n updates apply.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787850895&installation_model_id=428379&pr_number=1017&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1017&signature=f70d5613c8631eb25770d5ad00863e7d43c3256716861c568448ee42013ec850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->