### PR TITLE
fix: four pre-existing composer defects surfaced by the #981 split

### DIFF
--- a/resources/js/components/MessageComposer.attachmentRestore.test.ts
+++ b/resources/js/components/MessageComposer.attachmentRestore.test.ts
@@ -140,9 +140,10 @@ function attachmentDto(id: string, isImage = false) {
     };
 }
 
-function mountComposer() {
+function mountComposer(props: Record<string, unknown> = {}) {
     const sent: Array<{
         body: string;
+        toChannel: boolean;
         attachmentIds: string[];
         callbacks: SendCallbacks;
     }> = [];
@@ -162,10 +163,17 @@ function mountComposer() {
                     onSend: (
                         body: string,
                         _mentions: unknown,
-                        _toChannel: boolean,
+                        toChannel: boolean,
                         attachmentIds: string[],
                         callbacks: SendCallbacks,
-                    ) => sent.push({ body, attachmentIds, callbacks }),
+                    ) =>
+                        sent.push({
+                            body,
+                            toChannel,
+                            attachmentIds,
+                            callbacks,
+                        }),
+                    ...props,
                 }),
         }),
     );
@@ -298,5 +306,41 @@ describe('MessageComposer failed-send attachment restore', () => {
             container.querySelector('[data-test="composer-attachment"]'),
         ).toBeNull();
         expect(textarea.value).toBe('');
+    });
+
+    it('hands the "also send to channel" choice back when the send is rejected', async () => {
+        const { container, sent } = mountComposer({ allowSendToChannel: true });
+
+        const textarea = container.querySelector<HTMLTextAreaElement>(
+            '[data-test="message-composer-input"]',
+        )!;
+        const alsoSend = container.querySelector<HTMLInputElement>(
+            '[data-test="send-to-channel"]',
+        )!;
+
+        alsoSend.checked = true;
+        alsoSend.dispatchEvent(new Event('change', { bubbles: true }));
+        textarea.value = 'Shipping today';
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        await nextTick();
+
+        container
+            .querySelector<HTMLButtonElement>(
+                '[data-test="message-composer-send"]',
+            )!
+            .click();
+        await nextTick();
+
+        expect(sent[0].toChannel).toBe(true);
+        expect(alsoSend.checked).toBe(false);
+
+        // The retry has to post the same reply the user composed, so the ticked
+        // box comes back alongside the body rather than silently going
+        // thread-only.
+        sent[0].callbacks.onRejected?.();
+        await nextTick();
+
+        expect(textarea.value).toBe('Shipping today');
+        expect(alsoSend.checked).toBe(true);
     });
 });

