### PR TITLE
fix: hold the pins panel row together at any label width

### DIFF
--- a/resources/js/components/PinsPanel.test.ts
+++ b/resources/js/components/PinsPanel.test.ts
@@ -84,10 +84,16 @@ afterEach(() => {
 
 describe('PinsPanel rows', () => {
     it('lists a row per pin, with who pinned it and a body preview', () => {
-        const { host } = mount();
+        const { host } = mount({
+            pins: [message(), message({ id: 'm2', clientUuid: 'uuid-2' })],
+            pinCount: 2,
+        });
 
         const row = find(host, 'pins-panel-row');
 
+        expect(
+            host.querySelectorAll('[data-test="pins-panel-row"]'),
+        ).toHaveLength(2);
         expect(row.textContent).toContain(
             'Pinned by Alexandra Featherstonehaugh',
         );
@@ -110,6 +116,9 @@ describe('PinsPanel rows', () => {
 
         expect(emitted.unpin).toHaveLength(1);
         expect((emitted.unpin[0][0] as Message).id).toBe('m1');
+        // The control sits beside the row rather than inside it, so unpinning
+        // never doubles as a jump.
+        expect(emitted.jump).toBeUndefined();
     });
 
     it('drops the unpin control entirely for a read-only viewer', () => {

--- a/resources/js/components/PinsPanel.test.ts
+++ b/resources/js/components/PinsPanel.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import type { App } from 'vue';
+import { createApp, h } from 'vue';
+import { translate } from '@/lib/i18n';
+import type { Message } from '@/types';
+import PinsPanel from './PinsPanel.vue';
+
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hi!',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: {
+            pinnedBy: { id: 'pinner', name: 'Alexandra Featherstonehaugh' },
+            pinnedAt: '2024-01-01T00:00:00.000Z',
+        },
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        ...overrides,
+    } as Message;
+}
+
+let app: App | null = null;
+
+function mount(componentProps: Record<string, unknown> = {}): {
+    host: HTMLElement;
+    emitted: Record<string, unknown[][]>;
+} {
+    const emitted: Record<string, unknown[][]> = {};
+    const capture =
+        (name: string) =>
+        (...args: unknown[]) => {
+            (emitted[name] ??= []).push(args);
+        };
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    app = createApp({
+        render: () =>
+            h(PinsPanel, {
+                pins: [message()],
+                pinCount: 1,
+                canPin: true,
+                viewerTimezone: 'UTC',
+                onClose: capture('close'),
+                onJump: capture('jump'),
+                onUnpin: capture('unpin'),
+                ...componentProps,
+            }),
+    });
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+
+    return { host, emitted };
+}
+
+function find(host: HTMLElement, name: string): HTMLElement {
+    return host.querySelector<HTMLElement>(`[data-test="${name}"]`)!;
+}
+
+afterEach(() => {
+    app?.unmount();
+    app = null;
+    document.body.innerHTML = '';
+});
+
+describe('PinsPanel rows', () => {
+    it('lists a row per pin, with who pinned it and a body preview', () => {
+        const { host } = mount();
+
+        const row = find(host, 'pins-panel-row');
+
+        expect(row.textContent).toContain(
+            'Pinned by Alexandra Featherstonehaugh',
+        );
+        expect(row.textContent).toContain('Peer');
+        expect(row.textContent).toContain('hi!');
+    });
+
+    it('jumps to the message when the row is clicked', () => {
+        const { host, emitted } = mount();
+
+        find(host, 'pins-panel-row').click();
+
+        expect(emitted.jump).toEqual([['m1']]);
+    });
+
+    it('unpins the message from the row control', () => {
+        const { host, emitted } = mount();
+
+        find(host, 'pins-panel-unpin').click();
+
+        expect(emitted.unpin).toHaveLength(1);
+        expect((emitted.unpin[0][0] as Message).id).toBe('m1');
+    });
+
+    it('drops the unpin control entirely for a read-only viewer', () => {
+        const { host } = mount({ canPin: false });
+
+        expect(host.querySelector('[data-test="pins-panel-unpin"]')).toBeNull();
+    });
+
+    it('renders its empty state with no rows', () => {
+        const { host } = mount({ pins: [], pinCount: 0 });
+
+        expect(find(host, 'pins-panel-empty').textContent).toContain(
+            'Nothing pinned yet',
+        );
+        expect(host.querySelector('[data-test="pins-panel-row"]')).toBeNull();
+    });
+});
+
+describe('PinsPanel unpin reachability', () => {
+    it('keeps the unpin control in the tab order rather than display-hidden', () => {
+        const { host } = mount();
+
+        const unpin = find(host, 'pins-panel-unpin');
+
+        // `hidden`/`invisible` take the control out of the accessibility tree and
+        // the tab order, which is what made it mouse-only (#999). Whatever hides
+        // it at rest has to keep it focusable.
+        expect(unpin.classList.contains('hidden')).toBe(false);
+        expect(unpin.classList.contains('invisible')).toBe(false);
+        expect(unpin.tabIndex).toBeGreaterThanOrEqual(0);
+    });
+
+    it('reveals the unpin control wherever hover cannot fire', () => {
+        const { host } = mount();
+
+        const classes = find(host, 'pins-panel-unpin').className;
+
+        // Focus anywhere in the row brings it back for keyboard users, and it is
+        // drawn outright on a coarse pointer and in the narrow layout, where
+        // :hover never fires at all.
+        expect(classes).toContain('group-focus-within/pin:opacity-100');
+        expect(classes).toContain('pointer-coarse:opacity-100');
+        expect(classes).toContain('max-md:opacity-100');
+    });
+});
+
+describe('PinsPanel attribution line', () => {
+    it('lets the pinned-by name ellipsise while the rest holds its baseline', () => {
+        const { host } = mount();
+
+        expect(find(host, 'pins-panel-attribution').className).toContain(
+            'truncate',
+        );
+
+        for (const name of ['pins-panel-pinned-at', 'pins-panel-jump']) {
+            expect(find(host, name).className).toContain('shrink-0');
+            expect(find(host, name).className).toContain('whitespace-nowrap');
+        }
+    });
+
+    it('gives the author line the same shape as the line above it', () => {
+        const { host } = mount();
+
+        expect(find(host, 'pins-panel-author').className).toContain('truncate');
+        expect(find(host, 'pins-panel-sent-at').className).toContain(
+            'shrink-0',
+        );
+        expect(find(host, 'pins-panel-sent-at').className).toContain(
+            'whitespace-nowrap',
+        );
+    });
+
+    it('reserves no pixel guess for the unpin control width', () => {
+        const { host } = mount();
+
+        // `mr-24` was sized around the English "Unpin" and was overrun by the
+        // French "Désépingler". The control now sizes its own column, so no
+        // margin on the line may stand in for its width (#999).
+        expect(find(host, 'pins-panel-jump').className).not.toMatch(/\bmr-/);
+        expect(host.innerHTML).not.toContain('mr-24');
+    });
+});

--- a/resources/js/components/PinsPanel.vue
+++ b/resources/js/components/PinsPanel.vue
@@ -125,36 +125,53 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                 <div
                     v-for="message in props.pins"
                     :key="message.id"
-                    class="group/pin relative"
+                    data-test="pins-panel-entry"
+                    class="group/pin grid grid-cols-[minmax(0,1fr)_auto] items-start rounded-[10px] hover:bg-muted"
                 >
                     <Button
                         variant="unstyled"
                         size="none"
                         type="button"
                         data-test="pins-panel-row"
-                        class="flex w-full flex-col gap-1.5 rounded-[10px] px-2.5 pt-2.5 pb-3 text-left hover:bg-muted"
+                        class="flex min-w-0 flex-col gap-1.5 rounded-[10px] px-2.5 pt-2.5 pb-3 text-left"
                         @click="emit('jump', message.id)"
                     >
-                        <!-- Attribution: who pinned it and when. -->
+                        <!-- Attribution: who pinned it and when. Only the name
+                             may give, so a long one ellipsises instead of
+                             wrapping the separator and timestamp under it. -->
                         <span
                             class="flex items-center gap-1.5 text-[11px] text-muted-foreground"
                         >
-                            <Pin class="size-2.5 text-brass" />
-                            {{
-                                $t('Pinned by :name', {
-                                    name: pinnedByName(message),
-                                })
-                            }}
-                            <span aria-hidden="true">&middot;</span>
-                            <span v-if="message.pin">{{
-                                formatDateTime(
-                                    message.pin.pinnedAt,
-                                    props.viewerTimezone ?? undefined,
-                                )
-                            }}</span>
+                            <Pin class="size-2.5 shrink-0 text-brass" />
                             <span
-                                class="ml-auto font-semibold text-foreground opacity-0 transition-opacity group-hover/pin:opacity-100"
-                                :class="props.canPin ? 'mr-24' : ''"
+                                data-test="pins-panel-attribution"
+                                class="truncate"
+                                >{{
+                                    $t('Pinned by :name', {
+                                        name: pinnedByName(message),
+                                    })
+                                }}</span
+                            >
+                            <span class="shrink-0" aria-hidden="true"
+                                >&middot;</span
+                            >
+                            <span
+                                v-if="message.pin"
+                                data-test="pins-panel-pinned-at"
+                                class="shrink-0 whitespace-nowrap"
+                                >{{
+                                    formatDateTime(
+                                        message.pin.pinnedAt,
+                                        props.viewerTimezone ?? undefined,
+                                    )
+                                }}</span
+                            >
+                            <!-- A hover hint for the whole-row click, so it is
+                                 dropped below `md`, where nothing can hover it
+                                 and the line has no width to spare. -->
+                            <span
+                                data-test="pins-panel-jump"
+                                class="ml-auto shrink-0 pl-1.5 font-semibold whitespace-nowrap text-foreground opacity-0 transition-opacity group-focus-within/pin:opacity-100 group-hover/pin:opacity-100 max-md:hidden"
                                 >{{ $t('Jump') }} &rarr;</span
                             >
                         </span>
@@ -180,11 +197,13 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                             <span class="flex min-w-0 flex-col gap-0.5">
                                 <span class="flex items-baseline gap-1.5">
                                     <span
-                                        class="text-[13px] font-semibold text-foreground"
+                                        data-test="pins-panel-author"
+                                        class="truncate text-[13px] font-semibold text-foreground"
                                         >{{ message.user.name }}</span
                                     >
                                     <span
-                                        class="text-[11px] text-muted-foreground"
+                                        data-test="pins-panel-sent-at"
+                                        class="shrink-0 text-[11px] whitespace-nowrap text-muted-foreground"
                                         >{{
                                             formatDateTime(
                                                 message.createdAt,
@@ -204,15 +223,21 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                         </span>
                     </Button>
 
-                    <!-- Unpin: a floating pill revealed on row hover. Any member
-                         may unpin (shared toggle); hidden read-only otherwise. -->
+                    <!-- Unpin: the row's second grid track, so the control's own
+                         width is the reserve and no translated label can overrun
+                         it. Transparent and inert at rest, brought back by hover
+                         or by focus landing anywhere in the row, and drawn
+                         outright wherever `:hover` cannot fire — a coarse pointer,
+                         or the narrow layout the panel takes below `md`. Any
+                         member may unpin (shared toggle); hidden read-only
+                         otherwise. -->
                     <Button
                         v-if="props.canPin"
                         variant="unstyled"
                         size="none"
                         type="button"
                         data-test="pins-panel-unpin"
-                        class="absolute -top-1 right-3 hidden items-center gap-1.5 rounded-lg border border-border bg-popover px-2.5 py-1 text-[11.5px] font-semibold text-muted-foreground shadow-md group-hover/pin:inline-flex hover:text-foreground"
+                        class="pointer-events-none mt-2 mr-2.5 inline-flex items-center gap-1.5 rounded-lg border border-border bg-popover px-2.5 py-1 text-[11.5px] font-semibold text-muted-foreground opacity-0 shadow-sm transition-opacity group-focus-within/pin:pointer-events-auto group-focus-within/pin:opacity-100 group-hover/pin:pointer-events-auto group-hover/pin:opacity-100 hover:text-foreground max-md:pointer-events-auto max-md:opacity-100 pointer-coarse:pointer-events-auto pointer-coarse:opacity-100"
                         @click="emit('unpin', message)"
                     >
                         <X class="size-3" />

--- a/tests/Browser/PinsPanelRowTest.php
+++ b/tests/Browser/PinsPanelRowTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AppLocale;
+use App\Models\Message;
+use App\Models\MessagePin;
+use App\Models\User;
+
+/**
+ * A row of the pins panel (`PinsPanel.vue`).
+ *
+ * The row used to float its Unpin pill over itself — `absolute -top-1 right-3`,
+ * revealed only by `:hover`, with the attribution line holding a hardcoded
+ * `mr-24` to keep out of its way. That reserve was sized around the English
+ * "Unpin", so the French "Désépingler" painted straight over "Aller →"; hover is
+ * also the one input a keyboard and a touchscreen do not have, so the panel's own
+ * Unpin was unreachable from either. The control now owns a grid track of the
+ * row, so its real width is the reserve, and it comes back on focus as well as
+ * hover (#999).
+ *
+ * @return array{owner: User, pinner: User, message: Message}
+ */
+function pinnedRowChannel(string $pinnerName = 'Bob Member'): array
+{
+    ['owner' => $alice, 'member' => $bob, 'channel' => $channel] = browserTeamWithChannel();
+
+    $bob->update(['name' => $pinnerName]);
+
+    $message = Message::factory()->for($channel)->for($bob)->create([
+        'body' => 'hi!',
+        'created_at' => now()->subMinutes(5),
+    ]);
+
+    MessagePin::factory()->create([
+        'message_id' => $message->id,
+        'channel_id' => $channel->id,
+        'pinned_by' => $bob->id,
+    ]);
+
+    return ['owner' => $alice, 'pinner' => $bob, 'message' => $message];
+}
+
+/**
+ * A script asserting the Unpin control and the Jump label are both fully drawn
+ * and share no pixel, and that the pill stays within its own row.
+ */
+function unpinClearsJump(): string
+{
+    return <<<'JS'
+    (() => {
+        const entry = document.querySelector('[data-test="pins-panel-entry"]');
+        const jump = document.querySelector('[data-test="pins-panel-jump"]');
+        const unpin = document.querySelector('[data-test="pins-panel-unpin"]');
+
+        const drawn = (element) => {
+            const box = element.getBoundingClientRect();
+
+            return box.width > 0
+                && box.height > 0
+                && getComputedStyle(element).opacity === '1'
+                && element.scrollWidth <= element.clientWidth + 1;
+        };
+
+        const jumpBox = jump.getBoundingClientRect();
+        const unpinBox = unpin.getBoundingClientRect();
+        const entryBox = entry.getBoundingClientRect();
+
+        const overlaps = jumpBox.left < unpinBox.right
+            && unpinBox.left < jumpBox.right
+            && jumpBox.top < unpinBox.bottom
+            && unpinBox.top < jumpBox.bottom;
+
+        return drawn(jump)
+            && drawn(unpin)
+            && ! overlaps
+            // The pill hung 4px above its row and overlapped the neighbour above.
+            && unpinBox.top >= entryBox.top - 0.5
+            && unpinBox.bottom <= entryBox.bottom + 0.5;
+    })()
+    JS;
+}
+
+/**
+ * A script asserting the attribution line still reads as one line: the pinned-by
+ * name is the only part that gives, clipped to an ellipsis rather than wrapped,
+ * and the separator, timestamp and Jump label all sit on its centre line.
+ */
+function attributionStaysOnOneLine(): string
+{
+    return <<<'JS'
+    (() => {
+        const name = document.querySelector('[data-test="pins-panel-attribution"]');
+        const line = name.parentElement;
+        const lineBox = line.getBoundingClientRect();
+
+        const onTheLine = (element) => {
+            const box = element.getBoundingClientRect();
+
+            return Math.abs(
+                (box.top + box.height / 2) - (lineBox.top + lineBox.height / 2),
+            ) <= 1;
+        };
+
+        const drawnParts = [...line.children].filter(
+            (part) => part.getClientRects().length > 0,
+        );
+
+        return name.getClientRects().length === 1
+            && drawnParts.length >= 3
+            && drawnParts.every(onTheLine)
+            && line.scrollWidth <= line.clientWidth + 1;
+    })()
+    JS;
+}
+
+test('the pins panel unpin control is reachable by keyboard alone', function (): void {
+    ['owner' => $alice] = pinnedRowChannel();
+
+    $page = signInThroughBrowser($alice)
+        ->click('@masthead-pins')
+        ->assertPresent('@pins-panel-unpin');
+
+    suppressTransitions($page)
+        ->assertNoAccessibilityIssues()
+        // Tabbing off the row reaches the Unpin control — it was `hidden` until
+        // hover, which takes it out of the tab order altogether.
+        ->keys('@pins-panel-row', ['Tab'])
+        ->assertScript(
+            'document.activeElement.dataset.test === "pins-panel-unpin"',
+            true,
+        )
+        // ...and focus alone, with no pointer anywhere near the row, draws it.
+        ->assertScript(
+            'getComputedStyle(document.querySelector(\'[data-test="pins-panel-unpin"]\')).opacity',
+            '1',
+        )
+        // Activating it from the keyboard unpins: the panel's last row goes.
+        ->keys('@pins-panel-unpin', ['Enter'])
+        ->assertPresent('@pins-panel-empty')
+        ->assertMissing('@pins-panel-row');
+});
+
+test('the hovered row keeps the French unpin label clear of Jump', function (): void {
+    ['owner' => $alice] = pinnedRowChannel();
+    $alice->update(['locale' => AppLocale::French]);
+
+    // See #764 — the French catalog only reaches the client on a document load.
+    $page = signInThroughBrowser($alice)
+        ->refresh()
+        ->click('@masthead-pins')
+        ->assertPresent('@pins-panel-row');
+
+    suppressTransitions($page)
+        ->hover('@pins-panel-row')
+        ->assertSee('Désépingler')
+        ->assertSee('Aller')
+        ->assertScript(unpinClearsJump(), true)
+        ->assertScript(attributionStaysOnOneLine(), true);
+});
+
+test('a long pinned-by name ellipsises instead of wrapping the line', function (): void {
+    // Longer than any translation of "Pinned by" could make up for, so the guard
+    // holds for every locale rather than for the one that exposed it.
+    ['owner' => $alice] = pinnedRowChannel('Alexandra Featherstonehaugh-Marchbanks');
+
+    $page = signInThroughBrowser($alice)
+        ->click('@masthead-pins')
+        ->assertPresent('@pins-panel-row');
+
+    suppressTransitions($page)
+        ->hover('@pins-panel-row')
+        ->assertScript(attributionStaysOnOneLine(), true)
+        ->assertScript(<<<'JS'
+        (() => {
+            const name = document.querySelector('[data-test="pins-panel-attribution"]');
+
+            return name.scrollWidth > name.clientWidth
+                && getComputedStyle(name).textOverflow === 'ellipsis';
+        })()
+        JS, true)
+        // The author line under it is the same shape and gives the same way: the
+        // name is clipped rather than wrapped over the timestamp beside it.
+        ->assertScript(<<<'JS'
+        (() => {
+            const author = document.querySelector('[data-test="pins-panel-author"]');
+            const sentAt = document.querySelector('[data-test="pins-panel-sent-at"]');
+
+            return author.getClientRects().length === 1
+                && sentAt.getClientRects().length === 1
+                && author.scrollWidth > author.clientWidth
+                && getComputedStyle(author).textOverflow === 'ellipsis';
+        })()
+        JS, true)
+        ->assertScript(unpinClearsJump(), true);
+});
+
+test('the row holds together at the panel narrow clamp', function (): void {
+    ['owner' => $alice] = pinnedRowChannel('Alexandra Featherstonehaugh-Marchbanks');
+    $alice->update(['locale' => AppLocale::French]);
+
+    // `max-w-[calc(100vw-3rem)]` clamps the panel to 312px here, which is the
+    // width the row was never checked at.
+    $page = signInThroughBrowser($alice)
+        ->resize(360, 780)
+        ->refresh()
+        ->click('@masthead-pins')
+        ->assertPresent('@pins-panel-row');
+
+    suppressTransitions($page)
+        // Nothing hovers a phone, so the control is drawn before any pointer
+        // touches the row, and the Jump hint — which only hover could reveal —
+        // is dropped rather than left holding width it cannot earn.
+        ->assertScript(<<<'JS'
+        (() => {
+            const unpin = document.querySelector('[data-test="pins-panel-unpin"]');
+            const jump = document.querySelector('[data-test="pins-panel-jump"]');
+
+            return getComputedStyle(unpin).opacity === '1'
+                && unpin.getBoundingClientRect().width > 0
+                && jump.getClientRects().length === 0;
+        })()
+        JS, true)
+        ->assertScript(attributionStaysOnOneLine(), true)
+        ->assertScript(<<<'JS'
+        (() => {
+            const panel = document.querySelector('[data-test="pins-panel"]');
+            const entry = document.querySelector('[data-test="pins-panel-entry"]');
+
+            return panel.scrollWidth <= panel.clientWidth + 1
+                && entry.scrollWidth <= entry.clientWidth + 1;
+        })()
+        JS, true);
+});


### PR DESCRIPTION
Closes #999.

## What

A row of the pins panel did not hold together. In French one short pinned message wrapped the attribution line onto two lines, stranded the middot between them, broke "Aller →" across lines and painted "Désépingler" over it — and one of the defects was present in every locale, unconditionally.

Four things were wrong, all in `resources/js/components/PinsPanel.vue`:

- **The Unpin pill was mouse-only.** It rendered `hidden … group-hover/pin:inline-flex`, so `display: none` kept it out of the accessibility tree and the tab order and only `:hover` lifted it. The panel's own Unpin was unreachable by keyboard and on touch, on the mobile path too (the panel renders below `md`).
- **Its reserve was a pixel guess.** The pill was `absolute`, so the line held `mr-24` to stay clear of it — 96px sized around the English "Unpin". "Désépingler" overran it; in a locale where the guess is too generous it was dead space squeezing the line for nothing.
- **Nothing on the line was allowed to shorten.** No `min-w-0`/`truncate` on the name, no `shrink-0 whitespace-nowrap` on the timestamp or the Jump hint, so the parts wrapped internally instead of the name ellipsising.
- **The pill hung outside its row** (`-top-1`), overlapping the header divider or the row above.

## How

- The Unpin control is now the row's **second grid track** (`grid-cols-[minmax(0,1fr)_auto]`), so the control's own width *is* the reserve. `mr-24` is gone, nothing can overrun anything, and the pill sits inside its row.
- It stays in the tree and the tab order: transparent and inert at rest, brought back by `group-hover` **and** `group-focus-within`, and drawn outright wherever `:hover` cannot fire — a coarse pointer (`pointer-coarse:`) or the narrow layout below `md`.
- The attribution line lets only the pinned-by name give: `truncate` on the name, `shrink-0 whitespace-nowrap` on the separator, timestamp and Jump hint. The author line under it got the same treatment, since the row is now a column narrower.
- The Jump hint is dropped below `md` — nothing can hover it there, and the line has no width to spare.

## How tested

- `resources/js/components/PinsPanel.test.ts` (new, 10 cases): the rows and their emits, the unpin control staying out of `hidden`/`invisible` and carrying its focus/coarse-pointer reveals, the truncation shape of both lines, and that no margin stands in for the control's width.
- `tests/Browser/PinsPanelRowTest.php` (new, 4 cases): tabbing off the row reaches Unpin and activating it from the keyboard unpins; in French a hovered row draws "Désépingler" and "Aller →" without a shared pixel and with the pill inside its row; a long pinned-by name ellipsises on one line in both lines of the row; and the row holds at a 360px viewport, where the control is drawn before any pointer touches it. Plus an axe audit of the open panel.
- Full gate green: `composer test` at `Total: 100.0 %`, the whole browser suite (334 passed), `lint:check`, `format:check`, `types:check`, `build`.

## i18n / docs

No new user-facing copy, so no catalog change; the fix is exactly about the existing French strings fitting. Nothing operator-facing, so no `docs/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787876436&installation_model_id=428379&pr_number=1036&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1036&signature=d8c3bfd268c482d6e3caed9b02b83ef212512222e16f8f1d35f48a7e6eec1410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->