### PR TITLE
fix: paint the reminder nudge from the slab's own colour tokens

### DIFF
--- a/resources/js/components/ReminderNudge.vue
+++ b/resources/js/components/ReminderNudge.vue
@@ -33,16 +33,20 @@ const channelLabel = computed(() =>
 
 <template>
     <!-- The nudge's surface is the shared ink slab (#978); only its geometry
-         and its contents are its own. -->
+         and its contents are its own. That extends to the colours painted on
+         it: muted copy and the gold accent come from the slab's own tokens, not
+         from an opacity on --primary-foreground. The slab inverts between
+         themes, so a fixed opacity that clears contrast on ink falls under the
+         floor once the same slab is paper (#1009). -->
     <InkSlab
         data-test="reminder-nudge"
         :data-reminder="reminder.id"
         class="flex w-[min(22rem,calc(100vw-2rem))] flex-col gap-3 rounded-2xl p-4"
     >
         <div class="flex items-center gap-2">
-            <AlarmClock class="size-3.5 text-brass" />
+            <AlarmClock class="size-3.5 text-slab-accent" />
             <span
-                class="text-[11px] font-semibold tracking-[0.08em] text-brass uppercase"
+                class="text-[11px] font-semibold tracking-[0.08em] text-slab-accent uppercase"
             >
                 {{ $t('Reminder · due now') }}
             </span>
@@ -52,7 +56,7 @@ const channelLabel = computed(() =>
                 type="button"
                 data-test="reminder-nudge-close"
                 :aria-label="$t('Dismiss reminder')"
-                class="ml-auto rounded p-0.5 text-primary-foreground/50 transition-colors hover:text-primary-foreground"
+                class="ml-auto rounded p-0.5 text-slab-muted-foreground transition-colors hover:text-primary-foreground"
                 @click="emit('dismiss', reminder)"
             >
                 <X class="size-3.5" />
@@ -80,7 +84,7 @@ const channelLabel = computed(() =>
                     }}</span>
                     <span
                         v-if="channelLabel"
-                        class="truncate text-[11px] text-primary-foreground/50"
+                        class="truncate text-[11px] text-slab-muted-foreground"
                         >{{
                             $t('in :channel', { channel: channelLabel })
                         }}</span
@@ -95,7 +99,7 @@ const channelLabel = computed(() =>
                 >
                 <span
                     v-else-if="reminder.isDeleted"
-                    class="text-[13px] text-primary-foreground/50 italic"
+                    class="text-[13px] text-slab-muted-foreground italic"
                     >{{ $t('This message was deleted.') }}</span
                 >
                 <span
@@ -136,7 +140,7 @@ const channelLabel = computed(() =>
                 size="none"
                 type="button"
                 data-test="reminder-nudge-done"
-                class="ml-auto text-[12.5px] font-medium text-primary-foreground/60 transition-colors hover:text-primary-foreground"
+                class="ml-auto text-[12.5px] font-medium text-slab-muted-foreground transition-colors hover:text-primary-foreground"
                 @click="emit('dismiss', reminder)"
             >
                 {{ $t('Done') }}

--- a/tests/Browser/NotificationRailFocusTest.php
+++ b/tests/Browser/NotificationRailFocusTest.php
@@ -39,6 +39,39 @@ function browserFocusedTestId(): string
     JS;
 }
 
+/**
+ * A workspace whose owner has two reminders already fired, so the rail carries
+ * two nudges at once: one for a live message — the card in full, quote and
+ * channel line and all — and one for a since-deleted message, which is the only
+ * way its "message deleted" stub reaches the screen. Between the two, every
+ * muted string the card can paint is up at the same time (#1009).
+ */
+function browserOwnerWithFiredNudges(): User
+{
+    ['owner' => $alice, 'channel' => $channel] = browserTeamWithChannel();
+
+    $message = Message::factory()->for($channel)->for($alice, 'user')->create([
+        'body' => 'The message being reminded about',
+    ]);
+    MessageReminder::factory()->fired()->create([
+        'user_id' => $alice->id,
+        'message_id' => $message->id,
+        'remind_at' => now()->subMinute(),
+    ]);
+
+    $deleted = Message::factory()->for($channel)->for($alice, 'user')->create([
+        'body' => 'The message that has since been deleted',
+    ]);
+    MessageReminder::factory()->fired()->create([
+        'user_id' => $alice->id,
+        'message_id' => $deleted->id,
+        'remind_at' => now()->subMinutes(2),
+    ]);
+    $deleted->delete();
+
+    return $alice;
+}
+
 test('F6 focuses the toast region and holds its timer there', function (): void {
     $alice = User::factory()->create();
 
@@ -83,16 +116,7 @@ test('F6 leaves focus alone when the rail is empty', function (): void {
 });
 
 test('F6 goes to the reminder nudges when one is on the rail', function (): void {
-    ['owner' => $alice, 'channel' => $channel] = browserTeamWithChannel();
-
-    $message = Message::factory()->for($channel)->for($alice, 'user')->create([
-        'body' => 'The message being reminded about',
-    ]);
-    MessageReminder::factory()->fired()->create([
-        'user_id' => $alice->id,
-        'message_id' => $message->id,
-        'remind_at' => now()->subMinute(),
-    ]);
+    $alice = browserOwnerWithFiredNudges();
 
     $page = signInThroughBrowser($alice)
         ->assertPresent('[data-test=reminder-nudges]');
@@ -108,9 +132,22 @@ test('F6 goes to the reminder nudges when one is on the rail', function (): void
     // A named region, so landing there announces what it is rather than
     // dropping a screen-reader user into an unlabelled box — and a name on a
     // role that can carry one, which a bare div could not.
-    //
-    // An axe audit belongs here too, but the nudge card already carries a
-    // serious contrast failure of its own (#1009) and would fail it on arrival.
     $page->assertAttribute('[data-test=reminder-nudges]', 'role', 'region')
         ->assertAttribute('[data-test=reminder-nudges]', 'aria-label', 'Reminders');
+});
+
+test('a nudge on the rail passes the axe audit in either theme', function (): void {
+    $alice = browserOwnerWithFiredNudges();
+
+    // The slab inverts between themes — ink in light, paper in dark — so a
+    // colour that clears the floor on one of them says nothing about the other.
+    // Nothing audited a page with a nudge actually on the rail until now, which
+    // is how a serious contrast failure went unseen (#1009).
+    $page = signInThroughBrowser($alice)
+        ->assertPresent('[data-test=reminder-nudge]')
+        ->assertSee('in #general')
+        ->assertSee('This message was deleted.')
+        ->assertNoAccessibilityIssues();
+
+    switchToDarkTheme($page)->assertNoAccessibilityIssues();
 });


### PR DESCRIPTION
Closes #1009.

## What

The reminder nudge's muted copy failed WCAG AA on the ink slab — axe reported the `in #general` line at 4.43 against a required 4.5.

The cause is that the card painted its muted strings with a fixed opacity on `--primary-foreground`. That opacity is theme-blind, but the slab is not: it is ink in light and paper in dark, so one value cannot clear the floor on both. `ToastCard`, which sits on the same slab, already solved this with the slab's own tokens; the nudge never adopted them.

So the fix moves the token rather than nudging an opacity at the one call site axe happened to name:

- the three `text-primary-foreground/50` sites — the close glyph, the `in #general` channel line, and the deleted-message stub — become `text-slab-muted-foreground`
- `text-primary-foreground/60` on **Done** becomes the same token (4.34:1 in dark)
- the `text-brass` header glyph and label become `text-slab-accent` (2.05:1 in dark — brass gold on a paper slab)

The last two are not in the issue's list because nothing had ever audited this surface in dark. They surfaced the moment the new audit ran there, and the acceptance criterion asks for both themes, so they are fixed here rather than deferred.

**Left alone deliberately:** the "Open message" pill keeps `bg-brass` / `text-brass-foreground`. Its text is 7.4:1 in both themes, and switching the fill to `bg-slab-accent` would *break* it — dark bronze `#7d6023` under ink text is 2.9:1.

`ToastCard` and `ReminderNudge` are the only two `InkSlab` consumers, so no other surface carries this defect.

## How tested

`tests/Browser/NotificationRailFocusTest.php` now audits a page with fired nudges on the rail in light **and** dark — the file already built that fixture, and the issue names it as the natural home.

The fixture puts two nudges up, one for a live message and one for a since-deleted message: the deleted stub is one of the three failing sites and has no other route onto the screen. The F6 focus test shares the fixture, since its assertion is about the region taking focus and is unaffected by the card count.

Driven test-first: red at 4.43 on the 11px line exactly as reported, red again in dark on the two further sites, then green. Also compared side by side in both themes rather than trusting the audit alone.

Full gate green — `Total: 100.0 %`, clean Rector/PHPStan/Pint, plus `lint:check`, `format:check`, `types:check`, `test:js` (2231) and `build`.

## i18n / docs

No new user-facing copy and nothing operator-facing, so no catalog or `docs/` changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787877313&installation_model_id=428379&pr_number=1037&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1037&signature=f87c7118d3190e864d69052cecce78e7eaecc0449f1f461f235ef59dbf2d753d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->