### PR TITLE
ci: cache Playwright's Chromium between browser CI runs

### DIFF
--- a/.github/workflows/shell-capture.yml
+++ b/.github/workflows/shell-capture.yml
@@ -144,8 +144,37 @@ jobs:
         with:
           composer-options: '--optimize-autoloader'
 
+      # `install --with-deps` split in two so the log keeps timing the halves
+      # apart, because only one of them is cacheable: `install-deps` shells out to
+      # apt for nine font packages (`ubuntu-latest` already carries Chromium's
+      # shared libraries) and leaves runner state no cache can restore, while the
+      # ~300 MB browser bundle below is just files. Measured at ~14s and ~10s of a
+      # ~24s step over eight runs (#1078). Both browser-driving workflows carry
+      # this block verbatim — see tests/Unit/PlaywrightBrowserCacheTest.php.
+      - name: Resolve Playwright Version
+        id: playwright
+        run: |
+          echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # Keyed on the version npm resolved rather than on `package.json`, whose
+      # `^1.61.1` would hold a patch bump — and the new Chromium revision it pins
+      # — on the entry cut for the version before it.
+      - name: Cache Playwright Browser
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      # The fonts matter here beyond "Chromium starts": the committed captures are
+      # rendered with them, so dropping them would move pixels in the diff below.
+      - name: Install Playwright System Dependencies
+        run: npx playwright install-deps chromium
+
+      # Unconditional on purpose: `install` re-verifies what the cache restored
+      # and fetches whatever is missing, so a cold or half-written entry costs the
+      # download it always cost rather than a job with no browser.
       - name: Install Playwright Browser
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Copy Environment File
         run: cp .env.example .env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -239,8 +239,35 @@ jobs:
         with:
           composer-options: '--optimize-autoloader'
 
+      # `install --with-deps` split in two so the log keeps timing the halves
+      # apart, because only one of them is cacheable: `install-deps` shells out to
+      # apt for nine font packages (`ubuntu-latest` already carries Chromium's
+      # shared libraries) and leaves runner state no cache can restore, while the
+      # ~300 MB browser bundle below is just files. Measured at ~14s and ~10s of a
+      # ~24s step over eight runs (#1078). Both browser-driving workflows carry
+      # this block verbatim — see tests/Unit/PlaywrightBrowserCacheTest.php.
+      - name: Resolve Playwright Version
+        id: playwright
+        run: |
+          echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # Keyed on the version npm resolved rather than on `package.json`, whose
+      # `^1.61.1` would hold a patch bump — and the new Chromium revision it pins
+      # — on the entry cut for the version before it.
+      - name: Cache Playwright Browser
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      - name: Install Playwright System Dependencies
+        run: npx playwright install-deps chromium
+
+      # Unconditional on purpose: `install` re-verifies what the cache restored
+      # and fetches whatever is missing, so a cold or half-written entry costs the
+      # download it always cost rather than a job with no browser.
       - name: Install Playwright Browser
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       - name: Copy Environment File
         run: cp .env.example .env

