### PR TITLE
refactor: split ChannelMasthead.vue

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -252,7 +252,6 @@ export default defineConfigWithVueTs(
         // `eslint-rules/max-lines-policy.test.ts` fails as soon as an entry
         // stops breaching the threshold, so the list can only shrink.
         files: [
-            'resources/js/components/ChannelMasthead.vue',
             'resources/js/components/QuickSwitcher.vue',
             'resources/js/components/UserStatusDialog.vue',
             'resources/js/composables/useAttachmentUploads.test.ts',

--- a/resources/js/components/ChannelMasthead.actions.test.ts
+++ b/resources/js/components/ChannelMasthead.actions.test.ts
@@ -17,37 +17,37 @@ vi.mock('@inertiajs/vue3', async () => {
 });
 
 vi.mock('@lucide/vue', async () => {
-    const { lucideDouble } = await import('./ChannelMasthead.doubles');
+    const { lucideDouble } = await import('./ChannelMasthead.stubs');
 
     return lucideDouble();
 });
 
 vi.mock('@/components/AvatarStack.vue', async () => {
-    const { passthrough } = await import('./ChannelMasthead.doubles');
+    const { passthrough } = await import('./ChannelMasthead.stubs');
 
     return { default: passthrough('div') };
 });
 
 vi.mock('@/components/PresenceDot.vue', async () => {
-    const { passthrough } = await import('./ChannelMasthead.doubles');
+    const { passthrough } = await import('./ChannelMasthead.stubs');
 
     return { default: passthrough('span') };
 });
 
 vi.mock('@/components/ui/avatar', async () => {
-    const { avatarDouble } = await import('./ChannelMasthead.doubles');
+    const { avatarDouble } = await import('./ChannelMasthead.stubs');
 
     return avatarDouble();
 });
 
 vi.mock('@/components/ui/button', async () => {
-    const { buttonDouble } = await import('./ChannelMasthead.doubles');
+    const { buttonDouble } = await import('./ChannelMasthead.stubs');
 
     return buttonDouble();
 });
 
 vi.mock('@/components/ui/dropdown-menu', async () => {
-    const { dropdownMenuDouble } = await import('./ChannelMasthead.doubles');
+    const { dropdownMenuDouble } = await import('./ChannelMasthead.stubs');
 
     return dropdownMenuDouble();
 });
@@ -59,7 +59,7 @@ vi.mock('@/components/ui/sidebar', async () => {
 });
 
 vi.mock('@/components/ui/tooltip', async () => {
-    const { tooltipDouble } = await import('./ChannelMasthead.doubles');
+    const { tooltipDouble } = await import('./ChannelMasthead.stubs');
 
     return tooltipDouble();
 });

--- a/resources/js/components/ChannelMasthead.actions.test.ts
+++ b/resources/js/components/ChannelMasthead.actions.test.ts
@@ -1,0 +1,356 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Covers the masthead's right side: the member facepile with its readout, the
+ * add-people / pins / search controls, and every branch of the options menu —
+ * which items each permission opens, and what each one emits.
+ *
+ * Written against the masthead as it stands so a split of it can be checked
+ * against this suite. An extracted child that forgets to re-emit is exactly
+ * what a pure move risks, and it is what these assertions are here to catch.
+ */
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble } = await import('./ChannelMasthead.doubles');
+
+    return inertiaDouble();
+});
+
+vi.mock('@lucide/vue', async () => {
+    const { lucideDouble } = await import('./ChannelMasthead.doubles');
+
+    return lucideDouble();
+});
+
+vi.mock('@/components/AvatarStack.vue', async () => {
+    const { passthrough } = await import('./ChannelMasthead.doubles');
+
+    return { default: passthrough('div') };
+});
+
+vi.mock('@/components/PresenceDot.vue', async () => {
+    const { passthrough } = await import('./ChannelMasthead.doubles');
+
+    return { default: passthrough('span') };
+});
+
+vi.mock('@/components/ui/avatar', async () => {
+    const { avatarDouble } = await import('./ChannelMasthead.doubles');
+
+    return avatarDouble();
+});
+
+vi.mock('@/components/ui/button', async () => {
+    const { buttonDouble } = await import('./ChannelMasthead.doubles');
+
+    return buttonDouble();
+});
+
+vi.mock('@/components/ui/dropdown-menu', async () => {
+    const { dropdownMenuDouble } = await import('./ChannelMasthead.doubles');
+
+    return dropdownMenuDouble();
+});
+
+vi.mock('@/components/ui/sidebar', async () => {
+    const { sidebarDouble } = await import('./ChannelMasthead.doubles');
+
+    return sidebarDouble();
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { tooltipDouble } = await import('./ChannelMasthead.doubles');
+
+    return tooltipDouble();
+});
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { isMobileDouble } = await import('./ChannelMasthead.doubles');
+
+    return isMobileDouble();
+});
+
+vi.mock('@/composables/useNavPanel', async () => {
+    const { navPanelDouble } = await import('./ChannelMasthead.doubles');
+
+    return navPanelDouble();
+});
+
+vi.mock('@/composables/useQuickSwitcher', async () => {
+    const { quickSwitcherDouble } = await import('./ChannelMasthead.doubles');
+
+    return quickSwitcherDouble();
+});
+
+import type { Emitted } from './ChannelMasthead.doubles';
+import {
+    channel,
+    click,
+    dock,
+    find,
+    member,
+    mountMasthead,
+    navigation,
+    participant,
+    resetDoubles,
+    unmountAll,
+} from './ChannelMasthead.doubles';
+import ChannelMasthead from './ChannelMasthead.vue';
+
+function mount(props: Record<string, unknown> = {}): {
+    host: HTMLElement;
+    emitted: Emitted;
+} {
+    return mountMasthead(ChannelMasthead, props);
+}
+
+/** Every permission open at once, so a case can close the one it is about. */
+const allPermissions = {
+    canManagePreferences: true,
+    canArchive: true,
+    canLeave: true,
+};
+
+const levels = [
+    { value: 'all', label: 'All messages' },
+    { value: 'mentions', label: 'Mentions only' },
+    { value: 'nothing', label: 'Nothing' },
+];
+
+beforeEach(() => {
+    resetDoubles();
+});
+
+afterEach(() => {
+    unmountAll();
+});
+
+describe('the masthead facepile', () => {
+    it('shows three avatars and folds the rest into a +N chip', () => {
+        const { host } = mount({
+            members: [
+                member({ id: 'a', name: 'Ada' }),
+                member({ id: 'b', name: 'Bo' }),
+                member({ id: 'c', name: 'Cy' }),
+                member({ id: 'd', name: 'Di' }),
+                member({ id: 'e', name: 'Ed' }),
+            ],
+        });
+
+        const facepile = find(host, 'masthead-members') as HTMLElement;
+
+        expect(facepile.querySelectorAll('[title]')).toHaveLength(3);
+        expect(facepile.textContent).toContain('+2');
+    });
+
+    it('counts the active members against the roster, so away reads as present but idle', () => {
+        const { host } = mount({
+            members: [
+                member({ id: 'a' }),
+                member({ id: 'b' }),
+                member({ id: 'c' }),
+            ],
+            presenceFor: (id: string) => (id === 'a' ? 'active' : 'away'),
+        });
+
+        expect(find(host, 'masthead-active-count')?.textContent).toContain(
+            '1 of 3 active',
+        );
+    });
+
+    it('squares a bot’s avatar and gives it no presence dot', () => {
+        const { host } = mount({
+            members: [member({ id: 'bot', name: 'Ledger', isBot: true })],
+        });
+
+        const facepile = find(host, 'masthead-members') as HTMLElement;
+
+        expect(facepile.querySelector('.rounded-md')).not.toBeNull();
+        expect(find(host, 'masthead-member-presence')).toBeNull();
+    });
+
+    it('leaves the facepile off a DM, where the roster is the conversation', () => {
+        const { host } = mount({
+            channel: channel({
+                isDirect: true,
+                dmUserId: 'peer',
+                dmParticipants: [participant()],
+            }),
+            members: [member()],
+        });
+
+        expect(find(host, 'masthead-members')).toBeNull();
+    });
+});
+
+describe('the masthead controls', () => {
+    it('offers add-people only to someone who may grow the conversation', () => {
+        expect(find(mount().host, 'masthead-add-people')).toBeNull();
+
+        const { host, emitted } = mount({ canAddPeople: true });
+
+        click(host, '[data-test="masthead-add-people"]');
+
+        expect(emitted.map(([event]) => event)).toContain('addPeople');
+    });
+
+    it('keeps the add-people label off the row below the breakpoint', () => {
+        navigation.isMobile.value = true;
+
+        const { host } = mount({ canAddPeople: true });
+        const button = find(host, 'masthead-add-people') as HTMLElement;
+
+        expect(button.getAttribute('aria-label')).toBe('Add people');
+        expect(button.textContent?.trim()).toBe('');
+    });
+
+    it('badges the pins button with its count, and only when there are pins', () => {
+        expect(find(mount().host, 'masthead-pins-count')).toBeNull();
+
+        const { host, emitted } = mount({ pinCount: 4 });
+
+        expect(find(host, 'masthead-pins-count')?.textContent).toContain('4');
+        expect(host.querySelector('.fill-brass')).not.toBeNull();
+
+        click(host, '[data-test="masthead-pins"]');
+
+        expect(emitted.map(([event]) => event)).toContain('openPins');
+    });
+
+    it('opens the dock’s search destination from the glyph, expanding a shut dock', () => {
+        dock.open.value = false;
+
+        const { host } = mount();
+
+        click(host, '[data-test="masthead-search"]');
+
+        expect(dock.setOpen).toHaveBeenCalledWith(true);
+        expect(navigation.openDestination).toHaveBeenCalledWith('search');
+        expect(navigation.openQuickSwitcher).not.toHaveBeenCalled();
+    });
+
+    it('sends the same glyph to the jump-to overlay below the breakpoint', () => {
+        navigation.isMobile.value = true;
+
+        const { host } = mount();
+
+        click(host, '[data-test="masthead-search"]');
+
+        expect(navigation.openQuickSwitcher).toHaveBeenCalled();
+        expect(navigation.openDestination).not.toHaveBeenCalled();
+    });
+});
+
+describe('the masthead options menu', () => {
+    it('stays away entirely when the viewer may do none of it', () => {
+        expect(find(mount().host, 'channel-options')).toBeNull();
+    });
+
+    it('stars and unstars a channel without closing the menu', () => {
+        const { host, emitted } = mount({
+            ...allPermissions,
+            notificationLevels: levels,
+        });
+
+        const star = find(host, 'star-channel') as HTMLElement;
+
+        expect(star.getAttribute('aria-pressed')).toBe('false');
+        expect(star.textContent).toContain('Star channel');
+
+        star.click();
+
+        expect(emitted.map(([event]) => event)).toContain('toggleStar');
+    });
+
+    it('reads back as unstarring once the channel is starred', () => {
+        const { host } = mount({ ...allPermissions, starred: true });
+
+        const star = find(host, 'star-channel') as HTMLElement;
+
+        expect(star.getAttribute('aria-pressed')).toBe('true');
+        expect(star.textContent).toContain('Unstar channel');
+    });
+
+    it('never offers to star a DM, which the sidebar never files', () => {
+        const { host } = mount({
+            ...allPermissions,
+            channel: channel({
+                isDirect: true,
+                dmUserId: 'peer',
+                dmParticipants: [participant()],
+            }),
+        });
+
+        expect(find(host, 'channel-options')).not.toBeNull();
+        expect(find(host, 'star-channel')).toBeNull();
+    });
+
+    it('lists every notification level and reports the pick', () => {
+        const { host, emitted } = mount({
+            ...allPermissions,
+            notificationLevels: levels,
+            notificationLevel: 'all',
+        });
+
+        expect(
+            levels.map(
+                ({ value }) =>
+                    find(host, `notification-level-${value}`)?.textContent,
+            ),
+        ).toEqual(levels.map(({ label }) => label));
+
+        click(host, '[data-test="notification-level-mentions"]');
+
+        expect(emitted).toContainEqual(['notificationLevelChange', 'mentions']);
+    });
+
+    it('toggles the mute checkbox to the state it is not in', () => {
+        const { host, emitted } = mount({ ...allPermissions, muted: true });
+
+        const mute = find(host, 'mute-channel') as HTMLElement;
+
+        expect(mute.getAttribute('aria-checked')).toBe('true');
+        expect(mute.textContent).toContain('Mute channel');
+
+        mute.click();
+
+        expect(emitted).toContainEqual(['muteChange', false]);
+    });
+
+    it('offers archiving only to someone who may archive', () => {
+        expect(
+            find(mount({ canManagePreferences: true }).host, 'archive-channel'),
+        ).toBeNull();
+
+        const { host, emitted } = mount({ canArchive: true });
+
+        click(host, '[data-test="archive-channel"]');
+
+        expect(emitted.map(([event]) => event)).toContain('archive');
+    });
+
+    it('names leaving after the kind of conversation it is', () => {
+        const { host, emitted } = mount({ canLeave: true });
+
+        expect(find(host, 'leave-channel')?.textContent).toContain(
+            'Leave channel',
+        );
+
+        click(host, '[data-test="leave-channel"]');
+
+        expect(emitted.map(([event]) => event)).toContain('leave');
+
+        const dm = mount({
+            canLeave: true,
+            channel: channel({
+                isDirect: true,
+                dmUserId: 'peer',
+                dmParticipants: [participant()],
+            }),
+        });
+
+        expect(find(dm.host, 'leave-channel')?.textContent).toContain(
+            'Leave conversation',
+        );
+    });
+});

