### PR TITLE
fix: keep the worktree bootstrap's output off stdout

### DIFF
--- a/bin/worktree
+++ b/bin/worktree
@@ -58,7 +58,15 @@
 #                            php ^8.3 and the resulting vendor/ runs on php8.5.
 #
 # All diagnostics go to stderr; only machine-readable output (the worktree path
-# from `create`, the table from `list`) goes to stdout.
+# from `create`, the table from `list`) goes to stdout. That contract is enforced
+# rather than remembered: main() parks the real stdout on fd 3 and points the
+# script's own at stderr, so everything a subcommand shells out to — git,
+# Composer, npm, artisan, Sail — writes to stderr whether or not its call site
+# says so, and `emit` is the only way back out. Redirecting each call site
+# instead only held until the next bootstrap step was added without a `>&2`, and
+# the kilobytes it then wrote ahead of the path made the documented one-liner
+# `cd "$(bin/worktree create <NNN>)"` land nowhere on a fresh bootstrap (issue
+# #1043).
 
 set -euo pipefail
 
@@ -79,6 +87,10 @@ LOCK_DIR="${REGISTRY_DIR}/worktrees.lock"
 
 log() { printf '%s\n' "$*" >&2; }
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# The one route to the caller's stdout (fd 3; see main()), for machine-readable
+# output only. Everything else on the way past is diagnostics.
+emit() { printf '%s\n' "$*" >&3; }
 
 # --- git anchoring -----------------------------------------------------------
 # Resolve the MAIN working tree from the shared .git dir, so the script behaves
@@ -329,10 +341,9 @@ cmd_create() {
             # A bootstrap that could only degrade the Playwright step still
             # reached "ready" (issue #1005), so re-entry is where it gets its
             # retry. The sentinel keeps a healthy worktree's re-entry free of
-            # any container round-trip at all, and the retry is kept off stdout
-            # so `cd "$(bin/worktree create NNN)"` still sees only the path.
-            [ -f "${path}/.worktree-playwright-deps" ] || install_playwright_browsers "$path" >&2
-            printf '%s\n' "$path"
+            # any container round-trip at all.
+            [ -f "${path}/.worktree-playwright-deps" ] || install_playwright_browsers "$path"
+            emit "$path"
             return 0
         fi
         if [ ! -d "$path" ]; then
@@ -469,7 +480,7 @@ cmd_create() {
     touch "${path}/.worktree-ready"
     log "worktree ready — cd into it and run: ./vendor/bin/sail composer test"
     [ -z "$PLAYWRIGHT_DEGRADED" ] || log "note: Playwright is not fully installed (${PLAYWRIGHT_DEGRADED}), so tests/Browser will not run here yet — re-run 'bin/worktree create ${nnn}' to retry that step"
-    printf '%s\n' "$path"
+    emit "$path"
 }
 
 # Playwright ships its browser binaries out of band: `npm install` fetches the
@@ -705,9 +716,9 @@ cmd_list() {
     )"
     # Prefer aligned columns; fall back to raw TSV where `column` is unavailable.
     if command -v column >/dev/null 2>&1; then
-        printf '%s\n' "$rows" | column -t -s "$(printf '\t')"
+        printf '%s\n' "$rows" | column -t -s "$(printf '\t')" >&3
     else
-        printf '%s\n' "$rows"
+        emit "$rows"
     fi
 }
 
