### PR TITLE
refactor: split the channel page (pages/channels/Show.vue)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -259,7 +259,6 @@ export default defineConfigWithVueTs(
             'resources/js/composables/useMessageActions.test.ts',
             'resources/js/composables/useMessageActions.ts',
             'resources/js/layouts/MainLayout.vue',
-            'resources/js/pages/channels/Show.vue',
             'resources/js/pages/teams/Analytics.vue',
             'resources/js/pages/teams/AuditExports.vue',
             'resources/js/pages/teams/Edit.vue',

--- a/resources/js/components/channel/ArchiveChannelDialog.vue
+++ b/resources/js/components/channel/ArchiveChannelDialog.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+
+defineProps<{
+    /** Named in the title, so the confirmation says which channel it archives. */
+    channelName: string;
+}>();
+
+defineEmits<{
+    /** The viewer confirmed: archive the channel. */
+    confirm: [];
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle>{{
+                    $t('Archive #:channel', { channel: channelName })
+                }}</DialogTitle>
+                <DialogDescription>
+                    {{
+                        $t(
+                            'The channel becomes read-only and leaves the sidebar. Its messages are kept and stay searchable.',
+                        )
+                    }}
+                </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter class="gap-2">
+                <DialogClose as-child>
+                    <Button variant="secondary"> {{ $t('Cancel') }} </Button>
+                </DialogClose>
+
+                <Button
+                    data-test="archive-channel-confirm"
+                    variant="destructive"
+                    @click="$emit('confirm')"
+                >
+                    {{ $t('Archive') }}
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/channel/ArchivedNotice.vue
+++ b/resources/js/components/channel/ArchivedNotice.vue
@@ -1,0 +1,12 @@
+<template>
+    <div
+        data-test="archived-notice"
+        class="m-5 shrink-0 rounded-lg border border-border bg-muted/40 px-4 py-3 text-center text-[13px] text-muted-foreground"
+    >
+        {{
+            $t(
+                "This channel is archived. It's read-only, but its history is preserved.",
+            )
+        }}
+    </div>
+</template>

--- a/resources/js/components/channel/ChannelAnnouncers.vue
+++ b/resources/js/components/channel/ChannelAnnouncers.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { useMessageAnnouncer } from '@/composables/useMessageAnnouncer';
+import { useSendFailureAnnouncer } from '@/composables/useSendFailureAnnouncer';
+import type { Message } from '@/types';
+
+/**
+ * The two polite live regions the channel reads out to a screen reader: genuine
+ * inbound messages, and a send that failed. The virtualized timeline itself
+ * can't be a `role="log"` (its rows unmount), and a failed optimistic send rolls
+ * its row back silently — so both are announced from here instead.
+ */
+const props = defineProps<{
+    /** The live-merged timeline, watched for genuine arrivals. */
+    messages: Message[];
+    currentUserId: string;
+}>();
+
+const { announcement } = useMessageAnnouncer({
+    messages: () => props.messages,
+    currentUserId: () => props.currentUserId,
+});
+
+const { announcement: sendFailureAnnouncement, announce } =
+    useSendFailureAnnouncer();
+
+defineExpose({
+    /** Announce a failed send, mirroring the toast the page raises. */
+    announce,
+});
+</script>
+
+<template>
+    <div>
+        <div
+            aria-live="polite"
+            aria-atomic="true"
+            class="sr-only"
+            data-test="message-announcer"
+        >
+            {{ announcement }}
+        </div>
+
+        <div
+            aria-live="polite"
+            aria-atomic="true"
+            class="sr-only"
+            data-test="send-failure-announcer"
+        >
+            {{ sendFailureAnnouncement }}
+        </div>
+    </div>
+</template>

--- a/resources/js/components/channel/ChannelComposerDock.vue
+++ b/resources/js/components/channel/ChannelComposerDock.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+import OfflineQueueBanner from '@/components/channel/OfflineQueueBanner.vue';
+import MessageComposer from '@/components/MessageComposer.vue';
+import ScheduledCountChip from '@/components/ScheduledCountChip.vue';
+import TypingIndicator from '@/components/TypingIndicator.vue';
+import type {
+    CommandCallbacks,
+    SendCallbacks,
+} from '@/composables/useMessageActions';
+import type { Channel, Mention, Message, ScheduledMessage } from '@/types';
+
+/**
+ * The bottom of the conversation: the offline queue banner, the typing line, the
+ * scheduled-message chip and the composer itself. The page keeps ownership of
+ * what the composer sends; this owns only the furniture stacked above it.
+ */
+const props = defineProps<{
+    team: { slug: string };
+    channel: Channel;
+    /** The members the composer offers for `@`, the current user and bots aside. */
+    members: Mention[];
+    /** Whether the channel has a bot member, noted once in the mention menu. */
+    hasBots: boolean;
+    /** A DM addresses the conversation by name rather than by "#channel". */
+    placeholder?: string;
+    replyTarget: Message | null;
+    /** The live-merged timeline, so ↑ can edit the viewer's last message. */
+    messages: Message[];
+    currentUserId: string;
+    pendingUuids: string[];
+    timezone: string | null;
+    typingNames: string[];
+    scheduledMessages: ScheduledMessage[];
+    /** How many sends are held in the offline queue, and whether it is showing. */
+    queuedCount: number;
+    isOffline: boolean;
+}>();
+
+const emit = defineEmits<{
+    /**
+     * The composer's `sendToChannel` flag is dropped on the way out: it belongs
+     * to the thread composer's "also send to channel" box, which a channel
+     * composer never shows.
+     */
+    send: [
+        body: string,
+        mentions: Mention[],
+        attachmentIds: string[],
+        callbacks: SendCallbacks,
+    ];
+    command: [body: string, callbacks: CommandCallbacks];
+    schedule: [body: string, mentions: Mention[], sendAt: string];
+    typing: [];
+    cancelReply: [];
+    draftChange: [body: string];
+    edit: [message: Message, body: string];
+    editingChange: [messageId: string | null];
+    /** The viewer threw the offline queue away. */
+    discardQueue: [];
+    /** The chip was used: open the scheduled-messages dialog. */
+    viewScheduled: [];
+}>();
+
+const page = usePage();
+
+const composer = ref<InstanceType<typeof MessageComposer> | null>(null);
+
+/**
+ * The composer's own element, which the page publishes as the bottom-right
+ * rail's inset so toasts sit above it rather than over its send button.
+ */
+const composerElement = computed<HTMLElement | null>(
+    () => (composer.value?.$el as HTMLElement | null) ?? null,
+);
+
+defineExpose({
+    composerElement,
+    focus: (): void => composer.value?.focus(),
+    insertMention: (member: { id: string; name: string }): void =>
+        composer.value?.insertMention(member),
+    addFiles: (files: File[]): void => composer.value?.addFiles(files),
+});
+</script>
+
+<template>
+    <div class="contents">
+        <OfflineQueueBanner
+            v-if="props.isOffline && props.queuedCount > 0"
+            :count="props.queuedCount"
+            @discard="emit('discardQueue')"
+        />
+
+        <!-- Below `md` the line is indented to the message text column, so it
+             reads as the next message rather than a stray note against the
+             screen edge. -->
+        <TypingIndicator
+            :names="props.typingNames"
+            class="mx-5 shrink-0 max-md:pl-9"
+        />
+
+        <ScheduledCountChip
+            v-if="props.scheduledMessages.length > 0"
+            :count="props.scheduledMessages.length"
+            :channel-name="props.channel.name"
+            class="mx-5 mb-2.5"
+            @view="emit('viewScheduled')"
+        />
+
+        <MessageComposer
+            ref="composer"
+            :key="props.channel.id"
+            data-tour="composer"
+            :channel-name="props.channel.name"
+            :placeholder="props.placeholder"
+            :members="props.members"
+            :has-bots="props.hasBots"
+            :reply-target="props.replyTarget"
+            :initial-body="props.channel.draft ?? ''"
+            :messages="props.messages"
+            :current-user-id="props.currentUserId"
+            :pending-uuids="props.pendingUuids"
+            :team-slug="props.team.slug"
+            :channel-slug="props.channel.slug"
+            :max-attachment-size-mb="page.props.attachments.maxSizeMb"
+            :max-attachments-per-message="page.props.attachments.maxPerMessage"
+            allow-schedule
+            :timezone="props.timezone"
+            :slash-commands="page.props.slashCommands"
+            :gif-picker-enabled="page.props.gifPickerEnabled"
+            :polls-enabled="page.props.pollsEnabled"
+            @send="
+                (body, mentions, _sendToChannel, attachmentIds, callbacks) =>
+                    emit('send', body, mentions, attachmentIds, callbacks)
+            "
+            @command="(body, callbacks) => emit('command', body, callbacks)"
+            @schedule="
+                (body, mentions, sendAt) =>
+                    emit('schedule', body, mentions, sendAt)
+            "
+            @typing="emit('typing')"
+            @cancel-reply="emit('cancelReply')"
+            @draft-change="(body) => emit('draftChange', body)"
+            @edit="(message, body) => emit('edit', message, body)"
+            @editing-change="(id) => emit('editingChange', id)"
+        />
+    </div>
+</template>

--- a/resources/js/components/channel/ChannelDialogs.vue
+++ b/resources/js/components/channel/ChannelDialogs.vue
@@ -51,7 +51,9 @@ const {
     forwardablePeople,
     openForward,
     submitForward,
-} = useForwardDialog({ forwardMessage: props.forwardMessage });
+} = useForwardDialog({
+    forwardMessage: (source, payload) => props.forwardMessage(source, payload),
+});
 
 const {
     reminderCustomOpen,

--- a/resources/js/components/channel/ChannelDialogs.vue
+++ b/resources/js/components/channel/ChannelDialogs.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import { archive as archiveChannel } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import AddDirectMessagePeopleModal from '@/components/AddDirectMessagePeopleModal.vue';
+import ArchiveChannelDialog from '@/components/channel/ArchiveChannelDialog.vue';
+import ForwardMessageDialog from '@/components/ForwardMessageDialog.vue';
+import LeaveChannelModal from '@/components/LeaveChannelModal.vue';
+import ScheduledMessagesDialog from '@/components/ScheduledMessagesDialog.vue';
+import ScheduleMessageDialog from '@/components/ScheduleMessageDialog.vue';
+import { useForwardDialog } from '@/composables/useForwardDialog';
+import { useReminderPicker } from '@/composables/useReminderPicker';
+import { useToast } from '@/composables/useToast';
+import { useTranslations } from '@/composables/useTranslations';
+import type { Channel, Message, ScheduledMessage } from '@/types';
+import type { ForwardTarget } from '@/types/forward';
+
+/**
+ * Every dialog the channel page can raise, and the state that decides which one
+ * is open. The page opens them through the exposed handlers rather than holding
+ * a flag per dialog; what each one does on confirm stays with the page's own
+ * actions engine, handed in as callbacks.
+ */
+const props = defineProps<{
+    team: { slug: string };
+    channel: Channel;
+    currentUserId: string;
+    timezone: string | null;
+    /** The viewer's own pending scheduled messages for this channel. */
+    scheduledMessages: ScheduledMessage[];
+    forwardMessage: (
+        source: Message,
+        payload: { target: ForwardTarget; note: string },
+    ) => void;
+    setReminder: (messageId: string, remindAt: string) => void;
+    updateScheduled: (payload: {
+        id: string;
+        body: string;
+        sendAt: string;
+    }) => void;
+    cancelScheduled: (id: string) => void;
+}>();
+
+const { t } = useTranslations();
+const toast = useToast();
+
+const {
+    forwardTarget,
+    forwardDialogOpen,
+    forwardableChannels,
+    forwardablePeople,
+    openForward,
+    submitForward,
+} = useForwardDialog({ forwardMessage: props.forwardMessage });
+
+const {
+    reminderCustomOpen,
+    remindWith,
+    openCustomReminder,
+    confirmCustomReminder,
+} = useReminderPicker({
+    setReminder: (messageId, remindAt) =>
+        props.setReminder(messageId, remindAt),
+});
+
+/** Whether the "Scheduled messages" management dialog is open. */
+const scheduledDialogOpen = ref(false);
+
+/** Drives the archive confirmation dialog opened from the channel header menu. */
+const confirmingArchive = ref(false);
+
+/** Drives the leave-channel confirmation modal opened from the header menu. */
+const confirmingLeave = ref(false);
+
+const addingPeople = ref(false);
+
+function archive(): void {
+    confirmingArchive.value = false;
+
+    router.post(
+        archiveChannel({ team: props.team.slug, channel: props.channel.slug })
+            .url,
+        {},
+        {
+            onError: () => {
+                toast.error(t('Failed to archive the channel'));
+            },
+        },
+    );
+}
+
+defineExpose({
+    openForward,
+    remindWith,
+    openCustomReminder,
+    openScheduled: (): void => {
+        scheduledDialogOpen.value = true;
+    },
+    confirmArchive: (): void => {
+        confirmingArchive.value = true;
+    },
+    confirmLeave: (): void => {
+        confirmingLeave.value = true;
+    },
+    openAddPeople: (): void => {
+        addingPeople.value = true;
+    },
+    /**
+     * Close the add-people modal, so a switch to another conversation never
+     * carries it over onto the wrong DM.
+     */
+    closeAddPeople: (): void => {
+        addingPeople.value = false;
+    },
+});
+</script>
+
+<template>
+    <div class="contents">
+        <ForwardMessageDialog
+            v-model:open="forwardDialogOpen"
+            :message="forwardTarget"
+            :channels="forwardableChannels"
+            :people="forwardablePeople"
+            :current-user-id="props.currentUserId"
+            @submit="submitForward"
+        />
+
+        <ScheduledMessagesDialog
+            v-model:open="scheduledDialogOpen"
+            :scheduled-messages="props.scheduledMessages"
+            :channel-name="props.channel.name"
+            :timezone="props.timezone"
+            @update="props.updateScheduled"
+            @cancel="props.cancelScheduled"
+        />
+
+        <ScheduleMessageDialog
+            v-model:open="reminderCustomOpen"
+            :timezone="props.timezone"
+            :title="$t('Remind me about this')"
+            :confirm-label="$t('Set reminder')"
+            @confirm="confirmCustomReminder"
+        />
+
+        <ArchiveChannelDialog
+            v-model:open="confirmingArchive"
+            :channel-name="props.channel.name"
+            @confirm="archive"
+        />
+
+        <LeaveChannelModal
+            v-model:open="confirmingLeave"
+            :channel="props.channel"
+            :team-slug="props.team.slug"
+        />
+
+        <AddDirectMessagePeopleModal
+            v-if="props.channel.isDirect"
+            v-model:open="addingPeople"
+            :channel="props.channel"
+            :team-slug="props.team.slug"
+            :current-user-id="props.currentUserId"
+        />
+    </div>
+</template>

--- a/resources/js/components/channel/ChannelDropOverlay.vue
+++ b/resources/js/components/channel/ChannelDropOverlay.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
+import { Upload } from '@lucide/vue';
+
+defineProps<{
+    /** Named in the copy, so the reader knows where the files are landing. */
+    channelName: string;
+}>();
+
+const page = usePage();
+</script>
+
+<template>
+    <!-- Whole-pane drop target: dropping files anywhere over the channel stages
+         them in the composer. Pointer-events-none so the drop lands on the
+         pane's own handler, not the overlay. -->
+    <div
+        data-test="channel-drop-overlay"
+        class="pointer-events-none absolute inset-2.5 z-20 flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-brass bg-card/75 backdrop-blur-[2px]"
+    >
+        <span
+            class="flex size-14 items-center justify-center rounded-full bg-foreground text-brass"
+        >
+            <Upload class="size-6" />
+        </span>
+        <span class="font-serif text-2xl font-semibold text-foreground">
+            {{ $t('Drop to attach to #:channel', { channel: channelName }) }}
+        </span>
+        <span class="text-[13px] text-muted-foreground">
+            {{
+                $t('Up to :count files · :size MB each', {
+                    count: page.props.attachments.maxPerMessage,
+                    size: page.props.attachments.maxSizeMb,
+                })
+            }}
+        </span>
+    </div>
+</template>

--- a/resources/js/components/channel/ChannelHeader.vue
+++ b/resources/js/components/channel/ChannelHeader.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import ChannelMasthead from '@/components/ChannelMasthead.vue';
+import PinsPanel from '@/components/PinsPanel.vue';
+import { useChannelPins } from '@/composables/useChannelPins';
+import { useChannelPreferences } from '@/composables/useChannelPreferences';
+import type { ConnectionPill } from '@/composables/useConnectionState';
+import type { RenderedPresence } from '@/lib/presence';
+import type {
+    Channel,
+    Mention,
+    Message,
+    NotificationLevelOption,
+} from '@/types';
+
+/**
+ * The channel's header: the masthead and the pins popover it opens.
+ *
+ * It owns the two pieces of state that belong to the header rather than to the
+ * conversation — the member's own star/mute/notification-level preferences, and
+ * the pin count with its panel — and exposes the parts the page's realtime
+ * router has to reconcile against.
+ */
+const props = defineProps<{
+    team: { slug: string };
+    channel: Channel;
+    members: Mention[];
+    presenceFor: (userId: string) => RenderedPresence;
+    isDndFor: (userId: string) => boolean;
+    /** What the channel is called from this viewer's side of it. */
+    title: string;
+    canManagePreferences: boolean;
+    canArchive: boolean;
+    canLeave: boolean;
+    canAddPeople: boolean;
+    /** Whether the viewer may pin and unpin, as the panel's rows offer. */
+    canPin: boolean;
+    notificationLevels: NotificationLevelOption[];
+    /** The channel's pinned messages, most-recently-pinned first. */
+    pins: Message[];
+    /** The server's pin count, resynced on partial reloads and switches. */
+    pinCount: number;
+    connectionPill: ConnectionPill;
+    /** Whether conversation has scrolled under the masthead, taking a shadow. */
+    scrolled: boolean;
+    viewerTimezone: string | null;
+}>();
+
+const emit = defineEmits<{
+    archive: [];
+    leave: [];
+    addPeople: [];
+    /** A pinned message was picked: bring it into view in the timeline. */
+    jump: [messageId: string];
+    unpin: [message: Message];
+}>();
+
+/**
+ * The member's own star/mute/notification-level preferences for this channel:
+ * seeded from the server, reseeded on every channel switch, saved optimistically
+ * and rolled back on error. `threadUnreadSuppressed` mirrors the server's dot
+ * suppression and feeds the page's realtime router.
+ */
+const {
+    notificationLevel,
+    muted,
+    starred,
+    threadUnreadSuppressed,
+    notificationStatus,
+    toggleStar,
+    onNotificationLevelChange,
+    onMuteChange,
+} = useChannelPreferences({
+    channelId: () => props.channel.id,
+    channel: () => props.channel,
+    teamSlug: () => props.team.slug,
+    channelSlug: () => props.channel.slug,
+});
+
+const { pinCount, pinsPanelOpen, openPinsPanel, jumpToPin } = useChannelPins({
+    pinCount: () => props.pinCount,
+    jumpToMessage: (id) => emit('jump', id),
+});
+
+defineExpose({
+    /** Whether the server suppresses this channel's thread-unread dot. */
+    threadUnreadSuppressed,
+    /** Patch the badge from the MessagePinned broadcast. */
+    setPinCount: (count: number): void => {
+        pinCount.value = count;
+    },
+    /** Close the pins popover, e.g. on a channel switch. */
+    closePins: (): void => {
+        pinsPanelOpen.value = false;
+    },
+});
+</script>
+
+<template>
+    <div class="contents">
+        <ChannelMasthead
+            :channel="props.channel"
+            :members="props.members"
+            :presence-for="props.presenceFor"
+            :is-dnd-for="props.isDndFor"
+            :title="props.title"
+            :can-manage-preferences="props.canManagePreferences"
+            :can-archive="props.canArchive"
+            :can-leave="props.canLeave"
+            :can-add-people="props.canAddPeople"
+            :notification-levels="props.notificationLevels"
+            :starred="starred"
+            :muted="muted"
+            :pin-count="pinCount"
+            :notification-level="notificationLevel"
+            :notification-status="notificationStatus"
+            :connection-pill="props.connectionPill"
+            :scrolled="props.scrolled"
+            @toggle-star="toggleStar"
+            @notification-level-change="onNotificationLevelChange"
+            @mute-change="onMuteChange"
+            @archive="emit('archive')"
+            @leave="emit('leave')"
+            @add-people="emit('addPeople')"
+            @open-pins="openPinsPanel"
+        />
+
+        <PinsPanel
+            v-if="pinsPanelOpen"
+            :pins="props.pins"
+            :pin-count="pinCount"
+            :can-pin="props.canPin"
+            :viewer-timezone="props.viewerTimezone"
+            @close="pinsPanelOpen = false"
+            @jump="jumpToPin"
+            @unpin="(message) => emit('unpin', message)"
+        />
+    </div>
+</template>

--- a/resources/js/components/channel/ChannelPane.vue
+++ b/resources/js/components/channel/ChannelPane.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+import { InfiniteScroll } from '@inertiajs/vue3';
+import { computed, ref, watch } from 'vue';
+import ChannelDropOverlay from '@/components/channel/ChannelDropOverlay.vue';
+import LoadingOlderPill from '@/components/channel/LoadingOlderPill.vue';
+import StickyDayChip from '@/components/channel/StickyDayChip.vue';
+import UnreadJumpPill from '@/components/channel/UnreadJumpPill.vue';
+import ChannelEmptyState from '@/components/ChannelEmptyState.vue';
+import MessageList from '@/components/MessageList.vue';
+import ScrollableMessageList from '@/components/ScrollableMessageList.vue';
+import { useChannelHistory } from '@/composables/useChannelHistory';
+import { useMessageHighlight } from '@/composables/useMessageHighlight';
+import { usePaneFileDrop } from '@/composables/usePaneFileDrop';
+import { useStickyDayLabel } from '@/composables/useStickyDayLabel';
+import { useUnreadDivider } from '@/composables/useUnreadDivider';
+import { useUnreadJump } from '@/composables/useUnreadJump';
+import type { TimelineRange } from '@/composables/useUnreadJump';
+import type { RenderedPresence } from '@/lib/presence';
+import { buildTimelineItems } from '@/lib/timeline';
+import type { Channel, ChannelReader, Message } from '@/types';
+
+/**
+ * The conversation pane: the whole-pane file drop zone, the windowed timeline
+ * with its floating affordances, and the bottom slot the page fills with the
+ * composer (or the archived notice / join bar that stand in for it).
+ *
+ * The page keeps its scroll pin, since the realtime and action layers reconcile
+ * against it; this owns everything derived from the virtualizer's window.
+ */
+const props = defineProps<{
+    team: { name: string; slug: string };
+    channel: Channel;
+    /** The live-merged timeline: server page + optimistic sends + echoes. */
+    messages: Message[];
+    /**
+     * The server page alone, oldest-first. The unread boundary reads it rather
+     * than the merged list so it is immune to the order per-channel state resets
+     * on a channel switch.
+     */
+    serverMessages: Message[];
+    currentUserId: string;
+    /** Whether this is the viewer's own self-DM, so the empty state reads "You". */
+    isSelfDm: boolean;
+    pendingUuids: string[];
+    queuedUuids: string[];
+    canModerate: boolean;
+    canReact: boolean;
+    /** Whether a file drop would be staged (a member of a live channel). */
+    canDropFiles: boolean;
+    presenceFor: (userId: string) => RenderedPresence;
+    isDndFor: (userId: string) => boolean;
+    readers: ChannelReader[];
+    activeThreadRootId: string | null;
+    editingMessageId: string | null;
+    /** The viewer's read pointer at load time, placing the unread divider. */
+    lastReadMessageId: string | null;
+    /** Function ref handing the scroll element back to the page's scroll pin. */
+    registerContainer: (el: HTMLElement | null) => void;
+    pinnedToBottom: boolean;
+    newMessageCount: number;
+    /** The page's scroll pin, so a jump to present goes through one place. */
+    scrollToBottom: (smooth?: boolean) => void;
+}>();
+
+const emit = defineEmits<{
+    /** The history scrolled; the page forwards it to its scroll pin. */
+    scroll: [];
+    /** Files were dropped over the pane, for the composer's tray. */
+    files: [files: File[]];
+    /** The empty state's "Post your first message" card was used. */
+    focusComposer: [];
+    edit: [message: Message, body: string];
+    delete: [message: Message];
+    reply: [message: Message];
+    forward: [message: Message];
+    react: [message: Message, emoji: string];
+    vote: [message: Message, optionId: string];
+    closePoll: [message: Message];
+    pin: [message: Message];
+    unpin: [message: Message];
+    remind: [message: Message, remindAt: string];
+    remindCustom: [message: Message];
+    openThread: [messageId: string];
+    jump: [messageId: string];
+    mention: [member: { id: string; name: string }];
+}>();
+
+/**
+ * The scroll element the virtualizer and the unread divider bind to. It reaches
+ * the page's own scroll pin through `registerContainer`, so all three watch the
+ * very same node.
+ */
+const scrollElement = ref<HTMLElement | null>(null);
+
+function setScrollContainer(el: HTMLElement | null): void {
+    scrollElement.value = el;
+    props.registerContainer(el);
+}
+
+/**
+ * Whether the timeline has conversation scrolled above its top edge. Below the
+ * breakpoint the masthead sits over the timeline rather than beside it, so it
+ * takes a hairline shadow exactly when there is something passing under it.
+ */
+const scrolled = ref(false);
+
+function onScrolled(): void {
+    scrolled.value = (scrollElement.value?.scrollTop ?? 0) > 0;
+    emit('scroll');
+}
+
+watch(
+    () => props.channel.id,
+    () => {
+        scrolled.value = false;
+    },
+);
+
+/**
+ * The windowed timeline exposes `scrollToIndex` so off-screen jump targets can be
+ * brought into view, and `scrollToLatest` so the page's scroll pin can drive a
+ * jump the virtualizer re-targets as rows measure (#347).
+ */
+const messageListRef = ref<{
+    scrollToIndex: (
+        index: number,
+        align?: 'auto' | 'start' | 'center' | 'end',
+    ) => void;
+    scrollToLatest: (behavior?: ScrollBehavior) => void;
+} | null>(null);
+
+/**
+ * The virtualizer's visible render-item window, from which the position-dependent
+ * affordances are derived without a DOM `IntersectionObserver`.
+ */
+const timelineRange = ref<TimelineRange | null>(null);
+
+const scrollToIndex = (index: number, align: 'start' | 'center'): void =>
+    messageListRef.value?.scrollToIndex(index, align);
+
+const hasMessages = computed(() => props.messages.length > 0);
+
+const {
+    infiniteScrollRef,
+    loadingOlder,
+    hasOlder,
+    isLoadingOlder,
+    loadOlderMessages,
+} = useChannelHistory({ loadedCount: () => props.serverMessages.length });
+
+/**
+ * The "New messages" divider's lifecycle — freeze its position at open, refreeze
+ * on each channel switch, and hide the jump pill once it scrolls into view —
+ * lives in this composable.
+ */
+const { unreadDividerId } = useUnreadDivider({
+    channelId: () => props.channel.id,
+    scrollContainer: scrollElement,
+    messages: () => props.serverMessages,
+    lastReadMessageId: () => props.lastReadMessageId,
+    currentUserId: () => props.currentUserId,
+});
+
+/**
+ * The same grouped render list the virtualized `MessageList` builds, recomputed
+ * here so index-based affordances (jump-to-message, the unread boundary) can map
+ * a message or divider to the render-item index the virtualizer scrolls to.
+ */
+const timelineItems = computed(() =>
+    buildTimelineItems(props.messages, unreadDividerId.value ?? null),
+);
+
+const { highlightedMessageId, jumpToMessage } = useMessageHighlight({
+    timelineItems: () => timelineItems.value,
+    scrollToIndex,
+});
+
+const { showJumpToUnread, scrollToUnread, jumpToPresent } = useUnreadJump({
+    channelId: () => props.channel.id,
+    timelineItems: () => timelineItems.value,
+    timelineRange,
+    scrollToIndex,
+    scrollToBottom: (smooth) => props.scrollToBottom(smooth),
+});
+
+const stickyDayLabel = useStickyDayLabel({
+    timelineItems: () => timelineItems.value,
+    timelineRange,
+});
+
+const {
+    isDraggingFiles,
+    canDropAttachments,
+    onPaneDragEnter,
+    onPaneDragOver,
+    onPaneDragLeave,
+    onPaneDrop,
+} = usePaneFileDrop({
+    canDrop: () => props.canDropFiles,
+    onFiles: (files) => emit('files', files),
+});
+
+defineExpose({
+    /** Whether conversation has scrolled under the masthead, which takes a shadow. */
+    scrolled,
+    jumpToMessage,
+    scrollToLatest: (behavior?: ScrollBehavior) =>
+        messageListRef.value?.scrollToLatest(behavior),
+});
+</script>
+
+<template>
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- the pane is a file drop zone; keyboard users attach via the composer's Add-attachment button -->
+    <div
+        class="relative flex min-h-0 flex-1 flex-col"
+        @dragenter="onPaneDragEnter"
+        @dragover="onPaneDragOver"
+        @dragleave="onPaneDragLeave"
+        @drop="onPaneDrop"
+    >
+        <ChannelDropOverlay
+            v-if="isDraggingFiles && canDropAttachments()"
+            :channel-name="props.channel.name"
+        />
+
+        <div class="relative flex min-h-0 flex-1 flex-col">
+            <UnreadJumpPill :show="showJumpToUnread" @jump="scrollToUnread" />
+
+            <StickyDayChip
+                :label="
+                    !props.pinnedToBottom && !showJumpToUnread
+                        ? stickyDayLabel
+                        : null
+                "
+            />
+
+            <!-- The message history is a focusable, labelled region so keyboard
+                 users can Tab to it and arrow-scroll (which remounts virtualized
+                 rows). `ScrollableMessageList` renders the region + the
+                 jump-to-latest pill; the timeline itself can't be a `role="log"`
+                 since its rows unmount, so `role="region"` names it instead. -->
+            <ScrollableMessageList
+                variant="channel"
+                :region-label="$t('Message history')"
+                :register-container="setScrollContainer"
+                :pinned-to-bottom="props.pinnedToBottom"
+                :new-message-count="props.newMessageCount"
+                @scroll="onScrolled"
+                @jump="jumpToPresent"
+            >
+                <LoadingOlderPill :show="loadingOlder" />
+
+                <InfiniteScroll
+                    v-if="hasMessages"
+                    ref="infiniteScrollRef"
+                    data="messages"
+                    reverse
+                    manual
+                    preserve-url
+                >
+                    <MessageList
+                        ref="messageListRef"
+                        virtualize
+                        :scroll-element="scrollElement"
+                        :has-older="hasOlder"
+                        :is-loading-older="isLoadingOlder"
+                        :messages="props.messages"
+                        :team-slug="props.team.slug"
+                        :pending-uuids="props.pendingUuids"
+                        :queued-uuids="props.queuedUuids"
+                        :current-user-id="props.currentUserId"
+                        :is-direct="props.channel.isDirect"
+                        :can-moderate="props.canModerate"
+                        :can-react="props.canReact"
+                        :can-pin="props.canReact"
+                        :presence-for="props.presenceFor"
+                        :is-dnd-for="props.isDndFor"
+                        :readers="props.readers"
+                        :highlight-message-id="highlightedMessageId"
+                        :unread-divider-id="unreadDividerId"
+                        :active-thread-root-id="props.activeThreadRootId"
+                        :editing-message-id="props.editingMessageId"
+                        @edit="(message, body) => emit('edit', message, body)"
+                        @delete="(message) => emit('delete', message)"
+                        @reply="(message) => emit('reply', message)"
+                        @forward="(message) => emit('forward', message)"
+                        @react="
+                            (message, emoji) => emit('react', message, emoji)
+                        "
+                        @vote="
+                            (message, optionId) =>
+                                emit('vote', message, optionId)
+                        "
+                        @close-poll="(message) => emit('closePoll', message)"
+                        @pin="(message) => emit('pin', message)"
+                        @unpin="(message) => emit('unpin', message)"
+                        @remind="(message, at) => emit('remind', message, at)"
+                        @remind-custom="
+                            (message) => emit('remindCustom', message)
+                        "
+                        @open-thread="(id) => emit('openThread', id)"
+                        @jump="(id) => emit('jump', id)"
+                        @mention="(member) => emit('mention', member)"
+                        @load-older="loadOlderMessages"
+                        @range-change="timelineRange = $event"
+                    />
+                </InfiniteScroll>
+
+                <ChannelEmptyState
+                    v-else
+                    :channel="props.channel"
+                    :is-self-dm="props.isSelfDm"
+                    :team-name="props.team.name"
+                    :team-slug="props.team.slug"
+                    @focus-composer="emit('focusComposer')"
+                />
+            </ScrollableMessageList>
+        </div>
+
+        <!-- The bottom slot: the composer, or what stands in for it (the
+             archived notice, the join bar). It sits inside the drop zone so a
+             file dropped over the composer stages just as it does over the
+             history. -->
+        <slot />
+    </div>
+</template>

--- a/resources/js/components/channel/LoadingOlderPill.vue
+++ b/resources/js/components/channel/LoadingOlderPill.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+defineProps<{
+    /** Whether an older page is in flight. */
+    show: boolean;
+}>();
+</script>
+
+<template>
+    <Transition
+        enter-active-class="transition duration-150 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-100 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+    >
+        <div
+            v-if="show"
+            data-test="loading-older"
+            class="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center"
+        >
+            <span
+                class="inline-flex items-center gap-2 rounded-full bg-card px-3 py-1 text-[12px] text-muted-foreground shadow-sm ring-1 ring-border"
+            >
+                <span
+                    aria-hidden="true"
+                    class="size-3 animate-spin rounded-full border-2 border-border border-t-foreground"
+                />
+                {{ $t('Loading earlier messages…') }}
+            </span>
+        </div>
+    </Transition>
+</template>

--- a/resources/js/components/channel/OfflineQueueBanner.vue
+++ b/resources/js/components/channel/OfflineQueueBanner.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { WifiOff } from '@lucide/vue';
+import { Button } from '@/components/ui/button';
+
+defineProps<{
+    /** How many of the viewer's sends are being held locally. */
+    count: number;
+}>();
+
+defineEmits<{
+    /** Throw the whole queue away rather than waiting for the reconnect. */
+    discard: [];
+}>();
+</script>
+
+<template>
+    <!-- Offline queue banner: the socket is down and the viewer's sends are
+         being held locally; they flush automatically on reconnect, or can be
+         discarded here. -->
+    <div
+        data-test="offline-queue-banner"
+        class="mx-5 mb-1 flex shrink-0 items-center gap-2.5 rounded-lg border border-amber-200 bg-amber-50 px-3.5 py-2.5 text-[12.5px] font-medium text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-500"
+    >
+        <WifiOff class="size-3.5 shrink-0" />
+        <span class="min-w-0">
+            {{
+                count === 1
+                    ? $t(
+                          "You're offline. 1 message is queued and will send automatically.",
+                      )
+                    : $t(
+                          "You're offline. :count messages are queued and will send automatically.",
+                          { count },
+                      )
+            }}
+        </span>
+        <Button
+            variant="unstyled"
+            size="none"
+            type="button"
+            data-test="discard-queue"
+            class="ml-auto shrink-0 font-semibold text-rose-600 hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300"
+            @click="$emit('discard')"
+        >
+            {{ $t('Discard queue') }}
+        </Button>
+    </div>
+</template>

--- a/resources/js/components/channel/StickyDayChip.vue
+++ b/resources/js/components/channel/StickyDayChip.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+defineProps<{
+    /**
+     * The day the topmost visible row falls in, or null when the chip should
+     * stay down (pinned to the newest message, or a day divider already leads).
+     */
+    label: string | null;
+}>();
+</script>
+
+<template>
+    <Transition
+        enter-active-class="transition duration-150 ease-out"
+        enter-from-class="-translate-y-1 opacity-0"
+        enter-to-class="translate-y-0 opacity-100"
+        leave-active-class="transition duration-100 ease-in"
+        leave-from-class="translate-y-0 opacity-100"
+        leave-to-class="-translate-y-1 opacity-0"
+    >
+        <div
+            v-if="label"
+            data-test="sticky-date"
+            class="pointer-events-none absolute top-2.5 left-1/2 z-10 inline-flex h-6.5 -translate-x-1/2 items-center rounded-full bg-card px-3.5 text-[11.5px] font-semibold text-muted-foreground shadow-md ring-1 ring-border"
+        >
+            {{ label }}
+        </div>
+    </Transition>
+</template>

--- a/resources/js/components/channel/UnreadJumpPill.vue
+++ b/resources/js/components/channel/UnreadJumpPill.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { ArrowUp } from '@lucide/vue';
+
+defineProps<{
+    /** Whether the unread boundary is still above the reader's window. */
+    show: boolean;
+}>();
+
+defineEmits<{
+    /** The pill was clicked: scroll the boundary into view. */
+    jump: [];
+}>();
+</script>
+
+<template>
+    <Transition
+        enter-active-class="transition duration-150 ease-out"
+        enter-from-class="-translate-y-1 opacity-0"
+        enter-to-class="translate-y-0 opacity-100"
+        leave-active-class="transition duration-100 ease-in"
+        leave-from-class="translate-y-0 opacity-100"
+        leave-to-class="-translate-y-1 opacity-0"
+    >
+        <!-- eslint-disable-next-line local/no-raw-button -- jump pill: stays raw with the deferred jump-to-latest pills (#316); the primitive does not compose as a <Transition> child here -->
+        <button
+            v-if="show"
+            type="button"
+            data-test="jump-to-unread"
+            class="absolute top-2.5 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-rose-600 px-3 py-1 text-[12px] font-semibold text-white shadow-md hover:bg-rose-700"
+            @click="$emit('jump')"
+        >
+            <ArrowUp class="size-3.5" />
+            {{ $t('New messages') }}
+        </button>
+    </Transition>
+</template>

--- a/resources/js/composables/useChannelHistory.ts
+++ b/resources/js/composables/useChannelHistory.ts
@@ -1,0 +1,69 @@
+import { ref, watch } from 'vue';
+import type { Ref } from 'vue';
+
+/** The slice of Inertia's `<InfiniteScroll>` the timeline drives manually. */
+interface InfiniteScrollHandle {
+    fetchNext: () => void;
+    hasNext: () => boolean;
+}
+
+export interface ChannelHistoryOptions {
+    /** How many messages the server page currently holds. */
+    loadedCount: () => number;
+}
+
+export interface ChannelHistory {
+    /** Bind to Inertia's `<InfiniteScroll>` so the fetch can be driven manually. */
+    infiniteScrollRef: Ref<InfiniteScrollHandle | null>;
+    /** Whether an older page is in flight, driving the "Loading earlier…" pill. */
+    loadingOlder: Ref<boolean>;
+    hasOlder: () => boolean;
+    isLoadingOlder: () => boolean;
+    loadOlderMessages: () => void;
+}
+
+/**
+ * Reverse-paginated history for the channel timeline.
+ *
+ * In reverse mode, older history is the paginator's *next* page (the server
+ * returns messages newest-first), so "load older" maps to fetchNext/hasNext.
+ * The in-flight flag gates the virtualizer's top-load trigger so a burst of
+ * range updates can't stack duplicate requests; it clears once the merged page
+ * grows (older rows have landed).
+ */
+export function useChannelHistory(
+    options: ChannelHistoryOptions,
+): ChannelHistory {
+    const infiniteScrollRef = ref<InfiniteScrollHandle | null>(null);
+    const loadingOlder = ref(false);
+
+    const hasOlder = (): boolean => infiniteScrollRef.value?.hasNext() ?? false;
+
+    const isLoadingOlder = (): boolean => loadingOlder.value;
+
+    /**
+     * Fetch the next older page through Inertia's merge engine. The virtualizer
+     * decides *when* (the reader nears the top of loaded history); Inertia handles
+     * the cursor request, prepend, and scroll positioning.
+     */
+    function loadOlderMessages(): void {
+        if (loadingOlder.value || !hasOlder()) {
+            return;
+        }
+
+        loadingOlder.value = true;
+        infiniteScrollRef.value?.fetchNext();
+    }
+
+    watch(options.loadedCount, () => {
+        loadingOlder.value = false;
+    });
+
+    return {
+        infiniteScrollRef,
+        loadingOlder,
+        hasOlder,
+        isLoadingOlder,
+        loadOlderMessages,
+    };
+}

--- a/resources/js/composables/useChannelIdentity.ts
+++ b/resources/js/composables/useChannelIdentity.ts
@@ -1,0 +1,121 @@
+import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import type { ComputedRef } from 'vue';
+import { useTranslations } from '@/composables/useTranslations';
+import { groupDmMastheadName } from '@/lib/groupDm';
+import type { Channel, Mention } from '@/types';
+
+export interface ChannelIdentityOptions {
+    channel: () => Channel;
+    /** The channel's members, as the roster and the mention menu see them. */
+    members: () => Mention[];
+    /** Whether the viewer belongs to the channel. */
+    isMember: () => boolean;
+}
+
+export interface ChannelIdentity {
+    currentUser: ComputedRef<{ id: string; name: string }>;
+    /** Whether this is the viewer's own self-DM, which reads "You". */
+    isSelfDm: ComputedRef<boolean>;
+    /** What the channel is called from the viewer's side of it. */
+    mastheadTitle: ComputedRef<string>;
+    /** Whether the viewer may grow this DM by adding people. */
+    canAddPeople: ComputedRef<boolean>;
+    /** A DM's composer placeholder, or undefined to keep the channel default. */
+    composerPlaceholder: ComputedRef<string | undefined>;
+    /** Whether the viewer may delete anyone's message here (a team Admin+). */
+    canModerate: ComputedRef<boolean>;
+    /** The members the composer offers for `@`. */
+    mentionableMembers: ComputedRef<Mention[]>;
+    /** Whether the channel has a bot member. */
+    channelHasBots: ComputedRef<boolean>;
+}
+
+/**
+ * How the open channel reads to this viewer: its name, its composer
+ * placeholder, who they may mention, and what they are allowed to do in it.
+ *
+ * A direct message renders viewer-relative: no "#", the other participant's
+ * name (the viewer's own self-DM reads "You"), or a group's participant-joined
+ * name. That drives the `<Head>` title, the masthead, and the empty state's
+ * viewer-relative copy; the masthead owns the DM avatar and facepile itself.
+ */
+export function useChannelIdentity(
+    options: ChannelIdentityOptions,
+): ChannelIdentity {
+    const page = usePage();
+    const { t } = useTranslations();
+
+    const currentUser = computed(() => ({
+        id: String(page.props.auth.user.id),
+        name: page.props.auth.user.name,
+    }));
+
+    const isSelfDm = computed(
+        () =>
+            options.channel().isDirect &&
+            options.channel().dmUserId === currentUser.value.id,
+    );
+
+    const mastheadTitle = computed(() => {
+        if (options.channel().isGroupDirect) {
+            return (
+                groupDmMastheadName(options.channel().dmParticipants ?? []) ||
+                t('Group conversation')
+            );
+        }
+
+        return isSelfDm.value ? t('You') : options.channel().name;
+    });
+
+    /**
+     * The viewer may add people to any DM they belong to; grows a 1:1 into a group
+     * or a group further. Drives the masthead's "Add people" button and its modal.
+     */
+    const canAddPeople = computed(
+        () => options.channel().isDirect && options.isMember(),
+    );
+
+    /**
+     * A DM's composer addresses the conversation by its participant name rather
+     * than a "#channel", so its placeholder overrides the composer's default.
+     */
+    const composerPlaceholder = computed(() =>
+        options.channel().isDirect
+            ? t('Message :name', { name: mastheadTitle.value })
+            : undefined,
+    );
+
+    /** A team Admin+ may delete anyone's message in the channel (moderation). */
+    const canModerate = computed(() =>
+        ['admin', 'owner'].includes(page.props.currentTeam?.role ?? ''),
+    );
+
+    // You can't @mention yourself, and bots have no inbox to reach, so drop the
+    // current user and any bots from the composer list — the roster facepile still
+    // shows the bots.
+    const mentionableMembers = computed(() =>
+        options
+            .members()
+            .filter(
+                (member) => member.id !== currentUser.value.id && !member.isBot,
+            ),
+    );
+
+    // Whether this channel has a bot member, so the composer's mention menu can
+    // note once, quietly, why bots aren't mentionable.
+    const channelHasBots = computed(() =>
+        options.members().some((member) => member.isBot),
+    );
+
+    return {
+        currentUser,
+        isSelfDm,
+        mastheadTitle,
+        canAddPeople,
+        composerPlaceholder,
+        canModerate,
+        mentionableMembers,
+        channelHasBots,
+    };
+}

--- a/resources/js/composables/useChannelPins.ts
+++ b/resources/js/composables/useChannelPins.ts
@@ -1,0 +1,53 @@
+import { router } from '@inertiajs/vue3';
+import { ref, watch } from 'vue';
+import type { Ref } from 'vue';
+
+export interface ChannelPinsOptions {
+    /** The server's pin count for the open channel. */
+    pinCount: () => number;
+    /** Jump the timeline to a message, used by the panel's rows. */
+    jumpToMessage: (id: string) => void;
+}
+
+export interface ChannelPins {
+    /** The masthead's badge count, kept live by the MessagePinned broadcast. */
+    pinCount: Ref<number>;
+    pinsPanelOpen: Ref<boolean>;
+    openPinsPanel: () => void;
+    jumpToPin: (id: string) => void;
+}
+
+/**
+ * The channel-level pin count driving the masthead badge, and the pins popover
+ * state. The count is seeded from the server, resynced on partial reloads and
+ * channel switches (the prop watch below), and patched live by the MessagePinned
+ * broadcast; the pins list itself rides the `pins` prop, refreshed whenever the
+ * panel opens or a pin changes.
+ */
+export function useChannelPins(options: ChannelPinsOptions): ChannelPins {
+    const pinCount = ref(options.pinCount());
+
+    watch(options.pinCount, (count) => {
+        pinCount.value = count;
+    });
+
+    const pinsPanelOpen = ref(false);
+
+    /**
+     * Open the pins popover, pulling the freshest pins first — another member may
+     * have pinned or unpinned since this page loaded, and the count badge and list
+     * should agree with the server on open.
+     */
+    function openPinsPanel(): void {
+        pinsPanelOpen.value = true;
+        router.reload({ only: ['pins', 'pinCount'] });
+    }
+
+    /** Jump to a pinned message from the panel, closing the popover on the way. */
+    function jumpToPin(id: string): void {
+        pinsPanelOpen.value = false;
+        options.jumpToMessage(id);
+    }
+
+    return { pinCount, pinsPanelOpen, openPinsPanel, jumpToPin };
+}

--- a/resources/js/composables/useChannelReaders.ts
+++ b/resources/js/composables/useChannelReaders.ts
@@ -1,0 +1,40 @@
+import { computed, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { ChannelReader } from '@/types';
+
+export interface ChannelReadersOptions {
+    /** The server's read positions for the open channel. */
+    channelReaders: () => ChannelReader[];
+}
+
+export interface ChannelReaders {
+    /** Keyed by user id, for the realtime router to advance in place. */
+    readers: Ref<Map<string, ChannelReader>>;
+    /** Reseed from the server prop, on open and on every channel switch. */
+    seedReaders: () => void;
+    /** The same positions as a list, as the timeline renders them. */
+    channelReadersList: ComputedRef<ChannelReader[]>;
+}
+
+/**
+ * Read positions of the channel's other members who share read receipts, keyed
+ * by user id. Seeded from the server prop and kept current from the MessageRead
+ * broadcast, driving the "Seen by" affordance under the newest message.
+ */
+export function useChannelReaders(
+    options: ChannelReadersOptions,
+): ChannelReaders {
+    const readers = ref(new Map<string, ChannelReader>());
+
+    function seedReaders(): void {
+        readers.value = new Map(
+            options.channelReaders().map((reader) => [reader.user.id, reader]),
+        );
+    }
+
+    const channelReadersList = computed(() =>
+        Array.from(readers.value.values()),
+    );
+
+    return { readers, seedReaders, channelReadersList };
+}

--- a/resources/js/composables/useChannelTimeline.ts
+++ b/resources/js/composables/useChannelTimeline.ts
@@ -1,0 +1,44 @@
+import { computed } from 'vue';
+import type { ComputedRef } from 'vue';
+import { useMessageStream } from '@/composables/useMessageStream';
+import type { Message, MessagePage } from '@/types';
+
+export interface ChannelTimelineOptions {
+    /** The server's message page for the open channel. */
+    messages: () => MessagePage;
+}
+
+export interface ChannelTimeline {
+    /** The server page alone, oldest-first. */
+    serverMessages: ComputedRef<Message[]>;
+    /** The merge engine, which the realtime router and the actions engine drive. */
+    mainStream: ReturnType<typeof useMessageStream>;
+    /** What the timeline renders: the merged, deduped list. */
+    displayMessages: ComputedRef<Message[]>;
+    /** Client uuids of sends still in flight, so their rows can read as pending. */
+    pendingUuids: ComputedRef<string[]>;
+}
+
+/**
+ * The main channel timeline: optimistic sends + live echoes + edit/delete
+ * patches, all merged over the server page and deduped by client uuid.
+ *
+ * `Inertia::scroll` delivers messages newest-first, so the page is reversed for
+ * display before the stream merges over it.
+ */
+export function useChannelTimeline(
+    options: ChannelTimelineOptions,
+): ChannelTimeline {
+    const serverMessages = computed<Message[]>(() =>
+        [...(options.messages()?.data ?? [])].reverse(),
+    );
+
+    const mainStream = useMessageStream(serverMessages);
+
+    return {
+        serverMessages,
+        mainStream,
+        displayMessages: mainStream.displayMessages,
+        pendingUuids: mainStream.pendingUuids,
+    };
+}

--- a/resources/js/composables/useChannelTyping.ts
+++ b/resources/js/composables/useChannelTyping.ts
@@ -1,0 +1,49 @@
+import { echo } from '@laravel/echo-vue';
+import { typing as postTypingSignal } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { useTypingIndicator } from '@/composables/useTypingIndicator';
+import { parseXsrfToken } from '@/lib/uploadAttachment';
+
+export interface ChannelTypingOptions {
+    teamSlug: () => string;
+    channelSlug: () => string;
+}
+
+/**
+ * Peers currently composing on this channel, driven by the server-broadcast
+ * `UserTyping` event on the same private channel as the message events. The
+ * outbound signal is a plain fire-and-forget POST — the server derives the
+ * typist identity from the authenticated session, so a member cannot spoof
+ * another member's indicator — carrying the Echo socket id so the resulting
+ * broadcast skips this tab.
+ */
+export function useChannelTyping(
+    options: ChannelTypingOptions,
+): ReturnType<typeof useTypingIndicator> {
+    return useTypingIndicator(() => {
+        const headers: Record<string, string> = {
+            'X-Requested-With': 'XMLHttpRequest',
+        };
+
+        const xsrfToken = parseXsrfToken(document.cookie);
+
+        if (xsrfToken) {
+            headers['X-XSRF-TOKEN'] = xsrfToken;
+        }
+
+        const socketId = echo().socketId();
+
+        if (socketId) {
+            headers['X-Socket-ID'] = socketId;
+        }
+
+        void fetch(
+            postTypingSignal({
+                team: options.teamSlug(),
+                channel: options.channelSlug(),
+            }).url,
+            { method: 'POST', headers },
+        ).catch(() => {
+            // A lost typing beat is invisible; the next keystroke sends another.
+        });
+    });
+}

--- a/resources/js/composables/useComposerTarget.ts
+++ b/resources/js/composables/useComposerTarget.ts
@@ -1,0 +1,31 @@
+import { ref } from 'vue';
+import type { Ref } from 'vue';
+import type { Message } from '@/types';
+
+export interface ComposerTarget {
+    /** The message the composer is currently quoting, or null for a normal send. */
+    replyTarget: Ref<Message | null>;
+    /**
+     * The id of the message the main composer is editing in place (via the ↑
+     * shortcut), or null. Highlights the target row in the timeline while editing.
+     */
+    composerEditingId: Ref<string | null>;
+    startReply: (message: Message) => void;
+    cancelReply: () => void;
+}
+
+/** What the channel composer is currently pointed at: a quote, or an edit. */
+export function useComposerTarget(): ComposerTarget {
+    const replyTarget = ref<Message | null>(null);
+    const composerEditingId = ref<string | null>(null);
+
+    function startReply(message: Message): void {
+        replyTarget.value = message;
+    }
+
+    function cancelReply(): void {
+        replyTarget.value = null;
+    }
+
+    return { replyTarget, composerEditingId, startReply, cancelReply };
+}

--- a/resources/js/composables/useForwardDialog.ts
+++ b/resources/js/composables/useForwardDialog.ts
@@ -1,0 +1,76 @@
+import { usePage } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { Channel, Message } from '@/types';
+import type { ForwardTarget } from '@/types/forward';
+import type { PersonRef } from '@/types/people';
+
+export interface ForwardDialogOptions {
+    /** The actions engine's forward, run once the dialog is submitted. */
+    forwardMessage: (
+        source: Message,
+        payload: { target: ForwardTarget; note: string },
+    ) => void;
+}
+
+export interface ForwardDialog {
+    /** The message being forwarded, or null when the dialog is idle. */
+    forwardTarget: Ref<Message | null>;
+    forwardDialogOpen: Ref<boolean>;
+    /** The channels the viewer can post to, from the sidebar list. */
+    forwardableChannels: ComputedRef<Channel[]>;
+    /** Team members offered as DM forward targets. */
+    forwardablePeople: ComputedRef<PersonRef[]>;
+    openForward: (message: Message) => void;
+    submitForward: (payload: { target: ForwardTarget; note: string }) => void;
+}
+
+/**
+ * The forward dialog's state: which message is being forwarded, and the targets
+ * offered for it. Picking a person opens-or-creates the 1:1 DM on the server.
+ */
+export function useForwardDialog(options: ForwardDialogOptions): ForwardDialog {
+    const page = usePage();
+
+    const forwardTarget = ref<Message | null>(null);
+    const forwardDialogOpen = ref(false);
+
+    const forwardableChannels = computed<Channel[]>(
+        () => page.props.channels ?? [],
+    );
+
+    const forwardablePeople = computed<PersonRef[]>(
+        () => page.props.teamMembers ?? [],
+    );
+
+    function openForward(message: Message): void {
+        forwardTarget.value = message;
+        forwardDialogOpen.value = true;
+    }
+
+    /**
+     * Submit the forward dialog: hand the selected source and destination to the
+     * actions engine, then clear the target so the dialog resets.
+     */
+    function submitForward(payload: {
+        target: ForwardTarget;
+        note: string;
+    }): void {
+        const source = forwardTarget.value;
+
+        if (source) {
+            options.forwardMessage(source, payload);
+        }
+
+        forwardTarget.value = null;
+    }
+
+    return {
+        forwardTarget,
+        forwardDialogOpen,
+        forwardableChannels,
+        forwardablePeople,
+        openForward,
+        submitForward,
+    };
+}

--- a/resources/js/composables/useMessageHighlight.ts
+++ b/resources/js/composables/useMessageHighlight.ts
@@ -1,0 +1,67 @@
+import { nextTick, onScopeDispose, ref } from 'vue';
+import type { Ref } from 'vue';
+import type { TimelineItem } from '@/lib/timeline';
+import { timelineItemIndexForMessage } from '@/lib/virtualTimeline';
+
+/** How long a jumped-to message stays highlighted, in ms. */
+const HIGHLIGHT_MS = 2000;
+
+export interface MessageHighlightOptions {
+    /** The render list the target's index is resolved against. */
+    timelineItems: () => TimelineItem[];
+    /** Bring a render item into the virtualizer's window. */
+    scrollToIndex: (index: number, align: 'start' | 'center') => void;
+}
+
+export interface MessageHighlight {
+    /** The message to briefly highlight after a jump, or null. */
+    highlightedMessageId: Ref<string | null>;
+    jumpToMessage: (id: string) => void;
+}
+
+/**
+ * Jump to a message and mark it for a beat. The server windows the initial page
+ * so a search target is loaded; we scroll it into view and clear the highlight
+ * after a short beat.
+ */
+export function useMessageHighlight(
+    options: MessageHighlightOptions,
+): MessageHighlight {
+    const highlightedMessageId = ref<string | null>(null);
+    let highlightTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function jumpToMessage(id: string): void {
+        // Bring the target's render item into the window first — with windowing its
+        // element may not exist yet to scroll to — then refine and highlight once the
+        // row mounts. A missing index (target not loaded) still highlights on arrival.
+        const index = timelineItemIndexForMessage(options.timelineItems(), id);
+
+        if (index >= 0) {
+            options.scrollToIndex(index, 'center');
+        }
+
+        nextTick(() => {
+            document
+                .getElementById(`message-${id}`)
+                ?.scrollIntoView({ block: 'center' });
+
+            highlightedMessageId.value = id;
+
+            if (highlightTimer) {
+                clearTimeout(highlightTimer);
+            }
+
+            highlightTimer = setTimeout(() => {
+                highlightedMessageId.value = null;
+            }, HIGHLIGHT_MS);
+        });
+    }
+
+    onScopeDispose(() => {
+        if (highlightTimer) {
+            clearTimeout(highlightTimer);
+        }
+    });
+
+    return { highlightedMessageId, jumpToMessage };
+}

--- a/resources/js/composables/useOfflineOutbox.ts
+++ b/resources/js/composables/useOfflineOutbox.ts
@@ -1,0 +1,130 @@
+import { router } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import type { ComputedRef } from 'vue';
+import { useConnectionState } from '@/composables/useConnectionState';
+import type { ConnectionState } from '@/composables/useConnectionState';
+import { QUEUED_SENDS_TOAST_KEY } from '@/composables/useMessageActions';
+import { optimisticMessage } from '@/composables/useMessageStream';
+import type { useMessageStream } from '@/composables/useMessageStream';
+import { useToast } from '@/composables/useToast';
+import { useTranslations } from '@/composables/useTranslations';
+import { backgroundVisit } from '@/lib/backgroundVisit';
+import { createOutbox } from '@/lib/outbox';
+import type { Outbox } from '@/lib/outbox';
+
+type MessageStream = ReturnType<typeof useMessageStream>;
+
+export interface OfflineOutboxOptions {
+    /** Keys the persisted queue, so each channel keeps its own. */
+    channelId: () => string;
+    /** The sender, so a rehydrated row renders under their name. */
+    currentUser: () => { id: string; name: string };
+    /** The channel timeline the optimistic rows are re-added to. */
+    mainStream: MessageStream;
+}
+
+export interface OfflineOutbox {
+    /** The realtime connection cue (reconnecting / back-online pill). */
+    connection: ConnectionState;
+    outbox: Outbox;
+    /** Client uuids currently queued, so the timeline can mark each row. */
+    queuedUuids: ComputedRef<string[]>;
+    /** Drop the whole queue: the optimistic rows and the stored sends. */
+    discardQueue: () => void;
+    /**
+     * Wire the queue to the socket. Taken as a step of its own because the flush
+     * belongs to the actions engine, which is itself built over this queue.
+     */
+    flushOnReconnect: (flushOutbox: () => Promise<number>) => void;
+}
+
+/**
+ * The offline outbox: sends made while the socket is down queue here and flush
+ * on recovery. The queue persists per channel, so a refresh while offline keeps
+ * it.
+ */
+export function useOfflineOutbox(options: OfflineOutboxOptions): OfflineOutbox {
+    const { t } = useTranslations();
+    const toast = useToast();
+
+    const connection = useConnectionState();
+    const outbox = createOutbox({
+        storageKey: `outbox:${options.channelId()}`,
+    });
+
+    // A queue rehydrated from a previous session has no optimistic rows yet; re-add
+    // them so the queued sends still render in the timeline after a refresh. The
+    // reply quote isn't persisted, so a rehydrated row shows its body without it.
+    for (const item of outbox.items.value) {
+        options.mainStream.addPending(
+            optimisticMessage({
+                clientUuid: item.clientUuid,
+                body: item.body,
+                author: options.currentUser(),
+                mentions: [],
+            }),
+        );
+    }
+
+    const queuedUuids = computed(() =>
+        outbox.items.value.map((item) => item.clientUuid),
+    );
+
+    /** Discard the whole offline queue: drop the optimistic rows and clear the outbox. */
+    function discardQueue(): void {
+        for (const item of outbox.items.value) {
+            options.mainStream.removePending(item.clientUuid);
+        }
+
+        outbox.clear();
+    }
+
+    function flushOnReconnect(flushOutbox: () => Promise<number>): void {
+        // Whenever the socket connects, flush any queued sends — including a queue
+        // rehydrated on load, which connects for the first time rather than reconnecting.
+        // Only on a genuine reconnect do we also backfill messages that landed while the
+        // socket was down (the stream dedupes by client uuid, so re-fetching the latest
+        // page adds no gaps or dupes) and confirm the flush with a toast.
+        connection.onConnected(({ isReconnect }) => {
+            const flushed = flushOutbox();
+
+            if (!isReconnect) {
+                return;
+            }
+
+            // A reconnect is the socket's timing, not the user's; see
+            // {@see backgroundVisit}. Fired before the flush settles so the backfill
+            // isn't held up by a queue that is slow — or failing — to drain.
+            router.reload({ ...backgroundVisit, only: ['messages'] });
+
+            // "You're caught up" is only true of the sends that actually landed, so it
+            // waits for the flush and reports what it says landed. Anything still queued
+            // has already raised its own failure card, under the same key this replaces.
+            void flushed.then((sent) => {
+                if (sent === 0) {
+                    return;
+                }
+
+                toast.success(
+                    sent === 1
+                        ? t(
+                              "Reconnected — 1 queued message sent, you're caught up.",
+                          )
+                        : t(
+                              "Reconnected — :count queued messages sent, you're caught up.",
+                              { count: sent },
+                          ),
+                    { key: QUEUED_SENDS_TOAST_KEY },
+                );
+            });
+        });
+
+        // If we mount already connected with a rehydrated queue — the socket was up
+        // before this page (re)loaded, so no connect event will fire — flush it now.
+        if (connection.isOnline.value && outbox.count.value > 0) {
+            void flushOutbox();
+        }
+    }
+
+    return { connection, outbox, queuedUuids, discardQueue, flushOnReconnect };
+}

--- a/resources/js/composables/usePaneFileDrop.ts
+++ b/resources/js/composables/usePaneFileDrop.ts
@@ -1,0 +1,112 @@
+import { ref } from 'vue';
+import type { Ref } from 'vue';
+
+export interface PaneFileDropOptions {
+    /** Whether a drop would be staged at all (a member of a live channel). */
+    canDrop: () => boolean;
+    /** Where the dropped files go. */
+    onFiles: (files: File[]) => void;
+}
+
+export interface PaneFileDrop {
+    /** Whether the brass drop overlay is showing. */
+    isDraggingFiles: Ref<boolean>;
+    canDropAttachments: () => boolean;
+    onPaneDragEnter: (event: DragEvent) => void;
+    onPaneDragOver: (event: DragEvent) => void;
+    onPaneDragLeave: () => void;
+    onPaneDrop: (event: DragEvent) => void;
+}
+
+/** Whether a drag actually carries files (vs. selected text or an element). */
+function dragCarriesFiles(event: DragEvent): boolean {
+    return Array.from(event.dataTransfer?.types ?? []).includes('Files');
+}
+
+/**
+ * Whole-pane drag-and-drop: dropping files anywhere over the channel content
+ * stages them in the composer tray. A depth counter tracks nested
+ * dragenter/dragleave so the brass overlay doesn't flicker as the pointer
+ * crosses child elements. Only meaningful where the composer itself is shown.
+ */
+export function usePaneFileDrop(options: PaneFileDropOptions): PaneFileDrop {
+    const isDraggingFiles = ref(false);
+    let dragDepth = 0;
+
+    function canDropAttachments(): boolean {
+        return options.canDrop();
+    }
+
+    function onPaneDragEnter(event: DragEvent): void {
+        if (!canDropAttachments() || !dragCarriesFiles(event)) {
+            return;
+        }
+
+        dragDepth += 1;
+        isDraggingFiles.value = true;
+    }
+
+    function onPaneDragOver(event: DragEvent): void {
+        if (!dragCarriesFiles(event)) {
+            return;
+        }
+
+        // Claim every file drag so the browser never navigates to the dropped file,
+        // even where we won't accept it (archived channel, non-member).
+        event.preventDefault();
+
+        if (!canDropAttachments()) {
+            return;
+        }
+
+        // Show the copy cursor only where the drop will actually be staged.
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'copy';
+        }
+    }
+
+    function onPaneDragLeave(): void {
+        if (!isDraggingFiles.value) {
+            return;
+        }
+
+        dragDepth -= 1;
+
+        if (dragDepth <= 0) {
+            dragDepth = 0;
+            isDraggingFiles.value = false;
+        }
+    }
+
+    function onPaneDrop(event: DragEvent): void {
+        dragDepth = 0;
+        isDraggingFiles.value = false;
+
+        if (!dragCarriesFiles(event)) {
+            return;
+        }
+
+        // Prevent the browser navigating to the dropped file for every file drag,
+        // then only stage the files where the channel actually accepts them.
+        event.preventDefault();
+
+        if (!canDropAttachments()) {
+            return;
+        }
+
+        const files = Array.from(event.dataTransfer?.files ?? []);
+
+        if (files.length > 0) {
+            options.onFiles(files);
+        }
+    }
+
+    return {
+        isDraggingFiles,
+        canDropAttachments,
+        onPaneDragEnter,
+        onPaneDragOver,
+        onPaneDragLeave,
+        onPaneDrop,
+    };
+}

--- a/resources/js/composables/useReadOnFocus.ts
+++ b/resources/js/composables/useReadOnFocus.ts
@@ -1,0 +1,23 @@
+import { onBeforeUnmount, onMounted } from 'vue';
+
+/**
+ * Advance the given read pointers whenever the tab regains focus.
+ *
+ * A conversation is only "read" while the viewer is actually looking at it, so
+ * the pointers ride the window's focus event for as long as the page is
+ * mounted. The posts cancel themselves on teardown, so leaving the workspace
+ * never fires a stale mark-read.
+ */
+export function useReadOnFocus(...markRead: Array<() => void>): void {
+    onMounted(() => {
+        for (const mark of markRead) {
+            window.addEventListener('focus', mark);
+        }
+    });
+
+    onBeforeUnmount(() => {
+        for (const mark of markRead) {
+            window.removeEventListener('focus', mark);
+        }
+    });
+}

--- a/resources/js/composables/useReadPointer.ts
+++ b/resources/js/composables/useReadPointer.ts
@@ -1,0 +1,52 @@
+import { router } from '@inertiajs/vue3';
+import { echo } from '@laravel/echo-vue';
+import { read as markChannelRead } from '@/actions/App/Http/Controllers/Channels/ChannelController';
+import { useDebouncedPost } from '@/composables/useDebouncedPost';
+import { backgroundVisit } from '@/lib/backgroundVisit';
+
+export interface ReadPointerOptions {
+    teamSlug: () => string;
+    channelSlug: () => string;
+}
+
+/**
+ * Advance the read pointer for the open channel so its sidebar badge clears.
+ * Debounced and gated on tab focus: a channel is only "read" while the user is
+ * actually looking at it, and a burst of arriving messages collapses to one
+ * request. The redirect refreshes just the shared `channels` prop.
+ *
+ * The Echo socket id rides along so the resulting `ReadStateAdvanced` broadcast
+ * skips this tab: the response above already brings it fresh counts, and its
+ * own signal would only buy a second, redundant sidebar reload. The reader's
+ * *other* devices still receive it, which is the point of the broadcast.
+ */
+export function useReadPointer(options: ReadPointerOptions): {
+    markRead: () => void;
+} {
+    const readPost = useDebouncedPost(
+        () => {
+            const socketId = echo().socketId();
+
+            router.post(
+                markChannelRead({
+                    team: options.teamSlug(),
+                    channel: options.channelSlug(),
+                }).url,
+                {},
+                {
+                    // Interrupting a thread-panel GET strands the panel empty (#581)
+                    // and the redirect-follow would drop the `?thread=` param; see
+                    // {@see backgroundVisit}.
+                    ...backgroundVisit,
+                    preserveScroll: true,
+                    preserveState: true,
+                    only: ['channels'],
+                    headers: socketId ? { 'X-Socket-ID': socketId } : {},
+                },
+            );
+        },
+        { delay: 400, gate: () => document.hasFocus() },
+    );
+
+    return { markRead: () => readPost.schedule() };
+}

--- a/resources/js/composables/useReminderPicker.ts
+++ b/resources/js/composables/useReminderPicker.ts
@@ -1,0 +1,56 @@
+import { ref } from 'vue';
+import type { Ref } from 'vue';
+import type { Message } from '@/types';
+
+export interface ReminderPickerOptions {
+    /** The actions engine's reminder, run for both a preset and a custom time. */
+    setReminder: (messageId: string, remindAt: string) => void;
+}
+
+export interface ReminderPicker {
+    /** Whether the custom date & time picker is open. */
+    reminderCustomOpen: Ref<boolean>;
+    remindWith: (message: Message, remindAt: string) => void;
+    openCustomReminder: (message: Message) => void;
+    confirmCustomReminder: (remindAt: string) => void;
+}
+
+/**
+ * Reminders raised from a message's popover: a preset time is set straight away,
+ * while "Custom date & time…" holds the target until the picker confirms.
+ */
+export function useReminderPicker(
+    options: ReminderPickerOptions,
+): ReminderPicker {
+    /** The message a custom-time reminder is being set for. */
+    const reminderTargetId = ref<string | null>(null);
+    const reminderCustomOpen = ref(false);
+
+    /** A preset was chosen from a message's reminder popover. */
+    function remindWith(message: Message, remindAt: string): void {
+        options.setReminder(message.id, remindAt);
+    }
+
+    /** The viewer chose "Custom date & time…"; remember the target and open the picker. */
+    function openCustomReminder(message: Message): void {
+        reminderTargetId.value = message.id;
+        reminderCustomOpen.value = true;
+    }
+
+    /** Confirm the custom reminder time picked in the dialog. */
+    function confirmCustomReminder(remindAt: string): void {
+        if (reminderTargetId.value === null) {
+            return;
+        }
+
+        options.setReminder(reminderTargetId.value, remindAt);
+        reminderTargetId.value = null;
+    }
+
+    return {
+        reminderCustomOpen,
+        remindWith,
+        openCustomReminder,
+        confirmCustomReminder,
+    };
+}

--- a/resources/js/composables/useStickyDayLabel.ts
+++ b/resources/js/composables/useStickyDayLabel.ts
@@ -1,0 +1,52 @@
+import { computed } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { TimelineRange } from '@/composables/useUnreadJump';
+import { formatDayLabel } from '@/lib/datetime';
+import type { TimelineItem } from '@/lib/timeline';
+
+export interface StickyDayLabelOptions {
+    /** The render list the topmost visible row is read from. */
+    timelineItems: () => TimelineItem[];
+    /** The virtualizer's window, or null before the first range lands. */
+    timelineRange: Ref<TimelineRange | null>;
+}
+
+/**
+ * The day the topmost visible row falls in, driving the floating sticky date
+ * chip while the reader is scrolled up into history (design 1a). Reads the first
+ * dated render item at or after the window's top — a group's lead timestamp or a
+ * day divider's own ISO.
+ */
+export function useStickyDayLabel(
+    options: StickyDayLabelOptions,
+): ComputedRef<string | null> {
+    return computed<string | null>(() => {
+        const range = options.timelineRange.value;
+        const items = options.timelineItems();
+
+        if (!range || items.length === 0) {
+            return null;
+        }
+
+        for (
+            let i = Math.min(range.startIndex, items.length - 1);
+            i < items.length;
+            i += 1
+        ) {
+            const item = items[i];
+
+            // A day boundary already sits at the top of the window, shown inline —
+            // the chip would just duplicate it (e.g. scrolled to the very top), so
+            // suppress it until the divider scrolls off and a group leads instead.
+            if (item.type === 'divider' && item.variant === 'day') {
+                return null;
+            }
+
+            if (item.type === 'group') {
+                return formatDayLabel(item.leadCreatedAt);
+            }
+        }
+
+        return null;
+    });
+}

--- a/resources/js/composables/useUnreadJump.ts
+++ b/resources/js/composables/useUnreadJump.ts
@@ -1,0 +1,133 @@
+import { computed, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { TimelineItem } from '@/lib/timeline';
+import {
+    isDividerVisible,
+    shouldShowUnreadJump,
+    unreadDividerIndex,
+} from '@/lib/virtualTimeline';
+
+/** The virtualizer's visible render-item window. */
+export interface TimelineRange {
+    startIndex: number;
+    endIndex: number;
+}
+
+export interface UnreadJumpOptions {
+    /** The open channel's id; a change refreezes the per-visit latches. */
+    channelId: () => string;
+    /** The render list the unread boundary's index is resolved against. */
+    timelineItems: () => TimelineItem[];
+    /** The virtualizer's window, or null before the first range lands. */
+    timelineRange: Ref<TimelineRange | null>;
+    /** Bring a render item into the virtualizer's window. */
+    scrollToIndex: (index: number, align: 'start' | 'center') => void;
+    /** Return to the newest message. */
+    scrollToBottom: (smooth?: boolean) => void;
+}
+
+export interface UnreadJump {
+    /** Whether to float the "New messages" pill over the timeline. */
+    showJumpToUnread: ComputedRef<boolean>;
+    scrollToUnread: () => void;
+    jumpToPresent: () => void;
+}
+
+/**
+ * The floating "New messages" pill: whether the unread boundary is still ahead
+ * of the reader, and the two ways they can leave it behind.
+ *
+ * Windowing drops the off-screen divider from the DOM, so this is pure range
+ * math over the virtualizer's window plus a per-visit seen latch, rather than an
+ * `IntersectionObserver` on an element that may not exist.
+ */
+export function useUnreadJump(options: UnreadJumpOptions): UnreadJump {
+    /** The unread boundary's render-item index, or -1 when there's none. */
+    const unreadIndex = computed(() =>
+        unreadDividerIndex(options.timelineItems()),
+    );
+
+    /**
+     * Per-visit latch: once the reader reaches the unread boundary (it scrolls into
+     * the window) or jumps back to the present, the "New messages" pill is dismissed
+     * for the rest of this channel visit. Without it the pill reappears whenever the
+     * (frozen) divider sits above the window again — e.g. right after Jump to present
+     * (#411). Both flags are refrozen alongside the divider on every channel switch.
+     */
+    const unreadDividerSeen = ref(false);
+
+    /**
+     * Whether the boundary has ever sat above the window this visit. The reader
+     * "reaches" the divider only when it scrolls back into view *after* having been
+     * above — the transition the seen latch keys off. This guards against the initial
+     * pre-`scrollToBottom` render (rows start at the top, so the divider is briefly
+     * on screen before the open pins to the newest message) latching it prematurely.
+     */
+    const unreadDividerWasAbove = ref(false);
+
+    watch(options.channelId, () => {
+        unreadDividerSeen.value = false;
+        unreadDividerWasAbove.value = false;
+    });
+
+    // Track the boundary's position relative to the window and latch it as seen the
+    // moment it scrolls back into view after having been above — the reader clicking
+    // the pill or scrolling up to the divider.
+    watch([options.timelineRange, unreadIndex], ([range, index]) => {
+        if (!range || index < 0) {
+            return;
+        }
+
+        if (index < range.startIndex) {
+            unreadDividerWasAbove.value = true;
+        } else if (
+            unreadDividerWasAbove.value &&
+            isDividerVisible(index, range.startIndex, range.endIndex)
+        ) {
+            unreadDividerSeen.value = true;
+        }
+    });
+
+    /**
+     * Show the floating "New messages" pill while the unread boundary sits above the
+     * virtualizer's window and the reader hasn't reached it yet. Before the first
+     * range lands the view is pinned to the bottom, so an existing, unseen boundary
+     * is necessarily above it.
+     */
+    const showJumpToUnread = computed(() => {
+        const range = options.timelineRange.value;
+
+        if (!range) {
+            return unreadIndex.value >= 0 && !unreadDividerSeen.value;
+        }
+
+        return shouldShowUnreadJump(
+            unreadIndex.value,
+            range.startIndex,
+            range.endIndex,
+            unreadDividerSeen.value,
+        );
+    });
+
+    /**
+     * Scroll the unread boundary to the top of the viewport via the virtualizer,
+     * bringing it on screen even when it wasn't rendered.
+     */
+    function scrollToUnread(): void {
+        if (unreadIndex.value >= 0) {
+            options.scrollToIndex(unreadIndex.value, 'start');
+        }
+    }
+
+    /**
+     * Return to the newest message. Jumping to present counts as reaching the unread
+     * boundary, so latch it — the reader is done with the "New messages" pill for
+     * this visit even if the frozen divider now sits above the window again (#411).
+     */
+    function jumpToPresent(): void {
+        unreadDividerSeen.value = true;
+        options.scrollToBottom(true);
+    }
+
+    return { showJumpToUnread, scrollToUnread, jumpToPresent };
+}

--- a/resources/js/lib/backgroundVisit.test.ts
+++ b/resources/js/lib/backgroundVisit.test.ts
@@ -23,7 +23,7 @@ const FOREGROUND_RELOADS: { file: string; call: string; reason: string }[] = [
         reason: 'refreshes the list the user just registered a passkey into',
     },
     {
-        file: 'pages/channels/Show.vue',
+        file: 'composables/useChannelPins.ts',
         call: "router.reload({ only: ['pins', 'pinCount'] })",
         reason: 'the user opened the pins popover and is waiting on it',
     },

--- a/resources/js/pages/channels/Show.actions.test.ts
+++ b/resources/js/pages/channels/Show.actions.test.ts
@@ -1,0 +1,446 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Ref } from 'vue';
+import { defineComponent, h, nextTick } from 'vue';
+import {
+    click,
+    composerHandleDouble,
+    mountShow,
+    stubObservers,
+    unmountAll,
+} from './Show.doubles';
+
+/**
+ * Covers what the channel page does on the viewer's behalf: the typing beat, the
+ * debounced read pointer, the forward and reminder dialogs, the archive
+ * confirmation, and the offline outbox with its reconnect flush.
+ *
+ * Written against the page as it stands so a split of `Show.vue` can be checked
+ * against it — every request shape, every string and every selector is pinned
+ * here, and a pure move may change none of them.
+ */
+const router = vi.hoisted(() => ({
+    post: vi.fn(),
+    reload: vi.fn(),
+    visit: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble, inertiaPageProps } = await import('./Show.doubles');
+
+    return inertiaDouble(router, inertiaPageProps, {
+        fetchNext: vi.fn(),
+        hasNext: () => false,
+    });
+});
+
+/** The live socket status, so a suite can drop and restore the connection. */
+const connection = vi.hoisted(() => ({ status: null as Ref<string> | null }));
+
+vi.mock('@laravel/echo-vue', async () => {
+    const { ref } = await import('vue');
+
+    return {
+        echo: () => ({ socketId: () => 'socket-1' }),
+        useConnectionStatus: () => {
+            connection.status = ref('connected');
+
+            return connection.status;
+        },
+    };
+});
+
+const actions = vi.hoisted(() => ({
+    current: null as Record<string, ReturnType<typeof vi.fn>> | null,
+}));
+
+vi.mock('@/composables/useMessageActions', async () => {
+    const { messageActionsDouble } = await import('./Show.doubles');
+
+    actions.current = messageActionsDouble(2);
+
+    return {
+        QUEUED_SENDS_TOAST_KEY: 'queued-sends',
+        useMessageActions: () => actions.current,
+    };
+});
+
+vi.mock('@/composables/useChannelRealtime', () => ({
+    useChannelRealtime: vi.fn(),
+}));
+
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./Show.doubles');
+
+    return { useTeamPresence: teamPresenceDouble };
+});
+
+vi.mock('@/composables/useChannelDraft', async () => {
+    const { channelDraftDouble } = await import('./Show.doubles');
+
+    return { useChannelDraft: channelDraftDouble };
+});
+
+vi.mock('@/composables/useChannelPreferences', async () => {
+    const { channelPreferencesDouble } = await import('./Show.doubles');
+
+    return { useChannelPreferences: channelPreferencesDouble };
+});
+
+vi.mock('@/composables/useThreadPanel', async () => {
+    const { threadPanelDouble } = await import('./Show.doubles');
+
+    return { useThreadPanel: threadPanelDouble };
+});
+
+const toast = vi.hoisted(() => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+}));
+
+vi.mock('@/composables/useToast', () => ({ useToast: () => toast }));
+
+vi.mock('@/components/ChannelMasthead.vue', () => ({
+    default: defineComponent({
+        name: 'ChannelMastheadStub',
+        emits: ['archive'],
+        setup:
+            (_props, { emit }) =>
+            () =>
+                h('button', {
+                    'data-test': 'stub-archive',
+                    onClick: () => emit('archive'),
+                }),
+    }),
+}));
+
+vi.mock('@/components/MessageList.vue', async () => {
+    const { message } = await import('./Show.doubles');
+
+    return {
+        default: defineComponent({
+            name: 'MessageListStub',
+            emits: ['forward', 'remind', 'remindCustom'],
+            setup(_props, { emit, expose }) {
+                expose({ scrollToIndex: vi.fn(), scrollToLatest: vi.fn() });
+
+                return () =>
+                    h('div', [
+                        h('button', {
+                            'data-test': 'stub-forward',
+                            onClick: () => emit('forward', message()),
+                        }),
+                        h('button', {
+                            'data-test': 'stub-remind',
+                            onClick: () =>
+                                emit(
+                                    'remind',
+                                    message(),
+                                    '2024-03-06T09:00:00.000Z',
+                                ),
+                        }),
+                        h('button', {
+                            'data-test': 'stub-remind-custom',
+                            onClick: () => emit('remindCustom', message()),
+                        }),
+                    ]);
+            },
+        }),
+    };
+});
+
+vi.mock('@/components/MessageComposer.vue', () => ({
+    default: defineComponent({
+        name: 'MessageComposerStub',
+        emits: ['typing'],
+        setup(_props, { emit, expose }) {
+            expose(composerHandleDouble());
+
+            return () =>
+                h('button', {
+                    'data-test': 'stub-typing',
+                    onClick: () => emit('typing'),
+                });
+        },
+    }),
+}));
+
+vi.mock('@/components/ForwardMessageDialog.vue', () => ({
+    default: defineComponent({
+        name: 'ForwardMessageDialogStub',
+        props: { open: { type: Boolean, default: false } },
+        emits: ['submit'],
+        setup:
+            (props, { emit }) =>
+            () =>
+                props.open
+                    ? h('button', {
+                          'data-test': 'stub-forward-submit',
+                          onClick: () =>
+                              emit('submit', {
+                                  target: { type: 'channel', id: 'c2' },
+                                  note: 'fyi',
+                              }),
+                      })
+                    : null,
+    }),
+}));
+
+vi.mock('@/components/ScheduleMessageDialog.vue', () => ({
+    default: defineComponent({
+        name: 'ScheduleMessageDialogStub',
+        props: { open: { type: Boolean, default: false } },
+        emits: ['confirm'],
+        setup:
+            (props, { emit }) =>
+            () =>
+                props.open
+                    ? h('button', {
+                          'data-test': 'stub-reminder-confirm',
+                          onClick: () =>
+                              emit('confirm', '2024-03-07T09:00:00.000Z'),
+                      })
+                    : null,
+    }),
+}));
+
+vi.mock('@/components/PinsPanel.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('PinsPanelStub') };
+});
+
+vi.mock('@/components/ThreadPanel.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ThreadPanelStub') };
+});
+
+vi.mock('@/components/ScheduledMessagesDialog.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ScheduledMessagesDialogStub') };
+});
+
+vi.mock('@/components/LeaveChannelModal.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('LeaveChannelModalStub') };
+});
+
+vi.mock('@/components/AddDirectMessagePeopleModal.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('AddDirectMessagePeopleModalStub') };
+});
+
+vi.mock('@/components/ChannelEmptyState.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ChannelEmptyStateStub') };
+});
+
+import Show from './Show.vue';
+
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    return mountShow(Show, props).host;
+}
+
+beforeEach(() => {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(() => Promise.resolve(new Response())),
+    );
+    stubObservers();
+    localStorage.clear();
+});
+
+afterEach(() => {
+    unmountAll();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+});
+
+describe('the typing beat', () => {
+    it('posts a fire-and-forget signal carrying the socket id', () => {
+        document.cookie = 'XSRF-TOKEN=tok%3Den';
+
+        const host = mount();
+
+        click(host, '[data-test="stub-typing"]');
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+
+        const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+
+        expect(url).toContain('/t/acme/c/general/typing');
+        expect(init.method).toBe('POST');
+        expect(init.headers['X-Socket-ID']).toBe('socket-1');
+        expect(init.headers['X-Requested-With']).toBe('XMLHttpRequest');
+        expect(init.headers['X-XSRF-TOKEN']).toBe('tok=en');
+    });
+});
+
+describe('the read pointer', () => {
+    it('advances the pointer for the open channel, refreshing only the sidebar', async () => {
+        vi.useFakeTimers();
+        vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+
+        mount();
+
+        vi.advanceTimersByTime(400);
+        await nextTick();
+
+        const [url, payload, options] = router.post.mock.calls[0];
+
+        expect(url).toContain('/t/acme/c/general/read');
+        expect(payload).toEqual({});
+        expect(options.only).toEqual(['channels']);
+        expect(options.preserveScroll).toBe(true);
+        expect(options.preserveState).toBe(true);
+        expect(options.headers).toEqual({ 'X-Socket-ID': 'socket-1' });
+    });
+});
+
+describe('archiving the channel', () => {
+    it('confirms before archiving, then posts', async () => {
+        const host = mount();
+
+        expect(
+            host.ownerDocument.querySelector(
+                '[data-test="archive-channel-confirm"]',
+            ),
+        ).toBe(null);
+
+        click(host, '[data-test="stub-archive"]');
+        await nextTick();
+
+        const confirm = host.ownerDocument.querySelector(
+            '[data-test="archive-channel-confirm"]',
+        ) as HTMLElement;
+
+        expect(confirm).not.toBe(null);
+
+        confirm.click();
+
+        const archivePost = router.post.mock.calls.find(([url]) =>
+            String(url).includes('/archive'),
+        );
+
+        expect(archivePost?.[0]).toContain('/t/acme/c/general/archive');
+    });
+});
+
+describe('forwarding a message', () => {
+    it('opens the dialog on the timeline’s request and hands the pick to the actions engine', async () => {
+        const host = mount();
+
+        expect(host.querySelector('[data-test="stub-forward-submit"]')).toBe(
+            null,
+        );
+
+        click(host, '[data-test="stub-forward"]');
+        await nextTick();
+
+        click(host, '[data-test="stub-forward-submit"]');
+
+        expect(actions.current!.forwardMessage).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'm1' }),
+            { target: { type: 'channel', id: 'c2' }, note: 'fyi' },
+        );
+    });
+});
+
+describe('setting a reminder', () => {
+    it('sets a preset time straight away', () => {
+        const host = mount();
+
+        click(host, '[data-test="stub-remind"]');
+
+        expect(actions.current!.setReminder).toHaveBeenCalledWith(
+            'm1',
+            '2024-03-06T09:00:00.000Z',
+        );
+    });
+
+    it('asks for a custom time and remembers which message it is for', async () => {
+        const host = mount();
+
+        expect(host.querySelector('[data-test="stub-reminder-confirm"]')).toBe(
+            null,
+        );
+
+        click(host, '[data-test="stub-remind-custom"]');
+        await nextTick();
+
+        click(host, '[data-test="stub-reminder-confirm"]');
+
+        expect(actions.current!.setReminder).toHaveBeenCalledWith(
+            'm1',
+            '2024-03-07T09:00:00.000Z',
+        );
+    });
+});
+
+describe('the offline outbox', () => {
+    beforeEach(() => {
+        localStorage.setItem(
+            'outbox:c1',
+            JSON.stringify([
+                {
+                    clientUuid: 'queued-1',
+                    body: 'held back',
+                    replyToId: null,
+                    attachmentIds: [],
+                },
+            ]),
+        );
+    });
+
+    it('banners the queue while the socket is down and discards it on request', async () => {
+        const host = mount();
+
+        connection.status!.value = 'unavailable';
+        await nextTick();
+
+        const banner = host.querySelector(
+            '[data-test="offline-queue-banner"]',
+        ) as HTMLElement;
+
+        expect(banner.textContent).toContain(
+            "You're offline. 1 message is queued and will send automatically.",
+        );
+
+        click(host, '[data-test="discard-queue"]');
+        await nextTick();
+
+        expect(host.querySelector('[data-test="offline-queue-banner"]')).toBe(
+            null,
+        );
+    });
+
+    it('flushes on reconnect, backfills the timeline and confirms what landed', async () => {
+        mount();
+
+        connection.status!.value = 'unavailable';
+        await nextTick();
+        actions.current!.flushOutbox.mockClear();
+
+        connection.status!.value = 'connected';
+        await nextTick();
+
+        expect(actions.current!.flushOutbox).toHaveBeenCalledTimes(1);
+        expect(router.reload).toHaveBeenCalledWith(
+            expect.objectContaining({ only: ['messages'] }),
+        );
+
+        await nextTick();
+
+        expect(toast.success).toHaveBeenCalledWith(
+            "Reconnected — 2 queued messages sent, you're caught up.",
+            { key: 'queued-sends' },
+        );
+    });
+});

