### PR TITLE
refactor: split QuickSwitcher.vue

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -252,7 +252,6 @@ export default defineConfigWithVueTs(
         // `eslint-rules/max-lines-policy.test.ts` fails as soon as an entry
         // stops breaching the threshold, so the list can only shrink.
         files: [
-            'resources/js/components/QuickSwitcher.vue',
             'resources/js/components/UserStatusDialog.vue',
             'resources/js/composables/useAttachmentUploads.test.ts',
             'resources/js/layouts/MainLayout.vue',

--- a/resources/js/components/QuickSwitcher.destinations.test.ts
+++ b/resources/js/components/QuickSwitcher.destinations.test.ts
@@ -1,0 +1,325 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Covers what the palette lists before a message search comes back: the filter
+ * field on each side of the breakpoint, the Reminders action, and the ranked
+ * channel and people groups — their order, their highlighting, and where
+ * picking one sends the viewer.
+ *
+ * Written against the palette as it stands so a split of it can be checked
+ * against this suite: every selector, every string and every fallback is pinned
+ * here, and a pure move may change none of them.
+ */
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble } = await import('./QuickSwitcher.doubles');
+
+    return inertiaDouble();
+});
+
+vi.mock('@lucide/vue', async () => {
+    const { lucideDouble } = await import('./QuickSwitcher.stubs');
+
+    return lucideDouble();
+});
+
+vi.mock('reka-ui', async () => {
+    const { rekaDouble } = await import('./QuickSwitcher.stubs');
+
+    return rekaDouble();
+});
+
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/ChannelController',
+    async () => {
+        const { channelActionDouble } = await import('./QuickSwitcher.doubles');
+
+        return channelActionDouble();
+    },
+);
+
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/SearchController',
+    async () => {
+        const { searchActionDouble } = await import('./QuickSwitcher.doubles');
+
+        return searchActionDouble();
+    },
+);
+
+vi.mock('@/components/PresenceDot.vue', async () => {
+    const { presenceDotDouble } = await import('./QuickSwitcher.stubs');
+
+    return presenceDotDouble();
+});
+
+vi.mock('@/components/SafeHtml.vue', async () => {
+    const { safeHtmlDouble } = await import('./QuickSwitcher.stubs');
+
+    return safeHtmlDouble();
+});
+
+vi.mock('@/components/ui/button', async () => {
+    const { buttonDouble } = await import('./QuickSwitcher.stubs');
+
+    return buttonDouble();
+});
+
+vi.mock('@/components/ui/command', async () => {
+    const { commandDouble } = await import('./QuickSwitcher.stubs');
+
+    return commandDouble();
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { dialogDouble } = await import('./QuickSwitcher.stubs');
+
+    return dialogDouble();
+});
+
+vi.mock('@/components/ui/sidebar', async () => {
+    const { sidebarDouble } = await import('./QuickSwitcher.doubles');
+
+    return sidebarDouble();
+});
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { isMobileDouble } = await import('./QuickSwitcher.doubles');
+
+    return isMobileDouble();
+});
+
+vi.mock('@/composables/useMessageSearch', async () => {
+    const { messageSearchDouble } = await import('./QuickSwitcher.doubles');
+
+    return messageSearchDouble();
+});
+
+vi.mock('@/composables/useOpenDirectMessage', async () => {
+    const { openDirectMessageDouble } = await import('./QuickSwitcher.doubles');
+
+    return openDirectMessageDouble();
+});
+
+vi.mock('@/lib/pinUrl', async () => {
+    const { pinUrlDouble } = await import('./QuickSwitcher.doubles');
+
+    return pinUrlDouble();
+});
+
+import {
+    channel,
+    find,
+    findAll,
+    flush,
+    isMobile,
+    messageSearch,
+    mountSwitcher,
+    openDirectMessage,
+    person,
+    resetDoubles,
+    router,
+    type,
+    unmountAll,
+} from './QuickSwitcher.doubles';
+import QuickSwitcher from './QuickSwitcher.vue';
+
+function mount(props: Record<string, unknown> = {}) {
+    return mountSwitcher(QuickSwitcher, props);
+}
+
+/**
+ * What the rows carrying this selector read, in the order they render, with the
+ * enter hint dropped — it is drawn on every desktop row and says nothing about
+ * which one this is.
+ */
+function names(host: HTMLElement, dataTest: string): string[] {
+    return findAll(host, dataTest).map((row) =>
+        (row.textContent ?? '').replaceAll('↵', '').trim(),
+    );
+}
+
+beforeEach(() => {
+    resetDoubles();
+});
+
+afterEach(() => {
+    unmountAll();
+});
+
+describe('the filter field', () => {
+    it('offers a plain row from the breakpoint up, with no Cancel', () => {
+        const { host } = mount();
+
+        expect(find(host, 'quick-switcher-input')).not.toBeNull();
+        expect(find(host, 'quick-switcher-cancel')).toBeNull();
+    });
+
+    it('offers a Cancel beside the field below the breakpoint', () => {
+        isMobile.value = true;
+
+        const { host, open } = mount();
+
+        find(host, 'quick-switcher-cancel')?.click();
+
+        expect(open.value).toBe(false);
+    });
+
+    it('clears the query and the message results on dismissal', async () => {
+        const { host, open } = mount();
+
+        await type(host, 'quokka');
+        open.value = false;
+        await flush();
+
+        expect(
+            (find(host, 'quick-switcher-input') as HTMLInputElement).value,
+        ).toBe('');
+        expect(messageSearch.reset).toHaveBeenCalled();
+    });
+});
+
+describe('the actions group', () => {
+    it('offers Reminders while nothing is typed', () => {
+        const { host, emitted, open } = mount();
+
+        find(host, 'quick-switcher-reminders')?.click();
+
+        expect(emitted).toEqual([['openReminders', undefined]]);
+        expect(open.value).toBe(false);
+    });
+
+    it('keeps offering it for a bare hash, which reads as no query', async () => {
+        const { host } = mount();
+
+        await type(host, '#');
+
+        expect(find(host, 'quick-switcher-reminders')).not.toBeNull();
+    });
+
+    it('drops it as soon as the viewer types', async () => {
+        const { host } = mount();
+
+        await type(host, 'q');
+
+        expect(find(host, 'quick-switcher-reminders')).toBeNull();
+    });
+});
+
+describe('the channels group', () => {
+    const channels = [
+        channel({ id: 'c1', name: 'general', slug: 'general' }),
+        channel({
+            id: 'c2',
+            name: 'design',
+            slug: 'design',
+            lastActivityAt: '2026-01-03T00:00:00Z',
+        }),
+        channel({
+            id: 'c3',
+            name: 'planning',
+            slug: 'planning',
+            lastActivityAt: '2026-01-01T00:00:00Z',
+        }),
+    ];
+
+    it('ranks alphabetically from the breakpoint up', () => {
+        const { host } = mount({ channels });
+
+        expect(names(host, 'quick-switcher-channel')).toEqual([
+            '#design',
+            '#general',
+            '#planning',
+        ]);
+    });
+
+    it('ranks by activity below it, so an empty query reads as recents', () => {
+        isMobile.value = true;
+
+        const { host } = mount({ channels });
+
+        expect(names(host, 'quick-switcher-channel')).toEqual([
+            '#design',
+            '#planning',
+            '#general',
+        ]);
+    });
+
+    it('brightens the matched run below the breakpoint', async () => {
+        isMobile.value = true;
+
+        const { host } = mount({ channels });
+
+        await type(host, 'des');
+
+        expect(find(host, 'quick-switcher-match')?.textContent).toBe('des');
+    });
+
+    it('leaves the name whole from the breakpoint up', async () => {
+        const { host } = mount({ channels });
+
+        await type(host, 'des');
+
+        expect(find(host, 'quick-switcher-match')).toBeNull();
+        expect(names(host, 'quick-switcher-channel')).toEqual(['#design']);
+    });
+
+    it('navigates into the channel a pick names', () => {
+        const { host, open } = mount({ channels });
+
+        find(host, 'quick-switcher-channel')?.click();
+
+        expect(router.visit).toHaveBeenCalledWith('/t/acme/c/design');
+        expect(open.value).toBe(false);
+    });
+});
+
+describe('the people group', () => {
+    const members = [
+        person({ id: 'me', name: 'Ada Lovelace' }),
+        person({ id: 'u2', name: 'Bob Member' }),
+    ];
+
+    it('names the viewer themselves "You", with their initials beside it', () => {
+        const { host } = mount({ members, currentUserId: 'me' });
+
+        expect(names(host, 'quick-switcher-person')).toEqual([
+            'ALYou',
+            'BMBob Member',
+        ]);
+    });
+
+    it('reads out presence instead of the enter hint below the breakpoint', () => {
+        isMobile.value = true;
+
+        const { host } = mount({
+            members,
+            currentUserId: 'me',
+            presenceFor: () => 'away',
+        });
+
+        expect(names(host, 'quick-switcher-person')[0]).toContain('Away');
+    });
+
+    it('brightens the matched run of a name below the breakpoint', async () => {
+        isMobile.value = true;
+
+        const { host } = mount({ members, currentUserId: 'me' });
+
+        await type(host, 'bo');
+
+        expect(names(host, 'quick-switcher-person')).toEqual([
+            'BMBob MemberActive',
+        ]);
+        expect(find(host, 'quick-switcher-match')?.textContent).toBe('Bo');
+    });
+
+    it('opens the direct message a pick names', () => {
+        const { host, open } = mount({ members, currentUserId: 'me' });
+
+        findAll(host, 'quick-switcher-person')[1]?.click();
+
+        expect(openDirectMessage).toHaveBeenCalledWith('u2');
+        expect(open.value).toBe(false);
+    });
+});

