### PR TITLE
feat: cap workspace upload storage with a configurable quota

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,9 @@ ATTACHMENT_PENDING_TTL_HOURS=24
 # The private disk attachments are stored on. Defaults to the local disk; point
 # it at a configured S3 disk to store files in a bucket instead.
 # ATTACHMENT_DISK=local
+# Total upload storage each workspace may occupy, in megabytes. 0 (the default)
+# means unlimited; set a value to cap how far a workspace can grow your disk.
+STORAGE_QUOTA_MB=0
 
 # How long a per-user security event (sign-in, credential change, session
 # revocation, data-export activity) is kept before the daily sweep deletes it.

--- a/app/Data/TeamStorageData.php
+++ b/app/Data/TeamStorageData.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+use Spatie\LaravelData\Data;
+use Spatie\TypeScriptTransformer\Attributes\TypeScript;
+
+/**
+ * A workspace's storage footprint against its configured quota. Only built while
+ * the quota is on, so `quotaBytes` is always positive and `percent` always has a
+ * denominator; it is uncapped, so an instance whose quota was lowered below its
+ * existing usage reports the real overshoot rather than a flat 100%.
+ */
+#[TypeScript]
+class TeamStorageData extends Data
+{
+    public function __construct(
+        public int $usedBytes,
+        public int $quotaBytes,
+        public int $percent,
+    ) {}
+}

--- a/app/Http/Controllers/Teams/AnalyticsController.php
+++ b/app/Http/Controllers/Teams/AnalyticsController.php
@@ -6,16 +6,21 @@ use App\Enums\AnalyticsRange;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\ViewAnalyticsRequest;
 use App\Models\Team;
+use App\Support\TeamStorage;
 use App\Support\WorkspaceAnalytics;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class AnalyticsController extends Controller
 {
-    public function __construct(private readonly WorkspaceAnalytics $analytics) {}
+    public function __construct(private readonly WorkspaceAnalytics $analytics, private readonly TeamStorage $storage) {}
 
     /**
      * Show the workspace analytics dashboard for the selected time window.
+     *
+     * The storage read-out rides alongside the cached analytics snapshot rather
+     * than inside it: usage moves with every upload and delete, so it is read
+     * fresh on each view. It is null while no quota is configured.
      */
     public function index(ViewAnalyticsRequest $request, Team $team): Response
     {
@@ -28,6 +33,7 @@ class AnalyticsController extends Controller
                 'slug' => $team->slug,
             ],
             'analytics' => $this->analytics->for($team, $range),
+            'storage' => $this->storage->usage($team),
             'range' => $range->value,
             'rangeOptions' => AnalyticsRange::options(),
         ]);

--- a/app/Http/Requests/Channels/StoreAttachmentRequest.php
+++ b/app/Http/Requests/Channels/StoreAttachmentRequest.php
@@ -3,7 +3,10 @@
 namespace App\Http\Requests\Channels;
 
 use App\Models\Channel;
+use App\Models\Team;
 use App\Rules\NotExecutableFile;
+use App\Rules\WithinStorageQuota;
+use App\Support\TeamStorage;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
@@ -27,7 +30,8 @@ class StoreAttachmentRequest extends FormRequest
      * Any type is accepted by default (arbitrary-file download is a goal), capped
      * at the configured per-file size and rejecting the executable denylist. SVG
      * is accepted but never rendered inline (the serve route forces it to
-     * download).
+     * download). The workspace storage quota is checked here too, so an upload
+     * that would cross it is refused before any blob is written.
      *
      * @return array<string, ValidationRule|array<mixed>|string>
      */
@@ -39,6 +43,7 @@ class StoreAttachmentRequest extends FormRequest
                 'file',
                 'max:'.((int) config('attachments.max_size_mb') * 1024),
                 new NotExecutableFile,
+                new WithinStorageQuota($this->team(), app(TeamStorage::class)),
             ],
         ];
     }
@@ -66,5 +71,18 @@ class StoreAttachmentRequest extends FormRequest
         abort_if(! $channel instanceof Channel, 404);
 
         return $channel;
+    }
+
+    /**
+     * Get the workspace the attachment is being uploaded to. Read off the route
+     * (the channel is scope-bound to it) so the quota check costs no extra query.
+     */
+    public function team(): Team
+    {
+        $team = $this->route('team');
+
+        abort_if(! $team instanceof Team, 404);
+
+        return $team;
     }
 }

