### PR TITLE
fix: size the user menu by the room the rail avatar leaves

### DIFF
--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -50,7 +50,7 @@ const isPanel = computed(() => props.variant === 'panel');
     <div class="flex min-h-0 flex-1 flex-col">
         <UserMenuIdentity :user="user" :variant="variant" />
 
-        <div class="min-h-0 flex-1 overflow-y-auto">
+        <div data-test="user-menu-rows" class="min-h-0 flex-1 overflow-y-auto">
             <UserMenuStatusRows
                 :user="user"
                 :variant="variant"

--- a/resources/js/components/UserMenuIdentity.vue
+++ b/resources/js/components/UserMenuIdentity.vue
@@ -44,7 +44,8 @@ const presenceLabel = computed(() =>
 
 <template>
     <div
-        class="flex items-center border-b border-border"
+        data-test="user-menu-identity"
+        class="flex shrink-0 items-center border-b border-border"
         :class="isPanel ? 'gap-3.5 px-4.5 py-5' : 'gap-2.5 px-3 pt-3 pb-3.5'"
     >
         <span class="relative shrink-0">

--- a/resources/js/components/UserMenuPopover.vue
+++ b/resources/js/components/UserMenuPopover.vue
@@ -25,6 +25,12 @@ import UserMenuContent from '@/components/UserMenuContent.vue';
  * `modal` is deliberate: it is what puts the shell behind an `aria-hidden`
  * marker, which the app's own observer mirrors onto `inert` so the skip link
  * and the dock leave the tab order with it (#730).
+ *
+ * The card's height is whatever room the rail avatar leaves — Reka measures it
+ * as `--reka-popover-content-available-height`, the same way the emoji picker
+ * sizes itself. A fixed cap cannot do that job: `min(34rem, …)` froze the menu
+ * at 544px on every viewport taller than that, so its rows scrolled with screen
+ * to spare above and below the card (#998).
  */
 const emit = defineEmits<{
     /** The workspace sheet asked for the invite modal, which the host owns. */
@@ -73,7 +79,7 @@ function restoreFocusToTrigger(event: Event): void {
             :side-offset="8"
             :collision-padding="12"
             @close-auto-focus="restoreFocusToTrigger"
-            class="flex max-h-[min(34rem,calc(100dvh-2rem))] w-61.5 flex-col gap-0 rounded-[14px] border-border bg-popover p-0 shadow-[0_18px_40px_rgba(60,55,40,0.18)] dark:shadow-[0_18px_40px_rgba(0,0,0,0.5)]"
+            class="flex max-h-[var(--reka-popover-content-available-height)] w-61.5 flex-col gap-0 rounded-[14px] border-border bg-popover p-0 shadow-[0_18px_40px_rgba(60,55,40,0.18)] dark:shadow-[0_18px_40px_rgba(0,0,0,0.5)]"
         >
             <UserMenuContent
                 :user="page.props.auth.user"

--- a/tests/Browser/UserMenuHeightTest.php
+++ b/tests/Browser/UserMenuHeightTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The rail's user menu is sized by the room the trigger actually leaves, not by
+ * a fixed pixel cap (#998).
+ *
+ * The popover used to cap itself at `min(34rem, 100dvh - 2rem)`. 34rem is 544px,
+ * so on any viewport taller than ~576px the cap — not the viewport — decided:
+ * the menu froze at 544px and its rows started scrolling with empty screen above
+ * and below the card, while on a genuinely short viewport the same card ran past
+ * the bottom edge. Reka measures the space the anchor leaves as
+ * `--reka-popover-content-available-height`, which is what governs now.
+ */
+
+/** The pixel cap that used to bite, so the tall-viewport case cannot pass vacuously. */
+const OLD_MENU_HEIGHT_CAP = 544;
+
+/**
+ * Whether the menu is a card the screen fully contains: it has a real height,
+ * and neither edge is clipped by the viewport.
+ */
+function userMenuStaysInsideTheViewport(): string
+{
+    return <<<'JS'
+    (() => {
+        const menu = document.querySelector('[data-test="user-menu-popover"]');
+
+        if (menu === null) {
+            return false;
+        }
+
+        const box = menu.getBoundingClientRect();
+
+        return box.height > 0
+            && box.top >= -1
+            && box.bottom <= window.innerHeight + 1;
+    })()
+    JS;
+}
+
+/** Whether the scrolling region holds anything the viewer has to scroll to reach. */
+function userMenuRowsOverflow(): string
+{
+    return <<<'JS'
+    (() => {
+        const rows = document.querySelector('[data-test="user-menu-rows"]');
+
+        return rows !== null && rows.scrollHeight > rows.clientHeight + 1;
+    })()
+    JS;
+}
+
+/** Whether the given row sits fully inside both the menu card and the screen. */
+function menuRowIsFullyVisible(string $selector): string
+{
+    return <<<JS
+    (() => {
+        const menu = document.querySelector('[data-test="user-menu-popover"]');
+        const row = document.querySelector('[data-test="{$selector}"]');
+
+        if (menu === null || row === null) {
+            return false;
+        }
+
+        const menuBox = menu.getBoundingClientRect();
+        const box = row.getBoundingClientRect();
+
+        return box.height > 0
+            && box.top >= menuBox.top - 1
+            && box.bottom <= menuBox.bottom + 1
+            && box.top >= -1
+            && box.bottom <= window.innerHeight + 1;
+    })()
+    JS;
+}
+
+test('the rail menu shows every row without an inner scrollbar when the screen has room', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    $cap = OLD_MENU_HEIGHT_CAP;
+
+    signInThroughBrowser($alice)
+        ->resize(1280, 1000)
+        ->click('@rail-destination-you')
+        ->assertPresent('@user-menu-popover')
+        // Let the popover settle past its open animation, so the box being
+        // measured is the resting one rather than a zoom-in frame.
+        ->wait(0.5)
+        ->assertScript(userMenuStaysInsideTheViewport(), true)
+        // The menu grew past the cap that used to freeze it — without this the
+        // "no scrollbar" assertion below would hold for a menu that simply fits.
+        ->assertScript(<<<JS
+        (() => {
+            const menu = document.querySelector('[data-test="user-menu-popover"]');
+
+            return menu.getBoundingClientRect().height > {$cap};
+        })()
+        JS, true)
+        // Nothing is hidden behind a scrollbar...
+        ->assertScript(userMenuRowsOverflow(), false)
+        // ...so the last two things in the menu are on screen as it opens.
+        ->assertScript(menuRowIsFullyVisible('logout-button'), true)
+        ->assertScript(menuRowIsFullyVisible('user-menu-version'), true);
+});
+
+test('the rail menu stays inside a short screen and scrolls its rows instead', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    signInThroughBrowser($alice)
+        // Wide enough for the rail, short enough that the menu genuinely cannot
+        // fit — the case the fixed cap rendered clipped by the screen edge.
+        ->resize(1024, 520)
+        ->click('@rail-destination-you')
+        ->assertPresent('@user-menu-popover')
+        ->wait(0.5)
+        ->assertScript(userMenuStaysInsideTheViewport(), true)
+        ->assertScript(userMenuRowsOverflow(), true)
+        // Log out and the version footer are reachable by scrolling the rows...
+        ->assertScript(<<<'JS'
+        (() => {
+            const rows = document.querySelector('[data-test="user-menu-rows"]');
+            rows.scrollTop = rows.scrollHeight;
+
+            return true;
+        })()
+        JS, true)
+        ->assertScript(menuRowIsFullyVisible('logout-button'), true)
+        ->assertScript(menuRowIsFullyVisible('user-menu-version'), true)
+        // ...and the identity header did not scroll away with them.
+        ->assertScript(<<<'JS'
+        (() => {
+            const menu = document.querySelector('[data-test="user-menu-popover"]')
+                .getBoundingClientRect();
+            const identity = document.querySelector('[data-test="user-menu-identity"]')
+                .getBoundingClientRect();
+
+            return Math.round(identity.top) <= Math.round(menu.top) + 1
+                && identity.height > 0;
+        })()
+        JS, true);
+});
+
+test('the You panel takes the whole drawer rather than a height of its own', function (): void {
+    ['owner' => $alice] = browserTeamWithChannel();
+
+    // Below `md` the same content fills the dock's panel, so the drawer is what
+    // bounds it there. Nothing may cap it short of that: the rows run from the
+    // pinned header to the foot of the panel, and scroll only past that point.
+    signInThroughBrowser($alice)
+        ->resize(390, 844)
+        ->click('@sidebar-toggle')
+        ->click('@tab-destination-you')
+        ->assertPresent('@destination-panel-you')
+        ->wait(0.5)
+        ->assertScript(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-test="destination-panel-you"]')
+                .getBoundingClientRect();
+            const identity = document.querySelector('[data-test="user-menu-identity"]')
+                .getBoundingClientRect();
+            const rows = document.querySelector('[data-test="user-menu-rows"]')
+                .getBoundingClientRect();
+
+            return Math.abs(rows.top - identity.bottom) <= 1
+                && Math.abs(rows.bottom - panel.bottom) <= 1
+                && rows.height > 0;
+        })()
+        JS, true);
+});

--- a/tests/Browser/UserMenuHeightTest.php
+++ b/tests/Browser/UserMenuHeightTest.php
@@ -162,9 +162,15 @@ test('the You panel takes the whole drawer rather than a height of its own', fun
                 .getBoundingClientRect();
             const rows = document.querySelector('[data-test="user-menu-rows"]')
                 .getBoundingClientRect();
+            // The tab bar that opened the destination is the drawer's own floor,
+            // so reaching it is what tells a filled panel from one that merely
+            // agrees with itself about being short.
+            const tabs = document.querySelector('[data-test="navigation-tab-bar"]')
+                .getBoundingClientRect();
 
             return Math.abs(rows.top - identity.bottom) <= 1
                 && Math.abs(rows.bottom - panel.bottom) <= 1
+                && Math.abs(panel.bottom - tabs.top) <= 1
                 && rows.height > 0;
         })()
         JS, true);