--- a/resources/js/components/MessageComposer.keyboard.test.ts
+++ b/resources/js/components/MessageComposer.keyboard.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h, nextTick } from 'vue';
+import MessageComposer from './MessageComposer.vue';
+
+/**
+ * Covers `useComposerKeyboard`'s IME guard through the real `<MessageComposer>`.
+ *
+ * While an IME composition is open, Enter commits the candidate word rather than
+ * meaning "send" — so Japanese, Chinese and Korean users would post a
+ * half-finished word on every candidate they accept. The same Enter also reaches
+ * the mention and slash menus, and Escape/the arrows are used to pick a candidate
+ * in some IMEs, so the whole keydown model has to stand down until the
+ * composition ends.
+ */
+
+vi.mock('@/actions/App/Http/Controllers/Channels/AttachmentController', () => ({
+    store: () => ({ url: '/t/acme/c/general/attachments' }),
+}));
+
+vi.mock('@/components/ui/button', async () => {
+    const { defineComponent, h } = await import('vue');
+
+    return {
+        Button: defineComponent({
+            name: 'ButtonStub',
+            inheritAttrs: false,
+            setup:
+                (_props, { attrs, slots }) =>
+                () =>
+                    h('button', attrs, slots.default?.()),
+        }),
+    };
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { defineComponent, h } = await import('vue');
+    const slot = (name: string) =>
+        defineComponent({
+            name,
+            setup:
+                (_props, { slots }) =>
+                () =>
+                    h('div', slots.default?.()),
+        });
+
+    return {
+        Tooltip: slot('TooltipStub'),
+        TooltipContent: slot('TooltipContentStub'),
+        TooltipProvider: slot('TooltipProviderStub'),
+        TooltipTrigger: slot('TooltipTriggerStub'),
+    };
+});
+
+const MANIFEST: App.Data.SlashCommandData[] = [
+    {
+        name: 'shrug',
+        description: 'Append a shrug to your message',
+        argumentHint: '[message]',
+    },
+    {
+        name: 'tableflip',
+        description: 'Flip the table',
+        argumentHint: '[message]',
+    },
+];
+
+let active: Array<{ app: App; container: HTMLElement }> = [];
+
+function mountComposer() {
+    const sent: string[] = [];
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const app = createApp(
+        defineComponent({
+            setup: () => () =>
+                h(MessageComposer as Component, {
+                    channelName: 'general',
+                    members: [],
+                    teamSlug: 'acme',
+                    channelSlug: 'general',
+                    slashCommands: MANIFEST,
+                    onSend: (body: string) => sent.push(body),
+                }),
+        }),
+    );
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(container);
+    active.push({ app, container });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+        '[data-test="message-composer-input"]',
+    )!;
+
+    return { container, sent, textarea };
+}
+
+/** Set the field's value + caret and fire the composer's `input` handler. */
+function type(textarea: HTMLTextAreaElement, value: string): Promise<void> {
+    textarea.value = value;
+    textarea.setSelectionRange(value.length, value.length);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+    return nextTick();
+}
+
+function press(
+    textarea: HTMLTextAreaElement,
+    key: string,
+    init: KeyboardEventInit = {},
+): Promise<void> {
+    textarea.dispatchEvent(
+        new KeyboardEvent('keydown', {
+            key,
+            bubbles: true,
+            cancelable: true,
+            ...init,
+        }),
+    );
+
+    return nextTick();
+}
+
+function options(container: HTMLElement): HTMLElement[] {
+    return Array.from(
+        container.querySelectorAll<HTMLElement>('[data-test="slash-option"]'),
+    );
+}
+
+afterEach(() => {
+    active.forEach(({ app, container }) => {
+        app.unmount();
+        container.remove();
+    });
+    active = [];
+});
+
+describe('MessageComposer IME composition', () => {
+    it('does not send on the Enter that commits an IME candidate', async () => {
+        const { sent, textarea } = mountComposer();
+
+        await type(textarea, 'にほんご');
+        await press(textarea, 'Enter', { isComposing: true });
+
+        expect(sent).toHaveLength(0);
+        expect(textarea.value).toBe('にほんご');
+    });
+
+    it('does not send on the legacy keyCode 229 composition Enter', async () => {
+        const { sent, textarea } = mountComposer();
+
+        await type(textarea, '中文');
+        // Older WebKit/Safari builds report an in-composition key as 229 and
+        // leave `isComposing` unset, so the fallback has to carry them.
+        await press(textarea, 'Enter', { keyCode: 229 });
+
+        expect(sent).toHaveLength(0);
+        expect(textarea.value).toBe('中文');
+    });
+
+    it('still sends once the composition has ended', async () => {
+        const { sent, textarea } = mountComposer();
+
+        await type(textarea, 'にほんご');
+        await press(textarea, 'Enter');
+
+        expect(sent).toEqual(['にほんご']);
+    });
+
+    it('leaves the slash menu alone while a composition is open', async () => {
+        const { container, textarea } = mountComposer();
+
+        await type(textarea, '/');
+        await press(textarea, 'ArrowDown', { isComposing: true });
+        expect(options(container)[0].getAttribute('aria-selected')).toBe(
+            'true',
+        );
+
+        await press(textarea, 'Escape', { isComposing: true });
+        expect(
+            container.querySelector('[data-test="slash-menu"]'),
+        ).not.toBeNull();
+
+        await press(textarea, 'Enter', { isComposing: true });
+        expect(textarea.value).toBe('/');
+    });
+});

--- a/resources/js/components/MessageComposer.slashCommands.test.ts
+++ b/resources/js/components/MessageComposer.slashCommands.test.ts
@@ -116,6 +116,19 @@ function type(textarea: HTMLTextAreaElement, value: string): Promise<void> {
     return nextTick();
 }
 
+/** Set the field's value with the caret parked mid-body, then fire `input`. */
+function typeAt(
+    textarea: HTMLTextAreaElement,
+    value: string,
+    caret: number,
+): Promise<void> {
+    textarea.value = value;
+    textarea.setSelectionRange(caret, caret);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+
+    return nextTick();
+}
+
 function press(textarea: HTMLTextAreaElement, key: string): Promise<void> {
     textarea.dispatchEvent(
         new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }),
