### PR TITLE
refactor: split the bot integration page into racks and dialogs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -263,7 +263,6 @@ export default defineConfigWithVueTs(
             'resources/js/pages/teams/Analytics.vue',
             'resources/js/pages/teams/AuditExports.vue',
             'resources/js/pages/teams/Groups.vue',
-            'resources/js/pages/teams/integrations/Bot.vue',
         ],
         rules: {
             'max-lines': 'off',

--- a/resources/js/components/integrations/AddBotToChannelDialog.vue
+++ b/resources/js/components/integrations/AddBotToChannelDialog.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { Lock } from '@lucide/vue';
+import FormField from '@/components/FormField.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { store as channelStore } from '@/routes/teams/integrations/bots/channels';
+
+type BotSummary = App.Data.BotData;
+
+/** A channel the bot could be added to. */
+type ChannelMembership = {
+    id: string;
+    name: string;
+    visibility: 'public' | 'private';
+};
+
+const props = defineProps<{
+    /** The workspace slug the bot belongs to. */
+    team: string;
+    bot: BotSummary;
+    /** The team's standard channels the bot can still be added to. */
+    channels: ChannelMembership[];
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+
+const addChannelForm = useForm<{ channel_id: string }>({ channel_id: '' });
+
+function submitAddChannel(): void {
+    addChannelForm.post(
+        channelStore({ team: props.team, bot: props.bot.id }).url,
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                open.value = false;
+                addChannelForm.reset();
+            },
+        },
+    );
+}
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent data-test="add-channel-dialog">
+            <form @submit.prevent="submitAddChannel">
+                <DialogHeader>
+                    <DialogTitle>{{
+                        $t('Add :bot to a channel', { bot: bot.name })
+                    }}</DialogTitle>
+                    <DialogDescription>{{
+                        $t('The bot can post in every channel it belongs to.')
+                    }}</DialogDescription>
+                </DialogHeader>
+                <div class="py-4">
+                    <FormField
+                        id="add-channel-select"
+                        :label="$t('Channel')"
+                        :error="addChannelForm.errors.channel_id"
+                        v-slot="{ id }"
+                    >
+                        <Select v-model="addChannelForm.channel_id">
+                            <SelectTrigger
+                                :id="id"
+                                data-test="add-channel-select"
+                                class="w-full"
+                            >
+                                <SelectValue
+                                    :placeholder="$t('Select a channel')"
+                                />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem
+                                    v-for="channel in channels"
+                                    :key="channel.id"
+                                    :value="channel.id"
+                                    :data-test="`add-channel-option-${channel.id}`"
+                                >
+                                    <span class="flex items-center gap-2">
+                                        <Lock
+                                            v-if="
+                                                channel.visibility === 'private'
+                                            "
+                                            class="size-3.5 text-muted-foreground"
+                                            aria-hidden="true"
+                                        />
+                                        <span
+                                            v-else
+                                            aria-hidden="true"
+                                            class="text-brass"
+                                            >#</span
+                                        >
+                                        {{ channel.name }}
+                                    </span>
+                                </SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </FormField>
+                </div>
+                <DialogFooter>
+                    <DialogClose as-child>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            class="rounded-full"
+                            >{{ $t('Cancel') }}</Button
+                        >
+                    </DialogClose>
+                    <Button
+                        type="submit"
+                        class="rounded-full"
+                        data-test="add-channel-submit"
+                        :disabled="
+                            addChannelForm.processing ||
+                            !addChannelForm.channel_id
+                        "
+                        >{{ $t('Add to channel') }}</Button
+                    >
+                </DialogFooter>
+            </form>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/integrations/BotChannelsRack.vue
+++ b/resources/js/components/integrations/BotChannelsRack.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { Lock, Plus } from '@lucide/vue';
+import { Button } from '@/components/ui/button';
+
+/** A channel the bot is a member of. */
+type ChannelMembership = {
+    id: string;
+    name: string;
+    visibility: 'public' | 'private';
+};
+
+defineProps<{
+    /** The standard channels the bot currently belongs to. */
+    channels: ChannelMembership[];
+    /** Whether any channel is left for the bot to be added to. */
+    canAdd: boolean;
+}>();
+
+defineEmits<{
+    /** The rack's button asking for the add-to-channel dialog. */
+    create: [];
+    /** A row asking for the removal confirmation on its own channel. */
+    remove: [channel: ChannelMembership];
+}>();
+</script>
+
+<template>
+    <section class="flex flex-col gap-3">
+        <div class="flex items-start justify-between gap-4">
+            <div class="flex flex-col gap-0.5">
+                <h2 class="font-serif text-lg font-semibold">
+                    {{ $t('Channels') }}
+                </h2>
+                <p class="text-xs text-muted-foreground">
+                    {{
+                        $t(
+                            'Channels this bot can post in — membership-gated per channel.',
+                        )
+                    }}
+                </p>
+            </div>
+            <Button
+                type="button"
+                class="rounded-full"
+                data-test="add-channel-button"
+                :disabled="!canAdd"
+                @click="$emit('create')"
+            >
+                <Plus class="size-4" /> {{ $t('Add to channel') }}
+            </Button>
+        </div>
+
+        <p
+            v-if="channels.length === 0"
+            data-test="channels-empty"
+            class="text-sm text-muted-foreground"
+        >
+            {{
+                $t(
+                    'Not in any channel yet. Add it to a channel so it can post there.',
+                )
+            }}
+        </p>
+        <ul v-else class="flex flex-col divide-y divide-border" role="list">
+            <li
+                v-for="channel in channels"
+                :key="channel.id"
+                class="flex items-center gap-2.5 py-3"
+                :data-test="`channel-row-${channel.id}`"
+            >
+                <Lock
+                    v-if="channel.visibility === 'private'"
+                    class="size-4 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                />
+                <span v-else aria-hidden="true" class="text-brass">#</span>
+                <span class="sr-only">{{
+                    channel.visibility === 'private'
+                        ? $t('Private channel')
+                        : $t('Public channel')
+                }}</span>
+                <span class="flex-1 truncate text-sm font-semibold">{{
+                    channel.name
+                }}</span>
+                <Button
+                    type="button"
+                    variant="linkDestructive"
+                    size="none"
+                    class="text-xs font-semibold"
+                    :data-test="`remove-channel-${channel.id}`"
+                    @click="$emit('remove', channel)"
+                >
+                    {{ $t('Remove') }}
+                </Button>
+            </li>
+        </ul>
+    </section>
+</template>

--- a/resources/js/components/integrations/BotTokensRack.vue
+++ b/resources/js/components/integrations/BotTokensRack.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { Plus } from '@lucide/vue';
+import { Button } from '@/components/ui/button';
+import { useTimezone } from '@/composables/useTimezone';
+import { formatDateTime } from '@/lib/datetime';
+
+type BotToken = App.Data.BotTokenData;
+
+defineProps<{
+    /** The bot's tokens, newest first. */
+    tokens: BotToken[];
+}>();
+
+defineEmits<{
+    /** The rack's button asking for the creation dialog. */
+    create: [];
+    /** A row asking for the revoke confirmation on its own token. */
+    revoke: [token: BotToken];
+}>();
+
+const { timezone } = useTimezone();
+
+function when(iso: string | null): string {
+    return iso ? formatDateTime(iso, timezone.value ?? undefined) : '';
+}
+</script>
+
+<template>
+    <section class="flex flex-col gap-3">
+        <div class="flex items-start justify-between gap-4">
+            <div class="flex flex-col gap-0.5">
+                <h2 class="font-serif text-lg font-semibold">
+                    {{ $t('API tokens') }}
+                </h2>
+                <p class="text-xs text-muted-foreground">
+                    {{
+                        $t(
+                            'Scoped bearer tokens for the REST API — shown once at creation',
+                        )
+                    }}
+                </p>
+            </div>
+            <Button
+                type="button"
+                class="rounded-full"
+                data-test="new-token-button"
+                @click="$emit('create')"
+            >
+                <Plus class="size-4" /> {{ $t('New token') }}
+            </Button>
+        </div>
+
+        <p
+            v-if="tokens.length === 0"
+            data-test="tokens-empty"
+            class="text-sm text-muted-foreground"
+        >
+            {{ $t('No tokens yet.') }}
+        </p>
+        <ul v-else class="flex flex-col divide-y divide-border" role="list">
+            <li
+                v-for="token in tokens"
+                :key="token.id"
+                class="flex flex-col gap-1.5 py-3"
+                :data-test="`token-row-${token.id}`"
+            >
+                <div class="flex items-center gap-3">
+                    <span class="flex-1 truncate text-sm font-semibold">{{
+                        token.name
+                    }}</span>
+                    <span class="text-xs text-muted-foreground">
+                        {{
+                            token.lastUsedAt
+                                ? $t('last used :time', {
+                                      time: when(token.lastUsedAt),
+                                  })
+                                : $t('never used')
+                        }}
+                    </span>
+                    <Button
+                        type="button"
+                        variant="linkDestructive"
+                        size="none"
+                        class="text-xs font-semibold"
+                        :data-test="`revoke-token-${token.id}`"
+                        @click="$emit('revoke', token)"
+                    >
+                        {{ $t('Revoke') }}
+                    </Button>
+                </div>
+                <div class="flex flex-wrap gap-1">
+                    <span
+                        v-for="scope in token.abilities"
+                        :key="scope"
+                        class="rounded border border-brass-border bg-brass-fill px-1.5 py-0.5 font-mono text-[10px] text-brass-fill-foreground"
+                        >{{ scope }}</span
+                    >
+                </div>
+            </li>
+        </ul>
+    </section>
+</template>