--- a/tests/Unit/PlaywrightBrowserCacheTest.php
+++ b/tests/Unit/PlaywrightBrowserCacheTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Two jobs drive a real Chromium — `tests.yml`'s `browser` and
+ * `shell-capture.yml`'s `capture` — and both used to pay for it with a single
+ * `playwright install --with-deps chromium` on every run. Measured over eight
+ * runs that step costs ~24s, and it splits in two: ~14s of `apt-get` (nine font
+ * packages; `ubuntu-latest` already carries Chromium's shared libraries) and
+ * ~10s of downloading the ~300 MB browser bundle (#1078).
+ *
+ * Only the second half is files, so only the second half is cacheable. These
+ * tests pin the shape that follows: the two halves are separate steps so the log
+ * keeps timing them apart, the bundle is keyed on the Playwright version npm
+ * actually resolved, and the install still runs unconditionally so a cold or
+ * stale entry is slower rather than a job with no browser. They also keep the
+ * two workflows from drifting apart, since a browser installed one way here and
+ * another way there is how one of them quietly stops being cached.
+ */
+
+/**
+ * @return list<array<string, mixed>>
+ */
+function browserInstallSteps(string $workflow, string $job): array
+{
+    /** @var array{jobs: array<string, array{steps: list<array<string, mixed>>}>} $parsed */
+    $parsed = Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/'.$workflow);
+
+    return array_values(array_filter(
+        $parsed['jobs'][$job]['steps'],
+        static fn (array $step): bool => str_contains((string) ($step['name'] ?? ''), 'Playwright'),
+    ));
+}
+
+/**
+ * The two jobs that install a browser, as `[workflow, job]` pairs.
+ *
+ * @return array<string, array{string, string}>
+ */
+function browserInstallJobs(): array
+{
+    return [
+        'tests.yml → browser' => ['tests.yml', 'browser'],
+        'shell-capture.yml → capture' => ['shell-capture.yml', 'capture'],
+    ];
+}
+
+test('both browser jobs install Playwright the same way', function (): void {
+    [$tests, $capture] = array_map(
+        static fn (array $job): array => browserInstallSteps(...$job),
+        array_values(browserInstallJobs()),
+    );
+
+    expect($tests)->not->toBeEmpty('the browser job has to install a browser somewhere')
+        ->and($capture)->toBe($tests, 'the two workflows install Playwright differently; whatever is true of one has to be true of the other');
+});
+
+test('the apt half and the download half are separate steps', function (string $workflow, string $job): void {
+    $commands = array_map(
+        static fn (array $step): string => (string) ($step['run'] ?? ''),
+        browserInstallSteps($workflow, $job),
+    );
+
+    expect($commands)->toContain('npx playwright install-deps chromium')
+        ->and($commands)->toContain('npx playwright install chromium')
+        ->and(implode("\n", $commands))->not->toContain('--with-deps', 'the combined command times the fonts and the browser download as one number, and only one of the two is cacheable');
+})->with(browserInstallJobs());
+
+test('the browser bundle is restored from the actions cache', function (string $workflow, string $job): void {
+    $cache = collect(browserInstallSteps($workflow, $job))
+        ->first(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), 'actions/cache@'));
+
+    expect($cache)->not->toBeNull('nothing caches the browser bundle, so every run re-downloads it')
+        ->and($cache['with']['path'] ?? null)->toBe('~/.cache/ms-playwright');
+})->with(browserInstallJobs());
+
+/*
+ * `package.json` declares a caret range, so keying on it would hold a patch bump
+ * on the entry cut for the previous version — and a Playwright patch ships a new
+ * Chromium revision. Reading the version out of the installed package is reading
+ * what the lockfile resolved to.
+ */
+test('the cache key follows the Playwright version the lockfile resolved', function (string $workflow, string $job): void {
+    $steps = collect(browserInstallSteps($workflow, $job));
+
+    $resolve = $steps->first(static fn (array $step): bool => isset($step['id']) && str_contains((string) ($step['run'] ?? ''), 'GITHUB_OUTPUT'));
+
+    expect($resolve)->not->toBeNull('no step resolves the Playwright version, so the key cannot carry it');
+    expect($resolve['run'])->toContain("require('playwright/package.json')")
+        ->and($resolve['run'])->not->toContain("require('./package.json')");
+
+    $cache = $steps->first(static fn (array $step): bool => str_starts_with((string) ($step['uses'] ?? ''), 'actions/cache@'));
+
+    expect((string) ($cache['with']['key'] ?? ''))
+        ->toContain('steps.'.$resolve['id'].'.outputs.version')
+        ->toContain('runner.os');
+})->with(browserInstallJobs());
+
+test('the version is resolved after the dependencies it reads are installed', function (string $workflow, string $job): void {
+    /** @var array{jobs: array<string, array{steps: list<array<string, mixed>>}>} $parsed */
+    $parsed = Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/'.$workflow);
+
+    $names = array_map(
+        static fn (array $step): string => (string) ($step['name'] ?? ($step['uses'] ?? '')),
+        $parsed['jobs'][$job]['steps'],
+    );
+
+    $install = array_search('Install Node Dependencies', $names, true);
+    $resolve = array_search('Resolve Playwright Version', $names, true);
+
+    expect($install)->not->toBeFalse()
+        ->and($resolve)->not->toBeFalse()
+        ->and($resolve)->toBeGreaterThan($install, 'the version is read out of node_modules, which npm ci has to have written first');
+})->with(browserInstallJobs());
+
+/*
+ * The cache is an optimisation, and an optimisation that can leave a job without
+ * a browser is a liability. `install` re-verifies whatever the cache restored and
+ * fetches what is missing, so gating it on a cache hit is the one way to turn a
+ * cold or half-written entry into a red run.
+ */
+test('a cache miss still installs a working browser', function (string $workflow, string $job): void {
+    foreach (browserInstallSteps($workflow, $job) as $step) {
+        expect($step)->not->toHaveKey('if', ($step['name'] ?? '').' is conditional; the install has to run whether or not the cache hit');
+    }
+})->with(browserInstallJobs());


