### PR TITLE
fix: build queue-broadcasts from source instead of pulling it from GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -516,6 +516,27 @@ jobs:
           echo "APP_VERSION=$(sed -e 's/#.*//' VERSION | tr -d '[:space:]')" >> .env
           grep '^COMPOSE_FILE=' .env
 
+      # A service the overlay misses keeps the production `image:` and is pulled
+      # from GHCR instead of built. That is invisible most of the time — the pull
+      # succeeds whenever GHCR already holds the tag in APP_VERSION — and only
+      # fails on a commit no tag exists for, which is every release-please merge
+      # and every fork or private patch (#1040). Assert the merged config resolves
+      # nothing from the registry, so the next drift fails here rather than on
+      # whichever day GHCR happens to be missing the tag.
+      - name: Assert nothing resolves to the published image
+        run: |
+          set -euo pipefail
+
+          docker compose config --images | sort -u | tee images.txt
+
+          # Any GHCR reference at all: the app image is the only thing this stack
+          # ever pulls from there, and matching the registry rather than the
+          # repository path keeps the check working across a repo rename.
+          if grep -q 'ghcr\.io/' images.txt; then
+            echo "::error::The build overlay leaves a service on the published image, so \`up -d --build\` pulls it instead of building from source. Add it to docker-compose.build.yml."
+            exit 1
+          fi
+
       - name: Start the stack from source
         run: |
           docker compose up -d --build

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -8,10 +8,17 @@
 #   COMPOSE_FILE=docker-compose.prod.yml:docker-compose.build.yml
 #   docker compose up -d --build
 #
-# It restores a local `build:` for the four app-role services (they share one
-# image) and retags it to a local tag so the build never masquerades as the
-# registry image. Everything else (Postgres, Meilisearch, Redis, ports, volumes)
-# comes from docker-compose.prod.yml unchanged.
+# It restores a local `build:` for every app-role service (they share one image)
+# and retags it to a local tag so the build never masquerades as the registry
+# image. Everything else (Postgres, Meilisearch, Redis, ports, volumes) comes
+# from docker-compose.prod.yml unchanged.
+#
+# Every one of them, without exception: a service left out keeps the production
+# `image:` and is pulled from GHCR instead of built, which quietly runs registry
+# code beside your own build — and fails outright with `manifest unknown` on any
+# commit GHCR has no tag for, the very case this overlay exists for. That went
+# unnoticed for `queue-broadcasts` (#1040), so tests/Unit/BuildOverlayCoverageTest.php
+# now derives the list from docker-compose.prod.yml and fails if one is missing.
 
 x-build: &build
   build:
@@ -24,6 +31,8 @@ services:
   reverb:
     <<: *build
   queue:
+    <<: *build
+  queue-broadcasts:
     <<: *build
   scheduler:
     <<: *build

--- a/docs/src/content/docs/self-hosting/installation.md
+++ b/docs/src/content/docs/self-hosting/installation.md
@@ -158,8 +158,9 @@ your `.env` to drop the flag.
 
 Building from source genuinely needs the source tree, so this is the one path
 that still uses `git`: clone and check out the tag you want, then layer the build
