### PR TITLE
feat: surface uploads in a toast once the composer is away

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1407,5 +1407,11 @@
   "Files can be up to :max MB": "Les fichiers peuvent atteindre :max Mo",
   "Reminder snoozed": "Rappel reporté",
   "For 20 minutes": "De 20 minutes",
-  "Failed to update notification preferences": "Échec de la mise à jour des préférences de notification"
+  "Failed to update notification preferences": "Échec de la mise à jour des préférences de notification",
+  "Uploading 1 file": "Envoi d’un fichier",
+  "Uploading :count files": "Envoi de :count fichiers",
+  "1 file ready to send": "1 fichier prêt à envoyer",
+  ":count files ready to send": ":count fichiers prêts à envoyer",
+  "1 file didn't upload": "1 fichier n’a pas été envoyé",
+  ":count files didn't upload": ":count fichiers n’ont pas été envoyés"
 }

--- a/resources/js/components/ToastCard.test.ts
+++ b/resources/js/components/ToastCard.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { createApp, h, ref } from 'vue';
+
+/**
+ * Covers the two slots a progress card needs that no other tone does: the muted
+ * continuation of the title, and the figure hard right. The rest of the card —
+ * surface, tones, drain — is the slab's and `useToast`'s.
+ */
+vi.mock('vue-sonner', () => ({
+    toast: { custom: vi.fn(), dismiss: vi.fn() },
+    useVueSonner: () => ({ activeToasts: ref([{ id: 1 }, { id: 2 }]) }),
+}));
+
+import ToastCard from './ToastCard.vue';
+
+/** Mount the card and hand back its root element. */
+function mount(props: Record<string, unknown> = {}): HTMLElement {
+    const host = document.createElement('div');
+    document.body.append(host);
+
+    const app = createApp({
+        render: () =>
+            h(ToastCard, {
+                tone: 'progress',
+                title: 'Uploading 3 files',
+                duration: Infinity,
+                ...props,
+            }),
+    });
+    app.config.globalProperties.$t = (key: string) => key;
+    app.mount(host);
+
+    return host.firstElementChild as HTMLElement;
+}
+
+/** The element a `data-test` hook names, or null. */
+function slot(card: HTMLElement, name: string): HTMLElement | null {
+    return card.querySelector<HTMLElement>(`[data-test="${name}"]`);
+}
+
+describe('ToastCard', () => {
+    it('continues the title with its meta rather than starting a second line', () => {
+        const card = mount({ meta: '12.4 MB' });
+
+        expect(slot(card, 'toast-title')?.textContent).toBe(
+            'Uploading 3 files · 12.4 MB',
+        );
+        expect(slot(card, 'toast-detail')).toBeNull();
+    });
+
+    it('leaves the title alone when there is no meta', () => {
+        expect(slot(mount(), 'toast-title')?.textContent).toBe(
+            'Uploading 3 files',
+        );
+    });
+
+    it('sets a value hard right in monospace', () => {
+        const value = slot(mount({ value: '64%' }), 'toast-value');
+
+        expect(value?.textContent).toBe('64%');
+        expect(value?.className).toContain('font-mono');
+    });
+
+    it('hides the value from the announcement, which repeats every tick', () => {
+        // vue-sonner announces changed text inside a live toast, so a percent
+        // re-firing once a second would be read aloud about sixty times a
+        // minute. The title and meta carry what has to be heard.
+        expect(
+            slot(mount({ value: '64%' }), 'toast-value')?.getAttribute(
+                'aria-hidden',
+            ),
+        ).toBe('true');
+    });
+
+    it('gives the value the slot the stack’s overflow count would take', () => {
+        // Two toasts are active, so the front card would otherwise show "+1".
+        const card = mount({ value: '64%' });
+
+        expect(slot(card, 'toast-overflow')).toBeNull();
+        expect(slot(card, 'toast-value')).not.toBeNull();
+    });
+
+    it('still counts the stack when the card carries no value', () => {
+        expect(slot(mount(), 'toast-overflow')?.textContent).toBe('+1');
+    });
+});