--- a/resources/js/components/QuickSwitcher.doubles.ts
+++ b/resources/js/components/QuickSwitcher.doubles.ts
@@ -1,0 +1,278 @@
+import { vi } from 'vitest';
+import type { App, Component, Ref } from 'vue';
+import { createApp, h, nextTick, ref } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { RenderedPresence } from '@/lib/presence';
+import type { MessageSearchResult } from '@/types';
+import type { Channel } from '@/types/channels';
+import type { PersonRef } from '@/types/people';
+
+/**
+ * The harness the palette's suites share: the app state it reads through
+ * `usePage()` and its composables, the model factories, and the mount/teardown
+ * boilerplate that records what it emits. The design-system stand-ins it renders
+ * through live beside this, in `QuickSwitcher.stubs`.
+ */
+
+/** The viewer and the route, as `usePage()` reports them. */
+export const viewer = {
+    url: '/t/acme/c/general',
+    timezone: null as string | null,
+};
+
+/** Where a picked row sends the viewer. */
+export const router = { visit: vi.fn() };
+
+export function inertiaDouble(): Record<string, unknown> {
+    return {
+        router,
+        usePage: () => ({
+            url: viewer.url,
+            props: {
+                auth: { user: { timezone: viewer.timezone } },
+                customEmojis: {},
+                userGroups: [],
+            },
+        }),
+    };
+}
+
+/**
+ * The debounced message search, reduced to what it was asked and what it holds:
+ * the URL builder it was handed, the terms it was sent, and the results a suite
+ * writes back the way a response would.
+ */
+export const messageSearch = {
+    results: ref<MessageSearchResult[]>([]),
+    isSearching: ref(false),
+    search: vi.fn(),
+    reset: vi.fn(),
+    buildUrl: null as ((term: string) => string) | null,
+};
+
+export function messageSearchDouble(): Record<string, unknown> {
+    return {
+        useMessageSearch: (buildUrl: (term: string) => string) => {
+            messageSearch.buildUrl = buildUrl;
+
+            return {
+                results: messageSearch.results,
+                isSearching: messageSearch.isSearching,
+                search: messageSearch.search,
+                reset: messageSearch.reset,
+            };
+        },
+    };
+}
+
+/** The dock the hand-off to the Search panel has to reveal. */
+export const dock = {
+    open: ref(true),
+    setOpen: vi.fn((value: boolean) => {
+        dock.open.value = value;
+    }),
+    setOpenMobile: vi.fn(),
+};
+
+export function sidebarDouble(): Record<string, unknown> {
+    return { useSidebar: () => dock };
+}
+
+/** Which side of the breakpoint the palette renders for. */
+export const isMobile = ref(false);
+
+export function isMobileDouble(): Record<string, unknown> {
+    return { useIsMobile: () => isMobile };
+}
+
+export const openDirectMessage = vi.fn();
+
+export function openDirectMessageDouble(): Record<string, unknown> {
+    return { useOpenDirectMessage: () => ({ openDirectMessage }) };
+}
+
+/** The client-side write the Search hand-off lands on the current route. */
+export const pinUrl = vi.fn();
+
+export function pinUrlDouble(): Record<string, unknown> {
+    return { pinUrl };
+}
+
+/** The Wayfinder routes the palette navigates to, reduced to their URLs. */
+export function channelActionDouble(): Record<string, unknown> {
+    return {
+        show: (
+            params: { team: string; channel: string },
+            options?: { query?: Record<string, string> },
+        ) => ({
+            url: `/t/${params.team}/c/${params.channel}${
+                options?.query === undefined
+                    ? ''
+                    : `?${new URLSearchParams(options.query).toString()}`
+            }`,
+        }),
+    };
+}
+
+export function searchActionDouble(): Record<string, unknown> {
+    return {
+        suggest: (team: string, options: { query: unknown }) => ({
+            url: `/t/${team}/search/suggest?${JSON.stringify(options.query)}`,
+        }),
+    };
+}
+
+/** Reset every double's state between tests, so a suite reads in any order. */
+export function resetDoubles(): void {
+    viewer.url = '/t/acme/c/general';
+    viewer.timezone = null;
+    router.visit.mockClear();
+    messageSearch.results.value = [];
+    messageSearch.isSearching.value = false;
+    messageSearch.search.mockClear();
+    messageSearch.reset.mockClear();
+    dock.open.value = true;
+    dock.setOpen.mockClear();
+    dock.setOpenMobile.mockClear();
+    isMobile.value = false;
+    openDirectMessage.mockClear();
+    pinUrl.mockClear();
+}
+
+export function channel(overrides: Partial<Channel> = {}): Channel {
+    return {
+        id: 'c1',
+        name: 'general',
+        slug: 'general',
+        visibility: 'public',
+        topic: null,
+        isGeneral: true,
+        isArchived: false,
+        muted: false,
+        notificationLevel: 'all',
+        unreadCount: 0,
+        mentionCount: 0,
+        hasDraft: false,
+        draft: null,
+        starred: false,
+        sectionId: null,
+        position: 0,
+        isDirect: false,
+        isGroupDirect: false,
+        dmUserId: null,
+        dmParticipants: null,
+        lastActivityAt: null,
+        ...overrides,
+    };
+}
+
+export function person(overrides: Partial<PersonRef> = {}): PersonRef {
+    return { id: 'u1', name: 'Ada Lovelace', ...overrides };
+}
+
+export function searchResult(
+    overrides: Partial<MessageSearchResult> = {},
+): MessageSearchResult {
+    return {
+        message: {
+            id: 'm1',
+            body: 'the quokka danced at dawn',
+            mentions: [],
+            createdAt: '2026-01-02T15:04:05Z',
+            user: { id: 'u9', name: 'Grace Hopper', avatar: null },
+        },
+        channelName: 'general',
+        channelSlug: 'general',
+        isDirectMessage: false,
+        snippet: '',
+        teamId: 't1',
+        teamName: 'Acme',
+        teamSlug: 'acme',
+        ...overrides,
+    } as unknown as MessageSearchResult;
+}
+
+const mounted: Array<{ app: App; host: HTMLElement }> = [];
+
+/** Every event the palette emits, in the order it emitted them. */
+export type Emitted = Array<[string, unknown]>;
+
+/**
+ * Mount the palette over its defaults, recording what it emits. Its open state
+ * is a ref the harness owns, so a suite can watch the palette close itself —
+ * which is half of what picking a row is supposed to do.
+ */
+export function mountSwitcher(
+    Switcher: Component,
+    props: Record<string, unknown> = {},
+): { host: HTMLElement; emitted: Emitted; open: Ref<boolean> } {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const open = ref(true);
+    const emitted: Emitted = [];
+    const record =
+        (event: string) =>
+        (payload?: unknown): void => {
+            emitted.push([event, payload]);
+        };
+
+    const app = createApp({
+        render: () =>
+            h(Switcher, {
+                open: open.value,
+                'onUpdate:open': (value: boolean) => {
+                    open.value = value;
+                },
+                channels: [channel()],
+                members: [person()],
+                currentUserId: 'me',
+                teamSlug: 'acme',
+                presenceFor: () => 'active' as RenderedPresence,
+                isDndFor: () => false,
+                onOpenReminders: record('openReminders'),
+                ...props,
+            }),
+    });
+
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    mounted.push({ app, host });
+
+    return { host, emitted, open };
+}
+
+export function unmountAll(): void {
+    for (const { app, host } of mounted.splice(0)) {
+        app.unmount();
+        host.remove();
+    }
+}
+
+/** The element carrying a `data-test` selector, or null when it is absent. */
+export function find(host: HTMLElement, dataTest: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${dataTest}"]`);
+}
+
+/** Every element carrying a `data-test` selector, in document order. */
+export function findAll(host: HTMLElement, dataTest: string): HTMLElement[] {
+    return [...host.querySelectorAll<HTMLElement>(`[data-test="${dataTest}"]`)];
+}
+
+/** Type into the palette's filter field, as a viewer would. */
+export async function type(host: HTMLElement, value: string): Promise<void> {
+    const field = find(host, 'quick-switcher-input') as HTMLInputElement;
+    field.value = value;
+    field.dispatchEvent(new Event('input'));
+
+    await flush();
+}
+
+/**
+ * Settle the render. Twice over: a write reaches the palette through its own
+ * `open` model, so the watcher it wakes only reaches the DOM on the tick after.
+ */
+export async function flush(): Promise<void> {
+    await nextTick();
+    await nextTick();
+}