--- a/resources/js/components/ChannelMasthead.doubles.ts
+++ b/resources/js/components/ChannelMasthead.doubles.ts
@@ -1,19 +1,16 @@
 import { vi } from 'vitest';
-import type { App, Component, InjectionKey } from 'vue';
-import { createApp, defineComponent, h, inject, provide, ref } from 'vue';
+import type { App, Component } from 'vue';
+import { createApp, h, ref } from 'vue';
+import { passthrough } from '@/components/ChannelMasthead.stubs';
 import { translate } from '@/lib/i18n';
 import type { RenderedPresence } from '@/lib/presence';
 import type { Channel, DmParticipant, Mention } from '@/types';
 
 /**
- * The doubles the masthead's suites share: the shell primitives it renders
- * through, the composables that reach for the dock or the router, and the
- * mount/teardown boilerplate.
- *
- * They live outside the suites because the masthead pulls in enough of the
- * design system that the preamble, repeated per suite, would dwarf the
- * assertions. A `vi.mock` factory is hoisted above the imports, so a suite
- * reaches for what it needs with a dynamic `import()` inside the factory.
+ * The harness the masthead's suites share: the app state it reads through
+ * `usePage()` and its composables, the model factories, and the mount/teardown
+ * boilerplate that records what it emits. The design-system stand-ins it
+ * renders through live beside this, in `ChannelMasthead.stubs`.
  */
 
 /** The viewer, as `usePage()` reports them. Mutable so a suite can move them. */
@@ -29,169 +26,6 @@ export function inertiaDouble(): Record<string, unknown> {
             url: '/t/acme/c/general',
             props: { auth: { user: viewer } },
         }),
-    };
-}
-
-/**
- * Renders its tag with whatever it was handed, so a stubbed primitive still
- * carries the `data-test`, the classes and the ARIA the masthead puts on it —
- * which is exactly what these suites assert on.
- */
-export function passthrough(tag: string): Component {
-    return defineComponent({
-        name: `${tag}Passthrough`,
-        inheritAttrs: false,
-        setup:
-            (_props, { attrs, slots }) =>
-            () =>
-                h(tag, attrs, slots.default?.()),
-    });
-}
-
-/**
- * The design-system leaves the masthead composes, each reduced to the tag it
- * renders. They keep their own suites; what matters here is that the masthead's
- * attributes reach them, which `passthrough` preserves.
- */
-export function avatarDouble(): Record<string, Component> {
-    return {
-        Avatar: passthrough('div'),
-        AvatarImage: passthrough('img'),
-        AvatarFallback: passthrough('span'),
-    };
-}
-
-export function buttonDouble(): Record<string, Component> {
-    return { Button: passthrough('button') };
-}
-
-export function tooltipDouble(): Record<string, Component> {
-    return {
-        Tooltip: passthrough('div'),
-        TooltipTrigger: passthrough('div'),
-        TooltipContent: passthrough('div'),
-    };
-}
-
-/** The glyphs, each rendering as an `<svg>` that keeps its classes. */
-export function lucideDouble(): Record<string, Component> {
-    return Object.fromEntries(
-        [
-            'Archive',
-            'Bot',
-            'Check',
-            'EllipsisVertical',
-            'LogOut',
-            'Pin',
-            'Search',
-            'Star',
-            'UserPlus',
-        ].map((icon) => [icon, passthrough('svg')]),
-    );
-}
-
-type PickLevel = (value: string) => void;
-
-/** How a stubbed radio item reaches the group's update handler. */
-const PICK_LEVEL: InjectionKey<PickLevel | undefined> = Symbol('pick-level');
-
-/**
- * The dropdown-menu primitives, which unlike the rest are not inert: the menu's
- * whole job is to turn a pick into an emit, so each item stub reduces to the
- * one gesture that fires the handler the masthead bound to it.
- */
-export function dropdownMenuDouble(): Record<string, Component> {
-    const item = defineComponent({
-        name: 'DropdownMenuItemStub',
-        inheritAttrs: false,
-        setup:
-            (_props, { attrs, slots }) =>
-            () =>
-                h(
-                    'button',
-                    {
-                        ...attrs,
-                        // reka-ui's item announces a pick as `select`, whose
-                        // event the masthead sometimes calls `preventDefault()`
-                        // on to keep the menu open.
-                        onClick: () =>
-                            (attrs.onSelect as (event: Event) => void)?.(
-                                new Event('select', { cancelable: true }),
-                            ),
-                    },
-                    slots.default?.(),
-                ),
-    });
-
-    const checkboxItem = defineComponent({
-        name: 'DropdownMenuCheckboxItemStub',
-        inheritAttrs: false,
-        props: { modelValue: { type: Boolean, default: false } },
-        setup:
-            (props, { attrs, slots }) =>
-            () =>
-                h(
-                    'button',
-                    {
-                        ...attrs,
-                        'aria-checked': String(props.modelValue),
-                        onClick: () =>
-                            (
-                                attrs['onUpdate:modelValue'] as (
-                                    value: boolean,
-                                ) => void
-                            )?.(!props.modelValue),
-                    },
-                    slots.default?.(),
-                ),
-    });
-
-    /**
-     * The radio group hands its update handler to its items, so picking a level
-     * is one click on the item itself — the gesture reka-ui gives the viewer.
-     */
-    const radioGroup = defineComponent({
-        name: 'DropdownMenuRadioGroupStub',
-        inheritAttrs: false,
-        props: { modelValue: { type: String, default: '' } },
-        setup(props, { attrs, slots }) {
-            provide(PICK_LEVEL, attrs['onUpdate:modelValue'] as PickLevel);
-
-            return () =>
-                h(
-                    'div',
-                    { ...attrs, 'data-value': props.modelValue },
-                    slots.default?.(),
-                );
-        },
-    });
-
-    const radioItem = defineComponent({
-        name: 'DropdownMenuRadioItemStub',
-        inheritAttrs: false,
-        props: { value: { type: String, default: '' } },
-        setup(props, { attrs, slots }) {
-            const pick = inject(PICK_LEVEL, undefined);
-
-            return () =>
-                h(
-                    'button',
-                    { ...attrs, onClick: () => pick?.(props.value) },
-                    slots.default?.(),
-                );
-        },
-    });
-
-    return {
-        DropdownMenu: passthrough('div'),
-        DropdownMenuCheckboxItem: checkboxItem,
-        DropdownMenuContent: passthrough('div'),
-        DropdownMenuItem: item,
-        DropdownMenuLabel: passthrough('div'),
-        DropdownMenuRadioGroup: radioGroup,
-        DropdownMenuRadioItem: radioItem,
-        DropdownMenuSeparator: passthrough('hr'),
-        DropdownMenuTrigger: passthrough('div'),
     };
 }
 

