### PR TITLE
refactor: split MessageList.vue

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -253,7 +253,6 @@ export default defineConfigWithVueTs(
         // stops breaching the threshold, so the list can only shrink.
         files: [
             'resources/js/components/ChannelMasthead.vue',
-            'resources/js/components/MessageList.vue',
             'resources/js/components/QuickSwitcher.vue',
             'resources/js/components/UserStatusDialog.vue',
             'resources/js/composables/useAttachmentUploads.test.ts',

--- a/resources/js/components/MessageList.actionSheet.test.ts
+++ b/resources/js/components/MessageList.actionSheet.test.ts
@@ -34,17 +34,6 @@ vi.mock('@/composables/useIsMobile', async () => {
     return { useIsMobile: () => value };
 });
 
-/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
-function passthrough(name: string) {
-    return defineComponent({
-        name,
-        setup:
-            (_props, { slots }) =>
-            () =>
-                h('div', { 'data-stub': name }, slots.default?.()),
-    });
-}
-
 /** Renders an empty marker element, so a stubbed leaf is still findable. */
 function marker(name: string) {
     return defineComponent({
@@ -84,35 +73,6 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
     }),
 }));
 
-vi.mock('@/components/ui/hover-card', () => ({
-    HoverCard: passthrough('HoverCard'),
-    HoverCardTrigger: passthrough('HoverCardTrigger'),
-    HoverCardContent: passthrough('HoverCardContent'),
-}));
-
-vi.mock('@/components/ui/dialog', () => ({
-    Dialog: defineComponent({
-        name: 'DialogStub',
-        props: { open: { type: Boolean, default: false } },
-        setup:
-            (props, { slots }) =>
-            () =>
-                props.open
-                    ? h(
-                          'div',
-                          { 'data-test': 'delete-dialog' },
-                          slots.default?.(),
-                      )
-                    : null,
-    }),
-    DialogClose: passthrough('DialogClose'),
-    DialogContent: passthrough('DialogContent'),
-    DialogDescription: passthrough('DialogDescription'),
-    DialogFooter: passthrough('DialogFooter'),
-    DialogHeader: passthrough('DialogHeader'),
-    DialogTitle: passthrough('DialogTitle'),
-}));
-
 vi.mock('@/components/MessageAttachments.vue', () => ({
     default: marker('MessageAttachments'),
 }));
@@ -127,10 +87,6 @@ vi.mock('@/components/MessageReactions.vue', () => ({
 
 vi.mock('@/components/MessageForward.vue', () => ({
     default: marker('MessageForward'),
-}));
-
-vi.mock('@/components/LinkPreview.vue', () => ({
-    default: marker('LinkPreview'),
 }));
 
 import MessageList from './MessageList.vue';

--- a/resources/js/components/MessageList.actionSheet.test.ts
+++ b/resources/js/components/MessageList.actionSheet.test.ts
@@ -1,0 +1,322 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, nextTick, reactive } from 'vue';
+import { LONG_PRESS_MS } from '@/composables/useLongPress';
+import { translate } from '@/lib/i18n';
+import type { Message } from '@/types';
+
+/**
+ * Covers the touch stand-in for the hover toolbar: the actions sheet a hold on a
+ * message row opens, the rows it refuses to open on, and the two ways it closes
+ * itself again. It survives a split of `MessageList.vue` unchanged, so what is
+ * pinned here is when it opens and which message it resolves.
+ */
+const pageProps = vi.hoisted(() => ({
+    auth: { user: { timezone: 'UTC' } },
+    customEmojis: {} as Record<string, string>,
+    userGroups: [] as unknown[],
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: pageProps }),
+}));
+
+const mobile = vi.hoisted(() => ({
+    current: null as { value: boolean } | null,
+}));
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { ref } = await import('vue');
+    const value = ref(false);
+    mobile.current = value;
+
+    return { useIsMobile: () => value };
+});
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+function passthrough(name: string) {
+    return defineComponent({
+        name,
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', { 'data-stub': name }, slots.default?.()),
+    });
+}
+
+/** Renders an empty marker element, so a stubbed leaf is still findable. */
+function marker(name: string) {
+    return defineComponent({
+        name,
+        setup: () => () => h('div', { 'data-stub': name }),
+    });
+}
+
+vi.mock('@/components/MessageActions.vue', () => ({
+    default: marker('MessageActions'),
+}));
+
+/** Reports the sheet's open state and the message it resolved, nothing more. */
+vi.mock('@/components/MessageActionsSheet.vue', () => ({
+    default: defineComponent({
+        name: 'MessageActionsSheetStub',
+        props: {
+            open: { type: Boolean, default: false },
+            message: { type: Object, default: null },
+        },
+        setup: (props) => () =>
+            h('div', {
+                'data-test': 'actions-sheet',
+                'data-open': String(props.open),
+                'data-message': props.message?.id ?? '',
+            }),
+    }),
+}));
+
+vi.mock('@/components/UserHoverCard.vue', () => ({
+    default: defineComponent({
+        name: 'UserHoverCardStub',
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', slots.default?.()),
+    }),
+}));
+
+vi.mock('@/components/ui/hover-card', () => ({
+    HoverCard: passthrough('HoverCard'),
+    HoverCardTrigger: passthrough('HoverCardTrigger'),
+    HoverCardContent: passthrough('HoverCardContent'),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: defineComponent({
+        name: 'DialogStub',
+        props: { open: { type: Boolean, default: false } },
+        setup:
+            (props, { slots }) =>
+            () =>
+                props.open
+                    ? h(
+                          'div',
+                          { 'data-test': 'delete-dialog' },
+                          slots.default?.(),
+                      )
+                    : null,
+    }),
+    DialogClose: passthrough('DialogClose'),
+    DialogContent: passthrough('DialogContent'),
+    DialogDescription: passthrough('DialogDescription'),
+    DialogFooter: passthrough('DialogFooter'),
+    DialogHeader: passthrough('DialogHeader'),
+    DialogTitle: passthrough('DialogTitle'),
+}));
+
+vi.mock('@/components/MessageAttachments.vue', () => ({
+    default: marker('MessageAttachments'),
+}));
+
+vi.mock('@/components/MessagePoll.vue', () => ({
+    default: marker('MessagePoll'),
+}));
+
+vi.mock('@/components/MessageReactions.vue', () => ({
+    default: marker('MessageReactions'),
+}));
+
+vi.mock('@/components/MessageForward.vue', () => ({
+    default: marker('MessageForward'),
+}));
+
+vi.mock('@/components/LinkPreview.vue', () => ({
+    default: marker('LinkPreview'),
+}));
+
+import MessageList from './MessageList.vue';
+
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-03-04T10:30:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    } as Message;
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp({
+        render: () =>
+            h(MessageList, {
+                messages: [message()],
+                teamSlug: 'acme',
+                currentUserId: 'peer',
+                canReact: true,
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return host;
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+/** A pointer event shaped the way the row's long-press handlers read it. */
+function pointer(type: string, target: HTMLElement): PointerEvent {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+
+    Object.defineProperties(event, {
+        clientX: { value: 0 },
+        clientY: { value: 0 },
+        target: { value: target },
+        pointerType: { value: 'touch' },
+    });
+
+    return event as PointerEvent;
+}
+
+beforeEach(() => {
+    if (mobile.current) {
+        mobile.current.value = false;
+    }
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('the touch actions sheet', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    async function hold(host: HTMLElement): Promise<void> {
+        const body = find(host, 'message-body') as HTMLElement;
+        body.dispatchEvent(pointer('pointerdown', body));
+        vi.advanceTimersByTime(LONG_PRESS_MS);
+        await nextTick();
+    }
+
+    it('opens on a hold below the breakpoint, resolving the message live', async () => {
+        mobile.current!.value = true;
+        const host = mount();
+        await hold(host);
+
+        const sheet = find(host, 'actions-sheet');
+
+        expect(sheet?.getAttribute('data-open')).toBe('true');
+        expect(sheet?.getAttribute('data-message')).toBe('m1');
+    });
+
+    it('stays shut on a hover-capable layout, where the toolbar owns the actions', async () => {
+        const host = mount();
+        await hold(host);
+
+        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
+            'false',
+        );
+    });
+
+    it('stays shut on a row that offers no actions at all', async () => {
+        mobile.current!.value = true;
+        const host = mount({
+            messages: [message({ isDeleted: true })],
+            canReact: false,
+        });
+
+        const tombstone = find(host, 'message-tombstone') as HTMLElement;
+        tombstone.dispatchEvent(pointer('pointerdown', tombstone));
+        vi.advanceTimersByTime(LONG_PRESS_MS);
+        await nextTick();
+
+        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
+            'false',
+        );
+    });
+
+    it('closes when the viewport crosses up over the breakpoint mid-press', async () => {
+        mobile.current!.value = true;
+        const host = mount();
+        await hold(host);
+
+        mobile.current!.value = false;
+        await nextTick();
+
+        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
+            'false',
+        );
+    });
+
+    it('closes when the message it is open on is tombstoned in place', async () => {
+        mobile.current!.value = true;
+        const messages = reactive([message()]);
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+
+        const app = createApp({
+            render: () =>
+                h(MessageList, {
+                    messages,
+                    teamSlug: 'acme',
+                    currentUserId: 'peer',
+                    canReact: true,
+                }),
+        });
+        app.config.globalProperties.$t = translate;
+        app.mount(host);
+        active.push({ app, host });
+
+        await hold(host);
+
+        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
+            'true',
+        );
+
+        messages[0].isDeleted = true;
+        await nextTick();
+
+        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
+            'false',
+        );
+    });
+});

--- a/resources/js/components/MessageList.affordances.test.ts
+++ b/resources/js/components/MessageList.affordances.test.ts
@@ -34,17 +34,6 @@ vi.mock('@/composables/useIsMobile', async () => {
     return { useIsMobile: () => value };
 });
 