@@ -761,6 +772,12 @@ EOF
 }
 
 main() {
+    # Park the caller's stdout on fd 3 and send the script's own to stderr, so no
+    # step of a subcommand can reach stdout except through `emit`. Done here
+    # rather than at load time so sourcing the script as a library (WORKTREE_LIB)
+    # leaves the streams alone.
+    exec 3>&1 1>&2
+
     # EXIT runs the cleanup on any exit; INT/TERM just trigger an exit (with the
     # conventional 128+signal code) so an interrupted run can't resume bootstrap
     # or teardown without its locks.

--- a/dev-docs/concurrent-worktrees.md
+++ b/dev-docs/concurrent-worktrees.md
@@ -99,6 +99,13 @@ cd "$(bin/worktree create 441)"    # drops you into the isolated worktree
 
 ## Notes & limits
 
+- **stdout carries machine-readable output only** — the path from `create`, the
+  table from `list` — so `cd "$(bin/worktree create <NNN>)"` is composable even
+  on a fresh bootstrap, where Composer, npm and artisan each write kilobytes.
+  The script enforces that rather than relying on every call site remembering a
+  `>&2`: it parks the real stdout on fd 3 and points its own at stderr, and a
+  single `emit` helper is the only way back out. Progress is still shown — it is
+  simply all on stderr.
 - Dependencies are installed per worktree (isolation over speed). The first
   worktree pays the Sail image build; later ones reuse the cached image.
 - Running the **full** coverage gate in several worktrees at once is bound by

--- a/tests/Unit/WorktreeScriptTest.php
+++ b/tests/Unit/WorktreeScriptTest.php
@@ -12,13 +12,17 @@ use Symfony\Component\Yaml\Yaml;
  * branch resolution can be driven against throwaway repositories instead of
  * booting Docker.
  */
-function runWorktreeLib(string $cwd, string $snippet): Process
+/**
+ * @param  array<string, string>  $env  extra environment for the run, merged into the inherited one
+ */
+function runWorktreeLib(string $cwd, string $snippet, array $env = []): Process
 {
     $script = dirname(__DIR__, 2).'/bin/worktree';
 
     $process = new Process(
         ['bash', '-c', 'WORKTREE_LIB=1 . '.escapeshellarg($script).'; '.$snippet],
         $cwd,
+        $env,
     );
     $process->run();
 
@@ -120,6 +124,72 @@ function sailCalls(string $log): array
     }
 
     return array_values(array_filter(explode("\n", (string) file_get_contents($log)), strlen(...)));
+}
+
+/**
+ * A ./vendor/bin/sail that echoes its own argv on STDOUT, the way the Composer,
+ * npm and artisan steps of a real bootstrap do. fakeSailWorktree's stub keeps its
+ * record in a file instead, which is what makes it useless for telling apart the
+ * two streams.
+ */
+function writeNoisySail(string $path): void
+{
+    mkdir($path.'/vendor/bin', 0o755, true);
+    file_put_contents($path.'/vendor/bin/sail', <<<'BASH'
+        #!/usr/bin/env bash
+        printf 'sail %s: fetching packages, building, seeding...\n' "$*"
+        exit 0
+        BASH);
+    chmod($path.'/vendor/bin/sail', 0o755);
+}
+
+/**
+ * An "upstream" whose master already carries what a bootstrap expects to find in
+ * the worktree it checks out — an .env to copy and an executable, noisy
+ * ./vendor/bin/sail — cloned into a "main checkout". A committed sail is what
+ * lets cmd_create run to completion without Docker: its bootstrap only reaches
+ * for the throwaway Composer image when ./vendor/bin/sail is missing.
+ *
+ * @return array{0: string, 1: string} the clone path and its parent directory
+ */
+function worktreeBootstrapFixture(): array
+{
+    $root = realpath(sys_get_temp_dir()).'/worktree-bootstrap-'.bin2hex(random_bytes(6));
+    mkdir($root.'/upstream', 0o755, true);
+
+    file_put_contents($root.'/upstream/.env', "APP_NAME=Desk\nAPP_KEY=\nAPP_PORT=80\n");
+    writeNoisySail($root.'/upstream');
+
+    runGit($root.'/upstream', 'init', '--quiet', '--initial-branch=master', '.');
+    runGit($root.'/upstream', 'add', '-A', '-f');
+    runGit($root.'/upstream', 'commit', '--quiet', '-m', 'init');
+
+    runGit($root, 'clone', '--quiet', $root.'/upstream', 'main');
+
+    return [$root.'/main', $root];
+}
+
+/**
+ * The bootstrap dependencies this suite's container does not have, defined as
+ * shell functions so they shadow the binaries bin/worktree would otherwise call:
+ * `require_tooling` aborts on the missing docker, jq backs the registry, and gh
+ * supplies the title the branch slug is derived from. The jq stub answers the
+ * three filters a first-time `create` reaches — nothing registered for the issue
+ * yet, slot 0 free, and the entry it then stores.
+ */
+function worktreeCreateStubs(): string
+{
+    return <<<'BASH'
+        require_tooling() { :; }
+        gh() { printf 'fix the bootstrap\n'; }
+        jq() {
+            case "$*" in
+                *'// empty'*) return 0 ;;
+                *'any('*) return 1 ;;
+                *) printf '{}\n' ;;
+            esac
+        }
+        BASH;
 }
 
 function gitRevision(string $cwd, string $revision): string
@@ -500,6 +570,78 @@ test('no generated env value dials a compose service the bootstrap leaves down',
     );
 
     expect(envAssignmentsDialing($path.'/.env', unstartedComposeServices()))->toBe([]);