--- a/resources/js/components/ChannelMasthead.doubles.ts
+++ b/resources/js/components/ChannelMasthead.doubles.ts
@@ -1,0 +1,371 @@
+import { vi } from 'vitest';
+import type { App, Component, InjectionKey } from 'vue';
+import { createApp, defineComponent, h, inject, provide, ref } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { RenderedPresence } from '@/lib/presence';
+import type { Channel, DmParticipant, Mention } from '@/types';
+
+/**
+ * The doubles the masthead's suites share: the shell primitives it renders
+ * through, the composables that reach for the dock or the router, and the
+ * mount/teardown boilerplate.
+ *
+ * They live outside the suites because the masthead pulls in enough of the
+ * design system that the preamble, repeated per suite, would dwarf the
+ * assertions. A `vi.mock` factory is hoisted above the imports, so a suite
+ * reaches for what it needs with a dynamic `import()` inside the factory.
+ */
+
+/** The viewer, as `usePage()` reports them. Mutable so a suite can move them. */
+export const viewer = {
+    avatar: null as string | null,
+    presence: 'active' as RenderedPresence,
+};
+
+/** The pieces of `@inertiajs/vue3` the masthead reads. */
+export function inertiaDouble(): Record<string, unknown> {
+    return {
+        usePage: () => ({
+            url: '/t/acme/c/general',
+            props: { auth: { user: viewer } },
+        }),
+    };
+}
+
+/**
+ * Renders its tag with whatever it was handed, so a stubbed primitive still
+ * carries the `data-test`, the classes and the ARIA the masthead puts on it —
+ * which is exactly what these suites assert on.
+ */
+export function passthrough(tag: string): Component {
+    return defineComponent({
+        name: `${tag}Passthrough`,
+        inheritAttrs: false,
+        setup:
+            (_props, { attrs, slots }) =>
+            () =>
+                h(tag, attrs, slots.default?.()),
+    });
+}
+
+/**
+ * The design-system leaves the masthead composes, each reduced to the tag it
+ * renders. They keep their own suites; what matters here is that the masthead's
+ * attributes reach them, which `passthrough` preserves.
+ */
+export function avatarDouble(): Record<string, Component> {
+    return {
+        Avatar: passthrough('div'),
+        AvatarImage: passthrough('img'),
+        AvatarFallback: passthrough('span'),
+    };
+}
+
+export function buttonDouble(): Record<string, Component> {
+    return { Button: passthrough('button') };
+}
+
+export function tooltipDouble(): Record<string, Component> {
+    return {
+        Tooltip: passthrough('div'),
+        TooltipTrigger: passthrough('div'),
+        TooltipContent: passthrough('div'),
+    };
+}
+
+/** The glyphs, each rendering as an `<svg>` that keeps its classes. */
+export function lucideDouble(): Record<string, Component> {
+    return Object.fromEntries(
+        [
+            'Archive',
+            'Bot',
+            'Check',
+            'EllipsisVertical',
+            'LogOut',
+            'Pin',
+            'Search',
+            'Star',
+            'UserPlus',
+        ].map((icon) => [icon, passthrough('svg')]),
+    );
+}
+
+type PickLevel = (value: string) => void;
+
+/** How a stubbed radio item reaches the group's update handler. */
+const PICK_LEVEL: InjectionKey<PickLevel | undefined> = Symbol('pick-level');
+
+/**
+ * The dropdown-menu primitives, which unlike the rest are not inert: the menu's
+ * whole job is to turn a pick into an emit, so each item stub reduces to the
+ * one gesture that fires the handler the masthead bound to it.
+ */
+export function dropdownMenuDouble(): Record<string, Component> {
+    const item = defineComponent({
+        name: 'DropdownMenuItemStub',
+        inheritAttrs: false,
+        setup:
+            (_props, { attrs, slots }) =>
+            () =>
+                h(
+                    'button',
+                    {
+                        ...attrs,
+                        // reka-ui's item announces a pick as `select`, whose
+                        // event the masthead sometimes calls `preventDefault()`
+                        // on to keep the menu open.
+                        onClick: () =>
+                            (attrs.onSelect as (event: Event) => void)?.(
+                                new Event('select', { cancelable: true }),
+                            ),
+                    },
+                    slots.default?.(),
+                ),
+    });
+
+    const checkboxItem = defineComponent({
+        name: 'DropdownMenuCheckboxItemStub',
+        inheritAttrs: false,
+        props: { modelValue: { type: Boolean, default: false } },
+        setup:
+            (props, { attrs, slots }) =>
+            () =>
+                h(
+                    'button',
+                    {
+                        ...attrs,
+                        'aria-checked': String(props.modelValue),
+                        onClick: () =>
+                            (
+                                attrs['onUpdate:modelValue'] as (
+                                    value: boolean,
+                                ) => void
+                            )?.(!props.modelValue),
+                    },
+                    slots.default?.(),
+                ),
+    });
+
+    /**
+     * The radio group hands its update handler to its items, so picking a level
+     * is one click on the item itself — the gesture reka-ui gives the viewer.
+     */
+    const radioGroup = defineComponent({
+        name: 'DropdownMenuRadioGroupStub',
+        inheritAttrs: false,
+        props: { modelValue: { type: String, default: '' } },
+        setup(props, { attrs, slots }) {
+            provide(PICK_LEVEL, attrs['onUpdate:modelValue'] as PickLevel);
+
+            return () =>
+                h(
+                    'div',
+                    { ...attrs, 'data-value': props.modelValue },
+                    slots.default?.(),
+                );
+        },
+    });
+
+    const radioItem = defineComponent({
+        name: 'DropdownMenuRadioItemStub',
+        inheritAttrs: false,
+        props: { value: { type: String, default: '' } },
+        setup(props, { attrs, slots }) {
+            const pick = inject(PICK_LEVEL, undefined);
+
+            return () =>
+                h(
+                    'button',
+                    { ...attrs, onClick: () => pick?.(props.value) },
+                    slots.default?.(),
+                );
+        },
+    });
+
+    return {
+        DropdownMenu: passthrough('div'),
+        DropdownMenuCheckboxItem: checkboxItem,
+        DropdownMenuContent: passthrough('div'),
+        DropdownMenuItem: item,
+        DropdownMenuLabel: passthrough('div'),
+        DropdownMenuRadioGroup: radioGroup,
+        DropdownMenuRadioItem: radioItem,
+        DropdownMenuSeparator: passthrough('hr'),
+        DropdownMenuTrigger: passthrough('div'),
+    };
+}
+
+/** The dock's own open state, which the search glyph expands before pinning. */
+export const dock = {
+    open: ref(true),
+    setOpen: vi.fn((value: boolean) => {
+        dock.open.value = value;
+    }),
+};
+
+export function sidebarDouble(): Record<string, unknown> {
+    return {
+        SidebarTrigger: passthrough('button'),
+        useSidebar: () => ({ open: dock.open, setOpen: dock.setOpen }),
+    };
+}
+
+/** Where the search glyph sends the viewer, on each side of the breakpoint. */
+export const navigation = {
+    isMobile: ref(false),
+    openDestination: vi.fn(),
+    openQuickSwitcher: vi.fn(),
+};
+
+export function isMobileDouble(): Record<string, unknown> {
+    return { useIsMobile: () => navigation.isMobile };
+}
+
+export function navPanelDouble(): Record<string, unknown> {
+    return {
+        useNavPanel: () => ({ openDestination: navigation.openDestination }),
+    };
+}
+
+export function quickSwitcherDouble(): Record<string, unknown> {
+    return {
+        useQuickSwitcher: () => ({ open: navigation.openQuickSwitcher }),
+    };
+}
+
+/** Reset every double's state between tests, so a suite reads in any order. */
+export function resetDoubles(): void {
+    viewer.avatar = null;
+    viewer.presence = 'active';
+    dock.open.value = true;
+    dock.setOpen.mockClear();
+    navigation.isMobile.value = false;
+    navigation.openDestination.mockClear();
+    navigation.openQuickSwitcher.mockClear();
+}
+
+export function channel(overrides: Partial<Channel> = {}): Channel {
+    return {
+        id: 'c1',
+        name: 'general',
+        slug: 'general',
+        visibility: 'public',
+        topic: null,
+        isGeneral: true,
+        isArchived: false,
+        muted: false,
+        notificationLevel: 'all',
+        unreadCount: 0,
+        mentionCount: 0,
+        hasDraft: false,
+        draft: null,
+        starred: false,
+        sectionId: null,
+        position: 0,
+        isDirect: false,
+        isGroupDirect: false,
+        dmUserId: null,
+        dmParticipants: null,
+        lastActivityAt: null,
+        ...overrides,
+    };
+}
+
+export function member(overrides: Partial<Mention> = {}): Mention {
+    return { id: 'u1', name: 'Ada Lovelace', avatar: null, ...overrides };
+}
+
+/** The other side of a DM, as the channel payload carries them. */
+export function participant(
+    overrides: Partial<DmParticipant> = {},
+): DmParticipant {
+    return {
+        id: 'peer',
+        name: 'Ada Lovelace',
+        avatar: null,
+        isBot: false,
+        status: null,
+        presence: 'active',
+        isDnd: false,
+        ...overrides,
+    };
+}
+
+/** Stands in for the notification indicator's Lucide glyph. */
+export const notificationIcon = passthrough('svg');
+
+const mounted: Array<{ app: App; host: HTMLElement }> = [];
+
+/** Every event the masthead emits, in the order it emitted them. */
+export type Emitted = Array<[string, unknown]>;
+
+/**
+ * Mount the masthead over its defaults, recording what it emits. The prop bag
+ * is spread rather than made reactive: each case renders one variant of a
+ * header that only ever re-renders from above.
+ */
+export function mountMasthead(
+    Masthead: Component,
+    props: Record<string, unknown> = {},
+): { host: HTMLElement; emitted: Emitted } {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const emitted: Emitted = [];
+    const record =
+        (event: string) =>
+        (payload?: unknown): void => {
+            emitted.push([event, payload]);
+        };
+
+    const app = createApp({
+        render: () =>
+            h(Masthead, {
+                channel: channel(),
+                members: [],
+                presenceFor: () => 'active' as RenderedPresence,
+                isDndFor: () => false,
+                title: 'general',
+                canManagePreferences: false,
+                canArchive: false,
+                canLeave: false,
+                canAddPeople: false,
+                notificationLevels: [],
+                starred: false,
+                muted: false,
+                pinCount: 0,
+                notificationLevel: 'all',
+                notificationStatus: null,
+                onToggleStar: record('toggleStar'),
+                onNotificationLevelChange: record('notificationLevelChange'),
+                onMuteChange: record('muteChange'),
+                onArchive: record('archive'),
+                onLeave: record('leave'),
+                onAddPeople: record('addPeople'),
+                onOpenPins: record('openPins'),
+                ...props,
+            }),
+    });
+
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    mounted.push({ app, host });
+
+    return { host, emitted };
+}
+
+export function unmountAll(): void {
+    for (const { app, host } of mounted.splice(0)) {
+        app.unmount();
+        host.remove();
+    }
+}
+
+/** The element carrying a `data-test` selector, or null when it is absent. */
+export function find(host: HTMLElement, dataTest: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${dataTest}"]`);
+}
+
+export function click(host: HTMLElement, selector: string): void {
+    host.querySelector<HTMLElement>(selector)?.click();
+}

--- a/resources/js/components/ChannelMasthead.identity.test.ts
+++ b/resources/js/components/ChannelMasthead.identity.test.ts
@@ -18,37 +18,37 @@ vi.mock('@inertiajs/vue3', async () => {
 });
 
 vi.mock('@lucide/vue', async () => {
-    const { lucideDouble } = await import('./ChannelMasthead.doubles');
+    const { lucideDouble } = await import('./ChannelMasthead.stubs');
 
     return lucideDouble();
 });
 
 vi.mock('@/components/AvatarStack.vue', async () => {
-    const { passthrough } = await import('./ChannelMasthead.doubles');
+    const { passthrough } = await import('./ChannelMasthead.stubs');
 
     return { default: passthrough('div') };
 });
 
 vi.mock('@/components/PresenceDot.vue', async () => {
-    const { passthrough } = await import('./ChannelMasthead.doubles');
+    const { passthrough } = await import('./ChannelMasthead.stubs');
 
     return { default: passthrough('span') };
 });
 
 vi.mock('@/components/ui/avatar', async () => {
-    const { avatarDouble } = await import('./ChannelMasthead.doubles');
+    const { avatarDouble } = await import('./ChannelMasthead.stubs');
 
     return avatarDouble();
 });
 
 vi.mock('@/components/ui/button', async () => {
-    const { buttonDouble } = await import('./ChannelMasthead.doubles');
+    const { buttonDouble } = await import('./ChannelMasthead.stubs');
 
     return buttonDouble();
 });
 
 vi.mock('@/components/ui/dropdown-menu', async () => {
-    const { dropdownMenuDouble } = await import('./ChannelMasthead.doubles');
+    const { dropdownMenuDouble } = await import('./ChannelMasthead.stubs');
 
     return dropdownMenuDouble();
 });
@@ -60,7 +60,7 @@ vi.mock('@/components/ui/sidebar', async () => {
 });
 
 vi.mock('@/components/ui/tooltip', async () => {
-    const { tooltipDouble } = await import('./ChannelMasthead.doubles');
+    const { tooltipDouble } = await import('./ChannelMasthead.stubs');
 
     return tooltipDouble();
 });