-/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
-function passthrough(name: string) {
-    return defineComponent({
-        name,
-        setup:
-            (_props, { slots }) =>
-            () =>
-                h('div', { 'data-stub': name }, slots.default?.()),
-    });
-}
-
 /** Renders an empty marker element, so a stubbed leaf is still findable. */
 function marker(name: string) {
     return defineComponent({
@@ -61,22 +50,6 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
             () =>
                 h('div', slots.default?.()),
     }),
-}));
-
-vi.mock('@/components/ui/hover-card', () => ({
-    HoverCard: passthrough('HoverCard'),
-    HoverCardTrigger: passthrough('HoverCardTrigger'),
-    HoverCardContent: passthrough('HoverCardContent'),
-}));
-
-vi.mock('@/components/ui/dialog', () => ({
-    Dialog: passthrough('Dialog'),
-    DialogClose: passthrough('DialogClose'),
-    DialogContent: passthrough('DialogContent'),
-    DialogDescription: passthrough('DialogDescription'),
-    DialogFooter: passthrough('DialogFooter'),
-    DialogHeader: passthrough('DialogHeader'),
-    DialogTitle: passthrough('DialogTitle'),
 }));
 
 vi.mock('@/components/MessageActions.vue', () => ({
@@ -101,10 +74,6 @@ vi.mock('@/components/MessageReactions.vue', () => ({
 
 vi.mock('@/components/MessageForward.vue', () => ({
     default: marker('MessageForward'),
-}));
-
-vi.mock('@/components/LinkPreview.vue', () => ({
-    default: marker('LinkPreview'),
 }));
 
 import MessageList from './MessageList.vue';

--- a/resources/js/components/MessageList.affordances.test.ts
+++ b/resources/js/components/MessageList.affordances.test.ts
@@ -1,0 +1,388 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, ref } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { ChannelReader, Message } from '@/types';
+
+/**
+ * Covers the affordances hanging off the timeline rather than sitting in a row:
+ * a root's thread summary, the "Seen by" roster under the newest message, and
+ * the flat (unwindowed) render the thread panel takes. Each moves as a unit when
+ * `MessageList.vue` is split, so what is pinned here is the rendered markup and
+ * the guards deciding whether it renders at all.
+ */
+const pageProps = vi.hoisted(() => ({
+    auth: { user: { timezone: 'UTC' } },
+    customEmojis: {} as Record<string, string>,
+    userGroups: [] as Array<{ id: string }>,
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: pageProps }),
+}));
+
+const mobile = vi.hoisted(() => ({
+    current: null as { value: boolean } | null,
+}));
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { ref } = await import('vue');
+    const value = ref(false);
+    mobile.current = value;
+
+    return { useIsMobile: () => value };
+});
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+function passthrough(name: string) {
+    return defineComponent({
+        name,
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', { 'data-stub': name }, slots.default?.()),
+    });
+}
+
+/** Renders an empty marker element, so a stubbed leaf is still findable. */
+function marker(name: string) {
+    return defineComponent({
+        name,
+        setup: () => () => h('div', { 'data-stub': name }),
+    });
+}
+
+vi.mock('@/components/UserHoverCard.vue', () => ({
+    default: defineComponent({
+        name: 'UserHoverCardStub',
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', slots.default?.()),
+    }),
+}));
+
+vi.mock('@/components/ui/hover-card', () => ({
+    HoverCard: passthrough('HoverCard'),
+    HoverCardTrigger: passthrough('HoverCardTrigger'),
+    HoverCardContent: passthrough('HoverCardContent'),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: passthrough('Dialog'),
+    DialogClose: passthrough('DialogClose'),
+    DialogContent: passthrough('DialogContent'),
+    DialogDescription: passthrough('DialogDescription'),
+    DialogFooter: passthrough('DialogFooter'),
+    DialogHeader: passthrough('DialogHeader'),
+    DialogTitle: passthrough('DialogTitle'),
+}));
+
+vi.mock('@/components/MessageActions.vue', () => ({
+    default: marker('MessageActions'),
+}));
+
+vi.mock('@/components/MessageActionsSheet.vue', () => ({
+    default: marker('MessageActionsSheet'),
+}));
+
+vi.mock('@/components/MessageAttachments.vue', () => ({
+    default: marker('MessageAttachments'),
+}));
+
+vi.mock('@/components/MessagePoll.vue', () => ({
+    default: marker('MessagePoll'),
+}));
+
+vi.mock('@/components/MessageReactions.vue', () => ({
+    default: marker('MessageReactions'),
+}));
+
+vi.mock('@/components/MessageForward.vue', () => ({
+    default: marker('MessageForward'),
+}));
+
+vi.mock('@/components/LinkPreview.vue', () => ({
+    default: marker('LinkPreview'),
+}));
+
+import MessageList from './MessageList.vue';
+
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-03-04T10:30:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    } as Message;
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+type Mounted = {
+    host: HTMLElement;
+    events: Array<[string, unknown]>;
+};
+
+function mount(props: Record<string, unknown> = {}): Mounted {
+    const events: Array<[string, unknown]> = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp({
+        render: () =>
+            h(MessageList, {
+                messages: [message()],
+                teamSlug: 'acme',
+                currentUserId: 'me',
+                onJump: (id: string) => events.push(['jump', id]),
+                onOpenThread: (id: string) => events.push(['openThread', id]),
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return { host, events };
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+beforeEach(() => {
+    pageProps.customEmojis = {};
+    pageProps.userGroups = [];
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('the thread summary', () => {
+    const root = (overrides: Partial<Message> = {}) =>
+        message({
+            threadReplyCount: 2,
+            threadParticipants: [
+                { id: 'u1', name: 'Ada' },
+                { id: 'u2', name: 'Bo' },
+            ],
+            ...overrides,
+        });
+
+    it('opens the thread when pressed, naming the reply count', () => {
+        const { host, events } = mount({ messages: [root()] });
+
+        const summary = find(host, 'thread-summary');
+
+        expect(summary?.getAttribute('aria-label')).toBe(
+            'View thread, 2 replies',
+        );
+        expect(summary?.textContent).toContain('2 replies');
+        summary?.click();
+
+        expect(events).toEqual([['openThread', 'm1']]);
+    });
+
+    it('reads in the singular for a lone reply', () => {
+        const { host } = mount({
+            messages: [root({ threadReplyCount: 1 })],
+        });
+
+        expect(find(host, 'thread-summary')?.getAttribute('aria-label')).toBe(
+            'View thread, 1 reply',
+        );
+    });
+
+    it('collapses the participant facepile past three avatars', () => {
+        const { host } = mount({
+            messages: [
+                root({
+                    threadParticipants: [
+                        { id: 'u1', name: 'Ada' },
+                        { id: 'u2', name: 'Bo' },
+                        { id: 'u3', name: 'Cy' },
+                        { id: 'u4', name: 'Di' },
+                        { id: 'u5', name: 'Ed' },
+                    ],
+                }),
+            ],
+        });
+
+        expect(find(host, 'thread-summary')?.textContent).toContain('+2');
+    });
+
+    it('raises a dot while the thread holds unread replies', () => {
+        const { host } = mount({ messages: [root({ threadUnread: true })] });
+
+        expect(
+            find(host, 'thread-unread-dot')?.getAttribute('aria-label'),
+        ).toBe('Unread replies');
+    });
+
+    it('names when the thread was last replied to', () => {
+        const { host } = mount({
+            messages: [root({ threadLastReplyAt: '2024-03-04T12:45:00.000Z' })],
+        });
+
+        expect(
+            find(host, 'thread-summary')?.parentElement?.textContent,
+        ).toContain('12:45 PM');
+    });
+
+    it('survives its root being deleted, since the thread outlives it', () => {
+        const { host } = mount({
+            messages: [root({ isDeleted: true })],
+        });
+
+        expect(find(host, 'thread-summary')).not.toBeNull();
+    });
+
+    it('stays out of a thread panel, where the reader is already in the thread', () => {
+        const { host } = mount({ messages: [root()], inThread: true });
+
+        expect(find(host, 'thread-summary')).toBeNull();
+    });
+
+    it('stays off a message with no replies', () => {
+        const { host } = mount();
+
+        expect(find(host, 'thread-summary')).toBeNull();
+    });
+});
+
+describe('the "Seen by" row', () => {
+    const readers = (...names: string[]): ChannelReader[] =>
+        names.map((name) => ({
+            user: { id: name, name },
+            lastReadMessageId: 'm1',
+        }));
+
+    it('names a single reader', () => {
+        const { host } = mount({ readers: readers('Alice') });
+
+        expect(
+            host.querySelector('[data-test="seen-by"]')?.getAttribute('title'),
+        ).toBe('Seen by Alice');
+    });
+
+    it('joins two readers with "and"', () => {
+        const { host } = mount({ readers: readers('Alice', 'Bob') });
+
+        expect(
+            host.querySelector('[data-test="seen-by"]')?.getAttribute('title'),
+        ).toBe('Seen by Alice and Bob');
+    });
+
+    it('collapses the tail into a "+N" chip past three avatars', () => {
+        const { host } = mount({
+            readers: readers('Alice', 'Bob', 'Cara', 'Dan', 'Eve'),
+        });
+
+        const row = host.querySelector('[data-test="seen-by"]');
+
+        expect(row?.getAttribute('title')).toBe(
+            'Seen by Alice, Bob, Cara and 2 others',
+        );
+        expect(row?.querySelectorAll('img, .bg-primary\\/10')).toHaveLength(3);
+        expect(row?.textContent).toContain('+2');
+    });
+
+    it('reads in the singular for a single overflow reader', () => {
+        const { host } = mount({
+            readers: readers('Alice', 'Bob', 'Cara', 'Dan'),
+        });
+
+        expect(
+            host.querySelector('[data-test="seen-by"]')?.getAttribute('title'),
+        ).toBe('Seen by Alice, Bob, Cara and 1 other');
+    });
+
+    it('drops the viewer’s own read position from the roster', () => {
+        const { host } = mount({
+            readers: [
+                { user: { id: 'me', name: 'Me' }, lastReadMessageId: 'm1' },
+            ],
+        });
+
+        expect(host.querySelector('[data-test="seen-by"]')).toBeNull();
+    });
+
+    it('stays out of a thread panel', () => {
+        const { host } = mount({ inThread: true, readers: readers('Alice') });
+
+        expect(host.querySelector('[data-test="seen-by"]')).toBeNull();
+    });
+
+    it('stays out of an empty timeline', () => {
+        const { host } = mount({ messages: [], readers: readers('Alice') });
+
+        expect(host.querySelector('[data-test="seen-by"]')).toBeNull();
+    });
+});
+
+describe('the windowed timeline', () => {
+    it('renders every row flat when the consumer does not opt into windowing', () => {
+        const { host } = mount({
+            messages: [
+                message({ id: 'a' }),
+                message({ id: 'b', createdAt: '2024-03-04T10:30:10.000Z' }),
+            ],
+        });
+
+        expect(host.querySelectorAll('[role="listitem"]')).toHaveLength(2);
+        expect(host.querySelector('[data-test="message-skeleton"]')).toBeNull();
+    });
+
+    it('exposes the jump helpers the parent drives the list with', () => {
+        const exposed = ref<Record<string, unknown> | null>(null);
+        const host = document.createElement('div');
+        document.body.appendChild(host);
+
+        const app = createApp({
+            render: () =>
+                h(MessageList, {
+                    messages: [message()],
+                    teamSlug: 'acme',
+                    currentUserId: 'me',
+                    ref: (instance: unknown) => {
+                        exposed.value = instance as Record<string, unknown>;
+                    },
+                }),
+        });
+        app.config.globalProperties.$t = translate;
+        app.mount(host);
+        active.push({ app, host });
+
+        expect(typeof exposed.value?.scrollToIndex).toBe('function');
+        expect(typeof exposed.value?.scrollToLatest).toBe('function');
+    });
+});

--- a/resources/js/components/MessageList.editing.test.ts
+++ b/resources/js/components/MessageList.editing.test.ts
@@ -100,12 +100,6 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
     }),
 }));
 
-vi.mock('@/components/ui/hover-card', () => ({
-    HoverCard: passthrough('HoverCard'),
-    HoverCardTrigger: passthrough('HoverCardTrigger'),
-    HoverCardContent: passthrough('HoverCardContent'),
-}));
-
 vi.mock('@/components/ui/dialog', () => ({
     Dialog: defineComponent({
         name: 'DialogStub',
@@ -143,10 +137,6 @@ vi.mock('@/components/MessageReactions.vue', () => ({
 
 vi.mock('@/components/MessageForward.vue', () => ({
     default: marker('MessageForward'),
-}));
-
-vi.mock('@/components/LinkPreview.vue', () => ({
-    default: marker('LinkPreview'),
 }));
 
 import MessageList from './MessageList.vue';

--- a/resources/js/components/MessageList.editing.test.ts
+++ b/resources/js/components/MessageList.editing.test.ts
@@ -1,0 +1,410 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Message } from '@/types';
+
+/**
+ * Covers the two pieces of state the timeline owns on top of its rows: the
+ * inline editor a row swaps into, and the delete confirmation standing between
+ * the toolbar and the emit. Both survive a split of `MessageList.vue` unchanged,
+ * so what is pinned here is when each opens, what it suppresses while open, and
+ * which event it emits on the way out.
+ */
+const pageProps = vi.hoisted(() => ({
+    auth: { user: { timezone: 'UTC' } },
+    customEmojis: {} as Record<string, string>,
+    userGroups: [] as unknown[],
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: pageProps }),
+}));
+
+const mobile = vi.hoisted(() => ({
+    current: null as { value: boolean } | null,
+}));
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { ref } = await import('vue');
+    const value = ref(false);
+    mobile.current = value;
+
+    return { useIsMobile: () => value };
+});
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+function passthrough(name: string) {
+    return defineComponent({
+        name,
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', { 'data-stub': name }, slots.default?.()),
+    });
+}
+
+/** Renders an empty marker element, so a stubbed leaf is still findable. */
+function marker(name: string) {
+    return defineComponent({
+        name,
+        setup: () => () => h('div', { 'data-stub': name }),
+    });
+}
+
+/**
+ * Stands in for the hover toolbar with a button per event the timeline listens
+ * for, so the row's response to `edit` and `delete` is driven the way the real
+ * toolbar drives it.
+ */
+vi.mock('@/components/MessageActions.vue', () => ({
+    default: defineComponent({
+        name: 'MessageActionsStub',
+        emits: ['edit', 'delete'],
+        setup:
+            (_props, { emit }) =>
+            () =>
+                h('div', [
+                    h(
+                        'button',
+                        {
+                            'data-test': 'stub-edit',
+                            onClick: () => emit('edit'),
+                        },
+                        'edit',
+                    ),
+                    h(
+                        'button',
+                        {
+                            'data-test': 'stub-delete',
+                            onClick: () => emit('delete'),
+                        },
+                        'delete',
+                    ),
+                ]),
+    }),
+}));
+
+vi.mock('@/components/MessageActionsSheet.vue', () => ({
+    default: marker('MessageActionsSheet'),
+}));
+
+vi.mock('@/components/UserHoverCard.vue', () => ({
+    default: defineComponent({
+        name: 'UserHoverCardStub',
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', slots.default?.()),
+    }),
+}));
+
+vi.mock('@/components/ui/hover-card', () => ({
+    HoverCard: passthrough('HoverCard'),
+    HoverCardTrigger: passthrough('HoverCardTrigger'),
+    HoverCardContent: passthrough('HoverCardContent'),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: defineComponent({
+        name: 'DialogStub',
+        props: { open: { type: Boolean, default: false } },
+        setup:
+            (props, { slots }) =>
+            () =>
+                props.open
+                    ? h(
+                          'div',
+                          { 'data-test': 'delete-dialog' },
+                          slots.default?.(),
+                      )
+                    : null,
+    }),
+    DialogClose: passthrough('DialogClose'),
+    DialogContent: passthrough('DialogContent'),
+    DialogDescription: passthrough('DialogDescription'),
+    DialogFooter: passthrough('DialogFooter'),
+    DialogHeader: passthrough('DialogHeader'),
+    DialogTitle: passthrough('DialogTitle'),
+}));
+
+vi.mock('@/components/MessageAttachments.vue', () => ({
+    default: marker('MessageAttachments'),
+}));
+
+vi.mock('@/components/MessagePoll.vue', () => ({
+    default: marker('MessagePoll'),
+}));
+
+vi.mock('@/components/MessageReactions.vue', () => ({
+    default: marker('MessageReactions'),
+}));
+
+vi.mock('@/components/MessageForward.vue', () => ({
+    default: marker('MessageForward'),
+}));
+
+vi.mock('@/components/LinkPreview.vue', () => ({
+    default: marker('LinkPreview'),
+}));
+
+import MessageList from './MessageList.vue';
+
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-03-04T10:30:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    } as Message;
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+type Mounted = {
+    host: HTMLElement;
+    edits: Array<[string, string]>;
+    deletes: string[];
+};
+
+function mount(props: Record<string, unknown> = {}): Mounted {
+    const edits: Array<[string, string]> = [];
+    const deletes: string[] = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp({
+        render: () =>
+            h(MessageList, {
+                messages: [message()],
+                teamSlug: 'acme',
+                currentUserId: 'peer',
+                canReact: true,
+                onEdit: (target: Message, body: string) =>
+                    edits.push([target.id, body]),
+                onDelete: (target: Message) => deletes.push(target.id),
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return { host, edits, deletes };
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function click(host: HTMLElement, selector: string): void {
+    find(host, selector)?.click();
+}
+
+async function startEditing(host: HTMLElement): Promise<HTMLTextAreaElement> {
+    click(host, 'stub-edit');
+    await nextTick();
+
+    return find(host, 'message-edit-input') as HTMLTextAreaElement;
+}
+
+beforeEach(() => {
+    if (mobile.current) {
+        mobile.current.value = false;
+    }
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('editing a message inline', () => {
+    it('swaps the body for a textarea seeded with it', async () => {
+        const { host } = mount();
+        const field = await startEditing(host);
+
+        expect(field.value).toBe('hello');
+        expect(find(host, 'message-body')).toBeNull();
+        expect(find(host, 'message-hover-time')).not.toBeNull();
+    });
+
+    it('names both keys that end the edit', async () => {
+        const { host } = mount();
+        await startEditing(host);
+
+        expect(host.textContent).toContain('Enter to save · Esc to cancel');
+    });
+
+    it('hides the toolbar, reactions and cards of the row being edited', async () => {
+        const { host } = mount({
+            messages: [
+                message({
+                    attachments: [{ id: 'a1' }] as Message['attachments'],
+                    poll: { id: 'p1' } as Message['poll'],
+                }),
+            ],
+        });
+        await startEditing(host);
+
+        expect(
+            host.querySelector('[data-stub="MessageAttachments"]'),
+        ).toBeNull();
+        expect(host.querySelector('[data-stub="MessagePoll"]')).toBeNull();
+        expect(host.querySelector('[data-stub="MessageReactions"]')).toBeNull();
+        expect(find(host, 'stub-edit')).toBeNull();
+    });
+
+    it('saves the edited body on Enter and leaves the editor', async () => {
+        const { host, edits } = mount();
+        const field = await startEditing(host);
+
+        field.value = 'hello again';
+        field.dispatchEvent(new Event('input'));
+        await nextTick();
+        field.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+        );
+        await nextTick();
+
+        expect(edits).toEqual([['m1', 'hello again']]);
+        expect(find(host, 'message-edit-input')).toBeNull();
+    });
+
+    it('saves from the Save button too', async () => {
+        const { host, edits } = mount();
+        const field = await startEditing(host);
+
+        field.value = 'from the button';
+        field.dispatchEvent(new Event('input'));
+        await nextTick();
+        [...host.querySelectorAll('button')]
+            .find((button) => button.textContent?.trim() === 'Save')
+            ?.click();
+        await nextTick();
+
+        expect(edits).toEqual([['m1', 'from the button']]);
+    });
+
+    it('trims the draft before saving it', async () => {
+        const { host, edits } = mount();
+        const field = await startEditing(host);
+
+        field.value = '   spaced   ';
+        field.dispatchEvent(new Event('input'));
+        await nextTick();
+        field.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+        );
+        await nextTick();
+
+        expect(edits).toEqual([['m1', 'spaced']]);
+    });
+
+    it('treats an unchanged draft as a no-op', async () => {
+        const { host, edits } = mount();
+        const field = await startEditing(host);
+
+        field.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+        );
+        await nextTick();
+
+        expect(edits).toEqual([]);
+        expect(find(host, 'message-edit-input')).toBeNull();
+    });
+
+    it('treats an emptied draft as a no-op, since the server would reject it', async () => {
+        const { host, edits } = mount();
+        const field = await startEditing(host);
+
+        field.value = '   ';
+        field.dispatchEvent(new Event('input'));
+        await nextTick();
+        field.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+        );
+        await nextTick();
+
+        expect(edits).toEqual([]);
+    });
+
+    it('abandons the edit on Esc', async () => {
+        const { host, edits } = mount();
+        const field = await startEditing(host);
+
+        field.value = 'discarded';
+        field.dispatchEvent(new Event('input'));
+        await nextTick();
+        field.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+        );
+        await nextTick();
+
+        expect(edits).toEqual([]);
+        expect(find(host, 'message-edit-input')).toBeNull();
+        expect(find(host, 'message-body')?.textContent?.trim()).toBe('hello');
+    });
+
+    it('abandons the edit from the Cancel button', async () => {
+        const { host, edits } = mount();
+        await startEditing(host);
+
+        [...host.querySelectorAll('button')]
+            .find((button) => button.textContent?.trim() === 'Cancel')
+            ?.click();
+        await nextTick();
+
+        expect(edits).toEqual([]);
+        expect(find(host, 'message-edit-input')).toBeNull();
+    });
+});
+
+describe('deleting a message', () => {
+    it('asks before deleting, and emits only once confirmed', async () => {
+        const { host, deletes } = mount();
+
+        expect(find(host, 'delete-dialog')).toBeNull();
+
+        click(host, 'stub-delete');
+        await nextTick();
+
+        expect(find(host, 'delete-dialog')).not.toBeNull();
+        expect(host.textContent).toContain(
+            "Are you sure you want to delete this message? This can't be undone.",
+        );
+        expect(deletes).toEqual([]);
+
+        click(host, 'delete-message-confirm');
+        await nextTick();
+
+        expect(deletes).toEqual(['m1']);
+        expect(find(host, 'delete-dialog')).toBeNull();
+    });
+});

--- a/resources/js/components/MessageList.row.test.ts
+++ b/resources/js/components/MessageList.row.test.ts
@@ -1,0 +1,419 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Message } from '@/types';
+
+/**
+ * Covers a single message row: the body and the segments it tokenizes into, the
+ * markers riding above and below it (pinned, edited, queued, tombstone), the
+ * reply quote, and the thread summary. These all move together when
+ * `MessageList.vue` is split, so what is pinned here is the rendered markup —
+ * every selector, every guard that decides whether a piece renders at all.
+ */
+const pageProps = vi.hoisted(() => ({
+    auth: { user: { timezone: 'UTC' } },
+    customEmojis: {} as Record<string, string>,
+    userGroups: [] as Array<{ id: string }>,
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: pageProps }),
+}));
+
+const mobile = vi.hoisted(() => ({
+    current: null as { value: boolean } | null,
+}));
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { ref } = await import('vue');
+    const value = ref(false);
+    mobile.current = value;
+
+    return { useIsMobile: () => value };
+});
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+function passthrough(name: string) {
+    return defineComponent({
+        name,
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', { 'data-stub': name }, slots.default?.()),
+    });
+}
+
+/** Renders an empty marker element, so a stubbed leaf is still findable. */
+function marker(name: string) {
+    return defineComponent({
+        name,
+        setup: () => () => h('div', { 'data-stub': name }),
+    });
+}
+
+vi.mock('@/components/UserHoverCard.vue', () => ({
+    default: defineComponent({
+        name: 'UserHoverCardStub',
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', slots.default?.()),
+    }),
+}));
+
+vi.mock('@/components/ui/hover-card', () => ({
+    HoverCard: passthrough('HoverCard'),
+    HoverCardTrigger: passthrough('HoverCardTrigger'),
+    HoverCardContent: passthrough('HoverCardContent'),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: passthrough('Dialog'),
+    DialogClose: passthrough('DialogClose'),
+    DialogContent: passthrough('DialogContent'),
+    DialogDescription: passthrough('DialogDescription'),
+    DialogFooter: passthrough('DialogFooter'),
+    DialogHeader: passthrough('DialogHeader'),
+    DialogTitle: passthrough('DialogTitle'),
+}));
+
+vi.mock('@/components/MessageActions.vue', () => ({
+    default: marker('MessageActions'),
+}));
+
+vi.mock('@/components/MessageActionsSheet.vue', () => ({
+    default: marker('MessageActionsSheet'),
+}));
+
+vi.mock('@/components/MessageAttachments.vue', () => ({
+    default: marker('MessageAttachments'),
+}));
+
+vi.mock('@/components/MessagePoll.vue', () => ({
+    default: marker('MessagePoll'),
+}));
+
+vi.mock('@/components/MessageReactions.vue', () => ({
+    default: marker('MessageReactions'),
+}));
+
+vi.mock('@/components/MessageForward.vue', () => ({
+    default: marker('MessageForward'),
+}));
+
+vi.mock('@/components/LinkPreview.vue', () => ({
+    default: marker('LinkPreview'),
+}));
+
+import MessageList from './MessageList.vue';
+
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-03-04T10:30:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    } as Message;
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+type Mounted = {
+    host: HTMLElement;
+    events: Array<[string, unknown]>;
+};
+
+function mount(props: Record<string, unknown> = {}): Mounted {
+    const events: Array<[string, unknown]> = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp({
+        render: () =>
+            h(MessageList, {
+                messages: [message()],
+                teamSlug: 'acme',
+                currentUserId: 'me',
+                onJump: (id: string) => events.push(['jump', id]),
+                onOpenThread: (id: string) => events.push(['openThread', id]),
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return { host, events };
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function stub(host: HTMLElement, name: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-stub="${name}"]`);
+}
+
+beforeEach(() => {
+    pageProps.customEmojis = {};
+    pageProps.userGroups = [];
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('the message body', () => {
+    it('renders the body text with an anchor id for jump targets', () => {
+        const { host } = mount();
+
+        expect(find(host, 'message-body')?.textContent?.trim()).toBe('hello');
+        expect(host.querySelector('#message-m1')).not.toBeNull();
+    });
+
+    it('leaves the body out when the message carries only an attachment', () => {
+        const { host } = mount({
+            messages: [message({ body: '' })],
+        });
+
+        expect(find(host, 'message-body')).toBeNull();
+    });
+
+    it('renders a resolved mention as a hover-carded pill', () => {
+        const id = '11111111-1111-4111-8111-111111111111';
+        const { host } = mount({
+            messages: [
+                message({
+                    body: `hey @[Ada](${id})`,
+                    mentions: [{ id, name: 'Ada' }],
+                }),
+            ],
+        });
+
+        expect(find(host, 'message-mention')?.textContent).toBe('@Ada');
+    });
+
+    it('renders a resolved group mention as an inert pill of its own hue', () => {
+        const id = '22222222-2222-4222-8222-222222222222';
+        pageProps.userGroups = [{ id }];
+        const { host } = mount({
+            messages: [message({ body: `@[design](group:${id})` })],
+        });
+
+        const pill = find(host, 'message-group-mention');
+
+        expect(pill?.textContent).toBe('@design');
+        expect(find(host, 'message-mention')).toBeNull();
+    });
+
+    it('renders a custom emoji shortcode as its image', () => {
+        pageProps.customEmojis = { shipit: 'https://desk.test/shipit.png' };
+        const { host } = mount({
+            messages: [message({ body: 'ship it :shipit:' })],
+        });
+
+        const emoji = find(host, 'message-emoji') as HTMLImageElement | null;
+
+        expect(emoji?.getAttribute('src')).toBe('https://desk.test/shipit.png');
+        expect(emoji?.getAttribute('alt')).toBe(':shipit:');
+        expect(emoji?.getAttribute('title')).toBe(':shipit:');
+    });
+
+    it('links a bare URL, unwrapped while it has no preview', () => {
+        const { host } = mount({
+            messages: [message({ body: 'see https://desk.test/docs' })],
+        });
+
+        const link = find(host, 'message-link');
+
+        expect(link?.getAttribute('href')).toBe('https://desk.test/docs');
+        expect(link?.getAttribute('rel')).toBe('noopener noreferrer nofollow');
+        expect(link?.getAttribute('target')).toBe('_blank');
+        expect(stub(host, 'HoverCard')).toBeNull();
+    });
+
+    it('wraps a link in a hover card once its preview has unfurled', () => {
+        const { host } = mount({
+            messages: [
+                message({
+                    body: 'see https://desk.test/docs',
+                    linkPreviews: [
+                        {
+                            url: 'https://desk.test/docs',
+                            status: 'ready',
+                            title: 'Docs',
+                            description: null,
+                            imageUrl: null,
+                            siteName: null,
+                        },
+                    ],
+                }),
+            ],
+        });
+
+        expect(stub(host, 'HoverCard')).not.toBeNull();
+        expect(find(host, 'link-preview-card')).not.toBeNull();
+        expect(stub(host, 'LinkPreview')).not.toBeNull();
+    });
+
+    it('marks an edited message beside its body', () => {
+        const { host } = mount({
+            messages: [message({ editedAt: '2024-03-04T11:00:00.000Z' })],
+        });
+
+        expect(find(host, 'message-edited')?.textContent).toBe('(edited)');
+    });
+
+    it('fades a body still in flight to the server', () => {
+        const { host } = mount({ pendingUuids: ['uuid-1'] });
+
+        expect(find(host, 'message-body')?.className).toContain('opacity-60');
+    });
+});
+
+describe('a deleted message', () => {
+    it('replaces the body with its tombstone', () => {
+        const { host } = mount({ messages: [message({ isDeleted: true })] });
+
+        expect(find(host, 'message-tombstone')?.textContent?.trim()).toBe(
+            'This message was deleted',
+        );
+        expect(find(host, 'message-body')).toBeNull();
+    });
+
+    it('drops the attachments, poll, reactions and forward card with it', () => {
+        const { host } = mount({
+            messages: [
+                message({
+                    isDeleted: true,
+                    attachments: [{ id: 'a1' }] as Message['attachments'],
+                    poll: { id: 'p1' } as Message['poll'],
+                    forwardedFrom: {
+                        id: 'f1',
+                        body: 'x',
+                        authorName: 'Peer',
+                        channelName: 'general',
+                        isDeleted: false,
+                        mentions: [],
+                    },
+                }),
+            ],
+        });
+
+        expect(stub(host, 'MessageAttachments')).toBeNull();
+        expect(stub(host, 'MessagePoll')).toBeNull();
+        expect(stub(host, 'MessageReactions')).toBeNull();
+        expect(stub(host, 'MessageForward')).toBeNull();
+    });
+});
+
+describe('the markers around a row', () => {
+    it('names who pinned a pinned message', () => {
+        const { host } = mount({
+            messages: [
+                message({
+                    pin: {
+                        pinnedBy: { id: 'u2', name: 'Ada' },
+                        pinnedAt: '2024-03-04T10:31:00.000Z',
+                    },
+                }),
+            ],
+        });
+
+        expect(
+            find(host, 'message-pinned-indicator')?.textContent?.trim(),
+        ).toBe('Pinned by Ada');
+    });
+
+    it('marks a send held in the offline outbox', () => {
+        const { host } = mount({ queuedUuids: ['uuid-1'] });
+
+        expect(find(host, 'message-queued')?.textContent?.trim()).toBe(
+            'Queued — will send on reconnect',
+        );
+    });
+
+    it('leaves the queued marker off a message that has been sent', () => {
+        const { host } = mount();
+
+        expect(find(host, 'message-queued')).toBeNull();
+    });
+
+    it('carries a machine-readable hover timestamp on every row', () => {
+        const { host } = mount();
+
+        const time = find(host, 'message-hover-time');
+
+        expect(time?.getAttribute('datetime')).toBe('2024-03-04T10:30:00.000Z');
+        expect(time?.getAttribute('aria-hidden')).toBe('true');
+    });
+});
+
+describe('the reply quote', () => {
+    const replied = message({
+        replyTo: {
+            id: 'parent',
+            body: 'the question',
+            authorName: 'Ada',
+            isDeleted: false,
+            mentions: [],
+        },
+    });
+
+    it('jumps to the replied message when pressed', () => {
+        const { host, events } = mount({ messages: [replied] });
+
+        const quote = find(host, 'message-quote');
+
+        expect(quote?.getAttribute('aria-label')).toBe(
+            'Jump to replied message from Ada',
+        );
+        quote?.click();
+
+        expect(events).toEqual([['jump', 'parent']]);
+    });
+
+    it('bleeds the quote to the full timeline width below the breakpoint', () => {
+        const { host } = mount({ messages: [replied] });
+
+        expect(find(host, 'message-quote')?.className).toContain(
+            'max-md:-ml-14',
+        );
+    });
+
+    it('drops the quote once the message is deleted', () => {
+        const { host } = mount({
+            messages: [message({ ...replied, isDeleted: true })],
+        });
+
+        expect(find(host, 'message-quote')).toBeNull();
+    });
+});

--- a/resources/js/components/MessageList.row.test.ts
+++ b/resources/js/components/MessageList.row.test.ts
@@ -69,16 +69,6 @@ vi.mock('@/components/ui/hover-card', () => ({
     HoverCardContent: passthrough('HoverCardContent'),
 }));
 
-vi.mock('@/components/ui/dialog', () => ({
-    Dialog: passthrough('Dialog'),
-    DialogClose: passthrough('DialogClose'),
-    DialogContent: passthrough('DialogContent'),
-    DialogDescription: passthrough('DialogDescription'),
-    DialogFooter: passthrough('DialogFooter'),
-    DialogHeader: passthrough('DialogHeader'),
-    DialogTitle: passthrough('DialogTitle'),
-}));
-
 vi.mock('@/components/MessageActions.vue', () => ({
     default: marker('MessageActions'),
 }));

--- a/resources/js/components/MessageList.timeline.test.ts
+++ b/resources/js/components/MessageList.timeline.test.ts
@@ -1,0 +1,421 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Message } from '@/types';
+
+/**
+ * Covers the timeline's structural chrome: the day and unread dividers, system
+ * notices, the author group's avatar gutter and heading, the thread reply rule,
+ * and the "Seen by" row. These are the surfaces a split of `MessageList.vue`
+ * moves wholesale, so what is pinned here is the markup and the copy — every
+ * `data-test` selector, every guard on whether a row renders at all.
+ */
+const pageProps = vi.hoisted(() => ({
+    auth: { user: { timezone: 'UTC' } },
+    customEmojis: {} as Record<string, string>,
+    userGroups: [] as unknown[],
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: pageProps }),
+}));
+
+const mobile = vi.hoisted(() => ({
+    current: null as { value: boolean } | null,
+}));
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { ref } = await import('vue');
+    const value = ref(false);
+    mobile.current = value;
+
+    return { useIsMobile: () => value };
+});
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+function passthrough(name: string) {
+    return defineComponent({
+        name,
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', slots.default?.()),
+    });
+}
+
+/** Renders nothing, standing in for a leaf whose own tests cover it. */
+function inert(name: string) {
+    return defineComponent({ name, setup: () => () => null });
+}
+
+vi.mock('@/components/UserHoverCard.vue', () => ({
+    default: defineComponent({
+        name: 'UserHoverCardStub',
+        props: { userId: { type: String, default: '' } },
+        setup:
+            (props, { slots }) =>
+            () =>
+                h(
+                    'div',
+                    {
+                        'data-test': 'user-hover-card',
+                        'data-user-id': props.userId,
+                    },
+                    slots.default?.(),
+                ),
+    }),
+}));
+
+vi.mock('@/components/ui/hover-card', () => ({
+    HoverCard: passthrough('HoverCardStub'),
+    HoverCardTrigger: passthrough('HoverCardTriggerStub'),
+    HoverCardContent: passthrough('HoverCardContentStub'),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: passthrough('DialogStub'),
+    DialogClose: passthrough('DialogCloseStub'),
+    DialogContent: passthrough('DialogContentStub'),
+    DialogDescription: passthrough('DialogDescriptionStub'),
+    DialogFooter: passthrough('DialogFooterStub'),
+    DialogHeader: passthrough('DialogHeaderStub'),
+    DialogTitle: passthrough('DialogTitleStub'),
+}));
+
+vi.mock('@/components/MessageActions.vue', () => ({
+    default: inert('MessageActionsStub'),
+}));
+
+vi.mock('@/components/MessageActionsSheet.vue', () => ({
+    default: inert('MessageActionsSheetStub'),
+}));
+
+vi.mock('@/components/MessageAttachments.vue', () => ({
+    default: inert('MessageAttachmentsStub'),
+}));
+
+vi.mock('@/components/MessagePoll.vue', () => ({
+    default: inert('MessagePollStub'),
+}));
+
+vi.mock('@/components/MessageReactions.vue', () => ({
+    default: inert('MessageReactionsStub'),
+}));
+
+vi.mock('@/components/MessageForward.vue', () => ({
+    default: inert('MessageForwardStub'),
+}));
+
+vi.mock('@/components/LinkPreview.vue', () => ({
+    default: inert('LinkPreviewStub'),
+}));
+
+import MessageList from './MessageList.vue';
+
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-03-04T10:30:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    } as Message;
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp({
+        render: () =>
+            h(MessageList, {
+                messages: [message()],
+                teamSlug: 'acme',
+                currentUserId: 'me',
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return host;
+}
+
+function texts(host: HTMLElement, selector: string): string[] {
+    return [...host.querySelectorAll(`[data-test="${selector}"]`)].map(
+        (node) => node.textContent?.trim() ?? '',
+    );
+}
+
+beforeEach(() => {
+    pageProps.auth.user.timezone = 'UTC';
+
+    if (mobile.current) {
+        mobile.current.value = false;
+    }
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('the timeline’s dividers', () => {
+    it('opens the list with a day divider carrying the crossing message’s date', () => {
+        const host = mount();
+
+        expect(texts(host, 'day-divider')).toHaveLength(1);
+    });
+
+    it('renders one day divider per calendar day', () => {
+        const host = mount({
+            messages: [
+                message({ id: 'a', createdAt: '2024-03-04T10:30:00.000Z' }),
+                message({ id: 'b', createdAt: '2024-03-05T10:30:00.000Z' }),
+            ],
+        });
+
+        expect(texts(host, 'day-divider')).toHaveLength(2);
+    });
+
+    it('marks the unread boundary with the "new" rule above its message', () => {
+        const host = mount({
+            messages: [
+                message({ id: 'a' }),
+                message({ id: 'b', createdAt: '2024-03-04T10:30:10.000Z' }),
+            ],
+            unreadDividerId: 'b',
+        });
+
+        const divider = host.querySelector('[data-test="unread-divider"]');
+
+        expect(divider).not.toBeNull();
+        expect(divider?.id).toBe('unread-divider');
+        expect(divider?.getAttribute('role')).toBe('separator');
+        expect(divider?.getAttribute('aria-label')).toBe('New messages');
+        expect(divider?.textContent?.trim()).toBe('new');
+    });
+
+    it('leaves the unread rule out when there is no boundary to mark', () => {
+        const host = mount();
+
+        expect(host.querySelector('[data-test="unread-divider"]')).toBeNull();
+    });
+});
+
+describe('a system notice', () => {
+    it('renders a centered, inert line naming its type', () => {
+        const host = mount({
+            messages: [
+                message({
+                    id: 's1',
+                    type: 'member_joined',
+                    user: { id: 'peer', name: 'Peer' },
+                }),
+            ],
+        });
+
+        const notice = host.querySelector('[data-test="system-notice"]');
+
+        expect(notice?.id).toBe('message-s1');
+        expect(notice?.getAttribute('data-system-type')).toBe('member_joined');
+        expect(notice?.textContent?.trim()).toBe('Peer joined the channel');
+        expect(host.querySelector('[data-test="message-group"]')).toBeNull();
+    });
+
+    it('reads as the conversation rather than the channel in a direct message', () => {
+        const host = mount({
+            messages: [message({ id: 's1', type: 'member_left' })],
+            isDirect: true,
+        });
+
+        expect(texts(host, 'system-notice')).toEqual([
+            'Peer left the conversation',
+        ]);
+    });
+
+    it('names the channel for a member who left a channel', () => {
+        const host = mount({
+            messages: [message({ id: 's1', type: 'member_left' })],
+        });
+
+        expect(texts(host, 'system-notice')).toEqual(['Peer left the channel']);
+    });
+});
+
+describe('an author group', () => {
+    it('renders one group per author run, with the lead message’s time', () => {
+        const host = mount({
+            messages: [
+                message({ id: 'a' }),
+                message({
+                    id: 'b',
+                    createdAt: '2024-03-04T10:30:20.000Z',
+                    user: { id: 'other', name: 'Other' },
+                }),
+            ],
+        });
+
+        expect(texts(host, 'message-group')).toHaveLength(2);
+        expect(texts(host, 'message-group-time')).toEqual([
+            '10:30 AM',
+            '10:30 AM',
+        ]);
+    });
+
+    it('repeats the group time inline beside the author name for touch', () => {
+        const host = mount();
+
+        const inline = host.querySelector(
+            '[data-test="message-group-time-inline"]',
+        );
+
+        expect(inline?.getAttribute('aria-hidden')).toBe('true');
+        expect(inline?.textContent?.trim()).toBe('10:30 AM');
+    });
+
+    it('renders each timestamp in the viewer’s stored zone', () => {
+        pageProps.auth.user.timezone = 'Australia/Sydney';
+        const host = mount();
+
+        expect(texts(host, 'message-group-time')).toEqual(['9:30 PM']);
+    });
+
+    it('opens the author’s hover card from both the avatar and the name', () => {
+        const host = mount();
+
+        expect(
+            [...host.querySelectorAll('[data-test="user-hover-card"]')].map(
+                (node) => node.getAttribute('data-user-id'),
+            ),
+        ).toEqual(['peer', 'peer']);
+        expect(texts(host, 'message-author-name')).toEqual(['Peer']);
+    });
+
+    it('announces the author’s presence once per group', () => {
+        const host = mount({ presenceFor: () => 'away' });
+
+        expect(host.querySelector('.sr-only')?.textContent?.trim()).toBe(
+            'Away',
+        );
+        expect(host.querySelector('[data-test="presence-dot"]')).not.toBeNull();
+    });
+
+    it('falls back to offline when the surface carries no presence roster', () => {
+        const host = mount();
+
+        expect(host.querySelector('.sr-only')?.textContent?.trim()).toBe(
+            'Offline',
+        );
+    });
+
+    it('badges a bot author instead of announcing a presence it has none of', () => {
+        const host = mount({
+            messages: [
+                message({ user: { id: 'bot', name: 'Botto', isBot: true } }),
+            ],
+        });
+
+        expect(texts(host, 'author-bot-badge')).toEqual(['Bot']);
+        expect(host.querySelector('[data-test="presence-dot"]')).toBeNull();
+        expect(host.querySelector('.sr-only')).toBeNull();
+    });
+
+    it('names every message row for assistive technology', () => {
+        const host = mount();
+
+        expect(
+            host.querySelector('[role="listitem"]')?.getAttribute('aria-label'),
+        ).toBe('Peer, 10:30 AM');
+    });
+
+    it('marks the thread root with a brass accent inside a thread panel', () => {
+        const host = mount({ inThread: true });
+
+        expect(
+            host
+                .querySelector('[data-test="message-column"]')
+                ?.className.includes('border-brass'),
+        ).toBe(true);
+    });
+
+    it('keeps the ordinary border on a reply inside a thread panel', () => {
+        const host = mount({
+            messages: [message({ threadRootId: 'root' })],
+            inThread: true,
+        });
+
+        expect(
+            host
+                .querySelector('[data-test="message-column"]')
+                ?.className.includes('border-brass'),
+        ).toBe(false);
+    });
+});
+
+describe('the thread reply rule', () => {
+    it('separates the root from its replies when a count is given', () => {
+        const host = mount({ inThread: true, replyDividerCount: 3 });
+
+        const rule = host.querySelector('[data-test="thread-replies-divider"]');
+
+        expect(rule?.getAttribute('role')).toBe('separator');
+        expect(rule?.getAttribute('aria-label')).toBe('3 replies');
+        expect(rule?.textContent?.trim()).toBe('3 replies');
+    });
+
+    it('reads in the singular for a lone reply', () => {
+        const host = mount({ inThread: true, replyDividerCount: 1 });
+
+        expect(
+            host
+                .querySelector('[data-test="thread-replies-divider"]')
+                ?.getAttribute('aria-label'),
+        ).toBe('1 reply');
+    });
+
+    it('stays out of the main timeline, which has no root to separate', () => {
+        const host = mount({ replyDividerCount: 3 });
+
+        expect(
+            host.querySelector('[data-test="thread-replies-divider"]'),
+        ).toBeNull();
+    });
+
+    it('stays out of a thread with no replies yet', () => {
+        const host = mount({ inThread: true, replyDividerCount: 0 });
+
+        expect(
+            host.querySelector('[data-test="thread-replies-divider"]'),
+        ).toBeNull();
+    });
+});

--- a/resources/js/components/MessageList.timeline.test.ts
+++ b/resources/js/components/MessageList.timeline.test.ts
@@ -34,17 +34,6 @@ vi.mock('@/composables/useIsMobile', async () => {
     return { useIsMobile: () => value };
 });
 
-/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
-function passthrough(name: string) {
-    return defineComponent({
-        name,
-        setup:
-            (_props, { slots }) =>
-            () =>
-                h('div', slots.default?.()),
-    });
-}
-
 /** Renders nothing, standing in for a leaf whose own tests cover it. */
 function inert(name: string) {
     return defineComponent({ name, setup: () => () => null });
@@ -68,48 +57,12 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
     }),
 }));
 
-vi.mock('@/components/ui/hover-card', () => ({
-    HoverCard: passthrough('HoverCardStub'),
-    HoverCardTrigger: passthrough('HoverCardTriggerStub'),
-    HoverCardContent: passthrough('HoverCardContentStub'),
-}));
-
-vi.mock('@/components/ui/dialog', () => ({
-    Dialog: passthrough('DialogStub'),
-    DialogClose: passthrough('DialogCloseStub'),
-    DialogContent: passthrough('DialogContentStub'),
-    DialogDescription: passthrough('DialogDescriptionStub'),
-    DialogFooter: passthrough('DialogFooterStub'),
-    DialogHeader: passthrough('DialogHeaderStub'),
-    DialogTitle: passthrough('DialogTitleStub'),
-}));
-
 vi.mock('@/components/MessageActions.vue', () => ({
     default: inert('MessageActionsStub'),
 }));
 
 vi.mock('@/components/MessageActionsSheet.vue', () => ({
     default: inert('MessageActionsSheetStub'),
-}));
-
-vi.mock('@/components/MessageAttachments.vue', () => ({
-    default: inert('MessageAttachmentsStub'),
-}));
-
-vi.mock('@/components/MessagePoll.vue', () => ({
-    default: inert('MessagePollStub'),
-}));
-
-vi.mock('@/components/MessageReactions.vue', () => ({
-    default: inert('MessageReactionsStub'),
-}));
-
-vi.mock('@/components/MessageForward.vue', () => ({
-    default: inert('MessageForwardStub'),
-}));
-
-vi.mock('@/components/LinkPreview.vue', () => ({
-    default: inert('LinkPreviewStub'),
 }));
 
 import MessageList from './MessageList.vue';

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1,66 +1,27 @@
 <script setup lang="ts">
 import { usePage } from '@inertiajs/vue3';
-import { Bot, Clock, Pin } from '@lucide/vue';
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue';
-import InlineMarks from '@/components/InlineMarks.vue';
-import LinkPreview from '@/components/LinkPreview.vue';
-import MessageActions from '@/components/MessageActions.vue';
+import { computed, ref } from 'vue';
 import MessageActionsSheet from '@/components/MessageActionsSheet.vue';
-import MessageAttachments from '@/components/MessageAttachments.vue';
-import MessageForward from '@/components/MessageForward.vue';
-import MessagePoll from '@/components/MessagePoll.vue';
-import MessageQuote from '@/components/MessageQuote.vue';
-import MessageReactions from '@/components/MessageReactions.vue';
-import PresenceDot from '@/components/PresenceDot.vue';
-import SafeHtml from '@/components/SafeHtml.vue';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/button';
-import {
-    Dialog,
-    DialogClose,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog';
-import {
-    HoverCard,
-    HoverCardContent,
-    HoverCardTrigger,
-} from '@/components/ui/hover-card';
-import UserHoverCard from '@/components/UserHoverCard.vue';
-import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
-import { useCustomEmojis } from '@/composables/useCustomEmojis';
-import { useInitials } from '@/composables/useInitials';
+import DayDivider from '@/components/timeline/DayDivider.vue';
+import DeleteMessageDialog from '@/components/timeline/DeleteMessageDialog.vue';
+import MessageAuthorLine from '@/components/timeline/MessageAuthorLine.vue';
+import MessageAvatarGutter from '@/components/timeline/MessageAvatarGutter.vue';
+import MessageRow from '@/components/timeline/MessageRow.vue';
+import MessageSkeleton from '@/components/timeline/MessageSkeleton.vue';
+import SeenByRow from '@/components/timeline/SeenByRow.vue';
+import SystemNotice from '@/components/timeline/SystemNotice.vue';
+import ThreadRepliesDivider from '@/components/timeline/ThreadRepliesDivider.vue';
+import UnreadDivider from '@/components/timeline/UnreadDivider.vue';
 import { useIsMobile } from '@/composables/useIsMobile';
-import { useLongPress } from '@/composables/useLongPress';
-import { NEAR_BOTTOM_THRESHOLD } from '@/composables/useScrollPin';
-import { useTimelineVirtualizer } from '@/composables/useTimelineVirtualizer';
-import { useTranslations } from '@/composables/useTranslations';
-import { useUserGroups } from '@/composables/useUserGroups';
-import { formatDayLabel, formatTimeOfDay } from '@/lib/datetime';
-import {
-    canReactToMessage,
-    hasAnyMessageAction,
-    showsThreadSummary,
-} from '@/lib/messageActions';
-import type { MessageActionContext } from '@/lib/messageActions';
-import { tokenizeMessageBody } from '@/lib/messageBody';
-import type { MessageBodySegment } from '@/lib/messageBody';
-import { presenceLabelKey } from '@/lib/presence';
+import { useMessageActionSheet } from '@/composables/useMessageActionSheet';
+import { useTimelineWindow } from '@/composables/useTimelineWindow';
+import { formatTimeOfDay } from '@/lib/datetime';
+import { hasAnyMessageAction } from '@/lib/messageActions';
 import type { RenderedPresence } from '@/lib/presence';
 import { readersForMessage } from '@/lib/readReceipts';
-import { buildTimelineItems, messageAccessibleName } from '@/lib/timeline';
-import type { TimelineGroup, TimelineItem } from '@/lib/timeline';
-import { bottomGlueSettled, shouldRenderSkeleton } from '@/lib/virtualTimeline';
-import type {
-    ChannelReader,
-    Mention,
-    Message,
-    MessageAuthor,
-    MessagePreview,
-} from '@/types';
+import { buildTimelineItems } from '@/lib/timeline';
+import type { TimelineGroup } from '@/lib/timeline';
+import type { ChannelReader, Message, MessageAuthor } from '@/types';
 
 const props = defineProps<{
     messages: Message[];
@@ -175,33 +136,20 @@ const emit = defineEmits<{
     rangeChange: [range: { startIndex: number; endIndex: number }];
 }>();
 
+const page = usePage();
+
 /** The viewer's stored zone, feeding the reminder popover's wall-clock presets. */
 const viewerTimezone = computed<string | null>(
     () => page.props.auth.user.timezone ?? null,
 );
 
-/** How many participant avatars to preview on a root's "N replies" affordance. */
-const MAX_THREAD_AVATARS = 3;
+/** Render timestamps in the viewer's stored zone, falling back to the browser's. */
+const viewerTimeZone = computed(
+    () => page.props.auth.user.timezone ?? undefined,
+);
 
-/**
- * Below `md`, a rich card (poll, attachments, reply quote) breaks out of the
- * message row so it runs the full width of the timeline instead of the
- * 36px-indented text column, trading its rounded box for hairline top and
- * bottom rules (design "Mobile Message List", screen `1c`).
- *
- * The offsets are this row's own geometry — 20px of timeline padding plus the
- * 36px avatar gutter on the left, 20px of padding on the right — so they live
- * beside the row that defines them rather than inside each card.
- */
-const CARD_BLEED =
-    'max-md:-ml-14 max-md:-mr-5 max-md:rounded-none max-md:border-x-0';
-
-function threadAvatars(message: Message): Mention[] {
-    return message.threadParticipants.slice(0, MAX_THREAD_AVATARS);
-}
-
-function extraThreadParticipants(message: Message): number {
-    return Math.max(0, message.threadParticipants.length - MAX_THREAD_AVATARS);
+function formatTime(iso: string): string {
+    return formatTimeOfDay(iso, viewerTimeZone.value);
 }
 
 /**
@@ -212,22 +160,6 @@ function extraThreadParticipants(message: Message): number {
 function isThreadRoot(item: TimelineGroup): boolean {
     return props.inThread === true && item.messages[0]?.threadRootId === null;
 }
-
-/**
- * The reply-divider rule's label, shared by its visible text and the
- * separator's accessible name.
- */
-const replyDividerLabel = computed(() =>
-    props.replyDividerCount === 1
-        ? t(':count reply', { count: 1 })
-        : t(':count replies', { count: props.replyDividerCount ?? 0 }),
-);
-
-/**
- * How many reader avatars to preview on the "Seen by" row before collapsing the
- * rest into a "+N" overflow chip.
- */
-const MAX_SEEN_AVATARS = 3;
 
 /**
  * The members who have read up to the newest message, driving the "Seen by" row.
@@ -247,61 +179,6 @@ const seenByReaders = computed<MessageAuthor[]>(() => {
     );
 });
 
-const seenByAvatars = computed(() =>
-    seenByReaders.value.slice(0, MAX_SEEN_AVATARS),
-);
-
-const extraSeenBy = computed(() =>
-    Math.max(0, seenByReaders.value.length - MAX_SEEN_AVATARS),
-);
-
-/**
- * A full, human-readable roster ("Seen by Alice, Bob and 3 others") used as the
- * row's accessible label and hover title, so the compact avatars still name who.
- */
-const seenByLabel = computed(() => {
-    const names = seenByReaders.value.map((reader) => reader.name);
-
-    if (names.length === 0) {
-        return '';
-    }
-
-    if (names.length === 1) {
-        return t('Seen by :name', { name: names[0] });
-    }
-
-    if (names.length <= MAX_SEEN_AVATARS) {
-        return t('Seen by :names and :last', {
-            names: names.slice(0, -1).join(', '),
-            last: names[names.length - 1],
-        });
-    }
-
-    const shown = names.slice(0, MAX_SEEN_AVATARS).join(', ');
-    const others = names.length - MAX_SEEN_AVATARS;
-
-    return others === 1
-        ? t('Seen by :names and :count other', { names: shown, count: others })
-        : t('Seen by :names and :count others', {
-              names: shown,
-              count: others,
-          });
-});
-
-const { getInitials } = useInitials();
-
-const { t } = useTranslations();
-
-const { map: customEmojis } = useCustomEmojis();
-const { groups: userGroups } = useUserGroups();
-
-const page = usePage();
-
-/** Render timestamps in the viewer's stored zone, falling back to the browser's. */
-const viewerTimeZone = computed(
-    () => page.props.auth.user.timezone ?? undefined,
-);
-
 /**
  * How a message author reads on the team presence roster.
  */
@@ -317,53 +194,6 @@ function dndOf(authorId: string): boolean {
 }
 
 /**
- * Split a message body into HTML and link segments so the timeline can wrap each
- * URL in its own element (and, when the link has been unfurled, a hover card).
- */
-function bodySegments(message: Message): MessageBodySegment[] {
-    return tokenizeMessageBody(
-        message.body,
-        message.mentions,
-        customEmojis.value,
-        userGroups.value,
-    );
-}
-
-/**
- * The unfurled preview for a URL in a message, or undefined when the link has no
- * preview row yet. Pending rows resolve too, so the hover card can show a
- * skeleton until the queued unfurl broadcasts the resolved metadata.
- */
-function previewFor(
-    message: Message,
-    href: string,
-): MessagePreview | undefined {
-    return message.linkPreviews.find((preview) => preview.url === href);
-}
-
-function formatTime(iso: string): string {
-    return formatTimeOfDay(iso, viewerTimeZone.value);
-}
-
-/**
- * The localized line for a system notice, rendered from its type and author in
- * the viewer's own locale — the row stores no rendered English.
- */
-function systemNoticeText(message: Message): string {
-    const name = message.user.name;
-
-    if (message.type === 'member_left') {
-        return props.isDirect
-            ? t(':name left the conversation', { name })
-            : t(':name left the channel', { name });
-    }
-
-    return props.isDirect
-        ? t(':name joined the conversation', { name })
-        : t(':name joined the channel', { name });
-}
-
-/**
  * The grouped, divider-interleaved render list. The grouping and boundary logic
  * lives in a pure, unit-tested helper; the day label is formatted here so it
  * stays relative to the viewer's "today".
@@ -372,292 +202,23 @@ const renderItems = computed(() =>
     buildTimelineItems(props.messages, props.unreadDividerId ?? null),
 );
 
-/**
- * Windowed rendering. Only the main channel timeline opts in (`virtualize`); the
- * thread panel leaves the virtualizer idle (count 0) and renders every row. The
- * virtualizer drives the parent's scroll container, keeping its real
- * `scrollHeight`/`scrollTop` so the shared pin-to-bottom math is untouched.
- * Windowing is client-only: the virtualizer needs a live scroll element and
- * measured heights, neither of which exist during SSR. Rendering the full list
- * on the server (and through first hydration) keeps server and client markup
- * identical, then we switch to the window once mounted — a post-hydration
- * re-render, not a mismatch.
- */
-const isMounted = ref(false);
-
-onMounted(() => {
-    isMounted.value = true;
-});
-
-const virtualizeActive = computed(
-    () => props.virtualize === true && isMounted.value,
-);
-
-/**
- * True while a deliberate jump-to-present is in flight. The scrub skeletons swap
- * full message content for a fixed 56px placeholder, so measuring them mid-jump
- * feeds the virtualizer short heights; when rows then swap to their taller real
- * content the list grows and the animation is left stranded above the newest
- * message — the "it stops when the skeleton loads" symptom (#347). While this is
- * set, skeletons are suppressed so every row entering the window measures its
- * real height, and the virtualizer's upward size-change anchoring is disabled so
- * a row measured above the viewport can't drift us up as we settle on the bottom.
- */
-const jumpingToBottom = ref(false);
-
 const {
-    virtualRows,
+    virtualizeActive,
     totalSize,
-    isScrolling,
-    range,
-    scrollToIndex,
-    scrollToEnd,
+    renderRows,
     measureRow,
-} = useTimelineVirtualizer({
-    scrollElement: computed(() => props.scrollElement ?? null),
-    count: computed(() =>
-        virtualizeActive.value ? renderItems.value.length : 0,
-    ),
+    showsSkeleton,
+    scrollToIndex,
+    scrollToLatest,
+} = useTimelineWindow({
+    scrollElement: () => props.scrollElement ?? null,
+    renderItems,
+    virtualize: () => props.virtualize === true,
     hasOlder: () => props.hasOlder?.() ?? false,
     isLoadingOlder: () => props.isLoadingOlder?.() ?? false,
     loadOlder: () => emit('loadOlder'),
-    // Suppress upward anchor adjustments while jumping to the bottom: there we
-    // want to stay glued to the newest message, not compensate an upper row.
-    isPinning: () => jumpingToBottom.value,
+    onRangeChange: (range) => emit('rangeChange', range),
 });
-
-/** One rendered row: a render item plus its absolute offset when windowed. */
-type RenderRow = {
-    item: TimelineItem;
-    index: number;
-    offsetTop: number | null;
-};
-
-/**
- * The rows to render: the full list when the thread panel renders it flat, or
- * just the virtualizer's window (each carrying its absolute offset) for the main
- * timeline.
- */
-const renderRows = computed<RenderRow[]>(() => {
-    if (!virtualizeActive.value) {
-        return renderItems.value.map((item, index) => ({
-            item,
-            index,
-            offsetTop: null,
-        }));
-    }
-
-    return virtualRows.value.map((row) => ({
-        item: renderItems.value[row.index],
-        index: row.index,
-        offsetTop: row.start,
-    }));
-});
-
-/**
- * Render items whose height the virtualizer has already settled. A row is
- * recorded once scrolling stops, so a fast scrub shows height-stable skeletons
- * for rows it hasn't paused on, and they materialize the instant it settles.
- */
-const settledKeys = ref<Set<string>>(new Set());
-
-/**
- * Whether the container sits within the pinned threshold of the real bottom.
- * A missing element counts as pinned, mirroring `useScrollPin`.
- */
-function isAtBottom(): boolean {
-    const el = props.scrollElement;
-
-    if (!el) {
-        return true;
-    }
-
-    return (
-        el.scrollHeight - el.scrollTop - el.clientHeight <=
-        NEAR_BOTTOM_THRESHOLD
-    );
-}
-
-watch(isScrolling, (scrolling) => {
-    if (scrolling) {
-        return;
-    }
-
-    for (const row of virtualRows.value) {
-        const item = renderItems.value[row.index];
-
-        if (item) {
-            settledKeys.value.add(item.key);
-        }
-    }
-});
-
-/**
- * A windowed jump can't know the true bottom up front: `scrollToEnd` aims at the
- * bottom the virtualizer can see now, but each row measured as the animation
- * passes it grows the list, so the target keeps moving. `finalizeJump` follows
- * the animation to the bottom, then glues the view there frame by frame until both
- * the measured height plateaus and the scroll goes quiet, so late measurements
- * settle without a visible bounce.
- *
- * The glue releases on convergence, not a fixed frame count: it holds until the
- * scroll height has been steady for `JUMP_SETTLE_FRAMES` consecutive frames *and*
- * the container has stopped scrolling. A fixed budget let go too early on a slow
- * render — while rows were still measuring, or while the glue's own `scrollTop`
- * writes still counted as scrolling — so unsettled rows flipped in their scrub
- * skeletons and the virtualizer's re-enabled size-change anchoring drifted the
- * view below the fold: the timeline landing short of the newest message on initial
- * open of a long list of tall rows (#500).
- */
-const JUMP_SETTLE_FRAMES = 4;
-const JUMP_MAX_FRAMES = 180;
-let jumpRaf: number | null = null;
-
-/**
- * Drive an in-flight jump-to-present all the way to the newest message.
- *
- * Phase one follows the scroll: while the virtualizer reports it's still
- * scrolling the (possibly smooth) animation is running, so leave it be; only
- * once it has stopped short — stalled on a skeleton-height estimate rather than
- * the real bottom — snap the residual gap. Gating on the scrolling flag means an
- * explicit `smooth` jump keeps animating instead of being force-converted to an
- * instant snap. Once the bottom is reached, phase two pins `scrollTop` to the end
- * every frame — so a row measured late (taller or shorter than its estimate)
- * can't drift the view up or leave it short — and releases only once the measured
- * height has settled (`bottomGlueSettled`) *and* the scroll has quiesced, rather
- * than after a fixed budget that could expire mid-measurement and strand the view
- * (#347, #500). Bounded by a frame budget so a list that never settles can't spin
- * forever.
- */
-function finalizeJump(): void {
-    if (jumpRaf !== null) {
-        cancelAnimationFrame(jumpRaf);
-    }
-
-    let reachedBottom = false;
-    let stableFrames = 0;
-    // Sentinel so the first glue frame always registers as a change: the glue
-    // needs at least `JUMP_SETTLE_FRAMES` genuine same-height frames to release.
-    let lastHeight = -1;
-    let frames = 0;
-
-    const step = (): void => {
-        const el = props.scrollElement;
-
-        if (!el || !jumpingToBottom.value || frames >= JUMP_MAX_FRAMES) {
-            jumpingToBottom.value = false;
-            jumpRaf = null;
-
-            return;
-        }
-
-        frames += 1;
-
-        if (!reachedBottom) {
-            if (isAtBottom()) {
-                reachedBottom = true;
-            } else if (!isScrolling.value) {
-                // The scroll stopped short of the newest message; snap the gap
-                // and let the newly measured rows re-target.
-                scrollToEnd('auto');
-            }
-        } else {
-            // Glue to the bottom so late row measurements settle invisibly, and
-            // hold until the height stops moving — the true bottom has arrived.
-            el.scrollTop = el.scrollHeight;
-
-            const settle = bottomGlueSettled(
-                el.scrollHeight,
-                lastHeight,
-                stableFrames,
-                JUMP_SETTLE_FRAMES,
-            );
-            stableFrames = settle.stableFrames;
-            lastHeight = el.scrollHeight;
-
-            // Release only once the height has settled *and* the scroll has gone
-            // quiet. Letting go while `isScrolling` is still true (the glue's own
-            // `scrollTop` writes keep it set for ~150ms after the last change)
-            // would flip `jumpingToBottom` off mid-scroll, so unsettled rows render
-            // their 56px scrub skeletons — shrinking the content above the viewport
-            // and drifting the view up off the newest message (#347, #500). Waiting
-            // for the scroll to quiesce keeps skeletons suppressed until the view is
-            // safely at rest on the bottom.
-            if (settle.settled && !isScrolling.value) {
-                jumpingToBottom.value = false;
-                jumpRaf = null;
-
-                return;
-            }
-        }
-
-        jumpRaf = requestAnimationFrame(step);
-    };
-
-    jumpRaf = requestAnimationFrame(step);
-}
-
-onUnmounted(() => {
-    if (jumpRaf !== null) {
-        cancelAnimationFrame(jumpRaf);
-    }
-});
-
-/**
- * Whether a windowed group row should show its skeleton placeholder rather than
- * its full content: only mid-scrub, never during a jump-to-present (measuring
- * the placeholder height would strand the jump short), and only before the row
- * has settled.
- */
-function showsSkeleton(item: TimelineItem): boolean {
-    return (
-        virtualizeActive.value &&
-        !jumpingToBottom.value &&
-        item.type === 'group' &&
-        shouldRenderSkeleton(isScrolling.value, settledKeys.value.has(item.key))
-    );
-}
-
-// Surface the visible window so the parent can drive the unread-jump pill.
-watch(
-    () =>
-        range.value
-            ? `${range.value.startIndex}:${range.value.endIndex}`
-            : null,
-    () => {
-        if (range.value) {
-            emit('rangeChange', {
-                startIndex: range.value.startIndex,
-                endIndex: range.value.endIndex,
-            });
-        }
-    },
-);
-
-/**
- * Scroll to the newest message. When windowed, drive the virtualizer so it
- * re-targets the real bottom as off-screen rows measure (a native
- * `scrollTo(scrollHeight)` settles short on an estimated spacer, #347); when the
- * list is rendered flat (the thread panel), `scrollHeight` is already exact, so
- * scroll the container directly.
- */
-function scrollToLatest(behavior: ScrollBehavior = 'auto'): void {
-    if (virtualizeActive.value) {
-        // Suppress scrub skeletons for the whole jump so their fixed placeholder
-        // height can't strand the scroll short of the newest message (#347), then
-        // let `finalizeJump` watch the animation to the true bottom and release.
-        jumpingToBottom.value = true;
-        scrollToEnd(behavior);
-        finalizeJump();
-
-        return;
-    }
-
-    props.scrollElement?.scrollTo({
-        top: props.scrollElement.scrollHeight,
-        behavior,
-    });
-}
 
 // Let the parent bring an off-screen row (a jump target, the unread boundary)
 // into the window: with windowing the element may not exist to `scrollIntoView`.
@@ -676,65 +237,19 @@ function isQueued(message: Message): boolean {
     return queued.value.has(message.clientUuid);
 }
 
-/**
- * The viewer context each per-message guard resolves against. The hover-action
- * bar (extracted to MessageActions) owns the toolbar guards; the two rules below
- * stay here because they drive non-toolbar UI — the reaction pills and the
- * thread summary — and share the same context.
- */
-function actionContext(message: Message): MessageActionContext {
-    return {
-        currentUserId: props.currentUserId,
-        canReact: Boolean(props.canReact),
-        canPin: Boolean(props.canPin),
-        canModerate: Boolean(props.canModerate),
-        inThread: Boolean(props.inThread),
-        pending: isPending(message),
-    };
-}
-
-/**
- * The viewer may react to any live, confirmed message when they're a member of
- * the (non-archived) channel; drives whether the reaction pills accept toggles.
- */
-function canReactTo(message: Message): boolean {
-    return canReactToMessage(message, actionContext(message));
-}
-
-/**
- * The "N replies" affordance shows on any root that has replies, even a deleted
- * one — the thread outlives its root as a tombstone.
- */
-function showThreadSummary(message: Message): boolean {
-    return showsThreadSummary(message, actionContext(message));
-}
-
-/** The message currently being edited inline, and its working draft. */
+/** The message currently being edited inline. */
 const editingId = ref<string | null>(null);
-const editDraft = ref('');
-const editField = ref<HTMLTextAreaElement | null>(null);
-
-/**
- * A plain template ref inside v-for collects into an array; a function ref keeps
- * the single visible editor element (only one row edits at a time).
- */
-function setEditField(el: unknown): void {
-    editField.value = (el as HTMLTextAreaElement | null) ?? null;
-}
 
 function startEdit(message: Message): void {
     editingId.value = message.id;
-    editDraft.value = message.body;
-    nextTick(() => editField.value?.focus());
 }
 
 function cancelEdit(): void {
     editingId.value = null;
-    editDraft.value = '';
 }
 
-function saveEdit(message: Message): void {
-    const body = editDraft.value.trim();
+function saveEdit(message: Message, draft: string): void {
+    const body = draft.trim();
 
     // An empty or unchanged draft is a no-op; the server would reject the former.
     if (body !== '' && body !== message.body) {
@@ -744,75 +259,33 @@ function saveEdit(message: Message): void {
     cancelEdit();
 }
 
-/**
- * The touch stand-in for the hover toolbar (design m4): below `md`, pressing
- * and holding a message row opens its actions bottom sheet. The sheet resolves
- * the message live by id, so reaction and pin state stay current while it is
- * open, and the id survives the close animation.
- */
 const isMobile = useIsMobile();
-const actionSheetId = ref<string | null>(null);
-const actionSheetOpen = ref(false);
 
-const actionSheetMessage = computed(
-    () =>
-        props.messages.find((entry) => entry.id === actionSheetId.value) ??
-        null,
-);
-
-const longPress = useLongPress<Message>({
-    enabled: isMobile,
-    onLongPress: openActionsSheet,
+const {
+    open: actionSheetOpen,
+    message: actionSheetMessage,
+    longPress,
+    isHeld,
+} = useMessageActionSheet({
+    isMobile,
+    messages: () => props.messages,
+    canOpen: (message) =>
+        editingId.value !== message.id &&
+        hasAnyMessageAction(message, {
+            currentUserId: props.currentUserId,
+            canReact: Boolean(props.canReact),
+            canPin: Boolean(props.canPin),
+            canModerate: Boolean(props.canModerate),
+            inThread: Boolean(props.inThread),
+            pending: isPending(message),
+        }),
 });
-
-function openActionsSheet(message: Message): void {
-    if (
-        editingId.value === message.id ||
-        !hasAnyMessageAction(message, actionContext(message))
-    ) {
-        return;
-    }
-
-    actionSheetId.value = message.id;
-    actionSheetOpen.value = true;
-}
-
-/** The pressed row's hold cue while the long-press timer runs. */
-function isHeld(message: Message): boolean {
-    return longPress.pressing.value?.id === message.id;
-}
-
-// Crossing up over the breakpoint mid-press leaves the sheet stranded on a
-// hover-capable layout; the toolbar owns the actions there.
-watch(isMobile, (mobile) => {
-    if (!mobile) {
-        actionSheetOpen.value = false;
-    }
-});
-
-// A message deleted (or pruned from the window) while its sheet is up has no
-// actions left to offer. Watched through a getter so an in-place tombstone
-// patch from a broadcast closes it too, not only a replaced array entry.
-watch(
-    () => actionSheetMessage.value?.isDeleted,
-    (isDeleted) => {
-        if (isDeleted !== false) {
-            actionSheetOpen.value = false;
-        }
-    },
-);
 
 /** The message queued for deletion; a non-null value drives the confirm dialog. */
 const pendingDelete = ref<Message | null>(null);
 
 function requestDelete(message: Message): void {
     pendingDelete.value = message;
-}
-
-function setDeleteOpen(open: boolean): void {
-    if (!open) {
-        pendingDelete.value = null;
-    }
 }
 
 function confirmDelete(): void {
@@ -848,158 +321,39 @@ function confirmDelete(): void {
                         : undefined
                 "
             >
-                <div
-                    v-if="showsSkeleton(item)"
-                    data-test="message-skeleton"
-                    aria-hidden="true"
-                    class="mt-4.5 flex gap-3"
-                    :style="{ minHeight: '56px' }"
-                >
-                    <div class="size-8.5 shrink-0 rounded-full bg-muted" />
-                    <div class="flex flex-1 flex-col gap-2 pt-1">
-                        <div class="h-3 w-40 rounded bg-muted" />
-                        <div class="h-3 w-[60%] rounded bg-muted" />
-                    </div>
-                </div>
+                <MessageSkeleton v-if="showsSkeleton(item)" />
 
-                <div
+                <UnreadDivider
                     v-else-if="
                         item.type === 'divider' && item.variant === 'unread'
                     "
-                    id="unread-divider"
-                    data-test="unread-divider"
-                    role="separator"
-                    :aria-label="$t('New messages')"
-                    class="my-4 flex items-center gap-3"
-                >
-                    <span
-                        aria-hidden="true"
-                        class="h-px flex-1 bg-gradient-to-r from-transparent to-brass-border"
-                    />
-                    <span
-                        aria-hidden="true"
-                        class="font-serif text-[13px] text-brass-fill-foreground italic"
-                    >
-                        {{ $t('new') }}
-                    </span>
-                    <span
-                        aria-hidden="true"
-                        class="h-px flex-1 bg-gradient-to-r from-brass-border to-transparent"
-                    />
-                </div>
+                />
 
-                <div
+                <DayDivider
                     v-else-if="item.type === 'divider'"
-                    data-test="day-divider"
-                    class="my-4 flex items-center gap-3"
-                >
-                    <span aria-hidden="true" class="h-px flex-1 bg-border" />
-                    <span
-                        class="font-serif text-[13px] text-muted-foreground italic"
-                    >
-                        {{ formatDayLabel(item.iso!) }}
-                    </span>
-                    <span aria-hidden="true" class="h-px flex-1 bg-border" />
-                </div>
+                    :iso="item.iso!"
+                />
 
-                <!-- A system notice (member joined / left): a centered, inert
-                     line with no avatar, author bubble, or hover actions. -->
-                <div
+                <SystemNotice
                     v-else-if="item.type === 'system'"
-                    :id="`message-${item.message.id}`"
-                    data-test="system-notice"
-                    :data-system-type="item.message.type"
-                    class="my-2 flex justify-center"
-                >
-                    <span
-                        class="rounded-full bg-muted/60 px-3 py-1 text-center text-[12px] text-muted-foreground"
-                    >
-                        {{ systemNoticeText(item.message) }}
-                    </span>
-                </div>
+                    :message="item.message"
+                    :is-direct="props.isDirect"
+                />
 
                 <div
                     v-else
                     data-test="message-group"
                     class="mt-4.5 flex max-md:mt-3.5"
                 >
-                    <!-- The avatar gutter: 64px of centred column on desktop,
-                         a 26px avatar plus a 10px gap below `md`, where 64px of
-                         a 390px screen is a quarter of the row spent on chrome. -->
-                    <div
-                        class="flex w-16 shrink-0 flex-col items-center gap-1 pt-0.5 max-md:w-9 max-md:items-start max-md:gap-0 max-md:pt-0"
-                    >
-                        <UserHoverCard
-                            :team-slug="props.teamSlug"
-                            :user-id="item.author.id"
-                            :name="item.author.name"
-                            :presence="presenceOf(item.author.id)"
-                            :is-dnd="dndOf(item.author.id)"
-                            @mention="(member) => emit('mention', member)"
-                        >
-                            <div
-                                data-test="message-avatar"
-                                class="relative size-8.5 cursor-pointer max-md:size-6.5"
-                            >
-                                <!-- A bot squares off its avatar (rounded-lg vs a
-                                     human's full circle) and shows a glyph on the
-                                     ink-stone fill, so it reads as non-human at a
-                                     glance; a human keeps their gravatar/initials. -->
-                                <Avatar
-                                    class="size-8.5 text-[11px] max-md:size-6.5 max-md:text-[9px]"
-                                    :class="
-                                        item.author.isBot ? 'rounded-lg' : ''
-                                    "
-                                    aria-hidden="true"
-                                >
-                                    <AvatarImage
-                                        v-if="
-                                            item.author.avatar &&
-                                            !item.author.isBot
-                                        "
-                                        :src="item.author.avatar"
-                                        :alt="item.author.name"
-                                    />
-                                    <AvatarFallback
-                                        :class="
-                                            item.author.isBot
-                                                ? 'rounded-lg bg-muted-foreground text-background'
-                                                : 'bg-primary/10 font-semibold text-primary'
-                                        "
-                                    >
-                                        <Bot
-                                            v-if="item.author.isBot"
-                                            class="size-4.5"
-                                        />
-                                        <template v-else>{{
-                                            getInitials(item.author.name)
-                                        }}</template>
-                                    </AvatarFallback>
-                                </Avatar>
-                                <!-- Presence is announced once per author group
-                                     via the sr-only text beside the name below,
-                                     so this repeated dot is decorative to AT. A bot
-                                     has no presence, so it shows no dot. -->
-                                <PresenceDot
-                                    v-if="!item.author.isBot"
-                                    data-test="presence-dot"
-                                    :presence="presenceOf(item.author.id)"
-                                    :is-dnd="dndOf(item.author.id)"
-                                    surface-class="bg-card"
-                                    :size="isMobile ? '24' : '36'"
-                                    class="ring-card"
-                                />
-                            </div>
-                        </UserHoverCard>
-                        <!-- The stacked time sets a tall floor on every row even
-                             for a one-word message, so below `md` it gives way
-                             to the inline stamp on the author's own line. -->
-                        <span
-                            data-test="message-group-time"
-                            class="font-mono text-[9.5px] text-muted-foreground max-md:hidden"
-                            >{{ formatTime(item.leadCreatedAt) }}</span
-                        >
-                    </div>
+                    <MessageAvatarGutter
+                        :author="item.author"
+                        :team-slug="props.teamSlug"
+                        :presence="presenceOf(item.author.id)"
+                        :is-dnd="dndOf(item.author.id)"
+                        :time="formatTime(item.leadCreatedAt)"
+                        :is-mobile="isMobile"
+                        @mention="(member) => emit('mention', member)"
+                    />
                     <div
                         data-test="message-column"
                         class="min-w-0 flex-1 pl-4.5 max-md:border-l-0 max-md:pl-0"
@@ -1009,651 +363,90 @@ function confirmDelete(): void {
                                 : 'border-l border-border'
                         "
                     >
-                        <UserHoverCard
+                        <MessageAuthorLine
+                            :author="item.author"
                             :team-slug="props.teamSlug"
-                            :user-id="item.author.id"
-                            :name="item.author.name"
                             :presence="presenceOf(item.author.id)"
                             :is-dnd="dndOf(item.author.id)"
+                            :time="formatTime(item.leadCreatedAt)"
                             @mention="(member) => emit('mention', member)"
-                        >
-                            <span
-                                data-test="message-author-name"
-                                class="cursor-pointer text-[14px] font-semibold text-foreground hover:underline"
-                                >{{ item.author.name }}</span
-                            >
-                        </UserHoverCard>
-                        <!-- The author's status emoji rides beside their name;
-                             the full text lives on the hover card. -->
-                        <UserStatusEmoji
-                            :status="item.author.status"
-                            :name="item.author.name"
-                            class="ml-1.5 align-[-1px] text-[13px]"
                         />
-                        <!-- The uppercase "Bot" tag rides beside a bot author's
-                             name; a bot has no presence, so it replaces the
-                             Online/Offline announcement rather than adding to it. -->
-                        <span
-                            v-if="item.author.isBot"
-                            data-test="author-bot-badge"
-                            class="ml-1.5 inline-flex items-center rounded border border-border px-1.5 align-[1px] text-[9px] font-bold tracking-[0.08em] text-muted-foreground uppercase"
-                            >{{ $t('Bot') }}</span
-                        >
-                        <span v-else class="sr-only">{{
-                            $t(presenceLabelKey(presenceOf(item.author.id)))
-                        }}</span>
-                        <!-- Below `md` the group's time rides beside the author
-                             name instead of stacking under the avatar, where a
-                             36px gutter has no room for it. Hidden from AT on
-                             both layouts: each row's accessible name already
-                             carries its own time. -->
-                        <span
-                            data-test="message-group-time-inline"
-                            aria-hidden="true"
-                            class="ml-1.5 font-mono text-[10.5px] text-muted-foreground md:hidden"
-                            >{{ formatTime(item.leadCreatedAt) }}</span
-                        >
                         <div role="list">
-                            <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- a touch-only long-press gesture; every action it opens stays reachable through the toolbar's focusable buttons -->
-                            <div
-                                v-for="(message, index) in item.messages"
-                                :id="`message-${message.id}`"
+                            <MessageRow
+                                v-for="(message, row) in item.messages"
                                 :key="message.id"
-                                role="listitem"
-                                :aria-label="
-                                    messageAccessibleName(
-                                        item.author.name,
-                                        message.createdAt,
-                                        viewerTimeZone,
-                                    )
-                                "
-                                class="group/message relative -mx-2 rounded-md px-2 transition-colors duration-1000 hover:bg-muted/40 max-md:select-none max-md:[-webkit-touch-callout:none]"
-                                :class="[
-                                    index === 0
-                                        ? 'mt-0.5'
-                                        : 'mt-1.5 max-md:mt-0.5',
+                                :message="message"
+                                :author-name="item.author.name"
+                                :team-slug="props.teamSlug"
+                                :current-user-id="props.currentUserId"
+                                :can-react="props.canReact"
+                                :can-pin="props.canPin"
+                                :can-moderate="props.canModerate"
+                                :in-thread="props.inThread"
+                                :is-lead="row === 0"
+                                :pending="isPending(message)"
+                                :queued="isQueued(message)"
+                                :held="isHeld(message)"
+                                :editing="editingId === message.id"
+                                :highlighted="
                                     message.id === props.highlightMessageId
-                                        ? 'bg-primary/10'
-                                        : '',
+                                "
+                                :active-thread-root="
                                     message.id === props.activeThreadRootId
-                                        ? 'bg-primary/5'
-                                        : '',
+                                "
+                                :composer-editing="
                                     message.id === props.editingMessageId
-                                        ? 'bg-brass-fill'
-                                        : '',
-                                    isHeld(message)
-                                        ? 'scale-[0.98] opacity-80 transition-[transform,opacity] delay-100 duration-200'
-                                        : '',
-                                ]"
-                                @pointerdown="longPress.start($event, message)"
-                                @pointermove="longPress.move($event)"
-                                @pointerup="longPress.end()"
-                                @pointerleave="longPress.end()"
-                                @pointercancel="longPress.cancel()"
-                                @contextmenu="longPress.onContextMenu($event)"
-                            >
-                                <!-- Per-message timestamp: revealed in the avatar
-                                 gutter on hover, and hidden from AT since the
-                                 row's accessible name already carries the time.
-                                 The `<time datetime>` keeps the row machine-
-                                 readable regardless of the hover styling.
-                                 Only non-lead rows (index > 0) reveal it on
-                                 hover — the lead row already shows the group
-                                 time above, so revealing this here would stack a
-                                 duplicate on top of it. The lead's <time> stays
-                                 present but never fades in, so its machine-
-                                 readable value is unchanged.
-                                 Touch has no hover to reveal it with, so below
-                                 `md` it drops out entirely rather than compete
-                                 for a 36px gutter. -->
-                                <time
-                                    :datetime="message.createdAt"
-                                    data-test="message-hover-time"
-                                    aria-hidden="true"
-                                    class="pointer-events-none absolute top-1.5 -left-10.75 -translate-x-1/2 font-mono text-[9.5px] text-muted-foreground opacity-0 transition-opacity max-md:hidden"
-                                    :class="
-                                        index > 0
-                                            ? 'group-hover/message:opacity-100'
-                                            : ''
-                                    "
-                                    >{{ formatTime(message.createdAt) }}</time
-                                >
-
-                                <!-- Pinned indicator: renders whenever the
-                                 message is pinned, in the same slot as the
-                                 "edited" treatment above the body. Brass marks
-                                 pinned-ness; the content column is already
-                                 indented, so it aligns to the text column. -->
-                                <div
-                                    v-if="message.pin"
-                                    data-test="message-pinned-indicator"
-                                    class="flex items-center gap-1.5 pt-0.5 text-[11px] text-muted-foreground"
-                                >
-                                    <Pin class="size-3 fill-brass text-brass" />
-                                    <span>{{
-                                        $t('Pinned by :name', {
-                                            name: message.pin.pinnedBy.name,
-                                        })
-                                    }}</span>
-                                </div>
-
-                                <Button
-                                    v-if="
-                                        message.replyTo &&
-                                        !message.isDeleted &&
-                                        editingId !== message.id
-                                    "
-                                    variant="unstyled"
-                                    size="none"
-                                    type="button"
-                                    data-test="message-quote"
-                                    :aria-label="
-                                        $t(
-                                            'Jump to replied message from :author',
-                                            {
-                                                author: message.replyTo
-                                                    .authorName,
-                                            },
-                                        )
-                                    "
-                                    class="mt-0.5 flex max-w-full items-center rounded pr-1 text-left hover:opacity-80 max-md:border-y max-md:border-border max-md:bg-card max-md:py-1.5 max-md:pr-5 max-md:pl-5"
-                                    :class="CARD_BLEED"
-                                    @click="emit('jump', message.replyTo.id)"
-                                >
-                                    <MessageQuote
-                                        :author-name="
-                                            message.replyTo.authorName
-                                        "
-                                        :body="message.replyTo.body"
-                                        :is-deleted="message.replyTo.isDeleted"
-                                    />
-                                </Button>
-
-                                <p
-                                    v-if="message.isDeleted"
-                                    :data-test="'message-tombstone'"
-                                    class="py-0.5 font-serif text-[13.5px] text-muted-foreground italic"
-                                >
-                                    {{ $t('This message was deleted') }}
-                                </p>
-
-                                <div
-                                    v-else-if="editingId === message.id"
-                                    class="py-0.5"
-                                >
-                                    <textarea
-                                        :ref="setEditField"
-                                        v-model="editDraft"
-                                        data-test="message-edit-input"
-                                        rows="1"
-                                        class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-base leading-[1.55] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring md:text-[14.5px]"
-                                        @keydown.enter.exact.prevent="
-                                            saveEdit(message)
-                                        "
-                                        @keydown.esc.prevent="cancelEdit"
-                                    ></textarea>
-                                    <div
-                                        class="mt-1 flex items-center gap-2 text-[11.5px] text-muted-foreground"
-                                    >
-                                        <Button
-                                            size="sm"
-                                            type="button"
-                                            class="h-7 px-2"
-                                            @click="saveEdit(message)"
-                                        >
-                                            {{ $t('Save') }}
-                                        </Button>
-                                        <Button
-                                            variant="outline"
-                                            size="sm"
-                                            type="button"
-                                            class="h-7 px-2"
-                                            @click="cancelEdit"
-                                        >
-                                            {{ $t('Cancel') }}
-                                        </Button>
-                                        <span>{{
-                                            $t('Enter to save · Esc to cancel')
-                                        }}</span>
-                                    </div>
-                                </div>
-
-                                <p
-                                    v-else-if="message.body !== ''"
-                                    :data-test="'message-body'"
-                                    class="py-0.5 text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90 max-md:text-[15px] max-md:leading-[1.45]"
-                                    :class="
-                                        isPending(message) ? 'opacity-60' : ''
-                                    "
-                                >
-                                    <template
-                                        v-for="(segment, index) in bodySegments(
-                                            message,
-                                        )"
-                                        :key="index"
-                                    >
-                                        <SafeHtml
-                                            v-if="segment.kind === 'html'"
-                                            :html="segment.html"
-                                            variant="messageBody"
-                                        />
-                                        <InlineMarks
-                                            v-else-if="
-                                                segment.kind === 'mention'
-                                            "
-                                            :marks="segment.marks"
-                                        >
-                                            <UserHoverCard
-                                                :team-slug="props.teamSlug"
-                                                :user-id="segment.id"
-                                                :name="segment.name"
-                                                @mention="
-                                                    (member) =>
-                                                        emit('mention', member)
-                                                "
-                                            >
-                                                <span
-                                                    data-test="message-mention"
-                                                    class="cursor-pointer border-b-[1.5px] border-brass font-medium text-foreground hover:border-brass-border"
-                                                    >@{{ segment.name }}</span
-                                                >
-                                            </UserHoverCard>
-                                        </InlineMarks>
-                                        <InlineMarks
-                                            v-else-if="
-                                                segment.kind === 'groupMention'
-                                            "
-                                            :marks="segment.marks"
-                                        >
-                                            <!-- A group has no profile to hover,
-                                                 so the pill is inert: its own hue
-                                                 is what marks it as reaching more
-                                                 than one person. -->
-                                            <span
-                                                data-test="message-group-mention"
-                                                class="rounded bg-violet-500/10 px-1 py-0.5 font-medium text-violet-700 dark:bg-violet-400/15 dark:text-violet-300"
-                                                >@{{ segment.name }}</span
-                                            >
-                                        </InlineMarks>
-                                        <InlineMarks
-                                            v-else-if="segment.kind === 'emoji'"
-                                            :marks="segment.marks"
-                                        >
-                                            <img
-                                                :src="segment.url"
-                                                :alt="`:${segment.name}:`"
-                                                :title="`:${segment.name}:`"
-                                                data-test="message-emoji"
-                                                class="custom-emoji inline-block h-[1.35em] w-[1.35em] align-text-bottom"
-                                            />
-                                        </InlineMarks>
-                                        <InlineMarks
-                                            v-else
-                                            :marks="segment.marks"
-                                        >
-                                            <HoverCard
-                                                v-if="
-                                                    previewFor(
-                                                        message,
-                                                        segment.href,
-                                                    )
-                                                "
-                                                :open-delay="200"
-                                                :close-delay="100"
-                                            >
-                                                <HoverCardTrigger as-child>
-                                                    <a
-                                                        :href="segment.href"
-                                                        target="_blank"
-                                                        rel="noopener noreferrer nofollow"
-                                                        data-test="message-link"
-                                                        class="text-primary underline underline-offset-2 hover:no-underline"
-                                                        >{{ segment.href }}</a
-                                                    >
-                                                </HoverCardTrigger>
-                                                <HoverCardContent
-                                                    data-test="link-preview-card"
-                                                    class="w-80 overflow-hidden p-0"
-                                                >
-                                                    <LinkPreview
-                                                        :preview="
-                                                            previewFor(
-                                                                message,
-                                                                segment.href,
-                                                            )!
-                                                        "
-                                                    />
-                                                </HoverCardContent>
-                                            </HoverCard>
-                                            <a
-                                                v-else
-                                                :href="segment.href"
-                                                target="_blank"
-                                                rel="noopener noreferrer nofollow"
-                                                data-test="message-link"
-                                                class="text-primary underline underline-offset-2 hover:no-underline"
-                                                >{{ segment.href }}</a
-                                            >
-                                        </InlineMarks>
-                                    </template>
-                                    <span
-                                        v-if="message.editedAt"
-                                        :data-test="'message-edited'"
-                                        class="ml-1 align-baseline text-[11px] text-muted-foreground select-none"
-                                        >{{ $t('(edited)') }}</span
-                                    >
-                                </p>
-
-                                <MessageAttachments
-                                    v-if="
-                                        message.attachments.length > 0 &&
-                                        !message.isDeleted &&
-                                        editingId !== message.id
-                                    "
-                                    :class="CARD_BLEED"
-                                    :attachments="message.attachments"
-                                    :author-name="message.user.name"
-                                    :created-at="message.createdAt"
-                                    :viewer-time-zone="viewerTimeZone"
-                                />
-
-                                <MessagePoll
-                                    v-if="
-                                        message.poll &&
-                                        !message.isDeleted &&
-                                        editingId !== message.id
-                                    "
-                                    :class="CARD_BLEED"
-                                    :poll="message.poll"
-                                    :current-user-id="props.currentUserId"
-                                    :can-vote="canReactTo(message)"
-                                    :can-manage="
-                                        message.user.id ===
-                                            props.currentUserId ||
-                                        Boolean(props.canModerate)
-                                    "
-                                    @vote="
-                                        (optionId) =>
-                                            emit('vote', message, optionId)
-                                    "
-                                    @close="emit('closePoll', message)"
-                                />
-
-                                <span
-                                    v-if="isQueued(message)"
-                                    data-test="message-queued"
-                                    class="mt-0.5 inline-flex items-center gap-1 text-[11px] font-semibold text-muted-foreground select-none"
-                                >
-                                    <Clock class="size-3" />
-                                    {{ $t('Queued — will send on reconnect') }}
-                                </span>
-
-                                <MessageForward
-                                    v-if="
-                                        message.forwardedFrom &&
-                                        !message.isDeleted &&
-                                        editingId !== message.id
-                                    "
-                                    data-test="forwarded-message"
-                                    :author-name="
-                                        message.forwardedFrom.authorName
-                                    "
-                                    :channel-name="
-                                        message.forwardedFrom.channelName
-                                    "
-                                    :body="message.forwardedFrom.body"
-                                    :is-deleted="
-                                        message.forwardedFrom.isDeleted
-                                    "
-                                    :mentions="message.forwardedFrom.mentions"
-                                />
-
-                                <MessageReactions
-                                    v-if="
-                                        !message.isDeleted &&
-                                        editingId !== message.id
-                                    "
-                                    :reactions="message.reactions"
-                                    :current-user-id="props.currentUserId"
-                                    :can-react="canReactTo(message)"
-                                    @toggle="
-                                        (emoji) => emit('react', message, emoji)
-                                    "
-                                />
-
-                                <div
-                                    v-if="showThreadSummary(message)"
-                                    class="mt-1.5 flex flex-wrap items-center gap-2"
-                                >
-                                    <Button
-                                        variant="unstyled"
-                                        size="none"
-                                        type="button"
-                                        data-test="thread-summary"
-                                        :aria-label="
-                                            message.threadReplyCount === 1
-                                                ? $t(
-                                                      'View thread, :count reply',
-                                                      {
-                                                          count: message.threadReplyCount,
-                                                      },
-                                                  )
-                                                : $t(
-                                                      'View thread, :count replies',
-                                                      {
-                                                          count: message.threadReplyCount,
-                                                      },
-                                                  )
-                                        "
-                                        class="inline-flex items-center gap-2 rounded-full border border-border bg-card px-2.5 py-1 text-left transition-colors hover:bg-muted/50"
-                                        @click="emit('openThread', message.id)"
-                                    >
-                                        <span class="flex -space-x-1">
-                                            <Avatar
-                                                v-for="participant in threadAvatars(
-                                                    message,
-                                                )"
-                                                :key="participant.id"
-                                                class="size-4 text-[8px] ring-2 ring-card"
-                                                aria-hidden="true"
-                                            >
-                                                <AvatarImage
-                                                    v-if="participant.avatar"
-                                                    :src="participant.avatar"
-                                                    :alt="participant.name"
-                                                />
-                                                <AvatarFallback
-                                                    class="bg-primary/10 font-semibold text-primary"
-                                                >
-                                                    {{
-                                                        getInitials(
-                                                            participant.name,
-                                                        )
-                                                    }}
-                                                </AvatarFallback>
-                                            </Avatar>
-                                            <span
-                                                v-if="
-                                                    extraThreadParticipants(
-                                                        message,
-                                                    ) > 0
-                                                "
-                                                class="flex size-4 items-center justify-center rounded-full bg-muted text-[8px] font-semibold text-muted-foreground ring-2 ring-card select-none"
-                                                aria-hidden="true"
-                                            >
-                                                +{{
-                                                    extraThreadParticipants(
-                                                        message,
-                                                    )
-                                                }}
-                                            </span>
-                                        </span>
-                                        <span
-                                            v-if="message.threadUnread"
-                                            data-test="thread-unread-dot"
-                                            :aria-label="$t('Unread replies')"
-                                            class="size-2 shrink-0 rounded-full bg-rose-500"
-                                        ></span>
-                                        <span
-                                            class="text-[12px] font-semibold text-foreground"
-                                        >
-                                            {{
-                                                message.threadReplyCount === 1
-                                                    ? $t(':count reply', {
-                                                          count: message.threadReplyCount,
-                                                      })
-                                                    : $t(':count replies', {
-                                                          count: message.threadReplyCount,
-                                                      })
-                                            }}
-                                        </span>
-                                        <span
-                                            aria-hidden="true"
-                                            class="text-[12px] text-muted-foreground"
-                                            >→</span
-                                        >
-                                    </Button>
-                                    <span
-                                        v-if="message.threadLastReplyAt"
-                                        class="text-[11.5px] text-muted-foreground"
-                                    >
-                                        {{ $t('Last reply') }}
-                                        {{
-                                            formatTime(
-                                                message.threadLastReplyAt,
-                                            )
-                                        }}
-                                    </span>
-                                </div>
-
-                                <MessageActions
-                                    v-if="editingId !== message.id"
-                                    :message="message"
-                                    :current-user-id="props.currentUserId"
-                                    :can-react="props.canReact"
-                                    :can-pin="props.canPin"
-                                    :can-moderate="props.canModerate"
-                                    :in-thread="props.inThread"
-                                    :pending="isPending(message)"
-                                    :viewer-timezone="viewerTimezone"
-                                    @react="
-                                        (emoji) => emit('react', message, emoji)
-                                    "
-                                    @reply="emit('reply', message)"
-                                    @forward="emit('forward', message)"
-                                    @pin="emit('pin', message)"
-                                    @unpin="emit('unpin', message)"
-                                    @open-thread="
-                                        emit('openThread', message.id)
-                                    "
-                                    @remind="
-                                        (remindAt) =>
-                                            emit('remind', message, remindAt)
-                                    "
-                                    @remind-custom="
-                                        emit('remindCustom', message)
-                                    "
-                                    @edit="startEdit(message)"
-                                    @delete="requestDelete(message)"
-                                />
-                            </div>
+                                "
+                                :viewer-time-zone="viewerTimeZone"
+                                :viewer-timezone="viewerTimezone"
+                                :long-press="longPress"
+                                @start-edit="startEdit(message)"
+                                @save-edit="(body) => saveEdit(message, body)"
+                                @cancel-edit="cancelEdit"
+                                @request-delete="requestDelete(message)"
+                                @reply="emit('reply', message)"
+                                @forward="emit('forward', message)"
+                                @pin="emit('pin', message)"
+                                @unpin="emit('unpin', message)"
+                                @close-poll="emit('closePoll', message)"
+                                @remind-custom="emit('remindCustom', message)"
+                                @open-thread="(id) => emit('openThread', id)"
+                                @react="
+                                    (emoji) => emit('react', message, emoji)
+                                "
+                                @vote="
+                                    (optionId) =>
+                                        emit('vote', message, optionId)
+                                "
+                                @remind="
+                                    (remindAt) =>
+                                        emit('remind', message, remindAt)
+                                "
+                                @jump="(id) => emit('jump', id)"
+                                @mention="(member) => emit('mention', member)"
+                            />
                         </div>
                     </div>
                 </div>
 
-                <!-- The mobile thread push moves the reply count out of the
-                     panel header and into this rule under the root, separating
-                     the parent message from its replies (design m3). -->
-                <div
+                <ThreadRepliesDivider
                     v-if="
                         item.type === 'group' &&
                         isThreadRoot(item) &&
                         (props.replyDividerCount ?? 0) > 0
                     "
-                    data-test="thread-replies-divider"
-                    role="separator"
-                    :aria-label="replyDividerLabel"
-                    class="mt-4 flex items-center gap-2.5"
-                >
-                    <span
-                        aria-hidden="true"
-                        class="text-[11px] font-semibold tracking-[0.06em] whitespace-nowrap text-muted-foreground uppercase"
-                    >
-                        {{ replyDividerLabel }}
-                    </span>
-                    <span aria-hidden="true" class="h-px flex-1 bg-border" />
-                </div>
+                    :count="props.replyDividerCount ?? 0"
+                />
             </div>
         </div>
 
-        <div
-            v-if="seenByReaders.length > 0"
-            data-test="seen-by"
-            class="mt-1.5 flex items-center justify-end gap-1.5 pr-1"
-            :title="seenByLabel"
-        >
-            <span class="font-serif text-[11px] text-muted-foreground italic">
-                {{ $t('Seen by') }}
-            </span>
-            <span class="flex -space-x-1">
-                <Avatar
-                    v-for="reader in seenByAvatars"
-                    :key="reader.id"
-                    class="size-4 text-[8px] ring-2 ring-card"
-                    aria-hidden="true"
-                >
-                    <AvatarImage
-                        v-if="reader.avatar"
-                        :src="reader.avatar"
-                        :alt="reader.name"
-                    />
-                    <AvatarFallback
-                        class="bg-primary/10 font-semibold text-primary"
-                    >
-                        {{ getInitials(reader.name) }}
-                    </AvatarFallback>
-                </Avatar>
-                <span
-                    v-if="extraSeenBy > 0"
-                    class="flex size-4 items-center justify-center rounded-full bg-muted text-[8px] font-semibold text-muted-foreground ring-2 ring-card select-none"
-                    aria-hidden="true"
-                >
-                    +{{ extraSeenBy }}
-                </span>
-            </span>
-            <span class="sr-only">{{ seenByLabel }}</span>
-        </div>
+        <SeenByRow v-if="seenByReaders.length > 0" :readers="seenByReaders" />
 
-        <Dialog :open="pendingDelete !== null" @update:open="setDeleteOpen">
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>{{ $t('Delete message') }}</DialogTitle>
-                    <DialogDescription>
-                        {{
-                            $t(
-                                "Are you sure you want to delete this message? This can't be undone.",
-                            )
-                        }}
-                    </DialogDescription>
-                </DialogHeader>
-
-                <DialogFooter class="gap-2">
-                    <DialogClose as-child>
-                        <Button variant="secondary">
-                            {{ $t('Cancel') }}
-                        </Button>
-                    </DialogClose>
-
-                    <Button
-                        data-test="delete-message-confirm"
-                        variant="destructive"
-                        @click="confirmDelete"
-                    >
-                        {{ $t('Delete') }}
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
+        <DeleteMessageDialog
+            :open="pendingDelete !== null"
+            @confirm="confirmDelete"
+            @close="pendingDelete = null"
+        />
 
         <MessageActionsSheet
             v-model:open="actionSheetOpen"

--- a/resources/js/components/timeline/DayDivider.vue
+++ b/resources/js/components/timeline/DayDivider.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { formatDayLabel } from '@/lib/datetime';
+
+defineProps<{
+    /** The crossing message's timestamp, labelled relative to the viewer's today. */
+    iso: string;
+}>();
+</script>
+
+<template>
+    <div data-test="day-divider" class="my-4 flex items-center gap-3">
+        <span aria-hidden="true" class="h-px flex-1 bg-border" />
+        <span class="font-serif text-[13px] text-muted-foreground italic">
+            {{ formatDayLabel(iso) }}
+        </span>
+        <span aria-hidden="true" class="h-px flex-1 bg-border" />
+    </div>
+</template>

--- a/resources/js/components/timeline/DeleteMessageDialog.vue
+++ b/resources/js/components/timeline/DeleteMessageDialog.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+
+defineProps<{
+    /** The message queued for deletion; a non-null value opens the dialog. */
+    open: boolean;
+}>();
+
+defineEmits<{
+    /** Delete for real. */
+    confirm: [];
+    /** Dismiss without deleting. */
+    close: [];
+}>();
+</script>
+
+<template>
+    <Dialog :open="open" @update:open="(next) => !next && $emit('close')">
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle>{{ $t('Delete message') }}</DialogTitle>
+                <DialogDescription>
+                    {{
+                        $t(
+                            "Are you sure you want to delete this message? This can't be undone.",
+                        )
+                    }}
+                </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter class="gap-2">
+                <DialogClose as-child>
+                    <Button variant="secondary">
+                        {{ $t('Cancel') }}
+                    </Button>
+                </DialogClose>
+
+                <Button
+                    data-test="delete-message-confirm"
+                    variant="destructive"
+                    @click="$emit('confirm')"
+                >
+                    {{ $t('Delete') }}
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/timeline/MessageAuthorLine.vue
+++ b/resources/js/components/timeline/MessageAuthorLine.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import UserHoverCard from '@/components/UserHoverCard.vue';
+import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
+import { presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
+import type { MessageAuthor } from '@/types';
+
+defineProps<{
+    author: MessageAuthor;
+    teamSlug: string;
+    presence: RenderedPresence;
+    isDnd: boolean;
+    /** The group's lead timestamp, already formatted in the viewer's zone. */
+    time: string;
+}>();
+
+defineEmits<{
+    mention: [member: { id: string; name: string }];
+}>();
+</script>
+
+<template>
+    <span>
+        <UserHoverCard
+            :team-slug="teamSlug"
+            :user-id="author.id"
+            :name="author.name"
+            :presence="presence"
+            :is-dnd="isDnd"
+            @mention="(member) => $emit('mention', member)"
+        >
+            <span
+                data-test="message-author-name"
+                class="cursor-pointer text-[14px] font-semibold text-foreground hover:underline"
+                >{{ author.name }}</span
+            >
+        </UserHoverCard>
+        <!-- The author's status emoji rides beside their name; the full text
+             lives on the hover card. -->
+        <UserStatusEmoji
+            :status="author.status"
+            :name="author.name"
+            class="ml-1.5 align-[-1px] text-[13px]"
+        />
+        <!-- The uppercase "Bot" tag rides beside a bot author's name; a bot has
+             no presence, so it replaces the Online/Offline announcement rather
+             than adding to it. -->
+        <span
+            v-if="author.isBot"
+            data-test="author-bot-badge"
+            class="ml-1.5 inline-flex items-center rounded border border-border px-1.5 align-[1px] text-[9px] font-bold tracking-[0.08em] text-muted-foreground uppercase"
+            >{{ $t('Bot') }}</span
+        >
+        <span v-else class="sr-only">{{ $t(presenceLabelKey(presence)) }}</span>
+        <!-- Below `md` the group's time rides beside the author name instead of
+             stacking under the avatar, where a 36px gutter has no room for it.
+             Hidden from AT on both layouts: each row's accessible name already
+             carries its own time. -->
+        <span
+            data-test="message-group-time-inline"
+            aria-hidden="true"
+            class="ml-1.5 font-mono text-[10.5px] text-muted-foreground md:hidden"
+            >{{ time }}</span
+        >
+    </span>
+</template>

--- a/resources/js/components/timeline/MessageAvatarGutter.vue
+++ b/resources/js/components/timeline/MessageAvatarGutter.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { Bot } from '@lucide/vue';
+import PresenceDot from '@/components/PresenceDot.vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import UserHoverCard from '@/components/UserHoverCard.vue';
+import { useInitials } from '@/composables/useInitials';
+import type { RenderedPresence } from '@/lib/presence';
+import type { MessageAuthor } from '@/types';
+
+defineProps<{
+    author: MessageAuthor;
+    teamSlug: string;
+    presence: RenderedPresence;
+    isDnd: boolean;
+    /** The group's lead timestamp, already formatted in the viewer's zone. */
+    time: string;
+    /** Whether the viewport is below the breakpoint, sizing the presence dot. */
+    isMobile: boolean;
+}>();
+
+defineEmits<{
+    mention: [member: { id: string; name: string }];
+}>();
+
+const { getInitials } = useInitials();
+</script>
+
+<template>
+    <!-- The avatar gutter: 64px of centred column on desktop, a 26px avatar plus
+         a 10px gap below `md`, where 64px of a 390px screen is a quarter of the
+         row spent on chrome. -->
+    <div
+        class="flex w-16 shrink-0 flex-col items-center gap-1 pt-0.5 max-md:w-9 max-md:items-start max-md:gap-0 max-md:pt-0"
+    >
+        <UserHoverCard
+            :team-slug="teamSlug"
+            :user-id="author.id"
+            :name="author.name"
+            :presence="presence"
+            :is-dnd="isDnd"
+            @mention="(member) => $emit('mention', member)"
+        >
+            <div
+                data-test="message-avatar"
+                class="relative size-8.5 cursor-pointer max-md:size-6.5"
+            >
+                <!-- A bot squares off its avatar (rounded-lg vs a human's full
+                     circle) and shows a glyph on the ink-stone fill, so it reads
+                     as non-human at a glance; a human keeps their
+                     gravatar/initials. -->
+                <Avatar
+                    class="size-8.5 text-[11px] max-md:size-6.5 max-md:text-[9px]"
+                    :class="author.isBot ? 'rounded-lg' : ''"
+                    aria-hidden="true"
+                >
+                    <AvatarImage
+                        v-if="author.avatar && !author.isBot"
+                        :src="author.avatar"
+                        :alt="author.name"
+                    />
+                    <AvatarFallback
+                        :class="
+                            author.isBot
+                                ? 'rounded-lg bg-muted-foreground text-background'
+                                : 'bg-primary/10 font-semibold text-primary'
+                        "
+                    >
+                        <Bot v-if="author.isBot" class="size-4.5" />
+                        <template v-else>{{
+                            getInitials(author.name)
+                        }}</template>
+                    </AvatarFallback>
+                </Avatar>
+                <!-- Presence is announced once per author group via the sr-only
+                     text beside the name below, so this repeated dot is
+                     decorative to AT. A bot has no presence, so it shows no dot. -->
+                <PresenceDot
+                    v-if="!author.isBot"
+                    data-test="presence-dot"
+                    :presence="presence"
+                    :is-dnd="isDnd"
+                    surface-class="bg-card"
+                    :size="isMobile ? '24' : '36'"
+                    class="ring-card"
+                />
+            </div>
+        </UserHoverCard>
+        <!-- The stacked time sets a tall floor on every row even for a one-word
+             message, so below `md` it gives way to the inline stamp on the
+             author's own line. -->
+        <span
+            data-test="message-group-time"
+            class="font-mono text-[9.5px] text-muted-foreground max-md:hidden"
+            >{{ time }}</span
+        >
+    </div>
+</template>

--- a/resources/js/components/timeline/MessageBodyText.vue
+++ b/resources/js/components/timeline/MessageBodyText.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import InlineMarks from '@/components/InlineMarks.vue';
 import LinkPreview from '@/components/LinkPreview.vue';
 import SafeHtml from '@/components/SafeHtml.vue';
@@ -33,14 +34,14 @@ const { groups: userGroups } = useUserGroups();
  * Split a message body into HTML and link segments so the timeline can wrap each
  * URL in its own element (and, when the link has been unfurled, a hover card).
  */
-function bodySegments(): MessageBodySegment[] {
-    return tokenizeMessageBody(
+const bodySegments = computed<MessageBodySegment[]>(() =>
+    tokenizeMessageBody(
         props.message.body,
         props.message.mentions,
         customEmojis.value,
         userGroups.value,
-    );
-}
+    ),
+);
 
 /**
  * The unfurled preview for a URL in a message, or undefined when the link has no
@@ -58,7 +59,7 @@ function previewFor(href: string): MessagePreview | undefined {
         class="py-0.5 text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90 max-md:text-[15px] max-md:leading-[1.45]"
         :class="pending ? 'opacity-60' : ''"
     >
-        <template v-for="(segment, index) in bodySegments()" :key="index">
+        <template v-for="(segment, index) in bodySegments" :key="index">
             <SafeHtml
                 v-if="segment.kind === 'html'"
                 :html="segment.html"

--- a/resources/js/components/timeline/MessageBodyText.vue
+++ b/resources/js/components/timeline/MessageBodyText.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import InlineMarks from '@/components/InlineMarks.vue';
+import LinkPreview from '@/components/LinkPreview.vue';
+import SafeHtml from '@/components/SafeHtml.vue';
+import {
+    HoverCard,
+    HoverCardContent,
+    HoverCardTrigger,
+} from '@/components/ui/hover-card';
+import UserHoverCard from '@/components/UserHoverCard.vue';
+import { useCustomEmojis } from '@/composables/useCustomEmojis';
+import { useUserGroups } from '@/composables/useUserGroups';
+import { tokenizeMessageBody } from '@/lib/messageBody';
+import type { MessageBodySegment } from '@/lib/messageBody';
+import type { Message, MessagePreview } from '@/types';
+
+const props = defineProps<{
+    message: Message;
+    /** The team the mentions belong to, so their hover cards resolve a profile. */
+    teamSlug: string;
+    /** Whether the send is still in flight, fading the body while it is. */
+    pending: boolean;
+}>();
+
+defineEmits<{
+    mention: [member: { id: string; name: string }];
+}>();
+
+const { map: customEmojis } = useCustomEmojis();
+const { groups: userGroups } = useUserGroups();
+
+/**
+ * Split a message body into HTML and link segments so the timeline can wrap each
+ * URL in its own element (and, when the link has been unfurled, a hover card).
+ */
+function bodySegments(): MessageBodySegment[] {
+    return tokenizeMessageBody(
+        props.message.body,
+        props.message.mentions,
+        customEmojis.value,
+        userGroups.value,
+    );
+}
+
+/**
+ * The unfurled preview for a URL in a message, or undefined when the link has no
+ * preview row yet. Pending rows resolve too, so the hover card can show a
+ * skeleton until the queued unfurl broadcasts the resolved metadata.
+ */
+function previewFor(href: string): MessagePreview | undefined {
+    return props.message.linkPreviews.find((preview) => preview.url === href);
+}
+</script>
+
+<template>
+    <p
+        :data-test="'message-body'"
+        class="py-0.5 text-[14.5px] leading-[1.55] break-words whitespace-pre-wrap text-foreground/90 max-md:text-[15px] max-md:leading-[1.45]"
+        :class="pending ? 'opacity-60' : ''"
+    >
+        <template v-for="(segment, index) in bodySegments()" :key="index">
+            <SafeHtml
+                v-if="segment.kind === 'html'"
+                :html="segment.html"
+                variant="messageBody"
+            />
+            <InlineMarks
+                v-else-if="segment.kind === 'mention'"
+                :marks="segment.marks"
+            >
+                <UserHoverCard
+                    :team-slug="teamSlug"
+                    :user-id="segment.id"
+                    :name="segment.name"
+                    @mention="(member) => $emit('mention', member)"
+                >
+                    <span
+                        data-test="message-mention"
+                        class="cursor-pointer border-b-[1.5px] border-brass font-medium text-foreground hover:border-brass-border"
+                        >@{{ segment.name }}</span
+                    >
+                </UserHoverCard>
+            </InlineMarks>
+            <InlineMarks
+                v-else-if="segment.kind === 'groupMention'"
+                :marks="segment.marks"
+            >
+                <!-- A group has no profile to hover, so the pill is inert: its
+                     own hue is what marks it as reaching more than one person. -->
+                <span
+                    data-test="message-group-mention"
+                    class="rounded bg-violet-500/10 px-1 py-0.5 font-medium text-violet-700 dark:bg-violet-400/15 dark:text-violet-300"
+                    >@{{ segment.name }}</span
+                >
+            </InlineMarks>
+            <InlineMarks
+                v-else-if="segment.kind === 'emoji'"
+                :marks="segment.marks"
+            >
+                <img
+                    :src="segment.url"
+                    :alt="`:${segment.name}:`"
+                    :title="`:${segment.name}:`"
+                    data-test="message-emoji"
+                    class="custom-emoji inline-block h-[1.35em] w-[1.35em] align-text-bottom"
+                />
+            </InlineMarks>
+            <InlineMarks v-else :marks="segment.marks">
+                <HoverCard
+                    v-if="previewFor(segment.href)"
+                    :open-delay="200"
+                    :close-delay="100"
+                >
+                    <HoverCardTrigger as-child>
+                        <a
+                            :href="segment.href"
+                            target="_blank"
+                            rel="noopener noreferrer nofollow"
+                            data-test="message-link"
+                            class="text-primary underline underline-offset-2 hover:no-underline"
+                            >{{ segment.href }}</a
+                        >
+                    </HoverCardTrigger>
+                    <HoverCardContent
+                        data-test="link-preview-card"
+                        class="w-80 overflow-hidden p-0"
+                    >
+                        <LinkPreview :preview="previewFor(segment.href)!" />
+                    </HoverCardContent>
+                </HoverCard>
+                <a
+                    v-else
+                    :href="segment.href"
+                    target="_blank"
+                    rel="noopener noreferrer nofollow"
+                    data-test="message-link"
+                    class="text-primary underline underline-offset-2 hover:no-underline"
+                    >{{ segment.href }}</a
+                >
+            </InlineMarks>
+        </template>
+        <span
+            v-if="message.editedAt"
+            :data-test="'message-edited'"
+            class="ml-1 align-baseline text-[11px] text-muted-foreground select-none"
+            >{{ $t('(edited)') }}</span
+        >
+    </p>
+</template>

--- a/resources/js/components/timeline/MessageEditForm.vue
+++ b/resources/js/components/timeline/MessageEditForm.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { Button } from '@/components/ui/button';
+
+const props = defineProps<{
+    /** The body the editor opens on. */
+    body: string;
+}>();
+
+const emit = defineEmits<{
+    /** Commit the draft; an empty or unchanged one is the parent's to discard. */
+    save: [body: string];
+    /** Leave the editor without committing. */
+    cancel: [];
+}>();
+
+const draft = ref(props.body);
+const field = ref<HTMLTextAreaElement | null>(null);
+
+// Only one row edits at a time, so the editor mounting *is* the edit starting.
+onMounted(() => field.value?.focus());
+</script>
+
+<template>
+    <div class="py-0.5">
+        <textarea
+            ref="field"
+            v-model="draft"
+            data-test="message-edit-input"
+            rows="1"
+            class="w-full resize-none rounded-md border border-input bg-background px-2.5 py-1.5 text-base leading-[1.55] text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring md:text-[14.5px]"
+            @keydown.enter.exact.prevent="emit('save', draft)"
+            @keydown.esc.prevent="emit('cancel')"
+        ></textarea>
+        <div
+            class="mt-1 flex items-center gap-2 text-[11.5px] text-muted-foreground"
+        >
+            <Button
+                size="sm"
+                type="button"
+                class="h-7 px-2"
+                @click="emit('save', draft)"
+            >
+                {{ $t('Save') }}
+            </Button>
+            <Button
+                variant="outline"
+                size="sm"
+                type="button"
+                class="h-7 px-2"
+                @click="emit('cancel')"
+            >
+                {{ $t('Cancel') }}
+            </Button>
+            <span>{{ $t('Enter to save · Esc to cancel') }}</span>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/timeline/MessageReplyQuote.vue
+++ b/resources/js/components/timeline/MessageReplyQuote.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import MessageQuote from '@/components/MessageQuote.vue';
+import { Button } from '@/components/ui/button';
+import type { MessageReply } from '@/types';
+
+defineProps<{
+    /** The parent message this row answers. */
+    replyTo: MessageReply;
+    /**
+     * The row's own bleed geometry, letting the card run the full timeline width
+     * below `md` — passed in because the offsets belong to the row, not the card.
+     */
+    bleedClass: string;
+}>();
+
+defineEmits<{
+    /** Bring the replied-to message into view. */
+    jump: [messageId: string];
+}>();
+</script>
+
+<template>
+    <Button
+        variant="unstyled"
+        size="none"
+        type="button"
+        data-test="message-quote"
+        :aria-label="
+            $t('Jump to replied message from :author', {
+                author: replyTo.authorName,
+            })
+        "
+        class="mt-0.5 flex max-w-full items-center rounded pr-1 text-left hover:opacity-80 max-md:border-y max-md:border-border max-md:bg-card max-md:py-1.5 max-md:pr-5 max-md:pl-5"
+        :class="bleedClass"
+        @click="$emit('jump', replyTo.id)"
+    >
+        <MessageQuote
+            :author-name="replyTo.authorName"
+            :body="replyTo.body"
+            :is-deleted="replyTo.isDeleted"
+        />
+    </Button>
+</template>

--- a/resources/js/components/timeline/MessageRow.vue
+++ b/resources/js/components/timeline/MessageRow.vue
@@ -1,0 +1,299 @@
+<script setup lang="ts">
+import { Clock, Pin } from '@lucide/vue';
+import { computed } from 'vue';
+import MessageActions from '@/components/MessageActions.vue';
+import MessageAttachments from '@/components/MessageAttachments.vue';
+import MessageForward from '@/components/MessageForward.vue';
+import MessagePoll from '@/components/MessagePoll.vue';
+import MessageReactions from '@/components/MessageReactions.vue';
+import MessageBodyText from '@/components/timeline/MessageBodyText.vue';
+import MessageEditForm from '@/components/timeline/MessageEditForm.vue';
+import MessageReplyQuote from '@/components/timeline/MessageReplyQuote.vue';
+import ThreadSummary from '@/components/timeline/ThreadSummary.vue';
+import type { UseLongPress } from '@/composables/useLongPress';
+import { formatTimeOfDay } from '@/lib/datetime';
+import { canReactToMessage, showsThreadSummary } from '@/lib/messageActions';
+import type { MessageActionContext } from '@/lib/messageActions';
+import { messageAccessibleName } from '@/lib/timeline';
+import type { Message } from '@/types';
+
+/**
+ * Below `md`, a rich card (poll, attachments, reply quote) breaks out of the
+ * message row so it runs the full width of the timeline instead of the
+ * 36px-indented text column, trading its rounded box for hairline top and
+ * bottom rules (design "Mobile Message List", screen `1c`).
+ *
+ * The offsets are this row's own geometry — 20px of timeline padding plus the
+ * 36px avatar gutter on the left, 20px of padding on the right — so they live
+ * beside the row that defines them rather than inside each card.
+ */
+const CARD_BLEED =
+    'max-md:-ml-14 max-md:-mr-5 max-md:rounded-none max-md:border-x-0';
+
+const props = defineProps<{
+    message: Message;
+    /** The group author's name, naming the row for assistive technology. */
+    authorName: string;
+    teamSlug: string;
+    currentUserId: string;
+    canReact?: boolean;
+    canPin?: boolean;
+    canModerate?: boolean;
+    inThread?: boolean;
+    /** Whether this row leads its author group, which sets its top margin. */
+    isLead: boolean;
+    /** Whether the send is still in flight to the server. */
+    pending: boolean;
+    /** Whether the send is held in the offline outbox. */
+    queued: boolean;
+    /** Whether the row is under a live long press, showing its hold cue. */
+    held: boolean;
+    /** Whether this row is the one swapped into its inline editor. */
+    editing: boolean;
+    /** Whether this row is the current jump target. */
+    highlighted: boolean;
+    /** Whether this row is the root of the thread open beside the timeline. */
+    activeThreadRoot: boolean;
+    /** Whether the composer holds this row's text for an edit. */
+    composerEditing: boolean;
+    /** The viewer's zone, rendering every timestamp on the row. */
+    viewerTimeZone: string | undefined;
+    /** The viewer's stored zone, feeding the reminder popover's presets. */
+    viewerTimezone: string | null;
+    /** The gesture opening the touch actions sheet, owned by the timeline. */
+    longPress: UseLongPress<Message>;
+}>();
+
+const emit = defineEmits<{
+    /** Open this row's inline editor. */
+    startEdit: [];
+    /** Commit the inline editor's draft. */
+    saveEdit: [body: string];
+    /** Leave the inline editor without committing. */
+    cancelEdit: [];
+    /** Ask to delete this row, which the timeline confirms first. */
+    requestDelete: [];
+    reply: [];
+    forward: [];
+    pin: [];
+    unpin: [];
+    closePoll: [];
+    remindCustom: [];
+    openThread: [messageId: string];
+    react: [emoji: string];
+    vote: [optionId: string];
+    remind: [remindAt: string];
+    jump: [messageId: string];
+    mention: [member: { id: string; name: string }];
+}>();
+
+function formatTime(iso: string): string {
+    return formatTimeOfDay(iso, props.viewerTimeZone);
+}
+
+/**
+ * The viewer context each per-message guard resolves against. The hover-action
+ * bar (extracted to MessageActions) owns the toolbar guards; the two rules below
+ * stay here because they drive non-toolbar UI — the reaction pills and the
+ * thread summary — and share the same context.
+ */
+const actionContext = computed<MessageActionContext>(() => ({
+    currentUserId: props.currentUserId,
+    canReact: Boolean(props.canReact),
+    canPin: Boolean(props.canPin),
+    canModerate: Boolean(props.canModerate),
+    inThread: Boolean(props.inThread),
+    pending: props.pending,
+}));
+
+/**
+ * The viewer may react to any live, confirmed message when they're a member of
+ * the (non-archived) channel; drives whether the reaction pills accept toggles.
+ */
+const canReactTo = computed(() =>
+    canReactToMessage(props.message, actionContext.value),
+);
+
+/**
+ * The "N replies" affordance shows on any root that has replies, even a deleted
+ * one — the thread outlives its root as a tombstone.
+ */
+const showThreadSummary = computed(() =>
+    showsThreadSummary(props.message, actionContext.value),
+);
+</script>
+
+<template>
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- a touch-only long-press gesture; every action it opens stays reachable through the toolbar's focusable buttons -->
+    <div
+        :id="`message-${message.id}`"
+        role="listitem"
+        :aria-label="
+            messageAccessibleName(authorName, message.createdAt, viewerTimeZone)
+        "
+        class="group/message relative -mx-2 rounded-md px-2 transition-colors duration-1000 hover:bg-muted/40 max-md:select-none max-md:[-webkit-touch-callout:none]"
+        :class="[
+            isLead ? 'mt-0.5' : 'mt-1.5 max-md:mt-0.5',
+            highlighted ? 'bg-primary/10' : '',
+            activeThreadRoot ? 'bg-primary/5' : '',
+            composerEditing ? 'bg-brass-fill' : '',
+            held
+                ? 'scale-[0.98] opacity-80 transition-[transform,opacity] delay-100 duration-200'
+                : '',
+        ]"
+        @pointerdown="longPress.start($event, message)"
+        @pointermove="longPress.move($event)"
+        @pointerup="longPress.end()"
+        @pointerleave="longPress.end()"
+        @pointercancel="longPress.cancel()"
+        @contextmenu="longPress.onContextMenu($event)"
+    >
+        <!-- Per-message timestamp: revealed in the avatar gutter on hover, and
+             hidden from AT since the row's accessible name already carries the
+             time. The `<time datetime>` keeps the row machine-readable
+             regardless of the hover styling.
+             Only non-lead rows reveal it on hover — the lead row already shows
+             the group time above, so revealing this here would stack a duplicate
+             on top of it. The lead's <time> stays present but never fades in, so
+             its machine-readable value is unchanged.
+             Touch has no hover to reveal it with, so below `md` it drops out
+             entirely rather than compete for a 36px gutter. -->
+        <time
+            :datetime="message.createdAt"
+            data-test="message-hover-time"
+            aria-hidden="true"
+            class="pointer-events-none absolute top-1.5 -left-10.75 -translate-x-1/2 font-mono text-[9.5px] text-muted-foreground opacity-0 transition-opacity max-md:hidden"
+            :class="isLead ? '' : 'group-hover/message:opacity-100'"
+            >{{ formatTime(message.createdAt) }}</time
+        >
+
+        <!-- Pinned indicator: renders whenever the message is pinned, in the
+             same slot as the "edited" treatment above the body. Brass marks
+             pinned-ness; the content column is already indented, so it aligns to
+             the text column. -->
+        <div
+            v-if="message.pin"
+            data-test="message-pinned-indicator"
+            class="flex items-center gap-1.5 pt-0.5 text-[11px] text-muted-foreground"
+        >
+            <Pin class="size-3 fill-brass text-brass" />
+            <span>{{
+                $t('Pinned by :name', { name: message.pin.pinnedBy.name })
+            }}</span>
+        </div>
+
+        <MessageReplyQuote
+            v-if="message.replyTo && !message.isDeleted && !editing"
+            :reply-to="message.replyTo"
+            :bleed-class="CARD_BLEED"
+            @jump="(id) => emit('jump', id)"
+        />
+
+        <p
+            v-if="message.isDeleted"
+            :data-test="'message-tombstone'"
+            class="py-0.5 font-serif text-[13.5px] text-muted-foreground italic"
+        >
+            {{ $t('This message was deleted') }}
+        </p>
+
+        <MessageEditForm
+            v-else-if="editing"
+            :body="message.body"
+            @save="(body) => emit('saveEdit', body)"
+            @cancel="emit('cancelEdit')"
+        />
+
+        <MessageBodyText
+            v-else-if="message.body !== ''"
+            :message="message"
+            :team-slug="teamSlug"
+            :pending="pending"
+            @mention="(member) => emit('mention', member)"
+        />
+
+        <MessageAttachments
+            v-if="
+                message.attachments.length > 0 && !message.isDeleted && !editing
+            "
+            :class="CARD_BLEED"
+            :attachments="message.attachments"
+            :author-name="message.user.name"
+            :created-at="message.createdAt"
+            :viewer-time-zone="viewerTimeZone"
+        />
+
+        <MessagePoll
+            v-if="message.poll && !message.isDeleted && !editing"
+            :class="CARD_BLEED"
+            :poll="message.poll"
+            :current-user-id="currentUserId"
+            :can-vote="canReactTo"
+            :can-manage="
+                message.user.id === currentUserId || Boolean(canModerate)
+            "
+            @vote="(optionId) => emit('vote', optionId)"
+            @close="emit('closePoll')"
+        />
+
+        <span
+            v-if="queued"
+            data-test="message-queued"
+            class="mt-0.5 inline-flex items-center gap-1 text-[11px] font-semibold text-muted-foreground select-none"
+        >
+            <Clock class="size-3" />
+            {{ $t('Queued — will send on reconnect') }}
+        </span>
+
+        <MessageForward
+            v-if="message.forwardedFrom && !message.isDeleted && !editing"
+            data-test="forwarded-message"
+            :author-name="message.forwardedFrom.authorName"
+            :channel-name="message.forwardedFrom.channelName"
+            :body="message.forwardedFrom.body"
+            :is-deleted="message.forwardedFrom.isDeleted"
+            :mentions="message.forwardedFrom.mentions"
+        />
+
+        <MessageReactions
+            v-if="!message.isDeleted && !editing"
+            :reactions="message.reactions"
+            :current-user-id="currentUserId"
+            :can-react="canReactTo"
+            @toggle="(emoji) => emit('react', emoji)"
+        />
+
+        <ThreadSummary
+            v-if="showThreadSummary"
+            :message="message"
+            :last-reply-time="
+                message.threadLastReplyAt
+                    ? formatTime(message.threadLastReplyAt)
+                    : ''
+            "
+            @open-thread="(id) => emit('openThread', id)"
+        />
+
+        <MessageActions
+            v-if="!editing"
+            :message="message"
+            :current-user-id="currentUserId"
+            :can-react="canReact"
+            :can-pin="canPin"
+            :can-moderate="canModerate"
+            :in-thread="inThread"
+            :pending="pending"
+            :viewer-timezone="viewerTimezone"
+            @react="(emoji) => emit('react', emoji)"
+            @reply="emit('reply')"
+            @forward="emit('forward')"
+            @pin="emit('pin')"
+            @unpin="emit('unpin')"
+            @open-thread="emit('openThread', message.id)"
+            @remind="(remindAt) => emit('remind', remindAt)"
+            @remind-custom="emit('remindCustom')"
+            @edit="emit('startEdit')"
+            @delete="emit('requestDelete')"
+        />
+    </div>
+</template>

--- a/resources/js/components/timeline/MessageSkeleton.vue
+++ b/resources/js/components/timeline/MessageSkeleton.vue
@@ -1,0 +1,16 @@
+<template>
+    <!-- The height-stable stand-in a windowed row shows mid-scrub, before the
+         virtualizer has settled on its real height. -->
+    <div
+        data-test="message-skeleton"
+        aria-hidden="true"
+        class="mt-4.5 flex gap-3"
+        :style="{ minHeight: '56px' }"
+    >
+        <div class="size-8.5 shrink-0 rounded-full bg-muted" />
+        <div class="flex flex-1 flex-col gap-2 pt-1">
+            <div class="h-3 w-40 rounded bg-muted" />
+            <div class="h-3 w-[60%] rounded bg-muted" />
+        </div>
+    </div>
+</template>

--- a/resources/js/components/timeline/SeenByRow.vue
+++ b/resources/js/components/timeline/SeenByRow.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useInitials } from '@/composables/useInitials';
+import { useTranslations } from '@/composables/useTranslations';
+import type { MessageAuthor } from '@/types';
+
+/**
+ * How many reader avatars to preview on the "Seen by" row before collapsing the
+ * rest into a "+N" overflow chip.
+ */
+const MAX_SEEN_AVATARS = 3;
+
+const props = defineProps<{
+    /** The members who have read up to the newest message. Never empty here. */
+    readers: MessageAuthor[];
+}>();
+
+const { getInitials } = useInitials();
+
+const { t } = useTranslations();
+
+const avatars = computed(() => props.readers.slice(0, MAX_SEEN_AVATARS));
+
+const extra = computed(() =>
+    Math.max(0, props.readers.length - MAX_SEEN_AVATARS),
+);
+
+/**
+ * A full, human-readable roster ("Seen by Alice, Bob and 3 others") used as the
+ * row's accessible label and hover title, so the compact avatars still name who.
+ */
+const label = computed(() => {
+    const names = props.readers.map((reader) => reader.name);
+
+    if (names.length === 0) {
+        return '';
+    }
+
+    if (names.length === 1) {
+        return t('Seen by :name', { name: names[0] });
+    }
+
+    if (names.length <= MAX_SEEN_AVATARS) {
+        return t('Seen by :names and :last', {
+            names: names.slice(0, -1).join(', '),
+            last: names[names.length - 1],
+        });
+    }
+
+    const shown = names.slice(0, MAX_SEEN_AVATARS).join(', ');
+    const others = names.length - MAX_SEEN_AVATARS;
+
+    return others === 1
+        ? t('Seen by :names and :count other', { names: shown, count: others })
+        : t('Seen by :names and :count others', {
+              names: shown,
+              count: others,
+          });
+});
+</script>
+
+<template>
+    <div
+        data-test="seen-by"
+        class="mt-1.5 flex items-center justify-end gap-1.5 pr-1"
+        :title="label"
+    >
+        <span class="font-serif text-[11px] text-muted-foreground italic">
+            {{ $t('Seen by') }}
+        </span>
+        <span class="flex -space-x-1">
+            <Avatar
+                v-for="reader in avatars"
+                :key="reader.id"
+                class="size-4 text-[8px] ring-2 ring-card"
+                aria-hidden="true"
+            >
+                <AvatarImage
+                    v-if="reader.avatar"
+                    :src="reader.avatar"
+                    :alt="reader.name"
+                />
+                <AvatarFallback
+                    class="bg-primary/10 font-semibold text-primary"
+                >
+                    {{ getInitials(reader.name) }}
+                </AvatarFallback>
+            </Avatar>
+            <span
+                v-if="extra > 0"
+                class="flex size-4 items-center justify-center rounded-full bg-muted text-[8px] font-semibold text-muted-foreground ring-2 ring-card select-none"
+                aria-hidden="true"
+            >
+                +{{ extra }}
+            </span>
+        </span>
+        <span class="sr-only">{{ label }}</span>
+    </div>
+</template>

--- a/resources/js/components/timeline/SystemNotice.vue
+++ b/resources/js/components/timeline/SystemNotice.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useTranslations } from '@/composables/useTranslations';
+import type { Message } from '@/types';
+
+const props = defineProps<{
+    /** The `member_joined` / `member_left` row this notice renders. */
+    message: Message;
+    /**
+     * Whether the timeline belongs to a direct message, so the notice reads
+     * "left the conversation" rather than "left the channel".
+     */
+    isDirect?: boolean;
+}>();
+
+const { t } = useTranslations();
+
+/**
+ * The localized line for a system notice, rendered from its type and author in
+ * the viewer's own locale — the row stores no rendered English.
+ */
+const text = computed(() => {
+    const name = props.message.user.name;
+
+    if (props.message.type === 'member_left') {
+        return props.isDirect
+            ? t(':name left the conversation', { name })
+            : t(':name left the channel', { name });
+    }
+
+    return props.isDirect
+        ? t(':name joined the conversation', { name })
+        : t(':name joined the channel', { name });
+});
+</script>
+
+<template>
+    <!-- A system notice (member joined / left): a centered, inert line with no
+         avatar, author bubble, or hover actions. -->
+    <div
+        :id="`message-${message.id}`"
+        data-test="system-notice"
+        :data-system-type="message.type"
+        class="my-2 flex justify-center"
+    >
+        <span
+            class="rounded-full bg-muted/60 px-3 py-1 text-center text-[12px] text-muted-foreground"
+        >
+            {{ text }}
+        </span>
+    </div>
+</template>

--- a/resources/js/components/timeline/ThreadRepliesDivider.vue
+++ b/resources/js/components/timeline/ThreadRepliesDivider.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useTranslations } from '@/composables/useTranslations';
+
+const props = defineProps<{
+    /** How many replies the rule stands above. */
+    count: number;
+}>();
+
+const { t } = useTranslations();
+
+/**
+ * The rule's label, shared by its visible text and the separator's accessible
+ * name.
+ */
+const label = computed(() =>
+    props.count === 1
+        ? t(':count reply', { count: 1 })
+        : t(':count replies', { count: props.count }),
+);
+</script>
+
+<template>
+    <!-- The mobile thread push moves the reply count out of the panel header and
+         into this rule under the root, separating the parent message from its
+         replies (design m3). -->
+    <div
+        data-test="thread-replies-divider"
+        role="separator"
+        :aria-label="label"
+        class="mt-4 flex items-center gap-2.5"
+    >
+        <span
+            aria-hidden="true"
+            class="text-[11px] font-semibold tracking-[0.06em] whitespace-nowrap text-muted-foreground uppercase"
+        >
+            {{ label }}
+        </span>
+        <span aria-hidden="true" class="h-px flex-1 bg-border" />
+    </div>
+</template>

--- a/resources/js/components/timeline/ThreadSummary.vue
+++ b/resources/js/components/timeline/ThreadSummary.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { useInitials } from '@/composables/useInitials';
+import type { Message } from '@/types';
+
+/** How many participant avatars to preview on a root's "N replies" affordance. */
+const MAX_THREAD_AVATARS = 3;
+
+const props = defineProps<{
+    /** The thread root the summary hangs under. */
+    message: Message;
+    /** The last reply's time, already formatted in the viewer's zone. */
+    lastReplyTime: string;
+}>();
+
+defineEmits<{
+    openThread: [messageId: string];
+}>();
+
+const { getInitials } = useInitials();
+
+const avatars = computed(() =>
+    props.message.threadParticipants.slice(0, MAX_THREAD_AVATARS),
+);
+
+const extraParticipants = computed(() =>
+    Math.max(0, props.message.threadParticipants.length - MAX_THREAD_AVATARS),
+);
+</script>
+
+<template>
+    <div class="mt-1.5 flex flex-wrap items-center gap-2">
+        <Button
+            variant="unstyled"
+            size="none"
+            type="button"
+            data-test="thread-summary"
+            :aria-label="
+                message.threadReplyCount === 1
+                    ? $t('View thread, :count reply', {
+                          count: message.threadReplyCount,
+                      })
+                    : $t('View thread, :count replies', {
+                          count: message.threadReplyCount,
+                      })
+            "
+            class="inline-flex items-center gap-2 rounded-full border border-border bg-card px-2.5 py-1 text-left transition-colors hover:bg-muted/50"
+            @click="$emit('openThread', message.id)"
+        >
+            <span class="flex -space-x-1">
+                <Avatar
+                    v-for="participant in avatars"
+                    :key="participant.id"
+                    class="size-4 text-[8px] ring-2 ring-card"
+                    aria-hidden="true"
+                >
+                    <AvatarImage
+                        v-if="participant.avatar"
+                        :src="participant.avatar"
+                        :alt="participant.name"
+                    />
+                    <AvatarFallback
+                        class="bg-primary/10 font-semibold text-primary"
+                    >
+                        {{ getInitials(participant.name) }}
+                    </AvatarFallback>
+                </Avatar>
+                <span
+                    v-if="extraParticipants > 0"
+                    class="flex size-4 items-center justify-center rounded-full bg-muted text-[8px] font-semibold text-muted-foreground ring-2 ring-card select-none"
+                    aria-hidden="true"
+                >
+                    +{{ extraParticipants }}
+                </span>
+            </span>
+            <span
+                v-if="message.threadUnread"
+                data-test="thread-unread-dot"
+                :aria-label="$t('Unread replies')"
+                class="size-2 shrink-0 rounded-full bg-rose-500"
+            ></span>
+            <span class="text-[12px] font-semibold text-foreground">
+                {{
+                    message.threadReplyCount === 1
+                        ? $t(':count reply', {
+                              count: message.threadReplyCount,
+                          })
+                        : $t(':count replies', {
+                              count: message.threadReplyCount,
+                          })
+                }}
+            </span>
+            <span aria-hidden="true" class="text-[12px] text-muted-foreground"
+                >→</span
+            >
+        </Button>
+        <span
+            v-if="message.threadLastReplyAt"
+            class="text-[11.5px] text-muted-foreground"
+        >
+            {{ $t('Last reply') }}
+            {{ lastReplyTime }}
+        </span>
+    </div>
+</template>

--- a/resources/js/components/timeline/UnreadDivider.vue
+++ b/resources/js/components/timeline/UnreadDivider.vue
@@ -1,0 +1,24 @@
+<template>
+    <div
+        id="unread-divider"
+        data-test="unread-divider"
+        role="separator"
+        :aria-label="$t('New messages')"
+        class="my-4 flex items-center gap-3"
+    >
+        <span
+            aria-hidden="true"
+            class="h-px flex-1 bg-gradient-to-r from-transparent to-brass-border"
+        />
+        <span
+            aria-hidden="true"
+            class="font-serif text-[13px] text-brass-fill-foreground italic"
+        >
+            {{ $t('new') }}
+        </span>
+        <span
+            aria-hidden="true"
+            class="h-px flex-1 bg-gradient-to-r from-brass-border to-transparent"
+        />
+    </div>
+</template>

--- a/resources/js/composables/useMessageActionSheet.ts
+++ b/resources/js/composables/useMessageActionSheet.ts
@@ -1,0 +1,82 @@
+import { computed, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { useLongPress } from '@/composables/useLongPress';
+import type { UseLongPress } from '@/composables/useLongPress';
+import type { Message } from '@/types';
+
+export type MessageActionSheet = {
+    /** Whether the sheet is up. */
+    open: Ref<boolean>;
+    /** The message it is open on, resolved live so its state stays current. */
+    message: ComputedRef<Message | null>;
+    /** The gesture that opens it, bound to every message row's pointer events. */
+    longPress: UseLongPress<Message>;
+    /** Whether a given row is the one under a live press, for its hold cue. */
+    isHeld: (message: Message) => boolean;
+};
+
+/**
+ * The touch stand-in for the hover toolbar (design m4): below `md`, pressing
+ * and holding a message row opens its actions bottom sheet. The sheet resolves
+ * the message live by id, so reaction and pin state stay current while it is
+ * open, and the id survives the close animation.
+ */
+export function useMessageActionSheet(options: {
+    /** Whether the gesture is live at all (below the `md` breakpoint). */
+    isMobile: Ref<boolean>;
+    /** The timeline's messages, which the open sheet resolves its id against. */
+    messages: () => Message[];
+    /** Whether a row has any action to offer; a row with none never opens. */
+    canOpen: (message: Message) => boolean;
+}): MessageActionSheet {
+    const actionSheetId = ref<string | null>(null);
+    const open = ref(false);
+
+    const message = computed(
+        () =>
+            options
+                .messages()
+                .find((entry) => entry.id === actionSheetId.value) ?? null,
+    );
+
+    function openActionsSheet(pressed: Message): void {
+        if (!options.canOpen(pressed)) {
+            return;
+        }
+
+        actionSheetId.value = pressed.id;
+        open.value = true;
+    }
+
+    const longPress = useLongPress<Message>({
+        enabled: options.isMobile,
+        onLongPress: openActionsSheet,
+    });
+
+    /** The pressed row's hold cue while the long-press timer runs. */
+    function isHeld(row: Message): boolean {
+        return longPress.pressing.value?.id === row.id;
+    }
+
+    // Crossing up over the breakpoint mid-press leaves the sheet stranded on a
+    // hover-capable layout; the toolbar owns the actions there.
+    watch(options.isMobile, (mobile) => {
+        if (!mobile) {
+            open.value = false;
+        }
+    });
+
+    // A message deleted (or pruned from the window) while its sheet is up has no
+    // actions left to offer. Watched through a getter so an in-place tombstone
+    // patch from a broadcast closes it too, not only a replaced array entry.
+    watch(
+        () => message.value?.isDeleted,
+        (isDeleted) => {
+            if (isDeleted !== false) {
+                open.value = false;
+            }
+        },
+    );
+
+    return { open, message, longPress, isHeld };
+}

--- a/resources/js/composables/useTimelineWindow.ts
+++ b/resources/js/composables/useTimelineWindow.ts
@@ -1,0 +1,339 @@
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { NEAR_BOTTOM_THRESHOLD } from '@/composables/useScrollPin';
+import { useTimelineVirtualizer } from '@/composables/useTimelineVirtualizer';
+import type { TimelineItem } from '@/lib/timeline';
+import { bottomGlueSettled, shouldRenderSkeleton } from '@/lib/virtualTimeline';
+
+/** One rendered row: a render item plus its absolute offset when windowed. */
+export type RenderRow = {
+    item: TimelineItem;
+    index: number;
+    offsetTop: number | null;
+};
+
+/**
+ * A windowed jump can't know the true bottom up front: `scrollToEnd` aims at the
+ * bottom the virtualizer can see now, but each row measured as the animation
+ * passes it grows the list, so the target keeps moving. `finalizeJump` follows
+ * the animation to the bottom, then glues the view there frame by frame until both
+ * the measured height plateaus and the scroll goes quiet, so late measurements
+ * settle without a visible bounce.
+ *
+ * The glue releases on convergence, not a fixed frame count: it holds until the
+ * scroll height has been steady for `JUMP_SETTLE_FRAMES` consecutive frames *and*
+ * the container has stopped scrolling. A fixed budget let go too early on a slow
+ * render — while rows were still measuring, or while the glue's own `scrollTop`
+ * writes still counted as scrolling — so unsettled rows flipped in their scrub
+ * skeletons and the virtualizer's re-enabled size-change anchoring drifted the
+ * view below the fold: the timeline landing short of the newest message on initial
+ * open of a long list of tall rows (#500).
+ */
+const JUMP_SETTLE_FRAMES = 4;
+const JUMP_MAX_FRAMES = 180;
+
+export type TimelineWindow = {
+    /** Whether rows are being windowed right now (opted in, and mounted). */
+    virtualizeActive: ComputedRef<boolean>;
+    /** The virtual list's full height, spacing the absolutely-placed rows. */
+    totalSize: Ref<number>;
+    /** The rows to render: the whole list, or just the virtualizer's window. */
+    renderRows: ComputedRef<RenderRow[]>;
+    /** Function ref handing each rendered row to the virtualizer to measure. */
+    measureRow: ReturnType<typeof useTimelineVirtualizer>['measureRow'];
+    /** Whether a row should stand in as a height-stable scrub placeholder. */
+    showsSkeleton: (item: TimelineItem) => boolean;
+    /** Bring an off-screen row (a jump target, the unread boundary) into view. */
+    scrollToIndex: ReturnType<typeof useTimelineVirtualizer>['scrollToIndex'];
+    /** Scroll to the newest message, following it to the settled bottom. */
+    scrollToLatest: (behavior?: ScrollBehavior) => void;
+};
+
+/**
+ * Windowed rendering for the message timeline, and the jump-to-present that has
+ * to chase a bottom which moves as rows measure.
+ *
+ * Only the main channel timeline opts in (`virtualize`); the thread panel leaves
+ * the virtualizer idle (count 0) and renders every row. The virtualizer drives
+ * the parent's scroll container, keeping its real `scrollHeight`/`scrollTop` so
+ * the shared pin-to-bottom math is untouched. Windowing is client-only: the
+ * virtualizer needs a live scroll element and measured heights, neither of which
+ * exist during SSR. Rendering the full list on the server (and through first
+ * hydration) keeps server and client markup identical, then we switch to the
+ * window once mounted — a post-hydration re-render, not a mismatch.
+ */
+export function useTimelineWindow(options: {
+    /** The parent-owned scroll container the virtualizer drives. */
+    scrollElement: () => HTMLElement | null;
+    /** The flat, divider-interleaved render list being windowed. */
+    renderItems: ComputedRef<TimelineItem[]>;
+    /** Whether the consumer opts into windowing at all. */
+    virtualize: () => boolean;
+    hasOlder: () => boolean;
+    isLoadingOlder: () => boolean;
+    loadOlder: () => void;
+    /** Called whenever the visible render-item window changes. */
+    onRangeChange: (range: { startIndex: number; endIndex: number }) => void;
+}): TimelineWindow {
+    const isMounted = ref(false);
+
+    onMounted(() => {
+        isMounted.value = true;
+    });
+
+    const virtualizeActive = computed(
+        () => options.virtualize() && isMounted.value,
+    );
+
+    /**
+     * True while a deliberate jump-to-present is in flight. The scrub skeletons swap
+     * full message content for a fixed 56px placeholder, so measuring them mid-jump
+     * feeds the virtualizer short heights; when rows then swap to their taller real
+     * content the list grows and the animation is left stranded above the newest
+     * message — the "it stops when the skeleton loads" symptom (#347). While this is
+     * set, skeletons are suppressed so every row entering the window measures its
+     * real height, and the virtualizer's upward size-change anchoring is disabled so
+     * a row measured above the viewport can't drift us up as we settle on the bottom.
+     */
+    const jumpingToBottom = ref(false);
+
+    const {
+        virtualRows,
+        totalSize,
+        isScrolling,
+        range,
+        scrollToIndex,
+        scrollToEnd,
+        measureRow,
+    } = useTimelineVirtualizer({
+        scrollElement: computed(() => options.scrollElement()),
+        count: computed(() =>
+            virtualizeActive.value ? options.renderItems.value.length : 0,
+        ),
+        hasOlder: options.hasOlder,
+        isLoadingOlder: options.isLoadingOlder,
+        loadOlder: options.loadOlder,
+        // Suppress upward anchor adjustments while jumping to the bottom: there we
+        // want to stay glued to the newest message, not compensate an upper row.
+        isPinning: () => jumpingToBottom.value,
+    });
+
+    /**
+     * The rows to render: the full list when the thread panel renders it flat, or
+     * just the virtualizer's window (each carrying its absolute offset) for the main
+     * timeline.
+     */
+    const renderRows = computed<RenderRow[]>(() => {
+        if (!virtualizeActive.value) {
+            return options.renderItems.value.map((item, index) => ({
+                item,
+                index,
+                offsetTop: null,
+            }));
+        }
+
+        return virtualRows.value.map((row) => ({
+            item: options.renderItems.value[row.index],
+            index: row.index,
+            offsetTop: row.start,
+        }));
+    });
+
+    /**
+     * Render items whose height the virtualizer has already settled. A row is
+     * recorded once scrolling stops, so a fast scrub shows height-stable skeletons
+     * for rows it hasn't paused on, and they materialize the instant it settles.
+     */
+    const settledKeys = ref<Set<string>>(new Set());
+
+    /**
+     * Whether the container sits within the pinned threshold of the real bottom.
+     * A missing element counts as pinned, mirroring `useScrollPin`.
+     */
+    function isAtBottom(): boolean {
+        const el = options.scrollElement();
+
+        if (!el) {
+            return true;
+        }
+
+        return (
+            el.scrollHeight - el.scrollTop - el.clientHeight <=
+            NEAR_BOTTOM_THRESHOLD
+        );
+    }
+
+    watch(isScrolling, (scrolling) => {
+        if (scrolling) {
+            return;
+        }
+
+        for (const row of virtualRows.value) {
+            const item = options.renderItems.value[row.index];
+
+            if (item) {
+                settledKeys.value.add(item.key);
+            }
+        }
+    });
+
+    let jumpRaf: number | null = null;
+
+    /**
+     * Drive an in-flight jump-to-present all the way to the newest message.
+     *
+     * Phase one follows the scroll: while the virtualizer reports it's still
+     * scrolling the (possibly smooth) animation is running, so leave it be; only
+     * once it has stopped short — stalled on a skeleton-height estimate rather than
+     * the real bottom — snap the residual gap. Gating on the scrolling flag means an
+     * explicit `smooth` jump keeps animating instead of being force-converted to an
+     * instant snap. Once the bottom is reached, phase two pins `scrollTop` to the end
+     * every frame — so a row measured late (taller or shorter than its estimate)
+     * can't drift the view up or leave it short — and releases only once the measured
+     * height has settled (`bottomGlueSettled`) *and* the scroll has quiesced, rather
+     * than after a fixed budget that could expire mid-measurement and strand the view
+     * (#347, #500). Bounded by a frame budget so a list that never settles can't spin
+     * forever.
+     */
+    function finalizeJump(): void {
+        if (jumpRaf !== null) {
+            cancelAnimationFrame(jumpRaf);
+        }
+
+        let reachedBottom = false;
+        let stableFrames = 0;
+        // Sentinel so the first glue frame always registers as a change: the glue
+        // needs at least `JUMP_SETTLE_FRAMES` genuine same-height frames to release.
+        let lastHeight = -1;
+        let frames = 0;
+
+        const step = (): void => {
+            const el = options.scrollElement();
+
+            if (!el || !jumpingToBottom.value || frames >= JUMP_MAX_FRAMES) {
+                jumpingToBottom.value = false;
+                jumpRaf = null;
+
+                return;
+            }
+
+            frames += 1;
+
+            if (!reachedBottom) {
+                if (isAtBottom()) {
+                    reachedBottom = true;
+                } else if (!isScrolling.value) {
+                    // The scroll stopped short of the newest message; snap the gap
+                    // and let the newly measured rows re-target.
+                    scrollToEnd('auto');
+                }
+            } else {
+                // Glue to the bottom so late row measurements settle invisibly, and
+                // hold until the height stops moving — the true bottom has arrived.
+                el.scrollTop = el.scrollHeight;
+
+                const settle = bottomGlueSettled(
+                    el.scrollHeight,
+                    lastHeight,
+                    stableFrames,
+                    JUMP_SETTLE_FRAMES,
+                );
+                stableFrames = settle.stableFrames;
+                lastHeight = el.scrollHeight;
+
+                // Release only once the height has settled *and* the scroll has gone
+                // quiet. Letting go while `isScrolling` is still true (the glue's own
+                // `scrollTop` writes keep it set for ~150ms after the last change)
+                // would flip `jumpingToBottom` off mid-scroll, so unsettled rows render
+                // their 56px scrub skeletons — shrinking the content above the viewport
+                // and drifting the view up off the newest message (#347, #500). Waiting
+                // for the scroll to quiesce keeps skeletons suppressed until the view is
+                // safely at rest on the bottom.
+                if (settle.settled && !isScrolling.value) {
+                    jumpingToBottom.value = false;
+                    jumpRaf = null;
+
+                    return;
+                }
+            }
+
+            jumpRaf = requestAnimationFrame(step);
+        };
+
+        jumpRaf = requestAnimationFrame(step);
+    }
+
+    onUnmounted(() => {
+        if (jumpRaf !== null) {
+            cancelAnimationFrame(jumpRaf);
+        }
+    });
+
+    /**
+     * Whether a windowed group row should show its skeleton placeholder rather than
+     * its full content: only mid-scrub, never during a jump-to-present (measuring
+     * the placeholder height would strand the jump short), and only before the row
+     * has settled.
+     */
+    function showsSkeleton(item: TimelineItem): boolean {
+        return (
+            virtualizeActive.value &&
+            !jumpingToBottom.value &&
+            item.type === 'group' &&
+            shouldRenderSkeleton(
+                isScrolling.value,
+                settledKeys.value.has(item.key),
+            )
+        );
+    }
+
+    // Surface the visible window so the parent can drive the unread-jump pill.
+    watch(
+        () =>
+            range.value
+                ? `${range.value.startIndex}:${range.value.endIndex}`
+                : null,
+        () => {
+            if (range.value) {
+                options.onRangeChange({
+                    startIndex: range.value.startIndex,
+                    endIndex: range.value.endIndex,
+                });
+            }
+        },
+    );
+
+    /**
+     * Scroll to the newest message. When windowed, drive the virtualizer so it
+     * re-targets the real bottom as off-screen rows measure (a native
+     * `scrollTo(scrollHeight)` settles short on an estimated spacer, #347); when the
+     * list is rendered flat (the thread panel), `scrollHeight` is already exact, so
+     * scroll the container directly.
+     */
+    function scrollToLatest(behavior: ScrollBehavior = 'auto'): void {
+        if (virtualizeActive.value) {
+            // Suppress scrub skeletons for the whole jump so their fixed placeholder
+            // height can't strand the scroll short of the newest message (#347), then
+            // let `finalizeJump` watch the animation to the true bottom and release.
+            jumpingToBottom.value = true;
+            scrollToEnd(behavior);
+            finalizeJump();
+
+            return;
+        }
+
+        const el = options.scrollElement();
+
+        el?.scrollTo({ top: el.scrollHeight, behavior });
+    }
+
+    return {
+        virtualizeActive,
+        totalSize,
+        renderRows,
+        measureRow,
+        showsSkeleton,
+        scrollToIndex,
+        scrollToLatest,
+    };
+}


### PR DESCRIPTION
Closes #982. Second child of #980.

`MessageList.vue` goes from **1689 to 482 raw lines** — **1304 to 345** as
`max-lines` counts them, against the 400 cap. Its entry is gone from the
exemption block in `eslint.config.js`, so `max-lines-policy.test.ts` now holds
the file to the cap like any other.

The windowing, the jump/pin glue, the unread bookkeeping and every row's markup
shared one scope. They move out along the seams that were already there, script
half first — this was a composable-extraction job before it was a
component-extraction one.

## What moved

| New file | Lines | What it holds |
| --- | ---: | --- |
| `composables/useTimelineWindow.ts` | 186 | The virtualizer wiring, the render window, the scrub skeletons, and `finalizeJump` chasing a bottom that moves as rows measure (#347, #500) |
| `composables/useMessageActionSheet.ts` | 53 | The long-press sheet: which message it resolves, and the two ways it closes itself |
| `components/timeline/MessageRow.vue` | 239 | One message: the hover stamp, pin, quote, tombstone, cards, reactions, toolbar |
| `components/timeline/MessageBodyText.vue` | 133 | The body and the six segment kinds it tokenizes into |
| `components/timeline/ThreadSummary.vue` | 97 | The root's "N replies" affordance, facepile and unread dot |
| `components/timeline/MessageAvatarGutter.vue` | 91 | The avatar column, its presence dot and stacked time |
| `components/timeline/SeenByRow.vue` | 78 | The reader facepile and the roster it names |
| `components/timeline/MessageAuthorLine.vue` | 62 | The name, status emoji, bot badge and inline time |
| `components/timeline/MessageEditForm.vue` | 49 | The inline editor |
| `components/timeline/DeleteMessageDialog.vue` | 49 | The delete confirmation |
| `components/timeline/SystemNotice.vue` | 37 | The joined/left line, localized from its type |
| `components/timeline/MessageReplyQuote.vue` | 34 | The reply context button |
| `components/timeline/ThreadRepliesDivider.vue` | 32 | The rule under a thread root |
| `components/timeline/UnreadDivider.vue` | 24 | The "new" boundary |
| `components/timeline/MessageSkeleton.vue` | 16 | The height-stable scrub placeholder |
| `components/timeline/DayDivider.vue` | 15 | The day boundary |

The composables take their inputs as getters, matching the shape the sibling
composables here already use. Two structural notes: `MessageEditForm` owns its
own draft and textarea, so the timeline keeps only the id of the row being
edited (focus-on-open moves from a `nextTick` in the parent to `onMounted` in
the child — the same frame, the same behaviour); and `useMessageActionSheet`
takes the `canOpen` guard as a callback, so the viewer-context rules stay with
the component that owns the props they read.

## The move is provably a move

The first commit is **tests only, written against the untouched component**, so
their staying green across the second is the parity proof. Coverage was
non-existent exactly where the largest pieces were about to move: the timeline
had no vitest file at all, and every assertion about it lived in the browser
suite, which reaches the windowed scroll paths but not the markup of a row, a
divider, or the affordances hanging off them.

72 new cases across five files: `MessageList.timeline.test.ts` (21),
`MessageList.row.test.ts` (18), `MessageList.affordances.test.ts` (17),
`MessageList.editing.test.ts` (12), `MessageList.actionSheet.test.ts` (4).
Every `data-test` selector, string and guard is preserved verbatim, and
`lang/fr.json` is untouched.

## Testing

- `sail composer test` — `Total: 100.0 %`, clean Pint/PHPStan/Rector.
- `sail npm run lint:check` / `format:check` / `types:check` / `build` — clean.
- `sail npm run test:js` — 1882 passed, `max-lines-policy.test.ts` included.
- 79 browser assertions re-run against the split component, axe audits included:
  `A11yTimelineTest`, `A11yUserGroupsTest`, `A11yQuickReactionsTest`,
  `A11yEmojiOnboardingTest`, `TimelineInitialPinTest`, `TimelineUnreadPillTest`,
  `ThreadPanelVirtualizationTest`, `MobileMessageRowTest`,
  `MobileMessageActionsSheetTest`, `MobileThreadPanelTest`,
  `MobileComposerTrayTest`, `RealtimeMessagingTest`, `RealtimeEditDeleteTest`,
  `OfflineQueueRetryTest`, `ForwardUndoTest`, `ToastPositionTest`,
  `RemindersPanelTest`, `PollComposerPanelTest` — all green.

## Notes

A local CodeRabbit pass raised one finding, applied in the third commit: with
each body now in its own component the segment list is per-message state, so it
became a `computed` instead of a function the template re-invokes. The pass is
clean after it.

Every extracted source file is under the issue's ~260 target (largest:
`MessageRow.vue` at 239). The five parity test files run 222–328 as the rule
counts them — each is self-contained the way this repo's test files are, and
the preamble of mocks is what sets the floor; #1017's largest was 298.

No user-facing copy, config, or operator-facing behaviour changes, so no docs or
i18n updates apply.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787854147&installation_model_id=428379&pr_number=1018&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1018&signature=b769bc88255461a64f418622960c90a06171ec39b1b81c6f6b0302b28f44246f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->