@@ -173,6 +186,26 @@ describe('MessageComposer slash-command autocomplete', () => {
         await press(textarea, 'Enter');
 
         expect(textarea.value).toBe('/shrug ');
+    });
+
+    it('keeps the text after the caret when completing a command', async () => {
+        const { textarea } = mountComposer();
+
+        // The menu matches on the body up to the caret, so it opens on `/sh`
+        // even with the rest of a half-written message trailing behind it.
+        await typeAt(textarea, '/sh a draft', 3);
+        await press(textarea, 'Enter');
+
+        expect(textarea.value).toBe('/shrug a draft');
+    });
+
+    it('separates the completed command from a tail that runs into it', async () => {
+        const { textarea } = mountComposer();
+
+        await typeAt(textarea, '/shdraft', 3);
+        await press(textarea, 'Enter');
+
+        expect(textarea.value).toBe('/shrug draft');
     });
 
     it('navigates with the arrow keys and closes on Escape', async () => {

--- a/resources/js/components/MessageComposer.tray.test.ts
+++ b/resources/js/components/MessageComposer.tray.test.ts
@@ -279,4 +279,35 @@ describe('MessageComposer attachment tray', () => {
         await settle();
         expect(send.hasAttribute('disabled')).toBe(false);
     });
+
+    it('keeps saving drafts after an attachment-only send', async () => {
+        const drafts: string[] = [];
+        const { container } = mountComposer({
+            onDraftChange: (body: string) => drafts.push(body),
+        });
+
+        // An attachment-only send leaves the body empty throughout, so the
+        // clear-on-send assigns `''` to an already-empty field and fires no
+        // watcher — the draft guard must not be armed for a change that will
+        // never come, or it swallows the next genuine keystroke instead.
+        await stage(container, textFile());
+        uploads[0].resolve({ id: 'att-1' });
+        await settle();
+
+        container
+            .querySelector<HTMLButtonElement>(
+                '[data-test="message-composer-send"]',
+            )!
+            .click();
+        await nextTick();
+
+        const textarea = container.querySelector<HTMLTextAreaElement>(
+            '[data-test="message-composer-input"]',
+        )!;
+        textarea.value = 'a';
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        await nextTick();
+
+        expect(drafts).toEqual(['a']);
+    });
 });