-overlay (`docker-compose.build.yml`) on top, which restores a local build for the
-app services (they share one image):
+overlay (`docker-compose.build.yml`) on top, which restores a local build for
+every app-role service — `app`, `reverb`, `queue`, `queue-broadcasts`, and
+`scheduler` (they share one image), so nothing is pulled from the registry:
 
 ```bash
 # 1. Clone and check out the latest release tag.

--- a/tests/Support/ProductionCompose.php
+++ b/tests/Support/ProductionCompose.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Support;
 
+use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -64,10 +65,22 @@ final class ProductionCompose
      */
     public static function appRoleServices(): array
     {
-        return array_values(array_keys(array_filter(
+        $services = array_values(array_keys(array_filter(
             self::services(),
-            static fn (array $service): bool => str_contains(self::imageOf($service), self::APP_IMAGE),
+            static fn (array $service): bool => self::runsAppImage(self::imageOf($service)),
         )));
+
+        // Fail closed. Every guard over the stack drives its cases off this set,
+        // so a production `image:` the match no longer recognises would pass all
+        // of them vacuously — the one failure the derivation cannot report by
+        // returning a value.
+        throw_unless(
+            in_array('app', $services, true) && count($services) > 1,
+            RuntimeException::class,
+            'No app-role services derived from docker-compose.prod.yml — does it still run ['.self::APP_IMAGE.']?',
+        );
+
+        return $services;
     }
 
     /**
@@ -92,6 +105,17 @@ final class ProductionCompose
     public static function imageOf(array $service): string
     {
         return is_string($service['image'] ?? null) ? $service['image'] : '';
+    }
+
+    /**
+     * Whether an image reference runs the shared application image.
+     *
+     * Matched up to the tag or digest separator, so a sibling repository whose
+     * name merely starts with it is not swept in as an app-role service.
+     */
+    private static function runsAppImage(string $image): bool
+    {
+        return preg_match('#'.preg_quote(self::APP_IMAGE, '#').'[:@]#', $image) === 1;
     }
 
     /**

--- a/tests/Support/ProductionCompose.php
+++ b/tests/Support/ProductionCompose.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * The production compose stack, and the services in it that run the shared
+ * application image.
+ *
+ * That set is derived from the file rather than written down, because every
+ * guard over the stack — the branding bind mount, the shared `storage-app`
+ * volume, the build overlay — has to agree on it. Deriving it means a sixth
+ * app-role service joins the set on its own and fails whichever guard it is
+ * missing from, instead of drifting unnoticed until a release trips over it
+ * (see issue #1040).
+ */
+final class ProductionCompose
+{
+    /**
+     * The registry reference every app-role service resolves to by default.
+     */
+    public const string APP_IMAGE = 'ghcr.io/deskhq/the-desk';
+
+    /**
+     * The parsed production stack.
+     *
+     * @return array<string, mixed>
+     */
+    public static function stack(): array
+    {
+        return self::parse('docker-compose.prod.yml');
+    }
+
+    /**
+     * The parsed build-from-source overlay.
+     *
+     * @return array<string, mixed>
+     */
+    public static function buildOverlay(): array
+    {
+        return self::parse('docker-compose.build.yml');
+    }
+
+    /**
+     * Every production service, keyed by name.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function services(): array
+    {
+        /** @var array<string, array<string, mixed>> $services */
+        $services = self::stack()['services'];
+
+        return $services;
+    }
+
+    /**
+     * The services that run the shared application image.
+     *
+     * @return list<string>
+     */
+    public static function appRoleServices(): array
+    {
+        return array_values(array_keys(array_filter(
+            self::services(),
+            static fn (array $service): bool => str_contains(self::imageOf($service), self::APP_IMAGE),
+        )));
+    }
+
+    /**
+     * The app-role services other than `app` itself — the workers that wait for
+     * it before they start.
+     *
+     * @return list<string>
+     */
+    public static function appRoleWorkers(): array
+    {
+        return array_values(array_filter(
+            self::appRoleServices(),
+            static fn (string $service): bool => $service !== 'app',
+        ));
+    }
+
+    /**
+     * A service's image reference, or an empty string when it declares none.
+     *
+     * @param  array<string, mixed>  $service
+     */
+    public static function imageOf(array $service): string
+    {
+        return is_string($service['image'] ?? null) ? $service['image'] : '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function parse(string $file): array
+    {
+        /** @var array<string, mixed> $parsed */
+        $parsed = Yaml::parseFile(dirname(__DIR__, 2).'/'.$file);
+
+        return $parsed;
+    }
+}

--- a/tests/Unit/BrandingVolumeTest.php
+++ b/tests/Unit/BrandingVolumeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\Yaml\Yaml;
+use Tests\Support\ProductionCompose;
 
 /**
  * Whitelabeling has to survive an upgrade, so an operator's brand assets are
@@ -11,14 +11,10 @@ use Symfony\Component\Yaml\Yaml;
  * same directory: the web app resolves the assets, and the workers render mail
  * and notifications that reference them. See issue #970.
  */
-$compose = fn (): array => Yaml::parseFile(dirname(__DIR__, 2).'/docker-compose.prod.yml');
-
-$appServices = ['app', 'queue', 'queue-broadcasts', 'reverb', 'scheduler'];
-
-test('every app-role service mounts the operator branding directory read-only', function (string $service) use ($compose): void {
-    expect($compose()['services'][$service]['volumes'])
+test('every app-role service mounts the operator branding directory read-only', function (string $service): void {
+    expect(ProductionCompose::services()[$service]['volumes'])
         ->toContain('./branding:/app/storage/branding:ro');
-})->with($appServices);
+})->with(fn (): array => ProductionCompose::appRoleServices());
 
 test('the branding mount lands where the app resolves overrides from', function (): void {
     // The image installs the application at /app, so the mount target has to

--- a/tests/Unit/BuildOverlayCoverageTest.php
+++ b/tests/Unit/BuildOverlayCoverageTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Support\ProductionCompose;
+
+/**
+ * `docker-compose.build.yml` exists so an operator can run the stack from their
+ * own source. It does that by restoring a local `build:` on top of every
+ * service that would otherwise pull the published image — so a service it
+ * misses keeps the registry reference and is pulled instead of built.
+ *
+ * That drift is close to invisible: the pull quietly succeeds whenever GHCR
+ * happens to hold the tag in `APP_VERSION`, and only fails on an unreleased
+ * commit — a release-please merge, a fork, a private patch. Which is exactly
+ * the case the overlay is for. `queue-broadcasts` was missing for five months
+ * this way (#1040), so the coverage is asserted here rather than left to the
+ * calendar.
+ */
+$overlaid = function (): array {
+    $overlay = ProductionCompose::buildOverlay()['services'];
+    $merged = [];
+
+    foreach (ProductionCompose::services() as $name => $service) {
+        $merged[$name] = array_replace($service, $overlay[$name] ?? []);
+    }
+
+    return $merged;
+};
+
+test('the app-role services are derived from the stack rather than assumed', function (): void {
+    // Every guard below drives its cases off this set, so a production `image:`
+    // the derivation stops recognising would empty them all rather than fail.
+    expect(ProductionCompose::appRoleServices())->toContain('app')
+        ->and(ProductionCompose::appRoleServices())->toContain('queue-broadcasts');
+});
+
+test('the build overlay restores a local build for every service on the shared app image', function (string $service): void {
+    $overlaid = ProductionCompose::buildOverlay()['services'][$service] ?? null;
+
+    expect($overlaid)->not->toBeNull()
+        ->and($overlaid['build']['context'])->toBe('.')
+        ->and($overlaid['image'])->toBe('the-desk:latest');
+})->with(fn (): array => ProductionCompose::appRoleServices());
+
+test('no service is pulled from the registry once the overlay is layered on', function (string $service) use ($overlaid): void {
+    expect(ProductionCompose::imageOf($overlaid()[$service]))
+        ->not->toContain(ProductionCompose::APP_IMAGE);
+})->with(fn (): array => array_keys(ProductionCompose::services()));
+
+test('the overlay only names services the production stack declares', function (): void {
+    expect(array_keys(ProductionCompose::buildOverlay()['services']))
+        ->each->toBeIn(array_keys(ProductionCompose::services()));
+});
+
+test('the overlay leaves the infrastructure services alone', function () use ($overlaid): void {
+    foreach (['pgsql', 'meilisearch', 'redis'] as $service) {
+        expect($overlaid()[$service])->toEqual(ProductionCompose::services()[$service]);
+    }
+});

--- a/tests/Unit/BuildOverlayCoverageTest.php
+++ b/tests/Unit/BuildOverlayCoverageTest.php
@@ -29,10 +29,11 @@ $overlaid = function (): array {
 };
 
 test('the app-role services are derived from the stack rather than assumed', function (): void {
-    // Every guard below drives its cases off this set, so a production `image:`
-    // the derivation stops recognising would empty them all rather than fail.
-    expect(ProductionCompose::appRoleServices())->toContain('app')
-        ->and(ProductionCompose::appRoleServices())->toContain('queue-broadcasts');
+    // ProductionCompose fails closed if the derivation resolves nothing, which
+    // would otherwise pass every guard below vacuously. What it cannot know is
+    // that the workers belong in the set too — the whole defect here was one of
+    // them being treated as if it did not (#1040).
+    expect(ProductionCompose::appRoleServices())->toContain('queue-broadcasts');
 });
 
 test('the build overlay restores a local build for every service on the shared app image', function (string $service): void {

--- a/tests/Unit/ProductionComposeStorageVolumeTest.php
+++ b/tests/Unit/ProductionComposeStorageVolumeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Symfony\Component\Yaml\Yaml;
+use Tests\Support\ProductionCompose;
 
 /**
  * `app`, `queue`, `queue-broadcasts`, `reverb`, and `scheduler` all mount the
@@ -12,33 +12,26 @@ use Symfony\Component\Yaml\Yaml;
  * file exists`. Making the workers wait for `app` means exactly one container
  * triggers the copy-up. See issue #609.
  */
