### PR TITLE
fix: keep the toast rail off the composer under the dev server

### DIFF
--- a/resources/js/components/MessageComposer.root.test.ts
+++ b/resources/js/components/MessageComposer.root.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { NodeTypes } from '@vue/compiler-core';
+import { parse } from '@vue/compiler-sfc';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The page publishes the bottom-right rail's inset off the composer's `$el`, and
+ * `$el` is only the root element while the composer renders a single root node.
+ * Open the template with a comment and the component becomes a fragment whose
+ * `$el` is the anchor comment instead — but only under the dev server, since Vue
+ * strips root-level comments in a production build. The rail then loses the
+ * composer's claim in dev alone, which is exactly how #1051 hid: every local
+ * check of toast placement was misleading, and CI runs against the build.
+ *
+ * `useRailInset` no longer throws on such a node, so a regression here would be
+ * silent. This pins the composer's side of it; put the explanation in the
+ * `<script setup>` block rather than above the root element.
+ */
+const COMPOSER = fileURLToPath(
+    new URL('./MessageComposer.vue', import.meta.url),
+);
+
+/** The template's root nodes, ignoring the whitespace between them. */
+function rootNodes(source: string): { type: NodeTypes }[] {
+    const { descriptor } = parse(source);
+
+    return (descriptor.template?.ast?.children ?? []).filter(
+        (node) => node.type !== NodeTypes.TEXT || node.content.trim() !== '',
+    );
+}
+
+describe('the composer template', () => {
+    it('renders a single root element, so `$el` is measurable under the dev server too', () => {
+        const roots = rootNodes(readFileSync(COMPOSER, 'utf8'));
+
+        expect(roots).toHaveLength(1);
+        expect(roots[0]).toMatchObject({
+            type: NodeTypes.ELEMENT,
+            tag: 'div',
+        });
+    });
+
+    it('would catch a comment put back above the root element', () => {
+        const roots = rootNodes(
+            '<template><!-- a note --><div class="composer" /></template>',
+        );
+
+        expect(roots.map((node) => node.type)).toEqual([
+            NodeTypes.COMMENT,
+            NodeTypes.ELEMENT,
+        ]);
+    });
+});