### PR DESCRIPTION
Closes #998.

## What

The rail's user menu capped itself at `max-h-[min(34rem,calc(100dvh-2rem))]`. 34rem is 544px, so on any viewport taller than that the cap — not the screen — decided the height: the card froze at 544px and its rows started scrolling with empty space above and below it, while on a genuinely short viewport the same card ran past the bottom edge.

The cap is gone. The popover now takes the room the rail avatar actually leaves, which Reka measures for us as `--reka-popover-content-available-height` — the same way `EmojiPickerPopover` has always sized itself.

## Why it was the wrong control

A fixed pixel cap has no relation to the space the trigger leaves, and the menu is anchored to the avatar at the foot of the rail (`side="right" align="end"`). Measured in the running app, the menu's real content height is **715px**, so the cap was hiding ~170px of rows behind a scrollbar while 185px of screen sat unused below the card.

| viewport | card height | max-height applied | rows hidden | card bounds |
| --- | --- | --- | --- | --- |
| 1280x900 | 715px | 876px (available) | 0 | 158 -> 873, inside |
| 1024x520 | 496px | 496px (available) | 219px, scrolls | 12 -> 508, inside |

The identity header stays pinned throughout (top 13 against a card top of 12, after scrolling the rows to the bottom).

## The below-`md` panel