--- a/resources/js/pages/channels/Show.doubles.ts
+++ b/resources/js/pages/channels/Show.doubles.ts
@@ -1,0 +1,276 @@
+import { vi } from 'vitest';
+import type { App, Component } from 'vue';
+import {
+    computed,
+    createApp,
+    defineComponent,
+    h,
+    nextTick,
+    reactive,
+    ref,
+} from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Channel, Message, MessagePage } from '@/types';
+
+/**
+ * The doubles the channel page's suites share: the shared Inertia props, the
+ * model factories, the stand-ins for the composables that talk to Echo or the
+ * router, and the mount/teardown boilerplate.
+ *
+ * They live outside the suites because `Show.vue` reaches for enough of the app
+ * that the preamble, repeated three times, would itself breach the `max-lines`
+ * cap those suites exist to help lift (#983). A `vi.mock` factory is hoisted
+ * above the imports, so a suite pulls what it needs from here with a dynamic
+ * `import()` inside the factory.
+ */
+export const inertiaPageProps = {
+    auth: { user: { id: 'me', name: 'Me', timezone: 'UTC' } },
+    currentTeam: { role: 'member' },
+    channels: [] as unknown[],
+    teamMembers: [] as unknown[],
+    attachments: { maxSizeMb: 25, maxPerMessage: 10 },
+    slashCommands: [] as unknown[],
+    gifPickerEnabled: false,
+    pollsEnabled: false,
+};
+
+/** Renders nothing, standing in for a leaf whose own tests cover it. */
+export function inert(name: string): Component {
+    return defineComponent({ name, setup: () => () => null });
+}
+
+/**
+ * The pieces of `@inertiajs/vue3` the page renders through. The router is passed
+ * in so the suite asserting on it holds the same spies.
+ */
+export function inertiaDouble(
+    router: unknown,
+    page: Record<string, unknown>,
+    scroll: { fetchNext: () => void; hasNext: () => boolean },
+): Record<string, unknown> {
+    return {
+        usePage: () => ({ props: page }),
+        router,
+        Head: defineComponent({ name: 'HeadStub', setup: () => () => null }),
+        Form: defineComponent({
+            name: 'FormStub',
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('form', slots.default?.({ processing: false })),
+        }),
+        InfiniteScroll: defineComponent({
+            name: 'InfiniteScrollStub',
+            setup(_props, { slots, expose }) {
+                expose(scroll);
+
+                return () => h('div', slots.default?.());
+            },
+        }),
+    };
+}
+
+/** Every mutation the page hands to `useMessageActions`, as spies. */
+export function messageActionsDouble(flushed = 0) {
+    return {
+        send: vi.fn(),
+        flushOutbox: vi.fn(() => Promise.resolve(flushed)),
+        editMessage: vi.fn(),
+        deleteMessage: vi.fn(),
+        reactToMessage: vi.fn(),
+        voteOnPoll: vi.fn(),
+        closePoll: vi.fn(),
+        pinMessage: vi.fn(),
+        unpinMessage: vi.fn(),
+        sendThreadReply: vi.fn(),
+        scheduleMessage: vi.fn(),
+        updateScheduled: vi.fn(),
+        cancelScheduled: vi.fn(),
+        setReminder: vi.fn(),
+        sendCommand: vi.fn(),
+        forwardMessage: vi.fn(),
+    };
+}
+
+/** The member's own channel preferences, held steady at their defaults. */
+export function channelPreferencesDouble() {
+    return {
+        notificationLevel: ref('all'),
+        muted: ref(false),
+        starred: ref(false),
+        threadUnreadSuppressed: ref(false),
+        notificationStatus: computed(() => null),
+        toggleStar: vi.fn(),
+        onNotificationLevelChange: vi.fn(),
+        onMuteChange: vi.fn(),
+    };
+}
+
+/** A thread panel that stays shut, so the page renders its main pane alone. */
+export function threadPanelDouble() {
+    return {
+        activeThreadRootId: ref(null),
+        threadLoading: ref(false),
+        threadStream: {},
+        threadMessages: computed(() => []),
+        threadPendingUuids: computed(() => []),
+        openThread: vi.fn(),
+        closeThread: vi.fn(),
+        markThreadRead: vi.fn(),
+        adoptDeepLinkedThread: vi.fn(),
+    };
+}
+
+/** The team roster, with everyone offline and nobody in do-not-disturb. */
+export function teamPresenceDouble() {
+    return { presenceFor: () => 'offline', isDndFor: () => false };
+}
+
+/** The per-channel draft, persisting nothing. */
+export function channelDraftDouble() {
+    return { onDraftChange: vi.fn(), cancel: vi.fn(), clear: vi.fn() };
+}
+
+/** What the page holds a composer ref for: the drop zone and the hover cards. */
+export function composerHandleDouble() {
+    return { addFiles: vi.fn(), focus: vi.fn(), insertMention: vi.fn() };
+}
+
+export function channel(overrides: Partial<Channel> = {}): Channel {
+    return {
+        id: 'c1',
+        name: 'general',
+        slug: 'general',
+        visibility: 'public',
+        topic: null,
+        isGeneral: true,
+        isArchived: false,
+        muted: false,
+        notificationLevel: 'all',
+        unreadCount: 0,
+        mentionCount: 0,
+        hasDraft: false,
+        draft: null,
+        starred: false,
+        sectionId: null,
+        position: 0,
+        isDirect: false,
+        isGroupDirect: false,
+        dmUserId: null,
+        dmParticipants: null,
+        lastActivityAt: null,
+        ...overrides,
+    };
+}
+
+export function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-03-04T10:30:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    } as Message;
+}
+
+/** A page of messages, newest first, the way `Inertia::scroll` delivers them. */
+export function messagePage(data: Message[] = [message()]): MessagePage {
+    return { data, next_cursor: null, prev_cursor: null };
+}
+
+const mounted: Array<{ app: App; host: HTMLElement }> = [];
+
+/**
+ * Mount the channel page over a reactive prop bag, so a suite can move a prop
+ * the way a partial reload does — a jump into the already-open channel above
+ * all. The bag is returned alongside the host for exactly that.
+ */
+export function mountShow(
+    Show: Component,
+    props: Record<string, unknown> = {},
+): { host: HTMLElement; props: Record<string, unknown> } {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const bag = reactive({
+        team: { id: 't1', name: 'Acme', slug: 'acme' },
+        channel: channel(),
+        messages: messagePage(),
+        members: [],
+        canArchive: true,
+        canManagePreferences: true,
+        canLeave: true,
+        canReact: true,
+        isMember: true,
+        memberCount: 3,
+        pinCount: 0,
+        pins: [],
+        notificationLevels: [],
+        channelReaders: [],
+        threadReplies: messagePage([]),
+        scheduledMessages: [],
+        ...props,
+    });
+
+    const app = createApp({ render: () => h(Show, bag) });
+
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    mounted.push({ app, host });
+
+    return { host, props: bag };
+}
+
+export function unmountAll(): void {
+    for (const { app, host } of mounted.splice(0)) {
+        app.unmount();
+        host.remove();
+    }
+}
+
+/** The observers jsdom lacks, which the page's geometry wiring constructs. */
+export function stubObservers(): void {
+    class NoopObserver {
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+    }
+
+    vi.stubGlobal('IntersectionObserver', NoopObserver);
+    vi.stubGlobal('ResizeObserver', NoopObserver);
+}
+
+/**
+ * Let Vue render, then let any `<Transition>` finish leaving: a pill leaves the
+ * DOM only once its leave hook resolves, which jsdom drives off
+ * `requestAnimationFrame` rather than a real animation.
+ */
+export async function settle(): Promise<void> {
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    await nextTick();
+}
+
+export function click(host: HTMLElement, selector: string): void {
+    (host.querySelector(selector) as HTMLElement).click();
+}

