### PR TITLE
fix: format the bots rack's last-post stamp against the locale, not the zone

### DIFF
--- a/resources/js/components/integrations/BotsRack.vue
+++ b/resources/js/components/integrations/BotsRack.vue
@@ -3,7 +3,6 @@ import { Link, usePage } from '@inertiajs/vue3';
 import { Bot, Plus } from '@lucide/vue';
 import { computed } from 'vue';
 import { Button } from '@/components/ui/button';
-import { useTimezone } from '@/composables/useTimezone';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatRelativeTime } from '@/lib/datetime';
 import { show as botShow } from '@/routes/teams/integrations/bots';
@@ -23,11 +22,10 @@ defineEmits<{
 
 const page = usePage();
 const currentUserId = computed(() => String(page.props.auth.user.id));
-const { timezone } = useTimezone();
 const { t } = useTranslations();
 
 function relative(iso: string | null): string {
-    return iso ? formatRelativeTime(iso, timezone.value ?? undefined) : '';
+    return iso ? formatRelativeTime(iso) : '';
 }
 
 function createdByLabel(bot: BotSummary): string {

--- a/resources/js/pages/teams/integrations/Index.bots.test.ts
+++ b/resources/js/pages/teams/integrations/Index.bots.test.ts
@@ -197,6 +197,7 @@ function formFor(...fields: string[]): RecordedForm['form'] {
 beforeEach(() => {
     inertia.forms = [];
     inertia.posts = [];
+    inertia.pageProps.auth.user.timezone = 'UTC';
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-03-06T10:00:00.000Z'));
 });
@@ -278,6 +279,19 @@ describe('the bots rack', () => {
 
         expect(text(host, 'bot-row-b1')).toContain('never posted');
         expect(text(host, 'bot-row-b2')).toContain('last post 2 days ago');
+    });
+
+    it('still stamps the last post for a viewer whose zone is not UTC', () => {
+        // 'UTC' is structurally valid as a language tag, so a UTC viewer never
+        // catches a zone handed to a locale-taking formatter; any Region/City
+        // zone does, and only past the minute where the phrase is built.
+        inertia.pageProps.auth.user.timezone = 'America/New_York';
+
+        const host = mount({
+            bots: [bot({ lastPostedAt: '2024-03-04T10:00:00.000Z' })],
+        });
+
+        expect(text(host, 'bot-row-b1')).toContain('last post 2 days ago');
     });
 
     it('points each row at its own management page', () => {


### PR DESCRIPTION
Closes #1021.

## What was broken

`BotsRack.vue` passed the viewer's **time zone** where `formatRelativeTime()` expects a **locale**:

```ts
formatRelativeTime(iso, timezone.value ?? undefined)
```

That second argument goes straight into `new Intl.RelativeTimeFormat(locale)`, and an IANA zone is not a valid BCP-47 language tag, so it threw `RangeError: Incorrect locale information provided`. Vue unwound the render and the **entire bots section vanished** from the integrations home — no rows, no "New bot" button, no error the user could act on.

`'UTC'` happens to be structurally valid as a language tag, which is why the defect hid: any `Region/City` zone triggered it, and only for a bot whose last post was over a minute old (under a minute `formatRelativeTime` short-circuits to "just now" and never builds the formatter).

## The fix

Drop the argument. `formatRelativeTime`'s `locale` already defaults to `i18n.locale`, so the stamp now follows the active locale like every other relative time in the app — matching the neighbouring call in `components/teams/PendingInvitations.vue`. `useTimezone` is no longer needed in the component and its import is gone.

## Call-site sweep (AC 4)

Checked every `lib/datetime` helper against its callers. The family has two shapes, and only `formatRelativeTime` takes a **locale** second while its closest siblings take a **time zone** second — which is what made the mix-up easy:

- `(iso, timeZone?, locale?, format?)` — `formatTimeOfDay`, `formatDateTime`, `formatCompactTimestamp`: every call site passes a zone. Correct.
- `(value, locale?)` — `formatRelativeTime`, `formatDayLabel`, `formatCalendarDate`, `formatIsoDay`, `formatMonthLabel`, `formatWallTime`, `formatWallHour`: every call site passes either nothing or a real locale (`lib/dnd.ts`). Correct.
- `formatLocalTime(timeZone, at, locale?)` takes its zone first; both call sites match.

`BotsRack.vue` was the only offender.

## How it was tested

A regression test in `pages/teams/integrations/Index.bots.test.ts` covers exactly the case a UTC viewer cannot catch — `America/New_York` plus a last post two days old — and asserts the row still renders its `last post 2 days ago` stamp. It fails with the reported `RangeError` on the old code. The suite's shared `pageProps` timezone is now reset per test so the non-UTC case cannot leak into its neighbours.

Full gate green: `composer test` at `Total: 100.0 %`, plus `lint:check`, `format:check`, `types:check`, `test:js` (2250 passed) and `build`.

No user-facing copy changed, so no i18n catalog updates; nothing operator-facing, so no docs changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787881158&installation_model_id=428379&pr_number=1041&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1041&signature=5dfe6bf0d2068087ff43c899374f723cb4250a01ce3ac643d1e5e7f7f2e14735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->