### PR TITLE
fix: survive an unreachable apt mirror during the worktree Playwright install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-error.log
 /compose.override.yaml
 /.worktree-ready
 /.worktree-seeded
+/.worktree-playwright-deps

--- a/bin/worktree
+++ b/bin/worktree
@@ -21,7 +21,10 @@
 # The Browser suite (tests/Browser) is the exception: it drives a real Chromium
 # and points the broadcaster at a live Reverb. So the bootstrap also installs the
 # Playwright browsers into the app container and brings `reverb` up — four
-# containers in total.
+# containers in total. That install reaches third-party networks, so it is the
+# one step allowed to fail without taking the bootstrap with it: the worktree
+# still reaches "ready" (only tests/Browser is unavailable) and the next
+# `create` retries it.
 #
 # Because the worktree's .env is copied from the main checkout, it can name
 # services those four don't include (the opt-in `sso` profile's ldap/oidc,
@@ -323,6 +326,12 @@ cmd_create() {
         if [ -d "$path" ] && [ -f "${path}/.worktree-ready" ]; then
             release_lock
             log "worktree for #${nnn} already ready — re-entering ${path}"
+            # A bootstrap that could only degrade the Playwright step still
+            # reached "ready" (issue #1005), so re-entry is where it gets its
+            # retry. The sentinel keeps a healthy worktree's re-entry free of
+            # any container round-trip at all, and the retry is kept off stdout
+            # so `cd "$(bin/worktree create NNN)"` still sees only the path.
+            [ -f "${path}/.worktree-playwright-deps" ] || install_playwright_browsers "$path" >&2
             printf '%s\n' "$path"
             return 0
         fi
@@ -459,6 +468,7 @@ cmd_create() {
 
     touch "${path}/.worktree-ready"
     log "worktree ready — cd into it and run: ./vendor/bin/sail composer test"
+    [ -z "$PLAYWRIGHT_DEGRADED" ] || log "note: Playwright is not fully installed (${PLAYWRIGHT_DEGRADED}), so tests/Browser will not run here yet — re-run 'bin/worktree create ${nnn}' to retry that step"
     printf '%s\n' "$path"
 }
 
@@ -474,6 +484,16 @@ cmd_create() {
 # to 0, which means inside node_modules rather than a shared ~/.cache), so ask
 # Playwright itself where the build belongs instead of hardcoding a directory.
 PLAYWRIGHT_PROBE='loc=$(npx playwright install --dry-run chromium 2>/dev/null | sed -n "s/^ *Install location: *//p" | head -1); [ -n "$loc" ] && [ -d "$loc" ]'
+
+# The pair of container-side commands install_playwright_system_deps brackets the
+# apt install with. A list is the distro's own when it is Ubuntu's canonical
+# deb822 file or names one of Ubuntu's archives; everything else (nodesource,
+# pgdg, ppa:ondrej/php) is parked. Parking is resumable by construction: a run
+# interrupted between the two leaves the lists in the park directory, and the
+# next bootstrap's restore step puts them back. Both are kept to a single line so
+# each reads as one command in the bootstrap's output.
+APT_PARK_THIRD_PARTY_SOURCES='mkdir -p /var/tmp/worktree-apt-sources; for f in /etc/apt/sources.list.d/*; do [ -f "$f" ] || continue; [ "${f##*/}" = ubuntu.sources ] && continue; grep -qE "(archive|security|ports)\.ubuntu\.com" "$f" && continue; echo "parking third-party apt source ${f##*/}" >&2; mv "$f" /var/tmp/worktree-apt-sources/; done'
+APT_RESTORE_THIRD_PARTY_SOURCES='for f in /var/tmp/worktree-apt-sources/*; do [ -f "$f" ] || continue; mv "$f" /etc/apt/sources.list.d/; done; rmdir /var/tmp/worktree-apt-sources 2>/dev/null; true'
 
 # Each worktree gets its own Postgres volume, so the bootstrap starts on an empty
 # database and the login form has no account to accept — signing in to the
@@ -504,14 +524,63 @@ migrate_and_seed() {
 install_playwright_browsers() {
     local path="$1"
 
+    # Gated separately from the browser below, and on a sentinel of its own: an
+    # apt failure that left the libraries missing must still be retried on the
+    # next bootstrap, and by then the browser probe may well be passing.
+    if [ -f "${path}/.worktree-playwright-deps" ]; then
+        log "Playwright's system dependencies already installed — skipping"
+    else
+        log "installing Playwright's system dependencies"
+        if install_playwright_system_deps "$path"; then
+            touch "${path}/.worktree-playwright-deps"
+        else
+            degrade_playwright "apt could not install Chromium's system libraries inside the container"
+        fi
+    fi
+
     if (cd "$path" && ./vendor/bin/sail shell -c "$PLAYWRIGHT_PROBE" >/dev/null 2>&1); then
         log "Playwright chromium already present — skipping browser install"
         return 0
     fi
 
-    log "installing Playwright chromium and its system dependencies"
-    (cd "$path" && ./vendor/bin/sail root-shell -c "npx playwright install-deps chromium")
-    (cd "$path" && ./vendor/bin/sail npx playwright install chromium)
+    log "installing the Playwright chromium build"
+    if ! (cd "$path" && ./vendor/bin/sail npx playwright install chromium); then
+        degrade_playwright "the Chromium build could not be downloaded"
+    fi
+}
+
+# Record that Playwright is not fully installed and say so in the terms that
+# matter: which suite is affected, and how to get it back. The rest of the
+# bootstrap carries on — the failure is invariably an unreachable third-party
+# mirror, and abandoning several minutes of composer/npm/migrate work over it is
+# what made issue #1005 painful. cmd_create repeats the notice at the end so it
+# is the last thing on screen rather than scrolled away by the asset build.
+PLAYWRIGHT_DEGRADED=""
+
+degrade_playwright() {
+    PLAYWRIGHT_DEGRADED="$1"
+    log "warning: ${1}; tests/Browser will not run in this worktree until Playwright is installed"
+    log "         re-run 'bin/worktree create <NNN>' once the network recovers to retry just this step"
+}
+
+# `npx playwright install-deps` shells out to `apt-get update`, and apt fails the
+# whole run when ANY configured source is unreachable — including the third-party
+# lists the Sail image ships (nodesource, pgdg, ppa:ondrej/php), which Chromium's
+# shared libraries have nothing to do with. A 403 from one of those mirrors thus
+# took out the entire bootstrap (issue #1005).
+#
+# Every library Chromium links against comes from the distro's own archive, so
+# the third-party lists are moved out of apt's way for the duration of the
+# install and moved back afterwards — whatever the install did, which is why the
+# restore is sequenced here on the host rather than inside the container.
+install_playwright_system_deps() {
+    local path="$1" status=0
+
+    (cd "$path" && ./vendor/bin/sail root-shell -c "$APT_PARK_THIRD_PARTY_SOURCES") || true
+    (cd "$path" && ./vendor/bin/sail root-shell -c "npx playwright install-deps chromium") || status=$?
+    (cd "$path" && ./vendor/bin/sail root-shell -c "$APT_RESTORE_THIRD_PARTY_SOURCES") || true
+
+    return "$status"
 }
 
 # Copy $source to the worktree's .env, offsetting the ports it publishes on the

--- a/dev-docs/concurrent-worktrees.md
+++ b/dev-docs/concurrent-worktrees.md
@@ -34,8 +34,19 @@ make that work:
   driver. They install in two steps because the shared libraries Chromium links
   against need `apt` and therefore root (`sail root-shell -c "npx playwright
   install-deps chromium"`), while the browser itself installs as the `sail` user
-  so its cache lands in the `HOME` Pest reads it back from. Re-entry probes the
-  cache and skips both when a chromium build is already unpacked.
+  so its cache lands in the `HOME` Pest reads it back from. Each step is gated
+  separately: the browser download is skipped once the cache probe finds an
+  unpacked chromium, the `apt` step once a `.worktree-playwright-deps` sentinel
+  says it completed.
+- `install-deps` shells out to `apt-get update`, which fails the whole run when
+  *any* configured source is unreachable — including the third-party lists the
+  Sail image ships (nodesource, pgdg, `ppa:ondrej/php`), which Chromium's
+  libraries have nothing to do with. A 403 from one of those mirrors used to take
+  out an otherwise-complete bootstrap several minutes in (issue #1005). The
+  bootstrap now parks those lists for the duration of the install and puts them
+  back afterwards, and this is the one step allowed to fail soft: the worktree
+  still reaches `ready`, the run says that `tests/Browser` is unavailable, and
+  the next `bin/worktree create <NNN>` retries just that step.
 - `REVERB_PORT` is overloaded in `compose.yaml`: it is both the host side of
   `${REVERB_PORT}:8080` and — via `config/broadcasting.php` — the port the app
   dials at `reverb:<port>`. The generated `.env` therefore pins it to the

--- a/tests/Unit/WorktreeScriptTest.php
+++ b/tests/Unit/WorktreeScriptTest.php
@@ -80,20 +80,24 @@ function tempGitDir(string $prefix): string
  * Stand up a throwaway worktree directory whose ./vendor/bin/sail is a stub that
  * records every invocation, so the Playwright bootstrap can be driven without
  * Docker. The stub answers the "is chromium already there?" probe (`sail shell`)
- * with $probeExit and succeeds for everything else.
+ * with $probeExit, exits 100 (apt's own failure code) for any invocation whose
+ * arguments contain $failing, and succeeds for everything else.
  *
  * @return array{0: string, 1: string} the fake worktree path and its call log
  */
-function fakeSailWorktree(int $probeExit): array
+function fakeSailWorktree(int $probeExit, string $failing = ''): array
 {
     $path = tempGitDir('worktree-sail');
     mkdir($path.'/vendor/bin', 0o755, true);
+
+    $failClause = $failing === '' ? ':' : 'case "$*" in *'.$failing.'*) exit 100 ;; esac';
 
     $log = $path.'/sail-calls.log';
     file_put_contents($path.'/vendor/bin/sail', <<<BASH
         #!/usr/bin/env bash
         printf '%s\n' "\$*" >> {$log}
         [ "\$1" = "shell" ] && exit {$probeExit}
+        {$failClause}
         exit 0
         BASH);
     chmod($path.'/vendor/bin/sail', 0o755);
@@ -313,14 +317,61 @@ test('a fresh worktree installs the Playwright system deps as root and the chrom
         ->and(sailCalls($log))->toContain('npx playwright install chromium');
 });
 
+test('the Playwright dependency install parks third-party apt sources around itself', function (): void {
+    [$path, $log] = fakeSailWorktree(probeExit: 1);
+
+    $process = runWorktreeLib($path, 'install_playwright_browsers '.escapeshellarg($path));
+    $calls = sailCalls($log);
+    $install = array_search('root-shell -c npx playwright install-deps chromium', $calls, true);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($install)->toBeInt()
+        ->and($calls[$install - 1])->toContain('/etc/apt/sources.list.d')
+        ->and($calls[$install + 1])->toContain('/etc/apt/sources.list.d');
+});
+
+test('an unreachable apt mirror degrades the Playwright step instead of aborting the bootstrap', function (): void {
+    [$path, $log] = fakeSailWorktree(probeExit: 1, failing: 'install-deps');
+
+    $process = runWorktreeLib($path, 'install_playwright_browsers '.escapeshellarg($path));
+    $calls = sailCalls($log);
+    $install = array_search('root-shell -c npx playwright install-deps chromium', $calls, true);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getErrorOutput())->toContain('tests/Browser')
+        ->and($calls[$install + 1])->toContain('/etc/apt/sources.list.d')
+        ->and($calls)->toContain('npx playwright install chromium');
+});
+
 test('a worktree that already has chromium skips the Playwright install', function (): void {
     [$path, $log] = fakeSailWorktree(probeExit: 0);
+    touch($path.'/.worktree-playwright-deps');
 
     $process = runWorktreeLib($path, 'install_playwright_browsers '.escapeshellarg($path));
 
     expect($process->getExitCode())->toBe(0)
         ->and(sailCalls($log))->not->toContain('root-shell -c npx playwright install-deps chromium')
         ->and(sailCalls($log))->not->toContain('npx playwright install chromium');
+});
+
+test('a degraded system-dependency install is retried even once chromium is downloaded', function (): void {
+    [$path, $log] = fakeSailWorktree(probeExit: 0);
+
+    $process = runWorktreeLib($path, 'install_playwright_browsers '.escapeshellarg($path));
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(sailCalls($log))->toContain('root-shell -c npx playwright install-deps chromium')
+        ->and(sailCalls($log))->not->toContain('npx playwright install chromium')
+        ->and(is_file($path.'/.worktree-playwright-deps'))->toBeTrue();
+});
+
+test('a failed system-dependency install leaves no sentinel behind to skip the retry', function (): void {
+    [$path] = fakeSailWorktree(probeExit: 0, failing: 'install-deps');
+
+    $process = runWorktreeLib($path, 'install_playwright_browsers '.escapeshellarg($path));
+
+    expect($process->getExitCode())->toBe(0)
+        ->and(is_file($path.'/.worktree-playwright-deps'))->toBeFalse();
 });
 
 test('a fresh worktree migrates and seeds so the demo account can sign in', function (): void {


### PR DESCRIPTION
Closes #1005.

## What

`bin/worktree create` died at the Playwright step whenever a third-party apt mirror was unreachable. `npx playwright install-deps chromium` shells out to `apt-get update`, and apt fails the whole run when *any* configured source errors — including `nodesource.list`, which the Sail image ships and which Chromium's shared libraries have nothing to do with. `set -e` then aborted the bootstrap several minutes in, after `composer install` + `npm install` + migrate + seed, leaving the worktree half-built with no sentinel.

Two changes:

**Isolate the step from sources it does not need.** The apt install is now bracketed by a park/restore pair that moves every non-distro source list (`nodesource`, `pgdg`, `ppa_ondrej_php`) to `/var/tmp/worktree-apt-sources` and puts it back afterwards. A list counts as the distro's own when it is Ubuntu's canonical `ubuntu.sources` or names one of Ubuntu's archives. The restore is sequenced on the host, so it runs whatever the install did; and it is resumable — a run interrupted between the two leaves the lists in the park directory for the next bootstrap's restore step to return.

**Fail soft when it still cannot install.** The Playwright step is the one step allowed to fail without taking the bootstrap with it. A failure now logs a named warning saying `tests/Browser` will not run and how to retry, the remaining steps (reverb, `typescript:transform`, `npm run build`, the `.worktree-ready` sentinel) still run, and the notice is repeated at the end so it is not scrolled away by the asset build.

**Retry actually retries.** The `apt` half is gated on its own `.worktree-playwright-deps` sentinel rather than on the chromium cache probe — otherwise a run that downloaded the browser but failed the libraries would be skipped forever by the probe. Re-entry into a ready-but-degraded worktree re-runs just that step; a healthy worktree's re-entry still makes no container round-trip at all. The retry is redirected to stderr so `cd "$(bin/worktree create NNN)"` keeps seeing only the path.

## How tested

`tests/Unit/WorktreeScriptTest.php` drives `bin/worktree` as a bash library against a fake `sail` stub that records every invocation, extended here to fail a chosen command. Four new tests cover: the park/restore bracketing around the install, an apt failure degrading rather than aborting (and still restoring the sources), the system deps being retried once chromium is present, and no sentinel being left behind by a failed install.

The isolation itself was verified against the real `sail-8.5/app` image by reproducing the exact failure from the issue — a nodesource repo returning `403 Forbidden`:

```
E: Failed to fetch http://.../node_24.x/dists/nodistro/InRelease  403  Forbidden
E: The repository '...' is not signed.
with a 403 nodesource: apt-get update exit=100
after parking third-party sources: apt-get update exit=0
```

Full gate green at 100% coverage; `lint:check`, `format:check` and `types:check` pass.

## Docs

`dev-docs/concurrent-worktrees.md` updated with the new gating and the fail-soft contract. No operator-facing surface changed, so `docs/` is untouched.

## Found while doing this

#1043 — `bin/worktree create` pollutes stdout with its subprocesses' output, so the documented `cd "$(bin/worktree create NNN)"` breaks on a fresh bootstrap. Pre-existing and out of scope here; this PR only redirects the one call site it adds.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787882340&installation_model_id=428379&pr_number=1044&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1044&signature=4806e91e62fd6c133358955bcb12ddeda604a15fb696197c75734931fe0d2dc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->