### PR TITLE
docs: sign incoming webhooks with the header the ingest endpoint reads

### DIFF
--- a/docs/src/content/docs/reference/incoming-webhooks.md
+++ b/docs/src/content/docs/reference/incoming-webhooks.md
@@ -117,5 +117,6 @@ Deliveries _from_ The Desk are signed with `X-Desk-Signature`, which carries
 `t=<unix ts>,v1=<hex>` computed over `"{timestamp}.{body}"` — see
 [verifying an outgoing signature](/reference/webhooks/#verifying-the-signature).
 That is a different header with a different value format. Incoming ingest reads
-only `X-Signature-256`, and only the bare digest of the body.
+only `X-Signature-256`, and the digest there is over the body alone — bare or
+`sha256=`-prefixed, never timestamped.
 :::

--- a/docs/src/content/docs/reference/incoming-webhooks.md
+++ b/docs/src/content/docs/reference/incoming-webhooks.md
@@ -91,7 +91,31 @@ deleting the bot) stops it permanently.
 
 When you create the webhook you can also mint an **HMAC signing secret**, shown
 once alongside the URL. If you do, sign each request so The Desk can reject
-forgeries: compute `HMAC-SHA256` over the exact raw request body and send it in
-the `X-Desk-Signature` header. A webhook created without a secret accepts
-unsigned requests; one created with a secret rejects requests whose signature
-does not match.
+forgeries: compute `HMAC-SHA256` over the exact raw request body and send the hex
+digest in the **`X-Signature-256`** header. A bare digest and a `sha256=`-prefixed
+one (GitHub/Slack style) are both accepted.
+
+```bash
+BODY='{"text": "Build passed ✅"}'
+SIGNATURE=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SIGNING_SECRET" | awk '{print $2}')
+
+curl -X POST $WEBHOOK_URL \
+  -H 'Content-Type: application/json' \
+  -H "X-Signature-256: sha256=$SIGNATURE" \
+  -d "$BODY"
+```
+
+Sign the **exact bytes you send**: re-serializing the JSON, or letting an HTTP
+client reformat it, changes the digest and the request is refused.
+
+A webhook created without a secret accepts unsigned requests. One created with a
+secret rejects a missing, malformed, or mismatched signature with **401** — so a
+signature sent under any other header name fails as if it were absent.
+
+:::caution[Not the header outgoing deliveries use]
+Deliveries _from_ The Desk are signed with `X-Desk-Signature`, which carries
+`t=<unix ts>,v1=<hex>` computed over `"{timestamp}.{body}"` — see
+[verifying an outgoing signature](/reference/webhooks/#verifying-the-signature).
+That is a different header with a different value format. Incoming ingest reads
+only `X-Signature-256`, and only the bare digest of the body.
+:::

--- a/docs/src/content/docs/reference/webhooks.md
+++ b/docs/src/content/docs/reference/webhooks.md
@@ -111,6 +111,10 @@ if (! hash_equals($expected, $v1)) {
 abort_if(abs(time() - $t) > 300, 400, 'Timestamp outside tolerance');
 ```
 
+This header and format are for deliveries **from** The Desk. Signing a request
+_into_ The Desk is a separate scheme: see
+[signing an incoming webhook](/reference/incoming-webhooks/#signing-optional).
+
 ## Retries and auto-disabling
 
 A delivery that does not return a `2xx` status (or times out) is retried with

--- a/tests/Unit/IncomingWebhookSignatureDocsTest.php
+++ b/tests/Unit/IncomingWebhookSignatureDocsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Webhooks\IncomingWebhookController;
+
+/**
+ * The incoming-webhook reference page told integrators to sign with
+ * `X-Desk-Signature` — the header *outgoing* deliveries are signed with, which
+ * the ingest endpoint never reads and whose documented `t=…,v1=…` value would
+ * not parse here anyway. Anyone following it on a webhook created with a signing
+ * secret got a bare **401** with no hint as to why, and only signed webhooks —
+ * the security-conscious setups — were affected. These tests hold every
+ * operator-facing page to the header the controller actually reads, and keep the
+ * two headers from being confused for one another again. See #1060.
+ */
+$repoRoot = dirname(__DIR__, 2);
+
+$incomingPage = $repoRoot.'/docs/src/content/docs/reference/incoming-webhooks.md';
+$togglesPage = $repoRoot.'/docs/src/content/docs/reference/feature-toggles.md';
+
+/**
+ * The header the ingest controller reads an incoming signature from — the source
+ * of truth the docs have to mirror.
+ */
+$incomingHeader = function (): string {
+    $header = (new ReflectionClass(IncomingWebhookController::class))->getConstant('SIGNATURE_HEADER');
+
+    return is_string($header) ? $header : '';
+};
+
+/**
+ * The header an outgoing delivery is signed with, read off the job that sets it
+ * rather than restated here, so a rename cannot quietly split the two apart.
+ */
+$outgoingHeader = function () use ($repoRoot): string {
+    preg_match(
+        "/'(?<header>X-[A-Za-z0-9-]+)' => WebhookSignature::header\(/",
+        (string) file_get_contents($repoRoot.'/app/Jobs/DeliverWebhook.php'),
+        $matches,
+    );
+
+    return $matches['header'] ?? '';
+};
+
+test('the two webhook signature headers are distinct names', function () use ($incomingHeader, $outgoingHeader): void {
+    // Guard the guards below: a missed constant or a refactored job would leave
+    // every "the page names it" assertion matching the empty string.
+    expect($incomingHeader())->not->toBe('')
+        ->and($outgoingHeader())->not->toBe('')
+        ->and($incomingHeader())->not->toBe($outgoingHeader());
+});
+
+test('the incoming-webhook page signs with the header the ingest endpoint reads', function () use ($incomingPage, $incomingHeader): void {
+    expect((string) file_get_contents($incomingPage))->toContain($incomingHeader());
+});
+
+test('the feature-toggles page names the same incoming signature header', function () use ($togglesPage, $incomingHeader): void {
+    expect((string) file_get_contents($togglesPage))->toContain($incomingHeader());
+});
+
+test('the incoming-webhook page names the outgoing header only to tell them apart', function () use ($incomingPage, $outgoingHeader): void {
+    // Paragraphs rather than lines, because the prose is hard-wrapped: the word
+    // that disambiguates a mention routinely sits on a neighbouring line.
+    $paragraphs = preg_split('/\n\s*\n/', (string) file_get_contents($incomingPage)) ?: [];
+
+    $mentions = array_filter($paragraphs, fn (string $paragraph): bool => str_contains($paragraph, $outgoingHeader()));
+    $ambiguous = array_filter($mentions, fn (string $paragraph): bool => ! str_contains($paragraph, 'outgoing'));
+
+    // Both halves matter: the page has to draw the distinction *and* never name
+    // the outgoing header as the one to sign with.
+    expect($mentions)->not->toBe([])
+        ->and(array_values($ambiguous))->toBe([]);
+});

--- a/tests/Unit/IncomingWebhookSignatureDocsTest.php
+++ b/tests/Unit/IncomingWebhookSignatureDocsTest.php
@@ -21,12 +21,15 @@ $togglesPage = $repoRoot.'/docs/src/content/docs/reference/feature-toggles.md';
 
 /**
  * The header the ingest controller reads an incoming signature from — the source
- * of truth the docs have to mirror.
+ * of truth the docs have to mirror. It fails loudly rather than degrading to an
+ * empty needle, which every `toContain()` below would match.
  */
 $incomingHeader = function (): string {
     $header = (new ReflectionClass(IncomingWebhookController::class))->getConstant('SIGNATURE_HEADER');
 
-    return is_string($header) ? $header : '';
+    throw_if(! is_string($header) || $header === '', RuntimeException::class, 'IncomingWebhookController::SIGNATURE_HEADER no longer names a request header.');
+
+    return $header;
 };
 
 /**
@@ -40,23 +43,39 @@ $outgoingHeader = function () use ($repoRoot): string {
         $matches,
     );
 
-    return $matches['header'] ?? '';
+    throw_if(($matches['header'] ?? '') === '', RuntimeException::class, 'DeliverWebhook no longer signs a delivery under a recognisable header.');
+
+    return $matches['header'];
+};
+
+/**
+ * The page's "Signing (optional)" section, so an incidental mention elsewhere
+ * cannot stand in for the instructions an integrator actually follows.
+ */
+$signingSection = function (string $page): string {
+    preg_match('/^## Signing.*?(?=^## |\z)/ms', (string) file_get_contents($page), $matches);
+
+    return $matches[0] ?? '';
 };
 
 test('the two webhook signature headers are distinct names', function () use ($incomingHeader, $outgoingHeader): void {
-    // Guard the guards below: a missed constant or a refactored job would leave
-    // every "the page names it" assertion matching the empty string.
-    expect($incomingHeader())->not->toBe('')
-        ->and($outgoingHeader())->not->toBe('')
-        ->and($incomingHeader())->not->toBe($outgoingHeader());
+    expect($incomingHeader())->not->toBe($outgoingHeader());
 });
 
-test('the incoming-webhook page signs with the header the ingest endpoint reads', function () use ($incomingPage, $incomingHeader): void {
-    expect((string) file_get_contents($incomingPage))->toContain($incomingHeader());
+test('the signing section tells integrators to use the header the ingest endpoint reads', function () use ($incomingPage, $signingSection, $incomingHeader): void {
+    expect($signingSection($incomingPage))->toContain($incomingHeader());
 });
 
-test('the feature-toggles page names the same incoming signature header', function () use ($togglesPage, $incomingHeader): void {
-    expect((string) file_get_contents($togglesPage))->toContain($incomingHeader());
+test('the copy-paste signing sample never signs under the outgoing header', function () use ($incomingPage, $signingSection, $incomingHeader, $outgoingHeader): void {
+    preg_match_all('/^```.*?\n(?<body>.*?)^```/ms', $signingSection($incomingPage), $matches);
+
+    $samples = $matches['body'];
+
+    // The fenced sample is what gets pasted into a CI job, so it carries the
+    // whole cost of naming the wrong header.
+    expect($samples)->not->toBe([])
+        ->and(implode("\n", $samples))->toContain($incomingHeader())
+        ->and(implode("\n", $samples))->not->toContain($outgoingHeader());
 });
 
 test('the incoming-webhook page names the outgoing header only to tell them apart', function () use ($incomingPage, $outgoingHeader): void {
@@ -67,8 +86,12 @@ test('the incoming-webhook page names the outgoing header only to tell them apar
     $mentions = array_filter($paragraphs, fn (string $paragraph): bool => str_contains($paragraph, $outgoingHeader()));
     $ambiguous = array_filter($mentions, fn (string $paragraph): bool => ! str_contains($paragraph, 'outgoing'));
 
-    // Both halves matter: the page has to draw the distinction *and* never name
-    // the outgoing header as the one to sign with.
+    // Both halves matter: the page has to draw the distinction *and* never leave
+    // the outgoing header sitting there as if it were the one to send.
     expect($mentions)->not->toBe([])
         ->and(array_values($ambiguous))->toBe([]);
+});
+
+test('the feature-toggles page names the same incoming signature header', function () use ($togglesPage, $incomingHeader): void {
+    expect((string) file_get_contents($togglesPage))->toContain($incomingHeader());
 });


### PR DESCRIPTION
Closes #1060.

## What

The incoming-webhook reference told integrators to send their HMAC in
`X-Desk-Signature`, but `IncomingWebhookController` reads `X-Signature-256`.
Anyone following the docs on a webhook created **with** a signing secret put the
signature in a header the app never looks at, so `verifySignature()` saw nothing
and aborted with a bare **401** — and only signed webhooks, i.e. the
security-conscious setups, were affected.

`X-Desk-Signature` is also genuinely taken: it is the **outgoing** delivery
header, and it carries a different value (`t=<unix ts>,v1=<hex>` over
`"{timestamp}.{body}"`), so the documented format would not have parsed here
either.

## Why doc-side, not code-side

The issue asks for that decision explicitly. `X-Signature-256` is shipped and
covered by `tests/Feature/Integrations/IncomingWebhookIngestTest.php`, so
renaming it would break every integrator who is already signing correctly — for
no gain, since the collision is with a header whose format differs. Nothing in
`app/` changes.

## How

- `reference/incoming-webhooks.md` — the Signing section now names
  `X-Signature-256`, says the `sha256=` prefix is optional, carries a
  copy-paste `openssl` + `curl` sample, states the **401**, and closes with a
  caution distinguishing the outgoing header, cross-linked to its own section.
- `reference/webhooks.md` — a reciprocal pointer back, so a reader on either
  page cannot mistake one scheme for the other.
- `reference/feature-toggles.md` was already correct and is now held there.

## How tested

`tests/Unit/IncomingWebhookSignatureDocsTest.php` (new, written red first — two
of its guards failed on the old copy). It reads the incoming header off the
controller constant by reflection and the outgoing one off `DeliverWebhook`,
rather than restating either, then asserts that the signing **section** names the
former, that the fenced sample an integrator pastes never names the latter, that
any prose mention of the outgoing header is there to tell them apart, and that
the feature-toggles page agrees.

Gate: `composer test` green (Pint, PHPStan, Rector, 3099 tests at `--min=100`);
frontend lint/format/types green; `cd docs && npm run build` clean with both new
anchors resolving in `dist/`.

## i18n & docs

No user-facing app copy changed, so no new `lang/fr.json` keys. The change *is*
the docs update.

## Note

The local CodeRabbit pass reported 5 findings; 4 are applied (scope the header
assertion to the signing section and to the fenced sample, fail loudly when
either header can no longer be read off the code, stop the caution reading as if
`sha256=` were rejected). The fifth — "declare a `string` return type on the
`$outgoingHeader` closure" — is a false positive; it already has one. The
confirming re-run hit the free tier's rate limit, so the app-side review is the
backstop.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788038070&installation_model_id=428379&pr_number=1084&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1084&signature=ac93f33cf2bc22a13d9468a9c20f58290f508d9b58ef6e2d330afe8f2d97d706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->