### PR TITLE
test: settle geometry assertions on frames instead of a fixed wait

### DIFF
--- a/tests/Browser/GeometrySettleTest.php
+++ b/tests/Browser/GeometrySettleTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The frame-polling settle the geometry assertions across this suite lean on
+ * (#1049).
+ *
+ * It is worth pinning on its own, because its failure mode is silence: a settle
+ * that resolved true unconditionally would leave every caller reading a
+ * mid-animation box again, and each of them would still pass on an idle machine.
+ * So both answers are asserted here — that a page at rest settles, and that
+ * something which never stops moving is reported rather than waited out.
+ */
+test('a page that has stopped moving settles', function (): void {
+    visit('/login')
+        ->assertPresent('@login-button')
+        ->assertScript(geometrySettles(elementBox('[data-test="login-button"]')), true);
+});
+
+test('something that never stops moving comes back unsettled', function (): void {
+    // A probe reading differently on every frame is the shape of an animation
+    // that never lands, so the poll gives up and says so instead of hanging.
+    visit('/login')
+        ->assertScript(geometrySettles('performance.now()'), false);
+});

--- a/tests/Browser/Helpers.php
+++ b/tests/Browser/Helpers.php
@@ -232,6 +232,76 @@ function elementCountSettles(string $selector, int $count): string
 }
 
 /**
+ * A JS expression for an element's bounding box, or `null` while it is absent.
+ *
+ * The usual probe to hand `geometrySettles()`, including for something on its
+ * way out — whose settled state is being gone.
+ */
+function elementBox(string $selector): string
+{
+    $needle = json_encode($selector, JSON_THROW_ON_ERROR);
+
+    return "document.querySelector({$needle})?.getBoundingClientRect() ?? null";
+}
+
+/**
+ * A script resolving once the page has stopped moving under it: every one of
+ * `$probes` — JS expressions, compared by their JSON form — has held the same
+ * value across two consecutive animation frames.
+ *
+ * This is the geometry counterpart of `queryParamSettles()`, and it closes the
+ * same trap. `assertPresent` returns the moment a panel or popover reaches the
+ * DOM, which is a whole open animation before its geometry is final, and
+ * `assertScript` is a one-shot read that never retries — so what has to cover
+ * that animation is the settle in between. A fixed `->wait()` is a guess at how
+ * long it takes, and a CSS animation only advances as frames are committed, so
+ * on a CPU-starved runner it takes considerably longer than its nominal duration
+ * and the window is missed (#775, #1049). Waiting on the frames themselves
+ * adapts to whatever the runner can deliver.
+ *
+ * Pass every value the assertion depends on, not just the moving element: a
+ * measurement republished across a window of its own can still be in flight
+ * while the element it describes already looks settled.
+ */
+function geometrySettles(string ...$probes): string
+{
+    $sample = implode(",\n            ", array_map(
+        static fn (string $probe): string => "() => ({$probe})",
+        $probes,
+    ));
+
+    return <<<JS
+    (async () => {
+        const probes = [
+            {$sample},
+        ];
+        const sample = () => JSON.stringify(probes.map((probe) => probe()));
+
+        let previous = sample();
+        let stable = 0;
+
+        for (let frame = 0; frame < 120; frame++) {
+            await new Promise(requestAnimationFrame);
+
+            const current = sample();
+
+            stable = current === previous ? stable + 1 : 0;
+            previous = current;
+
+            // Two frames agreeing rather than one: a measurement republished on
+            // a frame of its own can hold still across a single frame before it
+            // has landed on its final value (see useRailInset).
+            if (stable === 2) {
+                return true;
+            }
+        }
+
+        return false;
+    })()
+    JS;
+}
+
+/**
  * Pin a live page to its settled styles by killing transitions and animations.
  *
  * axe reads `getComputedStyle` off whatever frame it lands on, so a tween in

--- a/tests/Browser/TeamsFieldErrorTest.php
+++ b/tests/Browser/TeamsFieldErrorTest.php
@@ -49,6 +49,20 @@ function browserRecordLayout(array $watched): string
     JS;
 }
 
+/**
+ * A script resolving once the given dialog has stopped moving.
+ *
+ * The baseline below is a single read, so it has to be taken at rest: the dialog
+ * fades and zooms in, and one recorded mid-transition measures the animation
+ * rather than the error line. `assertPresent` returns a whole animation before
+ * that, and the fixed settle this replaces was a guess — a CSS animation only
+ * advances as frames are committed, so a starved runner outlasts it (#1049).
+ */
+function browserDialogSettles(string $selector): string
+{
+    return geometrySettles(elementBox($selector));
+}
+
 /** Whether every element recorded by `browserRecordLayout` is still where it was. */
 function browserLayoutHeldStill(): string
 {
@@ -152,9 +166,7 @@ test('a rejected group rename leaves the editor dialog exactly where it was', fu
         ->navigate("/settings/teams/{$team->slug}/groups")
         ->click('@group-edit-dev-team')
         ->assertPresent('[data-test="group-edit-dialog"]')
-        // The dialog fades and zooms in; a baseline recorded mid-transition
-        // measures the animation rather than the error line.
-        ->wait(0.5)
+        ->assertScript(browserDialogSettles('[data-test="group-edit-dialog"]'), true)
         ->type('[data-test="group-edit-slug-input"]', 'BAD!!');
 
     $page->script(browserRecordLayout([
@@ -181,7 +193,7 @@ test('a rejected bot create leaves the dialog footer exactly where it was', func
         ->navigate("/settings/teams/{$team->slug}/integrations")
         ->click('@new-bot-button')
         ->assertPresent('[data-test="new-bot-dialog"]')
-        ->wait(0.5);
+        ->assertScript(browserDialogSettles('[data-test="new-bot-dialog"]'), true);
 
     $page->script(browserRecordLayout([
         'create' => '[data-test="bot-create-button"]',

--- a/tests/Browser/ToastPositionTest.php
+++ b/tests/Browser/ToastPositionTest.php
@@ -39,6 +39,24 @@ function browserRailRightInset(): string
     JS;
 }
 
+/**
+ * A script resolving once the thread panel has stopped moving and the inset the
+ * pane publishes for it has stopped changing with it.
+ *
+ * Both halves are needed, in either direction. The panel reflows the pane beside
+ * it and slides in under a transform, and the pane re-reads its position across
+ * a settling window of its own (see useRailInset), so either can still be in
+ * flight while the other already looks final. The panel's box reads `null` once
+ * it is gone, which is exactly the settled state on the way back out.
+ */
+function browserRailSettles(): string
+{
+    return geometrySettles(
+        elementBox('[data-test=thread-panel]'),
+        browserRailRightInset(),
+    );
+}
+
 test('toasts render in the bottom-right rail in the authenticated shell', function (): void {
     ['owner' => $alice] = browserTeamWithChannel();
 
@@ -94,9 +112,12 @@ test('the rail tracks the thread panel opening and closing', function (): void {
     // Nothing claims the right edge yet, so the rail sits at the viewport's.
     $page->assertScript(browserRailRightInset(), '');
 
+    // `assertPresent` returns as soon as the panel is in the DOM, a whole open
+    // animation before its geometry is final, and every assertion below is a
+    // one-shot read — so the settle in between is what has to cover it (#1049).
     $page->click('[data-test=thread-summary]')
         ->assertPresent('[data-test=thread-panel]')
-        ->wait(0.6);
+        ->assertScript(browserRailSettles(), true);
 
     // The panel now claims its own width, and the rail insets by it. Both halves
     // of the contract are asserted: what the pane publishes, and that the
@@ -119,7 +140,7 @@ test('the rail tracks the thread panel opening and closing', function (): void {
 
     $page->click('[data-test=thread-close]')
         ->assertMissing('[data-test=thread-panel]')
-        ->wait(0.6);
+        ->assertScript(browserRailSettles(), true);
 
     // Closing gives the edge back rather than stranding the rail inset.
     $page->assertScript(browserRailRightInset(), '');

--- a/tests/Browser/UserMenuHeightTest.php
+++ b/tests/Browser/UserMenuHeightTest.php
@@ -52,6 +52,19 @@ function userMenuRowsOverflow(): string
     JS;
 }
 
+/**
+ * A script resolving once the popover has stopped moving, so the box every
+ * assertion below measures is the resting one rather than a zoom-in frame.
+ *
+ * `assertPresent` returns on the card reaching the DOM, which is a whole open
+ * animation earlier, and `assertScript` never retries — the fixed settle this
+ * replaces was a guess a starved runner could outlast (#1049).
+ */
+function userMenuSettles(): string
+{
+    return geometrySettles(elementBox('[data-test="user-menu-popover"]'));
+}
+
 /** Whether the given row sits fully inside both the menu card and the screen. */
 function menuRowIsFullyVisible(string $selector): string
 {
@@ -85,9 +98,7 @@ test('the rail menu shows every row without an inner scrollbar when the screen h
         ->resize(1280, 1000)
         ->click('@rail-destination-you')
         ->assertPresent('@user-menu-popover')
-        // Let the popover settle past its open animation, so the box being
-        // measured is the resting one rather than a zoom-in frame.
-        ->wait(0.5)
+        ->assertScript(userMenuSettles(), true)
         ->assertScript(userMenuStaysInsideTheViewport(), true)
         // The menu grew past the cap that used to freeze it — without this the
         // "no scrollbar" assertion below would hold for a menu that simply fits.
@@ -114,7 +125,7 @@ test('the rail menu stays inside a short screen and scrolls its rows instead', f
         ->resize(1024, 520)
         ->click('@rail-destination-you')
         ->assertPresent('@user-menu-popover')
-        ->wait(0.5)
+        ->assertScript(userMenuSettles(), true)
         ->assertScript(userMenuStaysInsideTheViewport(), true)
         ->assertScript(userMenuRowsOverflow(), true)
         // Log out and the version footer are reachable by scrolling the rows...
@@ -153,7 +164,10 @@ test('the You panel takes the whole drawer rather than a height of its own', fun
         ->click('@sidebar-toggle')
         ->click('@tab-destination-you')
         ->assertPresent('@destination-panel-you')
-        ->wait(0.5)
+        ->assertScript(geometrySettles(
+            elementBox('[data-test="destination-panel-you"]'),
+            elementBox('[data-test="user-menu-rows"]'),
+        ), true)
         ->assertScript(<<<'JS'
         (() => {
             const panel = document.querySelector('[data-test="destination-panel-you"]')

--- a/tests/Browser/UserMenuLongLabelTest.php
+++ b/tests/Browser/UserMenuLongLabelTest.php
@@ -20,6 +20,19 @@ const MENU_WIDTH = 246;
 const MENU_ROW_HEIGHT = 32;
 
 /**
+ * A script resolving once the popover has stopped moving, past its open and
+ * pointer-grace window, so every row measured below is measured at rest.
+ *
+ * `assertPresent` returns on the row reaching the DOM, an animation earlier, and
+ * `assertScript` never retries — a fixed settle is a guess a starved runner can
+ * outlast, since a CSS animation only advances as frames are committed (#1049).
+ */
+function userMenuLabelsSettle(): string
+{
+    return geometrySettles(elementBox('[data-test="user-menu-popover"]'));
+}
+
+/**
  * A script asserting every fixed-height label row of the presence menu still
  * measures exactly one row (h-8) — the height a wrapped label overflows.
  */
@@ -54,8 +67,7 @@ test('the presence menu keeps its rows on one line in French', function (): void
     signInThroughBrowser($alice)
         ->click('@rail-destination-you')
         ->assertPresent('@pause-notifications-menu-item')
-        // Let the popover settle past its open/pointer-grace window.
-        ->wait(0.5)
+        ->assertScript(userMenuLabelsSettle(), true)
         // The French catalog is the one the middleware inlined...
         ->assertSee('Pause des notifications')
         ->assertSee('Définir un statut')
@@ -109,7 +121,7 @@ test('a menu label longer than the row ellipsises instead of wrapping', function
     signInThroughBrowser($alice)
         ->click('@rail-destination-you')
         ->assertPresent('@pause-notifications-menu-item')
-        ->wait(0.5)
+        ->assertScript(userMenuLabelsSettle(), true)
         ->assertScript(<<<'JS'
         (() => {
             const label = document.querySelector('[data-test="pause-notifications-menu-item"] span');
@@ -147,7 +159,7 @@ test('the presence menu renders at the width the design draws', function (): voi
         ->refresh()
         ->click('@rail-destination-you')
         ->assertPresent('@pause-notifications-menu-item')
-        ->wait(0.5)
+        ->assertScript(userMenuLabelsSettle(), true)
         ->assertScript(<<<JS
         (() => {
             const menu = document.querySelector('[data-test="user-menu-popover"]');
@@ -212,7 +224,7 @@ test('the paused card keeps its quiet-hours readout legible in French', function
     signInThroughBrowser($alice)
         ->click('@rail-destination-you')
         ->assertPresent('@dnd-paused-card')
-        ->wait(0.5)
+        ->assertScript(userMenuLabelsSettle(), true)
         // The state the card exists to show is on screen, not squeezed out by
         // the pill standing next to it...
         ->assertSee('En pause')
@@ -228,7 +240,7 @@ test('the paused card holds up against a pill label no locale would exceed', fun
     signInThroughBrowser($alice)
         ->click('@rail-destination-you')
         ->assertPresent('@dnd-snooze-menu-item')
-        ->wait(0.5)
+        ->assertScript(userMenuLabelsSettle(), true)
         // The English pill left the readout 14px to live in, which was already
         // too little to read even before the French one erased it outright.
         ->assertScript(pausedCardStillReads(), true)
@@ -264,7 +276,7 @@ test('the paused card leaves the manual-pause variant on one line', function ():
     signInThroughBrowser($alice)
         ->click('@rail-destination-you')
         ->assertPresent('@dnd-resume-menu-item')
-        ->wait(0.5)
+        ->assertScript(userMenuLabelsSettle(), true)
         ->assertSee('Reprendre')
         ->assertScript(pausedCardStillReads(), true)
         ->assertScript(<<<'JS'


### PR DESCRIPTION
Closes #1049.

## What

`tests/Browser/ToastPositionTest.php` guarded its rail-inset assertions with `->wait(0.6)`. `assertPresent` returns the moment the thread panel is in the DOM — a whole open animation before its geometry is final — and `assertScript` is a one-shot read with no retry, so the fixed settle was the only thing covering that animation. A CPU-starved runner outlasts it and nothing recovers, which is how the assertion came back `false` on an unrelated PR's CI run.

The settle is now driven by frames rather than by the clock.

## How

`geometrySettles()` (new, in `tests/Browser/Helpers.php`) takes JS expressions and resolves once every one of them has held the same value across two consecutive animation frames, giving up after 120 frames. It is the geometry counterpart of the existing `queryParamSettles()` / `elementCountSettles()`, and it adapts to whatever the runner can deliver instead of guessing.

For the rail test both probes matter, in both directions: the panel's bounding box **and** the `--rail-right-inset` the pane publishes, since `useRailInset` re-reads the position across a settling window of its own and either can be in flight while the other looks final. The same call covers the close, where an absent panel's box reads `null` — which is exactly its settled state on the way out.

The assertions themselves are untouched: the producer/consumer contract this test pins is correct, and only what precedes it changed.

## Sweep

The issue asked for a look at the other fixed settles guarding *geometry* rather than axe audits, since they share the failure mode. Converted:

- `UserMenuHeightTest` — 3 sites; the popover's box is measured straight after `assertPresent`.
- `UserMenuLongLabelTest` — 6 sites, same popover.
- `TeamsFieldErrorTest` — 2 sites, where the wait guarded the *baseline* `browserRecordLayout()` records: one taken mid-zoom measures the animation rather than the error line, which its own comment already said.

Deliberately left alone:

- The axe-audit settles (`MobileSheets`, `MobileUserPanel`, `WorkspaceSheet`, `A11yAudit`, …). Different mechanism, already addressed by `suppressTransitions()` / `switchToDarkTheme()`.
- The timeline and virtualizer scroll waits (`TimelineInitialPin`, `ThreadPanelVirtualization`, `MobileThreadPanel`, `MobileMessageRow`). Those settle a virtualizer measuring rows, and some deliberately assert a scroll position *holds* across a beat — polling until stable would defeat the assertion rather than harden it.

## New test

`tests/Browser/GeometrySettleTest.php` pins both answers of the primitive. Its failure mode is silence: a settle that resolved true unconditionally would put every caller back to reading a mid-animation box, and each of them would still pass on an idle machine. So the suite asserts that a page at rest settles, and that something which never stops moving comes back unsettled rather than being waited out.

## Testing

- `composer test` — green, `Total: 100.0 %`, clean Pint / PHPStan / Rector.
- `composer test:browser` — the full suite, 339 passed.
- Frontend `lint:check`, `format:check`, `types:check`, `build` — green (no frontend source touched).

The converted tests also got faster, since the settle returns as soon as it settles instead of always sleeping: `ToastPositionTest` went from ~16s to ~8.5s.

No user-facing behaviour, i18n keys, or operator-facing settings changed, so no catalog or `docs/` updates apply — hence the non-bumping `test:` type.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787918644&installation_model_id=428379&pr_number=1053&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1053&signature=7b277b81cb5bfb972e0450467ef4e41acea311b01b9a367a8527533d44d7d843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->