+});
+
+test('a fresh bootstrap prints nothing but the worktree path on stdout', function (): void {
+    [$clone, $root] = worktreeBootstrapFixture();
+
+    $process = runWorktreeLib(
+        $clone,
+        worktreeCreateStubs()."\nmain create 1043 master",
+        ['HOME' => $root.'/home'],
+    );
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toBe($root."/the-desk-worktrees/1043-fix-the-bootstrap\n")
+        ->and(is_file($root.'/the-desk-worktrees/1043-fix-the-bootstrap/.worktree-ready'))->toBeTrue();
+});
+
+test('a fresh bootstrap still shows every step it runs, on stderr', function (): void {
+    [$clone, $root] = worktreeBootstrapFixture();
+
+    $process = runWorktreeLib(
+        $clone,
+        worktreeCreateStubs()."\nmain create 1043 master",
+        ['HOME' => $root.'/home'],
+    );
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getErrorOutput())->toContain('composer install --no-interaction')
+        ->and($process->getErrorOutput())->toContain('npm run build')
+        ->and($process->getErrorOutput())->toContain('worktree ready');
+});
+
+test('re-entering a ready worktree prints nothing but its path either', function (): void {
+    $path = tempGitDir('worktree-reentry');
+    writeNoisySail($path);
+    touch($path.'/.worktree-ready');
+
+    $stubs = <<<BASH
+        require_tooling() { :; }
+        jq() {
+            case "\$*" in
+                *'// empty'*) printf '%s\n' '{"path":"{$path}"}' ;;
+                *) printf '%s\n' '{$path}' ;;
+            esac
+        }
+        BASH;
+
+    $process = runWorktreeLib($path, $stubs."\nmain create 1043", ['HOME' => $path.'/home']);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toBe($path."\n")
+        ->and($process->getErrorOutput())->toContain('playwright install-deps chromium');
+});
+
+test('list keeps its machine-readable table on stdout', function (): void {
+    $path = tempGitDir('worktree-list');
+
+    $stubs = <<<'BASH'
+        require_tooling() { :; }
+        jq() {
+            case "$*" in
+                *length*) printf '1\n' ;;
+                *) printf '1043\t0\t20000\t20001\t20002\t20003\t1043-slug\t/wt/1043-slug\n' ;;
+            esac
+        }
+        BASH;
+
+    $process = runWorktreeLib($path, $stubs."\nmain list", ['HOME' => $path.'/home']);
+
+    expect($process->getExitCode())->toBe(0)
+        ->and($process->getOutput())->toContain('ISSUE')
+        ->and($process->getOutput())->toContain('1043-slug')
+        ->and($process->getOutput())->toContain('/wt/1043-slug');
 });
 
 test('the services the bootstrap starts all exist in compose.yaml', function (): void {


### PR DESCRIPTION
Closes #1043.

## What

`bin/worktree`'s header promises that only machine-readable output reaches stdout — the path from `create`, the table from `list`. `cmd_create` honoured that for its own `log` calls but not for the subprocesses it shells out to: `sail composer install`, `sail npm install`, `sail artisan typescript:transform`, `sail npm run build`, `git worktree add` and the rest all ran unredirected.

So on a **fresh** bootstrap the documented one-liner

```bash
cd "$(bin/worktree create NNN)"
```

captured several kilobytes of Composer/npm/artisan chatter ahead of the path and `cd` got a word salad. It only looked fine because re-entry into an already-ready worktree runs no subprocesses at all, and that is the path most runs hit.

## How

Redirecting each call site with `>&2` is what failed here — one step added later without it and the one-liner breaks again, silently. So the contract is enforced structurally instead: `main()` parks the caller's stdout on fd 3 and points the script's own at stderr

```bash
exec 3>&1 1>&2
```

and a new `emit` helper is the only route back out. Every subprocess a subcommand starts — present or future — lands on stderr whether or not its call site says so. `create` emits its path and `list` emits its table through fd 3; progress is unchanged, just all on stderr.

The now-redundant `>&2` on the re-entry Playwright retry (added by #1044) is dropped, since the global redirect covers it.

## How tested

`tests/Unit/WorktreeScriptTest.php` gains four tests. Two of them drive the **real** `cmd_create` end to end through `main` — the container the suite runs in has no jq/gh/docker, so those three are shadowed by shell functions, and the fixture repo commits an executable `./vendor/bin/sail` stub that echoes its own argv on stdout the way the real steps do. That is enough for the bootstrap to run to completion (git worktree add, `.env` generation, compose override, every sail step, the sentinels) with no container:

- `a fresh bootstrap prints nothing but the worktree path on stdout` — the regression test; it failed before the fix with 14 lines of stub chatter ahead of the path.
- `a fresh bootstrap still shows every step it runs, on stderr` — progress is not swallowed.
- `re-entering a ready worktree prints nothing but its path either` — covers the fast path and its Playwright retry.
- `list keeps its machine-readable table on stdout` — guards the other half of the contract against this very change.

Because the guarantee now lives in `main()` rather than at each call site, a bootstrap step added later cannot silently reintroduce the bug, and the fresh-bootstrap test would catch it if it tried.

Full gate green at `Total: 100.0 %` (Pint + PHPStan + Rector + parallel coverage). No i18n or user-facing copy involved; `dev-docs/concurrent-worktrees.md` documents the stream contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787915374&installation_model_id=428379&pr_number=1048&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1048&signature=80c2d1f9adb105e3bceb827331cc3ab8517d30ba6e0c69453314c73277a8057d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->