--- a/resources/js/components/ChannelMasthead.identity.test.ts
+++ b/resources/js/components/ChannelMasthead.identity.test.ts
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Covers how the masthead names the conversation it heads: the three avatar
+ * treatments (group stack, 1:1 counterpart, `#`), the notification cue beside
+ * the title, and the sub-lines under it — the compact activity readout, the
+ * group's participant count, the archived badge and the topic.
+ *
+ * Written against the masthead as it stands so a split of it can be checked
+ * against this suite: every selector, every string and every fallback is
+ * pinned here, and a pure move may change none of them.
+ */
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble } = await import('./ChannelMasthead.doubles');
+
+    return inertiaDouble();
+});
+
+vi.mock('@lucide/vue', async () => {
+    const { lucideDouble } = await import('./ChannelMasthead.doubles');
+
+    return lucideDouble();
+});
+
+vi.mock('@/components/AvatarStack.vue', async () => {
+    const { passthrough } = await import('./ChannelMasthead.doubles');
+
+    return { default: passthrough('div') };
+});
+
+vi.mock('@/components/PresenceDot.vue', async () => {
+    const { passthrough } = await import('./ChannelMasthead.doubles');
+
+    return { default: passthrough('span') };
+});
+
+vi.mock('@/components/ui/avatar', async () => {
+    const { avatarDouble } = await import('./ChannelMasthead.doubles');
+
+    return avatarDouble();
+});
+
+vi.mock('@/components/ui/button', async () => {
+    const { buttonDouble } = await import('./ChannelMasthead.doubles');
+
+    return buttonDouble();
+});
+
+vi.mock('@/components/ui/dropdown-menu', async () => {
+    const { dropdownMenuDouble } = await import('./ChannelMasthead.doubles');
+
+    return dropdownMenuDouble();
+});
+
+vi.mock('@/components/ui/sidebar', async () => {
+    const { sidebarDouble } = await import('./ChannelMasthead.doubles');
+
+    return sidebarDouble();
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { tooltipDouble } = await import('./ChannelMasthead.doubles');
+
+    return tooltipDouble();
+});
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { isMobileDouble } = await import('./ChannelMasthead.doubles');
+
+    return isMobileDouble();
+});
+
+vi.mock('@/composables/useNavPanel', async () => {
+    const { navPanelDouble } = await import('./ChannelMasthead.doubles');
+
+    return navPanelDouble();
+});
+
+vi.mock('@/composables/useQuickSwitcher', async () => {
+    const { quickSwitcherDouble } = await import('./ChannelMasthead.doubles');
+
+    return quickSwitcherDouble();
+});
+
+import {
+    channel,
+    find,
+    member,
+    mountMasthead,
+    notificationIcon,
+    participant,
+    resetDoubles,
+    unmountAll,
+    viewer,
+} from './ChannelMasthead.doubles';
+import ChannelMasthead from './ChannelMasthead.vue';
+
+/** Mount the masthead over its defaults and hand back the host. */
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    return mountMasthead(ChannelMasthead, props).host;
+}
+
+/** The `src` of the avatar image inside the element with this selector. */
+function avatarSrc(host: HTMLElement, dataTest: string): string | null {
+    return (
+        find(host, dataTest)?.querySelector('img')?.getAttribute('src') ?? null
+    );
+}
+
+beforeEach(() => {
+    resetDoubles();
+});
+
+afterEach(() => {
+    unmountAll();
+});
+
+describe('the masthead title', () => {
+    it('marks a standard channel with the hash and its name', () => {
+        const host = mount({ title: 'general' });
+        const heading = host.querySelector('h1') as HTMLElement;
+
+        expect(heading.textContent).toContain('#');
+        expect(heading.textContent).toContain('general');
+        expect(find(host, 'masthead-dm-avatar')).toBeNull();
+        expect(find(host, 'masthead-group-avatars')).toBeNull();
+    });
+
+    it('shows the counterpart’s avatar and presence on a 1:1', () => {
+        const host = mount({
+            channel: channel({
+                isDirect: true,
+                name: 'Ada Lovelace',
+                dmUserId: 'peer',
+                dmParticipants: [participant({ avatar: '/ada.png' })],
+            }),
+            title: 'Ada Lovelace',
+            presenceFor: () => 'away',
+        });
+
+        expect(avatarSrc(host, 'masthead-dm-avatar')).toBe('/ada.png');
+        expect(
+            find(host, 'masthead-dm-presence')?.getAttribute('presence'),
+        ).toBe('away');
+        expect(find(host, 'masthead-dm-avatar')?.textContent).toContain('Away');
+    });
+
+    it('falls back to the viewer’s own avatar and presence in a self-DM', () => {
+        viewer.avatar = '/me.png';
+        viewer.presence = 'away';
+
+        const host = mount({
+            channel: channel({
+                isDirect: true,
+                name: 'Me',
+                dmUserId: null,
+                dmParticipants: [],
+            }),
+            title: 'You',
+            presenceFor: () => 'offline',
+        });
+
+        expect(avatarSrc(host, 'masthead-dm-avatar')).toBe('/me.png');
+        expect(
+            find(host, 'masthead-dm-presence')?.getAttribute('presence'),
+        ).toBe('away');
+    });
+
+    it('falls back to initials when the counterpart has no avatar', () => {
+        const host = mount({
+            channel: channel({
+                isDirect: true,
+                name: 'Ada Lovelace',
+                dmUserId: 'peer',
+                dmParticipants: [participant()],
+            }),
+            title: 'Ada Lovelace',
+        });
+
+        expect(avatarSrc(host, 'masthead-dm-avatar')).toBeNull();
+        expect(find(host, 'masthead-dm-avatar')?.textContent).toContain('AL');
+    });
+
+    it('announces a paused counterpart rather than their presence', () => {
+        const host = mount({
+            channel: channel({
+                isDirect: true,
+                name: 'Ada',
+                dmUserId: 'peer',
+                dmParticipants: [participant()],
+            }),
+            title: 'Ada',
+            isDndFor: () => true,
+        });
+
+        expect(find(host, 'masthead-dm-avatar')?.textContent).toContain(
+            'Notifications paused',
+        );
+        expect(find(host, 'masthead-dm-presence')?.getAttribute('is-dnd')).toBe(
+            'true',
+        );
+    });
+
+    it('stacks a group DM’s participants and counts the viewer into the subtitle', () => {
+        const host = mount({
+            channel: channel({
+                isDirect: true,
+                isGroupDirect: true,
+                dmParticipants: [
+                    participant({ id: 'a', name: 'Ada' }),
+                    participant({ id: 'b', name: 'Bo' }),
+                ],
+            }),
+            title: 'Ada, Bo',
+        });
+
+        expect(find(host, 'masthead-group-avatars')?.getAttribute('max')).toBe(
+            '3',
+        );
+        expect(find(host, 'masthead-group-count')?.textContent).toContain(
+            '3 participants, including you',
+        );
+    });
+
+    it('flags a non-default notification state beside the title', () => {
+        const host = mount({
+            notificationStatus: {
+                icon: notificationIcon,
+                label: 'Muted',
+                status: 'muted',
+            },
+        });
+
+        const cue = find(host, 'notification-status') as HTMLElement;
+
+        expect(cue.getAttribute('data-status')).toBe('muted');
+        expect(cue.getAttribute('aria-label')).toBe('Muted');
+    });
+
+    it('shows no cue while notifications are at their default', () => {
+        expect(find(mount(), 'notification-status')).toBeNull();
+    });
+});
+
+describe('the masthead sub-lines', () => {
+    it('stands the activity readout in for the facepile on a narrow viewport', () => {
+        const host = mount({
+            members: [
+                member({ id: 'a' }),
+                member({ id: 'b' }),
+                member({ id: 'c' }),
+            ],
+            presenceFor: (id: string) => (id === 'a' ? 'active' : 'offline'),
+        });
+
+        expect(find(host, 'masthead-compact-activity')?.textContent).toContain(
+            '1 of 3 active',
+        );
+    });
+
+    it('drops the readout on a DM, and on a channel with no roster', () => {
+        expect(find(mount(), 'masthead-compact-activity')).toBeNull();
+        expect(
+            find(
+                mount({
+                    channel: channel({ isDirect: true }),
+                    members: [member()],
+                }),
+                'masthead-compact-activity',
+            ),
+        ).toBeNull();
+    });
+
+    it('badges an archived channel and prints its topic', () => {
+        const host = mount({
+            channel: channel({ isArchived: true, topic: 'Ledger talk' }),
+        });
+
+        expect(host.textContent).toContain('Archived');
+        expect(host.textContent).toContain('Ledger talk');
+    });
+
+    it('leaves the meta row out when there is nothing in it', () => {
+        expect(mount().textContent).not.toContain('Archived');
+    });
+});

--- a/resources/js/components/ChannelMasthead.stubs.ts
+++ b/resources/js/components/ChannelMasthead.stubs.ts
@@ -1,0 +1,175 @@
+import type { Component, InjectionKey } from 'vue';
+import { defineComponent, h, inject, provide } from 'vue';
+
+/**
+ * The design-system stand-ins the masthead's suites render it through: the
+ * glyphs, the avatar and button primitives, the tooltip, and the menu.
+ *
+ * They live outside the suites because the masthead composes enough of the
+ * design system that the preamble, repeated per suite, would dwarf the
+ * assertions. A `vi.mock` factory is hoisted above the imports, so a suite
+ * reaches for what it needs with a dynamic `import()` inside the factory.
+ */
+
+/**
+ * Renders its tag with whatever it was handed, so a stubbed primitive still
+ * carries the `data-test`, the classes and the ARIA the masthead puts on it —
+ * which is exactly what these suites assert on.
+ */
+export function passthrough(tag: string): Component {
+    return defineComponent({
+        name: `${tag}Passthrough`,
+        inheritAttrs: false,
+        setup:
+            (_props, { attrs, slots }) =>
+            () =>
+                h(tag, attrs, slots.default?.()),
+    });
+}
+
+/**
+ * The design-system leaves the masthead composes, each reduced to the tag it
+ * renders. They keep their own suites; what matters here is that the masthead's
+ * attributes reach them, which `passthrough` preserves.
+ */
+export function avatarDouble(): Record<string, Component> {
+    return {
+        Avatar: passthrough('div'),
+        AvatarImage: passthrough('img'),
+        AvatarFallback: passthrough('span'),
+    };
+}
+
+export function buttonDouble(): Record<string, Component> {
+    return { Button: passthrough('button') };
+}
+
+export function tooltipDouble(): Record<string, Component> {
+    return {
+        Tooltip: passthrough('div'),
+        TooltipTrigger: passthrough('div'),
+        TooltipContent: passthrough('div'),
+    };
+}
+
+/** The glyphs, each rendering as an `<svg>` that keeps its classes. */
+export function lucideDouble(): Record<string, Component> {
+    return Object.fromEntries(
+        [
+            'Archive',
+            'Bot',
+            'Check',
+            'EllipsisVertical',
+            'LogOut',
+            'Pin',
+            'Search',
+            'Star',
+            'UserPlus',
+        ].map((icon) => [icon, passthrough('svg')]),
+    );
+}
+
+type PickLevel = (value: string) => void;
+
+/** How a stubbed radio item reaches the group's update handler. */
+const PICK_LEVEL: InjectionKey<PickLevel | undefined> = Symbol('pick-level');
+
+/**
+ * The dropdown-menu primitives, which unlike the rest are not inert: the menu's
+ * whole job is to turn a pick into an emit, so each item stub reduces to the
+ * one gesture that fires the handler the masthead bound to it.
+ */
+export function dropdownMenuDouble(): Record<string, Component> {
+    const item = defineComponent({
+        name: 'DropdownMenuItemStub',
+        inheritAttrs: false,
+        setup:
+            (_props, { attrs, slots }) =>
+            () =>
+                h(
+                    'button',
+                    {
+                        ...attrs,
+                        // reka-ui's item announces a pick as `select`, whose
+                        // event the masthead sometimes calls `preventDefault()`
+                        // on to keep the menu open.
+                        onClick: () =>
+                            (attrs.onSelect as (event: Event) => void)?.(
+                                new Event('select', { cancelable: true }),
+                            ),
+                    },
+                    slots.default?.(),
+                ),
+    });
+
+    const checkboxItem = defineComponent({
+        name: 'DropdownMenuCheckboxItemStub',
+        inheritAttrs: false,
+        props: { modelValue: { type: Boolean, default: false } },
+        setup:
+            (props, { attrs, slots }) =>
+            () =>
+                h(
+                    'button',
+                    {
+                        ...attrs,
+                        'aria-checked': String(props.modelValue),
+                        onClick: () =>
+                            (
+                                attrs['onUpdate:modelValue'] as (
+                                    value: boolean,
+                                ) => void
+                            )?.(!props.modelValue),
+                    },
+                    slots.default?.(),
+                ),
+    });
+
+    /**
+     * The radio group hands its update handler to its items, so picking a level
+     * is one click on the item itself — the gesture reka-ui gives the viewer.
+     */
+    const radioGroup = defineComponent({
+        name: 'DropdownMenuRadioGroupStub',
+        inheritAttrs: false,
+        props: { modelValue: { type: String, default: '' } },
+        setup(props, { attrs, slots }) {
+            provide(PICK_LEVEL, attrs['onUpdate:modelValue'] as PickLevel);
+
+            return () =>
+                h(
+                    'div',
+                    { ...attrs, 'data-value': props.modelValue },
+                    slots.default?.(),
+                );
+        },
+    });
+
+    const radioItem = defineComponent({
+        name: 'DropdownMenuRadioItemStub',
+        inheritAttrs: false,
+        props: { value: { type: String, default: '' } },
+        setup(props, { attrs, slots }) {
+            const pick = inject(PICK_LEVEL, undefined);
+
+            return () =>
+                h(
+                    'button',
+                    { ...attrs, onClick: () => pick?.(props.value) },
+                    slots.default?.(),
+                );
+        },
+    });
+
+    return {
+        DropdownMenu: passthrough('div'),
+        DropdownMenuCheckboxItem: checkboxItem,
+        DropdownMenuContent: passthrough('div'),
+        DropdownMenuItem: item,
+        DropdownMenuLabel: passthrough('div'),
+        DropdownMenuRadioGroup: radioGroup,
+        DropdownMenuRadioItem: radioItem,
+        DropdownMenuSeparator: passthrough('hr'),
+        DropdownMenuTrigger: passthrough('div'),
+    };
+}

