### PR TITLE
refactor: split the workspace settings page into sections

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -262,7 +262,6 @@ export default defineConfigWithVueTs(
             'resources/js/pages/channels/Show.vue',
             'resources/js/pages/teams/Analytics.vue',
             'resources/js/pages/teams/AuditExports.vue',
-            'resources/js/pages/teams/Edit.vue',
             'resources/js/pages/teams/Groups.vue',
             'resources/js/pages/teams/integrations/Bot.vue',
             'resources/js/pages/teams/integrations/Index.vue',

--- a/resources/js/components/teams/AdminLinkCard.vue
+++ b/resources/js/components/teams/AdminLinkCard.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
+import type { InertiaLinkProps } from '@inertiajs/vue3';
+import { ChevronRight } from '@lucide/vue';
+import type { LucideIcon } from '@lucide/vue';
+
+defineProps<{
+    /** Where the card leads. */
+    href: NonNullable<InertiaLinkProps['href']>;
+    /** The card's leading glyph. */
+    icon: LucideIcon;
+    /** What the destination is called. */
+    title: string;
+    /** The one-line summary under the title. */
+    description: string;
+}>();
+</script>
+
+<template>
+    <Link
+        :href="href"
+        class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border"
+    >
+        <component :is="icon" class="h-4 w-4 shrink-0 text-brass" />
+        <div class="min-w-0">
+            <div class="text-sm font-semibold">
+                {{ title }}
+            </div>
+            <div class="truncate text-xs text-muted-foreground">
+                {{ description }}
+            </div>
+        </div>
+        <ChevronRight
+            class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
+        />
+    </Link>
+</template>

--- a/resources/js/components/teams/AdminLinks.vue
+++ b/resources/js/components/teams/AdminLinks.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
+import {
+    ChartColumn,
+    Download,
+    Plug,
+    ScrollText,
+    ShieldCheck,
+    SmilePlus,
+    Users,
+} from '@lucide/vue';
+import { computed } from 'vue';
+import AdminLinkCard from '@/components/teams/AdminLinkCard.vue';
+import { index as analyticsIndex } from '@/routes/teams/analytics';
+import { index as auditIndex } from '@/routes/teams/audit';
+import { index as auditExportsIndex } from '@/routes/teams/audit-exports';
+import { index as emojisIndex } from '@/routes/teams/emojis';
+import { index as groupsIndex } from '@/routes/teams/groups';
+import { index as integrationsIndex } from '@/routes/teams/integrations';
+import { index as securityLogIndex } from '@/routes/teams/security-log';
+import type { Team, TeamPermissions } from '@/types';
+
+const props = defineProps<{
+    /** The workspace every card is scoped to. */
+    team: Team;
+    /** What the viewer may reach from here. */
+    permissions: TeamPermissions;
+}>();
+
+const page = usePage();
+
+// The integrations card shows only for managers (Owner + Admin) and only while
+// the platform toggle is on, mirroring the route's own gating.
+const showIntegrationsLink = computed(
+    () =>
+        props.permissions.canManageIntegrations &&
+        page.props.integrationsEnabled,
+);
+</script>
+
+<template>
+    <!-- Custom emoji + admin links -->
+    <section
+        v-if="
+            permissions.canViewAnalytics ||
+            permissions.canViewAudit ||
+            permissions.canViewSecurityLog ||
+            permissions.canManageUserGroups ||
+            showIntegrationsLink
+        "
+        class="border-b border-border py-6"
+    >
+        <div class="grid gap-3 sm:grid-cols-2">
+            <AdminLinkCard
+                :href="emojisIndex(team.slug)"
+                :icon="SmilePlus"
+                :title="$t('Custom emoji')"
+                :description="$t('Named emoji for messages and reactions')"
+                data-test="manage-emoji-link"
+            />
+
+            <AdminLinkCard
+                v-if="permissions.canManageUserGroups"
+                :href="groupsIndex(team.slug)"
+                :icon="Users"
+                :title="$t('User groups')"
+                :description="$t('Mentionable aliases for a set of people')"
+                data-test="manage-groups-link"
+            />
+
+            <AdminLinkCard
+                v-if="showIntegrationsLink"
+                :href="integrationsIndex(team.slug)"
+                :icon="Plug"
+                :title="$t('Integrations')"
+                :description="$t('Bots, API tokens, and webhooks')"
+                data-test="manage-integrations-link"
+            />
+
+            <AdminLinkCard
+                v-if="permissions.canViewAnalytics"
+                :href="analyticsIndex(team.slug)"
+                :icon="ChartColumn"
+                :title="$t('Analytics')"
+                :description="$t('Activity, growth, busiest channels')"
+                data-test="view-analytics-link"
+            />
+
+            <AdminLinkCard
+                v-if="permissions.canViewAudit"
+                :href="auditIndex(team.slug)"
+                :icon="ScrollText"
+                :title="$t('Audit log')"
+                :description="$t('Moderation and admin actions')"
+                data-test="view-audit-log-link"
+            />
+
+            <AdminLinkCard
+                v-if="permissions.canViewSecurityLog"
+                :href="securityLogIndex(team.slug)"
+                :icon="ShieldCheck"
+                :title="$t('Security log')"
+                :description="$t('Sign-ins and credential changes')"
+                data-test="view-security-log-link"
+            />
+
+            <AdminLinkCard
+                v-if="
+                    permissions.canViewAudit || permissions.canViewSecurityLog
+                "
+                :href="auditExportsIndex(team.slug)"
+                :icon="Download"
+                :title="$t('Exports')"
+                :description="$t('Export the audit and security logs')"
+                data-test="view-audit-exports-link"
+            />
+        </div>
+    </section>
+
+    <!-- Emoji-only fallback for members without admin links -->
+    <section v-else class="border-b border-border py-6">
+        <AdminLinkCard
+            :href="emojisIndex(team.slug)"
+            :icon="SmilePlus"
+            :title="$t('Custom emoji')"
+            :description="$t('Named emoji for messages and reactions')"
+            data-test="manage-emoji-link"
+            class="sm:max-w-sm"
+        />
+    </section>
+</template>

--- a/resources/js/components/teams/DangerZone.vue
+++ b/resources/js/components/teams/DangerZone.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import DemoLock from '@/components/DemoLock.vue';
+import { Button } from '@/components/ui/button';
+
+defineEmits<{
+    /** The viewer asked to delete the team; the page confirms it in a dialog. */
+    delete: [];
+}>();
+</script>
+
+<template>
+    <section class="py-6">
+        <div class="mb-3">
+            <h2 class="font-serif text-lg font-semibold text-destructive-text">
+                {{ $t('Delete team') }}
+            </h2>
+            <p class="mt-0.5 max-w-xl text-sm text-muted-foreground">
+                {{
+                    $t(
+                        'Permanently delete this team and all of its data. This cannot be undone.',
+                    )
+                }}
+            </p>
+        </div>
+        <DemoLock v-slot="{ disabled }">
+            <Button
+                data-test="delete-team-button"
+                variant="outline"
+                class="rounded-full border-destructive/40 text-destructive-text hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive-text"
+                :disabled="disabled"
+                @click="$emit('delete')"
+                >{{ $t('Delete team…') }}</Button
+            >
+        </DemoLock>
+    </section>
+</template>

--- a/resources/js/components/teams/MemberRoster.vue
+++ b/resources/js/components/teams/MemberRoster.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { UserPlus } from '@lucide/vue';
+import MemberRow from '@/components/teams/MemberRow.vue';
+import { Button } from '@/components/ui/button';
+import type { RoleOption, TeamMember, TeamPermissions } from '@/types';
+
+const props = defineProps<{
+    /** Everyone who belongs to the workspace, owner included. */
+    members: TeamMember[];
+    /** The workspace slug, for each member's profile link. */
+    teamSlug: string;
+    /** The viewer's own user id, so their row can mark itself. */
+    currentUserId: string;
+    /** What the viewer may do to this roster. */
+    permissions: TeamPermissions;
+    /** The roles the viewer may assign, owner excluded. */
+    availableRoles: RoleOption[];
+}>();
+
+defineEmits<{
+    /** The viewer opened the invite dialog. */
+    invite: [];
+    /** The viewer picked a different role for a member. */
+    updateRole: [member: TeamMember, role: string];
+    /** The viewer asked to hand the team over to a member. */
+    transferOwnership: [member: TeamMember];
+    /** The viewer asked to remove a member from the team. */
+    remove: [member: TeamMember];
+}>();
+
+const isCurrentUser = (member: TeamMember): boolean =>
+    String(member.id) === props.currentUserId;
+</script>
+
+<template>
+    <!-- Team members. The id is the anchor the dock's workspace sheet links
+         its "Members" row at, so that row lands on the roster rather than at
+         the top of the page. -->
+    <section id="members" class="border-b border-border py-6">
+        <div class="mb-4 flex flex-wrap items-start gap-3">
+            <div class="min-w-0">
+                <h2 class="font-serif text-lg font-semibold">
+                    {{ $t('Team members') }}
+                    <span class="font-normal text-muted-foreground"
+                        >&middot; {{ members.length }}</span
+                    >
+                </h2>
+                <p class="mt-0.5 text-sm text-muted-foreground">
+                    {{
+                        $t(
+                            'Manage who belongs to this team and what they can do',
+                        )
+                    }}
+                </p>
+            </div>
+
+            <Button
+                v-if="permissions.canCreateInvitation"
+                class="ml-auto rounded-full"
+                data-test="invite-member-button"
+                @click="$emit('invite')"
+            >
+                <UserPlus /> {{ $t('Invite member') }}
+            </Button>
+        </div>
+
+        <div class="flex flex-col gap-2">
+            <MemberRow
+                v-for="member in members"
+                :key="member.id"
+                :member="member"
+                :team-slug="teamSlug"
+                :is-current-user="isCurrentUser(member)"
+                :permissions="permissions"
+                :available-roles="availableRoles"
+                @update-role="$emit('updateRole', member, $event)"
+                @transfer-ownership="$emit('transferOwnership', member)"
+                @remove="$emit('remove', member)"
+            />
+        </div>
+    </section>
+</template>

--- a/resources/js/components/teams/MemberRow.vue
+++ b/resources/js/components/teams/MemberRow.vue
@@ -1,0 +1,277 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
+import { Check, ChevronDown, Crown, X } from '@lucide/vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
+import { useDemoMode } from '@/composables/useDemoMode';
+import { useInitials } from '@/composables/useInitials';
+import { useTranslations } from '@/composables/useTranslations';
+import { show as showMember } from '@/routes/teams/members';
+import type {
+    RoleOption,
+    TeamMember,
+    TeamPermissions,
+    TeamRole,
+} from '@/types';
+
+defineProps<{
+    /** The member this row stands for. */
+    member: TeamMember;
+    /** The workspace slug, for the member's profile link. */
+    teamSlug: string;
+    /** Whether the row is the viewer's own membership. */
+    isCurrentUser: boolean;
+    /** What the viewer may do to this roster. */
+    permissions: TeamPermissions;
+    /** The roles the viewer may assign, owner excluded. */
+    availableRoles: RoleOption[];
+}>();
+
+defineEmits<{
+    /** The viewer picked a different role for this member. */
+    updateRole: [role: string];
+    /** The viewer asked to hand the team over to this member. */
+    transferOwnership: [];
+    /** The viewer asked to remove this member from the team. */
+    remove: [];
+}>();
+
+const { getInitials } = useInitials();
+const { t } = useTranslations();
+const { demoMode } = useDemoMode();
+
+/**
+ * The one-line description of what each assignable role can do, shown under the
+ * role name inside the role dropdown. Keyed by role so the copy stays with the
+ * permission it describes.
+ */
+const roleDescription = (role: TeamRole): string => {
+    switch (role) {
+        case 'admin':
+            return t('Can manage members, channels, and invitations');
+        case 'member':
+            return t('Can read and post in channels they belong to');
+        default:
+            return '';
+    }
+};
+</script>
+
+<template>
+    <div
+        data-test="member-row"
+        class="flex flex-wrap items-center gap-4 rounded-xl border border-border bg-card p-3.5 shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
+    >
+        <Avatar class="h-10 w-10 shrink-0">
+            <AvatarImage
+                v-if="member.avatar"
+                :src="member.avatar"
+                :alt="member.name"
+            />
+            <AvatarFallback
+                :class="
+                    member.role === 'owner'
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-muted text-muted-foreground'
+                "
+                class="text-xs font-semibold"
+                >{{ getInitials(member.name) }}</AvatarFallback
+            >
+        </Avatar>
+
+        <div class="min-w-0">
+            <Link
+                :href="showMember([teamSlug, member.id])"
+                class="font-semibold underline-offset-4 hover:underline"
+                data-test="member-profile-link"
+            >
+                {{ member.name }}
+                <span
+                    v-if="isCurrentUser"
+                    class="text-sm font-medium text-muted-foreground"
+                    >{{ $t('(you)') }}</span
+                >
+                <UserStatusEmoji
+                    :status="member.status"
+                    :name="member.name"
+                    class="align-[-1px] text-xs"
+                />
+            </Link>
+            <div
+                v-if="member.email"
+                class="truncate text-sm text-muted-foreground"
+            >
+                {{ member.email }}
+            </div>
+            <div
+                v-if="member.status?.text"
+                data-test="member-status-text"
+                class="truncate text-sm text-muted-foreground"
+            >
+                {{ member.status.text }}
+            </div>
+        </div>
+
+        <div class="ml-auto flex items-center gap-1.5">
+            <span
+                v-if="member.role === 'owner'"
+                class="inline-flex items-center gap-1.5 rounded-full border border-brass-border bg-brass-fill px-3 py-1 text-xs font-semibold text-brass-fill-foreground"
+            >
+                <Crown class="h-3 w-3 text-brass" />
+                {{ member.role_label }}
+            </span>
+
+            <DropdownMenu v-else-if="permissions.canUpdateMember">
+                <DropdownMenuTrigger as-child>
+                    <Button
+                        data-test="member-role-trigger"
+                        variant="outline"
+                        size="sm"
+                        class="rounded-full"
+                    >
+                        {{ member.role_label }}
+                        <ChevronDown class="ml-1 h-3.5 w-3.5 opacity-50" />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" class="w-64">
+                    <DropdownMenuItem
+                        v-for="role in availableRoles"
+                        :key="role.value"
+                        data-test="member-role-option"
+                        class="flex-col items-start gap-0.5"
+                        @click="$emit('updateRole', role.value)"
+                    >
+                        <span
+                            class="flex w-full items-center gap-1.5 font-medium"
+                        >
+                            {{ role.label }}
+                            <Check
+                                v-if="member.role === role.value"
+                                class="ml-auto h-3.5 w-3.5 text-brass"
+                            />
+                        </span>
+                        <span class="text-xs text-muted-foreground">
+                            {{ roleDescription(role.value) }}
+                        </span>
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+            <span
+                v-else
+                class="rounded-full border border-border px-3 py-1 text-xs font-semibold"
+            >
+                {{ member.role_label }}
+            </span>
+
+            <TooltipProvider
+                v-if="
+                    member.role !== 'owner' && permissions.canTransferOwnership
+                "
+            >
+                <Tooltip>
+                    <!-- Off the demo the tooltip triggers on the
+                         focusable button (keyboard + hover); in the
+                         demo the button is disabled, so a
+                         tabindex'd span carries the trigger to keep
+                         the reason reachable by keyboard. -->
+                    <TooltipTrigger v-if="demoMode" as-child>
+                        <span
+                            tabindex="0"
+                            class="inline-flex cursor-not-allowed"
+                        >
+                            <Button
+                                data-test="member-transfer-ownership-button"
+                                variant="ghost"
+                                size="icon"
+                                class="rounded-full text-muted-foreground"
+                                disabled
+                            >
+                                <Crown class="h-4 w-4" />
+                            </Button>
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipTrigger v-else as-child>
+                        <Button
+                            data-test="member-transfer-ownership-button"
+                            variant="ghost"
+                            size="icon"
+                            class="rounded-full text-muted-foreground"
+                            @click="$emit('transferOwnership')"
+                        >
+                            <Crown class="h-4 w-4" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        <p>
+                            {{
+                                demoMode
+                                    ? $t('Disabled in the demo')
+                                    : $t('Transfer ownership')
+                            }}
+                        </p>
+                    </TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
+
+            <TooltipProvider
+                v-if="member.role !== 'owner' && permissions.canRemoveMember"
+            >
+                <Tooltip>
+                    <!-- Same focusable-trigger split as the transfer
+                         button above: enabled button off the demo,
+                         tabindex'd span around the disabled button
+                         in the demo. -->
+                    <TooltipTrigger v-if="demoMode" as-child>
+                        <span
+                            tabindex="0"
+                            class="inline-flex cursor-not-allowed"
+                        >
+                            <Button
+                                data-test="member-remove-button"
+                                variant="ghost"
+                                size="icon"
+                                class="rounded-full text-muted-foreground"
+                                disabled
+                            >
+                                <X class="h-4 w-4" />
+                            </Button>
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipTrigger v-else as-child>
+                        <Button
+                            data-test="member-remove-button"
+                            variant="ghost"
+                            size="icon"
+                            class="rounded-full text-muted-foreground"
+                            @click="$emit('remove')"
+                        >
+                            <X class="h-4 w-4" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        <p>
+                            {{
+                                demoMode
+                                    ? $t('Disabled in the demo')
+                                    : $t('Remove member')
+                            }}
+                        </p>
+                    </TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/teams/PendingInvitations.vue
+++ b/resources/js/components/teams/PendingInvitations.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { Mail, Send, X } from '@lucide/vue';
+import { Button } from '@/components/ui/button';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { formatRelativeTime } from '@/lib/datetime';
+import type { TeamInvitation, TeamPermissions } from '@/types';
+
+defineProps<{
+    /** Invitations sent but not yet accepted. */
+    invitations: TeamInvitation[];
+    /** What the viewer may do to those invitations. */
+    permissions: TeamPermissions;
+}>();
+
+defineEmits<{
+    /** The viewer asked to send the invitation again. */
+    resend: [invitation: TeamInvitation];
+    /** The viewer asked to withdraw the invitation. */
+    cancel: [invitation: TeamInvitation];
+}>();
+</script>
+
+<template>
+    <section class="border-b border-border py-6">
+        <div class="mb-4">
+            <h2 class="font-serif text-lg font-semibold">
+                {{ $t('Pending invitations') }}
+                <span class="font-normal text-muted-foreground"
+                    >&middot; {{ invitations.length }}</span
+                >
+            </h2>
+            <p class="mt-0.5 text-sm text-muted-foreground">
+                {{ $t('Sent but not yet accepted. They expire after 3 days') }}
+            </p>
+        </div>
+
+        <div class="flex flex-col gap-2">
+            <div
+                v-for="invitation in invitations"
+                :key="invitation.code"
+                data-test="invitation-row"
+                class="flex flex-wrap items-center gap-4 rounded-xl border border-dashed border-border bg-muted/30 p-3.5"
+            >
+                <div
+                    class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted"
+                >
+                    <Mail class="h-5 w-5 text-muted-foreground" />
+                </div>
+
+                <div class="min-w-0">
+                    <div class="truncate font-semibold text-muted-foreground">
+                        {{ invitation.email }}
+                    </div>
+                    <div class="text-sm text-muted-foreground">
+                        {{
+                            $t('Invited as :role · :time', {
+                                role: invitation.role_label,
+                                time: formatRelativeTime(invitation.created_at),
+                            })
+                        }}
+                    </div>
+                </div>
+
+                <div class="ml-auto flex items-center gap-1.5">
+                    <Button
+                        v-if="permissions.canCreateInvitation"
+                        data-test="invitation-resend-button"
+                        variant="outline"
+                        size="sm"
+                        class="rounded-full"
+                        @click="$emit('resend', invitation)"
+                    >
+                        <Send class="h-3.5 w-3.5" /> {{ $t('Resend') }}
+                    </Button>
+
+                    <TooltipProvider v-if="permissions.canCancelInvitation">
+                        <Tooltip>
+                            <TooltipTrigger as-child>
+                                <Button
+                                    data-test="invitation-cancel-button"
+                                    variant="ghost"
+                                    size="icon"
+                                    class="rounded-full text-muted-foreground"
+                                    @click="$emit('cancel', invitation)"
+                                >
+                                    <X class="h-4 w-4" />
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                <p>{{ $t('Cancel invitation') }}</p>
+                            </TooltipContent>
+                        </Tooltip>
+                    </TooltipProvider>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>

--- a/resources/js/components/teams/SettingsHeader.vue
+++ b/resources/js/components/teams/SettingsHeader.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
+import { ChevronRight, Crown } from '@lucide/vue';
+import { computed } from 'vue';
+import { index } from '@/routes/teams';
+import type { Team } from '@/types';
+
+const props = defineProps<{
+    /** The workspace whose settings are on screen. */
+    team: Team;
+}>();
+
+const isOwner = computed(() => props.team.role === 'owner');
+</script>
+
+<template>
+    <!-- Page header. Below the breakpoint the pushed screen's own header
+         already carries the trail and the team name, so only the ownership
+         badge survives there. -->
+    <header class="border-b border-border pb-6 max-md:border-0 max-md:pb-0">
+        <nav
+            class="hidden items-center gap-1.5 text-xs text-muted-foreground md:flex"
+            :aria-label="$t('breadcrumb')"
+        >
+            <Link :href="index()" class="hover:text-foreground">
+                {{ $t('Teams') }}
+            </Link>
+            <ChevronRight class="h-3 w-3 opacity-60" />
+            <span class="font-medium text-foreground/70">{{ team.name }}</span>
+        </nav>
+
+        <div class="flex flex-wrap items-end gap-3 md:mt-2">
+            <div class="min-w-0 max-md:hidden">
+                <h1 class="font-serif text-3xl font-semibold tracking-tight">
+                    {{ team.name }}
+                </h1>
+                <p class="mt-1 text-sm text-muted-foreground">
+                    {{ $t("Manage this team's name, members, and ownership") }}
+                </p>
+            </div>
+
+            <span
+                v-if="isOwner"
+                class="ml-auto inline-flex items-center gap-1.5 rounded-full border border-brass-border bg-brass-fill px-3 py-1 text-[11px] font-semibold tracking-wide text-brass-fill-foreground uppercase"
+            >
+                <Crown class="h-3 w-3 text-brass" />
+                {{ $t('You own this team') }}
+            </span>
+        </div>
+    </header>
+</template>

--- a/resources/js/components/teams/TeamNameForm.vue
+++ b/resources/js/components/teams/TeamNameForm.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { Form } from '@inertiajs/vue3';
+import DemoLock from '@/components/DemoLock.vue';
+import FormField from '@/components/FormField.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { update } from '@/routes/teams';
+import type { Team } from '@/types';
+
+defineProps<{
+    /** The workspace being renamed; also the form's route parameter. */
+    team: Team;
+}>();
+</script>
+
+<template>
+    <section class="border-b border-border py-6">
+        <div class="mb-4">
+            <h2 class="font-serif text-lg font-semibold">
+                {{ $t('Team name') }}
+            </h2>
+            <p class="mt-0.5 text-sm text-muted-foreground">
+                {{ $t('Shown in the team switcher and on invitations') }}
+            </p>
+        </div>
+
+        <Form v-bind="update.form(team.slug)" v-slot="{ errors, processing }">
+            <div class="flex flex-wrap items-start gap-3">
+                <!-- The section heading above already reads "Team name", so
+                     the field's own label is hidden rather than repeated.
+                     It stays a real `<label for>` all the same: it names
+                     the control for assistive tech and voice control, and
+                     it focuses the input when clicked. -->
+                <FormField
+                    id="name"
+                    :label="$t('Team name')"
+                    label-class="sr-only"
+                    :error="errors.name"
+                    class="w-full max-w-sm"
+                    v-slot="{ id }"
+                >
+                    <Input
+                        :id="id"
+                        name="name"
+                        data-test="team-name-input"
+                        :default-value="team.name"
+                        class="rounded-lg"
+                        required
+                    />
+                </FormField>
+
+                <DemoLock v-slot="{ disabled }">
+                    <Button
+                        type="submit"
+                        class="rounded-full px-6"
+                        data-test="team-save-button"
+                        :disabled="processing || disabled"
+                    >
+                        {{ $t('Save') }}
+                    </Button>
+                </DemoLock>
+            </div>
+        </Form>
+    </section>
+</template>

--- a/resources/js/pages/teams/Edit.invitations.test.ts
+++ b/resources/js/pages/teams/Edit.invitations.test.ts
@@ -1,0 +1,394 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import { translate } from '@/lib/i18n';
+import type {
+    RoleOption,
+    Team,
+    TeamInvitation,
+    TeamPermissions,
+} from '@/types';
+
+/**
+ * Covers the two sections at the bottom of the workspace settings page —
+ * pending invitations and the danger zone — plus the dialogs the page mounts
+ * for them. Both are permission-gated and demo-locked, and both survive the
+ * split of `pages/teams/Edit.vue` unchanged, so the selectors and the requests
+ * are pinned here.
+ */
+const pageProps = vi.hoisted(() => ({
+    auth: { user: { id: 'me' } },
+    integrationsEnabled: true,
+    demoMode: false,
+}));
+
+const visit = vi.hoisted(() => vi.fn());
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: pageProps }),
+    router: { visit },
+    Head: defineComponent({
+        props: { title: { type: String, default: '' } },
+        setup: (props) => () =>
+            h('div', { 'data-stub': 'Head', 'data-title': props.title }),
+    }),
+    Link: defineComponent({
+        props: { href: { type: String, default: '' } },
+        setup:
+            (props, { slots }) =>
+            () =>
+                h('a', { href: props.href }, slots.default?.()),
+    }),
+    Form: defineComponent({
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('form', slots.default?.({ errors: {}, processing: false })),
+    }),
+}));
+
+vi.mock('@lucide/vue', () => ({
+    ChartColumn: { render: () => h('svg') },
+    Check: { render: () => h('svg') },
+    ChevronDown: { render: () => h('svg') },
+    ChevronRight: { render: () => h('svg') },
+    Crown: { render: () => h('svg') },
+    Download: { render: () => h('svg') },
+    Mail: { render: () => h('svg', { 'data-stub': 'Mail' }) },
+    Plug: { render: () => h('svg') },
+    ScrollText: { render: () => h('svg') },
+    Send: { render: () => h('svg') },
+    ShieldCheck: { render: () => h('svg') },
+    SmilePlus: { render: () => h('svg') },
+    UserPlus: { render: () => h('svg') },
+    Users: { render: () => h('svg') },
+    X: { render: () => h('svg') },
+}));
+
+vi.mock('@/routes/teams', () => ({
+    edit: (slug: string) => `/teams/${slug}/edit`,
+    index: () => '/teams',
+    update: { form: (slug: string) => ({ action: `/teams/${slug}` }) },
+}));
+
+vi.mock('@/routes/teams/analytics', () => ({ index: () => '/analytics' }));
+vi.mock('@/routes/teams/audit', () => ({ index: () => '/audit' }));
+vi.mock('@/routes/teams/audit-exports', () => ({ index: () => '/exports' }));
+vi.mock('@/routes/teams/emojis', () => ({ index: () => '/emojis' }));
+vi.mock('@/routes/teams/groups', () => ({ index: () => '/groups' }));
+vi.mock('@/routes/teams/integrations', () => ({
+    index: () => '/integrations',
+}));
+vi.mock('@/routes/teams/invitations', () => ({
+    resend: ([slug, code]: [string, string]) =>
+        `/teams/${slug}/invitations/${code}/resend`,
+}));
+vi.mock('@/routes/teams/members', () => ({
+    show: ([slug, id]: [string, string]) => `/teams/${slug}/members/${id}`,
+    update: ([slug, id]: [string, string]) => `/teams/${slug}/members/${id}`,
+}));
+vi.mock('@/routes/teams/security-log', () => ({ index: () => '/security' }));
+
+vi.mock('@/lib/datetime', () => ({
+    formatRelativeTime: () => '2 hours ago',
+}));
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+function passthrough(tag = 'div') {
+    return defineComponent({
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h(tag, slots.default?.()),
+    });
+}
+
+/** Stands in for a dialog, reporting whether the page asked it to open. */
+function modalStub(name: string) {
+    return defineComponent({
+        name,
+        props: { open: { type: Boolean, default: false } },
+        setup: (props) => () =>
+            h('div', {
+                'data-stub': name,
+                'data-open': String(props.open),
+            }),
+    });
+}
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: passthrough(),
+    DropdownMenuTrigger: passthrough(),
+    DropdownMenuContent: passthrough(),
+    DropdownMenuItem: passthrough('button'),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+    Tooltip: passthrough(),
+    TooltipProvider: passthrough(),
+    TooltipTrigger: passthrough(),
+    TooltipContent: passthrough(),
+}));
+
+vi.mock('@/components/ui/avatar', () => ({
+    Avatar: passthrough(),
+    AvatarImage: passthrough('img'),
+    AvatarFallback: passthrough('span'),
+}));
+
+vi.mock('@/components/UserStatusEmoji.vue', () => ({
+    default: defineComponent({
+        setup: () => () => h('span', { 'data-stub': 'UserStatusEmoji' }),
+    }),
+}));
+
+vi.mock('@/components/InviteMemberModal.vue', () => ({
+    default: modalStub('InviteMemberModal'),
+}));
+vi.mock('@/components/RemoveMemberModal.vue', () => ({
+    default: modalStub('RemoveMemberModal'),
+}));
+vi.mock('@/components/TransferOwnershipModal.vue', () => ({
+    default: modalStub('TransferOwnershipModal'),
+}));
+vi.mock('@/components/CancelInvitationModal.vue', () => ({
+    default: modalStub('CancelInvitationModal'),
+}));
+vi.mock('@/components/DeleteTeamModal.vue', () => ({
+    default: modalStub('DeleteTeamModal'),
+}));
+
+import Edit from './Edit.vue';
+
+function team(overrides: Partial<Team> = {}): Team {
+    return {
+        id: 't-1',
+        name: 'Acme Corp',
+        slug: 'acme',
+        isPersonal: false,
+        role: 'owner',
+        membersCount: 1,
+        unreadCount: 0,
+        mentionCount: 0,
+        ...overrides,
+    };
+}
+
+function invitation(overrides: Partial<TeamInvitation> = {}): TeamInvitation {
+    return {
+        code: 'inv-1',
+        email: 'grace@example.com',
+        role: 'member',
+        role_label: 'Member',
+        created_at: '2024-03-04T10:30:00.000Z',
+        ...overrides,
+    };
+}
+
+function permissions(
+    overrides: Partial<TeamPermissions> = {},
+): TeamPermissions {
+    return {
+        canUpdateTeam: true,
+        canDeleteTeam: true,
+        canAddMember: true,
+        canUpdateMember: true,
+        canRemoveMember: true,
+        canCreateInvitation: true,
+        canCancelInvitation: true,
+        canTransferOwnership: true,
+        canViewAudit: true,
+        canViewSecurityLog: true,
+        canViewAnalytics: true,
+        canManageIntegrations: true,
+        canManageUserGroups: true,
+        ...overrides,
+    };
+}
+
+const availableRoles: RoleOption[] = [{ value: 'member', label: 'Member' }];
+
+let app: App | null = null;
+
+function mount(props: Record<string, unknown> = {}) {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    app = createApp({
+        render: () =>
+            h(Edit, {
+                team: team(),
+                members: [],
+                invitations: [invitation()],
+                permissions: permissions(),
+                availableRoles,
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+
+    return host;
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function all(host: HTMLElement, selector: string): HTMLElement[] {
+    return [...host.querySelectorAll<HTMLElement>(`[data-test="${selector}"]`)];
+}
+
+function stub(host: HTMLElement, name: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-stub="${name}"]`);
+}
+
+beforeEach(() => {
+    pageProps.auth.user.id = 'me';
+    pageProps.integrationsEnabled = true;
+    pageProps.demoMode = false;
+    visit.mockClear();
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('pending invitations', () => {
+    it('counts them beside the heading and names each invitee', () => {
+        const host = mount({
+            invitations: [
+                invitation(),
+                invitation({ code: 'inv-2', email: 'alan@example.com' }),
+            ],
+        });
+
+        expect(all(host, 'invitation-row')).toHaveLength(2);
+        expect(host.textContent).toContain('Pending invitations');
+        expect(find(host, 'invitation-row')?.textContent).toContain(
+            'grace@example.com',
+        );
+    });
+
+    it('reads out the role and how long ago it was sent', () => {
+        const host = mount();
+
+        expect(find(host, 'invitation-row')?.textContent).toContain(
+            'Invited as Member · 2 hours ago',
+        );
+    });
+
+    it('drops the whole section when nothing is pending', () => {
+        const host = mount({ invitations: [] });
+
+        expect(find(host, 'invitation-row')).toBeNull();
+        expect(host.textContent).not.toContain('Pending invitations');
+    });
+
+    it('resends an invitation without losing the scroll position', () => {
+        const host = mount();
+
+        find(host, 'invitation-resend-button')?.click();
+
+        expect(visit).toHaveBeenCalledWith(
+            '/teams/acme/invitations/inv-1/resend',
+            { preserveScroll: true },
+        );
+    });
+
+    it('offers resend only to someone who may invite', () => {
+        const host = mount({
+            permissions: permissions({ canCreateInvitation: false }),
+        });
+
+        expect(find(host, 'invitation-resend-button')).toBeNull();
+    });
+
+    it('opens the cancellation dialog from the cross', async () => {
+        const host = mount();
+
+        expect(stub(host, 'CancelInvitationModal')?.dataset.open).toBe('false');
+
+        find(host, 'invitation-cancel-button')?.click();
+        await Promise.resolve();
+
+        expect(stub(host, 'CancelInvitationModal')?.dataset.open).toBe('true');
+    });
+
+    it('offers cancellation only to someone who may cancel', () => {
+        const host = mount({
+            permissions: permissions({ canCancelInvitation: false }),
+        });
+
+        expect(find(host, 'invitation-cancel-button')).toBeNull();
+    });
+});
+
+describe('the danger zone', () => {
+    it('offers deletion to an owner of a real team', () => {
+        const host = mount();
+
+        expect(find(host, 'delete-team-button')).not.toBeNull();
+        expect(host.textContent).toContain(
+            'Permanently delete this team and all of its data. This cannot be undone.',
+        );
+    });
+
+    it('withholds it from someone who may not delete the team', () => {
+        const host = mount({
+            permissions: permissions({ canDeleteTeam: false }),
+        });
+
+        expect(find(host, 'delete-team-button')).toBeNull();
+        expect(stub(host, 'DeleteTeamModal')).toBeNull();
+    });
+
+    it('withholds it on a personal team', () => {
+        const host = mount({ team: team({ isPersonal: true }) });
+
+        expect(find(host, 'delete-team-button')).toBeNull();
+        expect(stub(host, 'DeleteTeamModal')).toBeNull();
+    });
+
+    it('opens the deletion dialog from the button', async () => {
+        const host = mount();
+
+        find(host, 'delete-team-button')?.click();
+        await Promise.resolve();
+
+        expect(stub(host, 'DeleteTeamModal')?.dataset.open).toBe('true');
+    });
+
+    it('locks the button in the demo and says why', () => {
+        pageProps.demoMode = true;
+
+        const host = mount();
+
+        expect(find(host, 'delete-team-button')?.hasAttribute('disabled')).toBe(
+            true,
+        );
+        expect(find(host, 'demo-lock')).not.toBeNull();
+        expect(host.textContent).toContain('Disabled in the demo');
+    });
+});
+
+describe('the dialogs the page mounts', () => {
+    it('leaves the invite dialog out for someone who may not invite', () => {
+        const host = mount({
+            permissions: permissions({ canCreateInvitation: false }),
+        });
+
+        expect(stub(host, 'InviteMemberModal')).toBeNull();
+    });
+
+    it('always mounts the member and invitation dialogs', () => {
+        const host = mount();
+
+        expect(stub(host, 'RemoveMemberModal')).not.toBeNull();
+        expect(stub(host, 'TransferOwnershipModal')).not.toBeNull();
+        expect(stub(host, 'CancelInvitationModal')).not.toBeNull();
+    });
+});

--- a/resources/js/pages/teams/Edit.members.test.ts
+++ b/resources/js/pages/teams/Edit.members.test.ts
@@ -1,0 +1,475 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { RoleOption, Team, TeamMember, TeamPermissions } from '@/types';
+
+/**
+ * Covers the member roster on the workspace settings page: the row itself, the
+ * role dropdown, and the two owner-level affordances riding beside it. These
+ * move together when `pages/teams/Edit.vue` is split, so what is pinned here is
+ * the rendered markup — every selector, every permission guard deciding whether
+ * a control renders at all, and the request each one sends.
+ */
+const pageProps = vi.hoisted(() => ({
+    auth: { user: { id: 'me' } },
+    integrationsEnabled: true,
+    demoMode: false,
+}));
+
+const visit = vi.hoisted(() => vi.fn());
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: pageProps }),
+    router: { visit },
+    Head: defineComponent({
+        props: { title: { type: String, default: '' } },
+        setup: (props) => () =>
+            h('div', { 'data-stub': 'Head', 'data-title': props.title }),
+    }),
+    Link: defineComponent({
+        props: { href: { type: String, default: '' } },
+        setup:
+            (props, { slots }) =>
+            () =>
+                h('a', { href: props.href }, slots.default?.()),
+    }),
+    Form: defineComponent({
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('form', slots.default?.({ errors: {}, processing: false })),
+    }),
+}));
+
+vi.mock('@lucide/vue', () => ({
+    ChartColumn: { render: () => h('svg') },
+    Check: { render: () => h('svg', { 'data-stub': 'Check' }) },
+    ChevronDown: { render: () => h('svg') },
+    ChevronRight: { render: () => h('svg') },
+    Crown: { render: () => h('svg') },
+    Download: { render: () => h('svg') },
+    Mail: { render: () => h('svg') },
+    Plug: { render: () => h('svg') },
+    ScrollText: { render: () => h('svg') },
+    Send: { render: () => h('svg') },
+    ShieldCheck: { render: () => h('svg') },
+    SmilePlus: { render: () => h('svg') },
+    UserPlus: { render: () => h('svg') },
+    Users: { render: () => h('svg') },
+    X: { render: () => h('svg') },
+}));
+
+vi.mock('@/routes/teams', () => ({
+    edit: (slug: string) => `/teams/${slug}/edit`,
+    index: () => '/teams',
+    update: { form: (slug: string) => ({ action: `/teams/${slug}` }) },
+}));
+
+vi.mock('@/routes/teams/analytics', () => ({ index: () => '/analytics' }));
+vi.mock('@/routes/teams/audit', () => ({ index: () => '/audit' }));
+vi.mock('@/routes/teams/audit-exports', () => ({ index: () => '/exports' }));
+vi.mock('@/routes/teams/emojis', () => ({ index: () => '/emojis' }));
+vi.mock('@/routes/teams/groups', () => ({ index: () => '/groups' }));
+vi.mock('@/routes/teams/integrations', () => ({
+    index: () => '/integrations',
+}));
+vi.mock('@/routes/teams/invitations', () => ({
+    resend: ([slug, code]: [string, string]) =>
+        `/teams/${slug}/invitations/${code}/resend`,
+}));
+vi.mock('@/routes/teams/members', () => ({
+    show: ([slug, id]: [string, string]) => `/teams/${slug}/members/${id}`,
+    update: ([slug, id]: [string, string]) => `/teams/${slug}/members/${id}`,
+}));
+vi.mock('@/routes/teams/security-log', () => ({ index: () => '/security' }));
+
+vi.mock('@/lib/datetime', () => ({
+    formatRelativeTime: () => '2 hours ago',
+}));
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+function passthrough(tag = 'div') {
+    return defineComponent({
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h(tag, slots.default?.()),
+    });
+}
+
+/** Stands in for a dialog, reporting whether the page asked it to open. */
+function modalStub(name: string) {
+    return defineComponent({
+        name,
+        props: { open: { type: Boolean, default: false } },
+        setup: (props) => () =>
+            h('div', {
+                'data-stub': name,
+                'data-open': String(props.open),
+            }),
+    });
+}
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: passthrough(),
+    DropdownMenuTrigger: passthrough(),
+    DropdownMenuContent: passthrough(),
+    DropdownMenuItem: passthrough('button'),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+    Tooltip: passthrough(),
+    TooltipProvider: passthrough(),
+    TooltipTrigger: passthrough(),
+    TooltipContent: passthrough(),
+}));
+
+vi.mock('@/components/ui/avatar', () => ({
+    Avatar: passthrough(),
+    AvatarImage: defineComponent({
+        props: { src: { type: String, default: '' } },
+        setup: (props) => () =>
+            h('img', { 'data-stub': 'AvatarImage', src: props.src }),
+    }),
+    AvatarFallback: passthrough('span'),
+}));
+
+vi.mock('@/components/UserStatusEmoji.vue', () => ({
+    default: defineComponent({
+        setup: () => () => h('span', { 'data-stub': 'UserStatusEmoji' }),
+    }),
+}));
+
+vi.mock('@/components/InviteMemberModal.vue', () => ({
+    default: modalStub('InviteMemberModal'),
+}));
+vi.mock('@/components/RemoveMemberModal.vue', () => ({
+    default: modalStub('RemoveMemberModal'),
+}));
+vi.mock('@/components/TransferOwnershipModal.vue', () => ({
+    default: modalStub('TransferOwnershipModal'),
+}));
+vi.mock('@/components/CancelInvitationModal.vue', () => ({
+    default: modalStub('CancelInvitationModal'),
+}));
+vi.mock('@/components/DeleteTeamModal.vue', () => ({
+    default: modalStub('DeleteTeamModal'),
+}));
+
+import Edit from './Edit.vue';
+
+function team(overrides: Partial<Team> = {}): Team {
+    return {
+        id: 't-1',
+        name: 'Acme Corp',
+        slug: 'acme',
+        isPersonal: false,
+        role: 'owner',
+        membersCount: 2,
+        unreadCount: 0,
+        mentionCount: 0,
+        ...overrides,
+    };
+}
+
+function member(overrides: Partial<TeamMember> = {}): TeamMember {
+    return {
+        id: 'm-1',
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        avatar: null,
+        role: 'member',
+        role_label: 'Member',
+        status: null,
+        ...overrides,
+    };
+}
+
+function permissions(
+    overrides: Partial<TeamPermissions> = {},
+): TeamPermissions {
+    return {
+        canUpdateTeam: true,
+        canDeleteTeam: true,
+        canAddMember: true,
+        canUpdateMember: true,
+        canRemoveMember: true,
+        canCreateInvitation: true,
+        canCancelInvitation: true,
+        canTransferOwnership: true,
+        canViewAudit: true,
+        canViewSecurityLog: true,
+        canViewAnalytics: true,
+        canManageIntegrations: true,
+        canManageUserGroups: true,
+        ...overrides,
+    };
+}
+
+const availableRoles: RoleOption[] = [
+    { value: 'admin', label: 'Admin' },
+    { value: 'member', label: 'Member' },
+];
+
+let app: App | null = null;
+
+function mount(props: Record<string, unknown> = {}) {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    app = createApp({
+        render: () =>
+            h(Edit, {
+                team: team(),
+                members: [member()],
+                invitations: [],
+                permissions: permissions(),
+                availableRoles,
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+
+    return host;
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function all(host: HTMLElement, selector: string): HTMLElement[] {
+    return [...host.querySelectorAll<HTMLElement>(`[data-test="${selector}"]`)];
+}
+
+function stub(host: HTMLElement, name: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-stub="${name}"]`);
+}
+
+beforeEach(() => {
+    pageProps.auth.user.id = 'me';
+    pageProps.integrationsEnabled = true;
+    pageProps.demoMode = false;
+    visit.mockClear();
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('the roster', () => {
+    it('counts the members beside the heading', () => {
+        const host = mount({
+            members: [member(), member({ id: 'm-2', name: 'Grace Hopper' })],
+        });
+
+        expect(all(host, 'member-row')).toHaveLength(2);
+        expect(host.textContent).toContain('Team members');
+        expect(host.textContent).toContain('2');
+    });
+
+    it('links each member to their profile and marks the viewer', () => {
+        const host = mount({
+            members: [member({ id: 'me', name: 'Ada Lovelace' })],
+        });
+
+        const link = find(host, 'member-profile-link');
+
+        expect(link?.getAttribute('href')).toBe('/teams/acme/members/me');
+        expect(link?.textContent).toContain('(you)');
+    });
+
+    it('leaves the viewer marker off everybody else', () => {
+        const host = mount();
+
+        expect(find(host, 'member-profile-link')?.textContent).not.toContain(
+            '(you)',
+        );
+    });
+
+    it('shows the avatar image when the member has one', () => {
+        const host = mount({
+            members: [member({ avatar: '/avatars/ada.png' })],
+        });
+
+        expect(stub(host, 'AvatarImage')?.getAttribute('src')).toBe(
+            '/avatars/ada.png',
+        );
+    });
+
+    it('falls back to the initials when the member has no avatar', () => {
+        const host = mount();
+
+        expect(stub(host, 'AvatarImage')).toBeNull();
+        expect(find(host, 'member-row')?.textContent).toContain('AL');
+    });
+
+    it('renders the email and the live status text', () => {
+        const host = mount({
+            members: [
+                member({
+                    status: {
+                        emoji: '🌴',
+                        text: 'On leave',
+                    } as TeamMember['status'],
+                }),
+            ],
+        });
+
+        expect(find(host, 'member-row')?.textContent).toContain(
+            'ada@example.com',
+        );
+        expect(find(host, 'member-status-text')?.textContent?.trim()).toBe(
+            'On leave',
+        );
+    });
+
+    it('leaves the status line out when the member has none', () => {
+        const host = mount();
+
+        expect(find(host, 'member-status-text')).toBeNull();
+    });
+
+    it('offers the invite button to someone who may invite', () => {
+        expect(find(mount(), 'invite-member-button')).not.toBeNull();
+    });
+
+    it('withholds the invite button from everyone else', () => {
+        const host = mount({
+            permissions: permissions({ canCreateInvitation: false }),
+        });
+
+        expect(find(host, 'invite-member-button')).toBeNull();
+    });
+
+    it('opens the invite dialog from the button', async () => {
+        const host = mount();
+
+        expect(stub(host, 'InviteMemberModal')?.dataset.open).toBe('false');
+
+        find(host, 'invite-member-button')?.click();
+        await Promise.resolve();
+
+        expect(stub(host, 'InviteMemberModal')?.dataset.open).toBe('true');
+    });
+});
+
+describe('the role control', () => {
+    it('badges the owner rather than offering them a role menu', () => {
+        const host = mount({
+            members: [member({ role: 'owner', role_label: 'Owner' })],
+        });
+
+        expect(find(host, 'member-role-trigger')).toBeNull();
+        expect(find(host, 'member-row')?.textContent).toContain('Owner');
+    });
+
+    it('lists every assignable role with its description', () => {
+        const host = mount();
+
+        const options = all(host, 'member-role-option');
+
+        expect(options).toHaveLength(2);
+        expect(options[0].textContent).toContain('Admin');
+        expect(options[0].textContent).toContain(
+            'Can manage members, channels, and invitations',
+        );
+        expect(options[1].textContent).toContain(
+            'Can read and post in channels they belong to',
+        );
+    });
+
+    it('ticks the role the member already holds', () => {
+        const host = mount();
+
+        const options = all(host, 'member-role-option');
+
+        expect(options[0].querySelector('[data-stub="Check"]')).toBeNull();
+        expect(options[1].querySelector('[data-stub="Check"]')).not.toBeNull();
+    });
+
+    it('sends the new role and keeps the scroll position', () => {
+        const host = mount();
+
+        all(host, 'member-role-option')[0].click();
+
+        expect(visit).toHaveBeenCalledWith('/teams/acme/members/m-1', {
+            data: { role: 'admin' },
+            preserveScroll: true,
+        });
+    });
+
+    it('renders a plain label for someone who may not change roles', () => {
+        const host = mount({
+            permissions: permissions({ canUpdateMember: false }),
+        });
+
+        expect(find(host, 'member-role-trigger')).toBeNull();
+        expect(find(host, 'member-row')?.textContent).toContain('Member');
+    });
+});
+
+describe('the owner-level affordances', () => {
+    it('offers transfer and removal on a non-owner row', () => {
+        const host = mount();
+
+        expect(find(host, 'member-transfer-ownership-button')).not.toBeNull();
+        expect(find(host, 'member-remove-button')).not.toBeNull();
+    });
+
+    it('offers neither on the owner row', () => {
+        const host = mount({
+            members: [member({ role: 'owner', role_label: 'Owner' })],
+        });
+
+        expect(find(host, 'member-transfer-ownership-button')).toBeNull();
+        expect(find(host, 'member-remove-button')).toBeNull();
+    });
+
+    it('withholds each control from someone lacking the permission', () => {
+        const host = mount({
+            permissions: permissions({
+                canTransferOwnership: false,
+                canRemoveMember: false,
+            }),
+        });
+
+        expect(find(host, 'member-transfer-ownership-button')).toBeNull();
+        expect(find(host, 'member-remove-button')).toBeNull();
+    });
+
+    it('opens the transfer dialog from the crown', async () => {
+        const host = mount();
+
+        find(host, 'member-transfer-ownership-button')?.click();
+        await Promise.resolve();
+
+        expect(stub(host, 'TransferOwnershipModal')?.dataset.open).toBe('true');
+    });
+
+    it('opens the removal dialog from the cross', async () => {
+        const host = mount();
+
+        find(host, 'member-remove-button')?.click();
+        await Promise.resolve();
+
+        expect(stub(host, 'RemoveMemberModal')?.dataset.open).toBe('true');
+    });
+
+    it('disables both controls in the demo and says why', () => {
+        pageProps.demoMode = true;
+
+        const host = mount();
+
+        const transfer = find(host, 'member-transfer-ownership-button');
+        const remove = find(host, 'member-remove-button');
+
+        expect(transfer?.hasAttribute('disabled')).toBe(true);
+        expect(remove?.hasAttribute('disabled')).toBe(true);
+        expect(host.textContent).toContain('Disabled in the demo');
+    });
+});

--- a/resources/js/pages/teams/Edit.sections.test.ts
+++ b/resources/js/pages/teams/Edit.sections.test.ts
@@ -1,0 +1,422 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { RoleOption, Team, TeamPermissions } from '@/types';
+
+/**
+ * Covers the page around the roster: its header, the team-name form, and the
+ * grid of admin destinations with the emoji-only fallback that replaces it for
+ * a plain member. Every card is permission-gated, and the whole grid collapses
+ * to one link when none of the gates open — the behaviour most at risk when
+ * `pages/teams/Edit.vue` is split into sections.
+ */
+const pageProps = vi.hoisted(() => ({
+    auth: { user: { id: 'me' } },
+    integrationsEnabled: true,
+    demoMode: false,
+}));
+
+const visit = vi.hoisted(() => vi.fn());
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: pageProps }),
+    router: { visit },
+    Head: defineComponent({
+        props: { title: { type: String, default: '' } },
+        setup: (props) => () =>
+            h('div', { 'data-stub': 'Head', 'data-title': props.title }),
+    }),
+    Link: defineComponent({
+        props: { href: { type: String, default: '' } },
+        setup:
+            (props, { slots }) =>
+            () =>
+                h('a', { href: props.href }, slots.default?.()),
+    }),
+    Form: defineComponent({
+        props: { action: { type: String, default: '' } },
+        setup:
+            (props, { slots }) =>
+            () =>
+                h(
+                    'form',
+                    { action: props.action },
+                    slots.default?.({ errors: {}, processing: false }),
+                ),
+    }),
+}));
+
+vi.mock('@lucide/vue', () => ({
+    ChartColumn: { render: () => h('svg') },
+    Check: { render: () => h('svg') },
+    ChevronDown: { render: () => h('svg') },
+    ChevronRight: { render: () => h('svg') },
+    Crown: { render: () => h('svg', { 'data-stub': 'Crown' }) },
+    Download: { render: () => h('svg') },
+    Mail: { render: () => h('svg') },
+    Plug: { render: () => h('svg') },
+    ScrollText: { render: () => h('svg') },
+    Send: { render: () => h('svg') },
+    ShieldCheck: { render: () => h('svg') },
+    SmilePlus: { render: () => h('svg') },
+    UserPlus: { render: () => h('svg') },
+    Users: { render: () => h('svg') },
+    X: { render: () => h('svg') },
+}));
+
+vi.mock('@/routes/teams', () => ({
+    edit: (slug: string) => `/teams/${slug}/edit`,
+    index: () => '/teams',
+    update: { form: (slug: string) => ({ action: `/teams/${slug}` }) },
+}));
+
+vi.mock('@/routes/teams/analytics', () => ({
+    index: (slug: string) => `/teams/${slug}/analytics`,
+}));
+vi.mock('@/routes/teams/audit', () => ({
+    index: (slug: string) => `/teams/${slug}/audit`,
+}));
+vi.mock('@/routes/teams/audit-exports', () => ({
+    index: (slug: string) => `/teams/${slug}/audit-exports`,
+}));
+vi.mock('@/routes/teams/emojis', () => ({
+    index: (slug: string) => `/teams/${slug}/emojis`,
+}));
+vi.mock('@/routes/teams/groups', () => ({
+    index: (slug: string) => `/teams/${slug}/groups`,
+}));
+vi.mock('@/routes/teams/integrations', () => ({
+    index: (slug: string) => `/teams/${slug}/integrations`,
+}));
+vi.mock('@/routes/teams/invitations', () => ({
+    resend: ([slug, code]: [string, string]) =>
+        `/teams/${slug}/invitations/${code}/resend`,
+}));
+vi.mock('@/routes/teams/members', () => ({
+    show: ([slug, id]: [string, string]) => `/teams/${slug}/members/${id}`,
+    update: ([slug, id]: [string, string]) => `/teams/${slug}/members/${id}`,
+}));
+vi.mock('@/routes/teams/security-log', () => ({
+    index: (slug: string) => `/teams/${slug}/security-log`,
+}));
+
+vi.mock('@/lib/datetime', () => ({
+    formatRelativeTime: () => '2 hours ago',
+}));
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+function passthrough(tag = 'div') {
+    return defineComponent({
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h(tag, slots.default?.()),
+    });
+}
+
+/** Stands in for a dialog, reporting whether the page asked it to open. */
+function modalStub(name: string) {
+    return defineComponent({
+        name,
+        props: { open: { type: Boolean, default: false } },
+        setup: (props) => () =>
+            h('div', {
+                'data-stub': name,
+                'data-open': String(props.open),
+            }),
+    });
+}
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: passthrough(),
+    DropdownMenuTrigger: passthrough(),
+    DropdownMenuContent: passthrough(),
+    DropdownMenuItem: passthrough('button'),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+    Tooltip: passthrough(),
+    TooltipProvider: passthrough(),
+    TooltipTrigger: passthrough(),
+    TooltipContent: passthrough(),
+}));
+
+vi.mock('@/components/ui/avatar', () => ({
+    Avatar: passthrough(),
+    AvatarImage: passthrough('img'),
+    AvatarFallback: passthrough('span'),
+}));
+
+vi.mock('@/components/UserStatusEmoji.vue', () => ({
+    default: defineComponent({
+        setup: () => () => h('span', { 'data-stub': 'UserStatusEmoji' }),
+    }),
+}));
+
+vi.mock('@/components/InviteMemberModal.vue', () => ({
+    default: modalStub('InviteMemberModal'),
+}));
+vi.mock('@/components/RemoveMemberModal.vue', () => ({
+    default: modalStub('RemoveMemberModal'),
+}));
+vi.mock('@/components/TransferOwnershipModal.vue', () => ({
+    default: modalStub('TransferOwnershipModal'),
+}));
+vi.mock('@/components/CancelInvitationModal.vue', () => ({
+    default: modalStub('CancelInvitationModal'),
+}));
+vi.mock('@/components/DeleteTeamModal.vue', () => ({
+    default: modalStub('DeleteTeamModal'),
+}));
+
+import Edit from './Edit.vue';
+
+function team(overrides: Partial<Team> = {}): Team {
+    return {
+        id: 't-1',
+        name: 'Acme Corp',
+        slug: 'acme',
+        isPersonal: false,
+        role: 'owner',
+        membersCount: 1,
+        unreadCount: 0,
+        mentionCount: 0,
+        ...overrides,
+    };
+}
+
+function permissions(
+    overrides: Partial<TeamPermissions> = {},
+): TeamPermissions {
+    return {
+        canUpdateTeam: true,
+        canDeleteTeam: true,
+        canAddMember: true,
+        canUpdateMember: true,
+        canRemoveMember: true,
+        canCreateInvitation: true,
+        canCancelInvitation: true,
+        canTransferOwnership: true,
+        canViewAudit: true,
+        canViewSecurityLog: true,
+        canViewAnalytics: true,
+        canManageIntegrations: true,
+        canManageUserGroups: true,
+        ...overrides,
+    };
+}
+
+/** A plain member: none of the admin destinations are open to them. */
+function memberPermissions(): TeamPermissions {
+    return permissions({
+        canUpdateTeam: false,
+        canDeleteTeam: false,
+        canViewAudit: false,
+        canViewSecurityLog: false,
+        canViewAnalytics: false,
+        canManageIntegrations: false,
+        canManageUserGroups: false,
+    });
+}
+
+const availableRoles: RoleOption[] = [{ value: 'member', label: 'Member' }];
+
+let app: App | null = null;
+
+function mount(props: Record<string, unknown> = {}) {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    app = createApp({
+        render: () =>
+            h(Edit, {
+                team: team(),
+                members: [],
+                invitations: [],
+                permissions: permissions(),
+                availableRoles,
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+
+    return host;
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function stub(host: HTMLElement, name: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-stub="${name}"]`);
+}
+
+beforeEach(() => {
+    pageProps.auth.user.id = 'me';
+    pageProps.integrationsEnabled = true;
+    pageProps.demoMode = false;
+    visit.mockClear();
+});
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('the page header', () => {
+    it('trails back to the team list and names the team', () => {
+        const host = mount();
+
+        expect(host.querySelector('nav a')?.getAttribute('href')).toBe(
+            '/teams',
+        );
+        expect(host.querySelector('h1')?.textContent?.trim()).toBe('Acme Corp');
+    });
+
+    it('badges the owner of the team', () => {
+        const host = mount();
+
+        expect(host.textContent).toContain('You own this team');
+    });
+
+    it('leaves the badge off for everyone else', () => {
+        const host = mount({ team: team({ role: 'admin' }) });
+
+        expect(host.textContent).not.toContain('You own this team');
+    });
+
+    it('titles the document for editing when the viewer may edit', () => {
+        expect(stub(mount(), 'Head')?.dataset.title).toBe('Edit Acme Corp');
+    });
+
+    it('titles it for viewing when they may not', () => {
+        const host = mount({ permissions: memberPermissions() });
+
+        expect(stub(host, 'Head')?.dataset.title).toBe('View Acme Corp');
+    });
+});
+
+describe('the team name form', () => {
+    it('posts to the team update route with the current name', () => {
+        const host = mount();
+
+        expect(
+            (find(host, 'team-name-input') as HTMLInputElement | null)?.value,
+        ).toBe('Acme Corp');
+        expect(host.querySelector('form')?.getAttribute('action')).toBe(
+            '/teams/acme',
+        );
+        expect(find(host, 'team-save-button')).not.toBeNull();
+    });
+
+    it('labels the input for assistive tech without repeating the heading', () => {
+        const host = mount();
+
+        const label = host.querySelector('label');
+
+        expect(label?.getAttribute('for')).toBe('name');
+        expect(label?.className).toContain('sr-only');
+    });
+
+    it('locks the save button in the demo', () => {
+        pageProps.demoMode = true;
+
+        const host = mount();
+
+        expect(find(host, 'team-save-button')?.hasAttribute('disabled')).toBe(
+            true,
+        );
+    });
+
+    it('is absent for someone who may not rename the team', () => {
+        const host = mount({ permissions: memberPermissions() });
+
+        expect(find(host, 'team-name-input')).toBeNull();
+        expect(find(host, 'team-save-button')).toBeNull();
+    });
+});
+
+describe('the admin destinations', () => {
+    it('links every card an owner can reach', () => {
+        const host = mount();
+
+        expect(find(host, 'manage-emoji-link')?.getAttribute('href')).toBe(
+            '/teams/acme/emojis',
+        );
+        expect(find(host, 'manage-groups-link')?.getAttribute('href')).toBe(
+            '/teams/acme/groups',
+        );
+        expect(
+            find(host, 'manage-integrations-link')?.getAttribute('href'),
+        ).toBe('/teams/acme/integrations');
+        expect(find(host, 'view-analytics-link')?.getAttribute('href')).toBe(
+            '/teams/acme/analytics',
+        );
+        expect(find(host, 'view-audit-log-link')?.getAttribute('href')).toBe(
+            '/teams/acme/audit',
+        );
+        expect(find(host, 'view-security-log-link')?.getAttribute('href')).toBe(
+            '/teams/acme/security-log',
+        );
+        expect(
+            find(host, 'view-audit-exports-link')?.getAttribute('href'),
+        ).toBe('/teams/acme/audit-exports');
+    });
+
+    it('withholds each card behind its own permission', () => {
+        const host = mount({
+            permissions: permissions({
+                canManageUserGroups: false,
+                canViewAnalytics: false,
+                canViewAudit: false,
+                canViewSecurityLog: false,
+            }),
+        });
+
+        expect(find(host, 'manage-groups-link')).toBeNull();
+        expect(find(host, 'view-analytics-link')).toBeNull();
+        expect(find(host, 'view-audit-log-link')).toBeNull();
+        expect(find(host, 'view-security-log-link')).toBeNull();
+        expect(find(host, 'view-audit-exports-link')).toBeNull();
+    });
+
+    it('keeps the exports card while either log is readable', () => {
+        const host = mount({
+            permissions: permissions({ canViewAudit: false }),
+        });
+
+        expect(find(host, 'view-audit-log-link')).toBeNull();
+        expect(find(host, 'view-audit-exports-link')).not.toBeNull();
+    });
+
+    it('hides integrations while the platform toggle is off', () => {
+        pageProps.integrationsEnabled = false;
+
+        const host = mount();
+
+        expect(find(host, 'manage-integrations-link')).toBeNull();
+    });
+
+    it('hides integrations from someone who may not manage them', () => {
+        const host = mount({
+            permissions: permissions({ canManageIntegrations: false }),
+        });
+
+        expect(find(host, 'manage-integrations-link')).toBeNull();
+    });
+
+    it('falls back to the emoji card alone for a plain member', () => {
+        const host = mount({ permissions: memberPermissions() });
+
+        expect(find(host, 'manage-emoji-link')?.getAttribute('href')).toBe(
+            '/teams/acme/emojis',
+        );
+        expect(find(host, 'manage-groups-link')).toBeNull();
+        expect(find(host, 'view-analytics-link')).toBeNull();
+        expect(find(host, 'view-audit-exports-link')).toBeNull();
+    });
+});

--- a/resources/js/pages/teams/Edit.vue
+++ b/resources/js/pages/teams/Edit.vue
@@ -1,71 +1,28 @@
 <script setup lang="ts">
-import { Form, Head, Link, router, usePage } from '@inertiajs/vue3';
-import {
-    ChartColumn,
-    Check,
-    ChevronDown,
-    ChevronRight,
-    Crown,
-    Download,
-    Mail,
-    Plug,
-    ScrollText,
-    Send,
-    ShieldCheck,
-    SmilePlus,
-    UserPlus,
-    Users,
-    X,
-} from '@lucide/vue';
+import { Head, router, usePage } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
 import CancelInvitationModal from '@/components/CancelInvitationModal.vue';
 import DeleteTeamModal from '@/components/DeleteTeamModal.vue';
-import DemoLock from '@/components/DemoLock.vue';
-import FormField from '@/components/FormField.vue';
 import InviteMemberModal from '@/components/InviteMemberModal.vue';
 import RemoveMemberModal from '@/components/RemoveMemberModal.vue';
+import AdminLinks from '@/components/teams/AdminLinks.vue';
+import DangerZone from '@/components/teams/DangerZone.vue';
+import MemberRoster from '@/components/teams/MemberRoster.vue';
+import PendingInvitations from '@/components/teams/PendingInvitations.vue';
+import SettingsHeader from '@/components/teams/SettingsHeader.vue';
+import TeamNameForm from '@/components/teams/TeamNameForm.vue';
 import TransferOwnershipModal from '@/components/TransferOwnershipModal.vue';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/button';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipProvider,
-    TooltipTrigger,
-} from '@/components/ui/tooltip';
-import UserStatusEmoji from '@/components/UserStatusEmoji.vue';
-import { useDemoMode } from '@/composables/useDemoMode';
-import { useInitials } from '@/composables/useInitials';
 import { useTranslations } from '@/composables/useTranslations';
-import { formatRelativeTime } from '@/lib/datetime';
 import { translate } from '@/lib/i18n';
-import { edit, index, update } from '@/routes/teams';
-import { index as analyticsIndex } from '@/routes/teams/analytics';
-import { index as auditIndex } from '@/routes/teams/audit';
-import { index as auditExportsIndex } from '@/routes/teams/audit-exports';
-import { index as emojisIndex } from '@/routes/teams/emojis';
-import { index as groupsIndex } from '@/routes/teams/groups';
-import { index as integrationsIndex } from '@/routes/teams/integrations';
+import { edit, index } from '@/routes/teams';
 import { resend as resendInvitationRoute } from '@/routes/teams/invitations';
-import {
-    show as showMember,
-    update as updateMember,
-} from '@/routes/teams/members';
-import { index as securityLogIndex } from '@/routes/teams/security-log';
+import { update as updateMember } from '@/routes/teams/members';
 import type {
     RoleOption,
     Team,
     TeamInvitation,
     TeamMember,
     TeamPermissions,
-    TeamRole,
 } from '@/types';
 
 type Props = {
@@ -93,20 +50,10 @@ defineOptions({
     }),
 });
 
-const { getInitials } = useInitials();
 const { t } = useTranslations();
-const { demoMode } = useDemoMode();
 
 const page = usePage();
 const currentUserId = computed(() => String(page.props.auth.user.id));
-
-// The integrations card shows only for managers (Owner + Admin) and only while
-// the platform toggle is on, mirroring the route's own gating.
-const showIntegrationsLink = computed(
-    () =>
-        props.permissions.canManageIntegrations &&
-        page.props.integrationsEnabled,
-);
 
 const inviteDialogOpen = ref(false);
 const deleteDialogOpen = ref(false);
@@ -122,27 +69,6 @@ const pageTitle = computed(() =>
         ? t('Edit :name', { name: props.team.name })
         : t('View :name', { name: props.team.name }),
 );
-
-const isOwner = computed(() => props.team.role === 'owner');
-
-const isCurrentUser = (member: TeamMember): boolean =>
-    String(member.id) === currentUserId.value;
-
-/**
- * The one-line description of what each assignable role can do, shown under the
- * role name inside the role dropdown. Keyed by role so the copy stays with the
- * permission it describes.
- */
-const roleDescription = (role: TeamRole): string => {
-    switch (role) {
-        case 'admin':
-            return t('Can manage members, channels, and invitations');
-        case 'member':
-            return t('Can read and post in channels they belong to');
-        default:
-            return '';
-    }
-};
 
 const updateMemberRole = (member: TeamMember, newRole: string) => {
     router.visit(updateMember([props.team.slug, member.id]), {
@@ -177,652 +103,36 @@ const confirmTransferOwnership = (member: TeamMember) => {
     <Head :title="pageTitle" />
 
     <div>
-        <!-- Page header. Below the breakpoint the pushed screen's own header
-             already carries the trail and the team name, so only the ownership
-             badge survives there. -->
-        <header class="border-b border-border pb-6 max-md:border-0 max-md:pb-0">
-            <nav
-                class="hidden items-center gap-1.5 text-xs text-muted-foreground md:flex"
-                :aria-label="$t('breadcrumb')"
-            >
-                <Link :href="index()" class="hover:text-foreground">
-                    {{ $t('Teams') }}
-                </Link>
-                <ChevronRight class="h-3 w-3 opacity-60" />
-                <span class="font-medium text-foreground/70">{{
-                    team.name
-                }}</span>
-            </nav>
+        <SettingsHeader :team="team" />
 
-            <div class="flex flex-wrap items-end gap-3 md:mt-2">
-                <div class="min-w-0 max-md:hidden">
-                    <h1
-                        class="font-serif text-3xl font-semibold tracking-tight"
-                    >
-                        {{ team.name }}
-                    </h1>
-                    <p class="mt-1 text-sm text-muted-foreground">
-                        {{
-                            $t(
-                                "Manage this team's name, members, and ownership",
-                            )
-                        }}
-                    </p>
-                </div>
+        <TeamNameForm v-if="permissions.canUpdateTeam" :team="team" />
 
-                <span
-                    v-if="isOwner"
-                    class="ml-auto inline-flex items-center gap-1.5 rounded-full border border-brass-border bg-brass-fill px-3 py-1 text-[11px] font-semibold tracking-wide text-brass-fill-foreground uppercase"
-                >
-                    <Crown class="h-3 w-3 text-brass" />
-                    {{ $t('You own this team') }}
-                </span>
-            </div>
-        </header>
+        <MemberRoster
+            :members="members"
+            :team-slug="team.slug"
+            :current-user-id="currentUserId"
+            :permissions="permissions"
+            :available-roles="availableRoles"
+            @invite="inviteDialogOpen = true"
+            @update-role="updateMemberRole"
+            @transfer-ownership="confirmTransferOwnership"
+            @remove="confirmRemoveMember"
+        />
 
-        <!-- Team name -->
-        <section
-            v-if="permissions.canUpdateTeam"
-            class="border-b border-border py-6"
-        >
-            <div class="mb-4">
-                <h2 class="font-serif text-lg font-semibold">
-                    {{ $t('Team name') }}
-                </h2>
-                <p class="mt-0.5 text-sm text-muted-foreground">
-                    {{ $t('Shown in the team switcher and on invitations') }}
-                </p>
-            </div>
-
-            <Form
-                v-bind="update.form(team.slug)"
-                v-slot="{ errors, processing }"
-            >
-                <div class="flex flex-wrap items-start gap-3">
-                    <!-- The section heading above already reads "Team name", so
-                         the field's own label is hidden rather than repeated.
-                         It stays a real `<label for>` all the same: it names
-                         the control for assistive tech and voice control, and
-                         it focuses the input when clicked. -->
-                    <FormField
-                        id="name"
-                        :label="$t('Team name')"
-                        label-class="sr-only"
-                        :error="errors.name"
-                        class="w-full max-w-sm"
-                        v-slot="{ id }"
-                    >
-                        <Input
-                            :id="id"
-                            name="name"
-                            data-test="team-name-input"
-                            :default-value="team.name"
-                            class="rounded-lg"
-                            required
-                        />
-                    </FormField>
-
-                    <DemoLock v-slot="{ disabled }">
-                        <Button
-                            type="submit"
-                            class="rounded-full px-6"
-                            data-test="team-save-button"
-                            :disabled="processing || disabled"
-                        >
-                            {{ $t('Save') }}
-                        </Button>
-                    </DemoLock>
-                </div>
-            </Form>
-        </section>
-
-        <!-- Team members. The id is the anchor the dock's workspace sheet links
-             its "Members" row at, so that row lands on the roster rather than at
-             the top of the page. -->
-        <section id="members" class="border-b border-border py-6">
-            <div class="mb-4 flex flex-wrap items-start gap-3">
-                <div class="min-w-0">
-                    <h2 class="font-serif text-lg font-semibold">
-                        {{ $t('Team members') }}
-                        <span class="font-normal text-muted-foreground"
-                            >&middot; {{ members.length }}</span
-                        >
-                    </h2>
-                    <p class="mt-0.5 text-sm text-muted-foreground">
-                        {{
-                            $t(
-                                'Manage who belongs to this team and what they can do',
-                            )
-                        }}
-                    </p>
-                </div>
-
-                <Button
-                    v-if="permissions.canCreateInvitation"
-                    class="ml-auto rounded-full"
-                    data-test="invite-member-button"
-                    @click="inviteDialogOpen = true"
-                >
-                    <UserPlus /> {{ $t('Invite member') }}
-                </Button>
-            </div>
-
-            <div class="flex flex-col gap-2">
-                <div
-                    v-for="member in members"
-                    :key="member.id"
-                    data-test="member-row"
-                    class="flex flex-wrap items-center gap-4 rounded-xl border border-border bg-card p-3.5 shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
-                >
-                    <Avatar class="h-10 w-10 shrink-0">
-                        <AvatarImage
-                            v-if="member.avatar"
-                            :src="member.avatar"
-                            :alt="member.name"
-                        />
-                        <AvatarFallback
-                            :class="
-                                member.role === 'owner'
-                                    ? 'bg-primary text-primary-foreground'
-                                    : 'bg-muted text-muted-foreground'
-                            "
-                            class="text-xs font-semibold"
-                            >{{ getInitials(member.name) }}</AvatarFallback
-                        >
-                    </Avatar>
-
-                    <div class="min-w-0">
-                        <Link
-                            :href="showMember([team.slug, member.id])"
-                            class="font-semibold underline-offset-4 hover:underline"
-                            data-test="member-profile-link"
-                        >
-                            {{ member.name }}
-                            <span
-                                v-if="isCurrentUser(member)"
-                                class="text-sm font-medium text-muted-foreground"
-                                >{{ $t('(you)') }}</span
-                            >
-                            <UserStatusEmoji
-                                :status="member.status"
-                                :name="member.name"
-                                class="align-[-1px] text-xs"
-                            />
-                        </Link>
-                        <div
-                            v-if="member.email"
-                            class="truncate text-sm text-muted-foreground"
-                        >
-                            {{ member.email }}
-                        </div>
-                        <div
-                            v-if="member.status?.text"
-                            data-test="member-status-text"
-                            class="truncate text-sm text-muted-foreground"
-                        >
-                            {{ member.status.text }}
-                        </div>
-                    </div>
-
-                    <div class="ml-auto flex items-center gap-1.5">
-                        <span
-                            v-if="member.role === 'owner'"
-                            class="inline-flex items-center gap-1.5 rounded-full border border-brass-border bg-brass-fill px-3 py-1 text-xs font-semibold text-brass-fill-foreground"
-                        >
-                            <Crown class="h-3 w-3 text-brass" />
-                            {{ member.role_label }}
-                        </span>
-
-                        <DropdownMenu v-else-if="permissions.canUpdateMember">
-                            <DropdownMenuTrigger as-child>
-                                <Button
-                                    data-test="member-role-trigger"
-                                    variant="outline"
-                                    size="sm"
-                                    class="rounded-full"
-                                >
-                                    {{ member.role_label }}
-                                    <ChevronDown
-                                        class="ml-1 h-3.5 w-3.5 opacity-50"
-                                    />
-                                </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" class="w-64">
-                                <DropdownMenuItem
-                                    v-for="role in availableRoles"
-                                    :key="role.value"
-                                    data-test="member-role-option"
-                                    class="flex-col items-start gap-0.5"
-                                    @click="
-                                        updateMemberRole(member, role.value)
-                                    "
-                                >
-                                    <span
-                                        class="flex w-full items-center gap-1.5 font-medium"
-                                    >
-                                        {{ role.label }}
-                                        <Check
-                                            v-if="member.role === role.value"
-                                            class="ml-auto h-3.5 w-3.5 text-brass"
-                                        />
-                                    </span>
-                                    <span class="text-xs text-muted-foreground">
-                                        {{ roleDescription(role.value) }}
-                                    </span>
-                                </DropdownMenuItem>
-                            </DropdownMenuContent>
-                        </DropdownMenu>
-                        <span
-                            v-else
-                            class="rounded-full border border-border px-3 py-1 text-xs font-semibold"
-                        >
-                            {{ member.role_label }}
-                        </span>
-
-                        <TooltipProvider
-                            v-if="
-                                member.role !== 'owner' &&
-                                permissions.canTransferOwnership
-                            "
-                        >
-                            <Tooltip>
-                                <!-- Off the demo the tooltip triggers on the
-                                     focusable button (keyboard + hover); in the
-                                     demo the button is disabled, so a
-                                     tabindex'd span carries the trigger to keep
-                                     the reason reachable by keyboard. -->
-                                <TooltipTrigger v-if="demoMode" as-child>
-                                    <span
-                                        tabindex="0"
-                                        class="inline-flex cursor-not-allowed"
-                                    >
-                                        <Button
-                                            data-test="member-transfer-ownership-button"
-                                            variant="ghost"
-                                            size="icon"
-                                            class="rounded-full text-muted-foreground"
-                                            disabled
-                                        >
-                                            <Crown class="h-4 w-4" />
-                                        </Button>
-                                    </span>
-                                </TooltipTrigger>
-                                <TooltipTrigger v-else as-child>
-                                    <Button
-                                        data-test="member-transfer-ownership-button"
-                                        variant="ghost"
-                                        size="icon"
-                                        class="rounded-full text-muted-foreground"
-                                        @click="
-                                            confirmTransferOwnership(member)
-                                        "
-                                    >
-                                        <Crown class="h-4 w-4" />
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                    <p>
-                                        {{
-                                            demoMode
-                                                ? $t('Disabled in the demo')
-                                                : $t('Transfer ownership')
-                                        }}
-                                    </p>
-                                </TooltipContent>
-                            </Tooltip>
-                        </TooltipProvider>
-
-                        <TooltipProvider
-                            v-if="
-                                member.role !== 'owner' &&
-                                permissions.canRemoveMember
-                            "
-                        >
-                            <Tooltip>
-                                <!-- Same focusable-trigger split as the transfer
-                                     button above: enabled button off the demo,
-                                     tabindex'd span around the disabled button
-                                     in the demo. -->
-                                <TooltipTrigger v-if="demoMode" as-child>
-                                    <span
-                                        tabindex="0"
-                                        class="inline-flex cursor-not-allowed"
-                                    >
-                                        <Button
-                                            data-test="member-remove-button"
-                                            variant="ghost"
-                                            size="icon"
-                                            class="rounded-full text-muted-foreground"
-                                            disabled
-                                        >
-                                            <X class="h-4 w-4" />
-                                        </Button>
-                                    </span>
-                                </TooltipTrigger>
-                                <TooltipTrigger v-else as-child>
-                                    <Button
-                                        data-test="member-remove-button"
-                                        variant="ghost"
-                                        size="icon"
-                                        class="rounded-full text-muted-foreground"
-                                        @click="confirmRemoveMember(member)"
-                                    >
-                                        <X class="h-4 w-4" />
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                    <p>
-                                        {{
-                                            demoMode
-                                                ? $t('Disabled in the demo')
-                                                : $t('Remove member')
-                                        }}
-                                    </p>
-                                </TooltipContent>
-                            </Tooltip>
-                        </TooltipProvider>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Pending invitations -->
-        <section
+        <PendingInvitations
             v-if="invitations.length > 0"
-            class="border-b border-border py-6"
-        >
-            <div class="mb-4">
-                <h2 class="font-serif text-lg font-semibold">
-                    {{ $t('Pending invitations') }}
-                    <span class="font-normal text-muted-foreground"
-                        >&middot; {{ invitations.length }}</span
-                    >
-                </h2>
-                <p class="mt-0.5 text-sm text-muted-foreground">
-                    {{
-                        $t(
-                            'Sent but not yet accepted. They expire after 3 days',
-                        )
-                    }}
-                </p>
-            </div>
+            :invitations="invitations"
+            :permissions="permissions"
+            @resend="resendInvitation"
+            @cancel="confirmCancelInvitation"
+        />
 
-            <div class="flex flex-col gap-2">
-                <div
-                    v-for="invitation in invitations"
-                    :key="invitation.code"
-                    data-test="invitation-row"
-                    class="flex flex-wrap items-center gap-4 rounded-xl border border-dashed border-border bg-muted/30 p-3.5"
-                >
-                    <div
-                        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted"
-                    >
-                        <Mail class="h-5 w-5 text-muted-foreground" />
-                    </div>
+        <AdminLinks :team="team" :permissions="permissions" />
 
-                    <div class="min-w-0">
-                        <div
-                            class="truncate font-semibold text-muted-foreground"
-                        >
-                            {{ invitation.email }}
-                        </div>
-                        <div class="text-sm text-muted-foreground">
-                            {{
-                                $t('Invited as :role · :time', {
-                                    role: invitation.role_label,
-                                    time: formatRelativeTime(
-                                        invitation.created_at,
-                                    ),
-                                })
-                            }}
-                        </div>
-                    </div>
-
-                    <div class="ml-auto flex items-center gap-1.5">
-                        <Button
-                            v-if="permissions.canCreateInvitation"
-                            data-test="invitation-resend-button"
-                            variant="outline"
-                            size="sm"
-                            class="rounded-full"
-                            @click="resendInvitation(invitation)"
-                        >
-                            <Send class="h-3.5 w-3.5" /> {{ $t('Resend') }}
-                        </Button>
-
-                        <TooltipProvider v-if="permissions.canCancelInvitation">
-                            <Tooltip>
-                                <TooltipTrigger as-child>
-                                    <Button
-                                        data-test="invitation-cancel-button"
-                                        variant="ghost"
-                                        size="icon"
-                                        class="rounded-full text-muted-foreground"
-                                        @click="
-                                            confirmCancelInvitation(invitation)
-                                        "
-                                    >
-                                        <X class="h-4 w-4" />
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                    <p>{{ $t('Cancel invitation') }}</p>
-                                </TooltipContent>
-                            </Tooltip>
-                        </TooltipProvider>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Custom emoji + admin links -->
-        <section
-            v-if="
-                permissions.canViewAnalytics ||
-                permissions.canViewAudit ||
-                permissions.canViewSecurityLog ||
-                permissions.canManageUserGroups ||
-                showIntegrationsLink
-            "
-            class="border-b border-border py-6"
-        >
-            <div class="grid gap-3 sm:grid-cols-2">
-                <Link
-                    :href="emojisIndex(team.slug)"
-                    data-test="manage-emoji-link"
-                    class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border"
-                >
-                    <SmilePlus class="h-4 w-4 shrink-0 text-brass" />
-                    <div class="min-w-0">
-                        <div class="text-sm font-semibold">
-                            {{ $t('Custom emoji') }}
-                        </div>
-                        <div class="truncate text-xs text-muted-foreground">
-                            {{ $t('Named emoji for messages and reactions') }}
-                        </div>
-                    </div>
-                    <ChevronRight
-                        class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                    />
-                </Link>
-
-                <Link
-                    v-if="permissions.canManageUserGroups"
-                    :href="groupsIndex(team.slug)"
-                    data-test="manage-groups-link"
-                    class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border"
-                >
-                    <Users class="h-4 w-4 shrink-0 text-brass" />
-                    <div class="min-w-0">
-                        <div class="text-sm font-semibold">
-                            {{ $t('User groups') }}
-                        </div>
-                        <div class="truncate text-xs text-muted-foreground">
-                            {{ $t('Mentionable aliases for a set of people') }}
-                        </div>
-                    </div>
-                    <ChevronRight
-                        class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                    />
-                </Link>
-
-                <Link
-                    v-if="showIntegrationsLink"
-                    :href="integrationsIndex(team.slug)"
-                    data-test="manage-integrations-link"
-                    class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border"
-                >
-                    <Plug class="h-4 w-4 shrink-0 text-brass" />
-                    <div class="min-w-0">
-                        <div class="text-sm font-semibold">
-                            {{ $t('Integrations') }}
-                        </div>
-                        <div class="truncate text-xs text-muted-foreground">
-                            {{ $t('Bots, API tokens, and webhooks') }}
-                        </div>
-                    </div>
-                    <ChevronRight
-                        class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                    />
-                </Link>
-
-                <Link
-                    v-if="permissions.canViewAnalytics"
-                    :href="analyticsIndex(team.slug)"
-                    data-test="view-analytics-link"
-                    class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border"
-                >
-                    <ChartColumn class="h-4 w-4 shrink-0 text-brass" />
-                    <div class="min-w-0">
-                        <div class="text-sm font-semibold">
-                            {{ $t('Analytics') }}
-                        </div>
-                        <div class="truncate text-xs text-muted-foreground">
-                            {{ $t('Activity, growth, busiest channels') }}
-                        </div>
-                    </div>
-                    <ChevronRight
-                        class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                    />
-                </Link>
-
-                <Link
-                    v-if="permissions.canViewAudit"
-                    :href="auditIndex(team.slug)"
-                    data-test="view-audit-log-link"
-                    class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border"
-                >
-                    <ScrollText class="h-4 w-4 shrink-0 text-brass" />
-                    <div class="min-w-0">
-                        <div class="text-sm font-semibold">
-                            {{ $t('Audit log') }}
-                        </div>
-                        <div class="truncate text-xs text-muted-foreground">
-                            {{ $t('Moderation and admin actions') }}
-                        </div>
-                    </div>
-                    <ChevronRight
-                        class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                    />
-                </Link>
-
-                <Link
-                    v-if="permissions.canViewSecurityLog"
-                    :href="securityLogIndex(team.slug)"
-                    data-test="view-security-log-link"
-                    class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border"
-                >
-                    <ShieldCheck class="h-4 w-4 shrink-0 text-brass" />
-                    <div class="min-w-0">
-                        <div class="text-sm font-semibold">
-                            {{ $t('Security log') }}
-                        </div>
-                        <div class="truncate text-xs text-muted-foreground">
-                            {{ $t('Sign-ins and credential changes') }}
-                        </div>
-                    </div>
-                    <ChevronRight
-                        class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                    />
-                </Link>
-
-                <Link
-                    v-if="
-                        permissions.canViewAudit ||
-                        permissions.canViewSecurityLog
-                    "
-                    :href="auditExportsIndex(team.slug)"
-                    data-test="view-audit-exports-link"
-                    class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border"
-                >
-                    <Download class="h-4 w-4 shrink-0 text-brass" />
-                    <div class="min-w-0">
-                        <div class="text-sm font-semibold">
-                            {{ $t('Exports') }}
-                        </div>
-                        <div class="truncate text-xs text-muted-foreground">
-                            {{ $t('Export the audit and security logs') }}
-                        </div>
-                    </div>
-                    <ChevronRight
-                        class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                    />
-                </Link>
-            </div>
-        </section>
-
-        <!-- Emoji-only fallback for members without admin links -->
-        <section v-else class="border-b border-border py-6">
-            <Link
-                :href="emojisIndex(team.slug)"
-                data-test="manage-emoji-link"
-                class="flex items-center gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-brass-border sm:max-w-sm"
-            >
-                <SmilePlus class="h-4 w-4 shrink-0 text-brass" />
-                <div class="min-w-0">
-                    <div class="text-sm font-semibold">
-                        {{ $t('Custom emoji') }}
-                    </div>
-                    <div class="truncate text-xs text-muted-foreground">
-                        {{ $t('Named emoji for messages and reactions') }}
-                    </div>
-                </div>
-                <ChevronRight
-                    class="ml-auto h-3.5 w-3.5 shrink-0 text-muted-foreground"
-                />
-            </Link>
-        </section>
-
-        <!-- Danger zone -->
-        <section
+        <DangerZone
             v-if="permissions.canDeleteTeam && !team.isPersonal"
-            class="py-6"
-        >
-            <div class="mb-3">
-                <h2
-                    class="font-serif text-lg font-semibold text-destructive-text"
-                >
-                    {{ $t('Delete team') }}
-                </h2>
-                <p class="mt-0.5 max-w-xl text-sm text-muted-foreground">
-                    {{
-                        $t(
-                            'Permanently delete this team and all of its data. This cannot be undone.',
-                        )
-                    }}
-                </p>
-            </div>
-            <DemoLock v-slot="{ disabled }">
-                <Button
-                    data-test="delete-team-button"
-                    variant="outline"
-                    class="rounded-full border-destructive/40 text-destructive-text hover:border-destructive/60 hover:bg-destructive/10 hover:text-destructive-text"
-                    :disabled="disabled"
-                    @click="deleteDialogOpen = true"
-                    >{{ $t('Delete team…') }}</Button
-                >
-            </DemoLock>
-        </section>
+            @delete="deleteDialogOpen = true"
+        />
     </div>
 
     <InviteMemberModal


### PR DESCRIPTION
Closes #984. Third child of #980.

`pages/teams/Edit.vue` goes from **863 to 173 raw lines**, and from **806 to 149** as `max-lines` counts them, against the 400 cap. Its entry is gone from the exemption block in `eslint.config.js`, so `max-lines-policy.test.ts` now holds the file to the cap like any other.

The file was almost entirely template: eight sections stacked in one scope, with the roster's member row alone accounting for a quarter of it. A section-per-component split is the shape here, so the page is now the list of its sections plus the dialogs they open.

## What moved

| New file | Lines | What it holds |
| --- | ---: | --- |
| `components/teams/MemberRow.vue` | 254 | One member: avatar, profile link, the role menu and its per-role copy, the transfer/remove pair with their demo-mode split |
| `components/teams/AdminLinks.vue` | 116 | The destination grid, each card behind its own permission, and the emoji-only fallback for a plain member |
| `components/teams/PendingInvitations.vue` | 92 | The invitation rows, resend and cancel |
| `components/teams/MemberRoster.vue` | 67 | The roster heading, its count, the invite button |
| `components/teams/TeamNameForm.vue` | 60 | The rename form and its demo-locked save |
| `components/teams/SettingsHeader.vue` | 45 | The breadcrumb trail, title and ownership badge |
| `components/teams/DangerZone.vue` | 33 | Delete team |
| `components/teams/AdminLinkCard.vue` | 31 | The card markup all eight destinations repeated verbatim |

Server-writing stays on the page: leaf components take props and emit, and the two `router.visit` calls (role change, invitation resend) plus every dialog ref are where they were.

## Parity

The page had almost no frontend coverage, so **50 tests land first** (`Edit.members`, `Edit.invitations`, `Edit.sections`), written against the unsplit file and green there. They mount the page and assert the rendered markup: every selector, every permission gate, the demo-mode variants, and the exact request each control sends. Their staying green across the move is the proof it was a pure move.

Mechanically verified too: all 24 `data-test` selectors and every `$t` key are byte-identical between the old file and the new set, and the only utility-class deltas are the eight admin cards collapsing into one component, with no class dropped. No copy changed, no `lang/fr.json` key added or moved.

## Testing

- `sail composer test`: **Total: 100.0 %**
- `lint:check` (0 errors), `format:check`, `types:check`, `test:js` (188 files / 1932 tests, `max-lines-policy.test.ts` included), `build`
- `tests/Browser/TeamsFieldErrorTest.php` + `tests/Browser/WorkspaceSheetTest.php`, which drive this page with the real components: 15 passed, 78 assertions

## Found while here

A local CodeRabbit pass flagged the three icon-only controls in this markup (transfer ownership, remove member, cancel invitation) as having no accessible name. It is a real gap, but pre-existing and untouched by this move, so it is filed as #1019 rather than fixed inline.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787858861&installation_model_id=428379&pr_number=1020&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1020&signature=de15f19b90d03ec35419d86271569de7d65543e155250facdac2c6825cdbad47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->