--- a/resources/js/components/ToastCard.vue
+++ b/resources/js/components/ToastCard.vue
@@ -19,6 +19,17 @@ const props = defineProps<{
     title: string;
     /** The value that was just set. Already translated. */
     detail?: string;
+    /**
+     * A muted continuation of the title on the same line, separated by the
+     * middle dot drawn below: "Uploading 3 files · 12.4 MB". Already translated.
+     */
+    meta?: string;
+    /**
+     * A short figure set hard right in monospace — a progress percentage. It
+     * takes the slot the overflow count otherwise has, and is `aria-hidden`
+     * with it: see the template.
+     */
+    value?: string;
     action?: ToastAction;
     /** Drives the drain hairline; `Infinity` leaves the toast up. */
     duration: number;
@@ -62,6 +73,12 @@ const glyphTint = computed(() => GLYPH_TINTS[props.tone]);
  */
 const overflow = computed(() => toastCount.value - 1);
 
+/**
+ * The title's continuation, separator included, so the dot never has to be
+ * carried in a translated string.
+ */
+const metaText = computed(() => ` · ${props.meta}`);
+
 const drains = computed(() => Number.isFinite(props.duration));
 
 /**
@@ -102,9 +119,15 @@ const closeable = computed(() => props.tone === 'error');
         </span>
 
         <div class="flex min-w-0 flex-1 flex-col gap-0.5">
-            <span data-test="toast-title" class="text-[13.5px] font-semibold">{{
-                title
-            }}</span>
+            <span data-test="toast-title" class="text-[13.5px] font-semibold"
+                >{{ title
+                }}<span
+                    v-if="meta"
+                    data-test="toast-meta"
+                    class="font-normal text-slab-muted-foreground"
+                    >{{ metaText }}</span
+                ></span
+            >
             <span
                 v-if="detail"
                 data-test="toast-detail"
@@ -125,8 +148,22 @@ const closeable = computed(() => props.tone === 'error');
             {{ action.label }}
         </Button>
 
+        <!-- One figure holds this slot. A `value` wins it: the overflow count
+             is decoration, whereas the percent is what the card is about. Both
+             are hidden from the announcement — the count says nothing the stack
+             does not, and the percent re-fires about once a second, which
+             `aria-relevant="additions text"` on sonner's region would otherwise
+             read aloud every time it changed. -->
         <span
-            v-if="overflow > 0"
+            v-if="value"
+            data-test="toast-value"
+            aria-hidden="true"
+            class="shrink-0 self-center font-mono text-[11px] text-slab-muted-foreground"
+            >{{ value }}</span
+        >
+
+        <span
+            v-else-if="overflow > 0"
             data-test="toast-overflow"
             aria-hidden="true"
             class="shrink-0 self-center font-mono text-[11px] text-slab-muted-foreground"

--- a/resources/js/composables/useChannelUploads.ts
+++ b/resources/js/composables/useChannelUploads.ts
@@ -1,5 +1,11 @@
-import { effectScope, onScopeDispose, watch } from 'vue';
-import type { EffectScope } from 'vue';
+import {
+    computed,
+    effectScope,
+    onScopeDispose,
+    shallowReactive,
+    watch,
+} from 'vue';
+import type { ComputedRef, EffectScope } from 'vue';
 import { useAttachmentUploads } from '@/composables/useAttachmentUploads';
 import type {
     AttachmentUploads,
@@ -24,7 +30,39 @@ interface RegistryEntry {
     consumers: number;
 }
 
-const registry = new Map<string, RegistryEntry>();
+/**
+ * Shallow rather than deep, so an entry reads back as the object that was put
+ * in: the tray a composer holds and the tray the registry hands the next one
+ * have to be the same object, not two proxies of it.
+ */
+const registry = shallowReactive(new Map<string, RegistryEntry>());
+
+/** One channel's tray, as everything outside the composer sees it. */
+export interface ChannelUploads {
+    /** The channel it belongs to, as `team/channel`. */
+    channelKey: string;
+    uploads: AttachmentUploads;
+}
+
+/**
+ * Every channel holding a tray right now — the whole of what is staged across
+ * the workspace, which is what lets a surface outside the composer (the upload
+ * toast) report on channels the user is not looking at.
+ */
+export const channelUploads: ComputedRef<ChannelUploads[]> = computed(() =>
+    [...registry.entries()].map(([channelKey, entry]) => ({
+        channelKey,
+        uploads: entry.uploads,
+    })),
+);
+
+/** The registry key for a channel's tray. */
+export function channelUploadKey(
+    teamSlug: string,
+    channelSlug: string,
+): string {
+    return `${teamSlug}/${channelSlug}`;
+}
 
 /**
  * Build a channel's tray in a scope of its own, outside whichever component

--- a/resources/js/composables/useComposerAttachments.ts
+++ b/resources/js/composables/useComposerAttachments.ts
@@ -5,7 +5,10 @@ import type {
     AttachmentUploads,
     PendingAttachment,
 } from '@/composables/useAttachmentUploads';
-import { useChannelUploads } from '@/composables/useChannelUploads';
+import {
+    channelUploadKey,
+    useChannelUploads,
+} from '@/composables/useChannelUploads';
 import { useVoiceRecorder } from '@/composables/useVoiceRecorder';
 import type { VoiceRecorder } from '@/composables/useVoiceRecorder';
 import { isVoiceRecordingSupported } from '@/lib/audio';
@@ -57,9 +60,12 @@ export function useComposerAttachments(options: {
      * mid-upload no longer aborts the transfer. Resolved once: a composer is
      * mounted per channel and remounts when that changes.
      */
-    const channelKey = attachmentsEnabled.value
-        ? `${options.teamSlug()}/${options.channelSlug()}`
-        : null;
+    const teamSlug = options.teamSlug();
+    const channelSlug = options.channelSlug();
+    const channelKey =
+        teamSlug && channelSlug
+            ? channelUploadKey(teamSlug, channelSlug)
+            : null;
 
     const uploads = useChannelUploads({
         channelKey,

--- a/resources/js/composables/useToast.test.ts
+++ b/resources/js/composables/useToast.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { sonner } = vi.hoisted(() => ({ sonner: { custom: vi.fn() } }));
+const { sonner } = vi.hoisted(() => ({
+    sonner: { custom: vi.fn(), dismiss: vi.fn() },
+}));
 
 vi.mock('vue-sonner', () => ({ toast: sonner }));
 
@@ -51,6 +53,16 @@ describe('useToast', () => {
 
             expect(cardPropsOf().title).toBe('Reminder set');
             expect(cardPropsOf().detail).toBe('Tomorrow, 9:00 AM');
+        });
+
+        it('hands the card the title’s continuation and its right-hand figure', () => {
+            useToast().progress('Uploading 3 files', {
+                meta: '12.4 MB',
+                value: '64%',
+            });
+
+            expect(cardPropsOf().meta).toBe('12.4 MB');
+            expect(cardPropsOf().value).toBe('64%');
         });
     });
 
@@ -140,6 +152,12 @@ describe('useToast', () => {
             useToast().success('Reminder set');
 
             expect(cardPropsOf().action).toBeUndefined();
+        });
+
+        it('takes a keyed toast back off the screen on request', () => {
+            useToast().dismiss('attachment-uploads');
+
+            expect(sonner.dismiss).toHaveBeenCalledWith('attachment-uploads');
         });
     });
 });

