### PR TITLE
fix: give success status text an AA-contrast token in both themes

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -46,6 +46,7 @@
     --color-destructive: var(--destructive);
     --color-destructive-foreground: var(--destructive-foreground);
     --color-destructive-text: var(--destructive-text);
+    --color-success-text: var(--success-text);
 
     --color-border: var(--border);
     --color-input: var(--input);
@@ -174,6 +175,15 @@
        which the fill token only just met on the page background (#678), and on
        the dimmer `bg-destructive/10` tint composited over either (#717). */
     --destructive-text: hsl(0 72% 40%);
+    /* Success as inline *text* — the "Active" pills and the delivery log's
+       success figure, the destructive tokens' counterpart. There is no --success
+       fill to derive it from, and Tailwind's `green-600` measured 3.19:1 on
+       --card at the text-xs these all use (#1064), so this is tuned straight to
+       the palette: deep enough to clear WCAG AA 4.5:1 on --background, the
+       darkest surface it lands on, and desaturated to sit with the warm greys
+       rather than shout. Doubles as the fill of the status dot each pill
+       carries, so a pill reads as one colour. */
+    --success-text: #33664b;
     --border: #e3dfd5;
     --input: #e0dbcd;
     /* Scrim behind a bottom sheet — ink at 50%, per the mobile design (#772).
@@ -281,6 +291,9 @@
        again for the `bg-destructive/10` tint, which composites *up* on a dark
        surface and left the text at 4.37:1 (#717). */
     --destructive-text: hsl(0 72% 64%);
+    /* The green-on-ink the slab already carries in the light theme, reused here:
+       the dark card is the same ink, and it measures 8.8:1 on it. */
+    --success-text: #86c8a1;
     --border: #2e2a21;
     --input: #2a271f;
     /* Deeper than the light theme's: the sheet is a light-on-dark card here, so

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -46,7 +46,7 @@
     --color-destructive: var(--destructive);
     --color-destructive-foreground: var(--destructive-foreground);
     --color-destructive-text: var(--destructive-text);
-    --color-success-text: var(--success-text);
+    --color-status-success: var(--status-success);
 
     --color-border: var(--border);
     --color-input: var(--input);
@@ -176,14 +176,17 @@
        the dimmer `bg-destructive/10` tint composited over either (#717). */
     --destructive-text: hsl(0 72% 40%);
     /* Success as inline *text* — the "Active" pills and the delivery log's
-       success figure, the destructive tokens' counterpart. There is no --success
-       fill to derive it from, and Tailwind's `green-600` measured 3.19:1 on
-       --card at the text-xs these all use (#1064), so this is tuned straight to
-       the palette: deep enough to clear WCAG AA 4.5:1 on --background, the
-       darkest surface it lands on, and desaturated to sit with the warm greys
-       rather than shout. Doubles as the fill of the status dot each pill
-       carries, so a pill reads as one colour. */
-    --success-text: #33664b;
+       success figure, the counterpart of --destructive-text above. There is no
+       --success fill to derive it from, and Tailwind's `green-600` measured
+       3.19:1 on --card at the text-xs these all use (#1064), so this is tuned
+       straight to the palette: deep enough to clear WCAG AA 4.5:1 on
+       --background, the darkest surface it lands on, and desaturated to sit with
+       the warm greys rather than shout. It also fills the status dot each pill
+       carries, so a pill reads as one colour. Named `--status-success` rather
+       than following --destructive-text into `--success-text`, which vue-sonner
+       already declares on `[data-sonner-toaster]`: that would shadow ours inside
+       every toast and quietly reinstate a sub-AA green. */
+    --status-success: #33664b;
     --border: #e3dfd5;
     --input: #e0dbcd;
     /* Scrim behind a bottom sheet — ink at 50%, per the mobile design (#772).
@@ -293,7 +296,7 @@
     --destructive-text: hsl(0 72% 64%);
     /* The green-on-ink the slab already carries in the light theme, reused here:
        the dark card is the same ink, and it measures 8.8:1 on it. */
-    --success-text: #86c8a1;
+    --status-success: #86c8a1;
     --border: #2e2a21;
     --input: #2a271f;
     /* Deeper than the light theme's: the sheet is a light-on-dark card here, so

--- a/resources/js/components/integrations/IncomingWebhooksRack.vue
+++ b/resources/js/components/integrations/IncomingWebhooksRack.vue
@@ -91,10 +91,10 @@ defineEmits<{
                     </span>
                 </div>
                 <span
-                    class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-green-600 dark:text-green-500"
+                    class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-success-text"
                 >
                     <span
-                        class="size-1.5 rounded-full bg-green-600 dark:bg-green-500"
+                        class="size-1.5 rounded-full bg-success-text"
                         aria-hidden="true"
                     />
                     {{ $t('Active') }}

--- a/resources/js/components/integrations/IncomingWebhooksRack.vue
+++ b/resources/js/components/integrations/IncomingWebhooksRack.vue
@@ -91,10 +91,10 @@ defineEmits<{
                     </span>
                 </div>
                 <span
-                    class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-success-text"
+                    class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-status-success"
                 >
                     <span
-                        class="size-1.5 rounded-full bg-success-text"
+                        class="size-1.5 rounded-full bg-status-success"
                         aria-hidden="true"
                     />
                     {{ $t('Active') }}

--- a/resources/js/components/integrations/OutgoingWebhooksRack.vue
+++ b/resources/js/components/integrations/OutgoingWebhooksRack.vue
@@ -88,10 +88,10 @@ function hostOf(url: string): string {
                 </div>
                 <span
                     v-if="sub.status === 'active'"
-                    class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-success-text"
+                    class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-status-success"
                 >
                     <span
-                        class="size-1.5 rounded-full bg-success-text"
+                        class="size-1.5 rounded-full bg-status-success"
                         aria-hidden="true"
                     />
                     {{ $t('Active') }}

--- a/resources/js/components/integrations/OutgoingWebhooksRack.vue
+++ b/resources/js/components/integrations/OutgoingWebhooksRack.vue
@@ -88,10 +88,10 @@ function hostOf(url: string): string {
                 </div>
                 <span
                     v-if="sub.status === 'active'"
-                    class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-green-600 dark:text-green-500"
+                    class="inline-flex shrink-0 items-center gap-1.5 text-xs font-semibold text-success-text"
                 >
                     <span
-                        class="size-1.5 rounded-full bg-green-600 dark:bg-green-500"
+                        class="size-1.5 rounded-full bg-success-text"
                         aria-hidden="true"
                     />
                     {{ $t('Active') }}

--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -190,7 +190,7 @@ function onTimezoneSelect(value: unknown): void {
 
                 <div
                     v-if="page.props.status === 'verification-link-sent'"
-                    class="mt-2 text-sm font-medium text-success-text"
+                    class="mt-2 text-sm font-medium text-status-success"
                 >
                     {{
                         $t(

--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -190,7 +190,7 @@ function onTimezoneSelect(value: unknown): void {
 
                 <div
                     v-if="page.props.status === 'verification-link-sent'"
-                    class="mt-2 text-sm font-medium text-green-600"
+                    class="mt-2 text-sm font-medium text-success-text"
                 >
                     {{
                         $t(

--- a/resources/js/pages/teams/integrations/Webhook.vue
+++ b/resources/js/pages/teams/integrations/Webhook.vue
@@ -172,10 +172,10 @@ function confirmRevoke(): void {
                     </span>
                     <span
                         v-else
-                        class="inline-flex items-center gap-1.5 text-xs font-semibold text-success-text"
+                        class="inline-flex items-center gap-1.5 text-xs font-semibold text-status-success"
                     >
                         <span
-                            class="size-1.5 rounded-full bg-success-text"
+                            class="size-1.5 rounded-full bg-status-success"
                             aria-hidden="true"
                         />
                         {{ $t('Active') }}
@@ -281,7 +281,7 @@ function confirmRevoke(): void {
                                         class="size-2 shrink-0 rounded-full"
                                         :class="
                                             delivery.succeeded
-                                                ? 'bg-success-text'
+                                                ? 'bg-status-success'
                                                 : 'bg-destructive'
                                         "
                                         aria-hidden="true"
@@ -294,7 +294,7 @@ function confirmRevoke(): void {
                                 class="py-2 pr-2 font-mono text-xs"
                                 :class="
                                     delivery.succeeded
-                                        ? 'text-success-text'
+                                        ? 'text-status-success'
                                         : 'text-destructive-text'
                                 "
                             >

--- a/resources/js/pages/teams/integrations/Webhook.vue
+++ b/resources/js/pages/teams/integrations/Webhook.vue
@@ -172,10 +172,10 @@ function confirmRevoke(): void {
                     </span>
                     <span
                         v-else
-                        class="inline-flex items-center gap-1.5 text-xs font-semibold text-green-600 dark:text-green-500"
+                        class="inline-flex items-center gap-1.5 text-xs font-semibold text-success-text"
                     >
                         <span
-                            class="size-1.5 rounded-full bg-green-600 dark:bg-green-500"
+                            class="size-1.5 rounded-full bg-success-text"
                             aria-hidden="true"
                         />
                         {{ $t('Active') }}
@@ -281,7 +281,7 @@ function confirmRevoke(): void {
                                         class="size-2 shrink-0 rounded-full"
                                         :class="
                                             delivery.succeeded
-                                                ? 'bg-green-600 dark:bg-green-500'
+                                                ? 'bg-success-text'
                                                 : 'bg-destructive'
                                         "
                                         aria-hidden="true"
@@ -294,7 +294,7 @@ function confirmRevoke(): void {
                                 class="py-2 pr-2 font-mono text-xs"
                                 :class="
                                     delivery.succeeded
-                                        ? 'text-green-600 dark:text-green-500'
+                                        ? 'text-success-text'
                                         : 'text-destructive-text'
                                 "
                             >

--- a/tests/Browser/A11ySuccessTextTest.php
+++ b/tests/Browser/A11ySuccessTextTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\IncomingWebhook;
+use App\Models\WebhookDelivery;
+use App\Models\WebhookSubscription;
+
+/**
+ * The "everything is fine" green, audited on every shape it takes. It is the
+ * counterpart of the destructive-text audit (#678, #717): the integrations
+ * surfaces are the only place success is spelled in colour, and it is spelled
+ * small — the "Active" pills are text-xs and the delivery log's success cell is
+ * a 12px monospace figure, so all of it needs 4.5:1 rather than the large-text
+ * 3:1 (#1064).
+ */
+test('success status text passes the axe audit in either theme', function (): void {
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    $subscription = WebhookSubscription::factory()->create([
+        'team_id' => $team->id,
+        'created_by' => $alice->id,
+        'name' => 'Ops mirror',
+        'url' => 'https://ops.example.test/desk',
+    ]);
+
+    IncomingWebhook::factory()->create([
+        'team_id' => $team->id,
+        'channel_id' => $channel->id,
+        'created_by' => $alice->id,
+        'name' => 'Deploy feed',
+    ]);
+
+    WebhookDelivery::factory()->for($subscription, 'subscription')->create();
+
+    // Both racks on the index list an "Active" pill; the detail page repeats it
+    // beside the subscription name and paints the delivery's response status in
+    // the same green.
+    $index = signInThroughBrowser($alice)
+        ->navigate("/settings/teams/{$team->slug}/integrations")
+        ->assertPresent("[data-test=\"outgoing-row-{$subscription->id}\"]")
+        ->assertSee('Active')
+        ->assertNoAccessibilityIssues();
+
+    switchToDarkTheme($index)
+        ->assertNoAccessibilityIssues();
+
+    $detail = signInThroughBrowser($alice)
+        ->navigate("/settings/teams/{$team->slug}/integrations/webhooks/{$subscription->id}")
+        ->assertSee('Recent deliveries')
+        ->assertSee('Active')
+        ->assertNoAccessibilityIssues();
+
+    switchToDarkTheme($detail)
+        ->assertNoAccessibilityIssues();
+});

--- a/tests/Browser/A11yWebhookDeliveryLogTest.php
+++ b/tests/Browser/A11yWebhookDeliveryLogTest.php
@@ -16,10 +16,9 @@ use App\Models\WebhookSubscription;
  * label has to keep the visible word "Replay" in it (WCAG 2.5.3, label in name),
  * which is what the script assertion below pins.
  *
- * Only failed attempts are seeded, and the subscription is disabled, to keep the
- * page clear of the pre-existing sub-AA `text-green-600` success colour (#1064)
- * — that is the only thing standing between this page and a clean audit. Seed a
- * successful delivery here again once #1064 lands.
+ * The log mixes both outcomes on purpose: a delivery that succeeded once and the
+ * two failed attempts that eventually disabled the subscription, so the audit
+ * covers the success colour beside the destructive one (#1064).
  */
 test('the webhook delivery log passes the axe audit in either theme', function (): void {
     ['owner' => $alice, 'team' => $team] = browserTeamWithChannel();
@@ -32,8 +31,11 @@ test('the webhook delivery log passes the axe audit in either theme', function (
         'consecutive_failures' => 5,
     ]);
 
+    // Only the failed attempt kept an envelope, so the replay button stays a
+    // single-row control: the earlier success predates envelope retention.
     $replayable = WebhookDelivery::factory()->for($subscription, 'subscription')->failed()->create();
     WebhookDelivery::factory()->for($subscription, 'subscription')->failed()->withoutEnvelope()->create();
+    WebhookDelivery::factory()->for($subscription, 'subscription')->withoutEnvelope()->create();
 
     $page = signInThroughBrowser($alice)
         ->navigate("/settings/teams/{$team->slug}/integrations/webhooks/{$subscription->id}")
@@ -42,7 +44,7 @@ test('the webhook delivery log passes the axe audit in either theme', function (
         ->assertPresent("[data-test=\"replay-delivery-{$replayable->id}\"]")
         ->assertNoAccessibilityIssues();
 
-    // Exactly one of the two logged attempts kept an envelope, so exactly one
+    // Exactly one of the three logged attempts kept an envelope, so exactly one
     // offers the button — and its accessible name contains its visible text.
     $page->assertScript(<<<'JS'
     (() => {


### PR DESCRIPTION
Closes #1064.

## What

`text-green-600` (`#00a63e`) measured **3.19:1** on the card in the light theme at the 12px these status texts use — axe flagged it as a serious violation on the outgoing-webhook delivery log. It was the only "everything is fine" signal on the integrations surfaces, so it is exactly the text a low-vision operator needs to read.

Adds a semantic token and moves all five call sites onto it:

| theme | value | measured |
| --- | --- | --- |
| light | `#33664b` | 6.6:1 on `--card`, 5.3:1 on `--background` |
| dark | `#86c8a1` | 8.8:1 on the dark card |

The dark value is the green-on-ink the slab already carries in the light theme, so no new colour enters the palette there. The status dot beside each pill moves onto the same token (it was `bg-green-600 dark:bg-green-500`), so a pill reads as one colour rather than two greens.

Call sites: `Webhook.vue` (the "Active" pill and the delivery log's success cell + dot), `OutgoingWebhooksRack.vue`, `IncomingWebhooksRack.vue`, `Profile.vue` (which had no `dark:` variant at all and now flips with the theme).

## Why `--status-success` and not `--success-text`

`--success-text` was the obvious name, following `--destructive-text`. It is also declared by **vue-sonner** on `[data-sonner-toaster]` — which would shadow ours inside every toast and quietly reinstate a sub-AA green the first time success copy landed in one. The token is named `--status-success` instead, with the reason recorded next to it in `app.css`.

## How tested

- New `tests/Browser/A11ySuccessTextTest.php`, mirroring `A11yDestructiveTextTest`: an active subscription and an incoming webhook, audited on the integrations index (both racks' "Active" pills) and on the detail page (the pill plus the successful delivery's response figure), in light **and** dark. It reproduced the reported 3.19:1 failure before the fix.
- `tests/Browser/A11yWebhookDeliveryLogTest.php` seeds a successful delivery again and its `#1064` workaround comment is gone. The success predates envelope retention, so the replay button stays the single-row control that test pins.
- Full gate green: `composer test` (Pint, PHPStan, Rector, 3094 tests at 100% coverage), `lint:check`, `format:check`, `types:check`, `test:js`, `build`, and all 51 `A11y*` browser tests.

No user-facing copy changed, so no new translation keys; nothing here is operator-facing, so no docs change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788039503&installation_model_id=428379&pr_number=1086&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1086&signature=24abe636c1d789dfdab15553974554a176736d8ddfdad755a1e6972dac6e440e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->