### PR TITLE
feat: keep composer uploads running when you leave a channel

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1407,5 +1407,11 @@
   "Files can be up to :max MB": "Les fichiers peuvent atteindre :max Mo",
   "Reminder snoozed": "Rappel reporté",
   "For 20 minutes": "De 20 minutes",
-  "Failed to update notification preferences": "Échec de la mise à jour des préférences de notification"
+  "Failed to update notification preferences": "Échec de la mise à jour des préférences de notification",
+  "Uploading 1 file": "Envoi d’un fichier",
+  "Uploading :count files": "Envoi de :count fichiers",
+  "1 file ready to send": "1 fichier prêt à envoyer",
+  ":count files ready to send": ":count fichiers prêts à envoyer",
+  "1 file didn't upload": "1 fichier n’a pas été envoyé",
+  ":count files didn't upload": ":count fichiers n’ont pas été envoyés"
 }

--- a/resources/js/components/MessageComposer.tray.test.ts
+++ b/resources/js/components/MessageComposer.tray.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { App, Component } from 'vue';
 import { createApp, defineComponent, h, nextTick } from 'vue';
+import { releaseChannelUploads } from '@/composables/useChannelUploads';
 import type { UploadHandle } from '@/lib/uploadAttachment';
 import MessageComposer from './MessageComposer.vue';
 
@@ -111,6 +112,13 @@ function mountComposer(props: Record<string, unknown> = {}) {
     return { container };
 }
 