--- a/resources/js/components/integrations/DeleteBotDialog.vue
+++ b/resources/js/components/integrations/DeleteBotDialog.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { destroy as botDestroy } from '@/routes/teams/integrations/bots';
+
+type BotSummary = App.Data.BotData;
+
+const props = defineProps<{
+    /** The workspace slug the bot belongs to. */
+    team: string;
+    bot: BotSummary;
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+
+const deleteForm = useForm({});
+
+function confirmDeleteBot(): void {
+    deleteForm.delete(botDestroy({ team: props.team, bot: props.bot.id }).url);
+}
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent data-test="delete-bot-dialog">
+            <DialogHeader>
+                <DialogTitle>{{
+                    $t('Delete :name?', { name: bot.name })
+                }}</DialogTitle>
+                <DialogDescription>{{
+                    $t(
+                        'This permanently deletes the bot and its credentials. Its past messages are reassigned to a deleted account. This cannot be undone.',
+                    )
+                }}</DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+                <DialogClose as-child>
+                    <Button variant="outline" class="rounded-full">{{
+                        $t('Cancel')
+                    }}</Button>
+                </DialogClose>
+                <Button
+                    variant="destructive"
+                    class="rounded-full"
+                    data-test="delete-bot-confirm"
+                    :disabled="deleteForm.processing"
+                    @click="confirmDeleteBot"
+                >
+                    {{ $t('Delete bot') }}
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/integrations/NewBotTokenDialog.vue
+++ b/resources/js/components/integrations/NewBotTokenDialog.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import FieldError from '@/components/FieldError.vue';
+import FormField from '@/components/FormField.vue';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { store as tokenStore } from '@/routes/teams/integrations/bots/tokens';
+
+type BotSummary = App.Data.BotData;
+type Option = { value: string; label: string };
+
+const props = defineProps<{
+    /** The workspace slug the bot belongs to. */
+    team: string;
+    bot: BotSummary;
+    /** The scopes a token can be granted. */
+    scopeOptions: Option[];
+}>();
+
+const open = defineModel<boolean>('open', { default: false });
+
+const tokenForm = useForm<{ name: string; abilities: string[] }>({
+    name: '',
+    abilities: [],
+});
+
+function toggleScope(value: string): void {
+    const at = tokenForm.abilities.indexOf(value);
+
+    if (at === -1) {
+        tokenForm.abilities.push(value);
+    } else {
+        tokenForm.abilities.splice(at, 1);
+    }
+}
+
+function submitToken(): void {
+    tokenForm.post(tokenStore({ team: props.team, bot: props.bot.id }).url, {
+        preserveScroll: true,
+        onSuccess: () => {
+            open.value = false;
+            tokenForm.reset();
+        },
+    });
+}
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogContent data-test="new-token-dialog">
+            <form @submit.prevent="submitToken">
+                <DialogHeader>
+                    <DialogTitle>{{
+                        $t('New token for :bot', { bot: bot.name })
+                    }}</DialogTitle>
+                    <DialogDescription>{{
+                        $t('Grant only the scopes this integration needs.')
+                    }}</DialogDescription>
+                </DialogHeader>
+                <div
+                    class="flex max-h-[60vh] flex-col gap-4 overflow-y-auto py-4"
+                >
+                    <FormField
+                        id="token-name"
+                        :label="$t('Name')"
+                        :error="tokenForm.errors.name"
+                        v-slot="{ id }"
+                    >
+                        <Input
+                            :id="id"
+                            v-model="tokenForm.name"
+                            data-test="token-name-input"
+                            :placeholder="$t('ci-pipeline')"
+                            autocomplete="off"
+                        />
+                    </FormField>
+                    <fieldset class="flex flex-col gap-2">
+                        <legend class="text-sm font-medium">
+                            {{ $t('Scopes') }}
+                        </legend>
+                        <label
+                            v-for="scope in scopeOptions"
+                            :key="scope.value"
+                            class="flex cursor-pointer items-start gap-2.5 rounded-xl border px-3 py-2.5 transition-colors"
+                            :class="
+                                tokenForm.abilities.includes(scope.value)
+                                    ? 'border-brass-border bg-brass-fill'
+                                    : 'border-border'
+                            "
+                            :data-test="`scope-${scope.value}`"
+                        >
+                            <Checkbox
+                                class="mt-0.5"
+                                :model-value="
+                                    tokenForm.abilities.includes(scope.value)
+                                "
+                                @update:model-value="
+                                    () => toggleScope(scope.value)
+                                "
+                            />
+                            <span class="flex flex-col">
+                                <span class="font-mono text-xs font-semibold">{{
+                                    scope.value
+                                }}</span>
+                                <span class="text-xs text-muted-foreground">{{
+                                    scope.label
+                                }}</span>
+                            </span>
+                        </label>
+                        <FieldError :message="tokenForm.errors.abilities" />
+                    </fieldset>
+                </div>
+                <DialogFooter>
+                    <DialogClose as-child>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            class="rounded-full"
+                            >{{ $t('Cancel') }}</Button
+                        >
+                    </DialogClose>
+                    <Button
+                        type="submit"
+                        class="rounded-full"
+                        data-test="token-create-button"
+                        :disabled="tokenForm.processing"
+                        >{{ $t('Create token') }}</Button
+                    >
+                </DialogFooter>
+            </form>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/integrations/RemoveBotFromChannelDialog.vue
+++ b/resources/js/components/integrations/RemoveBotFromChannelDialog.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { destroy as channelDestroy } from '@/routes/teams/integrations/bots/channels';
+
+type BotSummary = App.Data.BotData;
+
+/** A channel the bot is a member of. */
+type ChannelMembership = {
+    id: string;
+    name: string;
+    visibility: 'public' | 'private';
+};
+
+const props = defineProps<{
+    /** The workspace slug the bot belongs to. */
+    team: string;
+    bot: BotSummary;
+}>();
+
+/** The membership awaiting confirmation, or `null` while the dialog is closed. */
+const pendingChannel = defineModel<ChannelMembership | null>('channel', {
+    default: null,
+});
+
+const removeChannelForm = useForm({});
+
+function confirmRemoveChannel(): void {
+    const channel = pendingChannel.value;
+
+    if (!channel) {
+        return;
+    }
+
+    removeChannelForm.delete(
+        channelDestroy({
+            team: props.team,
+            bot: props.bot.id,
+            channel: channel.id,
+        }).url,
+        {
+            preserveScroll: true,
+            onFinish: () => (pendingChannel.value = null),
+        },
+    );
+}
+</script>
+
+<template>
+    <Dialog
+        :open="pendingChannel !== null"
+        @update:open="(open) => !open && (pendingChannel = null)"
+    >
+        <DialogContent data-test="remove-channel-dialog">
+            <DialogHeader>
+                <DialogTitle>{{
+                    $t('Remove :bot from :channel?', {
+                        bot: bot.name,
+                        channel: pendingChannel?.name ?? '',
+                    })
+                }}</DialogTitle>
+                <DialogDescription>{{
+                    $t(
+                        'The bot stops posting there immediately, and any incoming webhook bound to this channel starts returning 403.',
+                    )
+                }}</DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+                <DialogClose as-child>
+                    <Button variant="outline" class="rounded-full">{{
+                        $t('Cancel')
+                    }}</Button>
+                </DialogClose>
+                <Button
+                    variant="destructive"
+                    class="rounded-full"
+                    data-test="remove-channel-confirm"
+                    :disabled="removeChannelForm.processing"
+                    @click="confirmRemoveChannel"
+                >
+                    {{ $t('Remove from channel') }}
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/integrations/RevokeBotTokenDialog.vue
+++ b/resources/js/components/integrations/RevokeBotTokenDialog.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { destroy as tokenDestroy } from '@/routes/teams/integrations/bots/tokens';
+
+type BotSummary = App.Data.BotData;
+type BotToken = App.Data.BotTokenData;
+
+const props = defineProps<{
+    /** The workspace slug the bot belongs to. */
+    team: string;
+    bot: BotSummary;
+}>();
+
+/** The token awaiting confirmation, or `null` while the dialog is closed. */
+const pendingToken = defineModel<BotToken | null>('token', { default: null });
+
+const revokeForm = useForm({});
+
+function confirmRevoke(): void {
+    const token = pendingToken.value;
+
+    if (!token) {
+        return;
+    }
+
+    revokeForm.delete(
+        tokenDestroy({
+            team: props.team,
+            bot: props.bot.id,
+            token: token.id,
+        }).url,
+        {
+            preserveScroll: true,
+            onFinish: () => (pendingToken.value = null),
+        },
+    );
+}
+</script>
+
+<template>
+    <Dialog
+        :open="pendingToken !== null"
+        @update:open="(open) => !open && (pendingToken = null)"
+    >
+        <DialogContent data-test="revoke-token-dialog">
+            <DialogHeader>
+                <DialogTitle>{{
+                    $t('Revoke :name?', { name: pendingToken?.name ?? '' })
+                }}</DialogTitle>
+                <DialogDescription>{{
+                    $t(
+                        'The token stops working immediately. Any integration using it will get a 401.',
+                    )
+                }}</DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+                <DialogClose as-child>
+                    <Button variant="outline" class="rounded-full">{{
+                        $t('Cancel')
+                    }}</Button>
+                </DialogClose>
+                <Button
+                    variant="destructive"
+                    class="rounded-full"
+                    data-test="revoke-token-confirm"
+                    :disabled="revokeForm.processing"
+                    @click="confirmRevoke"
+                >
+                    {{ $t('Revoke token') }}
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/pages/teams/integrations/Bot.channels.test.ts
+++ b/resources/js/pages/teams/integrations/Bot.channels.test.ts
@@ -1,0 +1,498 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h, nextTick } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Team } from '@/types';
+
+/**
+ * Covers the bot detail page's channels rack — the membership list, the dialog
+ * that adds the bot to a channel and the one that takes it out — and the
+ * danger zone that deletes the bot. What is pinned here is the rendered markup
+ * and the request each form makes: every selector, every guard deciding
+ * whether a piece renders at all. The page is mounted whole, so the same
+ * expectations hold before and after its sections move into components (#987).
+ */
+type FormFields = Record<string, unknown>;
+
+type RecordedForm = {
+    fields: string[];
+    form: FormFields & { errors: Record<string, string>; processing: boolean };
+};
+
+type RecordedRequest = {
+    fields: string[];
+    url: string;
+    options: {
+        onSuccess?: () => void;
+        onFinish?: () => void;
+        preserveScroll?: boolean;
+    };
+};
+
+const inertia = vi.hoisted(() => ({
+    pageProps: { auth: { user: { id: 'me', timezone: 'UTC' } } },
+    forms: [] as RecordedForm[],
+    posts: [] as RecordedRequest[],
+    deletes: [] as RecordedRequest[],
+}));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { defineComponent, reactive } = await import('vue');
+
+    return {
+        Head: defineComponent({ name: 'HeadStub', setup: () => () => null }),
+        router: { patch: () => {} },
+        usePage: () => ({ props: inertia.pageProps }),
+        useForm: (initial: Record<string, unknown>) => {
+            const fields = Object.keys(initial);
+            const form = reactive({
+                ...structuredClone(initial),
+                errors: {} as Record<string, string>,
+                processing: false,
+                post(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.posts.push({ fields, url, options });
+                },
+                delete(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.deletes.push({ fields, url, options });
+                },
+                reset() {
+                    Object.assign(form, structuredClone(initial));
+                },
+            });
+
+            inertia.forms.push({ fields, form: form as RecordedForm['form'] });
+
+            return form;
+        },
+    };
+});
+
+vi.mock('@/components/integrations/RevealSecretDialog.vue', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        default: defineComponent({
+            name: 'RevealSecretDialogStub',
+            setup: () => () => h('div', { 'data-stub': 'RevealSecretDialog' }),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    const passthrough = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', { 'data-stub': name }, slots.default?.()),
+        });
+
+    return {
+        // Renders its content only while open, so a closed dialog is observably
+        // gone from the DOM the way the real overlay is.
+        Dialog: defineComponent({
+            name: 'DialogStub',
+            props: { open: { type: Boolean, default: false } },
+            emits: ['update:open'],
+            setup:
+                (props, { slots }) =>
+                () =>
+                    props.open
+                        ? h('div', { 'data-stub': 'Dialog' }, slots.default?.())
+                        : null,
+        }),
+        DialogClose: passthrough('DialogClose'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogFooter: passthrough('DialogFooter'),
+        DialogHeader: passthrough('DialogHeader'),
+        DialogTitle: passthrough('DialogTitle'),
+    };
+});
+
+/**
+ * The real select portals its list and only builds the options once opened,
+ * neither of which jsdom can drive. The stub keeps the parts the page owns —
+ * the option per channel, the placeholder, and the value a pick writes to the
+ * form — and drops the overlay mechanics reka is responsible for.
+ */
+vi.mock('@/components/ui/select', async () => {
+    const { defineComponent, h, inject, provide } = await import('vue');
+    const PICK = Symbol.for('select-stub-pick');
+
+    const passthrough = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', { 'data-stub': name }, slots.default?.()),
+        });
+
+    return {
+        Select: defineComponent({
+            name: 'SelectStub',
+            props: { modelValue: { type: String, default: '' } },
+            emits: ['update:modelValue'],
+            setup(_props, { slots, emit }) {
+                provide(PICK, (value: string) =>
+                    emit('update:modelValue', value),
+                );
+
+                return () =>
+                    h('div', { 'data-stub': 'Select' }, slots.default?.());
+            },
+        }),
+        SelectContent: passthrough('SelectContent'),
+        SelectItem: defineComponent({
+            name: 'SelectItemStub',
+            props: { value: { type: String, required: true } },
+            setup(props, { slots }) {
+                const pick = inject<(value: string) => void>(PICK);
+
+                return () =>
+                    h(
+                        'button',
+                        { type: 'button', onClick: () => pick?.(props.value) },
+                        slots.default?.(),
+                    );
+            },
+        }),
+        SelectTrigger: passthrough('SelectTrigger'),
+        SelectValue: defineComponent({
+            name: 'SelectValueStub',
+            props: { placeholder: { type: String, default: '' } },
+            setup: (props) => () => h('span', props.placeholder),
+        }),
+    };
+});
+
+import Bot from './Bot.vue';
+
+const team = {
+    id: 't1',
+    name: 'Acme',
+    slug: 'acme',
+    isPersonal: false,
+    membersCount: 3,
+    unreadCount: 0,
+    mentionCount: 0,
+} as Team;
+
+const bot: App.Data.BotData = {
+    id: 'b1',
+    name: 'Deploy Bot',
+    channelsCount: 3,
+    tokensCount: 2,
+    createdBy: null,
+    lastPostedAt: null,
+};
+
+type ChannelMembership = {
+    id: string;
+    name: string;
+    visibility: 'public' | 'private';
+};
+
+function channel(
+    overrides: Partial<ChannelMembership> = {},
+): ChannelMembership {
+    return { id: 'c1', name: 'ops', visibility: 'public', ...overrides };
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp({
+        render: () =>
+            h(Bot, {
+                team,
+                bot,
+                tokens: [],
+                scopeOptions: [],
+                channels: [],
+                addableChannels: [],
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return host;
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function text(host: HTMLElement, selector: string): string {
+    return find(host, selector)?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+/** The recorded form created with exactly these fields. */
+function formFor(...fields: string[]): RecordedForm['form'] {
+    const match = inertia.forms.find(
+        ({ fields: own }) =>
+            own.length === fields.length &&
+            fields.every((field) => own.includes(field)),
+    );
+
+    expect(match, `no form declared ${fields.join(', ')}`).toBeDefined();
+
+    return match!.form;
+}
+
+/**
+ * Marks every recorded form in flight. The confirmation forms are declared
+ * with no fields at all, so there is nothing to tell them apart by — and a
+ * button that disables on the wrong form's `processing` would still be wrong
+ * against the request it fires, which each test asserts separately.
+ */
+function markProcessing(): void {
+    for (const { form } of inertia.forms) {
+        form.processing = true;
+    }
+}
+
+beforeEach(() => {
+    inertia.forms = [];
+    inertia.posts = [];
+    inertia.deletes = [];
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('the channels rack', () => {
+    it('says so when the bot is in no channel yet', () => {
+        const host = mount();
+
+        expect(text(host, 'channels-empty')).toBe(
+            'Not in any channel yet. Add it to a channel so it can post there.',
+        );
+        expect(host.querySelector('[data-test^="channel-row-"]')).toBeNull();
+    });
+
+    it('renders a row per membership, marking public and private channels apart', () => {
+        const host = mount({
+            channels: [
+                channel(),
+                channel({ id: 'c2', name: 'secrets', visibility: 'private' }),
+            ],
+        });
+
+        expect(text(host, 'channel-row-c1')).toContain('ops');
+        expect(text(host, 'channel-row-c1')).toContain('Public channel');
+        expect(text(host, 'channel-row-c2')).toContain('Private channel');
+        expect(host.querySelector('[data-test="channels-empty"]')).toBeNull();
+    });
+
+    it('offers a remove control on every row', () => {
+        const host = mount({ channels: [channel()] });
+
+        expect(find(host, 'remove-channel-c1')).not.toBeNull();
+    });
+
+    it('refuses to add the bot when it is already in every channel', () => {
+        expect(find(mount(), 'add-channel-button')).toHaveProperty(
+            'disabled',
+            true,
+        );
+        expect(
+            find(mount({ addableChannels: [channel()] }), 'add-channel-button'),
+        ).toHaveProperty('disabled', false);
+    });
+});
+
+describe('the add to channel dialog', () => {
+    /** Open the add dialog and hand back its content element. */
+    async function openDialog(host: HTMLElement): Promise<HTMLElement> {
+        find(host, 'add-channel-button')?.click();
+        await nextTick();
+
+        return find(host, 'add-channel-dialog')!;
+    }
+
+    it('stays closed until the rack button is pressed', async () => {
+        const host = mount({ addableChannels: [channel()] });
+
+        expect(find(host, 'add-channel-dialog')).toBeNull();
+        expect(await openDialog(host)).not.toBeNull();
+    });
+
+    it('offers an option per addable channel behind a placeholder', async () => {
+        const host = mount({
+            addableChannels: [
+                channel(),
+                channel({ id: 'c2', name: 'secrets', visibility: 'private' }),
+            ],
+        });
+        const dialog = await openDialog(host);
+
+        expect(dialog.textContent).toContain('Select a channel');
+        expect(text(host, 'add-channel-option-c1')).toContain('ops');
+        expect(text(host, 'add-channel-option-c2')).toContain('secrets');
+    });
+
+    it('records the picked channel on the form and releases the submit', async () => {
+        const host = mount({ addableChannels: [channel()] });
+        await openDialog(host);
+
+        expect(find(host, 'add-channel-submit')).toHaveProperty(
+            'disabled',
+            true,
+        );
+
+        find(host, 'add-channel-option-c1')?.click();
+        await nextTick();
+
+        expect(formFor('channel_id').channel_id).toBe('c1');
+        expect(find(host, 'add-channel-submit')).toHaveProperty(
+            'disabled',
+            false,
+        );
+    });
+
+    it('posts the membership without losing the scroll, then closes and clears itself', async () => {
+        const host = mount({ addableChannels: [channel()] });
+        await openDialog(host);
+
+        find(host, 'add-channel-option-c1')?.click();
+        await nextTick();
+
+        find(host, 'add-channel-submit')?.click();
+        await nextTick();
+
+        const post = inertia.posts.at(-1)!;
+        expect(post.url).toBe(
+            '/settings/teams/acme/integrations/bots/b1/channels',
+        );
+        expect(post.options.preserveScroll).toBe(true);
+        expect(formFor('channel_id').channel_id).toBe('c1');
+
+        post.options.onSuccess?.();
+        await nextTick();
+
+        expect(find(host, 'add-channel-dialog')).toBeNull();
+        expect(formFor('channel_id').channel_id).toBe('');
+    });
+
+    it('shows the channel error the server sent back', async () => {
+        const host = mount({ addableChannels: [channel()] });
+        const dialog = await openDialog(host);
+
+        formFor('channel_id').errors.channel_id = 'Pick a channel.';
+        await nextTick();
+
+        expect(dialog.textContent).toContain('Pick a channel.');
+    });
+});
+
+describe('the remove from channel dialog', () => {
+    /** Open the removal dialog for the seeded membership. */
+    async function openDialog(host: HTMLElement): Promise<HTMLElement> {
+        find(host, 'remove-channel-c1')?.click();
+        await nextTick();
+
+        return find(host, 'remove-channel-dialog')!;
+    }
+
+    it('stays closed until a row asks to remove, and names both sides', async () => {
+        const host = mount({ channels: [channel()] });
+
+        expect(find(host, 'remove-channel-dialog')).toBeNull();
+        expect((await openDialog(host)).textContent).toContain(
+            'Remove Deploy Bot from ops?',
+        );
+    });
+
+    it('deletes the membership without losing the scroll, then closes itself', async () => {
+        const host = mount({ channels: [channel()] });
+        await openDialog(host);
+
+        find(host, 'remove-channel-confirm')?.click();
+        await nextTick();
+
+        const request = inertia.deletes.at(-1)!;
+        expect(request.url).toBe(
+            '/settings/teams/acme/integrations/bots/b1/channels/c1',
+        );
+        expect(request.options.preserveScroll).toBe(true);
+
+        request.options.onFinish?.();
+        await nextTick();
+
+        expect(find(host, 'remove-channel-dialog')).toBeNull();
+    });
+
+    it('holds the confirm button while the request is in flight', async () => {
+        const host = mount({ channels: [channel()] });
+        await openDialog(host);
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'remove-channel-confirm')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+});
+
+describe('the danger zone', () => {
+    /** Open the deletion dialog and hand back its content element. */
+    async function openDialog(host: HTMLElement): Promise<HTMLElement> {
+        find(host, 'delete-bot-button')?.click();
+        await nextTick();
+
+        return find(host, 'delete-bot-dialog')!;
+    }
+
+    it('stays closed until the danger zone asks, and names the bot', async () => {
+        const host = mount();
+
+        expect(find(host, 'delete-bot-dialog')).toBeNull();
+        expect((await openDialog(host)).textContent).toContain(
+            'Delete Deploy Bot?',
+        );
+    });
+
+    it('deletes the bot, leaving the page rather than preserving the scroll', async () => {
+        const host = mount();
+        await openDialog(host);
+
+        find(host, 'delete-bot-confirm')?.click();
+        await nextTick();
+
+        const request = inertia.deletes.at(-1)!;
+        expect(request.url).toBe('/settings/teams/acme/integrations/bots/b1');
+        expect(request.options.preserveScroll).toBeUndefined();
+    });
+
+    it('holds the confirm button while the request is in flight', async () => {
+        const host = mount();
+        await openDialog(host);
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'delete-bot-confirm')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+});

--- a/resources/js/pages/teams/integrations/Bot.tokens.test.ts
+++ b/resources/js/pages/teams/integrations/Bot.tokens.test.ts
@@ -1,0 +1,426 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h, nextTick } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Team } from '@/types';
+
+/**
+ * Covers the bot detail page's header and its API-tokens rack — the list, the
+ * usage stamp and scope chips each row composes, the dialog that mints a token
+ * and the one that revokes it. What is pinned here is the rendered markup and
+ * the request each form makes: every selector, every guard deciding whether a
+ * piece renders at all. The page is mounted whole, so the same expectations
+ * hold before and after its sections move into components (#987).
+ */
+type FormFields = Record<string, unknown>;
+
+type RecordedForm = {
+    fields: string[];
+    form: FormFields & { errors: Record<string, string>; processing: boolean };
+};
+
+type RecordedRequest = {
+    fields: string[];
+    url: string;
+    options: {
+        onSuccess?: () => void;
+        onFinish?: () => void;
+        preserveScroll?: boolean;
+    };
+};
+
+const inertia = vi.hoisted(() => ({
+    pageProps: { auth: { user: { id: 'me', timezone: 'UTC' } } },
+    forms: [] as RecordedForm[],
+    posts: [] as RecordedRequest[],
+    deletes: [] as RecordedRequest[],
+}));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { defineComponent, reactive } = await import('vue');
+
+    return {
+        Head: defineComponent({ name: 'HeadStub', setup: () => () => null }),
+        router: { patch: () => {} },
+        usePage: () => ({ props: inertia.pageProps }),
+        useForm: (initial: Record<string, unknown>) => {
+            const fields = Object.keys(initial);
+            const form = reactive({
+                ...structuredClone(initial),
+                errors: {} as Record<string, string>,
+                processing: false,
+                post(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.posts.push({ fields, url, options });
+                },
+                delete(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.deletes.push({ fields, url, options });
+                },
+                reset() {
+                    Object.assign(form, structuredClone(initial));
+                },
+            });
+
+            inertia.forms.push({ fields, form: form as RecordedForm['form'] });
+
+            return form;
+        },
+    };
+});
+
+vi.mock('@/components/integrations/RevealSecretDialog.vue', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        default: defineComponent({
+            name: 'RevealSecretDialogStub',
+            setup: () => () => h('div', { 'data-stub': 'RevealSecretDialog' }),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    const passthrough = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', { 'data-stub': name }, slots.default?.()),
+        });
+
+    return {
+        // Renders its content only while open, so a closed dialog is observably
+        // gone from the DOM the way the real overlay is.
+        Dialog: defineComponent({
+            name: 'DialogStub',
+            props: { open: { type: Boolean, default: false } },
+            emits: ['update:open'],
+            setup:
+                (props, { slots }) =>
+                () =>
+                    props.open
+                        ? h('div', { 'data-stub': 'Dialog' }, slots.default?.())
+                        : null,
+        }),
+        DialogClose: passthrough('DialogClose'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogFooter: passthrough('DialogFooter'),
+        DialogHeader: passthrough('DialogHeader'),
+        DialogTitle: passthrough('DialogTitle'),
+    };
+});
+
+import Bot from './Bot.vue';
+
+const team = {
+    id: 't1',
+    name: 'Acme',
+    slug: 'acme',
+    isPersonal: false,
+    membersCount: 3,
+    unreadCount: 0,
+    mentionCount: 0,
+} as Team;
+
+const bot: App.Data.BotData = {
+    id: 'b1',
+    name: 'Deploy Bot',
+    channelsCount: 3,
+    tokensCount: 2,
+    createdBy: null,
+    lastPostedAt: null,
+};
+
+function token(
+    overrides: Partial<App.Data.BotTokenData> = {},
+): App.Data.BotTokenData {
+    return {
+        id: 'tok1',
+        name: 'ci-pipeline',
+        abilities: ['messages:write'],
+        lastUsedAt: null,
+        createdAt: '2024-03-01T10:00:00.000Z',
+        ...overrides,
+    };
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp({
+        render: () =>
+            h(Bot, {
+                team,
+                bot,
+                tokens: [],
+                scopeOptions: [],
+                channels: [],
+                addableChannels: [],
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return host;
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function text(host: HTMLElement, selector: string): string {
+    return find(host, selector)?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+/** The recorded form created with exactly these fields. */
+function formFor(...fields: string[]): RecordedForm['form'] {
+    const match = inertia.forms.find(
+        ({ fields: own }) =>
+            own.length === fields.length &&
+            fields.every((field) => own.includes(field)),
+    );
+
+    expect(match, `no form declared ${fields.join(', ')}`).toBeDefined();
+
+    return match!.form;
+}
+
+/**
+ * Marks every recorded form in flight. The confirmation forms are declared
+ * with no fields at all, so there is nothing to tell them apart by — and a
+ * button that disables on the wrong form's `processing` would still be wrong
+ * against the request it fires, which each test asserts separately.
+ */
+function markProcessing(): void {
+    for (const { form } of inertia.forms) {
+        form.processing = true;
+    }
+}
+
+beforeEach(() => {
+    inertia.forms = [];
+    inertia.posts = [];
+    inertia.deletes = [];
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('the page header', () => {
+    it('names the bot, badges it as one, and counts what it holds', () => {
+        const host = mount();
+
+        expect(host.textContent).toContain('Deploy Bot');
+        expect(host.textContent).toContain('Bot');
+        expect(host.textContent?.replace(/\s+/g, ' ')).toContain(
+            '3 channels · 2 tokens',
+        );
+    });
+});
+
+describe('the tokens rack', () => {
+    it('says so when the bot has no tokens', () => {
+        const host = mount();
+
+        expect(text(host, 'tokens-empty')).toBe('No tokens yet.');
+        expect(host.querySelector('[data-test^="token-row-"]')).toBeNull();
+    });
+
+    it('renders a row per token with its name and granted scopes', () => {
+        const host = mount({
+            tokens: [token({ abilities: ['messages:write', 'channels:read'] })],
+        });
+
+        expect(text(host, 'token-row-tok1')).toContain('ci-pipeline');
+        expect(text(host, 'token-row-tok1')).toContain('messages:write');
+        expect(text(host, 'token-row-tok1')).toContain('channels:read');
+        expect(host.querySelector('[data-test="tokens-empty"]')).toBeNull();
+    });
+
+    it('stamps the last use, or says the token has never been used', () => {
+        const host = mount({
+            tokens: [
+                token(),
+                token({ id: 'tok2', lastUsedAt: '2024-03-04T10:00:00.000Z' }),
+            ],
+        });
+
+        expect(text(host, 'token-row-tok1')).toContain('never used');
+        expect(text(host, 'token-row-tok2')).toContain('last used Mar 4');
+    });
+
+    it('offers a revoke control on every row', () => {
+        const host = mount({ tokens: [token()] });
+
+        expect(find(host, 'revoke-token-tok1')).not.toBeNull();
+    });
+});
+
+describe('the new token dialog', () => {
+    const scopeOptions = [
+        { value: 'messages:write', label: 'Post messages' },
+        { value: 'channels:read', label: 'Read channels' },
+    ];
+
+    /** Open the creation dialog and hand back its content element. */
+    async function openDialog(host: HTMLElement): Promise<HTMLElement> {
+        find(host, 'new-token-button')?.click();
+        await nextTick();
+
+        return find(host, 'new-token-dialog')!;
+    }
+
+    it('stays closed until the rack button is pressed', async () => {
+        const host = mount();
+
+        expect(find(host, 'new-token-dialog')).toBeNull();
+        expect(await openDialog(host)).not.toBeNull();
+    });
+
+    it('offers a checkbox per scope, naming it and describing it', async () => {
+        const host = mount({ scopeOptions });
+        await openDialog(host);
+
+        expect(text(host, 'scope-messages:write')).toContain('messages:write');
+        expect(text(host, 'scope-messages:write')).toContain('Post messages');
+        expect(find(host, 'scope-channels:read')).not.toBeNull();
+    });
+
+    it('adds a scope on the first click and drops it on the second', async () => {
+        const host = mount({ scopeOptions });
+        await openDialog(host);
+
+        const checkbox = find(host, 'scope-messages:write')?.querySelector(
+            '[data-slot="checkbox"]',
+        ) as HTMLElement;
+
+        checkbox.click();
+        await nextTick();
+        expect(formFor('name', 'abilities').abilities).toEqual([
+            'messages:write',
+        ]);
+
+        checkbox.click();
+        await nextTick();
+        expect(formFor('name', 'abilities').abilities).toEqual([]);
+    });
+
+    it('posts the token without losing the scroll, then closes and clears itself', async () => {
+        const host = mount({ scopeOptions });
+        await openDialog(host);
+
+        const input = find(host, 'token-name-input') as HTMLInputElement;
+        input.value = 'release-bot';
+        input.dispatchEvent(new Event('input'));
+        await nextTick();
+
+        find(host, 'token-create-button')?.click();
+        await nextTick();
+
+        const post = inertia.posts.at(-1)!;
+        expect(post.url).toBe(
+            '/settings/teams/acme/integrations/bots/b1/tokens',
+        );
+        expect(post.options.preserveScroll).toBe(true);
+        expect(formFor('name', 'abilities').name).toBe('release-bot');
+
+        post.options.onSuccess?.();
+        await nextTick();
+
+        expect(find(host, 'new-token-dialog')).toBeNull();
+        expect(formFor('name', 'abilities').name).toBe('');
+    });
+
+    it('holds the submit button while the request is in flight', async () => {
+        const host = mount();
+        await openDialog(host);
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'token-create-button')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+
+    it('shows the errors the server sent back for the name and the scopes', async () => {
+        const host = mount({ scopeOptions });
+        const dialog = await openDialog(host);
+
+        Object.assign(formFor('name', 'abilities').errors, {
+            name: 'The name field is required.',
+            abilities: 'Pick at least one scope.',
+        });
+        await nextTick();
+
+        expect(dialog.textContent).toContain('The name field is required.');
+        expect(dialog.textContent).toContain('Pick at least one scope.');
+    });
+});
+
+describe('the revoke token dialog', () => {
+    /** Open the revoke dialog for the seeded token. */
+    async function openDialog(host: HTMLElement): Promise<HTMLElement> {
+        find(host, 'revoke-token-tok1')?.click();
+        await nextTick();
+
+        return find(host, 'revoke-token-dialog')!;
+    }
+
+    it('stays closed until a row asks to revoke, and names that token', async () => {
+        const host = mount({ tokens: [token()] });
+
+        expect(find(host, 'revoke-token-dialog')).toBeNull();
+        expect((await openDialog(host)).textContent).toContain(
+            'Revoke ci-pipeline?',
+        );
+    });
+
+    it('deletes the token without losing the scroll, then closes itself', async () => {
+        const host = mount({ tokens: [token()] });
+        await openDialog(host);
+
+        find(host, 'revoke-token-confirm')?.click();
+        await nextTick();
+
+        const request = inertia.deletes.at(-1)!;
+        expect(request.url).toBe(
+            '/settings/teams/acme/integrations/bots/b1/tokens/tok1',
+        );
+        expect(request.options.preserveScroll).toBe(true);
+
+        request.options.onFinish?.();
+        await nextTick();
+
+        expect(find(host, 'revoke-token-dialog')).toBeNull();
+    });
+
+    it('holds the confirm button while the request is in flight', async () => {
+        const host = mount({ tokens: [token()] });
+        await openDialog(host);
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'revoke-token-confirm')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+});

--- a/resources/js/pages/teams/integrations/Bot.vue
+++ b/resources/js/pages/teams/integrations/Bot.vue
@@ -1,43 +1,19 @@
 <script setup lang="ts">
-import { Head, useForm } from '@inertiajs/vue3';
-import { Bot, Lock, Plus, Trash2 } from '@lucide/vue';
+import { Head } from '@inertiajs/vue3';
+import { Bot, Trash2 } from '@lucide/vue';
 import { ref } from 'vue';
-import FieldError from '@/components/FieldError.vue';
-import FormField from '@/components/FormField.vue';
+import AddBotToChannelDialog from '@/components/integrations/AddBotToChannelDialog.vue';
+import BotChannelsRack from '@/components/integrations/BotChannelsRack.vue';
+import BotTokensRack from '@/components/integrations/BotTokensRack.vue';
+import DeleteBotDialog from '@/components/integrations/DeleteBotDialog.vue';
+import NewBotTokenDialog from '@/components/integrations/NewBotTokenDialog.vue';
+import RemoveBotFromChannelDialog from '@/components/integrations/RemoveBotFromChannelDialog.vue';
 import RevealSecretDialog from '@/components/integrations/RevealSecretDialog.vue';
+import RevokeBotTokenDialog from '@/components/integrations/RevokeBotTokenDialog.vue';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-    Dialog,
-    DialogClose,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from '@/components/ui/select';
-import { useTimezone } from '@/composables/useTimezone';
-import { formatDateTime } from '@/lib/datetime';
 import { translate } from '@/lib/i18n';
 import { edit, index } from '@/routes/teams';
 import { index as integrationsIndex } from '@/routes/teams/integrations';
-import { destroy as botDestroy } from '@/routes/teams/integrations/bots';
-import {
-    destroy as channelDestroy,
-    store as channelStore,
-} from '@/routes/teams/integrations/bots/channels';
-import {
-    destroy as tokenDestroy,
-    store as tokenStore,
-} from '@/routes/teams/integrations/bots/tokens';
 import type { Team } from '@/types';
 
 type BotSummary = App.Data.BotData;
@@ -51,7 +27,7 @@ type ChannelMembership = {
     visibility: 'public' | 'private';
 };
 
-const props = defineProps<{
+defineProps<{
     team: Team;
     bot: BotSummary;
     tokens: BotToken[];
@@ -79,116 +55,11 @@ defineOptions({
     }),
 });
 
-const { timezone } = useTimezone();
-
-function when(iso: string | null): string {
-    return iso ? formatDateTime(iso, timezone.value ?? undefined) : '';
-}
-
-// --- New token -------------------------------------------------------------
 const showTokenDialog = ref(false);
-const tokenForm = useForm<{ name: string; abilities: string[] }>({
-    name: '',
-    abilities: [],
-});
-
-function toggleScope(value: string): void {
-    const at = tokenForm.abilities.indexOf(value);
-
-    if (at === -1) {
-        tokenForm.abilities.push(value);
-    } else {
-        tokenForm.abilities.splice(at, 1);
-    }
-}
-
-function submitToken(): void {
-    tokenForm.post(
-        tokenStore({ team: props.team.slug, bot: props.bot.id }).url,
-        {
-            preserveScroll: true,
-            onSuccess: () => {
-                showTokenDialog.value = false;
-                tokenForm.reset();
-            },
-        },
-    );
-}
-
-// --- Revoke token ----------------------------------------------------------
 const pendingToken = ref<BotToken | null>(null);
-const revokeForm = useForm({});
-
-function confirmRevoke(): void {
-    const token = pendingToken.value;
-
-    if (!token) {
-        return;
-    }
-
-    revokeForm.delete(
-        tokenDestroy({
-            team: props.team.slug,
-            bot: props.bot.id,
-            token: token.id,
-        }).url,
-        {
-            preserveScroll: true,
-            onFinish: () => (pendingToken.value = null),
-        },
-    );
-}
-
-// --- Add to channel --------------------------------------------------------
 const showAddChannel = ref(false);
-const addChannelForm = useForm<{ channel_id: string }>({ channel_id: '' });
-
-function submitAddChannel(): void {
-    addChannelForm.post(
-        channelStore({ team: props.team.slug, bot: props.bot.id }).url,
-        {
-            preserveScroll: true,
-            onSuccess: () => {
-                showAddChannel.value = false;
-                addChannelForm.reset();
-            },
-        },
-    );
-}
-
-// --- Remove from channel ---------------------------------------------------
 const pendingChannel = ref<ChannelMembership | null>(null);
-const removeChannelForm = useForm({});
-
-function confirmRemoveChannel(): void {
-    const channel = pendingChannel.value;
-
-    if (!channel) {
-        return;
-    }
-
-    removeChannelForm.delete(
-        channelDestroy({
-            team: props.team.slug,
-            bot: props.bot.id,
-            channel: channel.id,
-        }).url,
-        {
-            preserveScroll: true,
-            onFinish: () => (pendingChannel.value = null),
-        },
-    );
-}
-
-// --- Delete bot ------------------------------------------------------------
 const showDeleteBot = ref(false);
-const deleteForm = useForm({});
-
-function confirmDeleteBot(): void {
-    deleteForm.delete(
-        botDestroy({ team: props.team.slug, bot: props.bot.id }).url,
-    );
-}
 </script>
 
 <template>
@@ -232,152 +103,18 @@ function confirmDeleteBot(): void {
             </div>
         </div>
 
-        <!-- Tokens -->
-        <section class="flex flex-col gap-3">
-            <div class="flex items-start justify-between gap-4">
-                <div class="flex flex-col gap-0.5">
-                    <h2 class="font-serif text-lg font-semibold">
-                        {{ $t('API tokens') }}
-                    </h2>
-                    <p class="text-xs text-muted-foreground">
-                        {{
-                            $t(
-                                'Scoped bearer tokens for the REST API — shown once at creation',
-                            )
-                        }}
-                    </p>
-                </div>
-                <Button
-                    type="button"
-                    class="rounded-full"
-                    data-test="new-token-button"
-                    @click="showTokenDialog = true"
-                >
-                    <Plus class="size-4" /> {{ $t('New token') }}
-                </Button>
-            </div>
+        <BotTokensRack
+            :tokens="tokens"
+            @create="showTokenDialog = true"
+            @revoke="(token) => (pendingToken = token)"
+        />
 
-            <p
-                v-if="tokens.length === 0"
-                data-test="tokens-empty"
-                class="text-sm text-muted-foreground"
-            >
-                {{ $t('No tokens yet.') }}
-            </p>
-            <ul v-else class="flex flex-col divide-y divide-border" role="list">
-                <li
-                    v-for="token in tokens"
-                    :key="token.id"
-                    class="flex flex-col gap-1.5 py-3"
-                    :data-test="`token-row-${token.id}`"
-                >
-                    <div class="flex items-center gap-3">
-                        <span class="flex-1 truncate text-sm font-semibold">{{
-                            token.name
-                        }}</span>
-                        <span class="text-xs text-muted-foreground">
-                            {{
-                                token.lastUsedAt
-                                    ? $t('last used :time', {
-                                          time: when(token.lastUsedAt),
-                                      })
-                                    : $t('never used')
-                            }}
-                        </span>
-                        <Button
-                            type="button"
-                            variant="linkDestructive"
-                            size="none"
-                            class="text-xs font-semibold"
-                            :data-test="`revoke-token-${token.id}`"
-                            @click="pendingToken = token"
-                        >
-                            {{ $t('Revoke') }}
-                        </Button>
-                    </div>
-                    <div class="flex flex-wrap gap-1">
-                        <span
-                            v-for="scope in token.abilities"
-                            :key="scope"
-                            class="rounded border border-brass-border bg-brass-fill px-1.5 py-0.5 font-mono text-[10px] text-brass-fill-foreground"
-                            >{{ scope }}</span
-                        >
-                    </div>
-                </li>
-            </ul>
-        </section>
-
-        <!-- Channels -->
-        <section class="flex flex-col gap-3">
-            <div class="flex items-start justify-between gap-4">
-                <div class="flex flex-col gap-0.5">
-                    <h2 class="font-serif text-lg font-semibold">
-                        {{ $t('Channels') }}
-                    </h2>
-                    <p class="text-xs text-muted-foreground">
-                        {{
-                            $t(
-                                'Channels this bot can post in — membership-gated per channel.',
-                            )
-                        }}
-                    </p>
-                </div>
-                <Button
-                    type="button"
-                    class="rounded-full"
-                    data-test="add-channel-button"
-                    :disabled="addableChannels.length === 0"
-                    @click="showAddChannel = true"
-                >
-                    <Plus class="size-4" /> {{ $t('Add to channel') }}
-                </Button>
-            </div>
-
-            <p
-                v-if="channels.length === 0"
-                data-test="channels-empty"
-                class="text-sm text-muted-foreground"
-            >
-                {{
-                    $t(
-                        'Not in any channel yet. Add it to a channel so it can post there.',
-                    )
-                }}
-            </p>
-            <ul v-else class="flex flex-col divide-y divide-border" role="list">
-                <li
-                    v-for="channel in channels"
-                    :key="channel.id"
-                    class="flex items-center gap-2.5 py-3"
-                    :data-test="`channel-row-${channel.id}`"
-                >
-                    <Lock
-                        v-if="channel.visibility === 'private'"
-                        class="size-4 shrink-0 text-muted-foreground"
-                        aria-hidden="true"
-                    />
-                    <span v-else aria-hidden="true" class="text-brass">#</span>
-                    <span class="sr-only">{{
-                        channel.visibility === 'private'
-                            ? $t('Private channel')
-                            : $t('Public channel')
-                    }}</span>
-                    <span class="flex-1 truncate text-sm font-semibold">{{
-                        channel.name
-                    }}</span>
-                    <Button
-                        type="button"
-                        variant="linkDestructive"
-                        size="none"
-                        class="text-xs font-semibold"
-                        :data-test="`remove-channel-${channel.id}`"
-                        @click="pendingChannel = channel"
-                    >
-                        {{ $t('Remove') }}
-                    </Button>
-                </li>
-            </ul>
-        </section>
+        <BotChannelsRack
+            :channels="channels"
+            :can-add="addableChannels.length > 0"
+            @create="showAddChannel = true"
+            @remove="(channel) => (pendingChannel = channel)"
+        />
 
         <!-- Danger zone -->
         <section class="flex flex-col gap-3 border-t border-border pt-6">
@@ -407,284 +144,35 @@ function confirmDeleteBot(): void {
         </section>
     </div>
 
-    <!-- Add to channel dialog -->
-    <Dialog
-        :open="showAddChannel"
-        @update:open="(open) => (showAddChannel = open)"
-    >
-        <DialogContent data-test="add-channel-dialog">
-            <form @submit.prevent="submitAddChannel">
-                <DialogHeader>
-                    <DialogTitle>{{
-                        $t('Add :bot to a channel', { bot: bot.name })
-                    }}</DialogTitle>
-                    <DialogDescription>{{
-                        $t('The bot can post in every channel it belongs to.')
-                    }}</DialogDescription>
-                </DialogHeader>
-                <div class="py-4">
-                    <FormField
-                        id="add-channel-select"
-                        :label="$t('Channel')"
-                        :error="addChannelForm.errors.channel_id"
-                        v-slot="{ id }"
-                    >
-                        <Select v-model="addChannelForm.channel_id">
-                            <SelectTrigger
-                                :id="id"
-                                data-test="add-channel-select"
-                                class="w-full"
-                            >
-                                <SelectValue
-                                    :placeholder="$t('Select a channel')"
-                                />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem
-                                    v-for="channel in addableChannels"
-                                    :key="channel.id"
-                                    :value="channel.id"
-                                    :data-test="`add-channel-option-${channel.id}`"
-                                >
-                                    <span class="flex items-center gap-2">
-                                        <Lock
-                                            v-if="
-                                                channel.visibility === 'private'
-                                            "
-                                            class="size-3.5 text-muted-foreground"
-                                            aria-hidden="true"
-                                        />
-                                        <span
-                                            v-else
-                                            aria-hidden="true"
-                                            class="text-brass"
-                                            >#</span
-                                        >
-                                        {{ channel.name }}
-                                    </span>
-                                </SelectItem>
-                            </SelectContent>
-                        </Select>
-                    </FormField>
-                </div>
-                <DialogFooter>
-                    <DialogClose as-child>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            class="rounded-full"
-                            >{{ $t('Cancel') }}</Button
-                        >
-                    </DialogClose>
-                    <Button
-                        type="submit"
-                        class="rounded-full"
-                        data-test="add-channel-submit"
-                        :disabled="
-                            addChannelForm.processing ||
-                            !addChannelForm.channel_id
-                        "
-                        >{{ $t('Add to channel') }}</Button
-                    >
-                </DialogFooter>
-            </form>
-        </DialogContent>
-    </Dialog>
+    <NewBotTokenDialog
+        v-model:open="showTokenDialog"
+        :team="team.slug"
+        :bot="bot"
+        :scope-options="scopeOptions"
+    />
 
-    <!-- Remove from channel dialog -->
-    <Dialog
-        :open="pendingChannel !== null"
-        @update:open="(open) => !open && (pendingChannel = null)"
-    >
-        <DialogContent data-test="remove-channel-dialog">
-            <DialogHeader>
-                <DialogTitle>{{
-                    $t('Remove :bot from :channel?', {
-                        bot: bot.name,
-                        channel: pendingChannel?.name ?? '',
-                    })
-                }}</DialogTitle>
-                <DialogDescription>{{
-                    $t(
-                        'The bot stops posting there immediately, and any incoming webhook bound to this channel starts returning 403.',
-                    )
-                }}</DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-                <DialogClose as-child>
-                    <Button variant="outline" class="rounded-full">{{
-                        $t('Cancel')
-                    }}</Button>
-                </DialogClose>
-                <Button
-                    variant="destructive"
-                    class="rounded-full"
-                    data-test="remove-channel-confirm"
-                    :disabled="removeChannelForm.processing"
-                    @click="confirmRemoveChannel"
-                >
-                    {{ $t('Remove from channel') }}
-                </Button>
-            </DialogFooter>
-        </DialogContent>
-    </Dialog>
+    <RevokeBotTokenDialog
+        v-model:token="pendingToken"
+        :team="team.slug"
+        :bot="bot"
+    />
 
-    <!-- New token dialog -->
-    <Dialog
-        :open="showTokenDialog"
-        @update:open="(open) => (showTokenDialog = open)"
-    >
-        <DialogContent data-test="new-token-dialog">
-            <form @submit.prevent="submitToken">
-                <DialogHeader>
-                    <DialogTitle>{{
-                        $t('New token for :bot', { bot: bot.name })
-                    }}</DialogTitle>
-                    <DialogDescription>{{
-                        $t('Grant only the scopes this integration needs.')
-                    }}</DialogDescription>
-                </DialogHeader>
-                <div
-                    class="flex max-h-[60vh] flex-col gap-4 overflow-y-auto py-4"
-                >
-                    <FormField
-                        id="token-name"
-                        :label="$t('Name')"
-                        :error="tokenForm.errors.name"
-                        v-slot="{ id }"
-                    >
-                        <Input
-                            :id="id"
-                            v-model="tokenForm.name"
-                            data-test="token-name-input"
-                            :placeholder="$t('ci-pipeline')"
-                            autocomplete="off"
-                        />
-                    </FormField>
-                    <fieldset class="flex flex-col gap-2">
-                        <legend class="text-sm font-medium">
-                            {{ $t('Scopes') }}
-                        </legend>
-                        <label
-                            v-for="scope in scopeOptions"
-                            :key="scope.value"
-                            class="flex cursor-pointer items-start gap-2.5 rounded-xl border px-3 py-2.5 transition-colors"
-                            :class="
-                                tokenForm.abilities.includes(scope.value)
-                                    ? 'border-brass-border bg-brass-fill'
-                                    : 'border-border'
-                            "
-                            :data-test="`scope-${scope.value}`"
-                        >
-                            <Checkbox
-                                class="mt-0.5"
-                                :model-value="
-                                    tokenForm.abilities.includes(scope.value)
-                                "
-                                @update:model-value="
-                                    () => toggleScope(scope.value)
-                                "
-                            />
-                            <span class="flex flex-col">
-                                <span class="font-mono text-xs font-semibold">{{
-                                    scope.value
-                                }}</span>
-                                <span class="text-xs text-muted-foreground">{{
-                                    scope.label
-                                }}</span>
-                            </span>
-                        </label>
-                        <FieldError :message="tokenForm.errors.abilities" />
-                    </fieldset>
-                </div>
-                <DialogFooter>
-                    <DialogClose as-child>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            class="rounded-full"
-                            >{{ $t('Cancel') }}</Button
-                        >
-                    </DialogClose>
-                    <Button
-                        type="submit"
-                        class="rounded-full"
-                        data-test="token-create-button"
-                        :disabled="tokenForm.processing"
-                        >{{ $t('Create token') }}</Button
-                    >
-                </DialogFooter>
-            </form>
-        </DialogContent>
-    </Dialog>
+    <AddBotToChannelDialog
+        v-model:open="showAddChannel"
+        :team="team.slug"
+        :bot="bot"
+        :channels="addableChannels"
+    />
 
-    <!-- Revoke token dialog -->
-    <Dialog
-        :open="pendingToken !== null"
-        @update:open="(open) => !open && (pendingToken = null)"
-    >
-        <DialogContent data-test="revoke-token-dialog">
-            <DialogHeader>
-                <DialogTitle>{{
-                    $t('Revoke :name?', { name: pendingToken?.name ?? '' })
-                }}</DialogTitle>
-                <DialogDescription>{{
-                    $t(
-                        'The token stops working immediately. Any integration using it will get a 401.',
-                    )
-                }}</DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-                <DialogClose as-child>
-                    <Button variant="outline" class="rounded-full">{{
-                        $t('Cancel')
-                    }}</Button>
-                </DialogClose>
-                <Button
-                    variant="destructive"
-                    class="rounded-full"
-                    data-test="revoke-token-confirm"
-                    :disabled="revokeForm.processing"
-                    @click="confirmRevoke"
-                >
-                    {{ $t('Revoke token') }}
-                </Button>
-            </DialogFooter>
-        </DialogContent>
-    </Dialog>
+    <RemoveBotFromChannelDialog
+        v-model:channel="pendingChannel"
+        :team="team.slug"
+        :bot="bot"
+    />
 
-    <!-- Delete bot dialog -->
-    <Dialog
-        :open="showDeleteBot"
-        @update:open="(open) => (showDeleteBot = open)"
-    >
-        <DialogContent data-test="delete-bot-dialog">
-            <DialogHeader>
-                <DialogTitle>{{
-                    $t('Delete :name?', { name: bot.name })
-                }}</DialogTitle>
-                <DialogDescription>{{
-                    $t(
-                        'This permanently deletes the bot and its credentials. Its past messages are reassigned to a deleted account. This cannot be undone.',
-                    )
-                }}</DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-                <DialogClose as-child>
-                    <Button variant="outline" class="rounded-full">{{
-                        $t('Cancel')
-                    }}</Button>
-                </DialogClose>
-                <Button
-                    variant="destructive"
-                    class="rounded-full"
-                    data-test="delete-bot-confirm"
-                    :disabled="deleteForm.processing"
-                    @click="confirmDeleteBot"
-                >
-                    {{ $t('Delete bot') }}
-                </Button>
-            </DialogFooter>
-        </DialogContent>
-    </Dialog>
+    <DeleteBotDialog
+        v-model:open="showDeleteBot"
+        :team="team.slug"
+        :bot="bot"
+    />
 </template>


### PR DESCRIPTION
Closes #987. Child of #980.

`pages/teams/integrations/Bot.vue` goes from **690 to 178 raw lines** — **647 to 148** as `max-lines` counts them, against the 400 cap. Its entry is gone from the exemption block in `eslint.config.js`, so `max-lines-policy.test.ts` now holds the file to the cap like any other.

Tokens, channel memberships and the danger zone had grown a rack, a creation form and a confirmation dialog each, sharing one scope and five `useForm` instances. They move out along the seams its sibling `integrations/Index.vue` already drew (#985): one component per rack, one per dialog, each dialog owning the form only it submits.

## What moved

| New file | Lines | What it holds |
| --- | ---: | --- |
| `components/integrations/NewBotTokenDialog.vue` | 143 | The token form: the name, the scope checkboxes and the `toggleScope` they share |
| `components/integrations/AddBotToChannelDialog.vue` | 139 | The membership form: the channel select and its public / private option markers |
| `components/integrations/BotTokensRack.vue` | 102 | The token list: the last-used stamp, the scope chips, and the revoke each row hands up |
| `components/integrations/BotChannelsRack.vue` | 98 | The membership list, its private-channel marker and the remove each row hands up |
| `components/integrations/RemoveBotFromChannelDialog.vue` | 95 | The removal confirmation, keyed on the pending membership |
| `components/integrations/RevokeBotTokenDialog.vue` | 84 | The revoke confirmation, keyed on the pending token |
| `components/integrations/DeleteBotDialog.vue` | 63 | The one-button deletion confirmation |

The page keeps the header, the danger-zone section, and the five `ref`s deciding which dialog is open. Each rack emits `create` and its per-row action; the three creation dialogs take `v-model:open` and the two confirmations take `v-model:token` / `v-model:channel`, so the pending row stays where the racks can hand it over — matching every other dialog in `components/`.

## Parity

The page had no client-side coverage, so the tests landed first, against the unsplit file (commit 1 of this PR): 29 tests mounting `Bot.vue` whole and pinning what each rack renders and what each form posts or deletes. They are unchanged across the move and green on both sides of it — that is the parity proof. Every `data-test` selector, route, `preserveScroll` and string is verbatim; no `lang/fr.json` key added, moved or removed.

The dialogs were also driven by hand in a browser against a seeded workspace, since the parity tests stub reka's `Dialog` and `Select`: minting a token (scope checkbox, the reveal dialog, the row it adds), adding and removing a channel membership through the real select, revoking the token, and deleting the bot back to the integrations index. No console errors beyond the environment's own (gravatar CSP, Reverb port).

## Deliberate non-moves

CodeRabbit raised three findings; all three are declined, and each is a change to behaviour rather than to structure:

- Both confirmation dialogs clear their pending row in `onFinish` rather than `onSuccess`, so a failed delete closes the dialog without surfacing the error. That is the page's own behaviour, moved verbatim per the epic's "move, do not improve" — worth a follow-up, but not inside a parity refactor.
- The matching test for that failure path would pin behaviour this PR does not change.
- Aliasing the type-only `App` import from `vue` so it cannot shadow the ambient `App` namespace: it does not shadow it. Probed by breaking a field's type in the fixture, which `vue-tsc` caught against `App.Data.BotTokenData` — and the harness is verbatim from the three sibling test files #1022 landed.

## Gates

- `sail composer test` — `Total: 100.0 %`, Pint / PHPStan / Rector clean
- `lint:check` (0 errors), `format:check`, `types:check`, `test:js` (193 files, 1993 tests), `build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787863453&installation_model_id=428379&pr_number=1025&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1025&signature=5235f3944996089b13847c1b6d48b365dd3e4928f774275c33334507a6629fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->