### PR DESCRIPTION
Closes #1078.

## What the measurement says

Pulled the raw job logs for eight recent runs (four `tests.yml` → `browser`, four `shell-capture.yml` → `capture`) and timed the two halves of `npx playwright install --with-deps chromium` from the log timestamps: apt runs from the step start to the first `Downloading Chrome for Testing` line, the download from there to the last `downloaded to /home/runner/.cache/ms-playwright/...` line.

| workflow | run | apt (`--with-deps`) | browser download | step total |
| --- | --- | --- | --- | --- |
| tests.yml | 30573520643 | 14.3s | 9.4s | 23.7s |
| tests.yml | 30573507338 | 17.2s | 10.6s | 27.8s |
| tests.yml | 30572661519 | 12.7s | 13.5s | 26.2s |
| tests.yml | 30567217851 | 15.8s | 9.2s | 25.0s |
| shell-capture.yml | 30574424326 | 15.1s | 8.8s | 23.8s |
| shell-capture.yml | 30573530830 | 11.4s | 9.3s | 20.8s |
| shell-capture.yml | 30570243382 | 15.5s | 9.4s | 25.0s |
| shell-capture.yml | 30561198088 | 10.9s | 8.9s | 19.8s |

Mean: **apt 14.1s, download 9.9s, total 24.0s**.

The split matters more than the totals, because of what `--with-deps` actually installs on `ubuntu-latest`: nine font packages (`fonts-ipafont-gothic`, `fonts-freefont-ttf`, `fonts-tlwg-loma-otf`, `fonts-unifont`, `fonts-wqy-zenhei`, `xfonts-encodings`, `xfonts-utils`, `xfonts-cyrillic`, `xfonts-scalable`) and **no shared libraries** — the runner image already carries Chromium's. So the larger half is apt state that no file cache can restore, and the ~10s download is the only cacheable part.

That also settles the issue's option 2. Dropping `--with-deps` is the bigger lever on paper, but the fonts are not decoration here: `shell-capture` pixel-diffs the rendered shell against committed captures, and removing font families changes fontconfig's fallback. Not worth trading a deterministic pixel check for ~14s, so the fonts stay.

## What this changes

Both browser-driving workflows get the same block, verbatim:

- the step is split in two, so the log keeps timing the apt half and the download half separately rather than reporting one number;
- `actions/cache` restores `~/.cache/ms-playwright`, keyed on the Playwright version read out of `node_modules/playwright/package.json` — i.e. what the lockfile resolved to, not `package.json`'s `^1.61.1`, which would keep a patch bump (and the new Chromium revision it pins) on the previous entry;
- `npx playwright install chromium` stays unconditional, so a cold, stale or half-written entry costs the download it always cost instead of producing a job with no browser.

Expected saving: **~10s per job, ~20s per push** across the two workflows, once `develop` holds a warm entry. The first run on this PR is necessarily a miss; a re-run of the same branch is what shows the warm number, and I will post the measured before/after here before this merges. Note the caveat the numbers have to clear: restoring ~300 MB from the Actions cache is not free either, and if the warm path does not beat playwright's CDN by a useful margin, the honest outcome is to close #1078 as `wontfix` and drop this — the issue says as much.

## Testing

- New `tests/Unit/PlaywrightBrowserCacheTest.php` pins the invariants: the two workflows install Playwright identically (drift is how one of them quietly stops being cached), the halves are separate steps with no `--with-deps`, the cache path and the lockfile-derived key, the resolve step ordered after `npm ci`, and no `if:` on any of it so a miss still installs.
- `./vendor/bin/sail composer test` green: Pint, PHPStan, Rector, 3059 tests at 100% coverage.

No user-facing copy and no operator-facing setting, so no i18n or `docs/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788031996&installation_model_id=428379&pr_number=1081&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1081&signature=541d2803d7e198a7d4c22acb53b167d4a4d10cd44dd1f5c62c7b4c3d0990ff1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->