--- a/resources/js/composables/useToast.ts
+++ b/resources/js/composables/useToast.ts
@@ -19,6 +19,20 @@ export type ToastOptions = {
      * carries "Tomorrow, 9:00 AM".
      */
     detail?: string;
+    /**
+     * A muted continuation of the title, on the same line and separated by a
+     * middle dot the card draws itself: "Uploading 3 files · 12.4 MB". Already
+     * translated. Where `detail` is a second line below the title, this is the
+     * same line — use it for a figure that belongs to the title's phrase.
+     */
+    meta?: string;
+    /**
+     * A short figure set hard right in monospace, e.g. a progress percentage.
+     * It takes the slot the stack's `+N` overflow otherwise has, and like it is
+     * `aria-hidden`: a toast re-firing once a second would otherwise be read
+     * aloud every second, so never put anything here that is said nowhere else.
+     */
+    value?: string;
     action?: ToastAction;
     /**
      * Merge identity. A repeat under the same key replaces the toast on screen
@@ -74,6 +88,8 @@ function notify(tone: ToastTone, title: string, options: ToastOptions): void {
             tone,
             title,
             detail: options.detail,
+            meta: options.meta,
+            value: options.value,
             action: options.action,
             duration,
         },
@@ -111,5 +127,13 @@ export function useToast() {
             notify('warning', title, options),
         progress: (title: string, options: ToastOptions = {}): void =>
             notify('progress', title, options),
+        /**
+         * Take a keyed toast off the screen without resolving it. For work that
+         * stops being worth reporting rather than finishing — a progress card
+         * whose inline surface the user has just come back to.
+         */
+        dismiss: (key: string): void => {
+            sonner.dismiss(key);
+        },
     };
 }

--- a/resources/js/composables/useUploadProgressToast.test.ts
+++ b/resources/js/composables/useUploadProgressToast.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { EffectScope, Ref } from 'vue';
+
+/**
+ * Covers the toast that reports uploads the composer is no longer showing: when
+ * it appears at all, which rows it counts, what it says while they run, and
+ * what it becomes when they land. The arithmetic is `lib/uploadBatch`'s and the
+ * rows are the registry's; what is watched here is the decision to speak.
+ */
+const { toast } = vi.hoisted(() => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+        dismiss: vi.fn(),
+    },
+}));
+
+vi.mock('@/composables/useToast', () => ({ useToast: () => toast }));
+
+import {
+    channelUploads,
+    releaseChannelUploads,
+} from '@/composables/useChannelUploads';
+import { useUploadProgressToast } from '@/composables/useUploadProgressToast';
+import {
+    attachment,
+    buildRegistry,
+    fakeFile,
+} from './useAttachmentUploads.doubles';
+import type { RegistryHarness } from './useAttachmentUploads.doubles';
+
+const MB = 1024 * 1024;
+const DESIGN = 'acme/design';
+const GENERAL = 'acme/general';
+
+describe('useUploadProgressToast', () => {
+    let registry: RegistryHarness;
+    let scope: EffectScope;
+    let onScreen: Ref<string | null>;
+    let opened: string[];
+    let clock: number;
+
+    /** The options the last toast of the given tone was raised with. */
+    function optionsOf(tone: 'progress' | 'success' | 'error') {
+        const { calls } = toast[tone].mock;
+
+        return calls[calls.length - 1][1] as {
+            key?: string;
+            meta?: string;
+            value?: string;
+            action?: { label: string; run: () => void };
+        };
+    }
+
+    /** The title of the last toast of the given tone. */
+    function titleOf(tone: 'progress' | 'success' | 'error'): string {
+        const { calls } = toast[tone].mock;
+
+        return calls[calls.length - 1][0] as string;
+    }
+
+    /** Let the watcher see everything staged since the last one. */
+    async function settle(): Promise<void> {
+        await Promise.resolve();
+        await Promise.resolve();
+        await nextTick();
+    }
+
+    /** Move the clock past the throttle window. */
+    function tick(): void {
+        clock += 1_500;
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        registry = buildRegistry();
+        onScreen = ref<string | null>(DESIGN);
+        opened = [];
+        clock = 0;
+
+        scope = effectScope();
+        scope.run(() => {
+            useUploadProgressToast({
+                channels: () => channelUploads.value,
+                activeChannelKey: () => onScreen.value,
+                channelName: (channelKey) =>
+                    channelKey === DESIGN ? '#design' : null,
+                openChannel: (channelKey) => opened.push(channelKey),
+                now: () => clock,
+            });
+        });
+    });
+
+    afterEach(() => {
+        scope.stop();
+        registry.closeAll();
+        releaseChannelUploads();
+    });
+
+    it('says nothing while the uploading channel is the one on screen', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        registry.calls[0].onProgress(40);
+        await settle();
+
+        expect(toast.progress).not.toHaveBeenCalled();
+    });
+
+    it('appears mid-flight at whatever percent it has reached when you leave', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', 12 * MB),
+        ]);
+        registry.calls[0].onProgress(64);
+        await settle();
+
+        onScreen.value = GENERAL;
+        await settle();
+
+        expect(titleOf('progress')).toBe('Uploading 1 file');
+        expect(optionsOf('progress')).toMatchObject({
+            key: 'attachment-uploads',
+            meta: '12 MB',
+            value: '64%',
+        });
+    });
+
+    it('counts two channels into one card rather than stacking two', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        const general = registry.open(GENERAL);
+        general.uploads.addFiles([
+            fakeFile('b.pdf', 'application/pdf', MB),
+            fakeFile('c.pdf', 'application/pdf', MB),
+        ]);
+
+        onScreen.value = null;
+        await settle();
+
+        expect(titleOf('progress')).toBe('Uploading 3 files');
+        expect(toast.progress).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves out rows that had already landed before it appeared', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', MB),
+            fakeFile('b.pdf', 'application/pdf', MB),
+            fakeFile('c.pdf', 'application/pdf', MB),
+        ]);
+        registry.calls[0].resolve(attachment('att-1'));
+        registry.calls[1].resolve(attachment('att-2'));
+        await settle();
+
+        onScreen.value = GENERAL;
+        await settle();
+
+        expect(titleOf('progress')).toBe('Uploading 1 file');
+    });
+
+    it('keeps the percent climbing when one of the batch lands', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', MB),
+            fakeFile('b.pdf', 'application/pdf', MB),
+        ]);
+        registry.calls[0].onProgress(50);
+        registry.calls[1].onProgress(50);
+        onScreen.value = GENERAL;
+        await settle();
+
+        expect(optionsOf('progress').value).toBe('50%');
+
+        registry.calls[0].resolve(attachment('att-1'));
+        tick();
+        await settle();
+
+        // The finished row stays in the denominator at 100 rather than leaving
+        // the set and dragging both the count and the figure backwards.
+        expect(titleOf('progress')).toBe('Uploading 2 files');
+        expect(optionsOf('progress').value).toBe('75%');
+    });
+
+    it('takes a row that starts uploading later into the batch', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        const general = registry.open(GENERAL);
+        expect(titleOf('progress')).toBe('Uploading 1 file');
+
+        // Uploaded from the drag-and-drop overlay of a channel the user then
+        // leaves again — it joins the card already on screen.
+        general.uploads.addFiles([fakeFile('b.pdf', 'application/pdf', MB)]);
+        onScreen.value = null;
+        tick();
+        await settle();
+
+        expect(titleOf('progress')).toBe('Uploading 2 files');
+    });
+
+    it('redraws about once a second rather than on every chunk', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        onScreen.value = GENERAL;
+        await settle();
+        expect(toast.progress).toHaveBeenCalledTimes(1);
+
+        for (const percent of [11, 12, 13, 14]) {
+            registry.calls[0].onProgress(percent);
+            await settle();
+        }
+
+        expect(toast.progress).toHaveBeenCalledTimes(1);
+
+        tick();
+        registry.calls[0].onProgress(15);
+        await settle();
+
+        expect(toast.progress).toHaveBeenCalledTimes(2);
+        expect(optionsOf('progress').value).toBe('15%');
+    });
+
+    it('is taken away, not resolved, when you come back to the channel', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        onScreen.value = DESIGN;
+        await settle();
+
+        expect(toast.dismiss).toHaveBeenCalledWith('attachment-uploads');
+        expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it('says nothing when the batch lands after you are already back', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        onScreen.value = DESIGN;
+        await settle();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        tick();
+        await settle();
+
+        // The tray in front of the user already said so.
+        expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it('confirms a landed batch without claiming anything was sent', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', MB),
+            fakeFile('b.pdf', 'application/pdf', MB),
+        ]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        registry.calls[1].resolve(attachment('att-2'));
+        tick();
+        await settle();
+
+        expect(titleOf('success')).toBe('2 files ready to send');
+        expect(optionsOf('success')).toMatchObject({
+            key: 'attachment-uploads',
+            meta: '#design',
+        });
+
+        optionsOf('success').action?.run();
+        expect(opened).toEqual([DESIGN]);
+    });
+
+    it('names no channel for a batch that spans several', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([fakeFile('a.pdf', 'application/pdf', MB)]);
+        const general = registry.open(GENERAL);
+        general.uploads.addFiles([fakeFile('b.pdf', 'application/pdf', MB)]);
+        onScreen.value = null;
+        await settle();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        registry.calls[1].resolve(attachment('att-2'));
+        tick();
+        await settle();
+
+        expect(titleOf('success')).toBe('2 files ready to send');
+        expect(optionsOf('success').meta).toBeUndefined();
+        expect(optionsOf('success').action).toBeUndefined();
+    });
+
+    it('names only the failures, and the retry re-enters progress under the same key', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addFiles([
+            fakeFile('a.pdf', 'application/pdf', MB),
+            fakeFile('b.pdf', 'application/pdf', MB),
+        ]);
+        onScreen.value = GENERAL;
+        await settle();
+
+        registry.calls[0].resolve(attachment('att-1'));
+        registry.calls[1].reject({
+            status: 500,
+            message: null,
+            aborted: false,
+        });
+        tick();
+        await settle();
+
+        expect(titleOf('error')).toBe("1 file didn't upload");
+        expect(optionsOf('error').key).toBe('attachment-uploads');
+
+        optionsOf('error').action?.run();
+        tick();
+        await settle();
+
+        // Back to the progress tone under the same key: no new card, no new key.
+        expect(registry.calls).toHaveLength(3);
+        expect(titleOf('progress')).toBe('Uploading 1 file');
+        expect(optionsOf('progress').key).toBe('attachment-uploads');
+    });
+
+    it('never counts a picked GIF, which arrives with nothing to transfer', async () => {
+        const design = registry.open(DESIGN);
+        design.uploads.addRemote({
+            id: 'gif-1',
+            filename: null,
+            mimeType: 'image/gif',
+            sizeBytes: 4 * MB,
+            width: 2,
+            height: 1,
+            isImage: true,
+            source: 'giphy',
+            url: 'https://media.giphy.com/gif-1/200.gif',
+            thumbUrl: null,
+            description: null,
+        });
+
+        onScreen.value = GENERAL;
+        await settle();
+
+        expect(toast.progress).not.toHaveBeenCalled();
+    });
+});

