### PR TITLE
fix: clear the older-history in-flight flag on a channel switch

### DIFF
--- a/resources/js/components/channel/ChannelPane.vue
+++ b/resources/js/components/channel/ChannelPane.vue
@@ -146,7 +146,10 @@ const {
     hasOlder,
     isLoadingOlder,
     loadOlderMessages,
-} = useChannelHistory({ loadedCount: () => props.serverMessages.length });
+} = useChannelHistory({
+    channelId: () => props.channel.id,
+    loadedCount: () => props.serverMessages.length,
+});
 
 /**
  * The "New messages" divider's lifecycle — freeze its position at open, refreeze

--- a/resources/js/composables/useChannelHistory.test.ts
+++ b/resources/js/composables/useChannelHistory.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import { useChannelHistory } from '@/composables/useChannelHistory';
+import type { ChannelHistory } from '@/composables/useChannelHistory';
+
+function withScope(options: {
+    channelId: { value: string };
+    loadedCount: { value: number };
+    hasNext?: () => boolean;
+}) {
+    const fetchNext = vi.fn();
+    const scope = effectScope();
+    let history!: ChannelHistory;
+
+    scope.run(() => {
+        history = useChannelHistory({
+            channelId: () => options.channelId.value,
+            loadedCount: () => options.loadedCount.value,
+        });
+    });
+
+    history.infiniteScrollRef.value = {
+        fetchNext,
+        hasNext: options.hasNext ?? ((): boolean => true),
+    };
+
+    return { history, fetchNext, unmount: () => scope.stop() };
+}
+
+describe('useChannelHistory', () => {
+    it('fetches the next older page and marks it in flight', () => {
+        const { history, fetchNext } = withScope({
+            channelId: ref('c1'),
+            loadedCount: ref(20),
+        });
+
+        expect(history.isLoadingOlder()).toBe(false);
+        history.loadOlderMessages();
+
+        expect(fetchNext).toHaveBeenCalledOnce();
+        expect(history.isLoadingOlder()).toBe(true);
+    });
+
+    it('does not stack a second request while one is in flight', () => {
+        const { history, fetchNext } = withScope({
+            channelId: ref('c1'),
+            loadedCount: ref(20),
+        });
+
+        history.loadOlderMessages();
+        history.loadOlderMessages();
+
+        expect(fetchNext).toHaveBeenCalledOnce();
+    });
+
+    it('does not fetch when there is no older history left', () => {
+        const { history, fetchNext } = withScope({
+            channelId: ref('c1'),
+            loadedCount: ref(20),
+            hasNext: () => false,
+        });
+
+        expect(history.hasOlder()).toBe(false);
+        history.loadOlderMessages();
+
+        expect(fetchNext).not.toHaveBeenCalled();
+        expect(history.isLoadingOlder()).toBe(false);
+    });
+
+    it('clears the in-flight flag once the older page lands', async () => {
+        const loadedCount = ref(20);
+        const { history } = withScope({ channelId: ref('c1'), loadedCount });
+
+        history.loadOlderMessages();
+        loadedCount.value = 40;
+        await nextTick();
+
+        expect(history.isLoadingOlder()).toBe(false);
+    });
+
+    it('clears the in-flight flag on a channel switch onto a page of the same length', async () => {
+        const channelId = ref('c1');
+        const loadedCount = ref(20);
+        const { history, fetchNext } = withScope({ channelId, loadedCount });
+
+        history.loadOlderMessages();
+        expect(history.isLoadingOlder()).toBe(true);
+
+        // The reader switches away before the page lands, and the new channel's
+        // first page happens to hold exactly as many messages as the old one.
+        channelId.value = 'c2';
+        await nextTick();
+
+        expect(history.isLoadingOlder()).toBe(false);
+
+        // Older history is fetchable again in the new channel.
+        history.loadOlderMessages();
+        expect(fetchNext).toHaveBeenCalledTimes(2);
+    });
+});

--- a/resources/js/composables/useChannelHistory.ts
+++ b/resources/js/composables/useChannelHistory.ts
@@ -8,6 +8,8 @@ interface InfiniteScrollHandle {
 }
 
 export interface ChannelHistoryOptions {
+    /** The channel on show, so a switch can retire an in-flight page. */
+    channelId: () => string;
     /** How many messages the server page currently holds. */
     loadedCount: () => number;
 }
@@ -29,7 +31,7 @@ export interface ChannelHistory {
  * returns messages newest-first), so "load older" maps to fetchNext/hasNext.
  * The in-flight flag gates the virtualizer's top-load trigger so a burst of
  * range updates can't stack duplicate requests; it clears once the merged page
- * grows (older rows have landed).
+ * grows (older rows have landed) or the channel changes under it.
  */
 export function useChannelHistory(
     options: ChannelHistoryOptions,
@@ -55,7 +57,11 @@ export function useChannelHistory(
         infiniteScrollRef.value?.fetchNext();
     }
 
-    watch(options.loadedCount, () => {
+    // The channel id is watched alongside the count because the pane component is
+    // reused across a switch: a page still in flight when the reader leaves would
+    // otherwise keep the flag raised in the new channel whenever the two first
+    // pages happen to hold the same number of messages (#1023).
+    watch([options.loadedCount, options.channelId], () => {
         loadingOlder.value = false;
     });
 


### PR DESCRIPTION
Closes #1023.

## What

`useChannelHistory` cleared its in-flight flag (`loadingOlder`) from a `loadedCount` watcher alone. Since `loadOlderMessages()` returns early while that flag is up, the flag is the gate on fetching older history at all.

A reader who triggers a load of older messages and then switches conversation before the page lands keeps the flag raised, because the channel page component is reused across a switch. If the new channel's first page happens to hold the same number of messages as the old one, the count watcher never fires — so the "Loading earlier messages…" pill stays up and reverse infinite scroll is dead in that channel until the loaded count changes for some other reason.

## How

The watcher now covers the channel id alongside the count:

```ts
watch([options.loadedCount, options.channelId], () => {
    loadingOlder.value = false;
});
```

`channelId: () => string` joins `ChannelHistoryOptions`, and `ChannelPane.vue` passes `() => props.channel.id` — the same getter shape `useUnreadDivider` and `useUnreadJump` already take at that call site. The reason both sources are watched together is recorded in a comment on the watcher.

## Testing

New `resources/js/composables/useChannelHistory.test.ts` (the composable had no spec). Five cases:

- the reported regression — with the flag set, switching channel onto a page of the **same** length clears it, and `loadOlderMessages()` genuinely fetches again rather than just reporting a lowered flag. This fails on `develop` (`expected true to be false`) and passes here.
- the in-flight gate does not stack a second request;
- no fetch when there is no older history left;
- the original clear-once-the-page-grows path;
- the initial fetch marks itself in flight.

Both gates green: Pint, PHPStan (0 errors), Rector (clean dry-run), PHP suite at **100.0%** coverage; `lint:check`, `format:check`, `types:check`, `build`, and Vitest (2255 tests) all pass.

No i18n or docs changes apply — no user-facing copy and nothing operator-facing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787883444&installation_model_id=428379&pr_number=1047&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1047&signature=1c9d69d983670c020de015d205a62b9bb6ffc9914ebfba08791f5d4947fa9f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->