Checked as the issue asked: `UserPanel` carries no cap of its own, so it already fills the dock's drawer and scrolls only on genuine overflow. It now has a regression guard rather than only an implicit one.

## How tested

New `tests/Browser/UserMenuHeightTest.php`, three cases:

- a tall viewport shows every row with no inner scrollbar — guarded against a vacuous pass by also asserting the card is now taller than the 544px cap, so a menu that merely fits cannot satisfy it;
- a short viewport keeps the card inside the screen, scrolls its rows to reach Log out and the version footer, and leaves the identity header pinned;
- the "You" panel runs from its pinned header down to the tab bar that opened it, so a prematurely capped panel fails.

The first case was red before the change and green after. `MobileUserPanelTest` and `UserMenuLongLabelTest` (29 browser tests, including the axe audit) still pass.

Full gate green: `composer test` at `Total: 100.0 %` with Pint, PHPStan and Rector clean; Vitest 2194 passed; `lint:check` (0 errors), `format:check`, `types:check` and `build`.

## i18n / docs

No user-facing copy and no operator-facing behaviour changed, so no catalog or `docs/` updates are due.

## Note

A local CodeRabbit pass raised one minor finding — the panel assertion compared the rows only against the panel's own box, so a panel capped short of the drawer would still have satisfied it. Applied: it now also pins the panel's foot to the tab bar. The follow-up pass hit the free tier's rate limit (27 minutes), so the app's review covers the rest.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787872979&installation_model_id=428379&pr_number=1035&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1035&signature=2853986e3381dad47a7c1f468940aae6bf3b8c4386457a1a998589115588d32c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->