-$compose = fn (): array => Yaml::parseFile(dirname(__DIR__, 2).'/docker-compose.prod.yml');
+test('every app-role service mounts the shared storage-app volume', function (string $service): void {
+    expect(ProductionCompose::services()[$service]['volumes'])
+        ->toContain('storage-app:/app/storage/app');
+})->with(fn (): array => ProductionCompose::appRoleServices());
 
-$sharedVolumeWorkers = ['queue', 'queue-broadcasts', 'reverb', 'scheduler'];
-
-test('every app-role service mounts the shared storage-app volume', function () use ($compose, $sharedVolumeWorkers): void {
-    $services = $compose()['services'];
-
-    foreach (['app', ...$sharedVolumeWorkers] as $service) {
-        expect($services[$service]['volumes'])->toContain('storage-app:/app/storage/app');
-    }
-});
-
-test('the shared storage-app volume is initialised by app alone', function (string $service) use ($compose): void {
-    $dependsOn = $compose()['services'][$service]['depends_on'];
+test('the shared storage-app volume is initialised by app alone', function (string $service): void {
+    $dependsOn = ProductionCompose::services()[$service]['depends_on'];
 
     expect($dependsOn)->toHaveKey('app')
         ->and($dependsOn['app']['condition'])->toBe('service_started');
-})->with($sharedVolumeWorkers);
+})->with(fn (): array => ProductionCompose::appRoleWorkers());
 
