### PR TITLE
test: wait out the jump pill's fade instead of a fixed number of ticks

### DIFF
--- a/resources/js/pages/channels/Show.doubles.ts
+++ b/resources/js/pages/channels/Show.doubles.ts
@@ -262,14 +262,64 @@ export function stubObservers(): void {
 }
 
 /**
- * Let Vue render, then let any `<Transition>` finish leaving: a pill leaves the
- * DOM only once its leave hook resolves, which jsdom drives off
- * `requestAnimationFrame` rather than a real animation.
+ * Let Vue render, then let any pending timer and promise drain.
+ *
+ * Do not lean on this to wait out a `<Transition>` — reach for
+ * {@link afterLeave} instead, which waits on the DOM rather than on the clock.
  */
 export async function settle(): Promise<void> {
     await nextTick();
     await new Promise((resolve) => setTimeout(resolve, 60));
     await nextTick();
+}
+
+/**
+ * Stretch every animation frame well past any fixed wait a suite could take,
+ * standing in for the machine a full `npm run test:js` run leaves behind.
+ *
+ * Vue's `<Transition>` needs two frames before it even starts leaving, so a
+ * suite that waits out a fade on the clock rather than on the DOM goes red here
+ * every time instead of once in a hundred loaded CI runs (#1072).
+ */
+export function starveAnimationFrames(): void {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+        setTimeout(() => callback(0), 50),
+    );
+}
+
+/** How long {@link afterLeave} polls before it reports what it can see. */
+const LEAVE_TIMEOUT_MS = 2000;
+
+/**
+ * Poll `selector` inside `host` until it has left the DOM, then report what is
+ * there: `null` once a `<Transition>` has finished leaving.
+ *
+ * Vue holds a leaving node in the DOM until its leave hook resolves, and drives
+ * that hook off `requestAnimationFrame`, whose jsdom ticks stretch under
+ * full-suite load. A fixed wait therefore races the fade and reads a node that
+ * is still mid-transition (#1072). Gives up after {@link LEAVE_TIMEOUT_MS} and
+ * returns the node it can still see, so a node that never leaves fails the
+ * caller's assertion instead of hanging the suite.
+ *
+ * Real timers only: under `vi.useFakeTimers()` the poll would never advance.
+ */
+export async function afterLeave(
+    host: HTMLElement,
+    selector: string,
+): Promise<Element | null> {
+    const deadline = Date.now() + LEAVE_TIMEOUT_MS;
+
+    for (;;) {
+        await nextTick();
+
+        const found = host.querySelector(selector);
+
+        if (found === null || Date.now() >= deadline) {
+            return found;
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
 }
 
 export function click(host: HTMLElement, selector: string): void {

--- a/resources/js/pages/channels/Show.timeline.test.ts
+++ b/resources/js/pages/channels/Show.timeline.test.ts
@@ -2,11 +2,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, h, nextTick } from 'vue';
 import {
+    afterLeave,
     click,
     composerHandleDouble,
     message,
     mountShow,
     settle,
+    starveAnimationFrames,
     stubObservers,
     unmountAll,
 } from './Show.doubles';
@@ -300,6 +302,10 @@ describe('jumping to a message', () => {
 });
 
 describe('the unread jump pill', () => {
+    // The pill rides a `<Transition>`, so every assertion here has to outlast a
+    // fade that only gets slower on a loaded machine.
+    beforeEach(starveAnimationFrames);
+
     it('offers the boundary while it sits above the window and scrolls to it', async () => {
         const { host } = mount({ lastReadMessageId: 'm1' });
 
@@ -340,9 +346,10 @@ describe('the unread jump pill', () => {
 
         timeline.range = { startIndex: 0, endIndex: 10 };
         click(host, '[data-test="stub-range"]');
-        await settle();
 
-        expect(host.querySelector('[data-test="jump-to-unread"]')).toBe(null);
+        expect(await afterLeave(host, '[data-test="jump-to-unread"]')).toBe(
+            null,
+        );
     });
 
     it('dismisses the pill when the reader jumps back to the present', async () => {
@@ -352,10 +359,11 @@ describe('the unread jump pill', () => {
         await scrollUp(host);
 
         click(host, '[data-test="jump-to-latest"]');
-        await settle();
 
+        expect(await afterLeave(host, '[data-test="jump-to-unread"]')).toBe(
+            null,
+        );
         expect(timeline.scrollToLatest).toHaveBeenCalledWith('smooth');
-        expect(host.querySelector('[data-test="jump-to-unread"]')).toBe(null);
     });
 });
 


### PR DESCRIPTION
Closes #1072.

## What

`Show.timeline.test.ts` → *"dismisses the pill when the reader jumps back to the present"* went red intermittently under a full `npm run test:js`, and passed every time the file ran alone.

## Why

The diagnosis in the issue holds. `settle()` waited a fixed 60ms, but Vue holds a leaving node in the DOM until its leave hook resolves, and drives that hook off two `requestAnimationFrame` ticks. Those ticks stretch under full-suite load, so the assertion landed while the pill was still mid-transition — exactly the `translate-y-0 opacity-100 … duration-100 ease-in` markup the issue captured.

Reproduced deterministically by stubbing `requestAnimationFrame` to 50ms per frame: precisely the two pill-dismissal assertions fail, with that same markup.

## How

- `afterLeave(host, selector)` in `Show.doubles.ts` polls until the node has left and returns what it can see, giving up after 2s so a node that never leaves fails the caller's assertion instead of hanging the suite.
- Both dismissal assertions in `describe('the unread jump pill')` now go through it. The other two tests in that describe read the pill after an *enter* — the node is inserted synchronously, so they were never racing.
- `starveAnimationFrames()` runs in that describe's `beforeEach` as a regression guard: a return to a clock-based wait now fails every run rather than one loaded run in a hundred. Verified by reverting one assertion to `settle()` and watching it fail.
- `settle()`'s doc no longer claims to cover a `<Transition>`; it points at `afterLeave`.

`describe('the pins popover')` has the same `await settle()` shape but is not affected — `PinsPanel` is a plain `v-if` with no `Transition` — so it is left alone.

## Testing

- `npm run test:js` green across 3 consecutive full runs (236 files / 2380 tests).
- `npm run lint:check`, `format:check`, `types:check`, `build` green.
- `composer test` green: Pint, PHPStan, Rector, 3093 Pest tests at `--min=100`.

No i18n or docs changes: the diff is test-harness only, with no user-facing copy and nothing an operator acts on.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788036844&installation_model_id=428379&pr_number=1083&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1083&signature=307371dbe89ce9106f8d74d4272927fbc8b4269646db5b8b22be661b8fb72477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->