--- a/resources/js/components/QuickSwitcher.messages.test.ts
+++ b/resources/js/components/QuickSwitcher.messages.test.ts
@@ -1,0 +1,346 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Covers the palette's message search: what it asks the suggest endpoint as the
+ * query is edited, how it reads while it waits and when nothing matches, how a
+ * match renders, and the two ways out of the group — into the message itself, or
+ * over to the Search panel with the criteria in hand.
+ *
+ * Written against the palette as it stands so a split of it can be checked
+ * against this suite: every selector, every string and every fallback is pinned
+ * here, and a pure move may change none of them.
+ */
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaDouble } = await import('./QuickSwitcher.doubles');
+
+    return inertiaDouble();
+});
+
+vi.mock('@lucide/vue', async () => {
+    const { lucideDouble } = await import('./QuickSwitcher.stubs');
+
+    return lucideDouble();
+});
+
+vi.mock('reka-ui', async () => {
+    const { rekaDouble } = await import('./QuickSwitcher.stubs');
+
+    return rekaDouble();
+});
+
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/ChannelController',
+    async () => {
+        const { channelActionDouble } = await import('./QuickSwitcher.doubles');
+
+        return channelActionDouble();
+    },
+);
+
+vi.mock(
+    '@/actions/App/Http/Controllers/Channels/SearchController',
+    async () => {
+        const { searchActionDouble } = await import('./QuickSwitcher.doubles');
+
+        return searchActionDouble();
+    },
+);
+
+vi.mock('@/components/PresenceDot.vue', async () => {
+    const { presenceDotDouble } = await import('./QuickSwitcher.stubs');
+
+    return presenceDotDouble();
+});
+
+vi.mock('@/components/SafeHtml.vue', async () => {
+    const { safeHtmlDouble } = await import('./QuickSwitcher.stubs');
+
+    return safeHtmlDouble();
+});
+
+vi.mock('@/components/ui/button', async () => {
+    const { buttonDouble } = await import('./QuickSwitcher.stubs');
+
+    return buttonDouble();
+});
+
+vi.mock('@/components/ui/command', async () => {
+    const { commandDouble } = await import('./QuickSwitcher.stubs');
+
+    return commandDouble();
+});
+
+vi.mock('@/components/ui/dialog', async () => {
+    const { dialogDouble } = await import('./QuickSwitcher.stubs');
+
+    return dialogDouble();
+});
+
+vi.mock('@/components/ui/sidebar', async () => {
+    const { sidebarDouble } = await import('./QuickSwitcher.doubles');
+
+    return sidebarDouble();
+});
+
+vi.mock('@/composables/useIsMobile', async () => {
+    const { isMobileDouble } = await import('./QuickSwitcher.doubles');
+
+    return isMobileDouble();
+});
+
+vi.mock('@/composables/useMessageSearch', async () => {
+    const { messageSearchDouble } = await import('./QuickSwitcher.doubles');
+
+    return messageSearchDouble();
+});
+
+vi.mock('@/composables/useOpenDirectMessage', async () => {
+    const { openDirectMessageDouble } = await import('./QuickSwitcher.doubles');
+
+    return openDirectMessageDouble();
+});
+
+vi.mock('@/lib/pinUrl', async () => {
+    const { pinUrlDouble } = await import('./QuickSwitcher.doubles');
+
+    return pinUrlDouble();
+});
+
+import {
+    dock,
+    find,
+    findAll,
+    isMobile,
+    messageSearch,
+    mountSwitcher,
+    person,
+    pinUrl,
+    resetDoubles,
+    router,
+    searchResult,
+    type,
+    unmountAll,
+    viewer,
+} from './QuickSwitcher.doubles';
+import QuickSwitcher from './QuickSwitcher.vue';
+
+function mount(props: Record<string, unknown> = {}) {
+    return mountSwitcher(QuickSwitcher, props);
+}
+
+/** The group's own text, with the rows it holds left in place. */
+function messagesGroup(host: HTMLElement): string {
+    return (
+        host
+            .querySelector('[data-heading="Messages"]')
+            ?.textContent?.replace(/\s+/g, ' ')
+            .trim() ?? ''
+    );
+}
+
+beforeEach(() => {
+    resetDoubles();
+});
+
+afterEach(() => {
+    unmountAll();
+});
+
+describe('what the palette asks for', () => {
+    it('sends the typed text as the query, on the suggest endpoint', async () => {
+        const { host } = mount();
+
+        await type(host, 'quokka');
+
+        expect(messageSearch.search).toHaveBeenCalledWith(
+            JSON.stringify({ q: 'quokka' }),
+        );
+        expect(messageSearch.buildUrl?.(JSON.stringify({ q: 'quokka' }))).toBe(
+            '/t/acme/search/suggest?{"q":"quokka"}',
+        );
+    });
+
+    it('resolves the tokens the page understands into the same filters', async () => {
+        const { host } = mount({
+            members: [person({ id: 'u2', name: 'Bob Member' })],
+        });
+
+        await type(host, 'from:bob quokka');
+
+        expect(messageSearch.search).toHaveBeenCalledWith(
+            JSON.stringify({ q: 'quokka', from: 'u2' }),
+        );
+    });
+
+    it('clears rather than asking for a query with no text left in it', async () => {
+        const { host } = mount({
+            members: [person({ id: 'u2', name: 'Bob Member' })],
+        });
+
+        await type(host, 'from:bob');
+
+        expect(messageSearch.search).not.toHaveBeenCalled();
+        expect(messageSearch.reset).toHaveBeenCalled();
+    });
+});
+
+describe('how the group reads', () => {
+    it('stays away entirely until there is text to search for', async () => {
+        const { host } = mount();
+
+        expect(messagesGroup(host)).toBe('');
+
+        await type(host, 'quokka');
+
+        expect(messagesGroup(host)).toContain('No messages match');
+    });
+
+    it('says it is searching while the first answer is outstanding', async () => {
+        const { host } = mount();
+
+        messageSearch.isSearching.value = true;
+        await type(host, 'quokka');
+
+        expect(messagesGroup(host)).toContain('Searching…');
+        expect(find(host, 'quick-switcher-no-messages')).toBeNull();
+    });
+
+    it('names the query back when nothing matched it', async () => {
+        const { host } = mount();
+
+        await type(host, 'quokka');
+
+        expect(find(host, 'quick-switcher-no-messages')?.textContent).toContain(
+            'No messages match “quokka”.',
+        );
+    });
+
+    it('reads a match as its author, its channel, its time and its body', async () => {
+        viewer.timezone = 'UTC';
+
+        const { host } = mount();
+
+        messageSearch.results.value = [searchResult()];
+        await type(host, 'quokka');
+
+        const row = find(host, 'quick-switcher-message');
+
+        expect(row?.textContent).toContain('Grace Hopper');
+        expect(row?.textContent).toContain('#general');
+        expect(row?.textContent).toContain('Jan 2, 3:04 PM');
+        expect(
+            row?.querySelector('[data-html]')?.getAttribute('data-html'),
+        ).toBe('the quokka danced at dawn');
+    });
+
+    it('stamps the time in the time zone the viewer reads in', async () => {
+        viewer.timezone = 'America/New_York';
+
+        const { host } = mount();
+
+        messageSearch.results.value = [searchResult()];
+        await type(host, 'quokka');
+
+        expect(find(host, 'quick-switcher-message')?.textContent).toContain(
+            'Jan 2, 10:04 AM',
+        );
+    });
+
+    it('drops the hash for a direct message, which has no channel name to mark', async () => {
+        const { host } = mount();
+
+        messageSearch.results.value = [
+            searchResult({
+                channelName: 'Grace Hopper',
+                isDirectMessage: true,
+            }),
+        ];
+        await type(host, 'quokka');
+
+        expect(find(host, 'quick-switcher-message')?.textContent).not.toContain(
+            '#',
+        );
+    });
+});
+
+describe('the ways out of the group', () => {
+    it('opens the channel a match sits in, pinned to the message', async () => {
+        const { host, open } = mount();
+
+        messageSearch.results.value = [searchResult()];
+        await type(host, 'quokka');
+        find(host, 'quick-switcher-message')?.click();
+
+        expect(router.visit).toHaveBeenCalledWith(
+            '/t/acme/c/general?message=m1',
+        );
+        expect(open.value).toBe(false);
+    });
+
+    it('hands the criteria to the Search destination on the current route', async () => {
+        const { host, open } = mount();
+
+        await type(host, 'quokka');
+        find(host, 'quick-switcher-see-all')?.click();
+
+        expect(pinUrl).toHaveBeenCalledWith(
+            '/t/acme/c/general?nav=search&q=quokka',
+        );
+        expect(open.value).toBe(false);
+    });
+
+    it('names the query in the hand-off row', async () => {
+        const { host } = mount();
+
+        await type(host, 'quokka');
+
+        expect(find(host, 'quick-switcher-see-all')?.textContent).toContain(
+            'See all results for “quokka”',
+        );
+    });
+
+    it('opens the drawer the panel lives in below the breakpoint', async () => {
+        isMobile.value = true;
+
+        const { host } = mount();
+
+        await type(host, 'quokka');
+        find(host, 'quick-switcher-see-all')?.click();
+
+        expect(dock.setOpenMobile).toHaveBeenCalledWith(true);
+        expect(dock.setOpen).not.toHaveBeenCalled();
+    });
+
+    it('expands a collapsed dock from the breakpoint up', async () => {
+        dock.open.value = false;
+
+        const { host } = mount();
+
+        await type(host, 'quokka');
+        find(host, 'quick-switcher-see-all')?.click();
+
+        expect(dock.setOpen).toHaveBeenCalledWith(true);
+        expect(dock.setOpenMobile).not.toHaveBeenCalled();
+    });
+
+    it('leaves an already-open dock alone', async () => {
+        const { host } = mount();
+
+        await type(host, 'quokka');
+        find(host, 'quick-switcher-see-all')?.click();
+
+        expect(dock.setOpen).not.toHaveBeenCalled();
+        expect(dock.setOpenMobile).not.toHaveBeenCalled();
+    });
+
+    it('offers the hand-off even where a match is already listed', async () => {
+        const { host } = mount();
+
+        messageSearch.results.value = [searchResult()];
+        await type(host, 'quokka');
+
+        expect(findAll(host, 'quick-switcher-message')).toHaveLength(1);
+        expect(find(host, 'quick-switcher-see-all')).not.toBeNull();
+    });
+});