--- a/resources/js/pages/channels/Show.pane.test.ts
+++ b/resources/js/pages/channels/Show.pane.test.ts
@@ -1,0 +1,426 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, nextTick } from 'vue';
+import { channel, mountShow, stubObservers, unmountAll } from './Show.doubles';
+
+/**
+ * Covers the conversation pane's chrome: the whole-pane file drop zone, the
+ * bottom slot (composer vs. join bar vs. archived notice), the offline queue
+ * banner, the screen-reader announcers and the older-history pill.
+ *
+ * Written against the page as it stands so that a split of `Show.vue` can be
+ * checked against it: what is pinned here is the observable behaviour — every
+ * `data-test` selector, every guard on whether a surface renders at all, and
+ * every string — none of which a pure move is allowed to change.
+ */
+const router = vi.hoisted(() => ({
+    post: vi.fn(),
+    reload: vi.fn(),
+    visit: vi.fn(),
+}));
+
+const infinite = vi.hoisted(() => ({
+    fetchNext: vi.fn(),
+    hasNext: vi.fn(() => true),
+}));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble, inertiaPageProps } = await import('./Show.doubles');
+
+    return inertiaDouble(router, inertiaPageProps, infinite);
+});
+
+vi.mock('@laravel/echo-vue', async () => {
+    const { ref } = await import('vue');
+
+    return {
+        echo: () => ({ socketId: () => 'socket-1' }),
+        useConnectionStatus: () => ref('connected'),
+    };
+});
+
+vi.mock('@/composables/useMessageActions', async () => {
+    const { messageActionsDouble } = await import('./Show.doubles');
+    const actions = messageActionsDouble();
+
+    return {
+        QUEUED_SENDS_TOAST_KEY: 'queued-sends',
+        useMessageActions: () => actions,
+    };
+});
+
+vi.mock('@/composables/useChannelRealtime', () => ({
+    useChannelRealtime: vi.fn(),
+}));
+
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./Show.doubles');
+
+    return { useTeamPresence: teamPresenceDouble };
+});
+
+vi.mock('@/composables/useChannelDraft', async () => {
+    const { channelDraftDouble } = await import('./Show.doubles');
+
+    return { useChannelDraft: channelDraftDouble };
+});
+
+vi.mock('@/composables/useChannelPreferences', async () => {
+    const { channelPreferencesDouble } = await import('./Show.doubles');
+
+    return { useChannelPreferences: channelPreferencesDouble };
+});
+
+vi.mock('@/composables/useThreadPanel', async () => {
+    const { threadPanelDouble } = await import('./Show.doubles');
+
+    return { useThreadPanel: threadPanelDouble };
+});
+
+vi.mock('@/composables/useToast', () => ({
+    useToast: () => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }),
+}));
+
+const timeline = vi.hoisted(() => ({
+    scrollToIndex: vi.fn(),
+    scrollToLatest: vi.fn(),
+}));
+
+vi.mock('@/components/MessageList.vue', () => ({
+    default: defineComponent({
+        name: 'MessageListStub',
+        emits: ['loadOlder', 'rangeChange'],
+        setup(_props, { emit, expose }) {
+            expose(timeline);
+
+            return () =>
+                h('button', {
+                    'data-test': 'stub-load-older',
+                    onClick: () => emit('loadOlder'),
+                });
+        },
+    }),
+}));
+
+const composer = vi.hoisted(() => ({
+    addFiles: vi.fn(),
+    focus: vi.fn(),
+    insertMention: vi.fn(),
+}));
+
+vi.mock('@/components/MessageComposer.vue', () => ({
+    default: defineComponent({
+        name: 'MessageComposerStub',
+        setup(_props, { expose }) {
+            expose(composer);
+
+            return () => h('div', { 'data-test': 'stub-composer' });
+        },
+    }),
+}));
+
+vi.mock('@/components/ChannelMasthead.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ChannelMastheadStub') };
+});
+
+vi.mock('@/components/ThreadPanel.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ThreadPanelStub') };
+});
+
+vi.mock('@/components/ForwardMessageDialog.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ForwardMessageDialogStub') };
+});
+
+vi.mock('@/components/ScheduledMessagesDialog.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ScheduledMessagesDialogStub') };
+});
+
+vi.mock('@/components/ScheduleMessageDialog.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ScheduleMessageDialogStub') };
+});
+
+vi.mock('@/components/LeaveChannelModal.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('LeaveChannelModalStub') };
+});
+
+vi.mock('@/components/AddDirectMessagePeopleModal.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('AddDirectMessagePeopleModalStub') };
+});
+
+vi.mock('@/components/ChannelEmptyState.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ChannelEmptyStateStub') };
+});
+
+import Show from './Show.vue';
+
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    return mountShow(Show, props).host;
+}
+
+/** A drag event carrying the given `dataTransfer.types`, as jsdom has no DataTransfer. */
+function dragEvent(type: string, types: string[] = ['Files'], files = []) {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+
+    Object.defineProperty(event, 'dataTransfer', {
+        value: { types, files, dropEffect: 'none' },
+    });
+
+    return event as DragEvent;
+}
+
+/**
+ * The drop handlers sit on the pane wrapping the whole conversation, so a drag
+ * over anything inside it reaches them by bubbling — dispatching on the message
+ * history binds the assertion to a selector rather than to the DOM's shape.
+ */
+function dropPane(host: HTMLElement): HTMLElement {
+    return host.querySelector('[data-test="message-history"]') as HTMLElement;
+}
+
+beforeEach(() => {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(() => Promise.resolve(new Response())),
+    );
+    stubObservers();
+    localStorage.clear();
+});
+
+afterEach(() => {
+    unmountAll();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+});
+
+describe('the channel page announcers', () => {
+    it('renders a polite live region for inbound messages and one for send failures', () => {
+        const host = mount();
+
+        const announcer = host.querySelector('[data-test="message-announcer"]');
+        const failures = host.querySelector(
+            '[data-test="send-failure-announcer"]',
+        );
+
+        expect(announcer?.getAttribute('aria-live')).toBe('polite');
+        expect(announcer?.getAttribute('aria-atomic')).toBe('true');
+        expect(announcer?.className).toContain('sr-only');
+        expect(failures?.getAttribute('aria-live')).toBe('polite');
+    });
+});
+
+describe('the whole-pane drop zone', () => {
+    it('shows the drop overlay while files are dragged over the pane', async () => {
+        const host = mount();
+        const pane = dropPane(host);
+
+        expect(host.querySelector('[data-test="channel-drop-overlay"]')).toBe(
+            null,
+        );
+
+        pane.dispatchEvent(dragEvent('dragenter'));
+        await nextTick();
+
+        const overlay = host.querySelector(
+            '[data-test="channel-drop-overlay"]',
+        ) as HTMLElement;
+
+        expect(overlay).not.toBe(null);
+        expect(overlay.textContent).toContain('Drop to attach to #general');
+        expect(overlay.textContent).toContain('Up to 10 files · 25 MB each');
+        expect(overlay.className).toContain('pointer-events-none');
+    });
+
+    it('ignores a drag that carries no files', async () => {
+        const host = mount();
+
+        dropPane(host).dispatchEvent(dragEvent('dragenter', ['text/plain']));
+        await nextTick();
+
+        expect(host.querySelector('[data-test="channel-drop-overlay"]')).toBe(
+            null,
+        );
+    });
+
+    it('keeps the overlay up until every nested dragleave has matched its dragenter', async () => {
+        const host = mount();
+        const pane = dropPane(host);
+
+        pane.dispatchEvent(dragEvent('dragenter'));
+        pane.dispatchEvent(dragEvent('dragenter'));
+        pane.dispatchEvent(dragEvent('dragleave'));
+        await nextTick();
+
+        expect(
+            host.querySelector('[data-test="channel-drop-overlay"]'),
+        ).not.toBe(null);
+
+        pane.dispatchEvent(dragEvent('dragleave'));
+        await nextTick();
+
+        expect(host.querySelector('[data-test="channel-drop-overlay"]')).toBe(
+            null,
+        );
+    });
+
+    it('claims every file drag and shows the copy cursor where the drop is accepted', () => {
+        const host = mount();
+        const event = dragEvent('dragover');
+
+        dropPane(host).dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(event.dataTransfer?.dropEffect).toBe('copy');
+    });
+
+    it('claims a file drag over an archived channel without offering the copy cursor', () => {
+        const host = mount({ channel: channel({ isArchived: true }) });
+        const event = dragEvent('dragover');
+
+        dropPane(host).dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(event.dataTransfer?.dropEffect).toBe('none');
+    });
+
+    it('leaves a drag carrying no files to the browser', () => {
+        const host = mount();
+        const event = dragEvent('dragover', ['text/plain']);
+
+        dropPane(host).dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('stages dropped files in the composer and clears the overlay', async () => {
+        const host = mount();
+        const pane = dropPane(host);
+        const file = new File(['a'], 'a.png', { type: 'image/png' });
+
+        pane.dispatchEvent(dragEvent('dragenter'));
+        pane.dispatchEvent(
+            dragEvent('drop', ['Files'], [file] as unknown as []),
+        );
+        await nextTick();
+
+        expect(composer.addFiles).toHaveBeenCalledWith([file]);
+        expect(host.querySelector('[data-test="channel-drop-overlay"]')).toBe(
+            null,
+        );
+    });
+
+    it('does not stage a drop on an archived channel', () => {
+        const host = mount({ channel: channel({ isArchived: true }) });
+        const file = new File(['a'], 'a.png', { type: 'image/png' });
+
+        dropPane(host).dispatchEvent(
+            dragEvent('drop', ['Files'], [file] as unknown as []),
+        );
+
+        expect(composer.addFiles).not.toHaveBeenCalled();
+    });
+
+    it('does not stage a drop that carries no files', () => {
+        const host = mount();
+
+        dropPane(host).dispatchEvent(dragEvent('drop', ['text/plain']));
+
+        expect(composer.addFiles).not.toHaveBeenCalled();
+    });
+});
+
+describe('the pane bottom slot', () => {
+    it('renders the composer for a member of a live channel', () => {
+        const host = mount();
+
+        expect(host.querySelector('[data-test="stub-composer"]')).not.toBe(
+            null,
+        );
+        expect(host.querySelector('[data-test="archived-notice"]')).toBe(null);
+    });
+
+    it('replaces the composer with a read-only notice on an archived channel', () => {
+        const host = mount({ channel: channel({ isArchived: true }) });
+
+        const notice = host.querySelector('[data-test="archived-notice"]');
+
+        expect(notice?.textContent).toContain(
+            "This channel is archived. It's read-only, but its history is preserved.",
+        );
+        expect(host.querySelector('[data-test="stub-composer"]')).toBe(null);
+    });
+
+    it('replaces the composer with the join bar for a non-member', () => {
+        const host = mount({ isMember: false });
+
+        expect(host.querySelector('[data-test="stub-composer"]')).toBe(null);
+        expect(host.querySelector('[data-test="join-channel"]')).not.toBe(null);
+    });
+});
+
+describe('the older-history pill', () => {
+    it('fetches the next page and shows the pill when the timeline asks for older messages', async () => {
+        const host = mount();
+
+        (
+            host.querySelector('[data-test="stub-load-older"]') as HTMLElement
+        ).click();
+        await nextTick();
+
+        expect(infinite.fetchNext).toHaveBeenCalledTimes(1);
+
+        const pill = host.querySelector('[data-test="loading-older"]');
+
+        expect(pill?.textContent).toContain('Loading earlier messages…');
+    });
+
+    it('does not stack a second request while one is in flight', async () => {
+        const host = mount();
+        const trigger = host.querySelector(
+            '[data-test="stub-load-older"]',
+        ) as HTMLElement;
+
+        trigger.click();
+        await nextTick();
+        trigger.click();
+
+        expect(infinite.fetchNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fetch when no older history remains', () => {
+        infinite.hasNext.mockReturnValueOnce(false);
+
+        const host = mount();
+
+        (
+            host.querySelector('[data-test="stub-load-older"]') as HTMLElement
+        ).click();
+
+        expect(infinite.fetchNext).not.toHaveBeenCalled();
+    });
+});
+
+describe('the offline queue banner', () => {
+    it('stays hidden while the socket is up', () => {
+        const host = mount();
+
+        expect(host.querySelector('[data-test="offline-queue-banner"]')).toBe(
+            null,
+        );
+    });
+});

--- a/resources/js/pages/channels/Show.timeline.test.ts
+++ b/resources/js/pages/channels/Show.timeline.test.ts
@@ -1,0 +1,433 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, nextTick } from 'vue';
+import {
+    click,
+    composerHandleDouble,
+    message,
+    mountShow,
+    settle,
+    stubObservers,
+    unmountAll,
+} from './Show.doubles';
+
+/**
+ * Covers the position-dependent affordances the channel page derives from the
+ * virtualizer's window: the jump-to-message highlight, the "New messages" pill
+ * and its per-visit seen latch, the sticky day chip, and the pins popover.
+ *
+ * Written against the page as it stands so a split of `Show.vue` can be checked
+ * against it — every selector, every string and every scroll call is pinned
+ * here, and a pure move may change none of them.
+ */
+const router = vi.hoisted(() => ({
+    post: vi.fn(),
+    reload: vi.fn(),
+    visit: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble, inertiaPageProps } = await import('./Show.doubles');
+
+    return inertiaDouble(router, inertiaPageProps, {
+        fetchNext: vi.fn(),
+        hasNext: () => false,
+    });
+});
+
+vi.mock('@/composables/useMessageActions', async () => {
+    const { messageActionsDouble } = await import('./Show.doubles');
+    const actions = messageActionsDouble();
+
+    return {
+        QUEUED_SENDS_TOAST_KEY: 'queued-sends',
+        useMessageActions: () => actions,
+    };
+});
+
+vi.mock('@laravel/echo-vue', async () => {
+    const { ref } = await import('vue');
+
+    return {
+        echo: () => ({ socketId: () => 'socket-1' }),
+        useConnectionStatus: () => ref('connected'),
+    };
+});
+
+vi.mock('@/composables/useChannelRealtime', () => ({
+    useChannelRealtime: vi.fn(),
+}));
+
+vi.mock('@/composables/useTeamPresence', async () => {
+    const { teamPresenceDouble } = await import('./Show.doubles');
+
+    return { useTeamPresence: teamPresenceDouble };
+});
+
+vi.mock('@/composables/useChannelDraft', async () => {
+    const { channelDraftDouble } = await import('./Show.doubles');
+
+    return { useChannelDraft: channelDraftDouble };
+});
+
+vi.mock('@/composables/useChannelPreferences', async () => {
+    const { channelPreferencesDouble } = await import('./Show.doubles');
+
+    return { useChannelPreferences: channelPreferencesDouble };
+});
+
+vi.mock('@/composables/useThreadPanel', async () => {
+    const { threadPanelDouble } = await import('./Show.doubles');
+
+    return { useThreadPanel: threadPanelDouble };
+});
+
+vi.mock('@/composables/useToast', () => ({
+    useToast: () => ({ success: vi.fn(), error: vi.fn(), info: vi.fn() }),
+}));
+
+vi.mock('@/components/ChannelMasthead.vue', () => ({
+    default: defineComponent({
+        name: 'ChannelMastheadStub',
+        emits: ['openPins'],
+        setup:
+            (_props, { emit }) =>
+            () =>
+                h('button', {
+                    'data-test': 'stub-open-pins',
+                    onClick: () => emit('openPins'),
+                }),
+    }),
+}));
+
+vi.mock('@/components/PinsPanel.vue', () => ({
+    default: defineComponent({
+        name: 'PinsPanelStub',
+        emits: ['jump'],
+        setup:
+            (_props, { emit }) =>
+            () =>
+                h('button', {
+                    'data-test': 'stub-pins-jump',
+                    onClick: () => emit('jump', 'm2'),
+                }),
+    }),
+}));
+
+const timeline = vi.hoisted(() => ({
+    scrollToIndex: vi.fn(),
+    scrollToLatest: vi.fn(),
+    /** The window the stub reports on its next `range-change`. */
+    range: { startIndex: 0, endIndex: 10 },
+}));
+
+vi.mock('@/components/MessageList.vue', () => ({
+    default: defineComponent({
+        name: 'MessageListStub',
+        props: {
+            highlightMessageId: { type: String, default: null },
+            unreadDividerId: { type: String, default: null },
+        },
+        emits: ['rangeChange'],
+        setup(props, { emit, expose }) {
+            expose(timeline);
+
+            return () =>
+                h('button', {
+                    'data-test': 'stub-range',
+                    'data-highlight': props.highlightMessageId ?? '',
+                    'data-unread-divider': props.unreadDividerId ?? '',
+                    onClick: () => emit('rangeChange', timeline.range),
+                });
+        },
+    }),
+}));
+
+vi.mock('@/components/MessageComposer.vue', () => ({
+    default: defineComponent({
+        name: 'MessageComposerStub',
+        setup(_props, { expose }) {
+            expose(composerHandleDouble());
+
+            return () => h('div', { 'data-test': 'stub-composer' });
+        },
+    }),
+}));
+
+vi.mock('@/components/ThreadPanel.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ThreadPanelStub') };
+});
+
+vi.mock('@/components/ForwardMessageDialog.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ForwardMessageDialogStub') };
+});
+
+vi.mock('@/components/ScheduledMessagesDialog.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ScheduledMessagesDialogStub') };
+});
+
+vi.mock('@/components/ScheduleMessageDialog.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ScheduleMessageDialogStub') };
+});
+
+vi.mock('@/components/LeaveChannelModal.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('LeaveChannelModalStub') };
+});
+
+vi.mock('@/components/AddDirectMessagePeopleModal.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('AddDirectMessagePeopleModalStub') };
+});
+
+vi.mock('@/components/ChannelEmptyState.vue', async () => {
+    const { inert } = await import('./Show.doubles');
+
+    return { default: inert('ChannelEmptyStateStub') };
+});
+
+import Show from './Show.vue';
+
+/** Two peer messages a day apart, so the timeline carries two day dividers. */
+function mount(props: Record<string, unknown> = {}): {
+    host: HTMLElement;
+    props: Record<string, unknown>;
+} {
+    return mountShow(Show, {
+        messages: {
+            data: [
+                message({
+                    id: 'm2',
+                    clientUuid: 'uuid-2',
+                    createdAt: '2024-03-05T10:30:00.000Z',
+                }),
+                message(),
+            ],
+            next_cursor: null,
+            prev_cursor: null,
+        },
+        pinCount: 2,
+        ...props,
+    });
+}
+
+/** The element the `MessageList` stub stands in for, carrying its props. */
+function stub(host: HTMLElement): HTMLElement {
+    return host.querySelector('[data-test="stub-range"]') as HTMLElement;
+}
+
+/** Scroll the history off its bottom edge, so the page reads as scrolled up. */
+async function scrollUp(host: HTMLElement): Promise<void> {
+    const el = host.querySelector(
+        '[data-test="message-history"]',
+    ) as HTMLElement;
+
+    Object.defineProperty(el, 'scrollHeight', {
+        value: 1000,
+        configurable: true,
+    });
+    Object.defineProperty(el, 'clientHeight', {
+        value: 200,
+        configurable: true,
+    });
+    el.scrollTop = 0;
+    el.dispatchEvent(new Event('scroll'));
+    await nextTick();
+}
+
+beforeEach(() => {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(() => Promise.resolve(new Response())),
+    );
+    stubObservers();
+    localStorage.clear();
+});
+
+afterEach(() => {
+    unmountAll();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+});
+
+describe('jumping to a message', () => {
+    it('centres the target in the window and highlights it for a beat', async () => {
+        vi.useFakeTimers();
+
+        const { host } = mount({ jumpToMessageId: 'm1' });
+
+        await nextTick();
+        await nextTick();
+
+        expect(timeline.scrollToIndex).toHaveBeenCalledWith(
+            expect.any(Number),
+            'center',
+        );
+        expect(stub(host).getAttribute('data-highlight')).toBe('m1');
+
+        vi.advanceTimersByTime(2000);
+        await nextTick();
+
+        expect(stub(host).getAttribute('data-highlight')).toBe('');
+    });
+
+    it('jumps again when a search result targets the already-open channel', async () => {
+        const { host, props } = mount();
+
+        await nextTick();
+        expect(timeline.scrollToIndex).not.toHaveBeenCalled();
+
+        props.jumpToMessageId = 'm2';
+        await settle();
+
+        expect(timeline.scrollToIndex).toHaveBeenCalledWith(
+            expect.any(Number),
+            'center',
+        );
+        expect(stub(host).getAttribute('data-highlight')).toBe('m2');
+    });
+});
+
+describe('the unread jump pill', () => {
+    it('offers the boundary while it sits above the window and scrolls to it', async () => {
+        const { host } = mount({ lastReadMessageId: 'm1' });
+
+        await nextTick();
+
+        const pill = host.querySelector('[data-test="jump-to-unread"]');
+
+        expect(pill?.textContent).toContain('New messages');
+
+        (pill as HTMLElement).click();
+
+        expect(timeline.scrollToIndex).toHaveBeenCalledWith(
+            expect.any(Number),
+            'start',
+        );
+    });
+
+    it('renders no pill when the channel has no unread boundary', async () => {
+        const { host } = mount({ lastReadMessageId: 'm2' });
+
+        await nextTick();
+
+        expect(host.querySelector('[data-test="jump-to-unread"]')).toBe(null);
+    });
+
+    it('dismisses the pill for the visit once the reader reaches the boundary', async () => {
+        const { host } = mount({ lastReadMessageId: 'm1' });
+
+        await nextTick();
+
+        timeline.range = { startIndex: 5, endIndex: 10 };
+        click(host, '[data-test="stub-range"]');
+        await nextTick();
+
+        expect(host.querySelector('[data-test="jump-to-unread"]')).not.toBe(
+            null,
+        );
+
+        timeline.range = { startIndex: 0, endIndex: 10 };
+        click(host, '[data-test="stub-range"]');
+        await settle();
+
+        expect(host.querySelector('[data-test="jump-to-unread"]')).toBe(null);
+    });
+
+    it('dismisses the pill when the reader jumps back to the present', async () => {
+        const { host } = mount({ lastReadMessageId: 'm1' });
+
+        await nextTick();
+        await scrollUp(host);
+
+        click(host, '[data-test="jump-to-latest"]');
+        await settle();
+
+        expect(timeline.scrollToLatest).toHaveBeenCalledWith('smooth');
+        expect(host.querySelector('[data-test="jump-to-unread"]')).toBe(null);
+    });
+});
+
+describe('the sticky day chip', () => {
+    it('names the day of the topmost visible row while scrolled up', async () => {
+        const { host } = mount();
+
+        await nextTick();
+        await scrollUp(host);
+
+        timeline.range = { startIndex: 1, endIndex: 10 };
+        click(host, '[data-test="stub-range"]');
+        await nextTick();
+
+        const chip = host.querySelector('[data-test="sticky-date"]');
+
+        expect(chip?.textContent?.trim()).not.toBe('');
+    });
+
+    it('suppresses the chip when a day divider already leads the window', async () => {
+        const { host } = mount();
+
+        await nextTick();
+        await scrollUp(host);
+
+        timeline.range = { startIndex: 0, endIndex: 10 };
+        click(host, '[data-test="stub-range"]');
+        await nextTick();
+
+        expect(host.querySelector('[data-test="sticky-date"]')).toBe(null);
+    });
+
+    it('stays hidden while the view is pinned to the newest message', async () => {
+        const { host } = mount();
+
+        await nextTick();
+
+        timeline.range = { startIndex: 1, endIndex: 10 };
+        click(host, '[data-test="stub-range"]');
+        await nextTick();
+
+        expect(host.querySelector('[data-test="sticky-date"]')).toBe(null);
+    });
+});
+
+describe('the pins popover', () => {
+    it('pulls the freshest pins as it opens', async () => {
+        const { host } = mount();
+
+        click(host, '[data-test="stub-open-pins"]');
+        await nextTick();
+
+        expect(router.reload).toHaveBeenCalledWith({
+            only: ['pins', 'pinCount'],
+        });
+        expect(host.querySelector('[data-test="stub-pins-jump"]')).not.toBe(
+            null,
+        );
+    });
+
+    it('closes itself on the way to a pinned message', async () => {
+        const { host } = mount();
+
+        click(host, '[data-test="stub-open-pins"]');
+        await nextTick();
+        click(host, '[data-test="stub-pins-jump"]');
+        await settle();
+
+        expect(host.querySelector('[data-test="stub-pins-jump"]')).toBe(null);
+        expect(timeline.scrollToIndex).toHaveBeenCalledWith(
+            expect.any(Number),
+            'center',
+        );
+    });
+});

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1,81 +1,30 @@
 <script setup lang="ts">