+/** Unmount the composer mounted last, the way leaving a channel does. */
+function unmountLast(): void {
+    const { app, container } = active.pop()!;
+    app.unmount();
+    container.remove();
+}
+
 /** Set the hidden input's `files` (read-only in jsdom) and fire `change`. */
 async function stage(container: HTMLElement, file: File): Promise<void> {
     const input = container.querySelector<HTMLInputElement>(
@@ -158,6 +166,9 @@ afterEach(() => {
     });
     active = [];
     uploads.length = 0;
+    // The tray is held by the channel now, not by the composer: unmounting is no
+    // longer enough to forget what a test staged in #general.
+    releaseChannelUploads();
 });
 
 describe('MessageComposer attachment tray', () => {
@@ -278,6 +289,40 @@ describe('MessageComposer attachment tray', () => {
         uploads[0].resolve({ id: 'att-1' });
         await settle();
         expect(send.hasAttribute('disabled')).toBe(false);
+    });
+
+    it('finds the tray as it left it when the channel is opened again', async () => {
+        const first = mountComposer();
+        await stage(first.container, textFile());
+        uploads[0].progress(40);
+
+        // Leaving the channel unmounts the composer; the upload runs on and
+        // lands while nobody is showing it.
+        unmountLast();
+        uploads[0].resolve({ id: 'att-1' });
+        await settle();
+
+        const { container } = mountComposer();
+
+        const [chip] = chips(container);
+        expect(chip.getAttribute('data-status')).toBe('done');
+        expect(chip.textContent).toContain('launch-checklist.txt');
+        // Still claimable, so the send the user came back to make can take it.
+        expect(
+            container
+                .querySelector('[data-test="message-composer-send"]')
+                ?.hasAttribute('disabled'),
+        ).toBe(false);
+    });
+
+    it('gives another channel a tray of its own', async () => {
+        const first = mountComposer();
+        await stage(first.container, textFile());
+        unmountLast();
+
+        const { container } = mountComposer({ channelSlug: 'design' });
+
+        expect(chips(container)).toHaveLength(0);
     });
 
     it('keeps saving drafts after an attachment-only send', async () => {

--- a/resources/js/components/ToastCard.test.ts
+++ b/resources/js/components/ToastCard.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { createApp, h, ref } from 'vue';
+
+/**
+ * Covers the two slots a progress card needs that no other tone does: the muted
+ * continuation of the title, and the figure hard right. The rest of the card —
+ * surface, tones, drain — is the slab's and `useToast`'s.
+ */
+vi.mock('vue-sonner', () => ({
+    toast: { custom: vi.fn(), dismiss: vi.fn() },
+    useVueSonner: () => ({ activeToasts: ref([{ id: 1 }, { id: 2 }]) }),
+}));
+
+import ToastCard from './ToastCard.vue';
+
+/** Mount the card and hand back its root element. */
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    const app = createApp({
+        render: () =>
+            h(ToastCard, {
+                tone: 'progress',
+                title: 'Uploading 3 files',
+                duration: Infinity,
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(host);
+
+    return host.firstElementChild as HTMLElement;
+}
+
+/** The element a `data-test` hook names, or null. */
+function slot(card: HTMLElement, name: string): HTMLElement | null {
+    return card.querySelector<HTMLElement>(`[data-test="${name}"]`);
+}
+
+describe('ToastCard', () => {
+    it('continues the title with its meta rather than starting a second line', () => {
+        const card = mount({ meta: '12.4 MB' });
+
+        expect(slot(card, 'toast-title')?.textContent).toBe(
+            'Uploading 3 files · 12.4 MB',
+        );
+        expect(slot(card, 'toast-detail')).toBeNull();
+    });
+
+    it('leaves the title alone when there is no meta', () => {
+        expect(slot(mount(), 'toast-title')?.textContent).toBe(
+            'Uploading 3 files',
+        );
+    });
+
+    it('sets a value hard right in monospace', () => {
+        const value = slot(mount({ value: '64%' }), 'toast-value');
+
+        expect(value?.textContent).toBe('64%');
+        expect(value?.className).toContain('font-mono');
+    });
+
+    it('hides the value from the announcement, which repeats every tick', () => {
+        // vue-sonner announces changed text inside a live toast, so a percent
+        // re-firing once a second would be read aloud about sixty times a
+        // minute. The title and meta carry what has to be heard.
+        expect(
+            slot(mount({ value: '64%' }), 'toast-value')?.getAttribute(
+                'aria-hidden',
+            ),
+        ).toBe('true');
+    });
+
+    it('gives the value the slot the stack’s overflow count would take', () => {
+        // Two toasts are active, so the front card would otherwise show "+1".
+        const card = mount({ value: '64%' });
+
+        expect(slot(card, 'toast-overflow')).toBeNull();
+        expect(slot(card, 'toast-value')).not.toBeNull();
+    });
+
+    it('still counts the stack when the card carries no value', () => {
+        expect(slot(mount(), 'toast-overflow')?.textContent).toBe('+1');
+    });
+});

--- a/resources/js/components/ToastCard.vue
+++ b/resources/js/components/ToastCard.vue
@@ -19,6 +19,17 @@ const props = defineProps<{
     title: string;
     /** The value that was just set. Already translated. */
     detail?: string;
+    /**
+     * A muted continuation of the title on the same line, separated by the
+     * middle dot drawn below: "Uploading 3 files · 12.4 MB". Already translated.
+     */
+    meta?: string;
+    /**
+     * A short figure set hard right in monospace — a progress percentage. It
+     * takes the slot the overflow count otherwise has, and is `aria-hidden`
+     * with it: see the template.
+     */
+    value?: string;
     action?: ToastAction;
     /** Drives the drain hairline; `Infinity` leaves the toast up. */
     duration: number;
@@ -62,6 +73,12 @@ const glyphTint = computed(() => GLYPH_TINTS[props.tone]);
  */
 const overflow = computed(() => toastCount.value - 1);
 
+/**
+ * The title's continuation, separator included, so the dot never has to be
+ * carried in a translated string.
+ */
+const metaText = computed(() => ` · ${props.meta}`);
+
 const drains = computed(() => Number.isFinite(props.duration));
 
 /**
@@ -102,9 +119,15 @@ const closeable = computed(() => props.tone === 'error');
         </span>
 
         <div class="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span data-test="toast-title" class="text-[13.5px] font-semibold">{{
-                title
-            }}</span>
+            <span data-test="toast-title" class="text-[13.5px] font-semibold"
+                >{{ title
+                }}<span
+                    v-if="meta"
+                    data-test="toast-meta"
+                    class="font-normal text-slab-muted-foreground"
+                    >{{ metaText }}</span
+                ></span
+            >
             <span
                 v-if="detail"
                 data-test="toast-detail"
@@ -125,8 +148,22 @@ const closeable = computed(() => props.tone === 'error');
             {{ action.label }}
         </Button>
 
+        <!-- One figure holds this slot. A `value` wins it: the overflow count
+             is decoration, whereas the percent is what the card is about. Both
+             are hidden from the announcement — the count says nothing the stack
+             does not, and the percent re-fires about once a second, which
+             `aria-relevant="additions text"` on sonner's region would otherwise
+             read aloud every time it changed. -->
         <span
-            v-if="overflow > 0"
+            v-if="value"
+            data-test="toast-value"
+            aria-hidden="true"
+            class="shrink-0 self-center font-mono text-[11px] text-slab-muted-foreground"
+            >{{ value }}</span
+        >
+
+        <span
+            v-else-if="overflow > 0"
             data-test="toast-overflow"
             aria-hidden="true"
             class="shrink-0 self-center font-mono text-[11px] text-slab-muted-foreground"

--- a/resources/js/composables/useAttachmentUploads.doubles.ts
+++ b/resources/js/composables/useAttachmentUploads.doubles.ts
@@ -3,6 +3,7 @@ import { effectScope } from 'vue';
 import type { EffectScope } from 'vue';
 import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
 import type { AttachmentUploads } from '@/composables/useAttachmentUploads';
+import { useChannelUploads } from '@/composables/useChannelUploads';
 import type { UploadFailure, UploadHandle } from '@/lib/uploadAttachment';
 
 /**
@@ -111,4 +112,78 @@ export function buildUploads(): UploadsHarness {
     });
 
     return { scope, uploads, calls: fake.calls, created, revoked };
+}
+
+/** One composer's view of a registry-backed tray, and the way it goes away. */
+export interface OpenedTray {
+    uploads: AttachmentUploads;
+    /** Tear this composer down, the way unmounting its component would. */
+    close: () => void;
+}
+
+/** What the registry harness hands its suite: openers and shared recorders. */
+export interface RegistryHarness {
+    /**
+     * Open a composer for a channel — or, with a null key, one that has no
+     * channel and so gets a tray of its own.
+     */
+    open: (
+        channelKey: string | null,
+        overrides?: { endpoint?: string; maxPerMessage?: number },
+    ) => OpenedTray;
+    /** Tear down every composer still open, as unmounting them would. */
+    closeAll: () => void;
+    calls: Deferred[];
+    created: string[];
+    revoked: string[];
+}
+
+/**
+ * A registry harness: many composers over one fake uploader and one pair of
+ * object-URL recorders, so a suite can watch what a channel's tray keeps as the
+ * composers around it come and go.
+ */
+export function buildRegistry(): RegistryHarness {
+    const fake = fakeUploader();
+    const created: string[] = [];
+    const revoked: string[] = [];
+    const scopes: EffectScope[] = [];
+
+    function open(
+        channelKey: string | null,
+        overrides: { endpoint?: string; maxPerMessage?: number } = {},
+    ): OpenedTray {
+        let uploads!: AttachmentUploads;
+
+        const scope = effectScope();
+        scopes.push(scope);
+        scope.run(() => {
+            uploads = useChannelUploads({
+                channelKey,
+                endpoint: () =>
+                    overrides.endpoint ??
+                    `/t/${channelKey ?? 'none'}/attachments`,
+                maxSizeMb: () => 25,
+                maxPerMessage: () => overrides.maxPerMessage ?? 3,
+                uploader: fake.uploader,
+                createObjectUrl: (file) => {
+                    const url = `blob:${file.name}`;
+                    created.push(url);
+
+                    return url;
+                },
+                revokeObjectUrl: (url) => revoked.push(url),
+            });
+        });
+
+        return { uploads, close: () => scope.stop() };
+    }
+
+    return {
+        open,
+        closeAll: () => scopes.forEach((scope) => scope.stop()),
+        calls: fake.calls,
+        created,
+        revoked,
+    };
 }

--- a/resources/js/composables/useAttachmentUploads.ts
+++ b/resources/js/composables/useAttachmentUploads.ts
@@ -81,6 +81,12 @@ export interface AttachmentUploads {
     isUploading: ComputedRef<boolean>;
     /** Whether any row failed and still needs a retry or removal (blocks send). */
     hasFailed: ComputedRef<boolean>;
+    /**
+     * Whether the tray holds nothing at all — no rows, and no snapshot detached
+     * for a send that could still restore them. The owner of a tray that
+     * outlives its composer reads this to know when it is safe to let go.
+     */
+    isIdle: ComputedRef<boolean>;
     /** The claimable ids of the finished uploads, in tray order. */
     attachmentIds: ComputedRef<string[]>;
     /** Stage and begin uploading the given files, validating size and count. */
@@ -130,12 +136,17 @@ function defaultRevokeObjectUrl(url: string): void {
 }
 
 /**
- * Own the composer's pre-send attachment tray: files upload the moment they are
- * dropped, pasted, or picked (the two-phase flow), each row tracking its own
- * progress, so the send later just claims the finished ids. Size and count are
- * pre-checked here for instant feedback; the server re-enforces both as the
- * source of truth. Pure and Vue-reactive with an injectable uploader, so the
- * whole lifecycle unit-tests without a real network or DOM.
+ * Own a pre-send attachment tray: files upload the moment they are dropped,
+ * pasted, or picked (the two-phase flow), each row tracking its own progress,
+ * so the send later just claims the finished ids. Size and count are pre-checked
+ * here for instant feedback; the server re-enforces both as the source of truth.
+ * Pure and Vue-reactive with an injectable uploader, so the whole lifecycle
+ * unit-tests without a real network or DOM.
+ *
+ * The tray is torn down with the scope that built it. A channel's tray is
+ * therefore built by {@see useChannelUploads} in a scope of the registry's own,
+ * not by the composer rendering it — a composer-owned tray would abort its
+ * uploads on every channel switch.
  */
 export function useAttachmentUploads(
     options: AttachmentUploadsOptions,
@@ -157,6 +168,10 @@ export function useAttachmentUploads(
     // preview URLs; disposing them on teardown keeps the no-leak guarantee.
     const outstanding = new Set<() => void>();
 
+    // The same set's size, reactively — `isIdle` has to see a send detach and
+    // settle, and a plain Set cannot be watched.
+    const outstandingCount = ref(0);
+
     const count = computed(() => items.value.length);
     const isUploading = computed(() =>
         items.value.some((item) => item.status === 'uploading'),
@@ -168,6 +183,9 @@ export function useAttachmentUploads(
         items.value.flatMap((item) =>
             item.attachment ? [item.attachment.id] : [],
         ),
+    );
+    const isIdle = computed(
+        () => items.value.length === 0 && outstandingCount.value === 0,
     );
 
     /** The current row for a local id, or undefined once it has been removed. */
@@ -380,6 +398,7 @@ export function useAttachmentUploads(
 
             settled = true;
             outstanding.delete(dispose);
+            outstandingCount.value = outstanding.size;
 
             for (const { row } of captured) {
                 if (row.previewUrl) {
@@ -395,6 +414,7 @@ export function useAttachmentUploads(
 
             settled = true;
             outstanding.delete(dispose);
+            outstandingCount.value = outstanding.size;
 
             for (const { row, source } of captured) {
                 if (source) {
@@ -407,6 +427,7 @@ export function useAttachmentUploads(
         }
 
         outstanding.add(dispose);
+        outstandingCount.value = outstanding.size;
 
         return { restore, dispose };
     }
@@ -433,6 +454,7 @@ export function useAttachmentUploads(
         count,
         isUploading,
         hasFailed,
+        isIdle,
         attachmentIds,
         addFiles,
         addRemote,

--- a/resources/js/composables/useChannelUploads.test.ts
+++ b/resources/js/composables/useChannelUploads.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Covers the lifetime the channel registry gives a tray: which composer shares
+ * which rows, what survives a composer going away, and when an entry is finally
+ * released. The tray's own behaviour — staging, progress, failures, snapshots —
+ * is pinned by the `useAttachmentUploads` suites; what is watched here is only
+ * who owns it and for how long.
+ */
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
+
+import { releaseChannelUploads } from '@/composables/useChannelUploads';
+import {
+    attachment,
+    buildRegistry,
+    fakeFile,
+} from './useAttachmentUploads.doubles';
+import type { RegistryHarness } from './useAttachmentUploads.doubles';
+
+describe('useChannelUploads', () => {
+    let registry: RegistryHarness;
+
+    beforeEach(() => {
+        toastError.mockClear();
+        registry = buildRegistry();
+    });
+
+    afterEach(() => {
+        registry.closeAll();
+        releaseChannelUploads();
+    });
+
+    /** Settle an upload's `.then` handlers. */
+    async function settle(): Promise<void> {
+        await Promise.resolve();
+        await Promise.resolve();
+    }
+
+    it('hands both composers of a channel the same tray', () => {
+        const first = registry.open('acme/design');
+        const second = registry.open('acme/design');
+
+        expect(second.uploads).toBe(first.uploads);
+    });
+
+    it('keeps a separate tray per channel', () => {
+        const design = registry.open('acme/design');
+        const general = registry.open('acme/general');
+
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf')]);
+
+        expect(general.uploads.items.value).toHaveLength(0);
+    });
+
+    it('keeps an upload running when the composer that started it goes away', () => {
+        const design = registry.open('acme/design');
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf')]);
+
+        design.close();
+
+        // Leaving the channel must neither abort the transfer nor drop the row.
+        expect(registry.calls[0].abort).not.toHaveBeenCalled();
+        expect(design.uploads.items.value).toHaveLength(1);
+    });
+
+    it('shows the tray as it was, finished rows included, on returning', async () => {
+        const away = registry.open('acme/design');
+        away.uploads.addFiles([fakeFile('pic.png', 'image/png')]);
+        away.close();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        await settle();
+
+        const back = registry.open('acme/design');
+
+        expect(back.uploads).toBe(away.uploads);
+        expect(back.uploads.items.value.map((row) => row.name)).toEqual([
+            'pic.png',
+        ]);
+        // Still claimable by the send the user came back to make.
+        expect(back.uploads.attachmentIds.value).toEqual(['att-1']);
+        expect(registry.revoked).toEqual([]);
+    });
+
+    it('drops an empty channel’s entry once its composer goes away', () => {
+        const first = registry.open('acme/design');
+        first.close();
+
+        // Nothing was staged, so nothing is worth keeping: a later visit starts
+        // from a fresh tray rather than an ever-growing registry of empties.
+        expect(registry.open('acme/design').uploads).not.toBe(first.uploads);
+    });
+
+    it('releases an entry and its previews once its last row leaves while away', async () => {
+        const away = registry.open('acme/design');
+        away.uploads.addFiles([fakeFile('pic.png', 'image/png')]);
+        away.close();
+
+        // The server rejects the file type: the row is dropped where it stands,
+        // emptying a tray nobody is watching.
+        registry.calls[0].reject({
+            status: 422,
+            message: 'This file type is not allowed.',
+            aborted: false,
+        });
+        await settle();
+
+        expect(registry.revoked).toContain('blob:pic.png');
+        expect(registry.open('acme/design').uploads).not.toBe(away.uploads);
+    });
+
+    it('holds an entry open while a send snapshot is still outstanding', async () => {
+        const sending = registry.open('acme/design');
+        sending.uploads.addFiles([fakeFile('pic.png', 'image/png')]);
+        registry.calls[0].resolve(attachment('att-1'));
+        await settle();
+
+        // The send empties the tray optimistically, then fails while the user is
+        // already in another channel — the rows must still have somewhere to go.
+        const snapshot = sending.uploads.detach();
+        sending.close();
+
+        const back = registry.open('acme/design');
+        expect(back.uploads).toBe(sending.uploads);
+
+        snapshot.restore();
+        expect(back.uploads.items.value.map((row) => row.name)).toEqual([
+            'pic.png',
+        ]);
+    });
+
+    it('keeps uploading to the endpoint the channel was opened with', () => {
+        const first = registry.open('acme/design', {
+            endpoint: '/t/acme/c/design/attachments',
+        });
+        first.uploads.addFiles([fakeFile('a.pdf', 'application/pdf')]);
+        first.close();
+
+        // A second composer re-adopts the entry rather than rebuilding it, so
+        // the rows it inherits keep the endpoint their transfers already use.
+        const back = registry.open('acme/design', {
+            endpoint: '/t/acme/c/other/attachments',
+        });
+        back.uploads.addFiles([fakeFile('b.pdf', 'application/pdf')]);
+
+        expect(registry.calls.map((call) => call.url)).toEqual([
+            '/t/acme/c/design/attachments',
+            '/t/acme/c/design/attachments',
+        ]);
+    });
+
+    it('drops every channel and its previews on a team switch', () => {
+        const design = registry.open('acme/design');
+        design.uploads.addFiles([fakeFile('pic.png', 'image/png')]);
+        const general = registry.open('acme/general');
+        general.uploads.addFiles([fakeFile('shot.png', 'image/png')]);
+
+        releaseChannelUploads();
+
+        expect(registry.revoked).toEqual(['blob:pic.png', 'blob:shot.png']);
+        expect(registry.calls[0].abort).toHaveBeenCalled();
+        expect(registry.open('acme/design').uploads).not.toBe(design.uploads);
+    });
+
+    it('gives a composer with no channel an unshared tray it owns outright', () => {
+        const thread = registry.open(null);
+        const other = registry.open(null);
+
+        expect(other.uploads).not.toBe(thread.uploads);
+
+        thread.uploads.addFiles([fakeFile('pic.png', 'image/png')]);
+        thread.close();
+
+        // Nothing to outlive: an unregistered tray dies with its composer.
+        expect(thread.uploads.items.value).toHaveLength(0);
+        expect(registry.revoked).toContain('blob:pic.png');
+    });
+});

--- a/resources/js/composables/useChannelUploads.ts
+++ b/resources/js/composables/useChannelUploads.ts
@@ -1,0 +1,148 @@
+import { effectScope, onScopeDispose, watch } from 'vue';
+import type { EffectScope } from 'vue';
+import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
+import type {
+    AttachmentUploads,
+    AttachmentUploadsOptions,
+} from '@/composables/useAttachmentUploads';
+
+export interface ChannelUploadsOptions extends AttachmentUploadsOptions {
+    /**
+     * The channel this tray belongs to, as `team/channel`. Null where the
+     * composer has no channel to upload to (a thread composer), which gets an
+     * unregistered tray owned by the calling scope instead.
+     */
+    channelKey: string | null;
+}
+
+/** One channel's tray, and what it takes to know when to let go of it. */
+interface RegistryEntry {
+    /** Owns the tray's effects, so stopping it runs the tray's own teardown. */
+    scope: EffectScope;
+    uploads: AttachmentUploads;
+    /** How many composers are mounted on this channel right now. */
+    consumers: number;
+}
+
+const registry = new Map<string, RegistryEntry>();
+
+/**
+ * Build a channel's tray in a scope of its own, outside whichever component
+ * happened to ask for it first, and arrange for it to be released the moment it
+ * holds nothing anyone is coming back for.
+ */
+function createEntry(
+    channelKey: string,
+    options: ChannelUploadsOptions,
+): RegistryEntry {
+    const scope = effectScope(true);
+
+    // Read the caller's getters once: they close over the props of the composer
+    // that opened the channel, which the entry now outlives. Everything they
+    // answer is fixed by the channel key anyway — a renamed channel is a new
+    // key, and the caps are server config — so freezing them here keeps a
+    // long-lived entry from reading an unmounted component's props.
+    const endpoint = options.endpoint();
+    const maxSizeMb = options.maxSizeMb();
+    const maxPerMessage = options.maxPerMessage();
+
+    let uploads!: AttachmentUploads;
+
+    scope.run(() => {
+        uploads = useAttachmentUploads({
+            endpoint: () => endpoint,
+            maxSizeMb: () => maxSizeMb,
+            maxPerMessage: () => maxPerMessage,
+            uploader: options.uploader,
+            createObjectUrl: options.createObjectUrl,
+            revokeObjectUrl: options.revokeObjectUrl,
+        });
+
+        // The tray's rows are the only reason to keep it: once the last one has
+        // been sent, removed or cleared and no composer is showing it, the entry
+        // has nothing left to hand back. Synchronous so the release lands with
+        // the removal that caused it rather than a tick later.
+        watch(uploads.isIdle, () => releaseIfSpent(channelKey), {
+            flush: 'sync',
+        });
+    });
+
+    const entry: RegistryEntry = { scope, uploads, consumers: 0 };
+    registry.set(channelKey, entry);
+
+    return entry;
+}
+
+/** Drop a channel's entry, running the tray's teardown and freeing its previews. */
+function release(channelKey: string): void {
+    const entry = registry.get(channelKey);
+
+    if (!entry) {
+        return;
+    }
+
+    // Deleted first, so the teardown below cannot re-enter this entry.
+    registry.delete(channelKey);
+    entry.scope.stop();
+}
+
+/** Release a channel's entry if nothing is watching it and nothing is in it. */
+function releaseIfSpent(channelKey: string): void {
+    const entry = registry.get(channelKey);
+
+    if (entry && entry.consumers === 0 && entry.uploads.isIdle.value) {
+        release(channelKey);
+    }
+}
+
+/**
+ * The pre-send attachment tray for a channel, held by the channel rather than
+ * by the composer that renders it.
+ *
+ * The composer is mounted per channel and remounts on every switch, so a tray
+ * it owned would abort its own in-flight uploads the moment the user looked at
+ * another channel — destroying the transfer rather than merely hiding it. Held
+ * here, an upload runs on to its end and its row is still in the tray on
+ * return, still claimable by a send (the server keeps an unclaimed upload for
+ * `attachments.pending_ttl_hours`).
+ *
+ * The lifetime that replaces "dies with its composer": an entry lives while it
+ * holds rows or an in-flight send's snapshot, and is released as soon as it
+ * holds neither and no composer is mounted on it — which is what frees its
+ * preview object URLs. There is no timed eviction and no LRU: a row in a tray
+ * is work the user can still see and act on, and evicting it loses that
+ * silently. {@see releaseChannelUploads} drops the lot on a team switch.
+ */
+export function useChannelUploads(
+    options: ChannelUploadsOptions,
+): AttachmentUploads {
+    const { channelKey } = options;
+
+    // No channel, no tray to outlive: a composer that cannot upload anywhere
+    // (the thread composer) keeps its own, torn down with it as it always was.
+    if (channelKey === null) {
+        return useAttachmentUploads(options);
+    }
+
+    const entry = registry.get(channelKey) ?? createEntry(channelKey, options);
+
+    entry.consumers += 1;
+
+    onScopeDispose(() => {
+        entry.consumers -= 1;
+        releaseIfSpent(channelKey);
+    });
+
+    return entry.uploads;
+}
+
+/**
+ * Drop every channel's tray, aborting what is in flight and releasing every
+ * preview. Called on a team switch: the registry is scoped to one workspace,
+ * and the trays of the one being left have no surface to come back to.
+ */
+export function releaseChannelUploads(): void {
+    for (const channelKey of [...registry.keys()]) {
+        release(channelKey);
+    }
+}

--- a/resources/js/composables/useChannelUploads.ts
+++ b/resources/js/composables/useChannelUploads.ts
@@ -1,5 +1,11 @@
-import { effectScope, onScopeDispose, watch } from 'vue';
-import type { EffectScope } from 'vue';
+import {
+    computed,
+    effectScope,
+    onScopeDispose,
+    shallowReactive,
+    watch,
+} from 'vue';
+import type { ComputedRef, EffectScope } from 'vue';
 import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
 import type {
     AttachmentUploads,
@@ -24,7 +30,39 @@ interface RegistryEntry {
     consumers: number;
 }
 
-const registry = new Map<string, RegistryEntry>();
+/**
+ * Shallow rather than deep, so an entry reads back as the object that was put
+ * in: the tray a composer holds and the tray the registry hands the next one
+ * have to be the same object, not two proxies of it.
+ */
+const registry = shallowReactive(new Map<string, RegistryEntry>());
+
+/** One channel's tray, as everything outside the composer sees it. */
+export interface ChannelUploads {
+    /** The channel it belongs to, as `team/channel`. */
+    channelKey: string;
+    uploads: AttachmentUploads;
+}
+
+/**
+ * Every channel holding a tray right now — the whole of what is staged across
+ * the workspace, which is what lets a surface outside the composer (the upload
+ * toast) report on channels the user is not looking at.
+ */
+export const channelUploads: ComputedRef<ChannelUploads[]> = computed(() =>
+    [...registry.entries()].map(([channelKey, entry]) => ({
+        channelKey,
+        uploads: entry.uploads,
+    })),
+);
+
+/** The registry key for a channel's tray. */
+export function channelUploadKey(
+    teamSlug: string,
+    channelSlug: string,
+): string {
+    return `${teamSlug}/${channelSlug}`;
+}
 
 /**
  * Build a channel's tray in a scope of its own, outside whichever component

--- a/resources/js/composables/useComposerAttachments.ts
+++ b/resources/js/composables/useComposerAttachments.ts
@@ -5,7 +5,10 @@ import type {
     AttachmentUploads,
     PendingAttachment,
 } from '@/composables/useAttachmentUploads';
-import { useChannelUploads } from '@/composables/useChannelUploads';
+import {
+    channelUploadKey,
+    useChannelUploads,
+} from '@/composables/useChannelUploads';
 import { useVoiceRecorder } from '@/composables/useVoiceRecorder';
 import type { VoiceRecorder } from '@/composables/useVoiceRecorder';
 import { isVoiceRecordingSupported } from '@/lib/audio';
@@ -57,9 +60,12 @@ export function useComposerAttachments(options: {
      * mid-upload no longer aborts the transfer. Resolved once: a composer is
      * mounted per channel and remounts when that changes.
      */
-    const channelKey = attachmentsEnabled.value
-        ? `${options.teamSlug()}/${options.channelSlug()}`
-        : null;
+    const teamSlug = options.teamSlug();
+    const channelSlug = options.channelSlug();
+    const channelKey =
+        teamSlug && channelSlug
+            ? channelUploadKey(teamSlug, channelSlug)
+            : null;
 
     const uploads = useChannelUploads({
         channelKey,

--- a/resources/js/composables/useComposerAttachments.ts
+++ b/resources/js/composables/useComposerAttachments.ts
@@ -1,11 +1,11 @@
 import { computed } from 'vue';
 import type { ComputedRef } from 'vue';
 import { store as storeAttachment } from '@/actions/App/Http/Controllers/Channels/AttachmentController';
-import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
 import type {
     AttachmentUploads,
     PendingAttachment,
 } from '@/composables/useAttachmentUploads';
+import { useChannelUploads } from '@/composables/useChannelUploads';
 import { useVoiceRecorder } from '@/composables/useVoiceRecorder';
 import type { VoiceRecorder } from '@/composables/useVoiceRecorder';
 import { isVoiceRecordingSupported } from '@/lib/audio';
@@ -52,8 +52,17 @@ export function useComposerAttachments(options: {
     /**
      * The pre-send attachment tray: files upload immediately on pick/paste/drop,
      * each row tracking its own progress; the send later claims the finished ids.
+     *
+     * It belongs to the channel, not to this composer, so leaving the channel
+     * mid-upload no longer aborts the transfer. Resolved once: a composer is
+     * mounted per channel and remounts when that changes.
      */
-    const uploads = useAttachmentUploads({
+    const channelKey = attachmentsEnabled.value
+        ? `${options.teamSlug()}/${options.channelSlug()}`
+        : null;
+
+    const uploads = useChannelUploads({
+        channelKey,
         endpoint: () =>
             storeAttachment({
                 team: options.teamSlug() ?? '',

--- a/resources/js/composables/useToast.test.ts
+++ b/resources/js/composables/useToast.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { sonner } = vi.hoisted(() => ({ sonner: { custom: vi.fn() } }));
+const { sonner } = vi.hoisted(() => ({
+    sonner: { custom: vi.fn(), dismiss: vi.fn() },
+}));
 
 vi.mock('vue-sonner', () => ({ toast: sonner }));
 
@@ -51,6 +53,16 @@ describe('useToast', () => {
 
             expect(cardPropsOf().title).toBe('Reminder set');
             expect(cardPropsOf().detail).toBe('Tomorrow, 9:00 AM');
+        });
+
+        it('hands the card the title’s continuation and its right-hand figure', () => {
+            useToast().progress('Uploading 3 files', {
+                meta: '12.4 MB',
+                value: '64%',
+            });
+
+            expect(cardPropsOf().meta).toBe('12.4 MB');
+            expect(cardPropsOf().value).toBe('64%');
         });
     });
 
@@ -140,6 +152,12 @@ describe('useToast', () => {
             useToast().success('Reminder set');
 
             expect(cardPropsOf().action).toBeUndefined();
+        });
+
+        it('takes a keyed toast back off the screen on request', () => {
+            useToast().dismiss('attachment-uploads');
+
+            expect(sonner.dismiss).toHaveBeenCalledWith('attachment-uploads');
         });
     });
 });

--- a/resources/js/composables/useToast.ts
+++ b/resources/js/composables/useToast.ts
@@ -19,6 +19,20 @@ export type ToastOptions = {
      * carries "Tomorrow, 9:00 AM".
      */
     detail?: string;
+    /**
+     * A muted continuation of the title, on the same line and separated by a
+     * middle dot the card draws itself: "Uploading 3 files · 12.4 MB". Already
+     * translated. Where `detail` is a second line below the title, this is the
+     * same line — use it for a figure that belongs to the title's phrase.
+     */
+    meta?: string;
+    /**
+     * A short figure set hard right in monospace, e.g. a progress percentage.
+     * It takes the slot the stack's `+N` overflow otherwise has, and like it is
+     * `aria-hidden`: a toast re-firing once a second would otherwise be read
+     * aloud every second, so never put anything here that is said nowhere else.
+     */
+    value?: string;
     action?: ToastAction;
     /**
      * Merge identity. A repeat under the same key replaces the toast on screen
@@ -74,6 +88,8 @@ function notify(tone: ToastTone, title: string, options: ToastOptions): void {
             tone,
             title,
             detail: options.detail,
+            meta: options.meta,
+            value: options.value,
             action: options.action,
             duration,
         },
@@ -111,5 +127,13 @@ export function useToast() {
             notify('warning', title, options),
         progress: (title: string, options: ToastOptions = {}): void =>
             notify('progress', title, options),
+        /**
+         * Take a keyed toast off the screen without resolving it. For work that
+         * stops being worth reporting rather than finishing — a progress card
+         * whose inline surface the user has just come back to.
+         */
+        dismiss: (key: string): void => {
+            sonner.dismiss(key);
+        },
     };
 }

--- a/resources/js/composables/useUploadProgressToast.test.ts
+++ b/resources/js/composables/useUploadProgressToast.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { EffectScope, Ref } from 'vue';
+
+/**
+ * Covers the toast that reports uploads the composer is no longer showing: when
+ * it appears at all, which rows it counts, what it says while they run, and
+ * what it becomes when they land. The arithmetic is `lib/uploadBatch`'s and the
+ * rows are the registry's; what is watched here is the decision to speak.
+ */
+const { toast } = vi.hoisted(() => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+        dismiss: vi.fn(),
+    },
+}));
+
+vi.mock('@/composables/useToast', () => ({ useToast: () => toast }));
+
+import {
+    channelUploads,
+    releaseChannelUploads,
+} from '@/composables/useChannelUploads';
+import { useUploadProgressToast } from '@/composables/useUploadProgressToast';
+import {
+    attachment,
+    buildRegistry,
+    fakeFile,
+} from './useAttachmentUploads.doubles';
+import type { RegistryHarness } from './useAttachmentUploads.doubles';
+
+const MB = 1024 * 1024;
+const DESIGN = 'acme/design';
+const GENERAL = 'acme/general';
+
+describe('useUploadProgressToast', () => {
+    let registry: RegistryHarness;
+    let scope: EffectScope;
+    let onScreen: Ref<string | null>;
+    let opened: string[];
+    let clock: number;
+
+    /** The options the last toast of the given tone was raised with. */
+    function optionsOf(tone: 'progress' | 'success' | 'error') {
+        const { calls } = toast[tone].mock;
+
+        return calls[calls.length - 1][1] as {
+            key?: string;
+            meta?: string;
+            value?: string;
+            action?: { label: string; run: () => void };
+        };
+    }
+
+    /** The title of the last toast of the given tone. */
+    function titleOf(tone: 'progress' | 'success' | 'error'): string {
+        const { calls } = toast[tone].mock;
+
+        return calls[calls.length - 1][0] as string;
+    }
+
+    /** Let the watcher see everything staged since the last one. */
+    async function settle(): Promise<void> {
+        await Promise.resolve();
+        await Promise.resolve();
+        await nextTick();
+    }
+
+    /** Move the clock past the throttle window. */
+    function tick(): void {
+        clock += 1_500;
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        registry = buildRegistry();
+        onScreen = ref<string | null>(DESIGN);
+        opened = [];
+        clock = 0;
+
+        scope = effectScope();
+        scope.run(() => {
+            useUploadProgressToast({
+                channels: () => channelUploads.value,
+                activeChannelKey: () => onScreen.value,
+                channelName: (channelKey) =>
+                    channelKey === DESIGN ? '#design' : null,
+                openChannel: (channelKey) => opened.push(channelKey),
+                now: () => clock,
+            });
+        });
+    });
+
+    afterEach(() => {
+        scope.stop();
+        registry.closeAll();
+        releaseChannelUploads();
+    });
+
+    it('says nothing while the uploading channel is the one on screen', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        registry.calls[0].onProgress(40);
+        await settle();
+
+        expect(toast.progress).not.toHaveBeenCalled();
+    });
+
+    it('appears mid-flight at whatever percent it has reached when you leave', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', 12 * MB),
+        ]);
+        registry.calls[0].onProgress(64);
+        await settle();
+
+        onScreen.value = GENERAL;
+        await settle();
+
+        expect(titleOf('progress')).toBe('Uploading 1 file');
+        expect(optionsOf('progress')).toMatchObject({
+            key: 'attachment-uploads',
+            meta: '12 MB',
+            value: '64%',
+        });
+    });
+
+    it('counts two channels into one card rather than stacking two', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        const general = registry.open(GENERAL);
+        general.uploads.addFiles([
+            fakeFile('b.pdf', 'application/pdf', MB),
+            fakeFile('c.pdf', 'application/pdf', MB),
+        ]);
+
+        onScreen.value = null;
+        await settle();
+
+        expect(titleOf('progress')).toBe('Uploading 3 files');
+        expect(toast.progress).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves out rows that had already landed before it appeared', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', MB),
+            fakeFile('b.pdf', 'application/pdf', MB),
+            fakeFile('c.pdf', 'application/pdf', MB),
+        ]);
+        registry.calls[0].resolve(attachment('att-1'));
+        registry.calls[1].resolve(attachment('att-2'));
+        await settle();
+
+        onScreen.value = GENERAL;
+        await settle();
+
+        expect(titleOf('progress')).toBe('Uploading 1 file');
+    });
+
+    it('keeps the percent climbing when one of the batch lands', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', MB),
+            fakeFile('b.pdf', 'application/pdf', MB),
+        ]);
+        registry.calls[0].onProgress(50);
+        registry.calls[1].onProgress(50);
+        onScreen.value = GENERAL;
+        await settle();
+
+        expect(optionsOf('progress').value).toBe('50%');
+
+        registry.calls[0].resolve(attachment('att-1'));
+        tick();
+        await settle();
+
+        // The finished row stays in the denominator at 100 rather than leaving
+        // the set and dragging both the count and the figure backwards.
+        expect(titleOf('progress')).toBe('Uploading 2 files');
+        expect(optionsOf('progress').value).toBe('75%');
+    });
+
+    it('takes a row that starts uploading later into the batch', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        const general = registry.open(GENERAL);
+        expect(titleOf('progress')).toBe('Uploading 1 file');
+
+        // Uploaded from the drag-and-drop overlay of a channel the user then
+        // leaves again — it joins the card already on screen.
+        general.uploads.addFiles([fakeFile('b.pdf', 'application/pdf', MB)]);
+        onScreen.value = null;
+        tick();
+        await settle();
+
+        expect(titleOf('progress')).toBe('Uploading 2 files');
+    });
+
+    it('redraws about once a second rather than on every chunk', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        onScreen.value = GENERAL;
+        await settle();
+        expect(toast.progress).toHaveBeenCalledTimes(1);
+
+        for (const percent of [11, 12, 13, 14]) {
+            registry.calls[0].onProgress(percent);
+            await settle();
+        }
+
+        expect(toast.progress).toHaveBeenCalledTimes(1);
+
+        tick();
+        registry.calls[0].onProgress(15);
+        await settle();
+
+        expect(toast.progress).toHaveBeenCalledTimes(2);
+        expect(optionsOf('progress').value).toBe('15%');
+    });
+
+    it('is taken away, not resolved, when you come back to the channel', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        onScreen.value = DESIGN;
+        await settle();
+
+        expect(toast.dismiss).toHaveBeenCalledWith('attachment-uploads');
+        expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it('says nothing when the batch lands after you are already back', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        onScreen.value = DESIGN;
+        await settle();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        tick();
+        await settle();
+
+        // The tray in front of the user already said so.
+        expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it('confirms a landed batch without claiming anything was sent', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', MB),
+            fakeFile('b.pdf', 'application/pdf', MB),
+        ]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        registry.calls[1].resolve(attachment('att-2'));
+        tick();
+        await settle();
+
+        expect(titleOf('success')).toBe('2 files ready to send');
+        expect(optionsOf('success')).toMatchObject({
+            key: 'attachment-uploads',
+            meta: '#design',
+        });
+
+        optionsOf('success').action?.run();
+        expect(opened).toEqual([DESIGN]);
+    });
+
+    it('names no channel for a batch that spans several', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        const general = registry.open(GENERAL);
+        general.uploads.addFiles([fakeFile('b.pdf', 'application/pdf', MB)]);
+        onScreen.value = null;
+        await settle();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        registry.calls[1].resolve(attachment('att-2'));
+        tick();
+        await settle();
+
+        expect(titleOf('success')).toBe('2 files ready to send');
+        expect(optionsOf('success').meta).toBeUndefined();
+        expect(optionsOf('success').action).toBeUndefined();
+    });
+
+    it('names only the failures, and the retry re-enters progress under the same key', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', MB),
+            fakeFile('b.pdf', 'application/pdf', MB),
+        ]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        registry.calls[1].reject({
+            status: 500,
+            message: null,
+            aborted: false,
+        });
+        tick();
+        await settle();
+
+        expect(titleOf('error')).toBe("1 file didn't upload");
+        expect(optionsOf('error').key).toBe('attachment-uploads');
+
+        optionsOf('error').action?.run();
+        tick();
+        await settle();
+
+        // Back to the progress tone under the same key: no new card, no new key.
+        expect(registry.calls).toHaveLength(3);
+        expect(titleOf('progress')).toBe('Uploading 1 file');
+        expect(optionsOf('progress').key).toBe('attachment-uploads');
+    });
+
+    it('never counts a picked GIF, which arrives with nothing to transfer', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addRemote({
+            id: 'gif-1',
+            filename: null,
+            mimeType: 'image/gif',
+            sizeBytes: 4 * MB,
+            width: 2,
+            height: 1,
+            isImage: true,
+            source: 'giphy',
+            url: 'https://media.giphy.com/gif-1/200.gif',
+            thumbUrl: null,
+            description: null,
+        });
+
+        onScreen.value = GENERAL;
+        await settle();
+
+        expect(toast.progress).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/composables/useUploadProgressToast.ts
+++ b/resources/js/composables/useUploadProgressToast.ts
@@ -1,0 +1,282 @@
+import { watchEffect } from 'vue';
+import type {
+    AttachmentUploads,
+    PendingAttachment,
+} from '@/composables/useAttachmentUploads';
+import type { ChannelUploads } from '@/composables/useChannelUploads';
+import { useToast } from '@/composables/useToast';
+import { useTranslations } from '@/composables/useTranslations';
+import { formatFileSize } from '@/lib/attachments';
+import { totalsForUploadBatch } from '@/lib/uploadBatch';
+
+/**
+ * The one key every staged upload reports under. Two channels uploading at once
+ * are one activity, not two events: the stack is for unrelated things.
+ */
+const MERGE_KEY = 'attachment-uploads';
+
+/**
+ * Roughly one redraw a second. Progress events arrive per chunk per file, so
+ * three files unthrottled are a redraw storm for a figure that only ever reads
+ * to a whole percent.
+ */
+const TICK_MS = 1_000;
+
+export interface UploadProgressToastOptions {
+    /** Every channel holding a tray right now, and the tray itself. */
+    channels: () => ChannelUploads[];
+    /**
+     * The channel whose composer is on screen, or null anywhere else — the
+     * settings pages, the workspace index, a thread with no channel behind it.
+     */
+    activeChannelKey: () => string | null;
+    /** A channel's display name, where the sidebar knows one. */
+    channelName: (channelKey: string) => string | null;
+    /** Take the user to a channel: the View action on a landed batch. */
+    openChannel: (channelKey: string) => void;
+    /** The clock, injected so the throttle needs no timers to test. */
+    now?: () => number;
+}
+
+/** One staged row, and the channel whose tray it is sitting in. */
+interface TrackedRow {
+    channelKey: string;
+    uploads: AttachmentUploads;
+    row: PendingAttachment;
+}
+
+/**
+ * Report staged uploads the user has walked away from, in a single toast.
+ *
+ * An upload's inline surface is the tray in its channel's composer, so it is
+ * worth a toast exactly when that composer is not the one on screen. The card
+ * therefore appears when the last visible surface goes away rather than when
+ * the upload starts — upload in #design and stay there and no toast ever fires
+ * — and coming back dismisses it rather than resolving it, because the tray has
+ * taken the job back.
+ *
+ * What it reports is a *batch*, fixed at the moment the card appears: the rows
+ * uploading right then, joined by any that start later. Summing whatever
+ * happens to be uploading at each instant instead would drop a row from the set
+ * the moment it landed, and the percentage would fall backwards — worse than no
+ * percentage at all. {@see totalsForUploadBatch} keeps the arithmetic honest;
+ * this owns which rows it runs over and when the card is worth firing.
+ */
+export function useUploadProgressToast(
+    options: UploadProgressToastOptions,
+): void {
+    const { t } = useTranslations();
+    const toast = useToast();
+    const clock = options.now ?? (() => Date.now());
+
+    /** The local ids the card is reporting on, in the order they joined. */
+    let batch: string[] = [];
+
+    /** Whether a progress card of ours is on screen. */
+    let showing = false;
+
+    let lastFiredAt = 0;
+    let lastSignature = '';
+
+    function forget(): void {
+        batch = [];
+        showing = false;
+        lastSignature = '';
+    }
+
+    /** Every staged row in the workspace, whichever channel is holding it. */
+    function stagedRows(): TrackedRow[] {
+        return options.channels().flatMap(({ channelKey, uploads }) =>
+            uploads.items.value.map((row) => ({
+                channelKey,
+                uploads,
+                row,
+            })),
+        );
+    }
+
+    /**
+     * Re-fire the progress card under the same key, which replaces it in place.
+     * Throttled: only a change in the count or the whole percent is worth a
+     * redraw, and then at most once a tick.
+     */
+    function reportProgress(rows: PendingAttachment[], force: boolean): void {
+        const totals = totalsForUploadBatch(rows);
+        const signature = `${totals.fileCount}:${totals.percent}`;
+        const now = clock();
+
+        if (
+            !force &&
+            (signature === lastSignature || now - lastFiredAt < TICK_MS)
+        ) {
+            return;
+        }
+
+        lastSignature = signature;
+        lastFiredAt = now;
+
+        toast.progress(
+            totals.fileCount === 1
+                ? t('Uploading 1 file')
+                : t('Uploading :count files', { count: totals.fileCount }),
+            {
+                key: MERGE_KEY,
+                meta: formatFileSize(totals.totalBytes),
+                value: `${totals.percent}%`,
+            },
+        );
+    }
+
+    /** Swap the progress card in place for what became of the batch. */
+    function resolve(members: TrackedRow[]): void {
+        const totals = totalsForUploadBatch(
+            members.map((member) => member.row),
+        );
+
+        if (totals.failed.length > 0) {
+            reportFailure(members, totals.failed);
+        } else {
+            reportReady(members, totals.fileCount);
+        }
+
+        forget();
+    }
+
+    /**
+     * Name only what failed, and offer the retry. Safe to treat everything here
+     * as retryable: a definitive rejection (a bad type, an over-size file) is
+     * removed from the tray with its own toast the moment it lands, so a row
+     * still `failed` at this point failed in transport.
+     */
+    function reportFailure(
+        members: TrackedRow[],
+        failed: PendingAttachment[],
+    ): void {
+        const ids = new Set(failed.map((row) => row.localId));
+        const retryable = members.filter((member) =>
+            ids.has(member.row.localId),
+        );
+
+        toast.error(
+            failed.length === 1
+                ? t("1 file didn't upload")
+                : t(":count files didn't upload", { count: failed.length }),
+            {
+                key: MERGE_KEY,
+                action: {
+                    label: t('Retry'),
+                    run: () => {
+                        for (const member of retryable) {
+                            member.uploads.retry(member.row.localId);
+                        }
+                    },
+                },
+            },
+        );
+    }
+
+    /**
+     * Confirm the batch — carefully. Nothing has been posted: the files are
+     * staged in a tray, waiting for a send. "3 files uploaded" would read as
+     * "your files went to the channel" to someone who was on another page when
+     * it fired.
+     */
+    function reportReady(members: TrackedRow[], fileCount: number): void {
+        const channelKeys = new Set(members.map((member) => member.channelKey));
+        const [only] = [...channelKeys];
+        const single = channelKeys.size === 1 ? only : null;
+
+        toast.success(
+            fileCount === 1
+                ? t('1 file ready to send')
+                : t(':count files ready to send', { count: fileCount }),
+            {
+                key: MERGE_KEY,
+                // A batch spanning channels has no one channel to name or to
+                // open, and picking a winner would be a lie either way.
+                meta: single
+                    ? (options.channelName(single) ?? undefined)
+                    : undefined,
+                action: single
+                    ? {
+                          label: t('View'),
+                          run: () => options.openChannel(single),
+                      }
+                    : undefined,
+            },
+        );
+    }
+
+    watchEffect(() => {
+        const active = options.activeChannelKey();
+        const staged = stagedRows();
+        const away = staged.filter((member) => member.channelKey !== active);
+
+        if (!showing) {
+            const starting = away.filter(
+                (member) => member.row.status === 'uploading',
+            );
+
+            // Rows that were already finished when the user walked away are not
+            // work in flight, so they never join a batch: leaving a channel
+            // where two files landed and a third is still going says
+            // "Uploading 1 file".
+            if (starting.length === 0) {
+                return;
+            }
+
+            batch = starting.map((member) => member.row.localId);
+            showing = true;
+            reportProgress(
+                starting.map((member) => member.row),
+                true,
+            );
+
+            return;
+        }
+
+        for (const member of away) {
+            if (
+                member.row.status === 'uploading' &&
+                !batch.includes(member.row.localId)
+            ) {
+                batch.push(member.row.localId);
+            }
+        }
+
+        const staying = new Map(
+            staged.map((member) => [member.row.localId, member]),
+        );
+        const members = batch.flatMap((localId) => {
+            const member = staying.get(localId);
+
+            return member ? [member] : [];
+        });
+
+        // Every row is back in front of the user, or gone from the tray
+        // altogether: the inline surface has the job back, so the card is taken
+        // away rather than resolved. A resolution the user is standing in front
+        // of would only repeat what the tray already says.
+        if (members.every((member) => member.channelKey === active)) {
+            toast.dismiss(MERGE_KEY);
+            forget();
+
+            return;
+        }
+
+        const totals = totalsForUploadBatch(
+            members.map((member) => member.row),
+        );
+
+        if (totals.isUploading) {
+            reportProgress(
+                members.map((member) => member.row),
+                false,
+            );
+
+            return;
+        }
+
+        resolve(members);
+    });
+}

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -44,7 +44,11 @@ import UpdateIndicator from '@/components/UpdateIndicator.vue';
 import UserStatusDialog from '@/components/UserStatusDialog.vue';
 import { adjacentSlug } from '@/composables/keyboardShortcuts';
 import { useChannelSections } from '@/composables/useChannelSections';
-import { releaseChannelUploads } from '@/composables/useChannelUploads';
+import {
+    channelUploadKey,
+    channelUploads,
+    releaseChannelUploads,
+} from '@/composables/useChannelUploads';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useDemoMode } from '@/composables/useDemoMode';
 import { useDndPauseDialog } from '@/composables/useDndPauseDialog';
@@ -71,8 +75,10 @@ import { useTimezone } from '@/composables/useTimezone';
 import { useToast, useToastCount } from '@/composables/useToast';
 import { useToastZoneHeight } from '@/composables/useToastZoneHeight';
 import { useTranslations } from '@/composables/useTranslations';
+import { useUploadProgressToast } from '@/composables/useUploadProgressToast';
 import { useUserStatusDialog } from '@/composables/useUserStatusDialog';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import type { Channel } from '@/types/channels';
 import type { MessageReminder } from '@/types/messages';
 import type { RoleOption } from '@/types/teams';
 
@@ -195,6 +201,57 @@ const activeChannelSlug = computed(
 );
 const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
 const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
+
+/**
+ * The sidebar's channels by the key their upload tray is filed under, so the
+ * upload toast can name and open a channel without taking the key apart again.
+ */
+const channelsByUploadKey = computed(() => {
+    const team = currentTeam.value;
+
+    if (!team) {
+        return new Map<string, Channel>();
+    }
+
+    return new Map(
+        channels.value.map((channel) => [
+            channelUploadKey(team.slug, channel.slug),
+            channel,
+        ]),
+    );
+});
+
+/**
+ * Report staged uploads whose composer is no longer on screen. It lives here
+ * because the layout is what knows which channel that is — and it outlives
+ * every channel the user passes through, which is the whole point of it.
+ */
+useUploadProgressToast({
+    channels: () => channelUploads.value,
+    activeChannelKey: () =>
+        currentTeam.value && activeChannelSlug.value
+            ? channelUploadKey(currentTeam.value.slug, activeChannelSlug.value)
+            : null,
+    channelName: (key) => {
+        const channel = channelsByUploadKey.value.get(key);
+
+        if (!channel) {
+            return null;
+        }
+
+        return channel.isDirect ? channel.name : `#${channel.name}`;
+    },
+    openChannel: (key) => {
+        const channel = channelsByUploadKey.value.get(key);
+
+        if (channel && currentTeam.value) {
+            router.visit(
+                show({ team: currentTeam.value.slug, channel: channel.slug })
+                    .url,
+            );
+        }
+    },
+});
 
 /**
  * Whether the reminders glyph wears its dot. The pending rows already ride

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { router, usePage } from '@inertiajs/vue3';
 import { ChevronDown, Plus, X } from '@lucide/vue';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { show } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import {
     destroy as destroyReminder,
@@ -44,6 +44,7 @@ import UpdateIndicator from '@/components/UpdateIndicator.vue';
 import UserStatusDialog from '@/components/UserStatusDialog.vue';
 import { adjacentSlug } from '@/composables/keyboardShortcuts';
 import { useChannelSections } from '@/composables/useChannelSections';
+import { releaseChannelUploads } from '@/composables/useChannelUploads';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useDemoMode } from '@/composables/useDemoMode';
 import { useDndPauseDialog } from '@/composables/useDndPauseDialog';
@@ -164,6 +165,16 @@ useNewDirectMessages();
 useMessageReminders();
 
 const currentTeam = computed(() => page.props.currentTeam);
+
+// Staged attachments outlive the composer that started them, but not the
+// workspace they were staged in: the channels they belong to are gone from the
+// sidebar, so their trays have no surface to come back to. Dropping the whole
+// registry here is what releases their previews.
+watch(
+    () => currentTeam.value?.id,
+    () => releaseChannelUploads(),
+);
+
 const teams = computed(() => page.props.teams ?? []);
 const channels = computed(() => page.props.channels ?? []);
 const currentUserId = computed(() => String(page.props.auth.user.id));

--- a/resources/js/lib/uploadBatch.test.ts
+++ b/resources/js/lib/uploadBatch.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import type { PendingAttachment } from '@/composables/useAttachmentUploads';
+import { totalsForUploadBatch } from '@/lib/uploadBatch';
+
+/**
+ * Covers the one line a progress toast has to fill: how many files, how many
+ * bytes, and the single percent standing for all of them.
+ */
+const MB = 1024 * 1024;
+
+/** A staged row with only the fields the totals read. */
+function row(
+    overrides: Partial<PendingAttachment> & { sizeBytes: number },
+): PendingAttachment {
+    return {
+        localId: `row-${overrides.sizeBytes}-${overrides.progress ?? 0}`,
+        name: 'file.bin',
+        isImage: false,
+        isAudio: false,
+        previewUrl: null,
+        status: 'uploading',
+        progress: 0,
+        attachment: null,
+        ...overrides,
+    };
+}
+
+describe('totalsForUploadBatch', () => {
+    it('counts the files and their total size, not the bytes sent so far', () => {
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: 10 * MB, progress: 50 }),
+            row({ sizeBytes: 2 * MB, progress: 0 }),
+        ]);
+
+        expect(totals.fileCount).toBe(2);
+        expect(totals.totalBytes).toBe(12 * MB);
+    });
+
+    it('weighs the percent by size rather than averaging the rows', () => {
+        // The big file is barely started, the small one is done: a mean of the
+        // row percentages would claim 55%, which is not the work remaining.
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: 40 * MB, progress: 10 }),
+            row({ sizeBytes: 12, status: 'done', progress: 100 }),
+        ]);
+
+        expect(totals.percent).toBe(10);
+    });
+
+    it('keeps a finished row in the denominator at 100 so the figure only climbs', () => {
+        const rows = [
+            row({ sizeBytes: MB, status: 'done', progress: 100 }),
+            row({ sizeBytes: MB, progress: 40 }),
+        ];
+
+        expect(totalsForUploadBatch(rows).percent).toBe(70);
+    });
+
+    it('holds a failed row at the percent it reached, stalling short of 100', () => {
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: MB, status: 'done', progress: 100 }),
+            row({ sizeBytes: MB, status: 'failed', progress: 30 }),
+        ]);
+
+        expect(totals.percent).toBe(65);
+        expect(totals.isUploading).toBe(false);
+        expect(totals.failed).toHaveLength(1);
+    });
+
+    it('never claims a hundred while a byte is still in flight', () => {
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: 1000 * MB, progress: 100 }),
+            row({ sizeBytes: MB, progress: 0 }),
+        ]);
+
+        expect(totals.percent).toBe(99);
+    });
+
+    it('holds at 99 while a fully-sent row waits for its answer', () => {
+        // `xhr.upload` reports 100 the moment the last byte leaves, but the row
+        // is only `done` once the server hands back the stored attachment — a
+        // card reading "Uploading 1 file · 100%" would be claiming otherwise.
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: MB, progress: 100 }),
+        ]);
+
+        expect(totals.percent).toBe(99);
+        expect(totals.isUploading).toBe(true);
+    });
+
+    it('averages the rows when the batch carries no bytes at all', () => {
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: 0, status: 'done', progress: 100 }),
+            row({ sizeBytes: 0, progress: 0 }),
+        ]);
+
+        expect(totals.percent).toBe(50);
+    });
+
+    it('reports an empty batch as untouched and settled', () => {
+        const totals = totalsForUploadBatch([]);
+
+        expect(totals).toEqual({
+            fileCount: 0,
+            totalBytes: 0,
+            percent: 0,
+            isUploading: false,
+            failed: [],
+        });
+    });
+});