--- a/resources/js/components/QuickSwitcher.stubs.ts
+++ b/resources/js/components/QuickSwitcher.stubs.ts
@@ -1,0 +1,146 @@
+import type { Component } from 'vue';
+import { defineComponent, h } from 'vue';
+
+/**
+ * The design-system stand-ins the palette's suites render it through: the
+ * dialog shell, the command list, the filter field, the glyphs and the sanitized
+ * body.
+ *
+ * They live outside the suites because the palette composes enough of the design
+ * system that the preamble, repeated per suite, would dwarf the assertions. A
+ * `vi.mock` factory is hoisted above the imports, so a suite reaches for what it
+ * needs with a dynamic `import()` inside the factory.
+ */
+
+/**
+ * Renders its tag with whatever it was handed, so a stubbed primitive still
+ * carries the `data-test`, the classes and the ARIA the palette puts on it —
+ * which is exactly what these suites assert on.
+ */
+export function passthrough(tag: string): Component {
+    return defineComponent({
+        name: `${tag}Passthrough`,
+        inheritAttrs: false,
+        setup:
+            (_props, { attrs, slots }) =>
+            () =>
+                h(tag, attrs, slots.default?.()),
+    });
+}
+
+/** The glyphs, each rendering as an `<svg>` that keeps its classes. */
+export function lucideDouble(): Record<string, Component> {
+    return Object.fromEntries(
+        ['AlarmClock', 'Search'].map((icon) => [icon, passthrough('svg')]),
+    );
+}
+
+/**
+ * reka-ui's filter field, reduced to the input it renders. Unlike the inert
+ * stubs it is bound both ways: the query it writes is what drives every ranked
+ * group below it, so a suite types into it exactly as a viewer would.
+ */
+const filterField = defineComponent({
+    name: 'ListboxFilterStub',
+    inheritAttrs: false,
+    props: { modelValue: { type: String, default: '' } },
+    setup:
+        (props, { attrs }) =>
+        () =>
+            h('input', {
+                ...attrs,
+                value: props.modelValue,
+                onInput: (event: Event) =>
+                    (attrs['onUpdate:modelValue'] as (value: string) => void)?.(
+                        (event.target as HTMLInputElement).value,
+                    ),
+            }),
+});
+
+export function rekaDouble(): Record<string, Component> {
+    return { ListboxFilter: filterField };
+}
+
+/**
+ * A command row, which unlike the rest is not inert: the palette's whole job is
+ * to turn a pick into a navigation, so the row reduces to the one gesture that
+ * fires the handler bound to it. reka-ui announces that pick as `select`.
+ */
+const commandItem = defineComponent({
+    name: 'CommandItemStub',
+    inheritAttrs: false,
+    setup:
+        (_props, { attrs, slots }) =>
+        () =>
+            h(
+                'button',
+                {
+                    ...attrs,
+                    onClick: () =>
+                        (attrs.onSelect as (event: Event) => void)?.(
+                            new Event('select', { cancelable: true }),
+                        ),
+                },
+                slots.default?.(),
+            ),
+});
+
+/** A group, keeping its heading where a suite can read which one it is. */
+const commandGroup = defineComponent({
+    name: 'CommandGroupStub',
+    inheritAttrs: false,
+    props: { heading: { type: String, default: '' } },
+    setup:
+        (props, { attrs, slots }) =>
+        () =>
+            h(
+                'section',
+                { ...attrs, 'data-heading': props.heading },
+                slots.default?.(),
+            ),
+});
+
+export function commandDouble(): Record<string, Component> {
+    return {
+        Command: passthrough('div'),
+        CommandGroup: commandGroup,
+        CommandItem: commandItem,
+        CommandList: passthrough('div'),
+    };
+}
+
+export function buttonDouble(): Record<string, Component> {
+    return { Button: passthrough('button') };
+}
+
+export function presenceDotDouble(): Record<string, Component> {
+    return { default: passthrough('span') };
+}
+
+export function dialogDouble(): Record<string, Component> {
+    return {
+        Dialog: passthrough('div'),
+        DialogContent: passthrough('div'),
+        DialogDescription: passthrough('p'),
+        DialogHeader: passthrough('div'),
+        DialogTitle: passthrough('h2'),
+    };
+}
+
+/**
+ * The sanitizing renderer, keeping the markup it was handed where a suite can
+ * read it back — the palette's own contribution is choosing what to hand over.
+ */
+const safeHtml = defineComponent({
+    name: 'SafeHtmlStub',
+    inheritAttrs: false,
+    props: { html: { type: String, default: '' } },
+    setup:
+        (props, { attrs }) =>
+        () =>
+            h('span', { ...attrs, 'data-html': props.html }),
+});
+
+export function safeHtmlDouble(): Record<string, Component> {
+    return { default: safeHtml };
+}

