### PR TITLE
refactor: split the user groups page (pages/teams/Groups.vue)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -258,7 +258,6 @@ export default defineConfigWithVueTs(
             'resources/js/layouts/MainLayout.vue',
             'resources/js/pages/teams/Analytics.vue',
             'resources/js/pages/teams/AuditExports.vue',
-            'resources/js/pages/teams/Groups.vue',
         ],
         rules: {
             'max-lines': 'off',

--- a/resources/js/components/teams/CreateUserGroupForm.vue
+++ b/resources/js/components/teams/CreateUserGroupForm.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { Plus, Users } from '@lucide/vue';
+import FormField from '@/components/FormField.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { store } from '@/routes/teams/groups';
+
+const props = defineProps<{
+    /** The workspace slug the new group belongs to. */
+    team: string;
+}>();
+
+const form = useForm({ name: '', slug: '' });
+
+function submit(): void {
+    form.post(store(props.team).url, {
+        preserveScroll: true,
+        onSuccess: () => form.reset(),
+    });
+}
+</script>
+
+<template>
+    <form
+        data-test="group-create-form"
+        class="flex flex-col gap-3 rounded-xl border border-dashed border-border p-4 sm:flex-row sm:items-start"
+        @submit.prevent="submit"
+    >
+        <div
+            class="flex size-10 shrink-0 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground"
+        >
+            <Users class="size-4" />
+        </div>
+        <div class="flex flex-1 flex-col gap-3">
+            <div class="flex flex-col gap-1">
+                <span class="text-sm font-semibold">{{
+                    $t('Create a group')
+                }}</span>
+                <span class="text-xs text-muted-foreground">{{
+                    $t(
+                        'The handle is what people type after @. Leave it blank to derive it from the name.',
+                    )
+                }}</span>
+            </div>
+            <!-- The row heading above names the pair, so each field's own
+                 label is hidden rather than repeated. It stays a real
+                 `<label for>` all the same: a placeholder disappears the
+                 moment someone types, which leaves the field unnamed
+                 exactly when they might look for the name again.
+
+                 The error's space is not reserved here. These cells are
+                 narrow enough that a message wraps to three lines, and the
+                 row is the last thing in the card — so drawn out of flow it
+                 would run past the card's own border, and there is nothing
+                 below it to be pushed around by letting it grow instead. -->
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
+                <FormField
+                    :label="$t('Group name')"
+                    label-class="sr-only"
+                    :error="form.errors.name"
+                    :reserve="false"
+                    v-slot="{ id }"
+                >
+                    <Input
+                        :id="id"
+                        v-model="form.name"
+                        data-test="group-name-input"
+                        :placeholder="$t('Dev Team')"
+                        class="max-md:h-11 sm:w-56"
+                        autocomplete="off"
+                    />
+                </FormField>
+                <FormField
+                    :label="$t('Group handle')"
+                    label-class="sr-only"
+                    :error="form.errors.slug"
+                    :reserve="false"
+                    v-slot="{ id }"
+                >
+                    <Input
+                        :id="id"
+                        v-model="form.slug"
+                        data-test="group-slug-input"
+                        placeholder="@dev-team"
+                        class="font-mono max-md:h-11 sm:w-48"
+                        autocapitalize="off"
+                        autocomplete="off"
+                        spellcheck="false"
+                    />
+                </FormField>
+                <Button
+                    type="submit"
+                    data-test="group-create-button"
+                    class="rounded-full max-md:h-11"
+                    :disabled="form.processing"
+                >
+                    <Plus class="size-4" /> {{ $t('Create') }}
+                </Button>
+            </div>
+        </div>
+    </form>
+</template>

--- a/resources/js/components/teams/DeleteUserGroupDialog.vue
+++ b/resources/js/components/teams/DeleteUserGroupDialog.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { destroy } from '@/routes/teams/groups';
+
+type UserGroup = App.Data.UserGroupData;
+
+const props = defineProps<{
+    /** The workspace slug the group belongs to. */
+    team: string;
+}>();
+
+/** The group awaiting confirmation, or `null` while the dialog is closed. */
+const pendingRemoval = defineModel<UserGroup | null>('group', {
+    default: null,
+});
+
+const removalForm = useForm({});
+
+function confirmRemoval(): void {
+    const group = pendingRemoval.value;
+
+    if (group === null) {
+        return;
+    }
+
+    removalForm.delete(destroy({ team: props.team, group: group.id }).url, {
+        preserveScroll: true,
+        // Closed only once the delete lands: a failed request leaves the
+        // dialog open rather than dismissing it as though it had worked.
+        onSuccess: () => {
+            pendingRemoval.value = null;
+        },
+    });
+}
+</script>
+
+<template>
+    <Dialog
+        :open="pendingRemoval !== null"
+        @update:open="(open) => !open && (pendingRemoval = null)"
+    >
+        <DialogContent data-test="group-remove-dialog">
+            <DialogHeader>
+                <DialogTitle
+                    >{{
+                        $t('Delete @:handle?', {
+                            handle: pendingRemoval?.slug ?? '',
+                        })
+                    }}
+                </DialogTitle>
+                <DialogDescription>
+                    {{
+                        $t(
+                            'The group stops being mentionable and its handle becomes available again. Messages that already mentioned it show plain text, and the notifications they sent are unaffected.',
+                        )
+                    }}
+                </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+                <DialogClose as-child>
+                    <Button variant="outline" class="rounded-full">{{
+                        $t('Cancel')
+                    }}</Button>
+                </DialogClose>
+                <Button
+                    variant="destructive"
+                    class="rounded-full"
+                    data-test="group-remove-confirm"
+                    :disabled="removalForm.processing"
+                    @click="confirmRemoval"
+                >
+                    {{ $t('Delete group') }}
+                </Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/teams/EditUserGroupDialog.vue
+++ b/resources/js/components/teams/EditUserGroupDialog.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { ref, watch } from 'vue';
+import FormField from '@/components/FormField.vue';
+import UserGroupMembersEditor from '@/components/teams/UserGroupMembersEditor.vue';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { update } from '@/routes/teams/groups';
+
+type UserGroup = App.Data.UserGroupData;
+type Member = App.Data.UserData;
+
+const props = defineProps<{
+    /** The workspace slug the group belongs to. */
+    team: string;
+    /** Every group in the workspace, re-read from after each change. */
+    groups: UserGroup[];
+    /** Everyone in the workspace, offered to the member picker. */
+    members: Member[];
+}>();
+
+/** The group being edited, or `null` while the dialog is closed. */
+const editing = ref<UserGroup | null>(null);
+
+const editForm = useForm({ name: '', slug: '' });
+const memberSearch = ref('');
+
+function open(group: UserGroup): void {
+    editing.value = group;
+    editForm.defaults({ name: group.name, slug: group.slug });
+    editForm.reset();
+    editForm.clearErrors();
+    memberSearch.value = '';
+}
+
+defineExpose({ open });
+
+/**
+ * The editor renders off the `groups` prop, so after every membership change it
+ * has to re-read the freshly reloaded group rather than the stale snapshot it
+ * was opened with.
+ */
+watch(
+    () => props.groups,
+    (groups) => {
+        if (editing.value === null) {
+            return;
+        }
+
+        editing.value =
+            groups.find((group) => group.id === editing.value?.id) ?? null;
+    },
+);
+
+function submitRename(): void {
+    const group = editing.value;
+
+    if (group === null) {
+        return;
+    }
+
+    editForm.patch(update({ team: props.team, group: group.id }).url, {
+        preserveScroll: true,
+    });
+}
+</script>
+
+<template>
+    <Dialog
+        :open="editing !== null"
+        @update:open="(open) => !open && (editing = null)"
+    >
+        <DialogContent data-test="group-edit-dialog">
+            <DialogHeader>
+                <DialogTitle>{{ $t('Edit group') }}</DialogTitle>
+                <DialogDescription>
+                    {{
+                        $t(
+                            'Renaming a group never rewrites messages already sent. They keep the handle they were written with.',
+                        )
+                    }}
+                </DialogDescription>
+            </DialogHeader>
+
+            <form
+                class="flex flex-col gap-3 sm:flex-row sm:items-start"
+                data-test="group-rename-form"
+                @submit.prevent="submitRename"
+            >
+                <FormField
+                    :label="$t('Group name')"
+                    label-class="sr-only"
+                    :error="editForm.errors.name"
+                    class="flex-1"
+                    v-slot="{ id }"
+                >
+                    <Input
+                        :id="id"
+                        v-model="editForm.name"
+                        data-test="group-edit-name-input"
+                        autocomplete="off"
+                    />
+                </FormField>
+                <FormField
+                    :label="$t('Group handle')"
+                    label-class="sr-only"
+                    :error="editForm.errors.slug"
+                    class="flex-1"
+                    v-slot="{ id }"
+                >
+                    <Input
+                        :id="id"
+                        v-model="editForm.slug"
+                        data-test="group-edit-slug-input"
+                        class="font-mono"
+                        autocapitalize="off"
+                        autocomplete="off"
+                        spellcheck="false"
+                    />
+                </FormField>
+                <Button
+                    type="submit"
+                    class="rounded-full"
+                    data-test="group-rename-button"
+                    :disabled="editForm.processing"
+                >
+                    {{ $t('Save') }}
+                </Button>
+            </form>
+
+            <UserGroupMembersEditor
+                v-if="editing"
+                v-model:search="memberSearch"
+                :team="team"
+                :group="editing"
+                :members="members"
+            />
+
+            <DialogFooter>
+                <DialogClose as-child>
+                    <Button variant="outline" class="rounded-full">{{
+                        $t('Done')
+                    }}</Button>
+                </DialogClose>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/components/teams/UserGroupMembersEditor.vue
+++ b/resources/js/components/teams/UserGroupMembersEditor.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { useForm } from '@inertiajs/vue3';
+import { X } from '@lucide/vue';
+import { computed } from 'vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useInitials } from '@/composables/useInitials';
+import {
+    destroy as removeMember,
+    store as addMember,
+} from '@/routes/teams/groups/members';
+
+type UserGroup = App.Data.UserGroupData;
+type Member = App.Data.UserData;
+
+const props = defineProps<{
+    /** The workspace slug the group belongs to. */
+    team: string;
+    group: UserGroup;
+    /** Everyone in the workspace, before the search narrows them. */
+    members: Member[];
+}>();
+
+/**
+ * The picker's search. It belongs to the editor's owner, which clears it every
+ * time the editor is opened.
+ */
+const search = defineModel<string>('search', { default: '' });
+
+const { getInitials } = useInitials();
+
+const membershipForm = useForm<{ user_id: string }>({ user_id: '' });
+
+const candidates = computed<Member[]>(() => {
+    const already = new Set(props.group.members.map((member) => member.id));
+    const needle = search.value.trim().toLowerCase();
+
+    return props.members
+        .filter(
+            (member) =>
+                !already.has(member.id) &&
+                (needle === '' || member.name.toLowerCase().includes(needle)),
+        )
+        .slice(0, 8);
+});
+
+function addToGroup(member: Member): void {
+    membershipForm.user_id = member.id;
+    membershipForm.post(
+        addMember({ team: props.team, group: props.group.id }).url,
+        { preserveScroll: true, onSuccess: () => (search.value = '') },
+    );
+}
+
+function removeFromGroup(memberId: string): void {
+    membershipForm.delete(
+        removeMember({
+            team: props.team,
+            group: props.group.id,
+            user: memberId,
+        }).url,
+        { preserveScroll: true },
+    );
+}
+</script>
+
+<template>
+    <!-- The two blocks are a grid row each in the dialog they sit in, so the
+         wrapper repeats its gap rather than collapsing them into one row. -->
+    <div class="grid gap-4">
+        <div class="flex flex-col gap-2">
+            <span class="text-sm font-semibold">{{ $t('Members') }}</span>
+            <p
+                v-if="group.members.length === 0"
+                data-test="group-members-empty"
+                class="text-sm text-muted-foreground"
+            >
+                {{ $t('This group has no members yet.') }}
+            </p>
+            <ul v-else class="flex flex-wrap gap-2">
+                <li
+                    v-for="member in group.members"
+                    :key="member.id"
+                    class="flex items-center gap-2 rounded-full border border-border py-1 pr-1 pl-2 text-sm"
+                    :data-test="`group-member-${member.id}`"
+                >
+                    <span
+                        class="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[8px] font-semibold text-primary"
+                        aria-hidden="true"
+                        >{{ getInitials(member.name) }}</span
+                    >
+                    <span class="truncate">{{ member.name }}</span>
+                    <Button
+                        variant="ghost"
+                        size="none"
+                        type="button"
+                        class="rounded-full p-1"
+                        :disabled="membershipForm.processing"
+                        :aria-label="
+                            $t('Remove :name from the group', {
+                                name: member.name,
+                            })
+                        "
+                        :data-test="`group-member-remove-${member.id}`"
+                        @click="removeFromGroup(member.id)"
+                    >
+                        <X class="size-3" />
+                    </Button>
+                </li>
+            </ul>
+        </div>
+
+        <div class="flex flex-col gap-2">
+            <Input
+                v-model="search"
+                data-test="group-member-search"
+                :placeholder="$t('Add a member')"
+                class="rounded-full"
+            />
+            <ul
+                v-if="candidates.length > 0"
+                class="flex flex-col gap-1"
+                data-test="group-member-candidates"
+            >
+                <li v-for="member in candidates" :key="member.id">
+                    <Button
+                        variant="ghost"
+                        type="button"
+                        class="w-full justify-start gap-2 rounded-lg text-sm"
+                        :disabled="membershipForm.processing"
+                        :data-test="`group-member-add-${member.id}`"
+                        @click="addToGroup(member)"
+                    >
+                        <span
+                            class="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[8px] font-semibold text-primary"
+                            aria-hidden="true"
+                            >{{ getInitials(member.name) }}</span
+                        >
+                        {{ member.name }}
+                    </Button>
+                </li>
+            </ul>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/teams/UserGroupsRack.vue
+++ b/resources/js/components/teams/UserGroupsRack.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import { Pencil, Search, Trash2, Users } from '@lucide/vue';
+import { computed, ref } from 'vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { translate } from '@/lib/i18n';
+
+type UserGroup = App.Data.UserGroupData;
+
+const props = defineProps<{
+    /** Every group in the workspace, before the search narrows them. */
+    groups: UserGroup[];
+    /** Whether the viewer may edit or delete a group. */
+    canManage: boolean;
+}>();
+
+defineEmits<{
+    /** A row asking for the editor on its own group. */
+    edit: [group: UserGroup];
+    /** A row asking for the deletion confirmation on its own group. */
+    remove: [group: UserGroup];
+}>();
+
+/** The row's member-count label, e.g. "3 members". */
+function memberCountLabel(group: UserGroup): string {
+    return group.membersCount === 1
+        ? translate(':count member', { count: group.membersCount })
+        : translate(':count members', { count: group.membersCount });
+}
+
+const search = ref('');
+const filteredGroups = computed<UserGroup[]>(() => {
+    const needle = search.value.trim().replace(/^@/, '').toLowerCase();
+
+    if (needle === '') {
+        return props.groups;
+    }
+
+    return props.groups.filter(
+        (group) =>
+            group.slug.includes(needle) ||
+            group.name.toLowerCase().includes(needle),
+    );
+});
+</script>
+
+<template>
+    <div class="flex flex-col gap-6">
+        <div class="relative">
+            <Search
+                class="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
+                v-model="search"
+                data-test="group-search"
+                :placeholder="$t('Search groups')"
+                class="rounded-full pl-9 max-md:h-11"
+            />
+        </div>
+
+        <p
+            v-if="filteredGroups.length === 0"
+            data-test="group-empty"
+            class="text-sm text-muted-foreground"
+        >
+            {{ $t('No user groups yet.') }}
+        </p>
+
+        <ul v-else class="space-y-2" data-test="group-list">
+            <li
+                v-for="group in filteredGroups"
+                :key="group.id"
+                class="flex items-center gap-3 rounded-xl border border-border bg-card p-3 max-md:flex-wrap"
+                :data-test="`group-row-${group.slug}`"
+            >
+                <div
+                    class="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground"
+                >
+                    <Users class="size-4" aria-hidden="true" />
+                </div>
+                <div class="flex min-w-0 flex-1 flex-col max-md:basis-3/5">
+                    <span
+                        class="truncate font-mono text-sm font-semibold text-foreground"
+                        >@{{ group.slug }}</span
+                    >
+                    <span class="truncate text-xs text-muted-foreground"
+                        >{{ group.name
+                        }}<span class="md:hidden">
+                            · {{ memberCountLabel(group) }}</span
+                        ></span
+                    >
+                </div>
+                <span
+                    class="w-28 shrink-0 text-xs text-muted-foreground max-md:hidden"
+                    >{{ memberCountLabel(group) }}</span
+                >
+                <!-- Icon actions rather than inline text links: the destructive
+                     token at 12px does not clear 4.5:1 on `bg-card` in the dark
+                     theme, while an icon only owes the 3:1 graphics threshold. -->
+                <div
+                    v-if="canManage"
+                    class="flex shrink-0 items-center gap-1 max-md:ml-auto"
+                >
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        type="button"
+                        :data-test="`group-edit-${group.slug}`"
+                        :aria-label="$t('Edit :name', { name: group.name })"
+                        class="shrink-0 rounded-full max-md:size-11"
+                        @click="$emit('edit', group)"
+                    >
+                        <Pencil class="size-4" />
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        type="button"
+                        :data-test="`group-remove-${group.slug}`"
+                        :aria-label="$t('Delete :name', { name: group.name })"
+                        class="shrink-0 rounded-full text-destructive-text max-md:size-11"
+                        @click="$emit('remove', group)"
+                    >
+                        <Trash2 class="size-4" />
+                    </Button>
+                </div>
+            </li>
+        </ul>
+    </div>
+</template>

--- a/resources/js/pages/teams/Groups.editor.test.ts
+++ b/resources/js/pages/teams/Groups.editor.test.ts
@@ -1,0 +1,335 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h, nextTick, ref } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Team } from '@/types';
+
+/**
+ * Covers the dialog a row's pencil opens, and the rename it carries — what the
+ * editor is seeded with, what it drops when it is reopened, and the request the
+ * form makes. Its membership half is pinned in `Groups.members.test.ts`. The
+ * page is mounted whole, so the same expectations hold before and after its
+ * sections move into components (#991).
+ */
+type FormFields = Record<string, unknown>;
+
+type RecordedForm = {
+    fields: string[];
+    form: FormFields & { errors: Record<string, string>; processing: boolean };
+};
+
+type RecordedRequest = {
+    /** The form that fired it, so a request identifies its own sender. */
+    form: RecordedForm['form'];
+    url: string;
+    options: { onSuccess?: () => void; preserveScroll?: boolean };
+};
+
+const inertia = vi.hoisted(() => ({
+    forms: [] as RecordedForm[],
+    posts: [] as RecordedRequest[],
+    patches: [] as RecordedRequest[],
+    deletes: [] as RecordedRequest[],
+}));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { defineComponent, reactive } = await import('vue');
+
+    return {
+        Head: defineComponent({ name: 'HeadStub', setup: () => () => null }),
+        useForm: (initial: Record<string, unknown>) => {
+            const fields = Object.keys(initial);
+            let defaults = structuredClone(initial);
+            const form = reactive({
+                ...structuredClone(initial),
+                errors: {} as Record<string, string>,
+                processing: false,
+                defaults(values: Record<string, unknown>) {
+                    defaults = structuredClone(values);
+                },
+                reset() {
+                    Object.assign(form, structuredClone(defaults));
+                },
+                clearErrors() {
+                    for (const key of Object.keys(form.errors)) {
+                        delete form.errors[key];
+                    }
+                },
+                post(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.posts.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+                patch(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.patches.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+                delete(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.deletes.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+            });
+
+            inertia.forms.push({ fields, form: form as RecordedForm['form'] });
+
+            return form;
+        },
+    };
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    const passthrough = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', { 'data-stub': name }, slots.default?.()),
+        });
+
+    return {
+        // Renders its content only while open, so a closed dialog is observably
+        // gone from the DOM the way the real overlay is.
+        Dialog: defineComponent({
+            name: 'DialogStub',
+            props: { open: { type: Boolean, default: false } },
+            emits: ['update:open'],
+            setup:
+                (props, { slots }) =>
+                () =>
+                    props.open
+                        ? h('div', { 'data-stub': 'Dialog' }, slots.default?.())
+                        : null,
+        }),
+        DialogClose: passthrough('DialogClose'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogFooter: passthrough('DialogFooter'),
+        DialogHeader: passthrough('DialogHeader'),
+        DialogTitle: passthrough('DialogTitle'),
+    };
+});
+
+import Groups from './Groups.vue';
+
+const team = {
+    id: 't1',
+    name: 'Acme',
+    slug: 'acme',
+    isPersonal: false,
+    membersCount: 3,
+    unreadCount: 0,
+    mentionCount: 0,
+} as Team;
+
+function group(
+    overrides: Partial<App.Data.UserGroupData> = {},
+): App.Data.UserGroupData {
+    return {
+        id: 'g1',
+        name: 'Dev Team',
+        slug: 'dev-team',
+        membersCount: 0,
+        members: [],
+        ...overrides,
+    };
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+/**
+ * Mounts the page with the `groups` prop held in a ref, so a test can push a
+ * fresh server payload the way a partial reload would.
+ */
+function mount(props: Record<string, unknown> = {}) {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const groups = ref((props.groups ?? []) as App.Data.UserGroupData[]);
+
+    const app = createApp({
+        render: () =>
+            h(Groups, {
+                team,
+                members: [],
+                permissions: { canManageUserGroups: true },
+                ...props,
+                groups: groups.value,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return { host, groups };
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+/** Types into a text input the way a person would, model binding included. */
+async function type(input: HTMLElement | null, value: string): Promise<void> {
+    (input as HTMLInputElement).value = value;
+    input?.dispatchEvent(new Event('input'));
+    await nextTick();
+}
+
+/** Marks every recorded form in flight, disabling whatever waits on one. */
+function markProcessing(): void {
+    for (const { form } of inertia.forms) {
+        form.processing = true;
+    }
+}
+
+/**
+ * The rename form, captured when the editor last opened. It declares the same
+ * two fields as the creation form, so it is told apart by the group the editor
+ * seeds it with rather than by the order the two were declared in.
+ */
+let renameForm: RecordedForm['form'];
+
+/** Opens the editor from the seeded group's pencil. */
+async function openEditor(host: HTMLElement): Promise<HTMLElement> {
+    find(host, 'group-edit-dev-team')?.click();
+    await nextTick();
+
+    const seeded = inertia.forms.find(
+        ({ fields, form }) =>
+            fields.length === 2 &&
+            fields.includes('name') &&
+            fields.includes('slug') &&
+            form.slug === 'dev-team',
+    );
+
+    expect(seeded, 'the editor seeded no rename form').toBeDefined();
+    renameForm = seeded!.form;
+
+    return find(host, 'group-edit-dialog')!;
+}
+
+beforeEach(() => {
+    inertia.forms = [];
+    inertia.posts = [];
+    inertia.patches = [];
+    inertia.deletes = [];
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('opening the editor', () => {
+    it('stays closed until a row asks for it', async () => {
+        const { host } = mount({ groups: [group()] });
+
+        expect(find(host, 'group-edit-dialog')).toBeNull();
+        expect(await openEditor(host)).not.toBeNull();
+    });
+
+    it('says a rename never rewrites the messages already sent', async () => {
+        const { host } = mount({ groups: [group()] });
+        const dialog = await openEditor(host);
+
+        expect(dialog.textContent).toContain('Edit group');
+        expect(dialog.textContent?.replace(/\s+/g, ' ')).toContain(
+            'Renaming a group never rewrites messages already sent. They keep the handle they were written with.',
+        );
+    });
+
+    it('fills the rename form with the group it was opened on', async () => {
+        const { host } = mount({ groups: [group()] });
+        await openEditor(host);
+
+        expect(find(host, 'group-edit-name-input')).toHaveProperty(
+            'value',
+            'Dev Team',
+        );
+        expect(find(host, 'group-edit-slug-input')).toHaveProperty(
+            'value',
+            'dev-team',
+        );
+    });
+
+    it('drops what was typed into the last edit, and its errors with it', async () => {
+        const { host } = mount({ groups: [group()] });
+        await openEditor(host);
+        await type(find(host, 'group-edit-name-input'), 'Half typed');
+        Object.assign(renameForm.errors, { name: 'Too short.' });
+        await type(find(host, 'group-member-search'), 'gra');
+
+        find(host, 'group-edit-dev-team')?.click();
+        await nextTick();
+
+        expect(find(host, 'group-edit-name-input')).toHaveProperty(
+            'value',
+            'Dev Team',
+        );
+        expect(renameForm.errors).toEqual({});
+        expect(find(host, 'group-member-search')).toHaveProperty('value', '');
+    });
+});
+
+describe('renaming a group', () => {
+    it('patches the group without losing the scroll', async () => {
+        const { host } = mount({ groups: [group()] });
+        await openEditor(host);
+
+        await type(find(host, 'group-edit-name-input'), 'Platform');
+        await type(find(host, 'group-edit-slug-input'), 'platform');
+
+        find(host, 'group-rename-form')?.dispatchEvent(
+            new Event('submit', { cancelable: true }),
+        );
+        await nextTick();
+
+        const patch = inertia.patches.at(-1)!;
+        expect(patch.url).toBe('/settings/teams/acme/groups/g1');
+        expect(patch.options.preserveScroll).toBe(true);
+        expect(renameForm.name).toBe('Platform');
+        expect(renameForm.slug).toBe('platform');
+    });
+
+    it('holds the save button while the request is in flight', async () => {
+        const { host } = mount({ groups: [group()] });
+        await openEditor(host);
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'group-rename-button')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+
+    it('shows the errors the server sent back', async () => {
+        const { host } = mount({ groups: [group()] });
+        const dialog = await openEditor(host);
+
+        Object.assign(renameForm.errors, {
+            name: 'The name field is required.',
+            slug: 'That handle is taken.',
+        });
+        await nextTick();
+
+        expect(dialog.textContent).toContain('The name field is required.');
+        expect(dialog.textContent).toContain('That handle is taken.');
+    });
+});

--- a/resources/js/pages/teams/Groups.list.test.ts
+++ b/resources/js/pages/teams/Groups.list.test.ts
@@ -1,0 +1,444 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h, nextTick } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Team } from '@/types';
+
+/**
+ * Covers the user-groups page's own surface — the creation form, the search
+ * box, the list of groups and the deletion confirmation. What is pinned here is
+ * the rendered markup and the request each form makes: every selector, every
+ * string, every guard deciding whether a piece renders at all. The page is
+ * mounted whole, so the same expectations hold before and after its sections
+ * move into components (#991).
+ */
+type FormFields = Record<string, unknown>;
+
+type RecordedForm = {
+    fields: string[];
+    form: FormFields & { errors: Record<string, string>; processing: boolean };
+};
+
+type RecordedRequest = {
+    /** The form that fired it, so a request identifies its own sender. */
+    form: RecordedForm['form'];
+    url: string;
+    options: { onSuccess?: () => void; preserveScroll?: boolean };
+};
+
+const inertia = vi.hoisted(() => ({
+    forms: [] as RecordedForm[],
+    posts: [] as RecordedRequest[],
+    patches: [] as RecordedRequest[],
+    deletes: [] as RecordedRequest[],
+}));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { defineComponent, reactive } = await import('vue');
+
+    return {
+        Head: defineComponent({ name: 'HeadStub', setup: () => () => null }),
+        useForm: (initial: Record<string, unknown>) => {
+            const fields = Object.keys(initial);
+            let defaults = structuredClone(initial);
+            const form = reactive({
+                ...structuredClone(initial),
+                errors: {} as Record<string, string>,
+                processing: false,
+                defaults(values: Record<string, unknown>) {
+                    defaults = structuredClone(values);
+                },
+                reset() {
+                    Object.assign(form, structuredClone(defaults));
+                },
+                clearErrors() {
+                    for (const key of Object.keys(form.errors)) {
+                        delete form.errors[key];
+                    }
+                },
+                post(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.posts.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+                patch(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.patches.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+                delete(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.deletes.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+            });
+
+            inertia.forms.push({ fields, form: form as RecordedForm['form'] });
+
+            return form;
+        },
+    };
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    const passthrough = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', { 'data-stub': name }, slots.default?.()),
+        });
+
+    return {
+        // Renders its content only while open, so a closed dialog is observably
+        // gone from the DOM the way the real overlay is.
+        Dialog: defineComponent({
+            name: 'DialogStub',
+            props: { open: { type: Boolean, default: false } },
+            emits: ['update:open'],
+            setup:
+                (props, { slots }) =>
+                () =>
+                    props.open
+                        ? h('div', { 'data-stub': 'Dialog' }, slots.default?.())
+                        : null,
+        }),
+        DialogClose: passthrough('DialogClose'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogFooter: passthrough('DialogFooter'),
+        DialogHeader: passthrough('DialogHeader'),
+        DialogTitle: passthrough('DialogTitle'),
+    };
+});
+
+import Groups from './Groups.vue';
+
+const team = {
+    id: 't1',
+    name: 'Acme',
+    slug: 'acme',
+    isPersonal: false,
+    membersCount: 3,
+    unreadCount: 0,
+    mentionCount: 0,
+} as Team;
+
+function group(
+    overrides: Partial<App.Data.UserGroupData> = {},
+): App.Data.UserGroupData {
+    return {
+        id: 'g1',
+        name: 'Dev Team',
+        slug: 'dev-team',
+        membersCount: 0,
+        members: [],
+        ...overrides,
+    };
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp({
+        render: () =>
+            h(Groups, {
+                team,
+                groups: [],
+                members: [],
+                permissions: { canManageUserGroups: true },
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return host;
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function text(host: HTMLElement, selector: string): string {
+    return find(host, selector)?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+/** Types into a text input the way a person would, model binding included. */
+async function type(input: HTMLElement | null, value: string): Promise<void> {
+    (input as HTMLInputElement).value = value;
+    input?.dispatchEvent(new Event('input'));
+    await nextTick();
+}
+
+/**
+ * Marks every recorded form in flight. The deletion form is declared with no
+ * fields at all, so there is nothing to tell it apart by — and a button that
+ * disables on the wrong form's `processing` would still be wrong against the
+ * request it fires, which each test asserts separately.
+ */
+function markProcessing(): void {
+    for (const { form } of inertia.forms) {
+        form.processing = true;
+    }
+}
+
+beforeEach(() => {
+    inertia.forms = [];
+    inertia.posts = [];
+    inertia.patches = [];
+    inertia.deletes = [];
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('the page heading', () => {
+    it('names the page and says what a group is for', () => {
+        const host = mount();
+
+        expect(host.textContent).toContain('User groups');
+        expect(host.textContent?.replace(/\s+/g, ' ')).toContain(
+            'Name a set of people so anyone in this workspace can notify them all with a single @mention',
+        );
+    });
+});
+
+describe('the creation form', () => {
+    it('asks for a name and a handle, and says where the handle is used', () => {
+        const host = mount();
+
+        expect(text(host, 'group-create-form')).toContain('Create a group');
+        expect(text(host, 'group-create-form')).toContain(
+            'The handle is what people type after @. Leave it blank to derive it from the name.',
+        );
+        expect(find(host, 'group-name-input')).not.toBeNull();
+        expect(find(host, 'group-slug-input')).not.toBeNull();
+    });
+
+    it('is withheld from someone who may not manage groups', () => {
+        const host = mount({ permissions: { canManageUserGroups: false } });
+
+        expect(find(host, 'group-create-form')).toBeNull();
+    });
+
+    it('posts the group without losing the scroll, then clears itself', async () => {
+        const host = mount();
+
+        await type(find(host, 'group-name-input'), 'Design');
+        await type(find(host, 'group-slug-input'), 'design');
+
+        find(host, 'group-create-form')?.dispatchEvent(
+            new Event('submit', { cancelable: true }),
+        );
+        await nextTick();
+
+        const post = inertia.posts.at(-1)!;
+        expect(post.url).toBe('/settings/teams/acme/groups');
+        expect(post.options.preserveScroll).toBe(true);
+        expect(post.form.name).toBe('Design');
+        expect(post.form.slug).toBe('design');
+
+        post.options.onSuccess?.();
+        await nextTick();
+
+        expect(post.form.name).toBe('');
+        expect(post.form.slug).toBe('');
+    });
+
+    it('holds the submit button while the request is in flight', async () => {
+        const host = mount();
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'group-create-button')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+
+    it('shows the errors the server sent back for the name and the handle', async () => {
+        const host = mount();
+
+        find(host, 'group-create-form')?.dispatchEvent(
+            new Event('submit', { cancelable: true }),
+        );
+        await nextTick();
+
+        Object.assign(inertia.posts.at(-1)!.form.errors, {
+            name: 'The name field is required.',
+            slug: 'That handle is taken.',
+        });
+        await nextTick();
+
+        expect(text(host, 'group-create-form')).toContain(
+            'The name field is required.',
+        );
+        expect(text(host, 'group-create-form')).toContain(
+            'That handle is taken.',
+        );
+    });
+});
+
+describe('the list of groups', () => {
+    it('says so when there are no groups at all', () => {
+        const host = mount();
+
+        expect(text(host, 'group-empty')).toBe('No user groups yet.');
+        expect(find(host, 'group-list')).toBeNull();
+    });
+
+    it('renders a row per group with its handle, its name and its size', () => {
+        const host = mount({
+            groups: [
+                group({ membersCount: 3 }),
+                group({ id: 'g2', name: 'Design', slug: 'design' }),
+            ],
+        });
+
+        expect(text(host, 'group-row-dev-team')).toContain('@dev-team');
+        expect(text(host, 'group-row-dev-team')).toContain('Dev Team');
+        expect(text(host, 'group-row-dev-team')).toContain('3 members');
+        expect(find(host, 'group-row-design')).not.toBeNull();
+        expect(find(host, 'group-empty')).toBeNull();
+    });
+
+    it('counts a single member in the singular', () => {
+        const host = mount({ groups: [group({ membersCount: 1 })] });
+
+        expect(text(host, 'group-row-dev-team')).toContain('1 member');
+        expect(text(host, 'group-row-dev-team')).not.toContain('1 members');
+    });
+
+    it('filters by handle, ignoring a leading @ and the case', async () => {
+        const host = mount({
+            groups: [
+                group(),
+                group({ id: 'g2', name: 'Design', slug: 'design' }),
+            ],
+        });
+
+        await type(find(host, 'group-search'), '@DEV');
+
+        expect(find(host, 'group-row-dev-team')).not.toBeNull();
+        expect(find(host, 'group-row-design')).toBeNull();
+    });
+
+    it('filters by name as well as by handle', async () => {
+        const host = mount({
+            groups: [
+                group(),
+                group({ id: 'g2', name: 'Design', slug: 'design' }),
+            ],
+        });
+
+        await type(find(host, 'group-search'), 'desi');
+
+        expect(find(host, 'group-row-design')).not.toBeNull();
+        expect(find(host, 'group-row-dev-team')).toBeNull();
+    });
+
+    it('falls back to the empty line when nothing matches the search', async () => {
+        const host = mount({ groups: [group()] });
+
+        await type(find(host, 'group-search'), 'nobody');
+
+        expect(text(host, 'group-empty')).toBe('No user groups yet.');
+    });
+
+    it('names each row action for a screen reader', () => {
+        const host = mount({ groups: [group()] });
+
+        expect(find(host, 'group-edit-dev-team')?.getAttribute('aria-label')) //
+            .toBe('Edit Dev Team');
+        expect(
+            find(host, 'group-remove-dev-team')?.getAttribute('aria-label'),
+        ).toBe('Delete Dev Team');
+    });
+
+    it('withholds the row actions from someone who may not manage groups', () => {
+        const host = mount({
+            groups: [group()],
+            permissions: { canManageUserGroups: false },
+        });
+
+        expect(find(host, 'group-row-dev-team')).not.toBeNull();
+        expect(find(host, 'group-edit-dev-team')).toBeNull();
+        expect(find(host, 'group-remove-dev-team')).toBeNull();
+    });
+});
+
+describe('the deletion dialog', () => {
+    /** Open the deletion dialog for the seeded group. */
+    async function openDialog(host: HTMLElement): Promise<HTMLElement> {
+        find(host, 'group-remove-dev-team')?.click();
+        await nextTick();
+
+        return find(host, 'group-remove-dialog')!;
+    }
+
+    it('stays closed until a row asks for it, and names that handle', async () => {
+        const host = mount({ groups: [group()] });
+
+        expect(find(host, 'group-remove-dialog')).toBeNull();
+
+        const dialog = await openDialog(host);
+
+        expect(dialog.textContent).toContain('Delete @dev-team?');
+        expect(dialog.textContent?.replace(/\s+/g, ' ')).toContain(
+            'The group stops being mentionable and its handle becomes available again. Messages that already mentioned it show plain text, and the notifications they sent are unaffected.',
+        );
+    });
+
+    it('deletes the group without losing the scroll, then closes itself', async () => {
+        const host = mount({ groups: [group()] });
+        await openDialog(host);
+
+        find(host, 'group-remove-confirm')?.click();
+        await nextTick();
+
+        const request = inertia.deletes.at(-1)!;
+        expect(request.url).toBe('/settings/teams/acme/groups/g1');
+        expect(request.options.preserveScroll).toBe(true);
+        expect(find(host, 'group-remove-dialog')).not.toBeNull();
+
+        request.options.onSuccess?.();
+        await nextTick();
+
+        expect(find(host, 'group-remove-dialog')).toBeNull();
+    });
+
+    it('holds the confirm button while the request is in flight', async () => {
+        const host = mount({ groups: [group()] });
+        await openDialog(host);
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'group-remove-confirm')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+});

--- a/resources/js/pages/teams/Groups.members.test.ts
+++ b/resources/js/pages/teams/Groups.members.test.ts
@@ -1,0 +1,430 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h, nextTick, ref } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Team } from '@/types';
+
+/**
+ * Covers the membership half of the editor a row's pencil opens — the roster of
+ * chips it can drop someone from, the search that adds one, and the re-read
+ * that keeps the roster from going stale after either. What is pinned here is
+ * the rendered markup and the request each form makes. The page is mounted
+ * whole, so the same expectations hold before and after its sections move into
+ * components (#991).
+ */
+type FormFields = Record<string, unknown>;
+
+type RecordedForm = {
+    fields: string[];
+    form: FormFields & { errors: Record<string, string>; processing: boolean };
+};
+
+type RecordedRequest = {
+    /** The form that fired it, so a request identifies its own sender. */
+    form: RecordedForm['form'];
+    url: string;
+    options: { onSuccess?: () => void; preserveScroll?: boolean };
+};
+
+const inertia = vi.hoisted(() => ({
+    forms: [] as RecordedForm[],
+    posts: [] as RecordedRequest[],
+    patches: [] as RecordedRequest[],
+    deletes: [] as RecordedRequest[],
+}));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { defineComponent, reactive } = await import('vue');
+
+    return {
+        Head: defineComponent({ name: 'HeadStub', setup: () => () => null }),
+        useForm: (initial: Record<string, unknown>) => {
+            const fields = Object.keys(initial);
+            let defaults = structuredClone(initial);
+            const form = reactive({
+                ...structuredClone(initial),
+                errors: {} as Record<string, string>,
+                processing: false,
+                defaults(values: Record<string, unknown>) {
+                    defaults = structuredClone(values);
+                },
+                reset() {
+                    Object.assign(form, structuredClone(defaults));
+                },
+                clearErrors() {
+                    for (const key of Object.keys(form.errors)) {
+                        delete form.errors[key];
+                    }
+                },
+                post(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.posts.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+                patch(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.patches.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+                delete(url: string, options: RecordedRequest['options'] = {}) {
+                    inertia.deletes.push({
+                        form: form as RecordedForm['form'],
+                        url,
+                        options,
+                    });
+                },
+            });
+
+            inertia.forms.push({ fields, form: form as RecordedForm['form'] });
+
+            return form;
+        },
+    };
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    const passthrough = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', { 'data-stub': name }, slots.default?.()),
+        });
+
+    return {
+        // Renders its content only while open, so a closed dialog is observably
+        // gone from the DOM the way the real overlay is.
+        Dialog: defineComponent({
+            name: 'DialogStub',
+            props: { open: { type: Boolean, default: false } },
+            emits: ['update:open'],
+            setup:
+                (props, { slots }) =>
+                () =>
+                    props.open
+                        ? h('div', { 'data-stub': 'Dialog' }, slots.default?.())
+                        : null,
+        }),
+        DialogClose: passthrough('DialogClose'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogFooter: passthrough('DialogFooter'),
+        DialogHeader: passthrough('DialogHeader'),
+        DialogTitle: passthrough('DialogTitle'),
+    };
+});
+
+import Groups from './Groups.vue';
+
+const team = {
+    id: 't1',
+    name: 'Acme',
+    slug: 'acme',
+    isPersonal: false,
+    membersCount: 3,
+    unreadCount: 0,
+    mentionCount: 0,
+} as Team;
+
+function member(
+    overrides: Partial<App.Data.MentionData> = {},
+): App.Data.MentionData {
+    return { id: 'u1', name: 'Ada Lovelace', avatar: null, ...overrides };
+}
+
+function group(
+    overrides: Partial<App.Data.UserGroupData> = {},
+): App.Data.UserGroupData {
+    return {
+        id: 'g1',
+        name: 'Dev Team',
+        slug: 'dev-team',
+        membersCount: 0,
+        members: [],
+        ...overrides,
+    };
+}
+
+function candidate(
+    overrides: Partial<App.Data.UserData> = {},
+): App.Data.UserData {
+    return {
+        id: 'u2',
+        name: 'Grace Hopper',
+        avatar: null,
+        isBot: false,
+        status: null,
+        presence: 'online' as App.Enums.PresenceState,
+        isDnd: false,
+        ...overrides,
+    };
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+/**
+ * Mounts the page with the `groups` prop held in a ref, so a test can push a
+ * fresh server payload the way a partial reload would.
+ */
+function mount(props: Record<string, unknown> = {}) {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const groups = ref((props.groups ?? []) as App.Data.UserGroupData[]);
+
+    const app = createApp({
+        render: () =>
+            h(Groups, {
+                team,
+                members: [],
+                permissions: { canManageUserGroups: true },
+                ...props,
+                groups: groups.value,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return { host, groups };
+}
+
+function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+function text(host: HTMLElement, selector: string): string {
+    return find(host, selector)?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+/** Types into a text input the way a person would, model binding included. */
+async function type(input: HTMLElement | null, value: string): Promise<void> {
+    (input as HTMLInputElement).value = value;
+    input?.dispatchEvent(new Event('input'));
+    await nextTick();
+}
+
+/** Marks every recorded form in flight, disabling whatever waits on one. */
+function markProcessing(): void {
+    for (const { form } of inertia.forms) {
+        form.processing = true;
+    }
+}
+
+/** Opens the editor from the seeded group's pencil. */
+async function openEditor(host: HTMLElement): Promise<HTMLElement> {
+    find(host, 'group-edit-dev-team')?.click();
+    await nextTick();
+
+    return find(host, 'group-edit-dialog')!;
+}
+
+beforeEach(() => {
+    inertia.forms = [];
+    inertia.posts = [];
+    inertia.patches = [];
+    inertia.deletes = [];
+});
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+describe('the roster of members', () => {
+    it('says so while the group is empty', async () => {
+        const { host } = mount({ groups: [group()] });
+        await openEditor(host);
+
+        expect(text(host, 'group-members-empty')).toBe(
+            'This group has no members yet.',
+        );
+    });
+
+    it('renders a chip per member, with their initials and their name', async () => {
+        const { host } = mount({
+            groups: [group({ members: [member()] })],
+        });
+        await openEditor(host);
+
+        expect(text(host, 'group-member-u1')).toContain('AL');
+        expect(text(host, 'group-member-u1')).toContain('Ada Lovelace');
+        expect(find(host, 'group-members-empty')).toBeNull();
+    });
+
+    it('names the chip’s cross for a screen reader', async () => {
+        const { host } = mount({
+            groups: [group({ members: [member()] })],
+        });
+        await openEditor(host);
+
+        expect(
+            find(host, 'group-member-remove-u1')?.getAttribute('aria-label'),
+        ).toBe('Remove Ada Lovelace from the group');
+    });
+
+    it('drops a member without losing the scroll', async () => {
+        const { host } = mount({
+            groups: [group({ members: [member()] })],
+        });
+        await openEditor(host);
+
+        find(host, 'group-member-remove-u1')?.click();
+        await nextTick();
+
+        const request = inertia.deletes.at(-1)!;
+        expect(request.url).toBe('/settings/teams/acme/groups/g1/members/u1');
+        expect(request.options.preserveScroll).toBe(true);
+    });
+
+    it('holds the chip’s cross while a membership request is in flight', async () => {
+        const { host } = mount({
+            groups: [group({ members: [member()] })],
+        });
+        await openEditor(host);
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'group-member-remove-u1')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+});
+
+describe('adding a member', () => {
+    it('offers everyone who is not already in the group', async () => {
+        const { host } = mount({
+            groups: [group({ members: [member()] })],
+            members: [
+                candidate({ id: 'u1', name: 'Ada Lovelace' }),
+                candidate(),
+            ],
+        });
+        await openEditor(host);
+
+        expect(find(host, 'group-member-add-u2')).not.toBeNull();
+        expect(find(host, 'group-member-add-u1')).toBeNull();
+    });
+
+    it('narrows the candidates by name, ignoring the case', async () => {
+        const { host } = mount({
+            groups: [group()],
+            members: [candidate(), candidate({ id: 'u3', name: 'Alan Kay' })],
+        });
+        await openEditor(host);
+
+        await type(find(host, 'group-member-search'), 'ALAN');
+
+        expect(find(host, 'group-member-add-u3')).not.toBeNull();
+        expect(find(host, 'group-member-add-u2')).toBeNull();
+    });
+
+    it('offers at most eight at a time', async () => {
+        const { host } = mount({
+            groups: [group()],
+            members: Array.from({ length: 12 }, (_, index) =>
+                candidate({ id: `u${index}`, name: `Member ${index}` }),
+            ),
+        });
+        await openEditor(host);
+
+        expect(
+            find(host, 'group-member-candidates')?.querySelectorAll('li'),
+        ).toHaveLength(8);
+    });
+
+    it('leaves the list out entirely when nobody is left to add', async () => {
+        const { host } = mount({ groups: [group()] });
+        await openEditor(host);
+
+        expect(find(host, 'group-member-candidates')).toBeNull();
+    });
+
+    it('posts the pick without losing the scroll, then clears the search', async () => {
+        const { host } = mount({
+            groups: [group()],
+            members: [candidate()],
+        });
+        await openEditor(host);
+        await type(find(host, 'group-member-search'), 'grace');
+
+        find(host, 'group-member-add-u2')?.click();
+        await nextTick();
+
+        const post = inertia.posts.at(-1)!;
+        expect(post.url).toBe('/settings/teams/acme/groups/g1/members');
+        expect(post.options.preserveScroll).toBe(true);
+        expect(post.form.user_id).toBe('u2');
+
+        post.options.onSuccess?.();
+        await nextTick();
+
+        expect(find(host, 'group-member-search')).toHaveProperty('value', '');
+    });
+
+    it('holds every candidate while a membership request is in flight', async () => {
+        const { host } = mount({
+            groups: [group()],
+            members: [candidate()],
+        });
+        await openEditor(host);
+
+        markProcessing();
+        await nextTick();
+
+        expect(find(host, 'group-member-add-u2')).toHaveProperty(
+            'disabled',
+            true,
+        );
+    });
+});
+
+describe('the roster after a reload', () => {
+    it('re-reads the open group, rather than showing the snapshot it opened with', async () => {
+        const { host, groups } = mount({ groups: [group()] });
+        await openEditor(host);
+
+        expect(find(host, 'group-members-empty')).not.toBeNull();
+
+        groups.value = [group({ members: [member()] })];
+        await nextTick();
+        await nextTick();
+
+        expect(text(host, 'group-member-u1')).toContain('Ada Lovelace');
+    });
+
+    it('closes itself when the group it was opened on is gone', async () => {
+        const { host, groups } = mount({ groups: [group()] });
+        await openEditor(host);
+
+        groups.value = [];
+        await nextTick();
+        await nextTick();
+
+        expect(find(host, 'group-edit-dialog')).toBeNull();
+    });
+
+    it('leaves a closed editor alone', async () => {
+        const { host, groups } = mount({ groups: [group()] });
+
+        groups.value = [group({ name: 'Renamed' })];
+        await nextTick();
+        await nextTick();
+
+        expect(find(host, 'group-edit-dialog')).toBeNull();
+        expect(text(host, 'group-row-dev-team')).toContain('Renamed');
+    });
+});

--- a/resources/js/pages/teams/Groups.vue
+++ b/resources/js/pages/teams/Groups.vue
@@ -1,39 +1,20 @@
 <script setup lang="ts">
-import { Head, useForm } from '@inertiajs/vue3';
-import { Pencil, Plus, Search, Trash2, Users, X } from '@lucide/vue';
-import { computed, ref, watch } from 'vue';
-import FormField from '@/components/FormField.vue';
+import { Head } from '@inertiajs/vue3';
+import { ref } from 'vue';
 import Heading from '@/components/Heading.vue';
-import { Button } from '@/components/ui/button';
-import {
-    Dialog,
-    DialogClose,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { useInitials } from '@/composables/useInitials';
+import CreateUserGroupForm from '@/components/teams/CreateUserGroupForm.vue';
+import DeleteUserGroupDialog from '@/components/teams/DeleteUserGroupDialog.vue';
+import EditUserGroupDialog from '@/components/teams/EditUserGroupDialog.vue';
+import UserGroupsRack from '@/components/teams/UserGroupsRack.vue';
 import { translate } from '@/lib/i18n';
 import { edit, index } from '@/routes/teams';
-import {
-    destroy,
-    index as groupsIndex,
-    store,
-    update,
-} from '@/routes/teams/groups';
-import {
-    destroy as removeMember,
-    store as addMember,
-} from '@/routes/teams/groups/members';
+import { index as groupsIndex } from '@/routes/teams/groups';
 import type { Team } from '@/types';
 
 type UserGroup = App.Data.UserGroupData;
 type Member = App.Data.UserData;
 
-const props = defineProps<{
+defineProps<{
     team: Team;
     groups: UserGroup[];
     members: Member[];
@@ -53,154 +34,11 @@ defineOptions({
     }),
 });
 
-const { getInitials } = useInitials();
+/** The editor, opened through its exposed handler so it can seed its form. */
+const editor = ref<InstanceType<typeof EditUserGroupDialog> | null>(null);
 
-/** The row's member-count label, e.g. "3 members". */
-function memberCountLabel(group: UserGroup): string {
-    return group.membersCount === 1
-        ? translate(':count member', { count: group.membersCount })
-        : translate(':count members', { count: group.membersCount });
-}
-
-const createForm = useForm({ name: '', slug: '' });
-
-function submitCreate(): void {
-    createForm.post(store(props.team.slug).url, {
-        preserveScroll: true,
-        onSuccess: () => createForm.reset(),
-    });
-}
-
-const search = ref('');
-const filteredGroups = computed<UserGroup[]>(() => {
-    const needle = search.value.trim().replace(/^@/, '').toLowerCase();
-
-    if (needle === '') {
-        return props.groups;
-    }
-
-    return props.groups.filter(
-        (group) =>
-            group.slug.includes(needle) ||
-            group.name.toLowerCase().includes(needle),
-    );
-});
-
-const editing = ref<UserGroup | null>(null);
-const editForm = useForm({ name: '', slug: '' });
-const memberSearch = ref('');
-
-function openEditor(group: UserGroup): void {
-    editing.value = group;
-    editForm.defaults({ name: group.name, slug: group.slug });
-    editForm.reset();
-    editForm.clearErrors();
-    memberSearch.value = '';
-}
-
-/**
- * The editor renders off the `groups` prop, so after every membership change it
- * has to re-read the freshly reloaded group rather than the stale snapshot it
- * was opened with.
- */
-watch(
-    () => props.groups,
-    (groups) => {
-        if (editing.value === null) {
-            return;
-        }
-
-        editing.value =
-            groups.find((group) => group.id === editing.value?.id) ?? null;
-    },
-);
-
-function submitRename(): void {
-    const group = editing.value;
-
-    if (group === null) {
-        return;
-    }
-
-    editForm.patch(update({ team: props.team.slug, group: group.id }).url, {
-        preserveScroll: true,
-    });
-}
-
-const membershipForm = useForm<{ user_id: string }>({ user_id: '' });
-
-const candidates = computed<Member[]>(() => {
-    const group = editing.value;
-
-    if (group === null) {
-        return [];
-    }
-
-    const already = new Set(group.members.map((member) => member.id));
-    const needle = memberSearch.value.trim().toLowerCase();
-
-    return props.members
-        .filter(
-            (member) =>
-                !already.has(member.id) &&
-                (needle === '' || member.name.toLowerCase().includes(needle)),
-        )
-        .slice(0, 8);
-});
-
-function addToGroup(member: Member): void {
-    const group = editing.value;
-
-    if (group === null) {
-        return;
-    }
-
-    membershipForm.user_id = member.id;
-    membershipForm.post(
-        addMember({ team: props.team.slug, group: group.id }).url,
-        { preserveScroll: true, onSuccess: () => (memberSearch.value = '') },
-    );
-}
-
-function removeFromGroup(memberId: string): void {
-    const group = editing.value;
-
-    if (group === null) {
-        return;
-    }
-
-    membershipForm.delete(
-        removeMember({
-            team: props.team.slug,
-            group: group.id,
-            user: memberId,
-        }).url,
-        { preserveScroll: true },
-    );
-}
-
+/** The group the deletion dialog is confirming, or `null` while it is closed. */
 const pendingRemoval = ref<UserGroup | null>(null);
-const removalForm = useForm({});
-
-function confirmRemoval(): void {
-    const group = pendingRemoval.value;
-
-    if (group === null) {
-        return;
-    }
-
-    removalForm.delete(
-        destroy({ team: props.team.slug, group: group.id }).url,
-        {
-            preserveScroll: true,
-            // Closed only once the delete lands: a failed request leaves the
-            // dialog open rather than dismissing it as though it had worked.
-            onSuccess: () => {
-                pendingRemoval.value = null;
-            },
-        },
-    );
-}
 </script>
 
 <template>
@@ -217,351 +55,25 @@ function confirmRemoval(): void {
             "
         />
 
-        <form
+        <CreateUserGroupForm
             v-if="permissions.canManageUserGroups"
-            data-test="group-create-form"
-            class="flex flex-col gap-3 rounded-xl border border-dashed border-border p-4 sm:flex-row sm:items-start"
-            @submit.prevent="submitCreate"
-        >
-            <div
-                class="flex size-10 shrink-0 items-center justify-center rounded-xl border border-border bg-muted text-muted-foreground"
-            >
-                <Users class="size-4" />
-            </div>
-            <div class="flex flex-1 flex-col gap-3">
-                <div class="flex flex-col gap-1">
-                    <span class="text-sm font-semibold">{{
-                        $t('Create a group')
-                    }}</span>
-                    <span class="text-xs text-muted-foreground">{{
-                        $t(
-                            'The handle is what people type after @. Leave it blank to derive it from the name.',
-                        )
-                    }}</span>
-                </div>
-                <!-- The row heading above names the pair, so each field's own
-                     label is hidden rather than repeated. It stays a real
-                     `<label for>` all the same: a placeholder disappears the
-                     moment someone types, which leaves the field unnamed
-                     exactly when they might look for the name again.
+            :team="team.slug"
+        />
 
-                     The error's space is not reserved here. These cells are
-                     narrow enough that a message wraps to three lines, and the
-                     row is the last thing in the card — so drawn out of flow it
-                     would run past the card's own border, and there is nothing
-                     below it to be pushed around by letting it grow instead. -->
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
-                    <FormField
-                        :label="$t('Group name')"
-                        label-class="sr-only"
-                        :error="createForm.errors.name"
-                        :reserve="false"
-                        v-slot="{ id }"
-                    >
-                        <Input
-                            :id="id"
-                            v-model="createForm.name"
-                            data-test="group-name-input"
-                            :placeholder="$t('Dev Team')"
-                            class="max-md:h-11 sm:w-56"
-                            autocomplete="off"
-                        />
-                    </FormField>
-                    <FormField
-                        :label="$t('Group handle')"
-                        label-class="sr-only"
-                        :error="createForm.errors.slug"
-                        :reserve="false"
-                        v-slot="{ id }"
-                    >
-                        <Input
-                            :id="id"
-                            v-model="createForm.slug"
-                            data-test="group-slug-input"
-                            placeholder="@dev-team"
-                            class="font-mono max-md:h-11 sm:w-48"
-                            autocapitalize="off"
-                            autocomplete="off"
-                            spellcheck="false"
-                        />
-                    </FormField>
-                    <Button
-                        type="submit"
-                        data-test="group-create-button"
-                        class="rounded-full max-md:h-11"
-                        :disabled="createForm.processing"
-                    >
-                        <Plus class="size-4" /> {{ $t('Create') }}
-                    </Button>
-                </div>
-            </div>
-        </form>
-
-        <div class="relative">
-            <Search
-                class="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground"
-            />
-            <Input
-                v-model="search"
-                data-test="group-search"
-                :placeholder="$t('Search groups')"
-                class="rounded-full pl-9 max-md:h-11"
-            />
-        </div>
-
-        <p
-            v-if="filteredGroups.length === 0"
-            data-test="group-empty"
-            class="text-sm text-muted-foreground"
-        >
-            {{ $t('No user groups yet.') }}
-        </p>
-
-        <ul v-else class="space-y-2" data-test="group-list">
-            <li
-                v-for="group in filteredGroups"
-                :key="group.id"
-                class="flex items-center gap-3 rounded-xl border border-border bg-card p-3 max-md:flex-wrap"
-                :data-test="`group-row-${group.slug}`"
-            >
-                <div
-                    class="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground"
-                >
-                    <Users class="size-4" aria-hidden="true" />
-                </div>
-                <div class="flex min-w-0 flex-1 flex-col max-md:basis-3/5">
-                    <span
-                        class="truncate font-mono text-sm font-semibold text-foreground"
-                        >@{{ group.slug }}</span
-                    >
-                    <span class="truncate text-xs text-muted-foreground"
-                        >{{ group.name
-                        }}<span class="md:hidden">
-                            · {{ memberCountLabel(group) }}</span
-                        ></span
-                    >
-                </div>
-                <span
-                    class="w-28 shrink-0 text-xs text-muted-foreground max-md:hidden"
-                    >{{ memberCountLabel(group) }}</span
-                >
-                <!-- Icon actions rather than inline text links: the destructive
-                     token at 12px does not clear 4.5:1 on `bg-card` in the dark
-                     theme, while an icon only owes the 3:1 graphics threshold. -->
-                <div
-                    v-if="permissions.canManageUserGroups"
-                    class="flex shrink-0 items-center gap-1 max-md:ml-auto"
-                >
-                    <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        type="button"
-                        :data-test="`group-edit-${group.slug}`"
-                        :aria-label="$t('Edit :name', { name: group.name })"
-                        class="shrink-0 rounded-full max-md:size-11"
-                        @click="openEditor(group)"
-                    >
-                        <Pencil class="size-4" />
-                    </Button>
-                    <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        type="button"
-                        :data-test="`group-remove-${group.slug}`"
-                        :aria-label="$t('Delete :name', { name: group.name })"
-                        class="shrink-0 rounded-full text-destructive-text max-md:size-11"
-                        @click="pendingRemoval = group"
-                    >
-                        <Trash2 class="size-4" />
-                    </Button>
-                </div>
-            </li>
-        </ul>
+        <UserGroupsRack
+            :groups="groups"
+            :can-manage="permissions.canManageUserGroups"
+            @edit="editor?.open($event)"
+            @remove="pendingRemoval = $event"
+        />
     </div>
 
-    <Dialog
-        :open="editing !== null"
-        @update:open="(open) => !open && (editing = null)"
-    >
-        <DialogContent data-test="group-edit-dialog">
-            <DialogHeader>
-                <DialogTitle>{{ $t('Edit group') }}</DialogTitle>
-                <DialogDescription>
-                    {{
-                        $t(
-                            'Renaming a group never rewrites messages already sent. They keep the handle they were written with.',
-                        )
-                    }}
-                </DialogDescription>
-            </DialogHeader>
+    <EditUserGroupDialog
+        ref="editor"
+        :team="team.slug"
+        :groups="groups"
+        :members="members"
+    />
 
-            <form
-                class="flex flex-col gap-3 sm:flex-row sm:items-start"
-                data-test="group-rename-form"
-                @submit.prevent="submitRename"
-            >
-                <FormField
-                    :label="$t('Group name')"
-                    label-class="sr-only"
-                    :error="editForm.errors.name"
-                    class="flex-1"
-                    v-slot="{ id }"
-                >
-                    <Input
-                        :id="id"
-                        v-model="editForm.name"
-                        data-test="group-edit-name-input"
-                        autocomplete="off"
-                    />
-                </FormField>
-                <FormField
-                    :label="$t('Group handle')"
-                    label-class="sr-only"
-                    :error="editForm.errors.slug"
-                    class="flex-1"
-                    v-slot="{ id }"
-                >
-                    <Input
-                        :id="id"
-                        v-model="editForm.slug"
-                        data-test="group-edit-slug-input"
-                        class="font-mono"
-                        autocapitalize="off"
-                        autocomplete="off"
-                        spellcheck="false"
-                    />
-                </FormField>
-                <Button
-                    type="submit"
-                    class="rounded-full"
-                    data-test="group-rename-button"
-                    :disabled="editForm.processing"
-                >
-                    {{ $t('Save') }}
-                </Button>
-            </form>
-
-            <div class="flex flex-col gap-2">
-                <span class="text-sm font-semibold">{{ $t('Members') }}</span>
-                <p
-                    v-if="editing && editing.members.length === 0"
-                    data-test="group-members-empty"
-                    class="text-sm text-muted-foreground"
-                >
-                    {{ $t('This group has no members yet.') }}
-                </p>
-                <ul v-else class="flex flex-wrap gap-2">
-                    <li
-                        v-for="member in editing?.members ?? []"
-                        :key="member.id"
-                        class="flex items-center gap-2 rounded-full border border-border py-1 pr-1 pl-2 text-sm"
-                        :data-test="`group-member-${member.id}`"
-                    >
-                        <span
-                            class="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[8px] font-semibold text-primary"
-                            aria-hidden="true"
-                            >{{ getInitials(member.name) }}</span
-                        >
-                        <span class="truncate">{{ member.name }}</span>
-                        <Button
-                            variant="ghost"
-                            size="none"
-                            type="button"
-                            class="rounded-full p-1"
-                            :disabled="membershipForm.processing"
-                            :aria-label="
-                                $t('Remove :name from the group', {
-                                    name: member.name,
-                                })
-                            "
-                            :data-test="`group-member-remove-${member.id}`"
-                            @click="removeFromGroup(member.id)"
-                        >
-                            <X class="size-3" />
-                        </Button>
-                    </li>
-                </ul>
-            </div>
-
-            <div class="flex flex-col gap-2">
-                <Input
-                    v-model="memberSearch"
-                    data-test="group-member-search"
-                    :placeholder="$t('Add a member')"
-                    class="rounded-full"
-                />
-                <ul
-                    v-if="candidates.length > 0"
-                    class="flex flex-col gap-1"
-                    data-test="group-member-candidates"
-                >
-                    <li v-for="member in candidates" :key="member.id">
-                        <Button
-                            variant="ghost"
-                            type="button"
-                            class="w-full justify-start gap-2 rounded-lg text-sm"
-                            :disabled="membershipForm.processing"
-                            :data-test="`group-member-add-${member.id}`"
-                            @click="addToGroup(member)"
-                        >
-                            <span
-                                class="flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[8px] font-semibold text-primary"
-                                aria-hidden="true"
-                                >{{ getInitials(member.name) }}</span
-                            >
-                            {{ member.name }}
-                        </Button>
-                    </li>
-                </ul>
-            </div>
-
-            <DialogFooter>
-                <DialogClose as-child>
-                    <Button variant="outline" class="rounded-full">{{
-                        $t('Done')
-                    }}</Button>
-                </DialogClose>
-            </DialogFooter>
-        </DialogContent>
-    </Dialog>
-
-    <Dialog
-        :open="pendingRemoval !== null"
-        @update:open="(open) => !open && (pendingRemoval = null)"
-    >
-        <DialogContent data-test="group-remove-dialog">
-            <DialogHeader>
-                <DialogTitle
-                    >{{
-                        $t('Delete @:handle?', {
-                            handle: pendingRemoval?.slug ?? '',
-                        })
-                    }}
-                </DialogTitle>
-                <DialogDescription>
-                    {{
-                        $t(
-                            'The group stops being mentionable and its handle becomes available again. Messages that already mentioned it show plain text, and the notifications they sent are unaffected.',
-                        )
-                    }}
-                </DialogDescription>
-            </DialogHeader>
-            <DialogFooter>
-                <DialogClose as-child>
-                    <Button variant="outline" class="rounded-full">{{
-                        $t('Cancel')
-                    }}</Button>
-                </DialogClose>
-                <Button
-                    variant="destructive"
-                    class="rounded-full"
-                    data-test="group-remove-confirm"
-                    :disabled="removalForm.processing"
-                    @click="confirmRemoval"
-                >
-                    {{ $t('Delete group') }}
-                </Button>
-            </DialogFooter>
-        </DialogContent>
-    </Dialog>
+    <DeleteUserGroupDialog v-model:group="pendingRemoval" :team="team.slug" />
 </template>


### PR DESCRIPTION
Closes #991. Child of #980.

`pages/teams/Groups.vue` goes from **567 to 79 raw lines** — **514 to 66** as
`max-lines` counts them, against the 400 cap. Its entry is gone from the
exemption block in `eslint.config.js`, so `max-lines-policy.test.ts` now holds
the file to the cap like any other.

Four dialogs and their five `useForm` instances shared one scope with the list
they were reached from. They move out along the seams the sibling splits
already drew (#984, #987): one component per surface, each owning the form only
it submits.

## Covered first, against the current code

`Groups.vue` had no colocated coverage, so a pure move had nothing watching it.
Three suites land ahead of the split (commit 1) and pin what it may not change
— every `data-test` selector, every request shape, every string:

| Suite | Holds |
| --- | --- |
| `Groups.list.test.ts` | The heading, the creation form (permission gate, request, reset, errors), the search and its filtering, the rows and their labels, the deletion confirmation |
| `Groups.editor.test.ts` | The editor's rename half: what it is seeded with, what a reopen drops, the patch it fires |
| `Groups.members.test.ts` | The roster of chips, the candidate picker and its cap of eight, and the re-read that keeps both fresh after a reload |

All 38 stayed green across the move, unedited.

## What moved

| New file | Lines | What it holds |
| --- | ---: | --- |
| `components/teams/EditUserGroupDialog.vue` | 157 | The editor: the rename form, and the re-read of the open group after each change |
| `components/teams/UserGroupMembersEditor.vue` | 145 | The membership form: the roster of chips and the candidate picker |
| `components/teams/UserGroupsRack.vue` | 130 | The search, the list of rows and the empty line |
| `components/teams/CreateUserGroupForm.vue` | 103 | The creation form |
| `components/teams/DeleteUserGroupDialog.vue` | 87 | The deletion confirmation, keyed on the pending group |

The page keeps the heading, the breadcrumbs, and the two refs deciding which
dialog is open. The editor is opened through an exposed handler rather than a
flag, the way `ChannelDialogs.vue` is (#983): reopening the same row has to
reseed the form and clear the picker's search, which a watcher on the model
alone would not do.

## Move, not improve

Rendering both versions and diffing the DOM leaves exactly two additions and
nothing else: the rack's `flex flex-col gap-6` wrapper (repeating the
`space-y-6` the two elements had as siblings) and the members editor's
`grid gap-4` one (repeating `DialogContent`'s own gap). No selector renamed, no
copy changed, no `lang/fr.json` key added or moved.

## Tested

- `sail composer test` — `Total: 100.0 %`
- `lint:check` / `format:check` / `types:check` / `test:js` (205 files, 2096 tests) / `build`
- Browser: `A11yUserGroupsTest`, `TeamsFieldErrorTest`, `MobileUndrawnScreensTest` — the axe audit of this page included
- Local CodeRabbit pass: 0 findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787868121&installation_model_id=428379&pr_number=1030&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1030&signature=b7c21a442fecd3b5847c9812e92f2cf50032e3e488351ca3195bf47798137e63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->