--- a/resources/js/components/MessageComposer.root.test.ts
+++ b/resources/js/components/MessageComposer.root.test.ts
@@ -23,7 +23,11 @@ const COMPOSER = fileURLToPath(
 
 /** The template's root nodes, ignoring the whitespace between them. */
 function rootNodes(source: string): { type: NodeTypes }[] {
-    const { descriptor } = parse(source);
+    // The parser keeps comments only in a dev build by default, and comments are
+    // the whole subject here, so ask for them rather than inherit them.
+    const { descriptor } = parse(source, {
+        templateParseOptions: { comments: true },
+    });
 
     return (descriptor.template?.ast?.children ?? []).filter(
         (node) => node.type !== NodeTypes.TEXT || node.content.trim() !== '',

--- a/resources/js/components/MessageComposer.vue
+++ b/resources/js/components/MessageComposer.vue
@@ -340,6 +340,17 @@ const toolsOpen = ref(false);
 /**
  * How much of the screen the on-screen keyboard covers, so the pill can sit
  * above it with its Send button reachable instead of behind it.
+ *
+ * The root pads itself by this on top of the device's home-indicator inset, so
+ * the pill stays clear of both: the safe-area inset is static, while the
+ * keyboard inset has to be measured live off visualViewport (the layout viewport
+ * `dvh` sizes against does not shrink when the keyboard opens).
+ *
+ * That note lives here rather than above the template's root element on purpose.
+ * Vue keeps a root-level comment in a dev build and strips it in production, so
+ * a leading comment would make this component a fragment under the dev server —
+ * and `$el`, which the page measures for the bottom-right rail's inset, would be
+ * the fragment's anchor comment instead of the root div (#1051).
  */
 const keyboardInsetPx = useKeyboardInset();
 
@@ -367,10 +378,6 @@ defineExpose({ insertMention, focus, addFiles: attachments.addFiles });
 </script>
 
 <template>
-    <!-- The pill stays clear of both the device's home indicator and the
-         on-screen keyboard: the safe-area inset is static, the keyboard inset is
-         measured live off visualViewport (the layout viewport `dvh` sizes
-         against does not shrink when the keyboard opens). -->
     <div
         class="@container mx-3 mb-2 shrink-0 md:mx-5 md:mb-4"
         :style="{

--- a/resources/js/composables/useRailInset.test.ts
+++ b/resources/js/composables/useRailInset.test.ts
@@ -144,16 +144,21 @@ function publishedBottom(): string {
 }
 
 describe('useRailBottomInset', () => {
+    let observed: unknown[];
+
     beforeEach(() => {
         document.documentElement.style.removeProperty(
             RAIL_BOTTOM_INSET_PROPERTY,
         );
         document.body.replaceChildren();
         vi.stubGlobal('innerHeight', 900);
+        observed = [];
         vi.stubGlobal(
             'ResizeObserver',
             class {
-                observe = vi.fn();
+                observe = (target: unknown): void => {
+                    observed.push(target);
+                };
                 disconnect = vi.fn();
             },
         );
@@ -177,6 +182,36 @@ describe('useRailBottomInset', () => {
         await nextTick();
 
         expect(publishedBottom()).toBe('');
+
+        scope.stop();
+    });
+
+    it('publishes nothing, rather than throwing, when the composer resolves to a fragment anchor', async () => {
+        // A component whose template opens with a comment is a fragment in a
+        // dev build, and its `$el` is then the anchor comment (#1051).
+        const anchor = document.createComment('') as unknown as HTMLElement;
+        const scope = effectScope();
+        scope.run(() => useRailBottomInset(ref<HTMLElement | null>(anchor)));
+        await nextTick();
+
+        expect(publishedBottom()).toBe('');
+        expect(observed).toEqual([]);
+
+        scope.stop();
+    });
+
+    it('claims the floor again once the anchor is replaced by the composer itself', async () => {
+        const composer = ref<HTMLElement | null>(
+            document.createComment('') as unknown as HTMLElement,
+        );
+        const scope = effectScope();
+        scope.run(() => useRailBottomInset(composer));
+        await nextTick();
+
+        composer.value = composerStub(96);
+        await nextTick();
+
+        expect(publishedBottom()).toBe('96px');
 
         scope.stop();
     });

--- a/resources/js/composables/useRailInset.test.ts
+++ b/resources/js/composables/useRailInset.test.ts
@@ -212,6 +212,7 @@ describe('useRailBottomInset', () => {
         await nextTick();
 
         expect(publishedBottom()).toBe('96px');
+        expect(observed).toEqual([composer.value]);
 
         scope.stop();
     });

--- a/resources/js/composables/useRailInset.ts
+++ b/resources/js/composables/useRailInset.ts
@@ -18,6 +18,22 @@ export const RAIL_INSET_PROPERTY = '--rail-right-inset';
 export const RAIL_BOTTOM_INSET_PROPERTY = '--rail-bottom-inset';
 
 /**
+ * The element to measure, or null where there is nothing measurable.
+ *
+ * A caller that reads a child component's `$el` can hand us something that is
+ * not an element at all: a component whose template opens with a comment renders
+ * as a fragment, and its `$el` is then the fragment's anchor comment. Vue keeps
+ * root-level comments in a dev build and strips them in production, so the very
+ * same component resolves to a comment under the dev server and to its root
+ * element in a build (#1051). Neither `getBoundingClientRect` nor
+ * `ResizeObserver.observe` accepts a comment, so anything that is not an element
+ * claims nothing — the documented fallback — instead of throwing.
+ */
+function measurable(node: HTMLElement | null): HTMLElement | null {
+    return node instanceof Element ? node : null;
+}
+
+/**
  * Keep `property` in step with what `element` claims of its edge, for as long as
  * the element is mounted.
  *
@@ -40,7 +56,7 @@ function publishInset(
     }
 
     function publish(): void {
-        const target = element.value;
+        const target = measurable(element.value);
         const inset = target ? claim(target) : null;
 
         if (inset === null) {
@@ -85,7 +101,9 @@ function publishInset(
 
     watch(
         element,
-        (target) => {
+        (node) => {
+            const target = measurable(node);
+
             observer?.disconnect();
             observer = target ? new ResizeObserver(publish) : null;
             observer?.observe(target as HTMLElement);


### PR DESCRIPTION
Closes #1051.

## What

Under the Vite dev server, `--rail-bottom-inset` was never published, so the bottom-right rail fell back to the viewport edge and landed on top of the composer — the exact failure `useRailBottomInset` exists to prevent.

## Why

`MessageComposer.vue`'s template opened with an HTML comment above its root `<div>`. Vue keeps root-level comments in a dev build and strips them in production, so in dev the component was a fragment and `$el` was the fragment's anchor comment rather than the root element. A Comment node has no `getBoundingClientRect`, so `publish()` threw before it could set the property — aborting the rest of that watcher flush in `<Show>` — and `ResizeObserver.observe` rejected it too. Production stripped the comment and published correctly, which is why CI (which runs against the build) never saw it.

## How

- **`useRailInset.ts`** — a `measurable()` guard: anything that is not an `Element` claims nothing instead of throwing, in both `publish()` and the `ResizeObserver` watcher. This is the part that generalises — roughly ten components here open their template with a comment, so any future caller reading a child's `$el` would hit the same thing.
- **`MessageComposer.vue`** — moved the safe-area/keyboard note from above the root element into the `keyboardInsetPx` JSDoc, so the component is single-rooted in dev as well and `$el` is the root `<div>`. The note now also records why it cannot live above the root.

## How tested

- `useRailInset.test.ts` gains two cases: a comment anchor publishes nothing and is never observed, and replacing that anchor with the real composer resumes both. Both failed with the reported `TypeError` before the guard.
- New `MessageComposer.root.test.ts` parses the SFC and pins the single-element root, with a second case proving the check still catches a re-added comment. Verified by temporarily putting the comment back — the test fails.
- Verified in the real app under the Vite dev server: `--rail-bottom-inset` now publishes `83px` (the value the issue recorded for the production build), and neither reported `TypeError` appears in the console.
- Full backend gate at 100% coverage, plus frontend lint / format / types / build and the whole Vitest suite.

No user-facing copy and no operator-facing settings changed, so no i18n or docs updates apply.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787919982&installation_model_id=428379&pr_number=1054&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1054&signature=c89aa6a9d53a408d80927f29a06b7cf902563bae4765a803cb8f5d394bb53c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->