--- a/resources/js/components/QuickSwitcher.vue
+++ b/resources/js/components/QuickSwitcher.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
-import { router, usePage } from '@inertiajs/vue3';
-import { AlarmClock, Search } from '@lucide/vue';
-import { ListboxFilter } from 'reka-ui';
-import { computed, ref, watch } from 'vue';
+import { router } from '@inertiajs/vue3';
+import { AlarmClock } from '@lucide/vue';
+import { computed, watch } from 'vue';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
-import { suggest as suggestMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
-import PresenceDot from '@/components/PresenceDot.vue';
-import SafeHtml from '@/components/SafeHtml.vue';
-import { Button } from '@/components/ui/button';
+import SwitcherChannels from '@/components/switcher/SwitcherChannels.vue';
+import SwitcherField from '@/components/switcher/SwitcherField.vue';
+import SwitcherMessages from '@/components/switcher/SwitcherMessages.vue';
+import SwitcherPeople from '@/components/switcher/SwitcherPeople.vue';
 import {
     Command,
     CommandGroup,
@@ -21,29 +20,15 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
-import { useSidebar } from '@/components/ui/sidebar';
 import {
-    matchRange,
     rankChannels,
     rankChannelsByActivity,
 } from '@/composables/quickSwitcher';
-import { useCustomEmojis } from '@/composables/useCustomEmojis';
-import { getInitials } from '@/composables/useInitials';
 import { useIsMobile } from '@/composables/useIsMobile';
-import { useMessageSearch } from '@/composables/useMessageSearch';
-import { urlForDestination } from '@/composables/useNavPanel';
 import { useOpenDirectMessage } from '@/composables/useOpenDirectMessage';
-import { useTranslations } from '@/composables/useTranslations';
-import { useUserGroups } from '@/composables/useUserGroups';
-import { formatDateTime } from '@/lib/datetime';
-import { renderMessageBody } from '@/lib/messageBody';
+import { useQuickSwitcherSearch } from '@/composables/useQuickSwitcherSearch';
 import { rankPeople } from '@/lib/peopleDirectory';
-import { pinUrl } from '@/lib/pinUrl';
-import { presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
-import { urlForSearchParams } from '@/lib/searchPanel';
-import { filtersToParams, parseSearchQuery } from '@/lib/searchTokens';
-import type { SearchParams } from '@/lib/searchTokens';
 import type { MessageSearchResult } from '@/types';
 import type { Channel } from '@/types/channels';
 import type { PersonRef } from '@/types/people';
@@ -69,30 +54,19 @@ const emit = defineEmits<{
     openReminders: [];
 }>();
 
-/**
- * Our own query drives the fuzzy channel ranking. The Command's internal filter
- * state is deliberately left untouched (empty) so it never hides a subsequence
- * match that `rankChannels` chose to surface — the ranked list is the single
- * source of truth for what shows and in what order.
- */
-const query = ref('');
-
-const trimmedQuery = computed(() => query.value.trim().replace(/^#+/, ''));
-
-/**
- * Parse the raw input into the shared filter model so `from:` / `in:` /
- * `before:` / `after:` tokens drive the same structured search the page uses —
- * the palette just has no visible chip bar. The residual text is the query the
- * results highlight and the channel/people groups keep ranking on.
- */
-const parsedFilters = computed(() =>
-    parseSearchQuery(query.value, {
-        members: props.members,
-        channels: props.channels,
-    }),
-);
-
-const searchText = computed(() => parsedFilters.value.text);
+const {
+    query,
+    trimmedQuery,
+    searchText,
+    messageResults,
+    isSearchingMessages,
+    clear,
+    handOffToSearch,
+} = useQuickSwitcherSearch({
+    teamSlug: () => props.teamSlug,
+    members: () => props.members,
+    channels: () => props.channels,
+});
 
 /**
  * Below the breakpoint the overlay is entered without a keyboard and often
@@ -108,100 +82,19 @@ const channelResults = computed(() =>
         : rankChannels(props.channels, query.value),
 );
 
-/** A run of a result's name, marked when it is the part the query matched. */
-type NameSegment = { text: string; highlighted: boolean };
-
-/**
- * Split a name around the typed query's contiguous match so the mobile rows
- * can brighten it; a single unhighlighted run when nothing contiguous matches.
- */
-function nameSegments(name: string): NameSegment[] {
-    const range = matchRange(name, query.value);
-
-    if (range === null) {
-        return [{ text: name, highlighted: false }];
-    }
-
-    return [
-        { text: name.slice(0, range.start), highlighted: false },
-        {
-            text: name.slice(range.start, range.start + range.length),
-            highlighted: true,
-        },
-        { text: name.slice(range.start + range.length), highlighted: false },
-    ].filter((segment) => segment.text !== '');
-}
-
 // Team members ranked next to channels; choosing one opens/creates their DM.
-const { t } = useTranslations();
 const { openDirectMessage } = useOpenDirectMessage(() => props.teamSlug);
 
 const peopleResults = computed(() =>
     rankPeople(props.members, query.value, props.currentUserId),
 );
 
-/**
- * Live message search: a debounced JSON call to the suggest endpoint, with the
- * in-flight request cancelled whenever the query changes so late responses
- * never overwrite newer ones.
- */
-const {
-    results: messageResults,
-    isSearching: isSearchingMessages,
-    search: searchMessages,
-    reset: resetMessages,
-} = useMessageSearch(
-    (params) =>
-        suggestMessages(props.teamSlug, {
-            query: JSON.parse(params) as SearchParams,
-        }).url,
-);
-
-// Re-search whenever the structured filters change (a token edit counts, not
-// just text), keyed on the serialized params so an identical filter set is not
-// re-fetched. A query with no residual text can never match, so it clears.
-watch(
-    parsedFilters,
-    (filters) => {
-        // A query with no residual text can never match, so clear rather than
-        // send an empty request (keeps the URL-builder off an empty params key).
-        if (filters.text === '') {
-            resetMessages();
-
-            return;
-        }
-
-        searchMessages(JSON.stringify(filtersToParams(filters)));
-    },
-    { deep: true },
-);
-
 // Reset everything on dismiss so the palette always reopens blank.
 watch(open, (isOpen) => {
     if (!isOpen) {
-        query.value = '';
-        resetMessages();
+        clear();
     }
 });
-
-const page = usePage();
-
-/**
- * The dock, which the hand-off to the Search panel has to reveal: the drawer on a
- * phone, the collapsed column on a desktop.
- */
-const { open: dockOpen, setOpen: setDockOpen, setOpenMobile } = useSidebar();
-
-const { map: customEmojis } = useCustomEmojis();
-const { groups: userGroups } = useUserGroups();
-
-const viewerTimeZone = computed(
-    () => page.props.auth.user.timezone ?? undefined,
-);
-
-function formatTimestamp(iso: string): string {
-    return formatDateTime(iso, viewerTimeZone.value);
-}
 
 function selectChannel(channel: Channel): void {
     open.value = false;
@@ -223,31 +116,9 @@ function selectMessage(result: MessageSearchResult): void {
     );
 }
 
-/**
- * Hand the palette's query over to the Search destination, which is where the
- * full result set lives now that search is a dock panel.
- *
- * The hand-off is a client-side write of the criteria onto the current route:
- * the dock adopts `?nav=search` from the URL, and the panel pulls the matches
- * itself. Either way the dock has to be showing first — the palette can be
- * reached with the drawer shut on a phone and with the column collapsed on a
- * desktop — or the hand-off lands somewhere nobody can see.
- */
 function seeAllResults(): void {
     open.value = false;
-
-    pinUrl(
-        urlForSearchParams(
-            urlForDestination(page.url, 'search'),
-            filtersToParams(parsedFilters.value),
-        ),
-    );
-
-    if (isMobile.value) {
-        setOpenMobile(true);
-    } else if (!dockOpen.value) {
-        setDockOpen(true);
-    }
+    handOffToSearch();
 }
 
 function openReminders(): void {
@@ -270,54 +141,11 @@ function openReminders(): void {
                 }}</DialogDescription>
             </DialogHeader>
             <Command>
-                <!-- Below the breakpoint the input is a pill with a Cancel
-                     affordance beside it (m5); the desktop palette keeps its
-                     plain underlined row. -->
-                <div
-                    v-if="isMobile"
-                    class="flex shrink-0 items-center gap-2.5 border-b px-3.5 pt-3.5 pb-3"
-                >
-                    <div
-                        class="flex h-10.5 min-w-0 flex-1 items-center gap-2 rounded-full border border-input bg-card px-3.5"
-                    >
-                        <Search
-                            class="size-3.5 shrink-0 text-muted-foreground/70"
-                        />
-                        <ListboxFilter
-                            v-model="query"
-                            auto-focus
-                            :placeholder="
-                                $t('Jump to a channel or search messages…')
-                            "
-                            data-test="quick-switcher-input"
-                            class="h-full w-full min-w-0 bg-transparent text-base outline-hidden placeholder:text-muted-foreground md:text-[15px]"
-                        />
-                    </div>
-                    <Button
-                        variant="ghost"
-                        type="button"
-                        data-test="quick-switcher-cancel"
-                        class="h-10.5 shrink-0 px-1.5 text-sm font-semibold text-muted-foreground"
-                        @click="open = false"
-                    >
-                        {{ $t('Cancel') }}
-                    </Button>
-                </div>
-                <div
-                    v-else
-                    class="flex h-12 items-center gap-2.5 border-b px-4"
-                >
-                    <Search class="size-4 shrink-0 text-muted-foreground/70" />
-                    <ListboxFilter
-                        v-model="query"
-                        auto-focus
-                        :placeholder="
-                            $t('Jump to a channel or search messages…')
-                        "
-                        data-test="quick-switcher-input"
-                        class="flex h-10 w-full rounded-md bg-transparent py-3 text-base outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-                    />
-                </div>
+                <SwitcherField
+                    v-model="query"
+                    :is-mobile="isMobile"
+                    @cancel="open = false"
+                />
                 <CommandList
                     :ariaLabel="$t('Quick switcher')"
                     class="max-md:max-h-none max-md:flex-1 max-md:p-1.5"
@@ -344,227 +172,30 @@ function openReminders(): void {
                         </CommandItem>
                     </CommandGroup>
 
-                    <CommandGroup
-                        v-if="channelResults.length > 0"
-                        :heading="$t('Channels')"
-                    >
-                        <CommandItem
-                            v-for="channel in channelResults"
-                            :key="channel.id"
-                            :value="`channel:${channel.id}`"
-                            data-test="quick-switcher-channel"
-                            class="group h-9.5 gap-2 rounded-lg px-2.5 max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground"
-                            @select="selectChannel(channel)"
-                        >
-                            <span
-                                class="shrink-0 font-semibold text-muted-foreground group-data-[highlighted]:text-brass max-md:font-serif max-md:text-[17px] max-md:italic"
-                                aria-hidden="true"
-                                >#</span
-                            >
-                            <span class="truncate max-md:text-[15px]">
-                                <template v-if="isMobile">
-                                    <template
-                                        v-for="(segment, index) in nameSegments(
-                                            channel.name,
-                                        )"
-                                        :key="index"
-                                    >
-                                        <span
-                                            v-if="segment.highlighted"
-                                            data-test="quick-switcher-match"
-                                            class="rounded-[3px] bg-brass/25"
-                                            >{{ segment.text }}</span
-                                        >
-                                        <template v-else>{{
-                                            segment.text
-                                        }}</template>
-                                    </template>
-                                </template>
-                                <template v-else>{{ channel.name }}</template>
-                            </span>
-                            <span
-                                class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100 max-md:hidden"
-                                aria-hidden="true"
-                                >↵</span
-                            >
-                        </CommandItem>
-                    </CommandGroup>
+                    <SwitcherChannels
+                        :channels="channelResults"
+                        :query="query"
+                        :is-mobile="isMobile"
+                        @select="selectChannel"
+                    />
 
-                    <CommandGroup
-                        v-if="peopleResults.length > 0"
-                        :heading="$t('People')"
-                    >
-                        <CommandItem
-                            v-for="person in peopleResults"
-                            :key="person.id"
-                            :value="`person:${person.id}`"
-                            data-test="quick-switcher-person"
-                            class="group h-9.5 gap-2 rounded-lg px-2.5 max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground"
-                            @select="selectPerson(person.id)"
-                        >
-                            <span
-                                v-if="isMobile"
-                                class="relative size-7 shrink-0"
-                                aria-hidden="true"
-                            >
-                                <span
-                                    class="flex size-7 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none"
-                                    >{{ getInitials(person.name) }}</span
-                                >
-                                <PresenceDot
-                                    :presence="presenceFor(person.id)"
-                                    :is-dnd="isDndFor?.(person.id) ?? false"
-                                    surface-class="bg-sidebar"
-                                    size="28"
-                                    class="ring-sidebar"
-                                />
-                            </span>
-                            <span
-                                v-else
-                                class="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none md:group-data-[highlighted]:bg-primary-foreground/20 md:group-data-[highlighted]:text-primary-foreground"
-                                aria-hidden="true"
-                                >{{ getInitials(person.name) }}</span
-                            >
-                            <span class="truncate max-md:text-[15px]">
-                                <template v-if="isMobile">
-                                    <template
-                                        v-for="(segment, index) in nameSegments(
-                                            person.isSelf
-                                                ? t('You')
-                                                : person.name,
-                                        )"
-                                        :key="index"
-                                    >
-                                        <span
-                                            v-if="segment.highlighted"
-                                            data-test="quick-switcher-match"
-                                            class="rounded-[3px] bg-brass/25"
-                                            >{{ segment.text }}</span
-                                        >
-                                        <template v-else>{{
-                                            segment.text
-                                        }}</template>
-                                    </template>
-                                </template>
-                                <template v-else>{{
-                                    person.isSelf ? t('You') : person.name
-                                }}</template>
-                            </span>
-                            <span
-                                v-if="isMobile"
-                                class="ml-auto shrink-0 text-[11.5px] text-muted-foreground"
-                                >{{
-                                    $t(presenceLabelKey(presenceFor(person.id)))
-                                }}</span
-                            >
-                            <span
-                                v-else
-                                class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100"
-                                aria-hidden="true"
-                                >↵</span
-                            >
-                        </CommandItem>
-                    </CommandGroup>
+                    <SwitcherPeople
+                        :people="peopleResults"
+                        :query="query"
+                        :is-mobile="isMobile"
+                        :presence-for="presenceFor"
+                        :is-dnd-for="isDndFor"
+                        @select="selectPerson"
+                    />
 
-                    <CommandGroup
+                    <SwitcherMessages
                         v-if="searchText !== ''"
-                        :heading="$t('Messages')"
-                    >
-                        <p
-                            v-if="
-                                isSearchingMessages &&
-                                messageResults.length === 0
-                            "
-                            class="px-2 py-2 text-xs text-muted-foreground"
-                        >
-                            {{ $t('Searching…') }}
-                        </p>
-                        <p
-                            v-else-if="messageResults.length === 0"
-                            data-test="quick-switcher-no-messages"
-                            class="px-2 py-2 text-xs text-muted-foreground"
-                        >
-                            {{
-                                $t('No messages match “:query”.', {
-                                    query: searchText,
-                                })
-                            }}
-                        </p>
-
-                        <CommandItem
-                            v-for="result in messageResults"
-                            :key="result.message.id"
-                            :value="`message:${result.message.id}`"
-                            data-test="quick-switcher-message"
-                            class="items-start gap-2.5 max-md:min-h-11.5 max-md:rounded-[11px] max-md:px-3"
-                            @select="selectMessage(result)"
-                        >
-                            <div
-                                class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-semibold text-primary select-none"
-                                aria-hidden="true"
-                            >
-                                {{ getInitials(result.message.user.name) }}
-                            </div>
-                            <div class="min-w-0 flex-1">
-                                <div
-                                    class="flex items-baseline gap-1.5 text-xs"
-                                >
-                                    <span
-                                        class="font-semibold text-foreground"
-                                        >{{ result.message.user.name }}</span
-                                    >
-                                    <span class="text-muted-foreground"
-                                        ><span
-                                            v-if="!result.isDirectMessage"
-                                            class="text-muted-foreground"
-                                            >#</span
-                                        >{{ result.channelName }}</span
-                                    >
-                                    <span
-                                        class="ml-auto shrink-0 text-[10px] text-muted-foreground"
-                                        >{{
-                                            formatTimestamp(
-                                                result.message.createdAt,
-                                            )
-                                        }}</span
-                                    >
-                                </div>
-                                <p
-                                    class="mt-0.5 line-clamp-1 text-[13px] text-foreground/80"
-                                >
-                                    <SafeHtml
-                                        :html="
-                                            renderMessageBody(
-                                                result.message.body,
-                                                result.message.mentions,
-                                                customEmojis,
-                                                userGroups,
-                                            )
-                                        "
-                                        variant="messageBody"
-                                    />
-                                </p>
-                            </div>
-                        </CommandItem>
-
-                        <CommandItem
-                            value="see-all-results"
-                            data-test="quick-switcher-see-all"
-                            class="mt-1 gap-2 rounded-lg border-t border-border px-2.5 font-serif text-[13px] text-muted-foreground italic data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground max-md:min-h-11.5 max-md:rounded-[11px] max-md:px-3"
-                            @select="seeAllResults"
-                        >
-                            <span class="truncate">{{
-                                $t('See all results for “:query”', {
-                                    query: searchText,
-                                })
-                            }}</span>
-                            <span
-                                class="ml-auto shrink-0 not-italic"
-                                aria-hidden="true"
-                                >&rarr;</span
-                            >
-                        </CommandItem>
-                    </CommandGroup>
+                        :results="messageResults"
+                        :is-searching="isSearchingMessages"
+                        :search-text="searchText"
+                        @select="selectMessage"
+                        @see-all="seeAllResults"
+                    />
                 </CommandList>
                 <!-- The design's standing explanation of the empty-query list:
                      it doubles as the overlay's ranking hint, so it stays put

--- a/resources/js/components/switcher/SwitcherChannels.vue
+++ b/resources/js/components/switcher/SwitcherChannels.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import SwitcherName from '@/components/switcher/SwitcherName.vue';
+import { CommandGroup, CommandItem } from '@/components/ui/command';
+import type { Channel } from '@/types/channels';
+
+defineProps<{
+    /** The ranked channels, in the order they render. */
+    channels: Channel[];
+    /** The raw query, whose match each mobile row brightens. */
+    query: string;
+    /** Whether the palette is rendering as the mobile full-screen overlay. */
+    isMobile: boolean;
+}>();
+
+defineEmits<{
+    /** The viewer picked a channel; the palette navigates into it. */
+    select: [channel: Channel];
+}>();
+</script>
+
+<template>
+    <CommandGroup v-if="channels.length > 0" :heading="$t('Channels')">
+        <CommandItem
+            v-for="channel in channels"
+            :key="channel.id"
+            :value="`channel:${channel.id}`"
+            data-test="quick-switcher-channel"
+            class="group h-9.5 gap-2 rounded-lg px-2.5 max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground"
+            @select="$emit('select', channel)"
+        >
+            <span
+                class="shrink-0 font-semibold text-muted-foreground group-data-[highlighted]:text-brass max-md:font-serif max-md:text-[17px] max-md:italic"
+                aria-hidden="true"
+                >#</span
+            >
+            <SwitcherName
+                :name="channel.name"
+                :query="query"
+                :highlight="isMobile"
+            />
+            <span
+                class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100 max-md:hidden"
+                aria-hidden="true"
+                >↵</span
+            >
+        </CommandItem>
+    </CommandGroup>
+</template>

--- a/resources/js/components/switcher/SwitcherField.vue
+++ b/resources/js/components/switcher/SwitcherField.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { Search } from '@lucide/vue';
+import { ListboxFilter } from 'reka-ui';
+import { Button } from '@/components/ui/button';
+
+defineProps<{
+    /** Whether the palette is rendering as the mobile full-screen overlay. */
+    isMobile: boolean;
+}>();
+
+const query = defineModel<string>({ required: true });
+
+defineEmits<{
+    /** The viewer dismissed the overlay from the Cancel affordance. */
+    cancel: [];
+}>();
+</script>
+
+<template>
+    <!-- Below the breakpoint the input is a pill with a Cancel
+         affordance beside it (m5); the desktop palette keeps its
+         plain underlined row. -->
+    <div
+        v-if="isMobile"
+        class="flex shrink-0 items-center gap-2.5 border-b px-3.5 pt-3.5 pb-3"
+    >
+        <div
+            class="flex h-10.5 min-w-0 flex-1 items-center gap-2 rounded-full border border-input bg-card px-3.5"
+        >
+            <Search class="size-3.5 shrink-0 text-muted-foreground/70" />
+            <ListboxFilter
+                v-model="query"
+                auto-focus
+                :placeholder="$t('Jump to a channel or search messages…')"
+                data-test="quick-switcher-input"
+                class="h-full w-full min-w-0 bg-transparent text-base outline-hidden placeholder:text-muted-foreground md:text-[15px]"
+            />
+        </div>
+        <Button
+            variant="ghost"
+            type="button"
+            data-test="quick-switcher-cancel"
+            class="h-10.5 shrink-0 px-1.5 text-sm font-semibold text-muted-foreground"
+            @click="$emit('cancel')"
+        >
+            {{ $t('Cancel') }}
+        </Button>
+    </div>
+    <div v-else class="flex h-12 items-center gap-2.5 border-b px-4">
+        <Search class="size-4 shrink-0 text-muted-foreground/70" />
+        <ListboxFilter
+            v-model="query"
+            auto-focus
+            :placeholder="$t('Jump to a channel or search messages…')"
+            data-test="quick-switcher-input"
+            class="flex h-10 w-full rounded-md bg-transparent py-3 text-base outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+        />
+    </div>
+</template>

--- a/resources/js/components/switcher/SwitcherMessages.vue
+++ b/resources/js/components/switcher/SwitcherMessages.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+import SafeHtml from '@/components/SafeHtml.vue';
+import { CommandGroup, CommandItem } from '@/components/ui/command';
+import { useCustomEmojis } from '@/composables/useCustomEmojis';
+import { getInitials } from '@/composables/useInitials';
+import { useUserGroups } from '@/composables/useUserGroups';
+import { formatDateTime } from '@/lib/datetime';
+import { renderMessageBody } from '@/lib/messageBody';
+import type { MessageSearchResult } from '@/types';
+
+defineProps<{
+    /** The matches the suggest endpoint last answered with. */
+    results: MessageSearchResult[];
+    /** Whether a request is outstanding, which reads as "Searching…". */
+    isSearching: boolean;
+    /** The residual text the matches were selected by, named back to the viewer. */
+    searchText: string;
+}>();
+
+defineEmits<{
+    /** The viewer picked a match; the palette opens it in its channel. */
+    select: [result: MessageSearchResult];
+    /** The viewer asked for the full result set, which the Search panel holds. */
+    seeAll: [];
+}>();
+
+const page = usePage();
+
+const { map: customEmojis } = useCustomEmojis();
+const { groups: userGroups } = useUserGroups();
+
+const viewerTimeZone = computed(
+    () => page.props.auth.user.timezone ?? undefined,
+);
+
+function formatTimestamp(iso: string): string {
+    return formatDateTime(iso, viewerTimeZone.value);
+}
+</script>
+
+<template>
+    <CommandGroup :heading="$t('Messages')">
+        <p
+            v-if="isSearching && results.length === 0"
+            class="px-2 py-2 text-xs text-muted-foreground"
+        >
+            {{ $t('Searching…') }}
+        </p>
+        <p
+            v-else-if="results.length === 0"
+            data-test="quick-switcher-no-messages"
+            class="px-2 py-2 text-xs text-muted-foreground"
+        >
+            {{ $t('No messages match “:query”.', { query: searchText }) }}
+        </p>
+
+        <CommandItem
+            v-for="result in results"
+            :key="result.message.id"
+            :value="`message:${result.message.id}`"
+            data-test="quick-switcher-message"
+            class="items-start gap-2.5 max-md:min-h-11.5 max-md:rounded-[11px] max-md:px-3"
+            @select="$emit('select', result)"
+        >
+            <div
+                class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-semibold text-primary select-none"
+                aria-hidden="true"
+            >
+                {{ getInitials(result.message.user.name) }}
+            </div>
+            <div class="min-w-0 flex-1">
+                <div class="flex items-baseline gap-1.5 text-xs">
+                    <span class="font-semibold text-foreground">{{
+                        result.message.user.name
+                    }}</span>
+                    <span class="text-muted-foreground"
+                        ><span
+                            v-if="!result.isDirectMessage"
+                            class="text-muted-foreground"
+                            >#</span
+                        >{{ result.channelName }}</span
+                    >
+                    <span
+                        class="ml-auto shrink-0 text-[10px] text-muted-foreground"
+                        >{{ formatTimestamp(result.message.createdAt) }}</span
+                    >
+                </div>
+                <p class="mt-0.5 line-clamp-1 text-[13px] text-foreground/80">
+                    <SafeHtml
+                        :html="
+                            renderMessageBody(
+                                result.message.body,
+                                result.message.mentions,
+                                customEmojis,
+                                userGroups,
+                            )
+                        "
+                        variant="messageBody"
+                    />
+                </p>
+            </div>
+        </CommandItem>
+
+        <CommandItem
+            value="see-all-results"
+            data-test="quick-switcher-see-all"
+            class="mt-1 gap-2 rounded-lg border-t border-border px-2.5 font-serif text-[13px] text-muted-foreground italic data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground max-md:min-h-11.5 max-md:rounded-[11px] max-md:px-3"
+            @select="$emit('seeAll')"
+        >
+            <span class="truncate">{{
+                $t('See all results for “:query”', { query: searchText })
+            }}</span>
+            <span class="ml-auto shrink-0 not-italic" aria-hidden="true"
+                >&rarr;</span
+            >
+        </CommandItem>
+    </CommandGroup>
+</template>

--- a/resources/js/components/switcher/SwitcherName.vue
+++ b/resources/js/components/switcher/SwitcherName.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { matchRange } from '@/composables/quickSwitcher';
+
+const props = defineProps<{
+    /** The result's name, as the row reads it out. */
+    name: string;
+    /** The raw query, whose contiguous match is the run to brighten. */
+    query: string;
+    /**
+     * Whether to mark the match at all. The mobile rows brighten it; the desktop
+     * palette leaves the name whole.
+     */
+    highlight: boolean;
+}>();
+
+/** A run of a result's name, marked when it is the part the query matched. */
+type NameSegment = { text: string; highlighted: boolean };
+
+/**
+ * Split a name around the typed query's contiguous match so the mobile rows
+ * can brighten it; a single unhighlighted run when nothing contiguous matches.
+ */
+const segments = computed<NameSegment[]>(() => {
+    const range = matchRange(props.name, props.query);
+
+    if (range === null) {
+        return [{ text: props.name, highlighted: false }];
+    }
+
+    return [
+        { text: props.name.slice(0, range.start), highlighted: false },
+        {
+            text: props.name.slice(range.start, range.start + range.length),
+            highlighted: true,
+        },
+        {
+            text: props.name.slice(range.start + range.length),
+            highlighted: false,
+        },
+    ].filter((segment) => segment.text !== '');
+});
+</script>
+
+<template>
+    <span class="truncate max-md:text-[15px]">
+        <template v-if="highlight">
+            <template v-for="(segment, index) in segments" :key="index">
+                <span
+                    v-if="segment.highlighted"
+                    data-test="quick-switcher-match"
+                    class="rounded-[3px] bg-brass/25"
+                    >{{ segment.text }}</span
+                >
+                <template v-else>{{ segment.text }}</template>
+            </template>
+        </template>
+        <template v-else>{{ name }}</template>
+    </span>
+</template>

--- a/resources/js/components/switcher/SwitcherPeople.vue
+++ b/resources/js/components/switcher/SwitcherPeople.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import PresenceDot from '@/components/PresenceDot.vue';
+import SwitcherName from '@/components/switcher/SwitcherName.vue';
+import { CommandGroup, CommandItem } from '@/components/ui/command';
+import { getInitials } from '@/composables/useInitials';
+import { useTranslations } from '@/composables/useTranslations';
+import { presenceLabelKey } from '@/lib/presence';
+import type { RenderedPresence } from '@/lib/presence';
+import type { PersonEntry } from '@/types/people';
+
+defineProps<{
+    /** The ranked team members, in the order they render. */
+    people: PersonEntry[];
+    /** The raw query, whose match each mobile row brightens. */
+    query: string;
+    /** Whether the palette is rendering as the mobile full-screen overlay. */
+    isMobile: boolean;
+    /**
+     * How each team member reads on the presence roster, driving the mobile
+     * overlay's avatar dots and presence words.
+     */
+    presenceFor: (userId: string) => RenderedPresence;
+    /** Whether each member is in do-not-disturb, driving the crescent badge. */
+    isDndFor?: (userId: string) => boolean;
+}>();
+
+defineEmits<{
+    /** The viewer picked a person; the palette opens/creates their DM. */
+    select: [userId: string];
+}>();
+
+const { t } = useTranslations();
+</script>
+
+<template>
+    <CommandGroup v-if="people.length > 0" :heading="$t('People')">
+        <CommandItem
+            v-for="person in people"
+            :key="person.id"
+            :value="`person:${person.id}`"
+            data-test="quick-switcher-person"
+            class="group h-9.5 gap-2 rounded-lg px-2.5 max-md:h-11.5 max-md:gap-2.5 max-md:rounded-[11px] max-md:px-3 md:data-[highlighted]:bg-primary md:data-[highlighted]:text-primary-foreground"
+            @select="$emit('select', person.id)"
+        >
+            <span
+                v-if="isMobile"
+                class="relative size-7 shrink-0"
+                aria-hidden="true"
+            >
+                <span
+                    class="flex size-7 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none"
+                    >{{ getInitials(person.name) }}</span
+                >
+                <PresenceDot
+                    :presence="presenceFor(person.id)"
+                    :is-dnd="isDndFor?.(person.id) ?? false"
+                    surface-class="bg-sidebar"
+                    size="28"
+                    class="ring-sidebar"
+                />
+            </span>
+            <span
+                v-else
+                class="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary select-none md:group-data-[highlighted]:bg-primary-foreground/20 md:group-data-[highlighted]:text-primary-foreground"
+                aria-hidden="true"
+                >{{ getInitials(person.name) }}</span
+            >
+            <SwitcherName
+                :name="person.isSelf ? t('You') : person.name"
+                :query="query"
+                :highlight="isMobile"
+            />
+            <span
+                v-if="isMobile"
+                class="ml-auto shrink-0 text-[11.5px] text-muted-foreground"
+                >{{ $t(presenceLabelKey(presenceFor(person.id))) }}</span
+            >
+            <span
+                v-else
+                class="ml-auto font-mono text-[11px] text-primary-foreground/70 opacity-0 group-data-[highlighted]:opacity-100"
+                aria-hidden="true"
+                >↵</span
+            >
+        </CommandItem>
+    </CommandGroup>
+</template>

--- a/resources/js/composables/useQuickSwitcherSearch.ts
+++ b/resources/js/composables/useQuickSwitcherSearch.ts
@@ -1,0 +1,168 @@
+import { usePage } from '@inertiajs/vue3';
+import { computed, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { suggest as suggestMessages } from '@/actions/App/Http/Controllers/Channels/SearchController';
+import { useSidebar } from '@/components/ui/sidebar';
+import { useIsMobile } from '@/composables/useIsMobile';
+import { useMessageSearch } from '@/composables/useMessageSearch';
+import { urlForDestination } from '@/composables/useNavPanel';
+import { pinUrl } from '@/lib/pinUrl';
+import { urlForSearchParams } from '@/lib/searchPanel';
+import { filtersToParams, parseSearchQuery } from '@/lib/searchTokens';
+import type { SearchFilters, SearchParams } from '@/lib/searchTokens';
+import type { MessageSearchResult } from '@/types';
+import type { Channel } from '@/types/channels';
+import type { PersonRef } from '@/types/people';
+
+/** What a token in the palette's query resolves against. */
+export type QuickSwitcherLookup = {
+    teamSlug: () => string;
+    members: () => PersonRef[];
+    channels: () => Channel[];
+};
+
+export type QuickSwitcherSearch = {
+    /** The raw input, which the ranked groups read as well. */
+    query: Ref<string>;
+    /** The query with its surrounding noise gone: `#gen` and `gen` are one. */
+    trimmedQuery: ComputedRef<string>;
+    /** The structured filter model the `from:`/`in:`/date tokens parse into. */
+    parsedFilters: ComputedRef<SearchFilters>;
+    /** The residual text the results highlight and the groups keep ranking on. */
+    searchText: ComputedRef<string>;
+    messageResults: Ref<MessageSearchResult[]>;
+    isSearchingMessages: Ref<boolean>;
+    /** Drop the query and the matches, so the palette reopens blank. */
+    clear: () => void;
+    /** Hand the criteria over to the Search destination, and reveal the dock. */
+    handOffToSearch: () => void;
+};
+
+/**
+ * The palette's query and everything it drives: the structured filters it parses
+ * into, the debounced message search it feeds, and the hand-off that carries
+ * both over to the Search panel.
+ *
+ * Kept apart from the palette's markup because the query is the one piece of it
+ * that reaches the server, and it does so on its own schedule — a debounce, a
+ * cancellation, and a client-side write of the criteria onto the current route.
+ */
+export function useQuickSwitcherSearch(
+    lookup: QuickSwitcherLookup,
+): QuickSwitcherSearch {
+    const page = usePage();
+    const isMobile = useIsMobile();
+
+    /**
+     * The dock, which the hand-off to the Search panel has to reveal: the drawer
+     * on a phone, the collapsed column on a desktop.
+     */
+    const {
+        open: dockOpen,
+        setOpen: setDockOpen,
+        setOpenMobile,
+    } = useSidebar();
+
+    /**
+     * Our own query drives the fuzzy channel ranking. The Command's internal
+     * filter state is deliberately left untouched (empty) so it never hides a
+     * subsequence match that `rankChannels` chose to surface — the ranked list is
+     * the single source of truth for what shows and in what order.
+     */
+    const query = ref('');
+
+    const trimmedQuery = computed(() => query.value.trim().replace(/^#+/, ''));
+
+    /**
+     * Parse the raw input into the shared filter model so `from:` / `in:` /
+     * `before:` / `after:` tokens drive the same structured search the page uses
+     * — the palette just has no visible chip bar. The residual text is the query
+     * the results highlight and the channel/people groups keep ranking on.
+     */
+    const parsedFilters = computed(() =>
+        parseSearchQuery(query.value, {
+            members: lookup.members(),
+            channels: lookup.channels(),
+        }),
+    );
+
+    const searchText = computed(() => parsedFilters.value.text);
+
+    /**
+     * Live message search: a debounced JSON call to the suggest endpoint, with
+     * the in-flight request cancelled whenever the query changes so late
+     * responses never overwrite newer ones.
+     */
+    const {
+        results: messageResults,
+        isSearching: isSearchingMessages,
+        search: searchMessages,
+        reset: resetMessages,
+    } = useMessageSearch(
+        (params) =>
+            suggestMessages(lookup.teamSlug(), {
+                query: JSON.parse(params) as SearchParams,
+            }).url,
+    );
+
+    // Re-search whenever the structured filters change (a token edit counts, not
+    // just text), keyed on the serialized params so an identical filter set is
+    // not re-fetched. A query with no residual text can never match, so it
+    // clears.
+    watch(
+        parsedFilters,
+        (filters) => {
+            // A query with no residual text can never match, so clear rather than
+            // send an empty request (keeps the URL-builder off an empty params key).
+            if (filters.text === '') {
+                resetMessages();
+
+                return;
+            }
+
+            searchMessages(JSON.stringify(filtersToParams(filters)));
+        },
+        { deep: true },
+    );
+
+    function clear(): void {
+        query.value = '';
+        resetMessages();
+    }
+
+    /**
+     * Hand the palette's query over to the Search destination, which is where the
+     * full result set lives now that search is a dock panel.
+     *
+     * The hand-off is a client-side write of the criteria onto the current route:
+     * the dock adopts `?nav=search` from the URL, and the panel pulls the matches
+     * itself. Either way the dock has to be showing first — the palette can be
+     * reached with the drawer shut on a phone and with the column collapsed on a
+     * desktop — or the hand-off lands somewhere nobody can see.
+     */
+    function handOffToSearch(): void {
+        pinUrl(
+            urlForSearchParams(
+                urlForDestination(page.url, 'search'),
+                filtersToParams(parsedFilters.value),
+            ),
+        );
+
+        if (isMobile.value) {
+            setOpenMobile(true);
+        } else if (!dockOpen.value) {
+            setDockOpen(true);
+        }
+    }
+
+    return {
+        query,
+        trimmedQuery,
+        parsedFilters,
+        searchText,
+        messageResults,
+        isSearchingMessages,
+        clear,
+        handOffToSearch,
+    };
+}


### PR DESCRIPTION
Closes #992. Fifth child of #980.

`QuickSwitcher.vue` goes from **586 to 216 raw lines** — **493 to 184** as `max-lines` counts them, against the 400 cap. Its entry is gone from the exemption block in `eslint.config.js`, so `max-lines-policy.test.ts` now holds the file to the cap like any other.

The palette mixed three concerns in one scope: the query (parsing its tokens, debouncing the suggest call, handing the criteria to the Search panel), the ranking of what it lists, and ~325 lines of template drawing four groups across both sides of the breakpoint. They move out along the seams that were already there.

## Covered first, against the current code

The file had no colocated suite — the mobile overlay had browser coverage, the desktop palette almost none — so a pure move had very little watching it. Two suites land ahead of the split and pin what it may not change:

| Suite | Holds |
| --- | --- |
| `QuickSwitcher.destinations.test.ts` | The filter field on each side of the breakpoint (Cancel below it, none above), the clear-on-dismiss, the Reminders action and the bare-`#` query that keeps it, the alphabetical desktop ranking against the by-activity mobile one, the highlighted match, the initials, "You", the presence readout, and where a channel or person pick sends the viewer |
| `QuickSwitcher.messages.test.ts` | What the suggest endpoint is asked (the serialized params, the resolved `from:` token, the clear rather than a request for a query with no text left), the searching / no-match / match renderings, the DM's missing hash, the viewer's time zone, and both ways out of the group — into the message, or over to Search with the criteria and the dock revealed on each side of the breakpoint |

Both were written and committed against the unsplit file, and pass unchanged across the move: 31 tests, no edit to any of them in the refactor commit. That is the parity proof.

## Where it went

| File | Effective lines | Holds |
| --- | ---: | --- |
| `composables/useQuickSwitcherSearch.ts` | 95 | The query, the structured filters its tokens parse into, the debounced suggest call, and the hand-off that writes the criteria onto the current route and reveals the dock |
| `components/switcher/SwitcherField.vue` | 53 | The mobile pill with its Cancel, and the desktop underlined row |
| `components/switcher/SwitcherName.vue` | 40 | The match-highlighting both ranked groups spelled out verbatim |
| `components/switcher/SwitcherChannels.vue` | 41 | The Channels group |
| `components/switcher/SwitcherPeople.vue` | 73 | The People group, with its two avatar treatments and the presence readout |
| `components/switcher/SwitcherMessages.vue` | 106 | The Messages group: the searching and empty states, a match, and the see-all row |

`QuickSwitcher.vue` keeps the dialog shell, the Actions group, the ranking, and the four handlers that turn a pick into a navigation.

## A move, not an improvement

Every `data-test` selector, every string and every class is verbatim. `lang/fr.json` is untouched — no key added, moved or renamed. The one place two copies became one is `SwitcherName`, which the channel and people rows had drawn identically.

## Verified

`sail composer test` at `Total: 100.0 %` (Pint, PHPStan and Rector clean), and `lint:check` / `format:check` / `types:check` / `test:js` (2120) / `build` all green — re-run after a rebase onto develop, since #1029 landed mid-work and touches the same exemption list.

Beyond the gate, the browser suites that exercise these selectors: `MobileQuickSwitcherTest` (8) plus `A11yShellTest` / `A11ySearchTest` / `RemindersPanelTest` / `MobileShellTest` (65), all passing — which carries the overlay's axe audit in light and dark across the split.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787869439&installation_model_id=428379&pr_number=1031&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1031&signature=73f611baf1fe64efa4665279aa6cb5e5e3d3ed3157434515f9bdbd1bf06e64be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->