--- a/resources/js/composables/useUploadProgressToast.ts
+++ b/resources/js/composables/useUploadProgressToast.ts
@@ -1,0 +1,282 @@
+import { watchEffect } from 'vue';
+import type {
+    AttachmentUploads,
+    PendingAttachment,
+} from '@/composables/useAttachmentUploads';
+import type { ChannelUploads } from '@/composables/useChannelUploads';
+import { useToast } from '@/composables/useToast';
+import { useTranslations } from '@/composables/useTranslations';
+import { formatFileSize } from '@/lib/attachments';
+import { totalsForUploadBatch } from '@/lib/uploadBatch';
+
+/**
+ * The one key every staged upload reports under. Two channels uploading at once
+ * are one activity, not two events: the stack is for unrelated things.
+ */
+const MERGE_KEY = 'attachment-uploads';
+
+/**
+ * Roughly one redraw a second. Progress events arrive per chunk per file, so
+ * three files unthrottled are a redraw storm for a figure that only ever reads
+ * to a whole percent.
+ */
+const TICK_MS = 1_000;
+
+export interface UploadProgressToastOptions {
+    /** Every channel holding a tray right now, and the tray itself. */
+    channels: () => ChannelUploads[];
+    /**
+     * The channel whose composer is on screen, or null anywhere else — the
+     * settings pages, the workspace index, a thread with no channel behind it.
+     */
+    activeChannelKey: () => string | null;
+    /** A channel's display name, where the sidebar knows one. */
+    channelName: (channelKey: string) => string | null;
+    /** Take the user to a channel: the View action on a landed batch. */
+    openChannel: (channelKey: string) => void;
+    /** The clock, injected so the throttle needs no timers to test. */
+    now?: () => number;
+}
+
+/** One staged row, and the channel whose tray it is sitting in. */
+interface TrackedRow {
+    channelKey: string;
+    uploads: AttachmentUploads;
+    row: PendingAttachment;
+}
+
+/**
+ * Report staged uploads the user has walked away from, in a single toast.
+ *
+ * An upload's inline surface is the tray in its channel's composer, so it is
+ * worth a toast exactly when that composer is not the one on screen. The card
+ * therefore appears when the last visible surface goes away rather than when
+ * the upload starts — upload in #design and stay there and no toast ever fires
+ * — and coming back dismisses it rather than resolving it, because the tray has
+ * taken the job back.
+ *
+ * What it reports is a *batch*, fixed at the moment the card appears: the rows
+ * uploading right then, joined by any that start later. Summing whatever
+ * happens to be uploading at each instant instead would drop a row from the set
+ * the moment it landed, and the percentage would fall backwards — worse than no
+ * percentage at all. {@see totalsForUploadBatch} keeps the arithmetic honest;
+ * this owns which rows it runs over and when the card is worth firing.
+ */
+export function useUploadProgressToast(
+    options: UploadProgressToastOptions,
+): void {
+    const { t } = useTranslations();
+    const toast = useToast();
+    const clock = options.now ?? (() => Date.now());
+
+    /** The local ids the card is reporting on, in the order they joined. */
+    let batch: string[] = [];
+
+    /** Whether a progress card of ours is on screen. */
+    let showing = false;
+
+    let lastFiredAt = 0;
+    let lastSignature = '';
+
+    function forget(): void {
+        batch = [];
+        showing = false;
+        lastSignature = '';
+    }
+
+    /** Every staged row in the workspace, whichever channel is holding it. */
+    function stagedRows(): TrackedRow[] {
+        return options.channels().flatMap(({ channelKey, uploads }) =>
+            uploads.items.value.map((row) => ({
+                channelKey,
+                uploads,
+                row,
+            })),
+        );
+    }
+
+    /**
+     * Re-fire the progress card under the same key, which replaces it in place.
+     * Throttled: only a change in the count or the whole percent is worth a
+     * redraw, and then at most once a tick.
+     */
+    function reportProgress(rows: PendingAttachment[], force: boolean): void {
+        const totals = totalsForUploadBatch(rows);
+        const signature = `${totals.fileCount}:${totals.percent}`;
+        const now = clock();
+
+        if (
+            !force &&
+            (signature === lastSignature || now - lastFiredAt < TICK_MS)
+        ) {
+            return;
+        }
+
+        lastSignature = signature;
+        lastFiredAt = now;
+
+        toast.progress(
+            totals.fileCount === 1
+                ? t('Uploading 1 file')
+                : t('Uploading :count files', { count: totals.fileCount }),
+            {
+                key: MERGE_KEY,
+                meta: formatFileSize(totals.totalBytes),
+                value: `${totals.percent}%`,
+            },
+        );
+    }
+
+    /** Swap the progress card in place for what became of the batch. */
+    function resolve(members: TrackedRow[]): void {
+        const totals = totalsForUploadBatch(
+            members.map((member) => member.row),
+        );
+
+        if (totals.failed.length > 0) {
+            reportFailure(members, totals.failed);
+        } else {
+            reportReady(members, totals.fileCount);
+        }
+
+        forget();
+    }
+
+    /**
+     * Name only what failed, and offer the retry. Safe to treat everything here
+     * as retryable: a definitive rejection (a bad type, an over-size file) is
+     * removed from the tray with its own toast the moment it lands, so a row
+     * still `failed` at this point failed in transport.
+     */
+    function reportFailure(
+        members: TrackedRow[],
+        failed: PendingAttachment[],
+    ): void {
+        const ids = new Set(failed.map((row) => row.localId));
+        const retryable = members.filter((member) =>
+            ids.has(member.row.localId),
+        );
+
+        toast.error(
+            failed.length === 1
+                ? t("1 file didn't upload")
+                : t(":count files didn't upload", { count: failed.length }),
+            {
+                key: MERGE_KEY,
+                action: {
+                    label: t('Retry'),
+                    run: () => {
+                        for (const member of retryable) {
+                            member.uploads.retry(member.row.localId);
+                        }
+                    },
+                },
+            },
+        );
+    }
+
+    /**
+     * Confirm the batch — carefully. Nothing has been posted: the files are
+     * staged in a tray, waiting for a send. "3 files uploaded" would read as
+     * "your files went to the channel" to someone who was on another page when
+     * it fired.
+     */
+    function reportReady(members: TrackedRow[], fileCount: number): void {
+        const channelKeys = new Set(members.map((member) => member.channelKey));
+        const [only] = [...channelKeys];
+        const single = channelKeys.size === 1 ? only : null;
+
+        toast.success(
+            fileCount === 1
+                ? t('1 file ready to send')
+                : t(':count files ready to send', { count: fileCount }),
+            {
+                key: MERGE_KEY,
+                // A batch spanning channels has no one channel to name or to
+                // open, and picking a winner would be a lie either way.
+                meta: single
+                    ? (options.channelName(single) ?? undefined)
+                    : undefined,
+                action: single
+                    ? {
+                          label: t('View'),
+                          run: () => options.openChannel(single),
+                      }
+                    : undefined,
+            },
+        );
+    }
+
+    watchEffect(() => {
+        const active = options.activeChannelKey();
+        const staged = stagedRows();
+        const away = staged.filter((member) => member.channelKey !== active);
+
+        if (!showing) {
+            const starting = away.filter(
+                (member) => member.row.status === 'uploading',
+            );
+
+            // Rows that were already finished when the user walked away are not
+            // work in flight, so they never join a batch: leaving a channel
+            // where two files landed and a third is still going says
+            // "Uploading 1 file".
+            if (starting.length === 0) {
+                return;
+            }
+
+            batch = starting.map((member) => member.row.localId);
+            showing = true;
+            reportProgress(
+                starting.map((member) => member.row),
+                true,
+            );
+
+            return;
+        }
+
+        for (const member of away) {
+            if (
+                member.row.status === 'uploading' &&
+                !batch.includes(member.row.localId)
+            ) {
+                batch.push(member.row.localId);
+            }
+        }
+
+        const staying = new Map(
+            staged.map((member) => [member.row.localId, member]),
+        );
+        const members = batch.flatMap((localId) => {
+            const member = staying.get(localId);
+
+            return member ? [member] : [];
+        });
+
+        // Every row is back in front of the user, or gone from the tray
+        // altogether: the inline surface has the job back, so the card is taken
+        // away rather than resolved. A resolution the user is standing in front
+        // of would only repeat what the tray already says.
+        if (members.every((member) => member.channelKey === active)) {
+            toast.dismiss(MERGE_KEY);
+            forget();
+
+            return;
+        }
+
+        const totals = totalsForUploadBatch(
+            members.map((member) => member.row),
+        );
+
+        if (totals.isUploading) {
+            reportProgress(
+                members.map((member) => member.row),
+                false,
+            );
+
+            return;
+        }
+
+        resolve(members);
+    });
+}