--- a/resources/js/composables/useComposerKeyboard.ts
+++ b/resources/js/composables/useComposerKeyboard.ts
@@ -7,10 +7,26 @@ import { isComposerEditTrigger } from '@/lib/composerEdit';
 import type { Message } from '@/types';
 
 /**
- * The composer's keydown model, in priority order: whichever autocomplete menu
- * is open owns the arrows, Enter/Tab and Escape; then the format shortcuts;
- * then Escape's fallbacks (leave edit mode, else drop the reply); then ArrowUp's
- * "edit last message" recall; and finally Enter to send or save.
+ * The keyCode browsers without `isComposing` report for any key pressed while an
+ * IME composition is open. Safari and older WebKit builds still lean on it.
+ */
+const COMPOSITION_KEY_CODE = 229;
+
+/**
+ * Whether the keypress belongs to an in-progress IME composition, where Enter
+ * commits the candidate word (and Escape/the arrows pick between candidates)
+ * rather than meaning anything to the composer.
+ */
+function isComposing(event: KeyboardEvent): boolean {
+    return event.isComposing || event.keyCode === COMPOSITION_KEY_CODE;
+}
+
+/**
+ * The composer's keydown model, in priority order: an open IME composition owns
+ * every key; then whichever autocomplete menu is open owns the arrows, Enter/Tab
+ * and Escape; then the format shortcuts; then Escape's fallbacks (leave edit
+ * mode, else drop the reply); then ArrowUp's "edit last message" recall; and
+ * finally Enter to send or save.
  */
 export function useComposerKeyboard(options: {
     field: ComposerField;
@@ -26,6 +42,12 @@ export function useComposerKeyboard(options: {
     const { mentions, slash, editing } = options;
 
     function onKeydown(event: KeyboardEvent): void {
+        // Stand down entirely until the composition ends, or a CJK user posts a
+        // half-finished word every time they accept an IME candidate.
+        if (isComposing(event)) {
+            return;
+        }
+
         if (mentions.showMenu.value) {
             if (event.key === 'ArrowDown') {
                 event.preventDefault();

--- a/resources/js/composables/useComposerSend.ts
+++ b/resources/js/composables/useComposerSend.ts
@@ -80,7 +80,11 @@ export function useComposerSend(options: {
      * scheduled one), flagging the wipe so it doesn't re-persist as a draft.
      */
     function clearAfterHandoff(): void {
-        options.suppressNextDraftChange(true);
+        // Suppress the draft echo from the wipe only when there is text to
+        // clear; an attachment-only send leaves the body empty throughout, and
+        // clearing an already-empty field fires no watcher — which would leave
+        // the guard armed to swallow the next genuine keystroke instead.
+        options.suppressNextDraftChange(body.value !== '');
         body.value = '';
         sendToChannel.value = false;
         options.mentions.closeMenu();
@@ -162,19 +166,24 @@ export function useComposerSend(options: {
         // send disposes the snapshot instead. `detach` empties the tray but keeps the
         // rows' previews alive until the outcome lands.
         const stagedBody = body.value;
+        // The clear-down resets the thread composer's "also send to channel"
+        // tick too, so it belongs in the snapshot: without it a rejected reply
+        // comes back thread-only and the retry quietly drops the choice.
+        const stagedSendToChannel = sendToChannel.value;
         const attachmentIds = uploads.attachmentIds.value;
         const snapshot = uploads.detach();
 
         options.onSend(
             trimmed,
             options.mentions.collectMentions(trimmed),
-            sendToChannel.value,
+            stagedSendToChannel,
             attachmentIds,
             {
                 onAccepted: () => snapshot.dispose(),
                 onRejected: () => {
                     snapshot.restore();
                     body.value = stagedBody;
+                    sendToChannel.value = stagedSendToChannel;
                 },
             },
         );

--- a/resources/js/composables/useComposerSlashCommands.ts
+++ b/resources/js/composables/useComposerSlashCommands.ts
@@ -221,10 +221,18 @@ export function useComposerSlashCommands(options: {
             return;
         }
 
-        body.value = `/${command.name} `;
+        // The menu matched on the body up to the caret, so only that prefix is
+        // the typed command — whatever trails it is the rest of a half-written
+        // message and has to survive the completion. The trailing space is the
+        // separator, so a tail that already opens with one keeps a single space
+        // rather than gaining a second.
+        const tail = body.value.slice(caretPosition());
+        const completed = `/${command.name} `;
+
+        body.value = completed + (tail.startsWith(' ') ? tail.slice(1) : tail);
         slashMenuOpen.value = false;
 
-        focusRange(body.value.length);
+        focusRange(completed.length);
     }
 
     function selectSlashActive(): void {


### PR DESCRIPTION
Closes #1016.

Four pre-existing composer defects that the #981 split surfaced but deliberately
left alone there ("move, do not improve"). All four are frontend-only.

## 1. A send that carries only an attachment stopped saving drafts

`clearAfterHandoff()` armed the draft-suppression flag unconditionally. The flag is
disarmed by the `body` watcher, but assigning `''` to an already-empty body fires no
watcher — so on an attachment-only send (where `canSubmit` allows an empty body) the
guard stayed armed and swallowed the user's *next* genuine keystroke instead.

It now mirrors `exitEditMode()`, which already guards exactly this case:
`suppressNextDraftChange(body.value !== '')`.

## 2. Enter mid-composition sent the message for CJK input

`onKeydown` had no `event.isComposing` guard, so the Enter that commits an IME
candidate was treated as "send" and Japanese, Chinese and Korean users posted a
half-finished word every time they accepted one. The whole keydown model — the
mention and slash menus' arrows/Enter/Escape included — now stands down until the
composition ends, with the legacy `keyCode === 229` fallback for Safari and older
WebKit builds.

## 3. Completing a slash command discarded everything after the caret

`selectSlashCommand()` replaced the whole body with `/name `. The menu opens on a
match against `body.slice(0, caret)`, so with `/he draft` and the caret after `/he`,
completing the command threw ` draft` away. It now replaces only that matched prefix
and keeps the tail, collapsing the separator so a tail that already opens with a
space doesn't gain a second one (and one that runs straight into the command still
gets separated).

## 4. A rejected thread send lost the "also send to channel" choice

`submit()` snapshotted the body and the staged attachments so a rejected online send
could hand them back, but `clearAfterHandoff()` also resets `sendToChannel` and
nothing restored it — the retry posted the reply thread-only. `sendToChannel` now
joins the snapshot and comes back through `onRejected`.

## Testing

- `MessageComposer.tray.test.ts` — an attachment-only send leaves the draft guard
  disarmed, and the next character typed emits `draftChange`.
- `MessageComposer.keyboard.test.ts` (new) — covers `useComposerKeyboard`'s IME
  guard: both composition Enters are inert, a post-composition Enter still sends,
  and the slash menu ignores the arrows/Escape/Enter mid-composition.
- `MessageComposer.slashCommands.test.ts` — completion keeps the text after the
  caret, and separates a tail that runs into the command.
- `MessageComposer.attachmentRestore.test.ts` — a rejected send hands the ticked
  "also send to channel" box back alongside the body.

Full Vitest suite green (219 files, 2249 tests); lint, format, types and build green.

## i18n / docs

No user-facing copy and no operator-facing behaviour changed, so no catalog or
`docs/` updates are needed.

## Not included

CodeRabbit's earlier suggestion to give the tray's image thumbnails
`alt="{filename}"` is left out deliberately, as the issue records — the chip's
remove control is already labelled and the tray passes its axe audit either way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787878033&installation_model_id=428379&pr_number=1038&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1038&signature=744a2144af1dfde190aa3966f62b7e5aa354cc7c00f64f3b42dded4967aa057b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->