### PR TITLE
fix: restore a thread root's follow and unread state when the reply fails

### DIFF
--- a/resources/js/composables/useMessageActions.mutations.test.ts
+++ b/resources/js/composables/useMessageActions.mutations.test.ts
@@ -157,5 +157,59 @@ describe('useMessageActions', () => {
             expect(h.mainStream.pendingUuids.value).toHaveLength(0);
             expect(toastError).toHaveBeenCalledOnce();
         });
+
+        it("restores the root's follow and unread state on error", () => {
+            const root = message({
+                id: 'root-1',
+                threadFollowed: false,
+                threadUnread: true,
+            });
+            const h = harness({
+                serverMain: [root],
+                activeThreadRootId: 'root-1',
+            });
+
+            h.actions.sendThreadReply('a reply', []);
+
+            const patched = h.mainStream.displayMessages.value.find(
+                (m) => m.id === 'root-1',
+            );
+            expect(patched?.threadFollowed).toBe(true);
+            expect(patched?.threadUnread).toBe(false);
+
+            optionsOf(post).onError?.();
+
+            const restored = h.mainStream.displayMessages.value.find(
+                (m) => m.id === 'root-1',
+            );
+            expect(restored?.threadFollowed).toBe(false);
+            expect(restored?.threadUnread).toBe(true);
+        });
+
+        it("leaves the root's other state alone when a reply fails", () => {
+            const root = message({
+                id: 'root-1',
+                threadFollowed: false,
+                threadUnread: true,
+                threadReplyCount: 2,
+            });
+            const h = harness({
+                serverMain: [root],
+                activeThreadRootId: 'root-1',
+            });
+
+            h.actions.sendThreadReply('a reply', []);
+            // Another member's reply lands while ours is still in flight.
+            h.mainStream.patchThreadState('root-1', { threadReplyCount: 3 });
+
+            optionsOf(post).onError?.();
+
+            const restored = h.mainStream.displayMessages.value.find(
+                (m) => m.id === 'root-1',
+            );
+            expect(restored?.threadFollowed).toBe(false);
+            expect(restored?.threadUnread).toBe(true);
+            expect(restored?.threadReplyCount).toBe(3);
+        });
     });
 });

--- a/resources/js/composables/useThreadReplies.ts
+++ b/resources/js/composables/useThreadReplies.ts
@@ -62,6 +62,21 @@ export function useThreadReplies(options: ThreadRepliesOptions): ThreadReplies {
 
         options.threadStream.addPending(optimistic);
 
+        // Snapshot only the two fields the optimistic patch below touches, so a
+        // failed send puts them back without reverting anything that landed on
+        // the root while the post was in flight (another member's reply bumping
+        // the count, say). The root is absent when the main timeline hasn't
+        // rendered it, in which case there is nothing to patch or restore.
+        const root = options.mainStream.displayMessages.value.find(
+            (m) => m.id === rootId,
+        );
+        const previousRootThreadState = root
+            ? {
+                  threadFollowed: root.threadFollowed,
+                  threadUnread: root.threadUnread,
+              }
+            : null;
+
         // Replying makes the viewer a follower of the thread and means they've
         // seen it, so keep the root's affordance in the main timeline dot-free.
         options.mainStream.patchThreadState(rootId, {
@@ -89,6 +104,13 @@ export function useThreadReplies(options: ThreadRepliesOptions): ThreadReplies {
 
                     if (sendToChannel) {
                         options.mainStream.removePending(clientUuid);
+                    }
+
+                    if (previousRootThreadState) {
+                        options.mainStream.patchThreadState(
+                            rootId,
+                            previousRootThreadState,
+                        );
                     }
 
                     toast.error(t('Your reply failed to send'));


### PR DESCRIPTION
Closes #1026.

## What

`sendThreadReply` patches the thread root in the main timeline before it posts — `threadFollowed: true`, `threadUnread: false` — and its `onError` handler reversed everything else (`threadStream.removePending`, and `mainStream.removePending` when the reply was echoed to the channel) but never put that root state back. A reply that failed to send left the root reading as followed with its unread dot cleared, even though the viewer never actually replied.

The root's `threadFollowed` / `threadUnread` are now snapshotted before the optimistic patch and restored in `onError`, alongside the pending-row cleanup that was already there.

## Why not `getPatch` / `restorePatch`

The issue notes that every other optimistic path in this module snapshots with `getPatch` and restores with `restorePatch`. Those don't fit here:

- They key off `clientUuid`, and this path only holds the root's message **id**.
- They restore the **whole** message. A broadcast landing while the post is in flight — another member's reply bumping `threadReplyCount`, a reaction, a pin — would be reverted along with our own patch. Worse, when there was no prior patch, `restorePatch` *deletes* the entry outright, wiping that broadcast entirely.

Restoring only the two fields the optimistic patch touched is the narrower and correct reversal. When the main timeline hasn't rendered the root at all, there is nothing to patch or to restore, and both sides no-op symmetrically.

## How tested

Two new vitest cases in the `sendThreadReply` group of `resources/js/composables/useMessageActions.mutations.test.ts`, both red before the fix:

- the root is back to unfollowed/unread after `onError`;
- an in-flight `threadReplyCount` bump survives the rollback (the regression a wholesale `restorePatch` would have introduced).

## Gates

- `composer test` — `Total: 100.0 %`, clean Pint / PHPStan / Rector.
- `npm run test:js` — 2252 passed.
- `lint:check` (0 errors), `format:check`, `types:check`, `build` — all clean.

No i18n or docs changes: the fix adds no user-facing copy and nothing operator-facing.

## Note

Local CodeRabbit could not run on this branch — the free OSS tier was rate-limited at the time. Leaning on the app's PR review instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787883438&installation_model_id=428379&pr_number=1046&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1046&signature=2676230d2b7cd0cd2a73eff2a1f8deecba677259192b7696e1e4ef697c66d4aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->