--- a/resources/js/lib/uploadBatch.ts
+++ b/resources/js/lib/uploadBatch.ts
@@ -1,0 +1,80 @@
+import type { PendingAttachment } from '@/composables/useAttachmentUploads';
+
+/** What one batch of staged uploads reports while it runs and when it lands. */
+export interface UploadBatchTotals {
+    /** How many rows the batch holds. */
+    fileCount: number;
+    /**
+     * The batch's total size in bytes — what the card names, rather than
+     * bytes-so-far, which would put two numbers on one line racing each other.
+     */
+    totalBytes: number;
+    /** Byte-weighted progress across the batch, a whole percent from 0 to 100. */
+    percent: number;
+    /** Whether any row is still transferring. */
+    isUploading: boolean;
+    /** The rows whose transport failed, in batch order. */
+    failed: PendingAttachment[];
+}
+
+/** How far one row has got, with a finished row pinned at 100. */
+function progressOf(row: PendingAttachment): number {
+    return row.status === 'done' ? 100 : row.progress;
+}
+
+/**
+ * Total up a batch of staged uploads for the one line a progress toast has.
+ *
+ * The percent is weighted by size rather than averaged across rows: a 40 MB
+ * video and a 12 KB screenshot are not half the work each. Every row the batch
+ * started with stays in the denominator whatever became of it — a finished one
+ * at 100, a failed one frozen at the percent it reached — so the figure only
+ * ever climbs, and a failure is what stalls it short of 100 rather than
+ * something that quietly leaves and drags the number backwards with it.
+ */
+export function totalsForUploadBatch(
+    rows: PendingAttachment[],
+): UploadBatchTotals {
+    const totalBytes = rows.reduce((total, row) => total + row.sizeBytes, 0);
+    const isUploading = rows.some((row) => row.status === 'uploading');
+
+    // 100% has to mean finished. Floored rather than rounded, so a batch at
+    // 99.6% does not claim it — and held at 99 for as long as anything is still
+    // in flight, because `xhr.upload` reports 100 the moment the last byte is
+    // sent, with the server's answer (and the stored id) still to come.
+    const ceiling = isUploading ? 99 : 100;
+
+    return {
+        fileCount: rows.length,
+        totalBytes,
+        percent: Math.max(
+            0,
+            Math.min(ceiling, Math.floor(weigh(rows, totalBytes))),
+        ),
+        isUploading,
+        failed: rows.filter((row) => row.status === 'failed'),
+    };
+}
+
+/** The batch's progress, weighted by each row's share of the bytes. */
+function weigh(rows: PendingAttachment[], totalBytes: number): number {
+    if (rows.length === 0) {
+        return 0;
+    }
+
+    // Zero-byte rows carry no weight to distribute, so the rows themselves are
+    // the only unit left to average over.
+    if (totalBytes === 0) {
+        return (
+            rows.reduce((total, row) => total + progressOf(row), 0) /
+            rows.length
+        );
+    }
+
+    return (
+        rows.reduce(
+            (total, row) => total + row.sizeBytes * progressOf(row),
+            0,
+        ) / totalBytes
+    );
+}