-import { Head, InfiniteScroll, router, usePage } from '@inertiajs/vue3';
-import { echo } from '@laravel/echo-vue';
-import { ArrowUp, Upload, WifiOff } from '@lucide/vue';
-import {
-    computed,
-    nextTick,
-    onBeforeUnmount,
-    onMounted,
-    ref,
-    watch,
-} from 'vue';
-import {
-    archive as archiveChannel,
-    read as markChannelRead,
-    typing as postTypingSignal,
-} from '@/actions/App/Http/Controllers/Channels/ChannelController';
-import AddDirectMessagePeopleModal from '@/components/AddDirectMessagePeopleModal.vue';
-import ChannelEmptyState from '@/components/ChannelEmptyState.vue';
-import ChannelMasthead from '@/components/ChannelMasthead.vue';
-import ForwardMessageDialog from '@/components/ForwardMessageDialog.vue';
+import { Head } from '@inertiajs/vue3';
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import ArchivedNotice from '@/components/channel/ArchivedNotice.vue';
+import ChannelAnnouncers from '@/components/channel/ChannelAnnouncers.vue';
+import ChannelComposerDock from '@/components/channel/ChannelComposerDock.vue';
+import ChannelDialogs from '@/components/channel/ChannelDialogs.vue';
+import ChannelHeader from '@/components/channel/ChannelHeader.vue';
+import ChannelPane from '@/components/channel/ChannelPane.vue';
 import JoinChannelBar from '@/components/JoinChannelBar.vue';