--- a/resources/js/layouts/MainLayout.vue
+++ b/resources/js/layouts/MainLayout.vue
@@ -44,7 +44,11 @@ import UpdateIndicator from '@/components/UpdateIndicator.vue';
 import UserStatusDialog from '@/components/UserStatusDialog.vue';
 import { adjacentSlug } from '@/composables/keyboardShortcuts';
 import { useChannelSections } from '@/composables/useChannelSections';
-import { releaseChannelUploads } from '@/composables/useChannelUploads';
+import {
+    channelUploadKey,
+    channelUploads,
+    releaseChannelUploads,
+} from '@/composables/useChannelUploads';
 import { useChimeNotifications } from '@/composables/useChimeNotifications';
 import { useDemoMode } from '@/composables/useDemoMode';
 import { useDndPauseDialog } from '@/composables/useDndPauseDialog';
@@ -71,8 +75,10 @@ import { useTimezone } from '@/composables/useTimezone';
 import { useToast, useToastCount } from '@/composables/useToast';
 import { useToastZoneHeight } from '@/composables/useToastZoneHeight';
 import { useTranslations } from '@/composables/useTranslations';
+import { useUploadProgressToast } from '@/composables/useUploadProgressToast';
 import { useUserStatusDialog } from '@/composables/useUserStatusDialog';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import type { Channel } from '@/types/channels';
 import type { MessageReminder } from '@/types/messages';
 import type { RoleOption } from '@/types/teams';
 