### PR DESCRIPTION
First of the two PRs planned in #1006 (the toast itself follows in the second, which closes the issue).

## Why

Leaving a channel mid-upload did not hide the upload, it **destroyed** it — silently and with no notice.

`ChannelComposerDock` mounts `<MessageComposer :key="channel.id">`, so the composer remounts on every channel switch even though the page survives (`preserveState: true`). That remount ran `useAttachmentUploads`' `onScopeDispose` → `clear()` → `remove()` → `source.abort()` on every row. The composer being per-channel is right; the *uploads* being per-composer is what had to change — and it is also what makes an honest progress toast possible, since otherwise it would report a percentage for bytes that are discarded on arrival.

`config('attachments.pending_ttl_hours')` governs the server-side sweep of unclaimed uploads, so a row that finishes while the user is away stays claimable for hours.

## What

- **`useChannelUploads`** — a module-level, channel-keyed registry (`team/channel`). Each entry builds its tray in a detached `effectScope` of its own, so no component's teardown can abort it. A composer that opens a channel adopts the entry it finds.
- **Retention, replacing the no-leak guarantee `onScopeDispose` gave for free:** an entry lives while it holds rows or an in-flight send's snapshot, and is released as soon as it holds neither *and* no composer is mounted on it — which is what revokes its preview object URLs. `releaseChannelUploads()` drops the lot on a team switch (wired to `MainLayout`'s `currentTeam` watcher). No timed eviction and no LRU: a row in a tray is work the user can still see and act on, and evicting it loses that silently.
- **`isIdle` on `AttachmentUploads`** — rows empty *and* no detached snapshot outstanding. This is what keeps a send that fails while the user is away from having nowhere to restore its rows to.
- A composer with no channel (the thread composer) still gets an unshared tray owned by its own scope: nothing to outlive.

## How tested

- New `useChannelUploads.test.ts`: sharing per channel, an upload surviving its composer, the tray as it was on return (finished rows included, still claimable), the entry dropped when empty, previews released when the last row leaves while away, the entry held open while a send snapshot is outstanding, the team-switch drop, and the unshared no-channel tray.
- `MessageComposer.tray.test.ts` gains the round trip through the real component — stage, unmount, land the upload, remount and find the chip `done` and sendable — plus a second channel keeping its own tray. Its `afterEach` now calls `releaseChannelUploads()`, since unmounting is no longer enough to forget what a test staged.
- Full gate green: `composer test` at `Total: 100.0 %` with a clean Rector dry-run, and `lint:check` / `format:check` / `types:check` / `test:js` / `build`.

No PHP, no new dependency, no user-facing copy (so no `lang/fr.json` change), nothing operator-facing to document.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787916075&installation_model_id=428379&pr_number=1050&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1050&signature=f3b13a30b98eeb314ba8d4391112a5bd8c46c75616737a93ff31c7a66f4faf36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->