-import LeaveChannelModal from '@/components/LeaveChannelModal.vue';
-import MessageComposer from '@/components/MessageComposer.vue';
-import MessageList from '@/components/MessageList.vue';
-import PinsPanel from '@/components/PinsPanel.vue';
-import ScheduledCountChip from '@/components/ScheduledCountChip.vue';
-import ScheduledMessagesDialog from '@/components/ScheduledMessagesDialog.vue';
-import ScheduleMessageDialog from '@/components/ScheduleMessageDialog.vue';
-import ScrollableMessageList from '@/components/ScrollableMessageList.vue';
 import ThreadPanel from '@/components/ThreadPanel.vue';
-import TypingIndicator from '@/components/TypingIndicator.vue';
-import { Button } from '@/components/ui/button';
-import {
-    Dialog,
-    DialogClose,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog';
 import { useChannelDraft } from '@/composables/useChannelDraft';
-import { useChannelPreferences } from '@/composables/useChannelPreferences';
+import { useChannelIdentity } from '@/composables/useChannelIdentity';
+import { useChannelReaders } from '@/composables/useChannelReaders';
 import { useChannelRealtime } from '@/composables/useChannelRealtime';
-import { useConnectionState } from '@/composables/useConnectionState';
-import { useDebouncedPost } from '@/composables/useDebouncedPost';
-import {
-    QUEUED_SENDS_TOAST_KEY,
-    useMessageActions,
-} from '@/composables/useMessageActions';
-import { useMessageAnnouncer } from '@/composables/useMessageAnnouncer';
-import {
-    optimisticMessage,
-    useMessageStream,
-} from '@/composables/useMessageStream';
+import { useChannelTimeline } from '@/composables/useChannelTimeline';
+import { useChannelTyping } from '@/composables/useChannelTyping';
+import { useComposerTarget } from '@/composables/useComposerTarget';
+import { useMessageActions } from '@/composables/useMessageActions';
+import { useOfflineOutbox } from '@/composables/useOfflineOutbox';
 import { useRailBottomInset } from '@/composables/useRailInset';
+import { useReadOnFocus } from '@/composables/useReadOnFocus';
+import { useReadPointer } from '@/composables/useReadPointer';
 import { useScrollPin } from '@/composables/useScrollPin';
-import { useSendFailureAnnouncer } from '@/composables/useSendFailureAnnouncer';
 import { useTeamPresence } from '@/composables/useTeamPresence';
 import { useThreadPanel } from '@/composables/useThreadPanel';
 import { useTimezone } from '@/composables/useTimezone';
-import { useToast } from '@/composables/useToast';
-import { useTranslations } from '@/composables/useTranslations';
-import { useTypingIndicator } from '@/composables/useTypingIndicator';
-import { useUnreadDivider } from '@/composables/useUnreadDivider';
-import { backgroundVisit } from '@/lib/backgroundVisit';
-import { formatDayLabel } from '@/lib/datetime';
-import { groupDmMastheadName } from '@/lib/groupDm';
-import { createOutbox } from '@/lib/outbox';
-import { buildTimelineItems } from '@/lib/timeline';
-import { parseXsrfToken } from '@/lib/uploadAttachment';
-import {
-    isDividerVisible,
-    shouldShowUnreadJump,
-    timelineItemIndexForMessage,
-    unreadDividerIndex,
-} from '@/lib/virtualTimeline';
 import type {
     Channel,
     ChannelReader,
@@ -86,8 +35,6 @@ import type {
     ScheduledMessage,
     Thread,
 } from '@/types';
-import type { ForwardTarget } from '@/types/forward';
-import type { PersonRef } from '@/types/people';
 
 const props = defineProps<{
     team: { id: string; name: string; slug: string };
@@ -150,50 +97,24 @@ const props = defineProps<{
     scheduledMessages: ScheduledMessage[];
 }>();
 
-const page = usePage();
+const {
+    currentUser,
+    isSelfDm,
+    mastheadTitle,
+    canAddPeople,
+    composerPlaceholder,
+    canModerate,
+    mentionableMembers,
+    channelHasBots,
+} = useChannelIdentity({
+    channel: () => props.channel,
+    members: () => props.members,
+    isMember: () => props.isMember,
+});
 
-const { t } = useTranslations();
-const toast = useToast();
-
-const currentUser = computed(() => ({
-    id: String(page.props.auth.user.id),
-    name: page.props.auth.user.name,
-}));
-
-/**
- * Peers currently composing on this channel, driven by the server-broadcast
- * `UserTyping` event on the same private channel as the message events. The
- * outbound signal is a plain fire-and-forget POST — the server derives the
- * typist identity from the authenticated session, so a member cannot spoof
- * another member's indicator — carrying the Echo socket id so the resulting
- * broadcast skips this tab.
- */
-const typing = useTypingIndicator(() => {
-    const headers: Record<string, string> = {
-        'X-Requested-With': 'XMLHttpRequest',
-    };
-
-    const xsrfToken = parseXsrfToken(document.cookie);
-
-    if (xsrfToken) {
-        headers['X-XSRF-TOKEN'] = xsrfToken;
-    }
-
-    const socketId = echo().socketId();
-
-    if (socketId) {
-        headers['X-Socket-ID'] = socketId;
-    }
-
-    void fetch(
-        postTypingSignal({
-            team: props.team.slug,
-            channel: props.channel.slug,
-        }).url,
-        { method: 'POST', headers },
-    ).catch(() => {
-        // A lost typing beat is invisible; the next keystroke sends another.
-    });
+const typing = useChannelTyping({
+    teamSlug: () => props.team.slug,
+    channelSlug: () => props.channel.slug,
 });
 
 const typingNames = typing.typingNames;
@@ -204,155 +125,39 @@ const typingNames = typing.typingNames;
  */
 const { presenceFor, isDndFor } = useTeamPresence(() => props.team.id);
 
-/**
- * Read positions of the channel's other members who share read receipts, keyed
- * by user id. Seeded from the server prop and kept current from the MessageRead
- * broadcast, driving the "Seen by" affordance under the newest message.
- */
-const readers = ref(new Map<string, ChannelReader>());
-
-function seedReaders(): void {
-    readers.value = new Map(
-        props.channelReaders.map((reader) => [reader.user.id, reader]),
-    );
-}
-
-const channelReadersList = computed(() => Array.from(readers.value.values()));
-
-function onTyping(): void {
-    typing.signalTyping();
-}
-
-// You can't @mention yourself, and bots have no inbox to reach, so drop the
-// current user and any bots from the composer list — the roster facepile still
-// shows the bots.
-const mentionableMembers = computed(() =>
-    props.members.filter(
-        (member) => member.id !== currentUser.value.id && !member.isBot,
-    ),
-);
-
-// Whether this channel has a bot member, so the composer's mention menu can note
-// once, quietly, why bots aren't mentionable.
-const channelHasBots = computed(() =>
-    props.members.some((member) => member.isBot),
-);
-
-/**
- * A direct message renders viewer-relative: no "#", the other participant's
- * name (the viewer's own self-DM reads "You"), or a group's participant-joined
- * name. Drives the `<Head>` title, the masthead, and the empty state's
- * viewer-relative copy; the masthead owns the DM avatar and facepile itself.
- */
-const isSelfDm = computed(
-    () =>
-        props.channel.isDirect &&
-        props.channel.dmUserId === currentUser.value.id,
-);
-const mastheadTitle = computed(() => {
-    if (props.channel.isGroupDirect) {
-        return (
-            groupDmMastheadName(props.channel.dmParticipants ?? []) ||
-            t('Group conversation')
-        );
-    }
-
-    return isSelfDm.value ? t('You') : props.channel.name;
+const { readers, seedReaders, channelReadersList } = useChannelReaders({
+    channelReaders: () => props.channelReaders,
 });
 
-/**
- * The viewer may add people to any DM they belong to; grows a 1:1 into a group
- * or a group further. Drives the masthead's "Add people" button and its modal.
- */
-const canAddPeople = computed(() => props.channel.isDirect && props.isMember);
-const addingPeople = ref(false);
+/** The page's live regions, which also announce a send that failed. */
+const announcers = ref<InstanceType<typeof ChannelAnnouncers> | null>(null);
+
+/** The channel header, which owns the viewer's own preferences and the pins. */
+const header = ref<InstanceType<typeof ChannelHeader> | null>(null);
+
+/** Every dialog the page can raise, opened through its exposed handlers. */
+const dialogs = ref<InstanceType<typeof ChannelDialogs> | null>(null);
 
 /**
- * A DM's composer addresses the conversation by its participant name rather than
- * a "#channel", so its placeholder overrides the composer's channel default.
+ * The composer dock, so a profile hover card in the main timeline can drop a
+ * mention straight into the composer and a pane drop can stage its files.
  */
-const composerPlaceholder = computed(() =>
-    props.channel.isDirect
-        ? t('Message :name', { name: mastheadTitle.value })
-        : undefined,
-);
+const dock = ref<InstanceType<typeof ChannelComposerDock> | null>(null);
 
-/** A team Admin+ may delete anyone's message in the channel (moderation). */
-const canModerate = computed(() =>
-    ['admin', 'owner'].includes(page.props.currentTeam?.role ?? ''),
-);
+/**
+ * The conversation pane, through which the page jumps to a message (from the
+ * pins popover, a thread, or a search deep link) and returns to the present.
+ */
+const pane = ref<InstanceType<typeof ChannelPane> | null>(null);
 
 const scrollContainer = ref<HTMLElement | null>(null);
 /**
- * `ScrollableMessageList` owns the scroll element; this points our ref at it so
- * `useScrollPin`, `useUnreadDivider`, and the virtualized `MessageList` all bind
- * to the very same node.
+ * The pane owns the scroll element; this points our ref at it so `useScrollPin`
+ * binds to the very same node the timeline and its affordances read.
  */
 const setScrollContainer = (el: HTMLElement | null): void => {
     scrollContainer.value = el;
 };
-
-/**
- * The windowed timeline exposes `scrollToIndex` so off-screen jump targets can be
- * brought into view; Inertia's `<InfiniteScroll>` (driven manually) exposes the
- * older-page fetch. Both are read through template refs.
- */
-const messageListRef = ref<{
-    scrollToIndex: (
-        index: number,
-        align?: 'auto' | 'start' | 'center' | 'end',
-    ) => void;
-    scrollToLatest: (behavior?: ScrollBehavior) => void;
-} | null>(null);
-
-const infiniteScrollRef = ref<{
-    fetchNext: () => void;
-    hasNext: () => boolean;
-} | null>(null);
-
-/**
- * The virtualizer's visible render-item window, surfaced by `MessageList` so the
- * unread-jump pill can be derived without a DOM `IntersectionObserver`.
- */
-const timelineRange = ref<{ startIndex: number; endIndex: number } | null>(
-    null,
-);
-
-/**
- * True while an older page is being fetched, gating the virtualizer's top-load
- * trigger so a burst of range updates can't stack duplicate requests. Cleared
- * once the merged page grows (older rows have landed).
- */
-const loadingOlder = ref(false);
-
-/**
- * In reverse mode, older history is the paginator's *next* page (the server
- * returns messages newest-first), so "load older" maps to fetchNext/hasNext.
- */
-const hasOlder = (): boolean => infiniteScrollRef.value?.hasNext() ?? false;
-
-const isLoadingOlder = (): boolean => loadingOlder.value;
-
-/**
- * Fetch the next older page through Inertia's merge engine. The virtualizer
- * decides *when* (the reader nears the top of loaded history); Inertia handles
- * the cursor request, prepend, and scroll positioning.
- */
-function loadOlderMessages(): void {
-    if (loadingOlder.value || !hasOlder()) {
-        return;
-    }
-
-    loadingOlder.value = true;
-    infiniteScrollRef.value?.fetchNext();
-}
-
-watch(
-    () => props.messages?.data?.length ?? 0,
-    () => {
-        loadingOlder.value = false;
-    },
-);
 
 /**
  * Shared scroll/pin bookkeeping: the pinned-to-newest flag, the "N new messages"
@@ -372,69 +177,11 @@ const {
     // of the present; drive the jump through the virtualizer, which re-targets
     // the true bottom as off-screen rows measure (#347).
     scrollToLatest: (smooth) =>
-        messageListRef.value?.scrollToLatest(smooth ? 'smooth' : 'auto'),
+        pane.value?.scrollToLatest(smooth ? 'smooth' : 'auto'),
 });
 
-/**
- * Whether the timeline has conversation scrolled above its top edge. Below the
- * breakpoint the masthead sits over the timeline rather than beside it, so it
- * takes a hairline shadow exactly when there is something passing under it.
- */
-const timelineScrolled = ref(false);
-
-function onTimelineScroll(): void {
-    onScroll();
-    timelineScrolled.value = (scrollContainer.value?.scrollTop ?? 0) > 0;
-}
-
-/** `Inertia::scroll` delivers messages newest-first; reverse for display. */
-const serverMessages = computed<Message[]>(() =>
-    [...(props.messages?.data ?? [])].reverse(),
-);
-
-/**
- * The main channel timeline: optimistic sends + live echoes + edit/delete
- * patches, all merged over the server page and deduped by client uuid.
- */
-const mainStream = useMessageStream(serverMessages);
-const displayMessages = mainStream.displayMessages;
-
-/**
- * Announce genuine inbound messages to screen readers via a polite live region;
- * the virtualized timeline itself can't be a `role="log"` (rows unmount).
- */
-const { announcement } = useMessageAnnouncer({
-    messages: () => displayMessages.value,
-    currentUserId: () => currentUser.value.id,
-});
-
-/**
- * A failed optimistic send rolls its row back silently; this polite live region
- * announces the failure so a screen-reader user hears it, mirroring the toast.
- */
-const { announcement: sendFailureAnnouncement, announce: announceSendFailure } =
-    useSendFailureAnnouncer();
-const pendingUuids = mainStream.pendingUuids;
-
-const hasMessages = computed(() => displayMessages.value.length > 0);
-
-/**
- * The same grouped render list the virtualized `MessageList` builds, recomputed
- * here so index-based affordances (jump-to-message, the unread boundary) can map
- * a message or divider to the render-item index the virtualizer scrolls to. Pure
- * and cheap; `unreadDividerId` is resolved lazily by the composable below.
- */
-const timelineItems = computed(() =>
-    buildTimelineItems(displayMessages.value, unreadDividerId.value ?? null),
-);
-
-/**
- * Focus the channel composer — from the empty-state welcome's "Post your first
- * message" card, or a profile hover card dropping in a mention.
- */
-function focusComposer(): void {
-    channelComposer.value?.focus();
-}
+const { serverMessages, mainStream, displayMessages, pendingUuids } =
+    useChannelTimeline({ messages: () => props.messages });
 
 /**
  * The thread panel's whole open → load → reset → mark-read lifecycle, with its own
@@ -461,275 +208,17 @@ const {
     threadReplies: () => props.threadReplies,
 });
 
-/**
- * The message to briefly highlight after a search jump. The server windows the
- * initial page so the target is loaded; we scroll it into view and clear the
- * highlight after a short beat.
- */
-const highlightedMessageId = ref<string | null>(null);
-let highlightTimer: ReturnType<typeof setTimeout> | null = null;
-
+/** Bring a message into view in the timeline and mark it for a beat. */
 function jumpToMessage(id: string): void {
-    // Bring the target's render item into the window first — with windowing its
-    // element may not exist yet to scroll to — then refine and highlight once the
-    // row mounts. A missing index (target not loaded) still highlights on arrival.
-    const index = timelineItemIndexForMessage(timelineItems.value, id);
-
-    if (index >= 0) {
-        messageListRef.value?.scrollToIndex(index, 'center');
-    }
-
-    nextTick(() => {
-        document
-            .getElementById(`message-${id}`)
-            ?.scrollIntoView({ block: 'center' });
-
-        highlightedMessageId.value = id;
-
-        if (highlightTimer) {
-            clearTimeout(highlightTimer);
-        }
-
-        highlightTimer = setTimeout(() => {
-            highlightedMessageId.value = null;
-        }, 2000);
-    });
+    pane.value?.jumpToMessage(id);
 }
 
-/**
- * The "New messages" divider's lifecycle — freeze its position at open, refreeze
- * on each channel switch, and hide the jump pill once it scrolls into view —
- * lives in this composable. It reads the server page (not the live-merged list)
- * so the boundary is immune to the order per-channel state resets on a switch.
- */
-const { unreadDividerId } = useUnreadDivider({
-    channelId: () => props.channel.id,
-    scrollContainer,
-    messages: () => serverMessages.value,
-    lastReadMessageId: () => props.lastReadMessageId ?? null,
-    currentUserId: () => currentUser.value.id,
-});
-
-/** The unread boundary's render-item index, or -1 when there's none. */
-const unreadIndex = computed(() => unreadDividerIndex(timelineItems.value));
-
-/**
- * Per-visit latch: once the reader reaches the unread boundary (it scrolls into
- * the window) or jumps back to the present, the "New messages" pill is dismissed
- * for the rest of this channel visit. Without it the pill reappears whenever the
- * (frozen) divider sits above the window again — e.g. right after Jump to present
- * (#411). Both flags are refrozen alongside the divider on every channel switch.
- */
-const unreadDividerSeen = ref(false);
-
-/**
- * Whether the boundary has ever sat above the window this visit. The reader
- * "reaches" the divider only when it scrolls back into view *after* having been
- * above — the transition the seen latch keys off. This guards against the initial
- * pre-`scrollToBottom` render (rows start at the top, so the divider is briefly
- * on screen before the open pins to the newest message) latching it prematurely.
- */
-const unreadDividerWasAbove = ref(false);
-
-watch(
-    () => props.channel.id,
-    () => {
-        unreadDividerSeen.value = false;
-        unreadDividerWasAbove.value = false;
-    },
-);
-
-// Track the boundary's position relative to the window and latch it as seen the
-// moment it scrolls back into view after having been above — the reader clicking
-// the pill or scrolling up to the divider.
-watch([timelineRange, unreadIndex], ([range, index]) => {
-    if (!range || index < 0) {
-        return;
-    }
-
-    if (index < range.startIndex) {
-        unreadDividerWasAbove.value = true;
-    } else if (
-        unreadDividerWasAbove.value &&
-        isDividerVisible(index, range.startIndex, range.endIndex)
-    ) {
-        unreadDividerSeen.value = true;
-    }
-});
-
-/**
- * Show the floating "New messages" pill while the unread boundary sits above the
- * virtualizer's window and the reader hasn't reached it yet. Windowing drops the
- * off-screen divider from the DOM, so this replaces the old IntersectionObserver
- * with pure range math plus the per-visit seen latch. Before the first range
- * lands the view is pinned to the bottom, so an existing, unseen boundary is
- * necessarily above it.
- */
-const showJumpToUnread = computed(() => {
-    const range = timelineRange.value;
-
-    if (!range) {
-        return unreadIndex.value >= 0 && !unreadDividerSeen.value;
-    }
-
-    return shouldShowUnreadJump(
-        unreadIndex.value,
-        range.startIndex,
-        range.endIndex,
-        unreadDividerSeen.value,
-    );
-});
-
-/**
- * Scroll the unread boundary to the top of the viewport via the virtualizer,
- * bringing it on screen even when it wasn't rendered.
- */
-function scrollToUnread(): void {
-    if (unreadIndex.value >= 0) {
-        messageListRef.value?.scrollToIndex(unreadIndex.value, 'start');
-    }
-}
-
-/**
- * Return to the newest message. Jumping to present counts as reaching the unread
- * boundary, so latch it — the reader is done with the "New messages" pill for
- * this visit even if the frozen divider now sits above the window again (#411).
- */
-function jumpToPresent(): void {
-    unreadDividerSeen.value = true;
-    scrollToBottom(true);
-}
-
-/**
- * The day the topmost visible row falls in, driving the floating sticky date
- * chip while the reader is scrolled up into history (design 1a). Reads the first
- * dated render item at or after the window's top — a group's lead timestamp or a
- * day divider's own ISO.
- */
-const stickyDayLabel = computed<string | null>(() => {
-    const range = timelineRange.value;
-    const items = timelineItems.value;
-
-    if (!range || items.length === 0) {
-        return null;
-    }
-
-    for (
-        let i = Math.min(range.startIndex, items.length - 1);
-        i < items.length;
-        i += 1
-    ) {
-        const item = items[i];
-
-        // A day boundary already sits at the top of the window, shown inline —
-        // the chip would just duplicate it (e.g. scrolled to the very top), so
-        // suppress it until the divider scrolls off and a group leads instead.
-        if (item.type === 'divider' && item.variant === 'day') {
-            return null;
-        }
-
-        if (item.type === 'group') {
-            return formatDayLabel(item.leadCreatedAt);
-        }
-    }
-
-    return null;
-});
-
-/**
- * Advance the read pointer for the open channel so its sidebar badge clears.
- * Debounced and gated on tab focus: a channel is only "read" while the user is
- * actually looking at it, and a burst of arriving messages collapses to one
- * request. The redirect refreshes just the shared `channels` prop.
- *
- * The Echo socket id rides along so the resulting `ReadStateAdvanced` broadcast
- * skips this tab: the response above already brings it fresh counts, and its
- * own signal would only buy a second, redundant sidebar reload. The reader's
- * *other* devices still receive it, which is the point of the broadcast.
- */
-const readPost = useDebouncedPost(
-    () => {
-        const socketId = echo().socketId();
-
-        router.post(
-            markChannelRead({
-                team: props.team.slug,
-                channel: props.channel.slug,
-            }).url,
-            {},
-            {
-                // Interrupting a thread-panel GET strands the panel empty (#581)
-                // and the redirect-follow would drop the `?thread=` param; see
-                // {@see backgroundVisit}.
-                ...backgroundVisit,
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channels'],
-                headers: socketId ? { 'X-Socket-ID': socketId } : {},
-            },
-        );
-    },
-    { delay: 400, gate: () => document.hasFocus() },
-);
-
-function markRead(): void {
-    readPost.schedule();
-}
-
-/**
- * The member's own star/mute/notification-level preferences for this channel:
- * seeded from the server, reseeded on every channel switch, saved optimistically
- * and rolled back on error. `threadUnreadSuppressed` mirrors the server's dot
- * suppression and feeds the realtime router below.
- */
-const {
-    notificationLevel,
-    muted,
-    starred,
-    threadUnreadSuppressed,
-    notificationStatus,
-    toggleStar,
-    onNotificationLevelChange,
-    onMuteChange,
-} = useChannelPreferences({
-    channelId: () => props.channel.id,
-    channel: () => props.channel,
+const { markRead } = useReadPointer({
     teamSlug: () => props.team.slug,
     channelSlug: () => props.channel.slug,
 });
 
-/**
- * The channel-level pin count driving the masthead badge, and the pins popover
- * state. The count is seeded from the server, resynced on partial reloads and
- * channel switches (the prop watch below), and patched live by the MessagePinned
- * broadcast; the pins list itself rides the `pins` prop, refreshed whenever the
- * panel opens or a pin changes.
- */
-const pinCount = ref(props.pinCount);
-watch(
-    () => props.pinCount,
-    (count) => {
-        pinCount.value = count;
-    },
-);
-
-const pinsPanelOpen = ref(false);
-
-/**
- * Open the pins popover, pulling the freshest pins first — another member may
- * have pinned or unpinned since this page loaded, and the count badge and list
- * should agree with the server on open.
- */
-function openPinsPanel(): void {
-    pinsPanelOpen.value = true;
-    router.reload({ only: ['pins', 'pinCount'] });
-}
-
-/** Jump to a pinned message from the panel, closing the popover on the way. */
-function jumpToPin(id: string): void {
-    pinsPanelOpen.value = false;
-    jumpToMessage(id);
-}
+useReadOnFocus(markRead, markThreadRead);
 
 // The active channel's Echo subscribe/route/teardown lives in this composable: it
 // moves the subscription as the open channel changes and routes each broadcast
@@ -741,23 +230,20 @@ useChannelRealtime({
     threadStream,
     activeThreadRootId,
     displayMessages: () => displayMessages.value,
-    isThreadUnreadSuppressed: () => threadUnreadSuppressed.value,
+    isThreadUnreadSuppressed: () =>
+        header.value?.threadUnreadSuppressed ?? false,
     readers,
     isNearBottom,
     notifyAppended,
     typing,
     markRead,
     markThreadRead,
-    updatePinCount: (count: number) => {
-        pinCount.value = count;
-    },
+    updatePinCount: (count: number) => header.value?.setPinCount(count),
 });
 
 onMounted(() => {
     seedReaders();
     markRead();
-    window.addEventListener('focus', markRead);
-    window.addEventListener('focus', markThreadRead);
 
     if (props.jumpToMessageId) {
         jumpToMessage(props.jumpToMessageId);
@@ -792,185 +278,23 @@ watch(
     () => {
         mainStream.reset();
         resetScrollPin();
-        timelineScrolled.value = false;
         replyTarget.value = null;
         typing.reset();
-        pinsPanelOpen.value = false;
-        // Close the add-people modal so a switch to another conversation never
-        // carries it over onto the wrong DM.
-        addingPeople.value = false;
+        header.value?.closePins();
+        dialogs.value?.closeAddPeople();
         seedReaders();
         markRead();
     },
 );
 
-onBeforeUnmount(() => {
-    // The draft persists itself on teardown (flushOnUnmount) and the read posts
-    // cancel themselves, so leaving the workspace neither loses a just-typed draft
-    // nor fires a stale mark-read.
-    window.removeEventListener('focus', markRead);
-    window.removeEventListener('focus', markThreadRead);
-
-    if (highlightTimer) {
-        clearTimeout(highlightTimer);
-    }
-});
-
-/** The message the composer is currently quoting, or null for a normal send. */
-const replyTarget = ref<Message | null>(null);
-
-/**
- * The id of the message the main composer is editing in place (via the ↑
- * shortcut), or null. Highlights the target row in the timeline while editing.
- */
-const composerEditingId = ref<string | null>(null);
-
-function startReply(message: Message): void {
-    replyTarget.value = message;
-}
-
-function cancelReply(): void {
-    replyTarget.value = null;
-}
-
-/**
- * The channel composer, so a profile hover card in the main timeline can drop a
- * mention straight into it.
- */
-const channelComposer = ref<InstanceType<typeof MessageComposer> | null>(null);
+const { replyTarget, composerEditingId, startReply, cancelReply } =
+    useComposerTarget();
 
 /**
  * The composer claims the bottom of the conversation pane, so the bottom-right
  * rail sits above it rather than over its send button and scheduled chip.
  */
-useRailBottomInset(
-    computed(() => (channelComposer.value?.$el as HTMLElement | null) ?? null),
-);
-
-function mentionInChannel(member: { id: string; name: string }): void {
-    channelComposer.value?.insertMention(member);
-}
-
-/**
- * Whole-pane drag-and-drop: dropping files anywhere over the channel content
- * stages them in the composer tray. A depth counter tracks nested
- * dragenter/dragleave so the brass overlay doesn't flicker as the pointer
- * crosses child elements. Only meaningful where the composer itself is shown.
- */
-const isDraggingFiles = ref(false);
-let dragDepth = 0;
-
-function canDropAttachments(): boolean {
-    return props.isMember && !props.channel.isArchived;
-}
-
-/** Whether a drag actually carries files (vs. selected text or an element). */
-function dragCarriesFiles(event: DragEvent): boolean {
-    return Array.from(event.dataTransfer?.types ?? []).includes('Files');
-}
-
-function onPaneDragEnter(event: DragEvent): void {
-    if (!canDropAttachments() || !dragCarriesFiles(event)) {
-        return;
-    }
-
-    dragDepth += 1;
-    isDraggingFiles.value = true;
-}
-
-function onPaneDragOver(event: DragEvent): void {
-    if (!dragCarriesFiles(event)) {
-        return;
-    }
-
-    // Claim every file drag so the browser never navigates to the dropped file,
-    // even where we won't accept it (archived channel, non-member).
-    event.preventDefault();
-
-    if (!canDropAttachments()) {
-        return;
-    }
-
-    // Show the copy cursor only where the drop will actually be staged.
-    if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = 'copy';
-    }
-}
-
-function onPaneDragLeave(): void {
-    if (!isDraggingFiles.value) {
-        return;
-    }
-
-    dragDepth -= 1;
-
-    if (dragDepth <= 0) {
-        dragDepth = 0;
-        isDraggingFiles.value = false;
-    }
-}
-
-function onPaneDrop(event: DragEvent): void {
-    dragDepth = 0;
-    isDraggingFiles.value = false;
-
-    if (!dragCarriesFiles(event)) {
-        return;
-    }
-
-    // Prevent the browser navigating to the dropped file for every file drag,
-    // then only stage the files where the channel actually accepts them.
-    event.preventDefault();
-
-    if (!canDropAttachments()) {
-        return;
-    }
-
-    const files = Array.from(event.dataTransfer?.files ?? []);
-
-    if (files.length > 0) {
-        channelComposer.value?.addFiles(files);
-    }
-}
-
-/**
- * The message being forwarded and whether the forward dialog is open. The dialog
- * picks a target channel (from the sidebar list — the channels the viewer can
- * post to) and an optional note.
- */
-const forwardTarget = ref<Message | null>(null);
-const forwardDialogOpen = ref(false);
-
-const forwardableChannels = computed<Channel[]>(
-    () => page.props.channels ?? [],
-);
-
-/**
- * Team members offered as DM forward targets; selecting one opens-or-creates the
- * 1:1 DM on the server.
- */
-const forwardablePeople = computed<PersonRef[]>(
-    () => page.props.teamMembers ?? [],
-);
-
-function openForward(message: Message): void {
-    forwardTarget.value = message;
-    forwardDialogOpen.value = true;
-}
-
-/**
- * Submit the forward dialog: hand the selected source and destination to the
- * actions engine, then clear the target so the dialog resets.
- */
-function submitForward(payload: { target: ForwardTarget; note: string }): void {
-    const source = forwardTarget.value;
-
-    if (source) {
-        actions.forwardMessage(source, payload);
-    }
-
-    forwardTarget.value = null;
-}
+useRailBottomInset(computed(() => dock.value?.composerElement ?? null));
 
 /**
  * The member's unsent composer text is persisted per channel so it survives
@@ -991,32 +315,13 @@ const {
 /**
  * The realtime connection cue (reconnecting / back-online pill) and the offline
  * outbox: sends made while the socket is down queue here and flush on recovery.
- * The outbox persists per channel, so a refresh while offline keeps the queue.
  */
-const connection = useConnectionState();
-const outbox = createOutbox({ storageKey: `outbox:${props.channel.id}` });
-
-// A queue rehydrated from a previous session has no optimistic rows yet; re-add
-// them so the queued sends still render in the timeline after a refresh. The
-// reply quote isn't persisted, so a rehydrated row shows its body without it.
-for (const item of outbox.items.value) {
-    mainStream.addPending(
-        optimisticMessage({
-            clientUuid: item.clientUuid,
-            body: item.body,
-            author: currentUser.value,
-            mentions: [],
-        }),
-    );
-}
-
-/**
- * Client uuids currently held in the outbox, so the timeline can mark each queued
- * row until it flushes.
- */
-const queuedUuids = computed(() =>
-    outbox.items.value.map((item) => item.clientUuid),
-);
+const { connection, outbox, queuedUuids, discardQueue, flushOnReconnect } =
+    useOfflineOutbox({
+        channelId: () => props.channel.id,
+        currentUser: () => currentUser.value,
+        mainStream,
+    });
 
 /**
  * The channel's optimistic-mutation engine: send/edit/delete/react/forward,
@@ -1028,7 +333,7 @@ const actions = useMessageActions({
     channel: () => props.channel,
     currentUser: () => currentUser.value,
     isOnline: () => connection.isOnline.value,
-    onSendFailure: announceSendFailure,
+    onSendFailure: (message) => announcers.value?.announce(message),
     outbox,
     mainStream,
     threadStream,
@@ -1041,133 +346,13 @@ const actions = useMessageActions({
     cancelReply,
 });
 
-const {
-    send,
-    flushOutbox,
-    editMessage,
-    deleteMessage,
-    reactToMessage,
-    voteOnPoll,
-    closePoll,
-    pinMessage,
-    unpinMessage,
-    sendThreadReply,
-    scheduleMessage,
-    updateScheduled,
-    cancelScheduled,
-    setReminder,
-    sendCommand,
-} = actions;
-
-/** Discard the whole offline queue: drop the optimistic rows and clear the outbox. */
-function discardQueue(): void {
-    for (const item of outbox.items.value) {
-        mainStream.removePending(item.clientUuid);
-    }
-
-    outbox.clear();
-}
-
-// Whenever the socket connects, flush any queued sends — including a queue
-// rehydrated on load, which connects for the first time rather than reconnecting.
-// Only on a genuine reconnect do we also backfill messages that landed while the
-// socket was down (the stream dedupes by client uuid, so re-fetching the latest
-// page adds no gaps or dupes) and confirm the flush with a toast.
-connection.onConnected(({ isReconnect }) => {
-    const flushed = flushOutbox();
-
-    if (!isReconnect) {
-        return;
-    }
-
-    // A reconnect is the socket's timing, not the user's; see
-    // {@see backgroundVisit}. Fired before the flush settles so the backfill
-    // isn't held up by a queue that is slow — or failing — to drain.
-    router.reload({ ...backgroundVisit, only: ['messages'] });
-
-    // "You're caught up" is only true of the sends that actually landed, so it
-    // waits for the flush and reports what it says landed. Anything still queued
-    // has already raised its own failure card, under the same key this replaces.
-    void flushed.then((sent) => {
-        if (sent === 0) {
-            return;
-        }
-
-        toast.success(
-            sent === 1
-                ? t("Reconnected — 1 queued message sent, you're caught up.")
-                : t(
-                      "Reconnected — :count queued messages sent, you're caught up.",
-                      { count: sent },
-                  ),
-            { key: QUEUED_SENDS_TOAST_KEY },
-        );
-    });
-});
-
-// If we mount already connected with a rehydrated queue — the socket was up
-// before this page (re)loaded, so no connect event will fire — flush it now.
-if (connection.isOnline.value && outbox.count.value > 0) {
-    void flushOutbox();
-}
+flushOnReconnect(actions.flushOutbox);
 
 /**
  * The viewer's stored timezone, driving the schedule picker's presets and the
  * list's "sends at" labels so a scheduled time always reads in their own zone.
  */
 const { timezone } = useTimezone();
-
-/** Whether the "Scheduled messages" management dialog is open. */
-const scheduledDialogOpen = ref(false);
-
-/**
- * The message a custom-time reminder is being set for, and whether the custom
- * date & time picker is open.
- */
-const reminderTargetId = ref<string | null>(null);
-const reminderCustomOpen = ref(false);
-
-/** A preset was chosen from a message's reminder popover. */
-function remindWith(message: Message, remindAt: string): void {
-    setReminder(message.id, remindAt);
-}
-
-/** The viewer chose "Custom date & time…"; remember the target and open the picker. */
-function openCustomReminder(message: Message): void {
-    reminderTargetId.value = message.id;
-    reminderCustomOpen.value = true;
-}
-
-/** Confirm the custom reminder time picked in the dialog. */
-function confirmCustomReminder(remindAt: string): void {
-    if (reminderTargetId.value === null) {
-        return;
-    }
-
-    setReminder(reminderTargetId.value, remindAt);
-    reminderTargetId.value = null;
-}
-
-/** Drives the archive confirmation dialog opened from the channel header menu. */
-const confirmingArchive = ref(false);
-
-/** Drives the leave-channel confirmation modal opened from the header menu. */
-const confirmingLeave = ref(false);
-
-function archive(): void {
-    confirmingArchive.value = false;
-
-    router.post(
-        archiveChannel({ team: props.team.slug, channel: props.channel.slug })
-            .url,
-        {},
-        {
-            onError: () => {
-                toast.error(t('Failed to archive the channel'));
-            },
-        },
-    );
-}
 </script>
 
 <template>
@@ -1177,23 +362,11 @@ function archive(): void {
         "
     />
 
-    <div
-        aria-live="polite"
-        aria-atomic="true"
-        class="sr-only"
-        data-test="message-announcer"
-    >
-        {{ announcement }}
-    </div>
-
-    <div
-        aria-live="polite"
-        aria-atomic="true"
-        class="sr-only"
-        data-test="send-failure-announcer"
-    >
-        {{ sendFailureAnnouncement }}
-    </div>
+    <ChannelAnnouncers
+        ref="announcers"
+        :messages="displayMessages"
+        :current-user-id="currentUser.id"
+    />
 
     <!-- `relative` anchors the thread panel below `lg`, where it covers this
          whole pane — masthead included — rather than being a flex sibling
@@ -1201,7 +374,9 @@ function archive(): void {
          card-sized overlay through the tablet band (#788). -->
     <div class="relative flex min-h-0 flex-1 overflow-hidden">
         <div class="relative flex min-w-0 flex-1 flex-col">
-            <ChannelMasthead
+            <ChannelHeader
+                ref="header"
+                :team="props.team"
                 :channel="props.channel"
                 :members="props.members"
                 :presence-for="presenceFor"
@@ -1211,227 +386,64 @@ function archive(): void {
                 :can-archive="props.canArchive"
                 :can-leave="props.canLeave"
                 :can-add-people="canAddPeople"
-                :notification-levels="props.notificationLevels"
-                :starred="starred"
-                :muted="muted"
-                :pin-count="pinCount"
-                :notification-level="notificationLevel"
-                :notification-status="notificationStatus"
-                :connection-pill="connection.pill.value"
-                :scrolled="timelineScrolled"
-                @toggle-star="toggleStar"
-                @notification-level-change="onNotificationLevelChange"
-                @mute-change="onMuteChange"
-                @archive="confirmingArchive = true"
-                @leave="confirmingLeave = true"
-                @add-people="addingPeople = true"
-                @open-pins="openPinsPanel"
-            />
-
-            <PinsPanel
-                v-if="pinsPanelOpen"
-                :pins="props.pins"
-                :pin-count="pinCount"
                 :can-pin="props.canReact"
+                :notification-levels="props.notificationLevels"
+                :pins="props.pins"
+                :pin-count="props.pinCount"
+                :connection-pill="connection.pill.value"
+                :scrolled="pane?.scrolled ?? false"
                 :viewer-timezone="timezone"
-                @close="pinsPanelOpen = false"
-                @jump="jumpToPin"
-                @unpin="(message) => unpinMessage(message)"
+                @archive="dialogs?.confirmArchive()"
+                @leave="dialogs?.confirmLeave()"
+                @add-people="dialogs?.openAddPeople()"
+                @jump="jumpToMessage"
+                @unpin="actions.unpinMessage"
             />
 
-            <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- the pane is a file drop zone; keyboard users attach via the composer's Add-attachment button -->
-            <div
-                class="relative flex min-h-0 flex-1 flex-col"
-                @dragenter="onPaneDragEnter"
-                @dragover="onPaneDragOver"
-                @dragleave="onPaneDragLeave"
-                @drop="onPaneDrop"
+            <ChannelPane
+                ref="pane"
+                :team="props.team"
+                :channel="props.channel"
+                :messages="displayMessages"
+                :server-messages="serverMessages"
+                :current-user-id="currentUser.id"
+                :is-self-dm="isSelfDm"
+                :pending-uuids="pendingUuids"
+                :queued-uuids="queuedUuids"
+                :can-moderate="canModerate"
+                :can-react="props.canReact"
+                :can-drop-files="props.isMember && !props.channel.isArchived"
+                :presence-for="presenceFor"
+                :is-dnd-for="isDndFor"
+                :readers="channelReadersList"
+                :active-thread-root-id="activeThreadRootId"
+                :editing-message-id="composerEditingId"
+                :last-read-message-id="props.lastReadMessageId ?? null"
+                :register-container="setScrollContainer"
+                :pinned-to-bottom="pinnedToBottom"
+                :new-message-count="newMessageCount"
+                :scroll-to-bottom="scrollToBottom"
+                @scroll="onScroll"
+                @files="(files) => dock?.addFiles(files)"
+                @focus-composer="dock?.focus()"
+                @edit="actions.editMessage"
+                @delete="actions.deleteMessage"
+                @reply="startReply"
+                @forward="(message) => dialogs?.openForward(message)"
+                @react="actions.reactToMessage"
+                @vote="actions.voteOnPoll"
+                @close-poll="actions.closePoll"
+                @pin="actions.pinMessage"
+                @unpin="actions.unpinMessage"
+                @remind="(message, at) => dialogs?.remindWith(message, at)"
+                @remind-custom="
+                    (message) => dialogs?.openCustomReminder(message)
+                "
+                @open-thread="openThread"
+                @jump="jumpToMessage"
+                @mention="(member) => dock?.insertMention(member)"
             >
-                <!-- Whole-pane drop target: dropping files anywhere over the
-                     channel stages them in the composer. Pointer-events-none so
-                     the drop lands on the pane's own handler, not the overlay. -->
-                <div
-                    v-if="isDraggingFiles && canDropAttachments()"
-                    data-test="channel-drop-overlay"
-                    class="pointer-events-none absolute inset-2.5 z-20 flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-brass bg-card/75 backdrop-blur-[2px]"
-                >
-                    <span
-                        class="flex size-14 items-center justify-center rounded-full bg-foreground text-brass"
-                    >
-                        <Upload class="size-6" />
-                    </span>
-                    <span
-                        class="font-serif text-2xl font-semibold text-foreground"
-                    >
-                        {{
-                            $t('Drop to attach to #:channel', {
-                                channel: props.channel.name,
-                            })
-                        }}
-                    </span>
-                    <span class="text-[13px] text-muted-foreground">
-                        {{
-                            $t('Up to :count files · :size MB each', {
-                                count: page.props.attachments.maxPerMessage,
-                                size: page.props.attachments.maxSizeMb,
-                            })
-                        }}
-                    </span>
-                </div>
-                <div class="relative flex min-h-0 flex-1 flex-col">
-                    <Transition
-                        enter-active-class="transition duration-150 ease-out"
-                        enter-from-class="-translate-y-1 opacity-0"
-                        enter-to-class="translate-y-0 opacity-100"
-                        leave-active-class="transition duration-100 ease-in"
-                        leave-from-class="translate-y-0 opacity-100"
-                        leave-to-class="-translate-y-1 opacity-0"
-                    >
-                        <!-- eslint-disable-next-line local/no-raw-button -- jump pill: stays raw with the deferred jump-to-latest pills (#316); the primitive does not compose as a <Transition> child here -->
-                        <button
-                            v-if="showJumpToUnread"
-                            type="button"
-                            data-test="jump-to-unread"
-                            class="absolute top-2.5 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full bg-rose-600 px-3 py-1 text-[12px] font-semibold text-white shadow-md hover:bg-rose-700"
-                            @click="scrollToUnread"
-                        >
-                            <ArrowUp class="size-3.5" />
-                            {{ $t('New messages') }}
-                        </button>
-                    </Transition>
-
-                    <Transition
-                        enter-active-class="transition duration-150 ease-out"
-                        enter-from-class="-translate-y-1 opacity-0"
-                        enter-to-class="translate-y-0 opacity-100"
-                        leave-active-class="transition duration-100 ease-in"
-                        leave-from-class="translate-y-0 opacity-100"
-                        leave-to-class="-translate-y-1 opacity-0"
-                    >
-                        <div
-                            v-if="
-                                !pinnedToBottom &&
-                                stickyDayLabel &&
-                                !showJumpToUnread
-                            "
-                            data-test="sticky-date"
-                            class="pointer-events-none absolute top-2.5 left-1/2 z-10 inline-flex h-6.5 -translate-x-1/2 items-center rounded-full bg-card px-3.5 text-[11.5px] font-semibold text-muted-foreground shadow-md ring-1 ring-border"
-                        >
-                            {{ stickyDayLabel }}
-                        </div>
-                    </Transition>
-
-                    <!-- The message history is a focusable, labelled region so
-                         keyboard users can Tab to it and arrow-scroll (which
-                         remounts virtualized rows). `ScrollableMessageList`
-                         renders the region + the jump-to-latest pill; the
-                         timeline itself can't be a `role="log"` since its rows
-                         unmount, so `role="region"` names it instead. -->
-                    <ScrollableMessageList
-                        variant="channel"
-                        :region-label="$t('Message history')"
-                        :register-container="setScrollContainer"
-                        :pinned-to-bottom="pinnedToBottom"
-                        :new-message-count="newMessageCount"
-                        @scroll="onTimelineScroll"
-                        @jump="jumpToPresent"
-                    >
-                        <Transition
-                            enter-active-class="transition duration-150 ease-out"
-                            enter-from-class="opacity-0"
-                            enter-to-class="opacity-100"
-                            leave-active-class="transition duration-100 ease-in"
-                            leave-from-class="opacity-100"
-                            leave-to-class="opacity-0"
-                        >
-                            <div
-                                v-if="loadingOlder"
-                                data-test="loading-older"
-                                class="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center"
-                            >
-                                <span
-                                    class="inline-flex items-center gap-2 rounded-full bg-card px-3 py-1 text-[12px] text-muted-foreground shadow-sm ring-1 ring-border"
-                                >
-                                    <span
-                                        aria-hidden="true"
-                                        class="size-3 animate-spin rounded-full border-2 border-border border-t-foreground"
-                                    />
-                                    {{ $t('Loading earlier messages…') }}
-                                </span>
-                            </div>
-                        </Transition>
-
-                        <InfiniteScroll
-                            v-if="hasMessages"
-                            ref="infiniteScrollRef"
-                            data="messages"
-                            reverse
-                            manual
-                            preserve-url
-                        >
-                            <MessageList
-                                ref="messageListRef"
-                                virtualize
-                                :scroll-element="scrollContainer"
-                                :has-older="hasOlder"
-                                :is-loading-older="isLoadingOlder"
-                                :messages="displayMessages"
-                                :team-slug="props.team.slug"
-                                :pending-uuids="pendingUuids"
-                                :queued-uuids="queuedUuids"
-                                :current-user-id="currentUser.id"
-                                :is-direct="props.channel.isDirect"
-                                :can-moderate="canModerate"
-                                :can-react="props.canReact"
-                                :can-pin="props.canReact"
-                                :presence-for="presenceFor"
-                                :is-dnd-for="isDndFor"
-                                :readers="channelReadersList"
-                                :highlight-message-id="highlightedMessageId"
-                                :unread-divider-id="unreadDividerId"
-                                :active-thread-root-id="activeThreadRootId"
-                                :editing-message-id="composerEditingId"
-                                @edit="editMessage"
-                                @delete="deleteMessage"
-                                @reply="startReply"
-                                @forward="openForward"
-                                @react="reactToMessage"
-                                @vote="voteOnPoll"
-                                @close-poll="closePoll"
-                                @pin="pinMessage"
-                                @unpin="unpinMessage"
-                                @remind="remindWith"
-                                @remind-custom="openCustomReminder"
-                                @open-thread="openThread"
-                                @jump="jumpToMessage"
-                                @mention="mentionInChannel"
-                                @load-older="loadOlderMessages"
-                                @range-change="timelineRange = $event"
-                            />
-                        </InfiniteScroll>
-
-                        <ChannelEmptyState
-                            v-else
-                            :channel="props.channel"
-                            :is-self-dm="isSelfDm"
-                            :team-name="props.team.name"
-                            :team-slug="props.team.slug"
-                            @focus-composer="focusComposer"
-                        />
-                    </ScrollableMessageList>
-                </div>
-
-                <div
-                    v-if="props.channel.isArchived"
-                    data-test="archived-notice"
-                    class="m-5 shrink-0 rounded-lg border border-border bg-muted/40 px-4 py-3 text-center text-[13px] text-muted-foreground"
-                >
-                    {{
-                        $t(
-                            "This channel is archived. It's read-only, but its history is preserved.",
-                        )
-                    }}
-                </div>
+                <ArchivedNotice v-if="props.channel.isArchived" />
 
                 <!-- A non-member reached this public channel by URL: the timeline
                      is read-only and the composer is replaced by a "Join channel"
@@ -1445,103 +457,35 @@ function archive(): void {
                     :member-count="props.memberCount"
                 />
 
-                <template v-else>
-                    <!-- Offline queue banner: the socket is down and the viewer's
-                         sends are being held locally; they flush automatically on
-                         reconnect, or can be discarded here. -->
-                    <div
-                        v-if="
-                            !connection.isOnline.value && outbox.count.value > 0
-                        "
-                        data-test="offline-queue-banner"
-                        class="mx-5 mb-1 flex shrink-0 items-center gap-2.5 rounded-lg border border-amber-200 bg-amber-50 px-3.5 py-2.5 text-[12.5px] font-medium text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-500"
-                    >
-                        <WifiOff class="size-3.5 shrink-0" />
-                        <span class="min-w-0">
-                            {{
-                                outbox.count.value === 1
-                                    ? $t(
-                                          "You're offline. 1 message is queued and will send automatically.",
-                                      )
-                                    : $t(
-                                          "You're offline. :count messages are queued and will send automatically.",
-                                          { count: outbox.count.value },
-                                      )
-                            }}
-                        </span>
-                        <Button
-                            variant="unstyled"
-                            size="none"
-                            type="button"
-                            data-test="discard-queue"
-                            class="ml-auto shrink-0 font-semibold text-rose-600 hover:text-rose-700 dark:text-rose-400 dark:hover:text-rose-300"
-                            @click="discardQueue"
-                        >
-                            {{ $t('Discard queue') }}
-                        </Button>
-                    </div>
-
-                    <!-- Below `md` the line is indented to the message text
-                         column, so it reads as the next message rather than a
-                         stray note against the screen edge. -->
-                    <TypingIndicator
-                        :names="typingNames"
-                        class="mx-5 shrink-0 max-md:pl-9"
-                    />
-
-                    <ScheduledCountChip
-                        v-if="props.scheduledMessages.length > 0"
-                        :count="props.scheduledMessages.length"
-                        :channel-name="props.channel.name"
-                        class="mx-5 mb-2.5"
-                        @view="scheduledDialogOpen = true"
-                    />
-
-                    <MessageComposer
-                        ref="channelComposer"
-                        :key="props.channel.id"
-                        data-tour="composer"
-                        :channel-name="props.channel.name"
-                        :placeholder="composerPlaceholder"
-                        :members="mentionableMembers"
-                        :has-bots="channelHasBots"
-                        :reply-target="replyTarget"
-                        :initial-body="props.channel.draft ?? ''"
-                        :messages="displayMessages"
-                        :current-user-id="currentUser.id"
-                        :pending-uuids="pendingUuids"
-                        :team-slug="props.team.slug"
-                        :channel-slug="props.channel.slug"
-                        :max-attachment-size-mb="
-                            page.props.attachments.maxSizeMb
-                        "
-                        :max-attachments-per-message="
-                            page.props.attachments.maxPerMessage
-                        "
-                        allow-schedule
-                        :timezone="timezone"
-                        :slash-commands="page.props.slashCommands"
-                        :gif-picker-enabled="page.props.gifPickerEnabled"
-                        :polls-enabled="page.props.pollsEnabled"
-                        @send="
-                            (
-                                body,
-                                mentions,
-                                _sendToChannel,
-                                attachmentIds,
-                                callbacks,
-                            ) => send(body, mentions, attachmentIds, callbacks)
-                        "
-                        @command="sendCommand"
-                        @schedule="scheduleMessage"
-                        @typing="onTyping"
-                        @cancel-reply="cancelReply"
-                        @draft-change="onDraftChange"
-                        @edit="editMessage"
-                        @editing-change="composerEditingId = $event"
-                    />
-                </template>
-            </div>
+                <ChannelComposerDock
+                    v-else
+                    ref="dock"
+                    :team="props.team"
+                    :channel="props.channel"
+                    :members="mentionableMembers"
+                    :has-bots="channelHasBots"
+                    :placeholder="composerPlaceholder"
+                    :reply-target="replyTarget"
+                    :messages="displayMessages"
+                    :current-user-id="currentUser.id"
+                    :pending-uuids="pendingUuids"
+                    :timezone="timezone"
+                    :typing-names="typingNames"
+                    :scheduled-messages="props.scheduledMessages"
+                    :queued-count="outbox.count.value"
+                    :is-offline="!connection.isOnline.value"
+                    @send="actions.send"
+                    @command="actions.sendCommand"
+                    @schedule="actions.scheduleMessage"
+                    @typing="typing.signalTyping"
+                    @cancel-reply="cancelReply"
+                    @draft-change="onDraftChange"
+                    @edit="actions.editMessage"
+                    @editing-change="composerEditingId = $event"
+                    @discard-queue="discardQueue"
+                    @view-scheduled="dialogs?.openScheduled()"
+                />
+            </ChannelPane>
         </div>
 
         <Transition
@@ -1570,91 +514,35 @@ function archive(): void {
                 :loading="threadLoading"
                 :read-only="props.channel.isArchived"
                 @close="closeThread"
-                @send="sendThreadReply"
-                @edit="editMessage"
-                @delete="deleteMessage"
-                @forward="openForward"
-                @react="reactToMessage"
-                @vote="voteOnPoll"
-                @close-poll="closePoll"
-                @pin="pinMessage"
-                @unpin="unpinMessage"
-                @remind="remindWith"
-                @remind-custom="openCustomReminder"
-                @typing="onTyping"
+                @send="actions.sendThreadReply"
+                @edit="actions.editMessage"
+                @delete="actions.deleteMessage"
+                @forward="(message) => dialogs?.openForward(message)"
+                @react="actions.reactToMessage"
+                @vote="actions.voteOnPoll"
+                @close-poll="actions.closePoll"
+                @pin="actions.pinMessage"
+                @unpin="actions.unpinMessage"
+                @remind="(message, at) => dialogs?.remindWith(message, at)"
+                @remind-custom="
+                    (message) => dialogs?.openCustomReminder(message)
+                "
+                @typing="typing.signalTyping"
                 @jump="jumpToMessage"
             />
         </Transition>
     </div>
 
-    <ForwardMessageDialog
-        v-model:open="forwardDialogOpen"
-        :message="forwardTarget"
-        :channels="forwardableChannels"
-        :people="forwardablePeople"
+    <ChannelDialogs
+        ref="dialogs"
+        :team="props.team"
+        :channel="props.channel"
         :current-user-id="currentUser.id"
-        @submit="submitForward"
-    />
-
-    <ScheduledMessagesDialog
-        v-model:open="scheduledDialogOpen"
+        :timezone="timezone"
         :scheduled-messages="props.scheduledMessages"
-        :channel-name="props.channel.name"
-        :timezone="timezone"
-        @update="updateScheduled"
-        @cancel="cancelScheduled"
-    />
-
-    <ScheduleMessageDialog
-        v-model:open="reminderCustomOpen"
-        :timezone="timezone"
-        :title="$t('Remind me about this')"
-        :confirm-label="$t('Set reminder')"
-        @confirm="confirmCustomReminder"
-    />
-
-    <Dialog v-model:open="confirmingArchive">
-        <DialogContent>
-            <DialogHeader>
-                <DialogTitle>{{
-                    $t('Archive #:channel', { channel: props.channel.name })
-                }}</DialogTitle>
-                <DialogDescription>
-                    {{
-                        $t(
-                            'The channel becomes read-only and leaves the sidebar. Its messages are kept and stay searchable.',
-                        )
-                    }}
-                </DialogDescription>
-            </DialogHeader>
-
-            <DialogFooter class="gap-2">
-                <DialogClose as-child>
-                    <Button variant="secondary"> {{ $t('Cancel') }} </Button>
-                </DialogClose>
-
-                <Button
-                    data-test="archive-channel-confirm"
-                    variant="destructive"
-                    @click="archive"
-                >
-                    {{ $t('Archive') }}
-                </Button>
-            </DialogFooter>
-        </DialogContent>
-    </Dialog>
-
-    <LeaveChannelModal
-        v-model:open="confirmingLeave"
-        :channel="props.channel"
-        :team-slug="props.team.slug"
-    />
-
-    <AddDirectMessagePeopleModal
-        v-if="props.channel.isDirect"
-        v-model:open="addingPeople"
-        :channel="props.channel"
-        :team-slug="props.team.slug"
-        :current-user-id="currentUser.id"
+        :forward-message="actions.forwardMessage"
+        :set-reminder="actions.setReminder"
+        :update-scheduled="actions.updateScheduled"
+        :cancel-scheduled="actions.cancelScheduled"
     />
 </template>


### PR DESCRIPTION
Closes #983. Third child of #980.

`pages/channels/Show.vue` goes from **1642 to 548 raw lines** — **1139 to 385** as
`max-lines` counts them, against the 400 cap. Its entry is gone from the exemption
block in `eslint.config.js`, so `max-lines-policy.test.ts` now holds the file to the
cap like any other.

The page every conversation feature reaches through had accumulated a share of each:
thread panel, realtime wiring, jump targets, pinned state, drag-and-drop, the offline
queue. They move out along the seams that were already there, script half first.

## Covered first, against the current code

`Show.vue` had no colocated coverage, so a pure move had nothing watching it. Three
suites land ahead of the split and pin what it may not change — every `data-test`
selector, every request shape, every string:

| Suite | Holds |
| --- | --- |
| `Show.pane.test.ts` | The whole-pane drop zone (nesting, guards, staging), the bottom slot (composer vs. join bar vs. archived notice), the announcers, the older-history pill |
| `Show.timeline.test.ts` | Jump-to-message and its highlight, the "New messages" pill with its per-visit seen latch, the sticky day chip, the pins popover |
| `Show.actions.test.ts` | The typing beat, the debounced read pointer, forward, reminders, archive, and the outbox's reconnect flush |

Their shared doubles live in `Show.doubles.ts`: repeated three times, the preamble
would itself have breached the cap this PR exists to lift.

All 36 stay green across the move, which is the parity proof.

## What moved

| New composable | Lines | What it holds |
| --- | ---: | --- |
| `useOfflineOutbox.ts` | 130 | The per-channel queue, its rehydrated rows, and the reconnect flush + backfill + toast |
| `useChannelIdentity.ts` | 121 | How the channel reads to this viewer: title, placeholder, who they may mention, what they may do |
| `usePaneFileDrop.ts` | 109 | The drag-depth counter and the four handlers behind the brass overlay |
| `useUnreadJump.ts` | 128 | The "New messages" pill: range math plus the two latches that dismiss it for the visit (#411) |
| `useChannelHistory.ts` | 68 | Reverse pagination: older history is the paginator's *next* page |
| `useMessageHighlight.ts` | 68 | Scroll a target into the window, then mark it for a beat |
| `useForwardDialog.ts` | 76 | Which message is being forwarded, and the targets offered for it |
| `useReminderPicker.ts` | 55 | Preset reminders, and the target a custom time is held for |
| `useStickyDayLabel.ts` | 51 | The day the topmost visible row falls in |
| `useReadPointer.ts` | 52 | The debounced, focus-gated read advance |
| `useChannelTimeline.ts` | 44 | The server page reversed, and the stream that merges over it |
| `useChannelTyping.ts` | 48 | The fire-and-forget typing beat and its socket id |
| `useChannelPins.ts` | 53 | The badge count and the popover that refreshes on open |
| `useChannelReaders.ts` | 39 | The read positions behind "Seen by" |
| `useComposerTarget.ts` | 30 | What the composer is pointed at: a quote, or an edit |
| `useReadOnFocus.ts` | 23 | Keep the channel and its thread read while the tab has focus |

| New component | Lines | What it holds |
| --- | ---: | --- |
| `channel/ChannelPane.vue` | 326 | The conversation pane: the drop zone, the windowed timeline with its floating affordances, and the bottom slot |
| `channel/ChannelDialogs.vue` | 168 | Every dialog the page can raise, and the state deciding which is open |
| `channel/ChannelComposerDock.vue` | 149 | The offline banner, typing line, scheduled chip and composer |
| `channel/ChannelHeader.vue` | 138 | The masthead and pins popover, owning the viewer's own channel preferences |
| `channel/ArchiveChannelDialog.vue` | 57 | The archive confirmation |
| `channel/ChannelAnnouncers.vue` | 52 | The two polite live regions |
| `channel/OfflineQueueBanner.vue` | 48 | The queued-sends banner and its discard |
| `channel/ChannelDropOverlay.vue` | 38 | The brass drop target and its limits copy |
| `channel/UnreadJumpPill.vue` | 36 | The floating "New messages" pill |
| `channel/LoadingOlderPill.vue` | 33 | "Loading earlier messages…" |
| `channel/StickyDayChip.vue` | 28 | The floating date chip |
| `channel/ArchivedNotice.vue` | 12 | The read-only notice |

`ChannelHeader` and `ChannelDialogs` absorb the state that belongs to them rather
than to the page (preferences, pin count, one flag per dialog), and expose the parts
the realtime router still has to reconcile against — so neither is a pass-through.

## Parity

Nothing user-observable changes. Every `data-test` selector, route, `only:` key list
and string moves verbatim; no key was added to or moved in `lang/fr.json`. Two
consequences of the move, both mechanical:

- The pins reload changed file, so its allowance in `backgroundVisit.test.ts` follows
  it — it is still the same deliberately-foreground reload.
- `ChannelComposerDock` drops the composer's `sendToChannel` flag on the way out: it
  belongs to the thread composer's "also send to channel" box, and the channel page
  already discarded it.

## Found while here

CodeRabbit flagged that `useChannelHistory`'s in-flight flag can stick across a
channel switch when the two pages happen to hold the same number of messages. That
watcher is exactly what `Show.vue` has always had, so fixing it here would cost the
reviewer the "if it moved, it did not change" assumption. Filed as #1023 instead.

## Testing

- `sail composer test` — **Total: 100.0 %**, clean Pint/PHPStan/Rector
- `lint:check` (0 errors with the exemption removed), `format:check`, `types:check`,
  `test:js` (1918 passed), `build`
- **Full browser suite: 327 passed** — the parity check that matters for a UI-only
  move, including the timeline, unread-pill, offline-queue, composer and a11y specs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787861429&installation_model_id=428379&pr_number=1024&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1024&signature=6335b4355e3b7b2375a39afe0ce122c55c3443e200571a1389c17300ac3565a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->