@@ -195,6 +201,57 @@ const activeChannelSlug = computed(
 );
 const pendingInvitations = computed(() => page.props.pendingInvitations ?? []);
 const hasUnreadThreads = computed(() => page.props.hasUnreadThreads ?? false);
+
+/**
+ * The sidebar's channels by the key their upload tray is filed under, so the
+ * upload toast can name and open a channel without taking the key apart again.
+ */
+const channelsByUploadKey = computed(() => {
+    const team = currentTeam.value;
+
+    if (!team) {
+        return new Map<string, Channel>();
+    }
+
+    return new Map(
+        channels.value.map((channel) => [
+            channelUploadKey(team.slug, channel.slug),
+            channel,
+        ]),
+    );
+});
+
+/**
+ * Report staged uploads whose composer is no longer on screen. It lives here
+ * because the layout is what knows which channel that is — and it outlives
+ * every channel the user passes through, which is the whole point of it.
+ */
+useUploadProgressToast({
+    channels: () => channelUploads.value,
+    activeChannelKey: () =>
+        currentTeam.value && activeChannelSlug.value
+            ? channelUploadKey(currentTeam.value.slug, activeChannelSlug.value)
+            : null,
+    channelName: (key) => {
+        const channel = channelsByUploadKey.value.get(key);
+
+        if (!channel) {
+            return null;
+        }
+
+        return channel.isDirect ? channel.name : `#${channel.name}`;
+    },
+    openChannel: (key) => {
+        const channel = channelsByUploadKey.value.get(key);
+
+        if (channel && currentTeam.value) {
+            router.visit(
+                show({ team: currentTeam.value.slug, channel: channel.slug })
+                    .url,
+            );
+        }
+    },
+});
 
 /**
  * Whether the reminders glyph wears its dot. The pending rows already ride

--- a/resources/js/lib/uploadBatch.test.ts
+++ b/resources/js/lib/uploadBatch.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import type { PendingAttachment } from '@/composables/useAttachmentUploads';
+import { totalsForUploadBatch } from '@/lib/uploadBatch';
+
+/**
+ * Covers the one line a progress toast has to fill: how many files, how many
+ * bytes, and the single percent standing for all of them.
+ */
+const MB = 1024 * 1024;
+
+/** A staged row with only the fields the totals read. */
+function row(
+    overrides: Partial<PendingAttachment> & { sizeBytes: number },
+): PendingAttachment {
+    return {
+        localId: `row-${overrides.sizeBytes}-${overrides.progress ?? 0}`,
+        name: 'file.bin',
+        isImage: false,
+        isAudio: false,
+        previewUrl: null,
+        status: 'uploading',
+        progress: 0,
+        attachment: null,
+        ...overrides,
+    };
+}
+
+describe('totalsForUploadBatch', () => {
+    it('counts the files and their total size, not the bytes sent so far', () => {
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: 10 * MB, progress: 50 }),
+            row({ sizeBytes: 2 * MB, progress: 0 }),
+        ]);
+
+        expect(totals.fileCount).toBe(2);
+        expect(totals.totalBytes).toBe(12 * MB);
+    });
+
+    it('weighs the percent by size rather than averaging the rows', () => {
+        // The big file is barely started, the small one is done: a mean of the
+        // row percentages would claim 55%, which is not the work remaining.
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: 40 * MB, progress: 10 }),
+            row({ sizeBytes: 12, status: 'done', progress: 100 }),
+        ]);
+
+        expect(totals.percent).toBe(10);
+    });
+
+    it('keeps a finished row in the denominator at 100 so the figure only climbs', () => {
+        const rows = [
+            row({ sizeBytes: MB, status: 'done', progress: 100 }),
+            row({ sizeBytes: MB, progress: 40 }),
+        ];
+
+        expect(totalsForUploadBatch(rows).percent).toBe(70);
+    });
+
+    it('holds a failed row at the percent it reached, stalling short of 100', () => {
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: MB, status: 'done', progress: 100 }),
+            row({ sizeBytes: MB, status: 'failed', progress: 30 }),
+        ]);
+
+        expect(totals.percent).toBe(65);
+        expect(totals.isUploading).toBe(false);
+        expect(totals.failed).toHaveLength(1);
+    });
+
+    it('never claims a hundred while a byte is still in flight', () => {
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: 1000 * MB, progress: 100 }),
+            row({ sizeBytes: MB, progress: 0 }),
+        ]);
+
+        expect(totals.percent).toBe(99);
+    });
+
+    it('averages the rows when the batch carries no bytes at all', () => {
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: 0, status: 'done', progress: 100 }),
+            row({ sizeBytes: 0, progress: 0 }),
+        ]);
+
+        expect(totals.percent).toBe(50);
+    });
+
+    it('reports an empty batch as untouched and settled', () => {
+        const totals = totalsForUploadBatch([]);
+
+        expect(totals).toEqual({
+            fileCount: 0,
+            totalBytes: 0,
+            percent: 0,
+            isUploading: false,
+            failed: [],
+        });
+    });
+});