-test('waiting on app does not drop the infrastructure dependencies', function (string $service) use ($compose): void {
-    $dependsOn = $compose()['services'][$service]['depends_on'];
+test('waiting on app does not drop the infrastructure dependencies', function (string $service): void {
+    $dependsOn = ProductionCompose::services()[$service]['depends_on'];
 
     foreach (['pgsql', 'redis', 'meilisearch'] as $dependency) {
         expect($dependsOn[$dependency]['condition'])->toBe('service_healthy');
     }
-})->with([...$sharedVolumeWorkers, 'app']);
+})->with(fn (): array => ProductionCompose::appRoleServices());
 
-test('app does not depend on itself', function () use ($compose): void {
-    expect($compose()['services']['app']['depends_on'])->not->toHaveKey('app');
+test('app does not depend on itself', function (): void {
+    expect(ProductionCompose::services()['app']['depends_on'])->not->toHaveKey('app');
 });


### PR DESCRIPTION
Closes #1040.

## What

`docker-compose.build.yml` restored a local `build:` for four of the five app-role services. `queue-broadcasts` — added to `docker-compose.prod.yml` by #768 — was never added to the overlay, so on the build-from-source path it kept the production reference `${APP_IMAGE:-ghcr.io/deskhq/the-desk:${APP_VERSION}}` and `docker compose up -d --build` pulled it from GHCR instead of building it.

## Why it matters

- **For operators**, the overlay silently did not do its job for that service: building from a released tag ran four locally-built containers beside one registry container, so any local change (patch, fork, branded build) never reached the broadcast worker, with nothing reporting the split.
- **For CI**, it fails outright with `manifest unknown` whenever GHCR has no tag for the commit — which is every release-please release merge. It accounted for 33 of the last 36 failures of the `docker` workflow.

## How

- `docker-compose.build.yml` applies the `*build` anchor to `queue-broadcasts`, and its header says why every app-role service has to be listed.
- `tests/Support/ProductionCompose.php` **derives** the app-role set from `docker-compose.prod.yml` (the services on the shared app image) rather than restating it, and fails closed if that derivation ever resolves nothing.
- `tests/Unit/BuildOverlayCoverageTest.php` asserts the overlay covers that whole derived set and that the merged config resolves nothing to `ghcr.io/deskhq/the-desk` — so a sixth app-role service fails the suite instead of the next release.
- `tests/Unit/BrandingVolumeTest.php` and `tests/Unit/ProductionComposeStorageVolumeTest.php` now drive their cases off the same derived set instead of their own hardcoded copies.
- The `Upgrade script (build from source)` CI job asserts `docker compose config --images` resolves nothing from GHCR before it starts the stack, so future drift fails on the assertion rather than only on the days GHCR happens not to have the tag.
- `docs/self-hosting/installation.md` names the five services the overlay builds.

## Testing

- `./vendor/bin/sail composer test` — Pint, PHPStan, Rector, 2898 tests, `Total: 100.0 %`.
- The two new guards were confirmed red before the fix (both failed on `queue-broadcasts`) and green after.
- Verified locally that `docker compose -f docker-compose.prod.yml -f docker-compose.build.yml config --images` now resolves only `the-desk:latest`, `postgres:18-alpine`, `getmeili/meilisearch:v1.49`, `redis:alpine`.
- `cd docs && npm run build` — 46 pages built.

No i18n changes (no user-facing copy).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787882429&installation_model_id=428379&pr_number=1045&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1045&signature=7d789f5fa1bea4c9532626c39b9d742c2a43a3abbafb5da1cd2c3aa69c5295b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->