--- a/app/Rules/WithinStorageQuota.php
+++ b/app/Rules/WithinStorageQuota.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\Team;
+use App\Support\TeamStorage;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+class WithinStorageQuota implements ValidationRule
+{
+    public function __construct(private readonly Team $team, private readonly TeamStorage $storage) {}
+
+    /**
+     * Reject an upload that would push the workspace past its storage quota.
+     *
+     * Checked at validation time, before the blob is written, so a refused upload
+     * leaves nothing on disk for the orphan sweep to reclaim. The check is
+     * inherently racy under concurrent uploads — two requests can both read the
+     * same usage — which is accepted: the quota is an operator's capacity guard,
+     * not a billing boundary, and the overshoot is bounded by one file.
+     *
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $value instanceof UploadedFile) {
+            return;
+        }
+
+        if ($this->storage->wouldExceedQuota($this->team, $value->getSize())) {
+            $fail(__('This upload would exceed the workspace storage limit of :size MB. Delete some files to free up space.', [
+                'size' => (int) config('attachments.storage_quota_mb'),
+            ]));
+        }
+    }
+}

--- a/app/Support/TeamStorage.php
+++ b/app/Support/TeamStorage.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Data\TeamStorageData;
+use App\Enums\AttachmentSource;
+use App\Models\Attachment;
+use App\Models\Channel;
+use App\Models\Team;
+
+/**
+ * A workspace's storage accounting: how many bytes its uploads occupy on the
+ * operator's disk, and whether the configured quota still has room.
+ *
+ * Usage is computed live rather than tracked in a counter column, so there is no
+ * dual-write across the create/force-delete/purge paths and no drift to repair.
+ * It equals the real disk footprint by construction: a force-deleted attachment
+ * has no row (its blob is gone), while a soft-deleted one keeps its row (its blob
+ * is retained), so reading trashed rows too counts exactly what is on disk.
+ */
+class TeamStorage
+{
+    /**
+     * Bytes in a megabyte, the unit the quota is configured in.
+     */
+    private const int BYTES_PER_MEGABYTE = 1024 * 1024;
+
+    /**
+     * The configured quota in bytes, or `0` when the feature is off.
+     */
+    public function quotaBytes(): int
+    {
+        return max(0, (int) config('attachments.storage_quota_mb')) * self::BYTES_PER_MEGABYTE;
+    }
+
+    /**
+     * Whether a quota is configured at all. Unset (or `0`) leaves every workspace
+     * unlimited, which is the default for a self-hosted instance.
+     */
+    public function enabled(): bool
+    {
+        return $this->quotaBytes() > 0;
+    }
+
+    /**
+     * The bytes the team's uploads occupy on the configured disk.
+     *
+     * Counts pending and claimed attachments alike — a staged file already sits on
+     * disk, so leaving unsent uploads out would let anyone stage their way past
+     * the quota. Giphy attachments are excluded: they are hotlinked CDN URLs with
+     * no blob of the operator's to reclaim.
+     */
+    public function usedBytes(Team $team): int
+    {
+        return (int) Attachment::withTrashed()
+            ->where('source', AttachmentSource::Upload)
+            ->whereIn('channel_id', Channel::query()->where('team_id', $team->id)->select('id'))
+            ->sum('size_bytes');
+    }
+
+    /**
+     * Whether storing another `$bytes` for this team would cross its quota. Always
+     * false while the feature is off.
+     */
+    public function wouldExceedQuota(Team $team, int $bytes): bool
+    {
+        $quota = $this->quotaBytes();
+
+        if ($quota === 0) {
+            return false;
+        }
+
+        return $this->usedBytes($team) + $bytes > $quota;
+    }
+
+    /**
+     * The team's usage read-out for the analytics dashboard, or null while the
+     * feature is off — there is no quota to measure against, so nothing is shown.
+     */
+    public function usage(Team $team): ?TeamStorageData
+    {
+        $quota = $this->quotaBytes();
+
+        if ($quota === 0) {
+            return null;
+        }
+
+        $used = $this->usedBytes($team);
+
+        return new TeamStorageData(
+            usedBytes: $used,
+            quotaBytes: $quota,
+            percent: (int) round($used / $quota * 100),
+        );
+    }
+}

--- a/config/attachments.php
+++ b/config/attachments.php
@@ -31,6 +31,14 @@ return [
     'pending_ttl_hours' => (int) env('ATTACHMENT_PENDING_TTL_HOURS', 24),
 
     /*
+    | The total storage each workspace's uploads may occupy, in megabytes. Applies
+    | uniformly to every team, personal ones included, and is enforced before a
+    | file is written so an over-quota upload leaves nothing behind. `0` (the
+    | default) means unlimited — the feature is off and no usage is computed.
+    */
+    'storage_quota_mb' => (int) env('STORAGE_QUOTA_MB', 0),
+
+    /*
     | The filesystem disk attachments live on. Private by default (not the
     | `public` disk custom emoji uses) because message attachments belong to
     | private channels — a guessable, auth-free URL would leak them. Files are

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -325,6 +325,7 @@ Files and images members attach to messages.
 | `ATTACHMENT_DISK`              | `local` | Private disk files are stored on. Point at a configured S3 disk for bucket storage. |
 | `ATTACHMENT_IMAGE_DRIVER`      | `imagick` | Image library used to strip EXIF metadata and build thumbnails: `imagick` or `gd`. |
 | `ATTACHMENT_THUMBNAIL_MAX_PX`  | `720`   | Longest edge, in pixels, of a generated image thumbnail. Images are only scaled down. |
+| `STORAGE_QUOTA_MB`             | `0`     | Total upload storage each workspace may occupy, in megabytes. `0` means unlimited. |
 
 :::note[Image processing needs a PHP image extension]
 Uploaded images have their EXIF metadata stripped (so photo GPS never leaks) and a thumbnail

--- a/docs/src/content/docs/reference/feature-toggles.md
+++ b/docs/src/content/docs/reference/feature-toggles.md
@@ -505,6 +505,42 @@ close endpoints return **404**. Existing poll messages render their last-known
 tally read-only. See
 [Environment variables → Feature toggles](/reference/environment-variables/#feature-toggles).
 
+## Workspace storage quota
+
+| Variable           | Default | Effect                                                     |
+| ------------------ | ------- | ---------------------------------------------------------- |
+| `STORAGE_QUOTA_MB` | `0`     | Caps the upload storage each workspace may occupy, in megabytes. |
+
+Storage is **unlimited** by default: `0` (or leaving the variable unset) turns
+the feature off entirely, and nothing is measured. Set a value in megabytes to
+cap how far a workspace can grow your disk — `STORAGE_QUOTA_MB=5000` gives every
+workspace 5 GB.
+
+The cap applies **uniformly to every workspace**, personal ones included: it is
+one instance-wide value, not a per-team setting. Enforcement is a hard block
+checked **before** the file is written, so an upload that would cross the quota is
+refused with an error in the composer and leaves nothing on disk.
+
+What counts toward the quota is exactly what sits on your disk:
+
+- **Uploaded files count**, whether they are already sent or still staged in a
+  composer — a pending upload occupies disk just like a sent one.
+- **Deleted messages keep counting** until their attachments are permanently
+  removed. A deleted message's files are retained (they are recoverable), so the
+  bytes are still yours; they are released once the row is purged for good.
+- **GIFs from the [Giphy picker](#gif-picker-giphy) do not count.** They are
+  hotlinked from Giphy's CDN and store no file of yours.
+
+Admins and the workspace owner see the workspace's usage — used, quota, and
+percentage — on the workspace **Analytics** dashboard. With no quota configured
+the read-out is absent, since there is nothing to measure against.
+
+:::note
+There is no per-workspace override yet, and no notification when a workspace
+nears its limit. Raising the value takes effect immediately for everyone: it is
+read at runtime, so a restart is all that is needed.
+:::
+
 ## "Powered by The Desk" attribution
 
 | Variable               | Default | Effect                                       |

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1478,5 +1478,13 @@
   "Always": "Toujours",
   "Make :channel a default channel": "Faire de :channel un canal par défaut",
   "Channel-creation policy changed": "Règle de création de canaux modifiée",
-  "Changed the %s channel-creation policy from “%s” to “%s”": "A modifié la règle de création des canaux %s de « %s » à « %s »"
+  "Changed the %s channel-creation policy from “%s” to “%s”": "A modifié la règle de création des canaux %s de « %s » à « %s »",
+  "Storage": "Stockage",
+  "Storage used": "Stockage utilisé",
+  "uploads across this workspace": "fichiers importés dans cet espace de travail",
+  ":percent% used": ":percent % utilisé",
+  ":used of :quota": ":used sur :quota",
+  ":size free": ":size disponible",
+  ":size over the limit": ":size au-delà de la limite",
+  "This upload would exceed the workspace storage limit of :size MB. Delete some files to free up space.": "Cet envoi dépasserait la limite de stockage de :size Mo de l’espace de travail. Supprimez des fichiers pour libérer de l’espace."
 }

--- a/resources/js/components/analytics/StorageUsageCard.vue
+++ b/resources/js/components/analytics/StorageUsageCard.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storageReadout } from '@/lib/storageUsage';
+import type { TeamStorage } from '@/types';
+
+type Props = {
+    storage: TeamStorage;
+};
+
+const props = defineProps<Props>();
+
+const readout = computed(() => storageReadout(props.storage));
+</script>
+
+<template>
+    <section
+        class="rounded-xl border border-border bg-card p-5 shadow-[0_2px_8px_rgba(29,26,21,0.05)]"
+        data-test="analytics-storage"
+    >
+        <div class="mb-4 flex items-baseline gap-2.5">
+            <h3 class="text-sm font-semibold">{{ $t('Storage') }}</h3>
+            <span class="text-xs text-muted-foreground">{{
+                $t('uploads across this workspace')
+            }}</span>
+            <span
+                class="ml-auto text-xs font-medium tabular-nums"
+                :class="readout.toneClass"
+                data-test="analytics-storage-percent"
+            >
+                {{ readout.percentText }}
+            </span>
+        </div>
+
+        <div
+            class="h-1.5 overflow-hidden rounded-full bg-muted"
+            role="progressbar"
+            :aria-label="$t('Storage used')"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-valuenow="readout.barPercent"
+            :aria-valuetext="readout.sizeText"
+        >
+            <div
+                class="h-full rounded-full"
+                :style="{
+                    width: `${readout.barPercent}%`,
+                    background: readout.barColor,
+                }"
+            ></div>
+        </div>
+
+        <div class="mt-2 flex items-baseline gap-2 text-xs">
+            <span
+                class="text-muted-foreground tabular-nums"
+                data-test="analytics-storage-size"
+            >
+                {{ readout.sizeText }}
+            </span>
+            <span
+                class="ml-auto tabular-nums"
+                :class="readout.toneClass"
+                data-test="analytics-storage-remaining"
+            >
+                {{ readout.remainingText }}
+            </span>
+        </div>
+    </section>
+</template>

--- a/resources/js/lib/storageUsage.test.ts
+++ b/resources/js/lib/storageUsage.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { storageReadout } from '@/lib/storageUsage';
+import type { TeamStorage } from '@/types';
+
+/**
+ * The workspace storage read-out, away from the markup that renders it: the
+ * copy each usage level produces, the tone that pairs with it, and the clamping
+ * the bar needs once the quota is overshot.
+ */
+const MEGABYTE = 1024 * 1024;
+
+function storage(overrides: Partial<TeamStorage> = {}): TeamStorage {
+    return {
+        usedBytes: MEGABYTE,
+        quotaBytes: 4 * MEGABYTE,
+        percent: 25,
+        ...overrides,
+    };
+}
+
+describe('the read-out copy', () => {
+    it('states the percent, the raw sizes and the space left', () => {
+        const readout = storageReadout(storage());
+
+        expect(readout.percentText).toBe('25% used');
+        expect(readout.sizeText).toBe('1 MB of 4 MB');
+        expect(readout.remainingText).toBe('3 MB free');
+    });
+
+    it('reports the overshoot once the quota is already spent', () => {
+        const readout = storageReadout(
+            storage({ usedBytes: 6 * MEGABYTE, percent: 150 }),
+        );
+
+        expect(readout.percentText).toBe('150% used');
+        expect(readout.remainingText).toBe('2 MB over the limit');
+    });
+
+    it('reads a full-to-the-byte workspace as having no space left', () => {
+        const readout = storageReadout(
+            storage({ usedBytes: 4 * MEGABYTE, percent: 100 }),
+        );
+
+        expect(readout.remainingText).toBe('0 B free');
+    });
+});
+
+describe('the bar', () => {
+    it('draws the percent consumed while there is room', () => {
+        expect(storageReadout(storage()).barPercent).toBe(25);
+    });
+
+    it('clamps an overshoot to a full bar', () => {
+        expect(
+            storageReadout(storage({ usedBytes: 9 * MEGABYTE, percent: 225 }))
+                .barPercent,
+        ).toBe(100);
+    });
+});
+
+describe('the tone', () => {
+    it('stays muted while the workspace has room to spare', () => {
+        const readout = storageReadout(storage());
+
+        expect(readout.toneClass).toBe('text-muted-foreground');
+        expect(readout.barColor).toBe('var(--chart-1)');
+    });
+
+    it('warns once the workspace is filling up', () => {
+        const readout = storageReadout(
+            storage({ usedBytes: 3.4 * MEGABYTE, percent: 85 }),
+        );
+
+        expect(readout.toneClass).toBe('text-amber-700 dark:text-amber-500');
+        expect(readout.barColor).toBe('var(--chart-2)');
+    });
+
+    it('turns destructive once the quota is spent', () => {
+        const readout = storageReadout(
+            storage({ usedBytes: 4 * MEGABYTE, percent: 100 }),
+        );
+
+        expect(readout.toneClass).toBe('text-destructive-text');
+        expect(readout.barColor).toBe('var(--destructive)');
+    });
+});

--- a/resources/js/lib/storageUsage.ts
+++ b/resources/js/lib/storageUsage.ts
@@ -1,5 +1,6 @@
 import { formatFileSize } from '@/lib/attachments';
 import { translate } from '@/lib/i18n';
+import { formatNumber } from '@/lib/numbers';
 import type { TeamStorage } from '@/types/teams';
 
 /** The share of the quota at which the read-out starts warning. */
@@ -34,7 +35,9 @@ export function storageReadout(storage: TeamStorage): StorageReadout {
         barPercent: Math.min(100, Math.max(0, percent)),
         toneClass: toneClass(percent),
         barColor: barColor(percent),
-        percentText: translate(':percent% used', { percent }),
+        percentText: translate(':percent% used', {
+            percent: formatNumber(percent),
+        }),
         sizeText: translate(':used of :quota', {
             used: formatFileSize(usedBytes),
             quota: formatFileSize(quotaBytes),

--- a/resources/js/lib/storageUsage.ts
+++ b/resources/js/lib/storageUsage.ts
@@ -1,0 +1,78 @@
+import { formatFileSize } from '@/lib/attachments';
+import { translate } from '@/lib/i18n';
+import type { TeamStorage } from '@/types/teams';
+
+/** The share of the quota at which the read-out starts warning. */
+const WARN_PERCENT = 80;
+
+/** The storage read-out, already formatted for display. */
+export type StorageReadout = {
+    /** The percent consumed, clamped to what the bar can draw. */
+    barPercent: number;
+    /** Tailwind tone for the percent and remainder lines. */
+    toneClass: string;
+    /** The bar fill, deepening as the workspace fills up. */
+    barColor: string;
+    /** "25% used" — the headline figure, uncapped. */
+    percentText: string;
+    /** "1 MB of 4 MB" — the raw sizes behind the percentage. */
+    sizeText: string;
+    /** "3 MB free", or how far past the quota the workspace already is. */
+    remainingText: string;
+};
+
+/**
+ * Map a workspace's storage usage onto its display copy and tone. Reads the
+ * reactive catalog through `translate`, so a caller computing this re-runs when
+ * the language is switched.
+ */
+export function storageReadout(storage: TeamStorage): StorageReadout {
+    const { usedBytes, quotaBytes, percent } = storage;
+    const overspill = usedBytes - quotaBytes;
+
+    return {
+        barPercent: Math.min(100, Math.max(0, percent)),
+        toneClass: toneClass(percent),
+        barColor: barColor(percent),
+        percentText: translate(':percent% used', { percent }),
+        sizeText: translate(':used of :quota', {
+            used: formatFileSize(usedBytes),
+            quota: formatFileSize(quotaBytes),
+        }),
+        remainingText:
+            overspill > 0
+                ? translate(':size over the limit', {
+                      size: formatFileSize(overspill),
+                  })
+                : translate(':size free', {
+                      size: formatFileSize(Math.abs(overspill)),
+                  }),
+    };
+}
+
+/**
+ * Tailwind tone for the read-out: muted with room to spare, amber once the
+ * workspace is filling up, and the destructive text token once it is full.
+ */
+function toneClass(percent: number): string {
+    if (percent >= 100) {
+        return 'text-destructive-text';
+    }
+
+    return percent >= WARN_PERCENT
+        ? 'text-amber-700 dark:text-amber-500'
+        : 'text-muted-foreground';
+}
+
+/**
+ * The bar fill for a usage level, drawn from the chart palette so it sits with
+ * the rest of the dashboard, and switching to the destructive token once the
+ * quota is spent.
+ */
+function barColor(percent: number): string {
+    if (percent >= 100) {
+        return 'var(--destructive)';
+    }
+
+    return percent >= WARN_PERCENT ? 'var(--chart-2)' : 'var(--chart-1)';
+}

--- a/resources/js/pages/teams/Analytics.tiles.test.ts
+++ b/resources/js/pages/teams/Analytics.tiles.test.ts
@@ -348,3 +348,53 @@ describe('the stat tiles', () => {
         ).toBeNull();
     });
 });
+
+describe('the storage read-out', () => {
+    it('stays off the page while no workspace quota is configured', () => {
+        expect(find(mount(), 'analytics-storage')).toBeNull();
+        expect(find(mount({ storage: null }), 'analytics-storage')).toBeNull();
+    });
+
+    it('reports the usage, the quota and the space left', () => {
+        const host = mount({
+            storage: {
+                usedBytes: 1024 * 1024,
+                quotaBytes: 4 * 1024 * 1024,
+                percent: 25,
+            },
+        });
+
+        expect(find(host, 'analytics-storage')?.textContent).toContain(
+            'Storage',
+        );
+        expect(find(host, 'analytics-storage-percent')?.textContent).toContain(
+            '25% used',
+        );
+        expect(find(host, 'analytics-storage-size')?.textContent).toContain(
+            '1 MB of 4 MB',
+        );
+        expect(
+            find(host, 'analytics-storage-remaining')?.textContent,
+        ).toContain('3 MB free');
+    });
+
+    it('exposes the bar as a labelled progressbar', () => {
+        const host = mount({
+            storage: {
+                usedBytes: 3 * 1024 * 1024,
+                quotaBytes: 4 * 1024 * 1024,
+                percent: 75,
+            },
+        });
+
+        const bar = find(host, 'analytics-storage')?.querySelector(
+            '[role="progressbar"]',
+        );
+
+        expect(bar?.getAttribute('aria-label')).toBe('Storage used');
+        expect(bar?.getAttribute('aria-valuenow')).toBe('75');
+        expect(bar?.getAttribute('aria-valuemin')).toBe('0');
+        expect(bar?.getAttribute('aria-valuemax')).toBe('100');
+        expect(bar?.getAttribute('aria-valuetext')).toBe('3 MB of 4 MB');
+    });
+});

--- a/resources/js/pages/teams/Analytics.vue
+++ b/resources/js/pages/teams/Analytics.vue
@@ -5,16 +5,24 @@ import AnalyticsHeader from '@/components/analytics/AnalyticsHeader.vue';
 import AnalyticsStatTiles from '@/components/analytics/AnalyticsStatTiles.vue';
 import MemberGrowthCard from '@/components/analytics/MemberGrowthCard.vue';
 import MessagesPerDayCard from '@/components/analytics/MessagesPerDayCard.vue';
+import StorageUsageCard from '@/components/analytics/StorageUsageCard.vue';
 import TopChannelsCard from '@/components/analytics/TopChannelsCard.vue';
 import TopContributorsCard from '@/components/analytics/TopContributorsCard.vue';
 import { translate } from '@/lib/i18n';
 import { edit, index } from '@/routes/teams';
 import { index as analyticsIndex } from '@/routes/teams/analytics';
-import type { AnalyticsRangeOption, Team, WorkspaceAnalytics } from '@/types';
+import type {
+    AnalyticsRangeOption,
+    Team,
+    TeamStorage,
+    WorkspaceAnalytics,
+} from '@/types';
 
 type Props = {
     team: Team;
     analytics: WorkspaceAnalytics;
+    /** The storage read-out, absent while no workspace quota is configured. */
+    storage?: TeamStorage | null;
     range: string;
     rangeOptions: AnalyticsRangeOption[];
 };
@@ -71,6 +79,8 @@ function selectRange(value: string): void {
         />
 
         <AnalyticsStatTiles :analytics="analytics" />
+
+        <StorageUsageCard v-if="storage" :storage="storage" />
 
         <MessagesPerDayCard
             :points="analytics.messagesByDay"

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -219,6 +219,18 @@ export type WorkspaceAnalytics = {
     topContributors: Contributor[];
 };
 
+/**
+ * A workspace's upload footprint against its configured storage quota. Mirrors
+ * the `TeamStorageData` DTO, and is only sent while a quota is configured — so
+ * `quotaBytes` is always positive and `percent` may exceed 100 when an operator
+ * lowers the quota below the space already in use.
+ */
+export type TeamStorage = {
+    usedBytes: number;
+    quotaBytes: number;
+    percent: number;
+};
+
 /** One option in the analytics range toggle (7d / 30d / 90d). */
 export type AnalyticsRangeOption = {
     value: string;

--- a/tests/Browser/A11yAnalyticsTest.php
+++ b/tests/Browser/A11yAnalyticsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Attachment;
+
+/**
+ * The analytics dashboard's axe coverage (#529).
+ *
+ * The storage read-out added here is the page's first progress indicator, and a
+ * bare styled `<div>` bar carries no meaning at all to a screen reader — so the
+ * audit exists to hold its `progressbar` role, its accessible name, and the tone
+ * it switches to once a workspace fills up, in both themes.
+ */
+test('the analytics dashboard passes the axe audit in either theme', function (): void {
+    config(['attachments.storage_quota_mb' => 4]);
+
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    Attachment::factory()->for($channel)->create(['size_bytes' => 1024 * 1024]);
+
+    $page = signInThroughBrowser($alice)
+        ->navigate("/settings/teams/{$team->slug}/analytics")
+        ->assertSee('Storage')
+        ->assertPresent('[data-test="analytics-storage"]')
+        ->assertNoAccessibilityIssues();
+
+    switchToDarkTheme($page)
+        ->assertNoAccessibilityIssues();
+});
+
+/**
+ * A workspace over its quota swaps the muted tone for the destructive one, which
+ * is the only state of the read-out drawn in a colour contrast could fail on.
+ */
+test('a workspace over its storage quota still passes the axe audit', function (): void {
+    config(['attachments.storage_quota_mb' => 1]);
+
+    ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithChannel();
+
+    Attachment::factory()->for($channel)->create(['size_bytes' => 2 * 1024 * 1024]);
+
+    $page = signInThroughBrowser($alice)
+        ->navigate("/settings/teams/{$team->slug}/analytics")
+        ->assertSee('200% used')
+        ->assertSee('1 MB over the limit')
+        ->assertNoAccessibilityIssues();
+
+    switchToDarkTheme($page)
+        ->assertNoAccessibilityIssues();
+});

--- a/tests/Browser/A11yAnalyticsTest.php
+++ b/tests/Browser/A11yAnalyticsTest.php
@@ -23,6 +23,10 @@ test('the analytics dashboard passes the axe audit in either theme', function ()
         ->navigate("/settings/teams/{$team->slug}/analytics")
         ->assertSee('Storage')
         ->assertPresent('[data-test="analytics-storage"]')
+        // The bar is a styled <div>: only the progressbar role, its name, and its
+        // value carry the reading to a screen reader.
+        ->assertPresent('[role="progressbar"][aria-label="Storage used"][aria-valuenow="25"][aria-valuetext="1 MB of 4 MB"]')
+        ->assertPresent('[data-test="analytics-storage-percent"].text-muted-foreground')
         ->assertNoAccessibilityIssues();
 
     switchToDarkTheme($page)
@@ -44,6 +48,10 @@ test('a workspace over its storage quota still passes the axe audit', function (
         ->navigate("/settings/teams/{$team->slug}/analytics")
         ->assertSee('200% used')
         ->assertSee('1 MB over the limit')
+        // The overshoot is clamped for the bar, which cannot draw past full.
+        ->assertPresent('[role="progressbar"][aria-valuenow="100"]')
+        ->assertPresent('[data-test="analytics-storage-percent"].text-destructive-text')
+        ->assertPresent('[data-test="analytics-storage-remaining"].text-destructive-text')
         ->assertNoAccessibilityIssues();
 
     switchToDarkTheme($page)

--- a/tests/Feature/Channels/AttachmentQuotaTest.php
+++ b/tests/Feature/Channels/AttachmentQuotaTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\AttachmentStatus;
+use App\Models\Attachment;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * A team with its owner in #general, with the attachment disk faked.
+ *
+ * @return array{0: User, 1: Team, 2: Channel}
+ */
+function quotaTeam(): array
+{
+    Storage::fake('local');
+
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+
+    return [$owner, $team, $general];
+}
+
+/**
+ * The upload route for a team + channel.
+ */
+function quotaRoute(Team $team, Channel $channel): string
+{
+    return route('channels.attachments.store', ['team' => $team->slug, 'channel' => $channel->slug]);
+}
+
+test('an upload that would exceed the workspace quota is rejected before any blob is written', function (): void {
+    config()->set('attachments.storage_quota_mb', 1);
+    [$owner, $team, $general] = quotaTeam();
+
+    Attachment::factory()->for($general)->create(['size_bytes' => 1024 * 1024]);
+
+    $this->actingAs($owner)
+        ->post(quotaRoute($team, $general), ['file' => UploadedFile::fake()->create('report.pdf', 20, 'application/pdf')])
+        ->assertSessionHasErrors('file');
+
+    // No row was registered and nothing landed on the disk.
+    expect(Attachment::where('status', AttachmentStatus::Pending)->whereNull('message_id')->count())->toBe(1);
+    expect(Storage::disk('local')->allFiles())->toBeEmpty();
+});
+
+test('an upload that fits inside the remaining quota is accepted', function (): void {
+    config()->set('attachments.storage_quota_mb', 1);
+    [$owner, $team, $general] = quotaTeam();
+
+    Attachment::factory()->for($general)->create(['size_bytes' => 512 * 1024]);
+
+    $this->actingAs($owner)
+        ->post(quotaRoute($team, $general), ['file' => UploadedFile::fake()->create('report.pdf', 20, 'application/pdf')])
+        ->assertCreated();
+});
+
+test('a pending upload counts against the quota, so staging unsent files cannot evade it', function (): void {
+    config()->set('attachments.storage_quota_mb', 1);
+    [$owner, $team, $general] = quotaTeam();
+
+    Attachment::factory()->for($general)->create([
+        'size_bytes' => 1024 * 1024,
+        'status' => AttachmentStatus::Pending,
+    ]);
+
+    $this->actingAs($owner)
+        ->post(quotaRoute($team, $general), ['file' => UploadedFile::fake()->create('note.txt', 1, 'text/plain')])
+        ->assertSessionHasErrors('file');
+});
+
+test('uploads are unlimited while no quota is configured', function (): void {
+    config()->set('attachments.storage_quota_mb', 0);
+    [$owner, $team, $general] = quotaTeam();
+
+    Attachment::factory()->for($general)->create(['size_bytes' => 500 * 1024 * 1024]);
+
+    $this->actingAs($owner)
+        ->post(quotaRoute($team, $general), ['file' => UploadedFile::fake()->create('report.pdf', 20, 'application/pdf')])
+        ->assertCreated();
+});
+
+test('a payload that is not a file is left to the plain file rule', function (): void {
+    config()->set('attachments.storage_quota_mb', 1);
+    [$owner, $team, $general] = quotaTeam();
+
+    $this->actingAs($owner)
+        ->post(quotaRoute($team, $general), ['file' => 'not-a-file'])
+        ->assertSessionHasErrors('file');
+});
+
+test('another workspace\'s usage does not consume this one\'s quota', function (): void {
+    config()->set('attachments.storage_quota_mb', 1);
+    [$owner, $team, $general] = quotaTeam();
+    [, , $foreign] = quotaTeam();
+
+    Attachment::factory()->for($foreign)->create(['size_bytes' => 5 * 1024 * 1024]);
+
+    $this->actingAs($owner)
+        ->post(quotaRoute($team, $general), ['file' => UploadedFile::fake()->create('report.pdf', 20, 'application/pdf')])
+        ->assertCreated();
+});

--- a/tests/Feature/Teams/TeamStorageTest.php
+++ b/tests/Feature/Teams/TeamStorageTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\AttachmentStatus;
+use App\Models\Attachment;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use App\Support\TeamStorage;
+
+/**
+ * A team owned by a fresh user, with its #general channel.
+ *
+ * @return array{0: Team, 1: Channel}
+ */
+function storageTeam(): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, 'Acme');
+    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+
+    return [$team, $general];
+}
+
+/**
+ * Register an upload of the given size in a channel, without touching any disk.
+ */
+function storageUpload(Channel $channel, int $bytes, array $attributes = []): Attachment
+{
+    return Attachment::factory()->for($channel)->create(['size_bytes' => $bytes, ...$attributes]);
+}
+
+test('usage sums the uploaded bytes across the team\'s channels', function (): void {
+    [$team, $general] = storageTeam();
+    $other = Channel::factory()->for($team)->create();
+
+    storageUpload($general, 1_000);
+    storageUpload($other, 2_500);
+
+    expect(app(TeamStorage::class)->usedBytes($team))->toBe(3_500);
+});
+
+test('usage counts pending and claimed uploads alike', function (): void {
+    [$team, $general] = storageTeam();
+
+    storageUpload($general, 400, ['status' => AttachmentStatus::Pending]);
+    storageUpload($general, 600, ['status' => AttachmentStatus::Attached]);
+
+    expect(app(TeamStorage::class)->usedBytes($team))->toBe(1_000);
+});
+
+test('usage keeps counting a soft-deleted upload, whose blob is retained', function (): void {
+    [$team, $general] = storageTeam();
+
+    storageUpload($general, 900)->delete();
+
+    expect(app(TeamStorage::class)->usedBytes($team))->toBe(900);
+});
+
+test('usage drops a force-deleted upload, whose blob is reclaimed', function (): void {
+    [$team, $general] = storageTeam();
+
+    storageUpload($general, 900)->forceDelete();
+
+    expect(app(TeamStorage::class)->usedBytes($team))->toBe(0);
+});
+
+test('usage excludes hotlinked giphy attachments, which occupy no disk', function (): void {
+    [$team, $general] = storageTeam();
+
+    storageUpload($general, 1_200);
+    Attachment::factory()->for($general)->giphy()->create(['size_bytes' => 5_000]);
+
+    expect(app(TeamStorage::class)->usedBytes($team))->toBe(1_200);
+});
+
+test('usage is scoped to the team, ignoring another workspace\'s uploads', function (): void {
+    [$team, $general] = storageTeam();
+    [, $foreign] = storageTeam();
+
+    storageUpload($general, 700);
+    storageUpload($foreign, 9_000);
+
+    expect(app(TeamStorage::class)->usedBytes($team))->toBe(700);
+});
+
+test('the quota is read from config in megabytes and converted to bytes', function (): void {
+    config()->set('attachments.storage_quota_mb', 5);
+
+    expect(app(TeamStorage::class)->quotaBytes())->toBe(5 * 1024 * 1024)
+        ->and(app(TeamStorage::class)->enabled())->toBeTrue();
+});
+
+test('a zero or negative quota turns the feature off', function (int $quota): void {
+    config()->set('attachments.storage_quota_mb', $quota);
+
+    expect(app(TeamStorage::class)->quotaBytes())->toBe(0)
+        ->and(app(TeamStorage::class)->enabled())->toBeFalse();
+})->with([0, -1]);
+
+test('an upload that would cross the quota is reported as exceeding it', function (): void {
+    config()->set('attachments.storage_quota_mb', 1);
+    [$team, $general] = storageTeam();
+
+    storageUpload($general, 1024 * 1024 - 100);
+
+    $storage = app(TeamStorage::class);
+    expect($storage->wouldExceedQuota($team, 100))->toBeFalse()
+        ->and($storage->wouldExceedQuota($team, 101))->toBeTrue();
+});
+
+test('nothing exceeds the quota while the feature is off', function (): void {
+    config()->set('attachments.storage_quota_mb', 0);
+    [$team, $general] = storageTeam();
+
+    storageUpload($general, 50_000_000);
+
+    expect(app(TeamStorage::class)->wouldExceedQuota($team, 50_000_000))->toBeFalse();
+});
+
+test('the usage read-out reports used bytes, the quota and the percent consumed', function (): void {
+    config()->set('attachments.storage_quota_mb', 4);
+    [$team, $general] = storageTeam();
+
+    storageUpload($general, 1024 * 1024);
+
+    $usage = app(TeamStorage::class)->usage($team);
+
+    expect($usage)->not->toBeNull()
+        ->and($usage->usedBytes)->toBe(1024 * 1024)
+        ->and($usage->quotaBytes)->toBe(4 * 1024 * 1024)
+        ->and($usage->percent)->toBe(25);
+});
+
+test('the usage read-out reports the real percent once the quota is overshot', function (): void {
+    config()->set('attachments.storage_quota_mb', 1);
+    [$team, $general] = storageTeam();
+
+    storageUpload($general, 2 * 1024 * 1024);
+
+    expect(app(TeamStorage::class)->usage($team)->percent)->toBe(200);
+});
+
+test('there is no usage read-out while the feature is off', function (): void {
+    config()->set('attachments.storage_quota_mb', 0);
+    [$team] = storageTeam();
+
+    expect(app(TeamStorage::class)->usage($team))->toBeNull();
+});

--- a/tests/Feature/Teams/WorkspaceAnalyticsPageTest.php
+++ b/tests/Feature/Teams/WorkspaceAnalyticsPageTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\Teams\CreateTeam;
 use App\Enums\TeamRole;
+use App\Models\Attachment;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
@@ -105,4 +106,30 @@ test('an invalid range is rejected', function (): void {
     $this->actingAs($owner)
         ->get(route('teams.analytics.index', [$team, 'range' => 'forever']))
         ->assertSessionHasErrors('range');
+});
+
+test('the dashboard reports the workspace storage usage against its quota', function (): void {
+    config()->set('attachments.storage_quota_mb', 4);
+    [$owner, $team] = analyticsPageTeam();
+    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
+    Attachment::factory()->for($general)->create(['size_bytes' => 1024 * 1024]);
+
+    $this->actingAs($owner)
+        ->get(route('teams.analytics.index', $team))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page
+            ->where('storage.usedBytes', 1024 * 1024)
+            ->where('storage.quotaBytes', 4 * 1024 * 1024)
+            ->where('storage.percent', 25)
+        );
+});
+
+test('the dashboard carries no storage read-out while no quota is configured', function (): void {
+    config()->set('attachments.storage_quota_mb', 0);
+    [$owner, $team] = analyticsPageTeam();
+
+    $this->actingAs($owner)
+        ->get(route('teams.analytics.index', $team))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page): Assert => $page->where('storage', null));
 });


### PR DESCRIPTION
Closes #529.

## What

A configurable per-workspace storage quota with live usage tracking and hard enforcement on upload.

- **`STORAGE_QUOTA_MB` → `attachments.storage_quota_mb`**, in megabytes. `0` (the default, and unset) means unlimited: the feature is off and nothing is measured.
- **`App\Support\TeamStorage`** computes usage live — `SUM(size_bytes)` over `attachments` read `withTrashed()`, `source = Upload`, scoped through `channel_id → channels.team_id`. No counter column, no dual-write across the create/force-delete/purge paths, so there is no drift to repair. The existing `attachments.channel_id` index already backs the scope, so no migration was needed.
- **Enforcement is a hard, pre-store block** (`App\Rules\WithinStorageQuota`, wired into `StoreAttachmentRequest::rules()`): an upload that would cross the quota is rejected with a translated validation error *before* the blob is written, so nothing is left on disk for the orphan sweep. Pending and claimed attachments both count — a staged file already occupies disk, so leaving unsent uploads out would let anyone stage their way past the cap. Giphy attachments are excluded: they are hotlinked CDN URLs with no blob of the operator's.
- **The read-out lands on the workspace Analytics dashboard** (used / quota / percent), inheriting its admins-and-owner gate. It rides alongside the cached analytics snapshot rather than inside it, since usage moves with every upload and delete. It is absent entirely while no quota is configured.

The quota applies uniformly to every workspace, personal teams included — one config value, one code path.

## Why

Self-hosting operators have no storage accounting today: attachment blobs accumulate on the configured disk with nothing to bound them, and a soft-deleted attachment keeps its blob (only a force-delete reclaims it). This gives operators a single knob to cap that growth, and workspace admins the visibility to act on it.

Usage equals the real disk footprint by construction: a force-deleted attachment has no row (bytes gone), a soft-deleted-but-retained one keeps its row (bytes present, counted).

## How tested

Built test-first. Backend gate green at 100% coverage.

- `tests/Feature/Teams/TeamStorageTest.php` — the scope (per team, pending + claimed, trashed vs force-deleted, Giphy excluded), the MB→bytes conversion, the off switch, and the percent read-out including an overshoot.
- `tests/Feature/Channels/AttachmentQuotaTest.php` — an over-quota upload is refused with no row and no blob on disk; one that fits is accepted; a pending upload counts; another workspace's usage does not; uploads are unlimited while the feature is off.
- `tests/Feature/Teams/WorkspaceAnalyticsPageTest.php` — the dashboard carries the read-out, and carries `null` while no quota is set.
- `resources/js/lib/storageUsage.test.ts` + `Analytics.tiles.test.ts` — the copy each usage level produces, the bar clamping, the three tones, and the card's absence when the feature is off.
- `tests/Browser/A11yAnalyticsTest.php` — the analytics dashboard passes the axe audit in both themes, with the storage bar's `progressbar` role, accessible name and value asserted, in the normal and the over-quota state (the only one drawn in the destructive colour).

Also run: full browser suite (347 passing), Vitest (2391), `lint:check` / `format:check` / `types:check` / `build`, and the docs site build.

## i18n

All new copy goes through `$t` / `__()`; every key has its French translation in `lang/fr.json` (including `Mo` for the megabyte unit, matching the existing attachment-size message).

## Docs

- `reference/environment-variables.md` — `STORAGE_QUOTA_MB` row in the Attachments table.
- `reference/feature-toggles.md` — a new **Workspace storage quota** section covering what counts toward the quota (uploads pending or sent; deleted messages until purged; Giphy excluded), where the read-out appears, and the deferred follow-ups.

## Out of scope

Per the issue's decisions, deferred to follow-ups: a per-workspace override column plus the operator admin UI to edit it (there is no operator area today), a proactive warn notification at a threshold, and counting non-attachment blobs (custom emoji, exports) toward the quota.

## Note

CodeRabbit flagged that the pre-store check is racy under concurrent uploads and suggested making admission atomic. Declined: that contradicts the issue's locked decision to compute usage live with no counter or reservation, and the overshoot is bounded by one file per concurrent request. The quota is a capacity guard, not a billing boundary — the trade-off is documented in `WithinStorageQuota`'s docblock rather than left silent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788041506&installation_model_id=428379&pr_number=1088&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1088&signature=263a950277749cf9013c3efd766b56321af13a9c7cb4f87a1cc417080000480b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->