### PR TITLE
feat: record which incoming webhook posted a message

### DIFF
--- a/app/Actions/Channels/PostMessage.php
+++ b/app/Actions/Channels/PostMessage.php
@@ -64,16 +64,22 @@ class PostMessage
      * they override only what is *displayed* — `$author` still authors the row, so
      * every surface keeps its non-human marking.
      *
+     * `$incomingWebhookId` names the credential a webhook ingest used, so an admin
+     * looking at a suspicious row can revoke exactly that webhook rather than every
+     * URL its bot holds. Null on every other path — the author alone identifies a
+     * human send, and the REST API's own credential is a separate question.
+     *
      * @param  list<string>  $attachmentIds
      * @param  (Closure(Message): void)|null  $afterCreate
      */
-    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null, ?string $forwardedFromId = null, ?string $threadRootId = null, bool $sentToChannel = false, bool $clearDraft = true, array $attachmentIds = [], MessageType $type = MessageType::Standard, ?Closure $afterCreate = null, ?string $authorOverrideName = null, ?string $authorOverrideAvatarUrl = null): Message
+    public function handle(Channel $channel, User $author, string $body, string $clientUuid, ?string $replyToId = null, ?string $forwardedFromId = null, ?string $threadRootId = null, bool $sentToChannel = false, bool $clearDraft = true, array $attachmentIds = [], MessageType $type = MessageType::Standard, ?Closure $afterCreate = null, ?string $authorOverrideName = null, ?string $authorOverrideAvatarUrl = null, ?string $incomingWebhookId = null): Message
     {
-        $message = DB::transaction(function () use ($channel, $author, $body, $clientUuid, $replyToId, $forwardedFromId, $threadRootId, $sentToChannel, $attachmentIds, $type, $afterCreate, $authorOverrideName, $authorOverrideAvatarUrl): Message {
+        $message = DB::transaction(function () use ($channel, $author, $body, $clientUuid, $replyToId, $forwardedFromId, $threadRootId, $sentToChannel, $attachmentIds, $type, $afterCreate, $authorOverrideName, $authorOverrideAvatarUrl, $incomingWebhookId): Message {
             $message = $channel->messages()->firstOrCreate(
                 ['client_uuid' => $clientUuid],
                 [
                     'user_id' => $author->id,
+                    'incoming_webhook_id' => $incomingWebhookId,
                     'body' => $body,
                     'author_override_name' => $authorOverrideName,
                     'author_override_avatar_url' => $authorOverrideAvatarUrl,

--- a/app/Data/IncomingWebhookSourceData.php
+++ b/app/Data/IncomingWebhookSourceData.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use App\Models\Message;
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+/**
+ * The incoming webhook that produced one message, so an admin reading a
+ * suspicious row can revoke exactly that credential.
+ *
+ * A bot holds one webhook per (bot, channel) pair, so naming the author is not
+ * enough: revoking on the strength of it would take down every URL that bot
+ * holds. This names the one.
+ *
+ * It is **not** carried on every message payload. A webhook's name is
+ * admin-authored and routinely spells out operational detail ("Prod PagerDuty
+ * bridge"), so it is resolved only for viewers who hold `manageIntegrations` on
+ * the channel's team — the people who could act on it. Every other viewer, and
+ * every viewer-free broadcast, sees null. See {@see MessageData::fromMessage()}.
+ */
+#[TypeScript]
+class IncomingWebhookSourceData extends Data
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+    ) {}
+
+    /**
+     * Build the source a message records, or null when it has none.
+     *
+     * Null on every non-ingest path, on a webhook message that predates the
+     * column, and once the webhook row itself is deleted — the message outlives
+     * its credential by design, so an unresolvable id degrades to no attribution
+     * rather than to an error.
+     */
+    public static function forMessage(Message $message): ?self
+    {
+        $webhook = $message->incomingWebhook;
+
+        return $webhook === null ? null : new self(id: $webhook->id, name: $webhook->name);
+    }
+}

--- a/app/Data/MessageData.php
+++ b/app/Data/MessageData.php
@@ -33,6 +33,13 @@ class MessageData extends Data
          * ordinary message. See {@see AuthorOverrideData}.
          */
         public ?AuthorOverrideData $authorOverride,
+        /**
+         * Which incoming webhook produced this message, for the viewers who
+         * could revoke it. Null on every ordinary message, and null for a viewer
+         * who cannot manage the team's integrations. See
+         * {@see IncomingWebhookSourceData}.
+         */
+        public ?IncomingWebhookSourceData $incomingWebhook,
         public string $createdAt,
         public ?string $editedAt,
         public bool $isDeleted,
@@ -93,8 +100,16 @@ class MessageData extends Data
      * selection, which its hidden roster can't convey). It is passed only on the
      * viewer-scoped timeline load; a broadcast omits it, so the payload stays
      * viewer-free and the client preserves the vote state it already holds.
+     *
+     * `$withWebhookSource` names the incoming webhook behind a message. It is a
+     * flag rather than something derived from `$viewerId` because the answer is
+     * per-viewer-per-team, not per-message: the caller resolves the
+     * `manageIntegrations` gate once for the whole page instead of once per row.
+     * Left false — as every broadcast, search, and post path leaves it — the
+     * field stays null and the admin-authored webhook name never reaches a client
+     * that has not been checked for it.
      */
-    public static function fromMessage(Message $message, ?string $viewerId = null): self
+    public static function fromMessage(Message $message, ?string $viewerId = null, bool $withWebhookSource = false): self
     {
         $isDeleted = $message->trashed();
 
@@ -111,6 +126,10 @@ class MessageData extends Data
             // it keeps rendering as it always did rather than reverting to the
             // bot's own name the moment the body is withdrawn.
             authorOverride: AuthorOverrideData::forMessage($message),
+            // Provenance, not content: a tombstone keeps naming the credential
+            // that produced it, since withdrawing the body is the very moment an
+            // admin wants to know which webhook to revoke.
+            incomingWebhook: $withWebhookSource ? IncomingWebhookSourceData::forMessage($message) : null,
             createdAt: $message->created_at->toIso8601String(),
             editedAt: $message->edited_at?->toIso8601String(),
             isDeleted: $isDeleted,

--- a/app/Http/Controllers/Webhooks/IncomingWebhookController.php
+++ b/app/Http/Controllers/Webhooks/IncomingWebhookController.php
@@ -90,6 +90,7 @@ class IncomingWebhookController extends Controller
             clientUuid: (string) Str::uuid(),
             authorOverrideName: $this->nullableString($validated, 'username'),
             authorOverrideAvatarUrl: $this->nullableString($validated, 'icon_url'),
+            incomingWebhookId: $webhook->id,
         );
 
         return response()->json(['ok' => true], 202);

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -25,6 +25,7 @@ use Laravel\Scout\Searchable;
  * @property string $id
  * @property string $channel_id
  * @property string $user_id
+ * @property string|null $incoming_webhook_id
  * @property string $client_uuid
  * @property string|null $reply_to_id
  * @property string|null $forwarded_from_id
@@ -42,6 +43,7 @@ use Laravel\Scout\Searchable;
  * @property Carbon|null $updated_at
  * @property-read Channel $channel
  * @property-read User $user
+ * @property-read IncomingWebhook|null $incomingWebhook
  * @property-read Message|null $replyTo
  * @property-read Message|null $forwardedFrom
  * @property-read Collection<int, Message> $threadReplies
@@ -52,7 +54,7 @@ use Laravel\Scout\Searchable;
  * @property-read MessagePin|null $pin
  * @property-read Collection<int, Attachment> $attachments
  */
-#[Fillable(['channel_id', 'user_id', 'client_uuid', 'reply_to_id', 'forwarded_from_id', 'thread_root_id', 'sent_to_channel', 'body', 'author_override_name', 'author_override_avatar_url', 'type', 'edited_at'])]
+#[Fillable(['channel_id', 'user_id', 'incoming_webhook_id', 'client_uuid', 'reply_to_id', 'forwarded_from_id', 'thread_root_id', 'sent_to_channel', 'body', 'author_override_name', 'author_override_avatar_url', 'type', 'edited_at'])]
 class Message extends Model
 {
     /** @use HasFactory<MessageFactory> */
@@ -87,6 +89,10 @@ class Message extends Model
      */
     private const array MESSAGE_DATA_RELATIONS = [
         'user',
+        // Read only for a viewer who can manage the team's integrations, but
+        // loaded for everyone: a conditional eager-load here would be a lazy
+        // load — or an N+1 — the day a caller forgets the condition.
+        'incomingWebhook',
         'mentionedUsers',
         'linkPreviews',
         'reactions.user',
@@ -123,6 +129,20 @@ class Message extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the incoming webhook that produced this message, if any.
+     *
+     * Null on every path but webhook ingest, and null on a webhook message that
+     * predates the column. Null too once the webhook row is deleted outright —
+     * the message survives its credential, which is the point.
+     *
+     * @return BelongsTo<IncomingWebhook, $this>
+     */
+    public function incomingWebhook(): BelongsTo
+    {
+        return $this->belongsTo(IncomingWebhook::class);
     }
 
     /**

--- a/app/Support/ChannelTimelineWindow.php
+++ b/app/Support/ChannelTimelineWindow.php
@@ -10,6 +10,7 @@ use App\Models\Message;
 use App\Models\User;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * Resolves where a channel's initial message window opens and assembles the
@@ -59,6 +60,8 @@ class ChannelTimelineWindow
     private bool $threadRootResolved = false;
 
     private ?Message $resolvedThreadRoot = null;
+
+    private ?bool $viewerManagesIntegrations = null;
 
     public function __construct(
         private readonly Channel $channel,
@@ -120,7 +123,7 @@ class ChannelTimelineWindow
             ->when($ceilingId, fn (Builder $query) => $query->where('id', '<=', $ceilingId))
             ->orderByDesc('id')
             ->cursorPaginate(self::MESSAGE_PAGE_SIZE)
-            ->through(fn (Message $message): MessageData => MessageData::fromMessage($message, $this->viewer->id));
+            ->through(fn (Message $message): MessageData => MessageData::fromMessage($message, $this->viewer->id, $this->viewerManagesIntegrations()));
     }
 
     /**
@@ -140,7 +143,7 @@ class ChannelTimelineWindow
             return null;
         }
 
-        return ['root' => MessageData::fromMessage($root, $this->viewer->id)];
+        return ['root' => MessageData::fromMessage($root, $this->viewer->id, $this->viewerManagesIntegrations())];
     }
 
     /**
@@ -165,7 +168,21 @@ class ChannelTimelineWindow
         return $query
             ->orderByDesc('id')
             ->cursorPaginate(self::THREAD_PAGE_SIZE, ['*'], 'thread_cursor')
-            ->through(fn (Message $message): MessageData => MessageData::fromMessage($message, $this->viewer->id));
+            ->through(fn (Message $message): MessageData => MessageData::fromMessage($message, $this->viewer->id, $this->viewerManagesIntegrations()));
+    }
+
+    /**
+     * Whether this viewer may be told which incoming webhook produced a message.
+     *
+     * The webhook's name is admin-authored and often operational, so it is
+     * resolved once per page for the `manageIntegrations` holders who could
+     * revoke it, rather than per message. Memoised: every row on the timeline,
+     * the thread root and its replies all ask.
+     */
+    private function viewerManagesIntegrations(): bool
+    {
+        return $this->viewerManagesIntegrations ??= Gate::forUser($this->viewer)
+            ->allows('manageIntegrations', $this->channel->team);
     }
 
     /**

--- a/database/migrations/2026_07_30_210451_add_incoming_webhook_id_to_messages_table.php
+++ b/database/migrations/2026_07_30_210451_add_incoming_webhook_id_to_messages_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table): void {
+            // Which incoming webhook produced this row. `user_id` names the bot
+            // that authored it, but a bot holds as many webhooks as it has
+            // (bot, channel) pairs — so the author alone cannot tell an admin
+            // which credential to revoke. This closes that gap: revocation
+            // becomes targetable at the granularity the credential is issued at.
+            //
+            // Null on every other path (human sends, the REST API, system
+            // messages) and null on webhook messages posted before this column
+            // existed, which cannot be attributed retroactively: nothing was
+            // recorded, and guessing from `user_id` + `channel_id` would be wrong
+            // for exactly the multi-hook bot that motivates the column.
+            //
+            // `nullOnDelete` so deleting a webhook never cascades into message
+            // history — the trail thins, the messages stay.
+            $table->foreignUuid('incoming_webhook_id')
+                ->nullable()
+                ->after('user_id')
+                ->constrained()
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('incoming_webhook_id');
+        });
+    }
+};

--- a/docs/src/content/docs/reference/incoming-webhooks.md
+++ b/docs/src/content/docs/reference/incoming-webhooks.md
@@ -87,6 +87,23 @@ of the channel. Remove the bot from the channel — via **Remove** under the bot
 API token follows, so there is no parallel way to post. Revoking the webhook (or
 deleting the bot) stops it permanently.
 
+## Tracing a message back to its webhook
+
+A bot holds one webhook per channel it posts into, so knowing which bot posted a
+message is not enough to revoke the right URL. Every message posted through an
+incoming webhook therefore records which webhook produced it.
+
+Workspace owners and admins see that on the message itself: hover the author, and
+the card names the webhook and offers **Review**, which opens **Integrations**
+with that hook singled out, ready to revoke. Members never see it, since a
+webhook's name is yours to write and often names internal systems.
+
+Two limits worth knowing. Messages posted before you upgraded to this version
+carry no attribution: nothing was recorded at the time, and it cannot be
+reconstructed after the fact. And revoking a webhook leaves its past messages
+exactly as they are, still naming the credential that produced them, so the trail
+survives the revocation.
+
 ## Signing (optional)
 
 When you create the webhook you can also mint an **HMAC signing secret**, shown

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1478,5 +1478,8 @@
   "Always": "Toujours",
   "Make :channel a default channel": "Faire de :channel un canal par défaut",
   "Channel-creation policy changed": "Règle de création de canaux modifiée",
-  "Changed the %s channel-creation policy from “%s” to “%s”": "A modifié la règle de création des canaux %s de « %s » à « %s »"
+  "Changed the %s channel-creation policy from “%s” to “%s”": "A modifié la règle de création des canaux %s de « %s » à « %s »",
+  "Posted by the :name webhook": "Publié par le webhook :name",
+  "Review": "Examiner",
+  "Review the :name webhook": "Examiner le webhook :name"
 }

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -349,6 +349,7 @@ function confirmDelete(): void {
                     <MessageAvatarGutter
                         :author="item.author"
                         :author-override="item.authorOverride"
+                        :incoming-webhook="item.incomingWebhook"
                         :team-slug="props.teamSlug"
                         :presence="presenceOf(item.author.id)"
                         :is-dnd="dndOf(item.author.id)"
@@ -368,6 +369,7 @@ function confirmDelete(): void {
                         <MessageAuthorLine
                             :author="item.author"
                             :author-override="item.authorOverride"
+                            :incoming-webhook="item.incomingWebhook"
                             :team-slug="props.teamSlug"
                             :presence="presenceOf(item.author.id)"
                             :is-dnd="dndOf(item.author.id)"

--- a/resources/js/components/UserHoverCard.test.ts
+++ b/resources/js/components/UserHoverCard.test.ts
@@ -13,10 +13,20 @@ vi.mock('@inertiajs/vue3', () => ({
     usePage: () => ({ props: {} }),
     Link: defineComponent({
         name: 'LinkStub',
+        props: { href: { type: [String, Object], default: '' } },
         setup:
-            (_, { slots }) =>
+            (props, { slots }) =>
             () =>
-                h('a', slots.default?.()),
+                h(
+                    'a',
+                    {
+                        href:
+                            typeof props.href === 'string'
+                                ? props.href
+                                : ((props.href as { url?: string })?.url ?? ''),
+                    },
+                    slots.default?.(),
+                ),
     }),
 }));
 
@@ -99,5 +109,36 @@ describe('the user hover card', () => {
         const host = mount();
 
         expect(host.querySelector('[data-test="hover-card-via"]')).toBeNull();
+    });
+
+    it('names the webhook behind the row and links straight to it', () => {
+        const host = mount({
+            webhook: { id: 'hook-1', name: 'CI alerts' },
+        });
+
+        expect(
+            host.querySelector('[data-test="hover-card-webhook"]')?.textContent,
+        ).toContain('CI alerts');
+
+        const link = host.querySelector(
+            '[data-test="hover-card-webhook-link"]',
+        );
+
+        // The link lands on the integrations page with the offending hook named,
+        // so revoking exactly that credential is the next click.
+        expect(link?.getAttribute('href')).toContain('webhook=hook-1');
+
+        // A link list would otherwise announce a bare "Review" per open card.
+        expect(link?.querySelector('.sr-only')?.textContent).toContain(
+            'Review the CI alerts webhook',
+        );
+    });
+
+    it('names no webhook when the viewer was not told of one', () => {
+        const host = mount();
+
+        expect(
+            host.querySelector('[data-test="hover-card-webhook"]'),
+        ).toBeNull();
     });
 });

--- a/resources/js/components/UserHoverCard.vue
+++ b/resources/js/components/UserHoverCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
-import { AtSign, MessageSquare, Moon, UserRound } from '@lucide/vue';
+import { AtSign, MessageSquare, Moon, UserRound, Webhook } from '@lucide/vue';
 import { computed, ref } from 'vue';
 import PresenceDot from '@/components/PresenceDot.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -18,6 +18,7 @@ import { fetchUserProfile } from '@/composables/useUserProfileCard';
 import { formatLocalTime, formatTimeOfDay } from '@/lib/datetime';
 import { presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
+import { index as integrationsIndex } from '@/routes/teams/integrations';
 import { show } from '@/routes/teams/members';
 import type { UserProfile } from '@/types';
 
@@ -32,6 +33,12 @@ const props = defineProps<{
      * row, where the displayed name already is the account.
      */
     viaName?: string | null;
+    /**
+     * The incoming webhook that produced the row, when the viewer is one of the
+     * people who could revoke it. The server sends it to nobody else, so its mere
+     * presence is the permission — this component adds no check of its own.
+     */
+    webhook?: App.Data.IncomingWebhookSourceData | null;
     /**
      * How the member reads on the team presence roster. Absent on the surfaces
      * that open a card without a roster to hand, which then show no dot at all.
@@ -92,6 +99,16 @@ const statusClearsAt = computed(() =>
     profile.value?.status?.expiresAt
         ? formatTimeOfDay(profile.value.status.expiresAt)
         : null,
+);
+
+/**
+ * The integrations page with the offending hook named, so an admin who arrives
+ * from a suspicious message lands on the row they came to revoke.
+ */
+const webhookHref = computed(() =>
+    integrationsIndex(props.teamSlug, {
+        query: { webhook: props.webhook?.id },
+    }),
 );
 
 function onMention(): void {
@@ -243,6 +260,46 @@ function onMessage(): void {
                         class="shrink-0 font-serif text-[10.5px] text-muted-foreground italic"
                         >{{ $t('until :time', { time: statusClearsAt }) }}</span
                     >
+                </div>
+
+                <!-- Which credential produced the row, for the admins who could
+                     revoke it. Everyone else is never sent one, so nothing here
+                     needs to hide it. -->
+                <div
+                    v-if="webhook"
+                    data-test="hover-card-webhook"
+                    class="flex items-center gap-2.5 rounded-[10px] border border-border bg-muted px-3 py-2"
+                >
+                    <Webhook
+                        class="size-3.5 shrink-0 text-muted-foreground"
+                        aria-hidden="true"
+                    />
+                    <span
+                        class="min-w-0 flex-1 truncate text-xs text-foreground"
+                    >
+                        {{
+                            $t('Posted by the :name webhook', {
+                                name: webhook.name,
+                            })
+                        }}
+                    </span>
+                    <!-- "Review" alone is what a link list would announce, so
+                         the accessible name spells the hook out. Carried as
+                         visually-hidden text rather than an `aria-label`: both
+                         strings stay whole for translation, where a split label
+                         would fix English word order. -->
+                    <Link
+                        :href="webhookHref"
+                        data-test="hover-card-webhook-link"
+                        class="shrink-0 text-xs font-semibold text-brass-fill-foreground underline-offset-2 hover:underline"
+                    >
+                        <span aria-hidden="true">{{ $t('Review') }}</span>
+                        <span class="sr-only">{{
+                            $t('Review the :name webhook', {
+                                name: webhook.name,
+                            })
+                        }}</span>
+                    </Link>
                 </div>
 
                 <div class="space-y-2">

--- a/resources/js/components/integrations/IncomingWebhooksRack.vue
+++ b/resources/js/components/integrations/IncomingWebhooksRack.vue
@@ -10,6 +10,11 @@ defineProps<{
     team: string;
     webhooks: IncomingWebhook[];
     /**
+     * The hook to single out, named by an admin arriving from a message that
+     * this webhook posted. Null on an ordinary visit.
+     */
+    highlightedId?: string | null;
+    /**
      * Whether a hook can be minted at all. A hook posts as a bot, so the
      * workspace needs one before the button does anything.
      */
@@ -58,11 +63,23 @@ defineEmits<{
             {{ $t('No incoming webhooks yet.') }}
         </p>
         <ul v-else class="flex flex-col divide-y divide-border" role="list">
+            <!-- A highlighted row is outlined rather than filled: a brass fill
+                 under it drops its muted sub-line to 4.45:1 in the dark theme,
+                 where a border singles the row out without changing the
+                 background any text sits on. -->
             <li
                 v-for="hook in webhooks"
                 :key="hook.id"
                 class="flex items-center gap-3 py-3"
+                :class="
+                    hook.id === highlightedId
+                        ? 'rounded-lg border border-brass px-3'
+                        : ''
+                "
                 :data-test="`incoming-row-${hook.id}`"
+                :data-highlighted="
+                    hook.id === highlightedId ? 'true' : undefined
+                "
             >
                 <div
                     class="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground"

--- a/resources/js/components/timeline/MessageAuthorLine.vue
+++ b/resources/js/components/timeline/MessageAuthorLine.vue
@@ -15,6 +15,11 @@ const props = defineProps<{
      * name shown here; the bot badge below rides along regardless.
      */
     authorOverride?: AuthorOverride | null;
+    /**
+     * The incoming webhook behind the run, when the viewer is one of the people
+     * who could revoke it. Passed straight to the hover card, which names it.
+     */
+    incomingWebhook?: App.Data.IncomingWebhookSourceData | null;
     teamSlug: string;
     presence: RenderedPresence;
     isDnd: boolean;
@@ -51,6 +56,7 @@ const viaName = computed(() =>
             :user-id="author.id"
             :name="author.name"
             :via-name="viaName"
+            :webhook="incomingWebhook"
             :presence="presence"
             :is-dnd="isDnd"
             @mention="(member) => $emit('mention', member)"

--- a/resources/js/components/timeline/MessageAvatarGutter.vue
+++ b/resources/js/components/timeline/MessageAvatarGutter.vue
@@ -20,6 +20,11 @@ const props = defineProps<{
      * tile's image; the squared-off bot shape rides along regardless.
      */
     authorOverride?: AuthorOverride | null;
+    /**
+     * The incoming webhook behind the run, when the viewer is one of the people
+     * who could revoke it. Passed straight to the hover card, which names it.
+     */
+    incomingWebhook?: App.Data.IncomingWebhookSourceData | null;
     teamSlug: string;
     presence: RenderedPresence;
     isDnd: boolean;
@@ -69,6 +74,7 @@ const viaName = computed(() =>
             :user-id="author.id"
             :name="author.name"
             :via-name="viaName"
+            :webhook="incomingWebhook"
             :presence="presence"
             :is-dnd="isDnd"
             @mention="(member) => $emit('mention', member)"

--- a/resources/js/composables/useMessageStream.test.ts
+++ b/resources/js/composables/useMessageStream.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+import { useMessageStream } from '@/composables/useMessageStream';
+import type { Message } from '@/types';
+
+/**
+ * Covers what a broadcast patch must not destroy. A broadcast carries no viewer
+ * context, so every viewer-scoped field on it is the server default; overlaying
+ * one wholesale would silently strip what the viewer-scoped page load resolved.
+ */
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'Deploy finished',
+        type: 'standard',
+        user: { id: 'bot', name: 'Deploy Bot', isBot: true },
+        createdAt: '2026-07-10T12:00:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        linkPreviews: [],
+        attachments: [],
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    } as unknown as Message;
+}
+
+describe('applyPatch', () => {
+    it('keeps the webhook attribution a viewer-free broadcast cannot carry', () => {
+        const server = ref<Message[]>([
+            message({ incomingWebhook: { id: 'hook-a', name: 'CI alerts' } }),
+        ]);
+        const stream = useMessageStream(server);
+
+        // What an unfurl or an edit broadcasts: the same row, resolved without a
+        // viewer, so it names no webhook.
+        stream.applyPatch(message({ body: 'Deploy finished (edited)' }));
+
+        expect(stream.displayMessages.value[0].body).toBe(
+            'Deploy finished (edited)',
+        );
+        expect(stream.displayMessages.value[0].incomingWebhook?.name).toBe(
+            'CI alerts',
+        );
+    });
+
+    it('leaves an ordinary message without an attribution', () => {
+        const server = ref<Message[]>([message()]);
+        const stream = useMessageStream(server);
+
+        stream.applyPatch(message({ body: 'edited' }));
+
+        expect(
+            stream.displayMessages.value[0].incomingWebhook ?? null,
+        ).toBeNull();
+    });
+});

--- a/resources/js/composables/useMessageStream.ts
+++ b/resources/js/composables/useMessageStream.ts
@@ -118,12 +118,18 @@ export function useMessageStream(
         // viewer context, so its `threadFollowed`/`threadUnread` are always the
         // server defaults. Preserve whatever the client has already derived for
         // this message so a root's dot isn't cleared by its own reply-count bump.
+        //
+        // `incomingWebhook` is viewer-scoped the same way — only an integrations
+        // admin is ever told one — so it is preserved too. Without this, a link
+        // unfurl broadcasting an otherwise unchanged row would quietly strip the
+        // provenance an admin is in the middle of acting on.
         const prior = currentCopy(message.clientUuid);
 
         patches.value.set(message.clientUuid, {
             ...message,
             threadFollowed: prior?.threadFollowed ?? message.threadFollowed,
             threadUnread: prior?.threadUnread ?? message.threadUnread,
+            incomingWebhook: message.incomingWebhook ?? prior?.incomingWebhook,
         });
     }
 

--- a/resources/js/lib/timeline.test.ts
+++ b/resources/js/lib/timeline.test.ts
@@ -110,6 +110,51 @@ describe('buildTimelineItems', () => {
         ).toBeNull();
     });
 
+    it('splits a run when the same bot posts through two different webhooks', () => {
+        const first = message('m1', 'bot', 'Deploy Bot', DAY_1_NOON);
+        const second = message(
+            'm2',
+            'bot',
+            'Deploy Bot',
+            minutesLater(DAY_1_NOON, 1),
+        );
+        first.incomingWebhook = { id: 'hook-a', name: 'CI alerts' };
+        second.incomingWebhook = { id: 'hook-b', name: 'Pager bridge' };
+
+        const groups = buildTimelineItems([first, second], null).filter(
+            (item) => item.type === 'group',
+        );
+
+        // The group header is what names the credential, so a run may never span
+        // two of them — an admin would otherwise revoke on the strength of a name
+        // that speaks for only some of the rows beneath it.
+        expect(groups).toHaveLength(2);
+        expect(
+            groups[0].type === 'group' && groups[0].incomingWebhook?.name,
+        ).toBe('CI alerts');
+        expect(
+            groups[1].type === 'group' && groups[1].incomingWebhook?.name,
+        ).toBe('Pager bridge');
+    });
+
+    it('keeps one group when the same webhook posts twice', () => {
+        const first = message('m1', 'bot', 'Deploy Bot', DAY_1_NOON);
+        const second = message(
+            'm2',
+            'bot',
+            'Deploy Bot',
+            minutesLater(DAY_1_NOON, 1),
+        );
+        first.incomingWebhook = { id: 'hook-a', name: 'CI alerts' };
+        second.incomingWebhook = { id: 'hook-a', name: 'CI alerts' };
+
+        const groups = buildTimelineItems([first, second], null).filter(
+            (item) => item.type === 'group',
+        );
+
+        expect(groups).toHaveLength(1);
+    });
+
     it('starts a new group when the author changes', () => {
         const items = buildTimelineItems(
             [

--- a/resources/js/lib/timeline.ts
+++ b/resources/js/lib/timeline.ts
@@ -23,6 +23,12 @@ export type TimelineGroup = {
      * defines the run: one bot posting as two logical sources gets two groups.
      */
     authorOverride: AuthorOverride | null;
+    /**
+     * The incoming webhook behind the run, for the viewers the server told. Also
+     * part of what defines the run: the header's hover card names this credential
+     * on behalf of every row beneath it, so a run may never span two of them.
+     */
+    incomingWebhook: App.Data.IncomingWebhookSourceData | null;
     leadCreatedAt: string;
     messages: Message[];
 };
@@ -134,12 +140,15 @@ export function buildTimelineItems(
             });
         }
 
-        // Same account *and* same displayed identity: a webhook posting as two
-        // logical sources must not collapse them under one name and avatar.
+        // Same account, same displayed identity *and* same credential: a webhook
+        // posting as two logical sources must not collapse them under one name
+        // and avatar, and two webhooks must not collapse under one provenance.
         const sameAuthor =
             currentGroup?.author.id === message.user.id &&
             authorOverrideKey(currentGroup?.authorOverride) ===
-                authorOverrideKey(message.authorOverride);
+                authorOverrideKey(message.authorOverride) &&
+            (currentGroup?.incomingWebhook?.id ?? null) ===
+                (message.incomingWebhook?.id ?? null);
         const withinWindow =
             lastCreatedAt !== null &&
             new Date(message.createdAt).getTime() -
@@ -158,6 +167,7 @@ export function buildTimelineItems(
                 key: `group-${message.id}`,
                 author: message.user,
                 authorOverride: message.authorOverride ?? null,
+                incomingWebhook: message.incomingWebhook ?? null,
                 leadCreatedAt: message.createdAt,
                 messages: [message],
             };

--- a/resources/js/pages/teams/integrations/Index.incoming.test.ts
+++ b/resources/js/pages/teams/integrations/Index.incoming.test.ts
@@ -27,6 +27,7 @@ type RecordedPost = {
 
 const inertia = vi.hoisted(() => ({
     pageProps: { auth: { user: { id: 'me', timezone: 'UTC' } } },
+    url: '/settings/teams/acme/integrations',
     forms: [] as RecordedForm[],
     posts: [] as RecordedPost[],
 }));
@@ -54,7 +55,7 @@ vi.mock('@inertiajs/vue3', async () => {
                     ),
         }),
         router: { patch: () => {} },
-        usePage: () => ({ props: inertia.pageProps }),
+        usePage: () => ({ props: inertia.pageProps, url: inertia.url }),
         useForm: (initial: Record<string, unknown>) => {
             const fields = Object.keys(initial);
             const form = reactive({
@@ -245,6 +246,7 @@ async function openDialog(host: HTMLElement): Promise<HTMLElement> {
 beforeEach(() => {
     inertia.forms = [];
     inertia.posts = [];
+    inertia.url = '/settings/teams/acme/integrations';
 });
 
 afterEach(() => {
@@ -273,6 +275,27 @@ describe('the incoming webhooks rack', () => {
         );
         expect(text(host, 'incoming-row-w1')).toContain('Active');
         expect(host.querySelector('[data-test="incoming-empty"]')).toBeNull();
+    });
+
+    it('singles out the hook a message sent the admin here to revoke', () => {
+        inertia.url = '/settings/teams/acme/integrations?webhook=w2';
+
+        const host = mount({
+            incomingWebhooks: [webhook(), webhook({ id: 'w2' })],
+        });
+
+        expect(find(host, 'incoming-row-w2')?.dataset.highlighted).toBe('true');
+        expect(
+            find(host, 'incoming-row-w1')?.dataset.highlighted,
+        ).toBeUndefined();
+    });
+
+    it('singles out nothing when the page was opened on its own', () => {
+        const host = mount({ incomingWebhooks: [webhook()] });
+
+        expect(
+            find(host, 'incoming-row-w1')?.dataset.highlighted,
+        ).toBeUndefined();
     });
 
     it('hands each row its own revoke control, scoped to the team', () => {

--- a/resources/js/pages/teams/integrations/Index.vue
+++ b/resources/js/pages/teams/integrations/Index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { Head } from '@inertiajs/vue3';
+import { Head, usePage } from '@inertiajs/vue3';
 import { ExternalLink } from '@lucide/vue';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import BotsRack from '@/components/integrations/BotsRack.vue';
 import IncomingWebhooksRack from '@/components/integrations/IncomingWebhooksRack.vue';
 import NewBotDialog from '@/components/integrations/NewBotDialog.vue';
@@ -44,6 +44,24 @@ defineOptions({
 });
 
 const DOCS_URL = 'https://docs.thedeskhq.app/reference/api/';
+
+/**
+ * Inertia's `page.url` is a root-relative path, which `URL` cannot parse on its
+ * own. The base below only satisfies that constructor and never reaches the
+ * result.
+ */
+const URL_BASE = 'http://localhost';
+
+const page = usePage();
+
+/**
+ * The hook an admin arrived here to act on, named by `?webhook=` on the link a
+ * message's provenance card offers. Null on an ordinary visit, which singles out
+ * nothing.
+ */
+const highlightedWebhookId = computed(() =>
+    new URL(page.url, URL_BASE).searchParams.get('webhook'),
+);
 
 const showBotDialog = ref(false);
 const showIncomingDialog = ref(false);
@@ -92,6 +110,7 @@ const showOutgoingDialog = ref(false);
         <IncomingWebhooksRack
             :team="team.slug"
             :webhooks="incomingWebhooks"
+            :highlighted-id="highlightedWebhookId"
             :can-create="bots.length > 0"
             @create="showIncomingDialog = true"
         />

--- a/resources/js/types/messages.ts
+++ b/resources/js/types/messages.ts
@@ -220,6 +220,13 @@ export type Message = {
      * one, which is built client-side under the sender's own identity.
      */
     authorOverride?: AuthorOverride | null;
+    /**
+     * The incoming webhook that produced this message (mirrors the `MessageData`
+     * DTO's `incomingWebhook`), for the viewers who could revoke it. Null on
+     * every ordinary message, null for a viewer who cannot manage the team's
+     * integrations, and absent on an optimistic one.
+     */
+    incomingWebhook?: App.Data.IncomingWebhookSourceData | null;
     createdAt: string;
     editedAt: string | null;
     isDeleted: boolean;

--- a/tests/Feature/Integrations/IncomingWebhookIngestTest.php
+++ b/tests/Feature/Integrations/IncomingWebhookIngestTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Actions\Integrations\RevokeIncomingWebhook;
 use App\Events\MessageSent;
 use App\Models\Channel;
 use App\Models\IncomingWebhook;
@@ -324,6 +325,32 @@ it('keeps the snapshot after the webhook is revoked and its bot renamed', functi
     $message = Message::query()->where('channel_id', $webhook->channel_id)->sole();
 
     expect($message->author_override_name)->toBe('Release Train');
+});
+
+it('records which webhook produced the message', function (): void {
+    [$webhook, $token] = makeWebhook();
+
+    $this->postJson("/webhooks/incoming/{$token}", ['text' => 'Deploy finished'])
+        ->assertStatus(202);
+
+    $message = Message::query()->where('channel_id', $webhook->channel_id)->sole();
+
+    expect($message->incoming_webhook_id)->toBe($webhook->id);
+});
+
+it('keeps a webhook message after its webhook is revoked', function (): void {
+    [$webhook, $token] = makeWebhook();
+
+    $this->postJson("/webhooks/incoming/{$token}", ['text' => 'Deploy finished'])
+        ->assertStatus(202);
+
+    app(RevokeIncomingWebhook::class)->handle($webhook->bot, $webhook);
+
+    $message = Message::query()->where('channel_id', $webhook->channel_id)->sole();
+
+    // Revocation is an audit event, not a retraction: the row keeps pointing at
+    // the credential that produced it so the trail survives the revoke.
+    expect($message->incoming_webhook_id)->toBe($webhook->id);
 });
 
 it('throttles each webhook token independently, not by shared IP', function (): void {

--- a/tests/Feature/Integrations/MessageWebhookSourceTest.php
+++ b/tests/Feature/Integrations/MessageWebhookSourceTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\IncomingWebhook;
+use App\Models\Message;
+use App\Models\Team;
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/**
+ * A channel holding one message posted through an incoming webhook, plus an
+ * integrations admin and an ordinary member who can both read it.
+ *
+ * @return array{team: Team, channel: Channel, webhook: IncomingWebhook, admin: User, member: User}
+ */
+function webhookSourcedMessage(): array
+{
+    $team = Team::factory()->create();
+    $admin = User::factory()->create();
+    $member = User::factory()->create();
+    $team->members()->attach($admin, ['role' => TeamRole::Admin->value]);
+    $team->members()->attach($member, ['role' => TeamRole::Member->value]);
+
+    $bot = User::factory()->bot($team)->create(['name' => 'Deploy Bot']);
+    $channel = Channel::factory()->for($team)->create(['name' => 'ops']);
+    $channel->channelMembers()->create(['user_id' => $bot->id]);
+    $channel->channelMembers()->create(['user_id' => $admin->id]);
+    $channel->channelMembers()->create(['user_id' => $member->id]);
+
+    $webhook = IncomingWebhook::factory()
+        ->for($team)->for($channel)->for($bot, 'bot')
+        ->create(['name' => 'CI alerts']);
+
+    Message::factory()->for($channel)->for($bot, 'user')->create([
+        'body' => 'Deploy finished',
+        'incoming_webhook_id' => $webhook->id,
+    ]);
+
+    return ['team' => $team, 'channel' => $channel, 'webhook' => $webhook, 'admin' => $admin, 'member' => $member];
+}
+
+/**
+ * Open the channel as the given viewer and hand back the timeline assertion.
+ */
+function visitChannelAs(User $viewer, Team $team, Channel $channel): Assert
+{
+    $page = null;
+
+    test()->actingAs($viewer)
+        ->get(route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]))
+        ->assertOk()
+        ->assertInertia(function (Assert $assertable) use (&$page): void {
+            $page = $assertable;
+        });
+
+    return $page;
+}
+
+it('names the webhook that produced a message for an integrations admin', function (): void {
+    ['team' => $team, 'channel' => $channel, 'webhook' => $webhook, 'admin' => $admin] = webhookSourcedMessage();
+
+    visitChannelAs($admin, $team, $channel)
+        ->where('messages.data.0.incomingWebhook.id', $webhook->id)
+        ->where('messages.data.0.incomingWebhook.name', 'CI alerts');
+});
+
+it('withholds the webhook name from a viewer who cannot manage integrations', function (): void {
+    ['team' => $team, 'channel' => $channel, 'member' => $member] = webhookSourcedMessage();
+
+    // A webhook's name is admin-authored and routinely carries operational
+    // detail, so it reaches only the people who could act on it.
+    visitChannelAs($member, $team, $channel)
+        ->where('messages.data.0.incomingWebhook', null);
+});
+
+it('carries no webhook source on an ordinary human message', function (): void {
+    ['team' => $team, 'channel' => $channel, 'admin' => $admin] = webhookSourcedMessage();
+
+    Message::factory()->for($channel)->for($admin, 'user')->create(['body' => 'Nice one']);
+
+    visitChannelAs($admin, $team, $channel)
+        ->where('messages.data.0.body', 'Nice one')
+        ->where('messages.data.0.incomingWebhook', null);
+});


### PR DESCRIPTION
Closes #1061.

## What

A bot holds one incoming webhook per `(bot, channel)` pair, so naming the author of a suspicious message told an admin which bot to distrust but not which credential to revoke. Revocation was not targetable at the granularity the credential is issued at.

Messages now record the webhook that produced them, and a workspace admin can trace a row back to that hook and revoke exactly it.

## How

**Storage.** `messages.incoming_webhook_id`, nullable and `nullOnDelete` so deleting a webhook never cascades into message history. Set by `Webhooks\IncomingWebhookController` on the ingest path only — null on human sends, the REST API, and system messages.

**Exposure is admin-gated.** A webhook's name is admin-authored and routinely spells out operational detail, so it is not on every message payload. `MessageData` gains a nullable `incomingWebhook` (`IncomingWebhookSourceData`: id + name), populated only when `fromMessage()` is asked for it. `ChannelTimelineWindow` resolves the `manageIntegrations` gate **once per page** and passes the answer down, so it is one gate check per request rather than one per row. Every other caller — broadcasts, search, edits, posts — leaves the flag false, so the name never reaches a client that has not been checked for it.

**The affordance.** The hover card's existing provenance block (from #389) gains a line naming the hook plus a **Review** link to the integrations page with `?webhook=<id>`, which outlines that row ready to revoke.

**Grouping.** A timeline run now splits when the credential changes. The group header's hover card names the hook on behalf of every row beneath it, so a run may never span two of them — otherwise an admin would revoke on the strength of a header that speaks for only some of the rows.

## Decisions carried from the issue

- **No backfill.** Existing webhook messages stay null. Guessing from `user_id` + `channel_id` is wrong precisely for the multi-hook bot that motivates the column, and fabricated provenance is worse than none in an incident.
- **REST API v1 `token_id` is out of scope** — same class of problem, different credential and auth model. Filed as #1085.
- Search results do not carry the attribution; the affordance lives on the timeline a search result links into.

## Notable during implementation

- **A broadcast could silently strip the attribution.** A link unfurl broadcasts `MessageUpdated` for any message containing a URL, and `applyPatch` overlays that viewer-free copy wholesale — erasing the provenance an admin was mid-way through acting on. It already preserves `threadFollowed`/`threadUnread` for exactly this reason; `incomingWebhook` now joins them, with a regression test.
- **Live-arriving webhook messages carry no attribution until reload**, since broadcasts are viewer-free by design (the same limitation `threadFollowed` lives with). Such a row gets its own group header rather than inheriting one that names a hook it cannot vouch for — the fail-closed direction.

## Accessibility

- Highlighting the target row with a brass fill dropped its muted sub-line to 4.45:1 in the dark theme, under AA. The highlight is a border instead, so no text sits on a changed background (light 5.83:1, dark 5.70:1, both unchanged). The hover-card link is 6.26:1 light / 7.71:1 dark.
- The **Review** link carries its accessible name as visually-hidden text rather than `aria-label`: the lint rule cannot tell `<Link>` renders an `<a>`, and it keeps both translation strings whole rather than fixing English word order.

## Testing

- `IncomingWebhookIngestTest` — ingest stamps the hook; a revoked webhook leaves its past messages intact. All 34 pre-existing ingest tests pass **unmodified**.
- `MessageWebhookSourceTest` — an integrations admin is told the hook, an ordinary member is not, and a human message carries none.
- Vitest — hover-card affordance and accessible name, grouping splits per credential, and the broadcast-patch preservation.
- Backend gate green at 100% coverage (3099 tests); lint, format, types, build and the 2388-test Vitest suite green.

## i18n + docs

- New keys `Posted by the :name webhook`, `Review`, `Review the :name webhook`, each with its `lang/fr.json` translation.
- `docs/src/content/docs/reference/incoming-webhooks.md` gains a *Tracing a message back to its webhook* section, including the two honest limits (no retroactive attribution, revocation preserves the trail).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788040339&installation_model_id=428379&pr_number=1087&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1087&signature=61182d398a7202a83843ecdb47c86761cf3bed56d74580999d47957a204df551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->