--- a/resources/js/components/ChannelMasthead.vue
+++ b/resources/js/components/ChannelMasthead.vue
@@ -1,47 +1,20 @@
 <script setup lang="ts">
-import { usePage } from '@inertiajs/vue3';
-import {
-    Archive,
-    Bot,
-    Check,
-    EllipsisVertical,
-    LogOut,
-    Pin,
-    Search,
-    Star,
-    UserPlus,
-} from '@lucide/vue';
+import { Pin, Search, UserPlus } from '@lucide/vue';
 import type { AcceptableValue } from 'reka-ui';
-import { computed } from 'vue';
-import AvatarStack from '@/components/AvatarStack.vue';
-import PresenceDot from '@/components/PresenceDot.vue';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import MastheadConnectionPill from '@/components/channel/MastheadConnectionPill.vue';
+import MastheadFacepile from '@/components/channel/MastheadFacepile.vue';
+import MastheadOptionsMenu from '@/components/channel/MastheadOptionsMenu.vue';
+import MastheadTitle from '@/components/channel/MastheadTitle.vue';
 import { Button } from '@/components/ui/button';
-import {
-    DropdownMenu,
-    DropdownMenuCheckboxItem,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuRadioGroup,
-    DropdownMenuRadioItem,
-    DropdownMenuSeparator,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { SidebarTrigger, useSidebar } from '@/components/ui/sidebar';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import {
     Tooltip,
     TooltipContent,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import type { ConnectionPill } from '@/composables/useConnectionState';
-import { getInitials } from '@/composables/useInitials';
-import { useIsMobile } from '@/composables/useIsMobile';
-import { useNavPanel } from '@/composables/useNavPanel';
-import { useQuickSwitcher } from '@/composables/useQuickSwitcher';
-import { memberAvatarStack } from '@/lib/memberAvatars';
+import { useMastheadSearch } from '@/composables/useMastheadSearch';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
-import { dmParticipantPresence, presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
 import type {
     Channel,
@@ -112,117 +85,7 @@ const emit = defineEmits<{
     openPins: [];
 }>();
 
-/**
- * How many member avatars the masthead shows before collapsing the rest into a
- * single "+N" overflow chip.
- */
-const MAX_MASTHEAD_AVATARS = 3;
-
-/** The overlapping member avatars for the masthead's right side. */
-const mastheadAvatars = computed(() =>
-    memberAvatarStack(props.members, MAX_MASTHEAD_AVATARS),
-);
-
-const page = usePage();
-
-/**
- * Below the breakpoint the search glyph is the jump-to overlay's entry point
- * (m5): a phone has no ⌘K, and the overlay leads on to the Search panel via its
- * message results. From `md` up the same glyph opens that panel directly.
- */
-const isMobile = useIsMobile();
-const { open: openQuickSwitcher } = useQuickSwitcher();
-
-const { openDestination } = useNavPanel();
-const { open: dockOpen, setOpen: setDockOpen } = useSidebar();
-
-/**
- * Search is a dock destination now, so the glyph swaps the panel rather than
- * navigating anywhere — the channel it was pressed from stays open behind it. A
- * collapsed dock is expanded first, or the click would pin `?nav=search` on a
- * panel nobody can see.
- *
- * The two behaviours share one button rather than a `v-if` pair, now that both
- * are handlers rather than a handler beside a link: one control, one selector,
- * and no chance of the pair disagreeing about which is rendered.
- */
-function openSearch(): void {
-    if (isMobile.value) {
-        openQuickSwitcher();
-
-        return;
-    }
-
-    if (!dockOpen.value) {
-        setDockOpen(true);
-    }
-
-    openDestination('search');
-}
-
-/** The other participant of a 1:1 DM, whose avatar the masthead shows. */
-const dmParticipant = computed(() => props.channel.dmParticipants?.[0] ?? null);
-
-/**
- * The avatar image for the 1:1 masthead: the other participant's, or — in a
- * self-DM, which has no other participant — the viewer's own. Null (so the
- * initials fallback shows) when that person has no avatar.
- */
-const dmAvatar = computed(() =>
-    dmParticipant.value
-        ? (dmParticipant.value.avatar ?? null)
-        : (page.props.auth.user.avatar ?? null),
-);
-
-/**
- * A 1:1 DM renders viewer-relative: the other participant's presence dot follows
- * the team roster. A DM is a fixed set, so the "who's in the channel" facepile is
- * meaningless and hidden.
- */
-const dmPresence = computed<RenderedPresence>(() =>
-    dmParticipantPresence(
-        props.channel.dmUserId,
-        props.presenceFor,
-        page.props.auth.user.presence,
-    ),
-);
-
-/** Whether the 1:1 counterpart shows the crescent DND badge. */
-const dmDnd = computed(
-    () =>
-        props.channel.dmUserId != null &&
-        (props.isDndFor?.(props.channel.dmUserId) ?? false),
-);
-
-/**
- * How many of the channel's members are active right now.
- *
- * Away counts as present but not active, which is the whole point of the third
- * state: the readout answers "who could answer me now", not "who has the tab
- * open".
- */
-const activeMemberCount = computed(
-    () =>
-        props.members.filter(
-            (member) => props.presenceFor(member.id) === 'active',
-        ).length,
-);
-
-/** The group's participant count, including the viewer, for the subtitle. */
-const groupParticipantCount = computed(
-    () => (props.channel.dmParticipants?.length ?? 0) + 1,
-);
-
-/**
- * Whether the masthead has an activity readout to show.
- *
- * Below the breakpoint there is no room for the facepile, so its readout stands
- * in for it on its own sub-line under the channel name — the same numbers the
- * avatars carry on a wide viewport, in the space a phone actually has.
- */
-const hasActivityReadout = computed(
-    () => !props.channel.isDirect && props.members.length > 0,
-);
+const { isMobile, openSearch } = useMastheadSearch();
 </script>
 
 <template>
@@ -246,242 +109,26 @@ const hasActivityReadout = computed(
             class="-my-1.5 -ml-2 size-9 shrink-0 text-muted-foreground md:hidden"
         />
 
-        <div class="min-w-0 flex-1">
-            <h1
-                class="flex items-center gap-2 truncate font-serif text-[22px] leading-none font-semibold tracking-[-0.02em] text-foreground @2xl:text-[32px]"
-            >
-                <!-- A group DM shows an avatar stack of its participants; a 1:1
-                     shows the other participant's avatar + presence dot; a
-                     standard channel shows the "#". The name is already
-                     viewer-relative (self reads "You"). -->
-                <AvatarStack
-                    v-if="props.channel.isGroupDirect"
-                    data-test="masthead-group-avatars"
-                    :members="props.channel.dmParticipants ?? []"
-                    :max="MAX_MASTHEAD_AVATARS"
-                    size="md"
-                    ring-class="ring-card"
-                />
-                <span
-                    v-else-if="props.channel.isDirect"
-                    data-test="masthead-dm-avatar"
-                    class="relative inline-flex size-7 shrink-0"
-                >
-                    <Avatar class="size-7" aria-hidden="true">
-                        <AvatarImage
-                            v-if="dmAvatar"
-                            :src="dmAvatar"
-                            :alt="props.title"
-                        />
-                        <AvatarFallback
-                            class="text-[11px] font-semibold text-primary"
-                        >
-                            {{ getInitials(props.channel.name) }}
-                        </AvatarFallback>
-                    </Avatar>
-                    <PresenceDot
-                        data-test="masthead-dm-presence"
-                        :presence="dmPresence"
-                        :is-dnd="dmDnd"
-                        surface-class="bg-card"
-                        size="28"
-                        class="ring-card"
-                    />
-                    <!-- Announced through a screen-reader-only label rather than
-                         an aria-label on the role-less dot, which assistive tech
-                         ignores on a bare <span>. -->
-                    <span class="sr-only">{{
-                        dmDnd
-                            ? $t('Notifications paused')
-                            : $t(presenceLabelKey(dmPresence))
-                    }}</span>
-                </span>
-                <span v-else class="text-brass italic">#</span>
-                <span class="truncate">{{ props.title }}</span>
-                <!-- The mute / notification-level indicator sits inline with the
-                     title so it reads as a property of this conversation rather
-                     than floating in the meta row (which is empty for a DM with
-                     no topic). -->
-                <Tooltip v-if="props.notificationStatus">
-                    <TooltipTrigger as-child>
-                        <span
-                            data-test="notification-status"
-                            :data-status="props.notificationStatus.status"
-                            class="inline-flex shrink-0 items-center text-muted-foreground"
-                            :aria-label="$t(props.notificationStatus.label)"
-                        >
-                            <component
-                                :is="props.notificationStatus.icon"
-                                class="size-4"
-                            />
-                        </span>
-                    </TooltipTrigger>
-                    <TooltipContent>{{
-                        $t(props.notificationStatus.label)
-                    }}</TooltipContent>
-                </Tooltip>
-            </h1>
-
-            <!-- The facepile's readout, standing in for the avatars below the
-                 breakpoint where they don't fit. Same numbers, one line down. -->
-            <p
-                v-if="hasActivityReadout"
-                data-test="masthead-compact-activity"
-                class="mt-1 truncate text-[11.5px] text-muted-foreground @2xl:hidden"
-            >
-                {{
-                    $t(':active of :total active', {
-                        active: activeMemberCount,
-                        total: props.members.length,
-                    })
-                }}
-            </p>
-
-            <!-- A group DM's subtitle names how many people are in the
-                 conversation, the viewer included. -->
-            <p
-                v-if="props.channel.isGroupDirect"
-                data-test="masthead-group-count"
-                class="mt-1 text-[13px] text-muted-foreground"
-            >
-                {{
-                    $t(':count participants, including you', {
-                        count: groupParticipantCount,
-                    })
-                }}
-            </p>
-
-            <div
-                v-if="props.channel.isArchived || props.channel.topic"
-                class="mt-1.5 flex items-center gap-2 text-[13px] text-muted-foreground"
-            >
-                <span
-                    v-if="props.channel.isArchived"
-                    class="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
-                >
-                    <Archive class="size-3" />
-                    {{ $t('Archived') }}
-                </span>
-
-                <p v-if="props.channel.topic" class="min-w-0 truncate">
-                    {{ props.channel.topic }}
-                </p>
-            </div>
-        </div>
+        <MastheadTitle
+            :channel="props.channel"
+            :members="props.members"
+            :presence-for="props.presenceFor"
+            :is-dnd-for="props.isDndFor"
+            :title="props.title"
+            :notification-status="props.notificationStatus"
+        />
 
         <div class="flex shrink-0 items-center gap-1 @2xl:gap-3 @2xl:pb-1">
-            <!-- Realtime connection cue: a quiet amber pill while reconnecting,
-                 flipping to a brief green confirmation once the socket recovers.
-                 The app stays fully usable throughout. Below the breakpoint the
-                 masthead has no room for it, so it hangs toast-style under the
-                 header (which anchors it) over the timeline instead of squeezing
-                 the flex row — pointer-events pass through, so it never blocks
-                 the first message row it floats over. -->
-            <span
-                v-if="props.connectionPill === 'reconnecting'"
-                data-test="connection-reconnecting"
-                role="status"
-                class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3.5 py-1.5 text-[13px] font-semibold text-amber-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-amber-900/50 dark:bg-amber-950 dark:text-amber-500 md:dark:bg-amber-950/40"
-            >
-                <span
-                    class="size-1.5 animate-pulse rounded-full bg-amber-500"
-                />
-                {{ $t('Reconnecting')
-                }}<span
-                    aria-hidden="true"
-                    class="inline-flex w-2.5 justify-start"
-                    ><span class="animate-pulse [animation-delay:0ms]">.</span
-                    ><span class="animate-pulse [animation-delay:200ms]">.</span
-                    ><span class="animate-pulse [animation-delay:400ms]"
-                        >.</span
-                    ></span
-                >
-            </span>
-            <span
-                v-else-if="props.connectionPill === 'back-online'"
-                data-test="connection-back-online"
-                role="status"
-                class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3.5 py-1.5 text-[13px] font-semibold text-emerald-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-emerald-900/50 dark:bg-emerald-950 dark:text-emerald-500 md:dark:bg-emerald-950/40"
-            >
-                <Check class="size-3" />
-                {{ $t('Back online') }}
-            </span>
+            <MastheadConnectionPill :pill="props.connectionPill" />
 
-            <span
-                v-if="
-                    !props.channel.isDirect &&
-                    mastheadAvatars.visible.length > 0
-                "
-                data-test="masthead-members"
-                class="hidden items-center gap-2 @2xl:flex"
-            >
-                <span class="flex -space-x-1.5">
-                    <!-- A bot in the roster squares its avatar (rounded-md vs a
-                         human's circle) and shows a glyph, so it reads as
-                         non-human even at this size — matching its message-row
-                         treatment. A bot has no presence, so it shows no dot. -->
-                    <span
-                        v-for="member in mastheadAvatars.visible"
-                        :key="member.id"
-                        class="relative size-6"
-                        :title="member.name"
-                        aria-hidden="true"
-                    >
-                        <Avatar
-                            class="size-6 text-[9px] ring-2 ring-card"
-                            :class="member.isBot ? 'rounded-md' : ''"
-                        >
-                            <AvatarImage
-                                v-if="member.avatar && !member.isBot"
-                                :src="member.avatar"
-                                :alt="member.name"
-                            />
-                            <AvatarFallback
-                                :class="
-                                    member.isBot
-                                        ? 'rounded-md bg-muted-foreground text-background'
-                                        : 'bg-primary/10 font-semibold text-primary'
-                                "
-                            >
-                                <Bot v-if="member.isBot" class="size-3" />
-                                <template v-else>{{
-                                    getInitials(member.name)
-                                }}</template>
-                            </AvatarFallback>
-                        </Avatar>
-                        <PresenceDot
-                            v-if="!member.isBot"
-                            data-test="masthead-member-presence"
-                            :presence="props.presenceFor(member.id)"
-                            :is-dnd="props.isDndFor?.(member.id) ?? false"
-                            surface-class="bg-card"
-                            size="24"
-                            class="ring-card"
-                        />
-                    </span>
-                    <span
-                        v-if="mastheadAvatars.overflow > 0"
-                        class="flex size-6 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-card select-none"
-                        aria-hidden="true"
-                    >
-                        +{{ mastheadAvatars.overflow }}
-                    </span>
-                </span>
-                <!-- The one readout of the facepile, and the only place the
-                     member count is spelled out — away counts as present but not
-                     active, so the two numbers can differ. -->
-                <span
-                    data-test="masthead-active-count"
-                    class="text-[11.5px] text-muted-foreground"
-                >
-                    {{
-                        $t(':active of :total active', {
-                            active: activeMemberCount,
-                            total: props.members.length,
-                        })
-                    }}
-                </span>
-            </span>
+            <!-- A DM is a fixed set, so the "who's in the channel" facepile is
+                 meaningless there and hidden. -->
+            <MastheadFacepile
+                v-if="!props.channel.isDirect"
+                :members="props.members"
+                :presence-for="props.presenceFor"
+                :is-dnd-for="props.isDndFor"
+            />
 
             <!-- Add people: opens the picker that grows this DM into (or reuses)
                  a group conversation. Only shown to a member of a DM. Below the
@@ -552,121 +199,23 @@ const hasActivityReadout = computed(
                 <Search class="size-4" />
             </Button>
 
-            <DropdownMenu
-                v-if="
-                    props.canManagePreferences ||
-                    props.canArchive ||
-                    props.canLeave
+            <MastheadOptionsMenu
+                :is-direct="props.channel.isDirect"
+                :can-manage-preferences="props.canManagePreferences"
+                :can-archive="props.canArchive"
+                :can-leave="props.canLeave"
+                :notification-levels="props.notificationLevels"
+                :starred="props.starred"
+                :muted="props.muted"
+                :notification-level="props.notificationLevel"
+                @toggle-star="emit('toggleStar')"
+                @notification-level-change="
+                    (value) => emit('notificationLevelChange', value)
                 "
-            >
-                <DropdownMenuTrigger as-child>
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        :aria-label="$t('Channel options')"
-                        data-test="channel-options"
-                        class="-mr-2 size-9 rounded text-muted-foreground hover:bg-muted hover:text-foreground @2xl:mr-0 @2xl:size-auto @2xl:p-1"
-                    >
-                        <EllipsisVertical class="size-4" />
-                    </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" class="w-56">
-                    <template v-if="props.canManagePreferences">
-                        <!-- Starring files a channel into the sidebar's "Starred"
-                             group; DMs live in their own fixed group and are never
-                             filed, so the affordance is hidden for them. -->
-                        <DropdownMenuItem
-                            v-if="!props.channel.isDirect"
-                            data-test="star-channel"
-                            :aria-pressed="props.starred"
-                            @select="
-                                (event: Event) => {
-                                    event.preventDefault();
-                                    emit('toggleStar');
-                                }
-                            "
-                        >
-                            <Star
-                                :class="
-                                    props.starred
-                                        ? 'fill-current text-amber-500'
-                                        : ''
-                                "
-                            />
-                            {{
-                                props.starred
-                                    ? $t('Unstar channel')
-                                    : $t('Star channel')
-                            }}
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator v-if="!props.channel.isDirect" />
-                        <DropdownMenuLabel
-                            class="text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
-                        >
-                            {{ $t('Notifications') }}
-                        </DropdownMenuLabel>
-                        <DropdownMenuRadioGroup
-                            :model-value="props.notificationLevel"
-                            @update:model-value="
-                                (value) =>
-                                    emit('notificationLevelChange', value)
-                            "
-                        >
-                            <DropdownMenuRadioItem
-                                v-for="level in props.notificationLevels"
-                                :key="level.value"
-                                :value="level.value"
-                                :data-test="`notification-level-${level.value}`"
-                            >
-                                {{ level.label }}
-                            </DropdownMenuRadioItem>
-                        </DropdownMenuRadioGroup>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuCheckboxItem
-                            :model-value="props.muted"
-                            data-test="mute-channel"
-                            @update:model-value="
-                                (value) => emit('muteChange', value)
-                            "
-                            @select="(event: Event) => event.preventDefault()"
-                        >
-                            {{ $t('Mute channel') }}
-                        </DropdownMenuCheckboxItem>
-                    </template>
-                    <template v-if="props.canArchive">
-                        <DropdownMenuSeparator
-                            v-if="props.canManagePreferences"
-                        />
-                        <DropdownMenuItem
-                            data-test="archive-channel"
-                            class="text-destructive-text focus:text-destructive-text"
-                            @select="emit('archive')"
-                        >
-                            <Archive class="size-4" />
-                            {{ $t('Archive channel') }}
-                        </DropdownMenuItem>
-                    </template>
-                    <template v-if="props.canLeave">
-                        <DropdownMenuSeparator
-                            v-if="
-                                props.canManagePreferences || props.canArchive
-                            "
-                        />
-                        <DropdownMenuItem
-                            data-test="leave-channel"
-                            class="text-destructive-text focus:text-destructive-text"
-                            @select="emit('leave')"
-                        >
-                            <LogOut class="size-4" />
-                            {{
-                                props.channel.isDirect
-                                    ? $t('Leave conversation')
-                                    : $t('Leave channel')
-                            }}
-                        </DropdownMenuItem>
-                    </template>
-                </DropdownMenuContent>
-            </DropdownMenu>
+                @mute-change="(value) => emit('muteChange', value)"
+                @archive="emit('archive')"
+                @leave="emit('leave')"
+            />
         </div>
     </header>
 </template>

--- a/resources/js/components/channel/MastheadConnectionPill.vue
+++ b/resources/js/components/channel/MastheadConnectionPill.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { Check } from '@lucide/vue';
+import type { ConnectionPill } from '@/composables/useConnectionState';
+
+/**
+ * The realtime connection cue: a reconnecting pill, a transient back-online
+ * confirmation, or nothing when the socket is steadily connected.
+ */
+const props = defineProps<{
+    pill?: ConnectionPill;
+}>();
+</script>
+
+<template>
+    <!-- A quiet amber pill while reconnecting, flipping to a brief green
+         confirmation once the socket recovers. The app stays fully usable
+         throughout. Below the breakpoint the masthead has no room for it, so it
+         hangs toast-style under the header (which anchors it) over the timeline
+         instead of squeezing the flex row — pointer-events pass through, so it
+         never blocks the first message row it floats over. -->
+    <span
+        v-if="props.pill === 'reconnecting'"
+        data-test="connection-reconnecting"
+        role="status"
+        class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3.5 py-1.5 text-[13px] font-semibold text-amber-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-amber-900/50 dark:bg-amber-950 dark:text-amber-500 md:dark:bg-amber-950/40"
+    >
+        <span class="size-1.5 animate-pulse rounded-full bg-amber-500" />
+        {{ $t('Reconnecting')
+        }}<span aria-hidden="true" class="inline-flex w-2.5 justify-start"
+            ><span class="animate-pulse [animation-delay:0ms]">.</span
+            ><span class="animate-pulse [animation-delay:200ms]">.</span
+            ><span class="animate-pulse [animation-delay:400ms]">.</span></span
+        >
+    </span>
+    <span
+        v-else-if="props.pill === 'back-online'"
+        data-test="connection-back-online"
+        role="status"
+        class="pointer-events-none absolute top-full left-1/2 mt-2 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-3.5 py-1.5 text-[13px] font-semibold text-emerald-700 shadow-md md:static md:mt-0 md:translate-x-0 md:px-2.5 md:py-1 md:text-[11.5px] md:shadow-none dark:border-emerald-900/50 dark:bg-emerald-950 dark:text-emerald-500 md:dark:bg-emerald-950/40"
+    >
+        <Check class="size-3" />
+        {{ $t('Back online') }}
+    </span>
+</template>

--- a/resources/js/components/channel/MastheadFacepile.vue
+++ b/resources/js/components/channel/MastheadFacepile.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { Bot } from '@lucide/vue';
+import { computed } from 'vue';
+import PresenceDot from '@/components/PresenceDot.vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { getInitials } from '@/composables/useInitials';
+import { MAX_MASTHEAD_AVATARS, memberAvatarStack } from '@/lib/memberAvatars';
+import { activeMemberCount } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
+import type { Mention } from '@/types';
+
+/**
+ * The channel roster's overlapping avatars and its one activity readout. A DM
+ * is a fixed set, so its masthead renders no facepile at all.
+ */
+const props = defineProps<{
+    /**
+     * The team roster the page already carries for the composer, reused for the
+     * overlapping member facepile.
+     */
+    members: Mention[];
+    /** How each team member reads on the presence roster, driving every dot here. */
+    presenceFor: (userId: string) => RenderedPresence;
+    /** Whether each member is in do-not-disturb, driving the crescent badge. */
+    isDndFor?: (userId: string) => boolean;
+}>();
+
+/** The overlapping member avatars for the masthead's right side. */
+const mastheadAvatars = computed(() =>
+    memberAvatarStack(props.members, MAX_MASTHEAD_AVATARS),
+);
+
+/** How many of the roster are active, as the readout beside the stack says. */
+const activeCount = computed(() =>
+    activeMemberCount(props.members, props.presenceFor),
+);
+</script>
+
+<template>
+    <span
+        v-if="mastheadAvatars.visible.length > 0"
+        data-test="masthead-members"
+        class="hidden items-center gap-2 @2xl:flex"
+    >
+        <span class="flex -space-x-1.5">
+            <!-- A bot in the roster squares its avatar (rounded-md vs a
+                 human's circle) and shows a glyph, so it reads as
+                 non-human even at this size — matching its message-row
+                 treatment. A bot has no presence, so it shows no dot. -->
+            <span
+                v-for="member in mastheadAvatars.visible"
+                :key="member.id"
+                class="relative size-6"
+                :title="member.name"
+                aria-hidden="true"
+            >
+                <Avatar
+                    class="size-6 text-[9px] ring-2 ring-card"
+                    :class="member.isBot ? 'rounded-md' : ''"
+                >
+                    <AvatarImage
+                        v-if="member.avatar && !member.isBot"
+                        :src="member.avatar"
+                        :alt="member.name"
+                    />
+                    <AvatarFallback
+                        :class="
+                            member.isBot
+                                ? 'rounded-md bg-muted-foreground text-background'
+                                : 'bg-primary/10 font-semibold text-primary'
+                        "
+                    >
+                        <Bot v-if="member.isBot" class="size-3" />
+                        <template v-else>{{
+                            getInitials(member.name)
+                        }}</template>
+                    </AvatarFallback>
+                </Avatar>
+                <PresenceDot
+                    v-if="!member.isBot"
+                    data-test="masthead-member-presence"
+                    :presence="props.presenceFor(member.id)"
+                    :is-dnd="props.isDndFor?.(member.id) ?? false"
+                    surface-class="bg-card"
+                    size="24"
+                    class="ring-card"
+                />
+            </span>
+            <span
+                v-if="mastheadAvatars.overflow > 0"
+                class="flex size-6 items-center justify-center rounded-full bg-muted text-[9px] font-semibold text-muted-foreground ring-2 ring-card select-none"
+                aria-hidden="true"
+            >
+                +{{ mastheadAvatars.overflow }}
+            </span>
+        </span>
+        <!-- The one readout of the facepile, and the only place the
+             member count is spelled out — away counts as present but not
+             active, so the two numbers can differ. -->
+        <span
+            data-test="masthead-active-count"
+            class="text-[11.5px] text-muted-foreground"
+        >
+            {{
+                $t(':active of :total active', {
+                    active: activeCount,
+                    total: props.members.length,
+                })
+            }}
+        </span>
+    </span>
+</template>

--- a/resources/js/components/channel/MastheadOptionsMenu.vue
+++ b/resources/js/components/channel/MastheadOptionsMenu.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { Archive, EllipsisVertical, LogOut, Star } from '@lucide/vue';
+import type { AcceptableValue } from 'reka-ui';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuCheckboxItem,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import type { NotificationLevel, NotificationLevelOption } from '@/types';
+
+/**
+ * The masthead's kebab menu: the viewer's own preferences for this
+ * conversation, then the two ways out of it. Each section only appears for a
+ * viewer allowed that much, and the menu itself stays away when none of them
+ * are.
+ */
+const props = defineProps<{
+    /**
+     * Whether this conversation is a direct message. A DM is never filed into
+     * the sidebar's "Starred" group, and it is left rather than departed.
+     */
+    isDirect: boolean;
+    canManagePreferences: boolean;
+    canArchive: boolean;
+    /**
+     * Whether the viewer may leave the channel — a member of a standard channel
+     * that isn't #general, or of a group DM.
+     */
+    canLeave: boolean;
+    notificationLevels: NotificationLevelOption[];
+    starred: boolean;
+    muted: boolean;
+    notificationLevel: NotificationLevel;
+}>();
+
+const emit = defineEmits<{
+    toggleStar: [];
+    notificationLevelChange: [value: AcceptableValue];
+    muteChange: [value: boolean];
+    archive: [];
+    leave: [];
+}>();
+</script>
+
+<template>
+    <DropdownMenu
+        v-if="props.canManagePreferences || props.canArchive || props.canLeave"
+    >
+        <DropdownMenuTrigger as-child>
+            <Button
+                variant="ghost"
+                size="icon"
+                :aria-label="$t('Channel options')"
+                data-test="channel-options"
+                class="-mr-2 size-9 rounded text-muted-foreground hover:bg-muted hover:text-foreground @2xl:mr-0 @2xl:size-auto @2xl:p-1"
+            >
+                <EllipsisVertical class="size-4" />
+            </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" class="w-56">
+            <template v-if="props.canManagePreferences">
+                <!-- Starring files a channel into the sidebar's "Starred"
+                     group; DMs live in their own fixed group and are never
+                     filed, so the affordance is hidden for them. -->
+                <DropdownMenuItem
+                    v-if="!props.isDirect"
+                    data-test="star-channel"
+                    :aria-pressed="props.starred"
+                    @select="
+                        (event: Event) => {
+                            event.preventDefault();
+                            emit('toggleStar');
+                        }
+                    "
+                >
+                    <Star
+                        :class="
+                            props.starred ? 'fill-current text-amber-500' : ''
+                        "
+                    />
+                    {{
+                        props.starred
+                            ? $t('Unstar channel')
+                            : $t('Star channel')
+                    }}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator v-if="!props.isDirect" />
+                <DropdownMenuLabel
+                    class="text-[11px] font-semibold tracking-[0.06em] text-muted-foreground uppercase"
+                >
+                    {{ $t('Notifications') }}
+                </DropdownMenuLabel>
+                <DropdownMenuRadioGroup
+                    :model-value="props.notificationLevel"
+                    @update:model-value="
+                        (value) => emit('notificationLevelChange', value)
+                    "
+                >
+                    <DropdownMenuRadioItem
+                        v-for="level in props.notificationLevels"
+                        :key="level.value"
+                        :value="level.value"
+                        :data-test="`notification-level-${level.value}`"
+                    >
+                        {{ level.label }}
+                    </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuCheckboxItem
+                    :model-value="props.muted"
+                    data-test="mute-channel"
+                    @update:model-value="(value) => emit('muteChange', value)"
+                    @select="(event: Event) => event.preventDefault()"
+                >
+                    {{ $t('Mute channel') }}
+                </DropdownMenuCheckboxItem>
+            </template>
+            <template v-if="props.canArchive">
+                <DropdownMenuSeparator v-if="props.canManagePreferences" />
+                <DropdownMenuItem
+                    data-test="archive-channel"
+                    class="text-destructive-text focus:text-destructive-text"
+                    @select="emit('archive')"
+                >
+                    <Archive class="size-4" />
+                    {{ $t('Archive channel') }}
+                </DropdownMenuItem>
+            </template>
+            <template v-if="props.canLeave">
+                <DropdownMenuSeparator
+                    v-if="props.canManagePreferences || props.canArchive"
+                />
+                <DropdownMenuItem
+                    data-test="leave-channel"
+                    class="text-destructive-text focus:text-destructive-text"
+                    @select="emit('leave')"
+                >
+                    <LogOut class="size-4" />
+                    {{
+                        props.isDirect
+                            ? $t('Leave conversation')
+                            : $t('Leave channel')
+                    }}
+                </DropdownMenuItem>
+            </template>
+        </DropdownMenuContent>
+    </DropdownMenu>
+</template>

--- a/resources/js/components/channel/MastheadTitle.vue
+++ b/resources/js/components/channel/MastheadTitle.vue
@@ -1,0 +1,225 @@
+<script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
+import { Archive } from '@lucide/vue';
+import { computed } from 'vue';
+import AvatarStack from '@/components/AvatarStack.vue';
+import PresenceDot from '@/components/PresenceDot.vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { getInitials } from '@/composables/useInitials';
+import { MAX_MASTHEAD_AVATARS } from '@/lib/memberAvatars';
+import type { NotificationIndicator } from '@/lib/notificationIndicator';
+import {
+    activeMemberCount,
+    dmParticipantPresence,
+    presenceLabelKey,
+} from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
+import type { Channel, Mention } from '@/types';
+
+/**
+ * What the masthead calls the conversation it heads: its avatar treatment, its
+ * name, the notification cue beside it, and the sub-lines under it.
+ */
+const props = defineProps<{
+    channel: Channel;
+    /** The team roster, which the activity readout counts. */
+    members: Mention[];
+    /** How each team member reads on the presence roster. */
+    presenceFor: (userId: string) => RenderedPresence;
+    /** Whether each member is in do-not-disturb, driving the crescent badge. */
+    isDndFor?: (userId: string) => boolean;
+    /**
+     * The viewer-relative title (self-DM reads "You"); the page also feeds it to
+     * `<Head>`, so it is resolved once there and passed down.
+     */
+    title: string;
+    /** A compact header cue for a non-default notification state, or null. */
+    notificationStatus: NotificationIndicator | null;
+}>();
+
+const page = usePage();
+
+/** The other participant of a 1:1 DM, whose avatar the masthead shows. */
+const dmParticipant = computed(() => props.channel.dmParticipants?.[0] ?? null);
+
+/**
+ * The avatar image for the 1:1 masthead: the other participant's, or — in a
+ * self-DM, which has no other participant — the viewer's own. Null (so the
+ * initials fallback shows) when that person has no avatar.
+ */
+const dmAvatar = computed(() =>
+    dmParticipant.value
+        ? (dmParticipant.value.avatar ?? null)
+        : (page.props.auth.user.avatar ?? null),
+);
+
+/**
+ * A 1:1 DM renders viewer-relative: the other participant's presence dot follows
+ * the team roster.
+ */
+const dmPresence = computed<RenderedPresence>(() =>
+    dmParticipantPresence(
+        props.channel.dmUserId,
+        props.presenceFor,
+        page.props.auth.user.presence,
+    ),
+);
+
+/** Whether the 1:1 counterpart shows the crescent DND badge. */
+const dmDnd = computed(
+    () =>
+        props.channel.dmUserId != null &&
+        (props.isDndFor?.(props.channel.dmUserId) ?? false),
+);
+
+/** How many of the roster are active, for the compact activity readout. */
+const activeCount = computed(() =>
+    activeMemberCount(props.members, props.presenceFor),
+);
+
+/** The group's participant count, including the viewer, for the subtitle. */
+const groupParticipantCount = computed(
+    () => (props.channel.dmParticipants?.length ?? 0) + 1,
+);
+
+/**
+ * Whether the masthead has an activity readout to show.
+ *
+ * Below the breakpoint there is no room for the facepile, so its readout stands
+ * in for it on its own sub-line under the channel name — the same numbers the
+ * avatars carry on a wide viewport, in the space a phone actually has.
+ */
+const hasActivityReadout = computed(
+    () => !props.channel.isDirect && props.members.length > 0,
+);
+</script>
+
+<template>
+    <div class="min-w-0 flex-1">
+        <h1
+            class="flex items-center gap-2 truncate font-serif text-[22px] leading-none font-semibold tracking-[-0.02em] text-foreground @2xl:text-[32px]"
+        >
+            <!-- A group DM shows an avatar stack of its participants; a 1:1
+                 shows the other participant's avatar + presence dot; a
+                 standard channel shows the "#". The name is already
+                 viewer-relative (self reads "You"). -->
+            <AvatarStack
+                v-if="props.channel.isGroupDirect"
+                data-test="masthead-group-avatars"
+                :members="props.channel.dmParticipants ?? []"
+                :max="MAX_MASTHEAD_AVATARS"
+                size="md"
+                ring-class="ring-card"
+            />
+            <span
+                v-else-if="props.channel.isDirect"
+                data-test="masthead-dm-avatar"
+                class="relative inline-flex size-7 shrink-0"
+            >
+                <Avatar class="size-7" aria-hidden="true">
+                    <AvatarImage
+                        v-if="dmAvatar"
+                        :src="dmAvatar"
+                        :alt="props.title"
+                    />
+                    <AvatarFallback
+                        class="text-[11px] font-semibold text-primary"
+                    >
+                        {{ getInitials(props.channel.name) }}
+                    </AvatarFallback>
+                </Avatar>
+                <PresenceDot
+                    data-test="masthead-dm-presence"
+                    :presence="dmPresence"
+                    :is-dnd="dmDnd"
+                    surface-class="bg-card"
+                    size="28"
+                    class="ring-card"
+                />
+                <!-- Announced through a screen-reader-only label rather than
+                     an aria-label on the role-less dot, which assistive tech
+                     ignores on a bare <span>. -->
+                <span class="sr-only">{{
+                    dmDnd
+                        ? $t('Notifications paused')
+                        : $t(presenceLabelKey(dmPresence))
+                }}</span>
+            </span>
+            <span v-else class="text-brass italic">#</span>
+            <span class="truncate">{{ props.title }}</span>
+            <!-- The mute / notification-level indicator sits inline with the
+                 title so it reads as a property of this conversation rather
+                 than floating in the meta row (which is empty for a DM with
+                 no topic). -->
+            <Tooltip v-if="props.notificationStatus">
+                <TooltipTrigger as-child>
+                    <span
+                        data-test="notification-status"
+                        :data-status="props.notificationStatus.status"
+                        class="inline-flex shrink-0 items-center text-muted-foreground"
+                        :aria-label="$t(props.notificationStatus.label)"
+                    >
+                        <component
+                            :is="props.notificationStatus.icon"
+                            class="size-4"
+                        />
+                    </span>
+                </TooltipTrigger>
+                <TooltipContent>{{
+                    $t(props.notificationStatus.label)
+                }}</TooltipContent>
+            </Tooltip>
+        </h1>
+
+        <!-- The facepile's readout, standing in for the avatars below the
+             breakpoint where they don't fit. Same numbers, one line down. -->
+        <p
+            v-if="hasActivityReadout"
+            data-test="masthead-compact-activity"
+            class="mt-1 truncate text-[11.5px] text-muted-foreground @2xl:hidden"
+        >
+            {{
+                $t(':active of :total active', {
+                    active: activeCount,
+                    total: props.members.length,
+                })
+            }}
+        </p>
+
+        <!-- A group DM's subtitle names how many people are in the
+             conversation, the viewer included. -->
+        <p
+            v-if="props.channel.isGroupDirect"
+            data-test="masthead-group-count"
+            class="mt-1 text-[13px] text-muted-foreground"
+        >
+            {{
+                $t(':count participants, including you', {
+                    count: groupParticipantCount,
+                })
+            }}
+        </p>
+
+        <div
+            v-if="props.channel.isArchived || props.channel.topic"
+            class="mt-1.5 flex items-center gap-2 text-[13px] text-muted-foreground"
+        >
+            <span
+                v-if="props.channel.isArchived"
+                class="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+            >
+                <Archive class="size-3" />
+                {{ $t('Archived') }}
+            </span>
+
+            <p v-if="props.channel.topic" class="min-w-0 truncate">
+                {{ props.channel.topic }}
+            </p>
+        </div>
+    </div>
+</template>

--- a/resources/js/composables/useMastheadSearch.ts
+++ b/resources/js/composables/useMastheadSearch.ts
@@ -1,0 +1,51 @@
+import type { Ref } from 'vue';
+import { useSidebar } from '@/components/ui/sidebar';
+import { useIsMobile } from '@/composables/useIsMobile';
+import { useNavPanel } from '@/composables/useNavPanel';
+import { useQuickSwitcher } from '@/composables/useQuickSwitcher';
+
+export interface MastheadSearch {
+    /**
+     * Whether the viewport is below the breakpoint. It decides where the glyph
+     * sends the viewer, and it is the same answer the masthead's controls fold
+     * on, so they read it from here rather than asking a second time.
+     */
+    isMobile: Ref<boolean>;
+    openSearch: () => void;
+}
+
+/**
+ * Where the masthead's search glyph sends the viewer.
+ *
+ * Below the breakpoint it is the jump-to overlay's entry point (m5): a phone
+ * has no ⌘K, and the overlay leads on to the Search panel via its message
+ * results. From `md` up, search is a dock destination, so the glyph swaps the
+ * panel rather than navigating anywhere — the channel it was pressed from stays
+ * open behind it. A collapsed dock is expanded first, or the click would pin
+ * `?nav=search` on a panel nobody can see.
+ *
+ * The two behaviours share one control rather than a `v-if` pair: one button,
+ * one selector, and no chance of the pair disagreeing about which is rendered.
+ */
+export function useMastheadSearch(): MastheadSearch {
+    const isMobile = useIsMobile();
+    const { open: openQuickSwitcher } = useQuickSwitcher();
+    const { openDestination } = useNavPanel();
+    const { open: dockOpen, setOpen: setDockOpen } = useSidebar();
+
+    function openSearch(): void {
+        if (isMobile.value) {
+            openQuickSwitcher();
+
+            return;
+        }
+
+        if (!dockOpen.value) {
+            setDockOpen(true);
+        }
+
+        openDestination('search');
+    }
+
+    return { isMobile, openSearch };
+}

--- a/resources/js/lib/memberAvatars.ts
+++ b/resources/js/lib/memberAvatars.ts
@@ -13,6 +13,13 @@ export type StackMember = {
 };
 
 /**
+ * How many member avatars a channel masthead shows before collapsing the rest
+ * into a single "+N" overflow chip. Read by both of the masthead's stacks — a
+ * group DM's participants and a channel's roster facepile — which must agree.
+ */
+export const MAX_MASTHEAD_AVATARS = 3;
+
+/**
  * The overlapping member avatars: the first `max` members render as circles and
  * the remainder collapse into a single `+N` overflow chip.
  */

--- a/resources/js/lib/presence.ts
+++ b/resources/js/lib/presence.ts
@@ -23,6 +23,22 @@ export function dmParticipantPresence(
 }
 
 /**
+ * How many of a roster are active right now.
+ *
+ * Away counts as present but not active, which is the whole point of the third
+ * state: the readout answers "who could answer me now", not "who has the tab
+ * open". Shared by the masthead's facepile and the compact readout that stands
+ * in for it below the breakpoint, which must never disagree.
+ */
+export function activeMemberCount(
+    members: Array<{ id: string }>,
+    presenceFor: (userId: string) => RenderedPresence,
+): number {
+    return members.filter((member) => presenceFor(member.id) === 'active')
+        .length;
+}
+
+/**
  * The message key announcing a presence to assistive tech.
  *
  * Returned untranslated so the caller resolves it through `$t` and the label


### PR DESCRIPTION
Closes #989. Fourth child of #980.

`ChannelMasthead.vue` goes from **672 to 221 raw lines** — **563 to 178** as `max-lines`
counts them, against the 400 cap. Its entry is gone from the exemption block in
`eslint.config.js`, so `max-lines-policy.test.ts` now holds the file to the cap like any
other.

The masthead renders differently on desktop and mobile and for channels versus DMs, and
every one of those variants was spelled out inline: ~445 lines of template holding the
title zone, the connection cue, the presence facepile, the controls and the options menu
in one scope. They move out along the seams that were already there.

## Covered first, against the current code

The file had one colocated suite (the connection pill's mobile overlay) and a handful of
browser tests touching four of its selectors, so a pure move had almost nothing watching
it. Two suites land ahead of the split and pin what it may not change:

| Suite | Holds |
| --- | --- |
| `ChannelMasthead.identity.test.ts` | The three avatar treatments and their fallbacks (participant avatar, initials, the viewer's own in a self-DM), the DND announcement, the group stack and participant count, the notification cue, the compact activity readout, the archived badge and topic |
| `ChannelMasthead.actions.test.ts` | The facepile (three avatars + `+N`, the bot treatment, the active-vs-roster count), add-people / pins / search on both sides of the breakpoint, and every branch of the options menu **with what each one emits** |

A child that forgets to re-emit is exactly what this kind of move risks, so the menu's
stubs are not inert: each item reduces to the one gesture that fires the handler the
masthead bound to it. Both suites were mutation-checked against the pre-split file (a
renamed selector, a swapped emit and a changed string each turn them red).

## What moved

| New file | Lines | What it holds |
| --- | ---: | --- |
| `components/channel/MastheadTitle.vue` | 177 | The avatar treatment, the name, the notification cue, and the three sub-lines under them |
| `components/channel/MastheadOptionsMenu.vue` | 138 | The kebab menu's three sections and their permissions |
| `components/channel/MastheadFacepile.vue` | 96 | The roster stack and its one readout |
| `components/channel/MastheadConnectionPill.vue` | 38 | The two socket cues and their overlay placement |
| `composables/useMastheadSearch.ts` | 26 | Where the search glyph sends the viewer, and the breakpoint the controls fold on |

`MAX_MASTHEAD_AVATARS` moves to `lib/memberAvatars` and the active-member count to
`lib/presence`, so the two stacks — and the two readouts that must agree — cannot drift
apart now that they live in different files.

## Parity

Pure refactor. Every `data-test` selector, every string and every `aria-*` survives
verbatim; no `lang/fr.json` key is added, moved or changed.

Beyond the suites, the masthead was rendered in a real browser on the pre-split and
post-split builds and its DOM hashed: **byte-identical** (7925 chars, `ec185604`), and the
same for the open options menu (5647, `1b9a532`). The browser tests that touch it pass
unchanged — `PresenceFacepileTest`, `MobileMastheadAddPeopleTest`, `MobileThreadPanelTest`,
`MobileQuickSwitcherTest` — as do the axe audits `A11ySearchTest`, `A11yTimelineTest`,
`A11yShellTest` and `A11yAuditTest`. The demo team carries no DMs, so the DM variants are
covered by the new vitest suites rather than that browser diff.

One comment was trimmed rather than moved verbatim: the sentence explaining why a DM hides
the facepile now sits where the facepile is gated, instead of on a computed in
`MastheadTitle` that no longer decides it.

## Gates

`sail composer test` at `Total: 100.0 %` (Pint, PHPStan and Rector clean), and
`lint:check` / `format:check` / `types:check` / `test:js` (198 files, 2058 tests) /
`build` all green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787866333&installation_model_id=428379&pr_number=1028&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1028&signature=90388335a3ac53d0dd5df33c7af4758ee37bceb86c4363eccdc89611567762d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->