--- a/resources/js/lib/uploadBatch.test.ts
+++ b/resources/js/lib/uploadBatch.test.ts
@@ -76,6 +76,18 @@ describe('totalsForUploadBatch', () => {
         expect(totals.percent).toBe(99);
     });
 
+    it('holds at 99 while a fully-sent row waits for its answer', () => {
+        // `xhr.upload` reports 100 the moment the last byte leaves, but the row
+        // is only `done` once the server hands back the stored attachment — a
+        // card reading "Uploading 1 file · 100%" would be claiming otherwise.
+        const totals = totalsForUploadBatch([
+            row({ sizeBytes: MB, progress: 100 }),
+        ]);
+
+        expect(totals.percent).toBe(99);
+        expect(totals.isUploading).toBe(true);
+    });
+
     it('averages the rows when the batch carries no bytes at all', () => {
         const totals = totalsForUploadBatch([
             row({ sizeBytes: 0, status: 'done', progress: 100 }),

--- a/resources/js/lib/uploadBatch.ts
+++ b/resources/js/lib/uploadBatch.ts
@@ -1,0 +1,75 @@
+import type { PendingAttachment } from '@/composables/useAttachmentUploads';
+
+/** What one batch of staged uploads reports while it runs and when it lands. */
+export interface UploadBatchTotals {
+    /** How many rows the batch holds. */
+    fileCount: number;
+    /**
+     * The batch's total size in bytes — what the card names, rather than
+     * bytes-so-far, which would put two numbers on one line racing each other.
+     */
+    totalBytes: number;
+    /** Byte-weighted progress across the batch, a whole percent from 0 to 100. */
+    percent: number;
+    /** Whether any row is still transferring. */
+    isUploading: boolean;
+    /** The rows whose transport failed, in batch order. */
+    failed: PendingAttachment[];
+}
+
+/** How far one row has got, with a finished row pinned at 100. */
+function progressOf(row: PendingAttachment): number {
+    return row.status === 'done' ? 100 : row.progress;
+}
+
+/**
+ * Total up a batch of staged uploads for the one line a progress toast has.
+ *
+ * The percent is weighted by size rather than averaged across rows: a 40 MB
+ * video and a 12 KB screenshot are not half the work each. Every row the batch
+ * started with stays in the denominator whatever became of it — a finished one
+ * at 100, a failed one frozen at the percent it reached — so the figure only
+ * ever climbs, and a failure is what stalls it short of 100 rather than
+ * something that quietly leaves and drags the number backwards with it.
+ */
+export function totalsForUploadBatch(
+    rows: PendingAttachment[],
+): UploadBatchTotals {
+    const totalBytes = rows.reduce((total, row) => total + row.sizeBytes, 0);
+
+    return {
+        fileCount: rows.length,
+        totalBytes,
+        // Floored, never rounded: 100% has to mean finished, so a batch at
+        // 99.6% must not claim it.
+        percent: Math.max(
+            0,
+            Math.min(100, Math.floor(weigh(rows, totalBytes))),
+        ),
+        isUploading: rows.some((row) => row.status === 'uploading'),
+        failed: rows.filter((row) => row.status === 'failed'),
+    };
+}
+
+/** The batch's progress, weighted by each row's share of the bytes. */
+function weigh(rows: PendingAttachment[], totalBytes: number): number {
+    if (rows.length === 0) {
+        return 0;
+    }
+
+    // Zero-byte rows carry no weight to distribute, so the rows themselves are
+    // the only unit left to average over.
+    if (totalBytes === 0) {
+        return (
+            rows.reduce((total, row) => total + progressOf(row), 0) /
+            rows.length
+        );
+    }
+
+    return (
+        rows.reduce(
+            (total, row) => total + row.sizeBytes * progressOf(row),
+            0,
+        ) / totalBytes
+    );
+}

--- a/resources/js/lib/uploadBatch.ts
+++ b/resources/js/lib/uploadBatch.ts
@@ -36,17 +36,22 @@ export function totalsForUploadBatch(
     rows: PendingAttachment[],
 ): UploadBatchTotals {
     const totalBytes = rows.reduce((total, row) => total + row.sizeBytes, 0);
+    const isUploading = rows.some((row) => row.status === 'uploading');
+
+    // 100% has to mean finished. Floored rather than rounded, so a batch at
+    // 99.6% does not claim it — and held at 99 for as long as anything is still
+    // in flight, because `xhr.upload` reports 100 the moment the last byte is
+    // sent, with the server's answer (and the stored id) still to come.
+    const ceiling = isUploading ? 99 : 100;
 
     return {
         fileCount: rows.length,
         totalBytes,
-        // Floored, never rounded: 100% has to mean finished, so a batch at
-        // 99.6% must not claim it.
         percent: Math.max(
             0,
-            Math.min(100, Math.floor(weigh(rows, totalBytes))),
+            Math.min(ceiling, Math.floor(weigh(rows, totalBytes))),
         ),
-        isUploading: rows.some((row) => row.status === 'uploading'),
+        isUploading,
         failed: rows.filter((row) => row.status === 'failed'),
     };
 }


### PR DESCRIPTION
Closes #1006. Second of the two PRs planned there; stacked on #1050, so **this targets that branch** for a clean diff — GitHub retargets it to `develop` when #1050 merges. (An issue closed from `develop` does not autoclose, so #1006 gets closed by hand.)

## What

An upload's inline surface is the tray in its channel's composer, so it is worth a toast exactly when that composer is not the one on screen. Now that a tray outlives its composer (#1050), that upload is real work in flight rather than something already destroyed — which is what makes reporting a percentage for it honest.

- **`useUploadProgressToast`** — one card, one merge key (`attachment-uploads`), aggregating every in-flight row whose channel is not the open one, plus every row when the user is not on a channel page. Two channels uploading at once give "Uploading 5 files", not two cards: the stack is for unrelated events, this is one activity.
  - **It appears when the last visible surface goes away, not when the upload starts.** Upload in #design and stay there: no toast, ever. Switch away: the card appears mid-flight at whatever percent it has reached.
  - **Returning dismisses it rather than resolving it** — the tray has taken the job back. That needed `dismiss(key)` on `useToast`, which did not exist.
  - **The batch is fixed when the card appears**: the rows uploading at that instant, joined by any that start later. Rows already `done` never join, so leaving a channel where two files landed and a third is going says "Uploading 1 file". Summing only what is `uploading` at each instant would drop a row the moment it landed and the percent would *fall backwards*.
  - **A resolution only fires if the user was away when it landed.** Finished while away swaps the card in place; finished after returning says nothing.
- **`lib/uploadBatch`** — the arithmetic, pure and unit-tested. Percent is **byte-weighted** (`sum(sizeBytes × progress) / sum(sizeBytes)`): a 40 MB video and a 12 KB screenshot are not half the work each. Completed rows stay in the denominator at 100 and failed rows freeze at their last percent, so the figure only climbs and a failure is what stalls it short of 100. The byte figure is the batch's **total size**, matching frame `1b` — not bytes-so-far, which would put two numbers on one line racing each other.
- **`ToastCard` gains `meta` and `value`** per frame `1b`: `meta` is the muted continuation of the title on the same line (` · 12.4 MB`, separator drawn by the card so it never enters a translated string), `value` the monospace figure hard right, taking the slot the `+N` overflow otherwise has. **`value` is `aria-hidden`** — sonner's region is `aria-relevant="additions text"`, so a card re-firing once a second would read the percent aloud about sixty times a minute; the title and meta are announced once and neither changes during a batch.
- **Resolution copy that does not claim a send happened.** These files are staged in a tray; nothing has been posted. So it is **"2 files ready to send"** with the channel in `meta` and a **View** action when the batch is one channel (both dropped when it spans several, rather than picking a winner). A failure names only the failures — **"1 file didn't upload"**, action **Retry**, which re-enters the progress tone under the same key. Safe because a definitive rejection (bad type, over-size) is already removed from the tray with its own toast, so anything still `failed` is genuinely retryable.
- Ticking re-fires under the same key, **throttled to roughly once a second** with the terminal state always fired; XHR progress arrives per chunk per file, which unthrottled is a redraw storm for a figure that reads to whole percent.

## How tested

Vitest is the whole gate here, as the issue sets out: `attach()` is still unusable in the Pest browser suite, so a test cannot stage a real file and then navigate away. The design deliberately puts every interesting decision in pure code.

- `uploadBatch.test.ts` — byte weighting, the finished row held in the denominator, the failed row frozen, the zero-byte fallback, and the 100% boundary.
- `useUploadProgressToast.test.ts` — silence while the channel is on screen, the mid-flight appearance, two channels in one card, rows excluded that had already landed, the percent climbing through a completion, a late row joining, the throttle, dismissal on return, silence when it lands after the return, both resolution branches, the retry round trip, and a picked GIF never counting.
- `ToastCard.test.ts` (new) — the meta continuation, the monospace value, its `aria-hidden`, and the value winning the overflow slot.
- Full gate green: `composer test` at `Total: 100.0 %` with a clean Rector dry-run, and `lint:check` / `format:check` / `types:check` / `test:js` / `build`.

Also verified by hand against the running app: the card renders as frame `1b` draws it, and rides above the composer.

## i18n

Six new keys through `$t`, all in `lang/fr.json`; `View` and `Retry` were already in the catalog. No pluralisation layer exists, so each count-bearing string ships as the two explicit forms the codebase already uses.

## Found on the way

#1051 — under the Vite dev server the rail's bottom inset is never published (a root comment in `MessageComposer.vue` makes `$el` a fragment anchor in dev builds only), so *every* toast lands on the composer locally. Pre-existing, dev-only, correct in the production build. Not fixed here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787918066&installation_model_id=428379&pr_number=1052&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1052&signature=40c3b547cdb0a7dfaf5964bb8e934e5a1ac9ba0dfb7ef9dc2d9eab8d52afa819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->