### PR TITLE
refactor: finish the ADR-0005 domain-event recording seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,10 +75,18 @@ built; build them once, then reuse.
   that resolves where a channel's initial message window opens (unread anchoring,
   jump context, paging). Takes explicit params; the controller keeps HTTP glue.
 - **Domain-event recording** _(ADR-0005)_ — audit and security events are recorded
-  via the event→listener seam (`RecordSecurityEvents`), next to the mutation, not
-  by inline `record()` calls in controllers.
+  via the event→listener seam, next to the mutation, never by a `record()` call in
+  a controller. The Action dispatches `AuditableActionOccurred` (carrying team,
+  actor, `AuditAction`, target and context) or `SecurityEventOccurred`;
+  `RecordAuditActivity` and `RecordSecurityEvents` append the row. "Is this
+  auditable?" is a rule of the mutation, so it lives in the Action too — a member
+  joining a channel is not an add, a member deleting their own message is not
+  moderation.
 - **`AuditRecorder` / `SecurityEventRecorder`** — deep modules hiding the
-  activity-log builder. Keep them; only change *where they're called from*.
+  activity-log builder, each with exactly one caller: its listener. Keep them; a
+  new call site is a sign the event seam was skipped. Neither depends on the live
+  `Request` — `RecordSecurityEvents` captures the device context and passes it in,
+  which is what lets a queued job record.
 - **`ExportLifecycle`** — the one lifecycle every asynchronous file export runs:
   resolve-or-bail, write, mark ready, send the ready notice, and fail cleanly.
   `GenerateAuditExport` and `ExportUserData` are adapters over it, supplying only
@@ -135,7 +143,8 @@ built; build them once, then reuse.
   `lib/`; never inline in a page.
 - New channel message payload → the **Message load-set scope**.
 - New "which channels can this user see" check → the **Visible-channels ACL**.
-- New auditable mutation → record it via the **domain-event seam**, next to the
+- New auditable mutation → give it an Action if it has none, then dispatch
+  `AuditableActionOccurred` from it — the **domain-event seam**, next to the
   mutation.
 - New channel-member preference → the **channel membership settings** concern.
 - A `.vue` file crossing ~400 lines or owning several independent lifecycles →

--- a/app/Actions/Channels/ArchiveChannel.php
+++ b/app/Actions/Channels/ArchiveChannel.php
@@ -2,7 +2,10 @@
 
 namespace App\Actions\Channels;
 
+use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\Channel;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 
 class ArchiveChannel
@@ -11,13 +14,21 @@ class ArchiveChannel
      * Archive a channel, marking it read-only and hidden from the active sidebar.
      *
      * Archiving is a soft state (never a hard delete): messages are retained and
-     * stay searchable. An already-archived channel is left untouched.
+     * stay searchable. An already-archived channel is left untouched, and
+     * records nothing — only a fresh archive is a workspace action.
+     *
+     * `$actor` is who archived it, nullable for a platform-initiated archive
+     * with no human causer.
      */
-    public function handle(Channel $channel): Channel
+    public function handle(Channel $channel, ?User $actor): Channel
     {
-        return DB::transaction(function () use ($channel): Channel {
+        return DB::transaction(function () use ($channel, $actor): Channel {
             if (! $channel->isArchived()) {
                 $channel->update(['archived_at' => now()]);
+
+                event(new AuditableActionOccurred($channel->team, $actor, AuditAction::ChannelArchived, $channel, [
+                    'channel_name' => $channel->name,
+                ]));
             }
 
             return $channel;

--- a/app/Actions/Channels/CreateChannel.php
+++ b/app/Actions/Channels/CreateChannel.php
@@ -2,7 +2,9 @@
 
 namespace App\Actions\Channels;
 
+use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
+use App\Events\AuditableActionOccurred;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
@@ -15,6 +17,11 @@ class CreateChannel
 
     /**
      * Create a channel in the team and add its creator as a member.
+     *
+     * Every channel an admin creates is audited. The protected #general is the
+     * one exception: it is not created by anyone deciding to, it is bootstrapped
+     * with the workspace when its first membership lands, so it would only ever
+     * add a row nobody acted on.
      */
     public function handle(
         Team $team,
@@ -37,6 +44,12 @@ class CreateChannel
             // The creator seeds the channel rather than joining it, so no
             // "member joined" notice is posted for them.
             $this->joinChannel->handle($channel, $creator, announce: false);
+
+            if (! $channel->isGeneral()) {
+                event(new AuditableActionOccurred($team, $creator, AuditAction::ChannelCreated, $channel, [
+                    'channel_name' => $channel->name,
+                ]));
+            }
 
             return $channel;
         });

--- a/app/Actions/Channels/DeleteChannel.php
+++ b/app/Actions/Channels/DeleteChannel.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Actions\Channels;
 
+use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Jobs\PurgeDeletedChannel;
 use App\Models\Channel;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 
 class DeleteChannel
@@ -22,11 +25,16 @@ class DeleteChannel
      * otherwise both see it live, and the second would overwrite `deleted_at`
      * and silently extend the grace window. Under the lock the loser sees the
      * winner's stamp and leaves it alone, so the channel keeps the deletion date
-     * it actually got — which is the date the purge is scheduled from.
+     * it actually got — which is the date the purge is scheduled from, and the
+     * date the audit entry names. Only the request that actually deleted the
+     * channel records one; the loser of that race records nothing.
+     *
+     * The audit entry carries the purge date because it is the only lasting
+     * record of the channel once the grace window closes.
      */
-    public function handle(Channel $channel): Channel
+    public function handle(Channel $channel, ?User $actor): Channel
     {
-        return DB::transaction(function () use ($channel): Channel {
+        return DB::transaction(function () use ($channel, $actor): Channel {
             $locked = Channel::withTrashed()
                 ->whereKey($channel->getKey())
                 ->lockForUpdate()
@@ -34,6 +42,11 @@ class DeleteChannel
 
             if (! $locked->trashed()) {
                 $locked->delete();
+
+                event(new AuditableActionOccurred($locked->team, $actor, AuditAction::ChannelDeleted, $locked, [
+                    'channel_name' => $locked->name,
+                    'purge_at' => $locked->deleted_at->addDays(PurgeDeletedChannel::GRACE_WINDOW_DAYS)->toDateString(),
+                ]));
             }
 
             return $locked;

--- a/app/Actions/Channels/DeleteMessage.php
+++ b/app/Actions/Channels/DeleteMessage.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Actions\Channels;
 
 use App\Data\MessageData;
+use App\Enums\AuditAction;
 use App\Enums\WebhookEvent;
+use App\Events\AuditableActionOccurred;
 use App\Events\MessageDeleted;
 use App\Events\WebhookEventOccurred;
 use App\Models\Channel;
 use App\Models\Message;
+use App\Models\User;
 
 class DeleteMessage
 {
@@ -21,9 +24,16 @@ class DeleteMessage
      * The row is kept so the client can render a "message deleted" placeholder
      * in place. The broadcast reuses {@see MessageData}, which blanks the body of
      * a trashed message, so no deleted content ever reaches other subscribers.
+     *
+     * `$deletedBy` names who deleted it. Only a moderation deletion — someone
+     * removing a message that isn't theirs — is audited; a member deleting their
+     * own message is not an admin action.
      */
-    public function handle(Channel $channel, Message $message): void
+    public function handle(Channel $channel, Message $message, ?User $deletedBy = null): void
     {
+        $message->loadMissing('user');
+        $author = $message->user;
+
         // A soft delete leaves the row (and its FK-cascading children) in place,
         // so drop the reactions explicitly — a tombstone shows none, and they
         // would otherwise linger unreachable behind the deleted message.
@@ -42,9 +52,15 @@ class DeleteMessage
 
         $message->delete();
 
-        $message->loadMissing('user');
         $data = MessageData::fromMessage($message);
         event(new MessageDeleted($channel, $data));
         event(new WebhookEventOccurred(WebhookEvent::MessageDeleted, $channel, $data->toArray()));
+
+        if ($deletedBy instanceof User && ! $deletedBy->is($author)) {
+            event(new AuditableActionOccurred($channel->team, $deletedBy, AuditAction::MessageDeleted, $message, [
+                'channel_name' => $channel->name,
+                'author_name' => $author->name,
+            ]));
+        }
     }
 }

--- a/app/Actions/Channels/JoinChannel.php
+++ b/app/Actions/Channels/JoinChannel.php
@@ -3,8 +3,10 @@
 namespace App\Actions\Channels;
 
 use App\Data\UserData;
+use App\Enums\AuditAction;
 use App\Enums\MessageType;
 use App\Enums\WebhookEvent;
+use App\Events\AuditableActionOccurred;
 use App\Events\WebhookEventOccurred;
 use App\Models\Channel;
 use App\Models\ChannelMember;
@@ -27,8 +29,15 @@ class JoinChannel
      * don't "join" it) and the team-onboarding auto-join to the protected
      * #general channel (which would otherwise post a join notice for every new
      * workspace member). Only an explicit channel join announces.
+     *
+     * `$addedBy` names the member who put someone *else* in the channel, which
+     * is what makes the membership an administrative act worth auditing — pass
+     * it from any surface that adds a member on their behalf. A plain join, and
+     * the structural joins above, leave it null and record nothing; the webhook
+     * fires either way, because a subscriber cares that membership changed, not
+     * who decided it.
      */
-    public function handle(Channel $channel, User $user, bool $announce = true): ChannelMember
+    public function handle(Channel $channel, User $user, bool $announce = true, ?User $addedBy = null): ChannelMember
     {
         $membership = DB::transaction(fn (): ChannelMember => $channel->channelMembers()->firstOrCreate([
             'user_id' => $user->id,
@@ -43,6 +52,13 @@ class JoinChannel
                 'channel_id' => $channel->id,
                 'user' => UserData::fromUser($user)->toArray(),
             ]));
+
+            if ($addedBy instanceof User && ! $addedBy->is($user)) {
+                event(new AuditableActionOccurred($channel->team, $addedBy, AuditAction::ChannelMemberAdded, $channel, [
+                    'channel_name' => $channel->name,
+                    'member_name' => $user->name,
+                ]));
+            }
         }
 
         return $membership;

--- a/app/Actions/Channels/RemoveChannelMember.php
+++ b/app/Actions/Channels/RemoveChannelMember.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Actions\Channels;
 
+use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\Channel;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -12,13 +14,23 @@ class RemoveChannelMember
 {
     /**
      * Remove the user's membership from the channel.
+     *
+     * `$removedBy` names the member who removed someone *else*, which is what
+     * makes the removal an administrative act worth auditing — pass it from any
+     * surface that removes a member on their behalf. A member leaving of their
+     * own accord (see {@see LeaveChannel}) leaves it null and records nothing.
      */
-    public function handle(Channel $channel, User $user): void
+    public function handle(Channel $channel, User $user, ?User $removedBy = null): void
     {
-        DB::transaction(function () use ($channel, $user): void {
-            $channel->channelMembers()
-                ->where('user_id', $user->id)
-                ->delete();
-        });
+        $removed = DB::transaction(fn (): int => $channel->channelMembers()
+            ->where('user_id', $user->id)
+            ->delete());
+
+        if ($removed > 0 && $removedBy instanceof User && ! $removedBy->is($user)) {
+            event(new AuditableActionOccurred($channel->team, $removedBy, AuditAction::ChannelMemberRemoved, $channel, [
+                'channel_name' => $channel->name,
+                'member_name' => $user->name,
+            ]));
+        }
     }
 }

--- a/app/Actions/Channels/RestoreChannel.php
+++ b/app/Actions/Channels/RestoreChannel.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\Channels;
 
+use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\Channel;
+use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -25,9 +28,9 @@ class RestoreChannel
      *
      * @throws ValidationException when a live channel already holds the slug
      */
-    public function handle(Channel $channel): Channel
+    public function handle(Channel $channel, ?User $actor): Channel
     {
-        return DB::transaction(function () use ($channel): Channel {
+        return DB::transaction(function () use ($channel, $actor): Channel {
             $taken = Channel::query()
                 ->where('team_id', $channel->team_id)
                 ->where('slug', $channel->slug)
@@ -41,6 +44,10 @@ class RestoreChannel
             }
 
             $channel->restore();
+
+            event(new AuditableActionOccurred($channel->team, $actor, AuditAction::ChannelRestored, $channel, [
+                'channel_name' => $channel->name,
+            ]));
 
             return $channel;
         });

--- a/app/Actions/Integrations/CreateBot.php
+++ b/app/Actions/Integrations/CreateBot.php
@@ -6,9 +6,9 @@ namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
 use App\Enums\UserType;
+use App\Events\AuditableActionOccurred;
 use App\Models\Team;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -22,8 +22,6 @@ use Illuminate\Support\Str;
  */
 class CreateBot
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     public function handle(Team $team, User $actor, string $name): User
     {
         return DB::transaction(function () use ($team, $actor, $name): User {
@@ -38,9 +36,9 @@ class CreateBot
                 'created_by' => $actor->id,
             ])->save();
 
-            $this->recorder->record($team, $actor, AuditAction::BotCreated, $bot, [
+            event(new AuditableActionOccurred($team, $actor, AuditAction::BotCreated, $bot, [
                 'bot_name' => $name,
-            ]);
+            ]));
 
             return $bot;
         });

--- a/app/Actions/Integrations/CreateIncomingWebhook.php
+++ b/app/Actions/Integrations/CreateIncomingWebhook.php
@@ -3,10 +3,10 @@
 namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\Channel;
 use App\Models\IncomingWebhook;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use App\Support\Integrations\ApiChannelAccess;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -20,8 +20,6 @@ use Illuminate\Validation\ValidationException;
  */
 class CreateIncomingWebhook
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     /**
      * @param  bool  $withSigningSecret  Whether to mint an HMAC shared secret too.
      */
@@ -46,11 +44,11 @@ class CreateIncomingWebhook
             'signing_secret' => $signingSecret,
         ]);
 
-        $this->recorder->record($channel->team, $actor, AuditAction::IncomingWebhookCreated, $webhook, [
+        event(new AuditableActionOccurred($channel->team, $actor, AuditAction::IncomingWebhookCreated, $webhook, [
             'webhook_name' => $name,
             'bot_name' => $bot->name,
             'channel_name' => $channel->name,
-        ]);
+        ]));
 
         return new NewIncomingWebhook($webhook, $token, $signingSecret);
     }

--- a/app/Actions/Integrations/CreateWebhookSubscription.php
+++ b/app/Actions/Integrations/CreateWebhookSubscription.php
@@ -6,10 +6,10 @@ namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
 use App\Enums\WebhookSubscriptionStatus;
+use App\Events\AuditableActionOccurred;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\WebhookSubscription;
-use App\Support\AuditRecorder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -19,8 +19,6 @@ use Illuminate\Support\Facades\DB;
  */
 class CreateWebhookSubscription
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     /**
      * @param  list<string>  $events  The subscribed event values (see App\Enums\WebhookEvent).
      * @param  list<string>|null  $channelIds  Optional channel allow-list; null means all channels.
@@ -38,9 +36,9 @@ class CreateWebhookSubscription
                 'status' => WebhookSubscriptionStatus::Active,
             ]);
 
-            $this->recorder->record($team, $actor, AuditAction::WebhookSubscriptionCreated, $subscription, [
+            event(new AuditableActionOccurred($team, $actor, AuditAction::WebhookSubscriptionCreated, $subscription, [
                 'subscription_name' => $name,
-            ]);
+            ]));
 
             return $subscription;
         });

--- a/app/Actions/Integrations/DeleteBot.php
+++ b/app/Actions/Integrations/DeleteBot.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\Message;
 use App\Models\MessagePin;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -22,8 +22,6 @@ use Illuminate\Support\Facades\DB;
  */
 class DeleteBot
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     public function handle(User $actor, User $bot): void
     {
         $team = $bot->ownerTeam()->firstOrFail();
@@ -41,9 +39,9 @@ class DeleteBot
 
             $bot->delete();
 
-            $this->recorder->record($team, $actor, AuditAction::BotDeleted, $bot, [
+            event(new AuditableActionOccurred($team, $actor, AuditAction::BotDeleted, $bot, [
                 'bot_name' => $name,
-            ]);
+            ]));
         });
     }
 }

--- a/app/Actions/Integrations/MintBotToken.php
+++ b/app/Actions/Integrations/MintBotToken.php
@@ -4,8 +4,8 @@ namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
 use App\Enums\IntegrationScope;
+use App\Events\AuditableActionOccurred;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Illuminate\Support\Facades\DB;
 use Laravel\Sanctum\NewAccessToken;
 
@@ -17,8 +17,6 @@ use Laravel\Sanctum\NewAccessToken;
  */
 class MintBotToken
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     /**
      * @param  list<string>  $abilities  The granted scopes (least-privilege).
      */
@@ -27,10 +25,10 @@ class MintBotToken
         return DB::transaction(function () use ($bot, $actor, $name, $abilities): NewAccessToken {
             $token = $bot->createToken($name, $abilities);
 
-            $this->recorder->record($bot->ownerTeam()->firstOrFail(), $actor, AuditAction::BotTokenCreated, $bot, [
+            event(new AuditableActionOccurred($bot->ownerTeam()->firstOrFail(), $actor, AuditAction::BotTokenCreated, $bot, [
                 'token_name' => $name,
                 'bot_name' => $bot->name,
-            ]);
+            ]));
 
             return $token;
         });

--- a/app/Actions/Integrations/MintPersonalAccessToken.php
+++ b/app/Actions/Integrations/MintPersonalAccessToken.php
@@ -6,9 +6,9 @@ namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
 use App\Enums\IntegrationScope;
+use App\Events\AuditableActionOccurred;
 use App\Models\Team;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Laravel\Sanctum\NewAccessToken;
 
 /**
@@ -21,8 +21,6 @@ use Laravel\Sanctum\NewAccessToken;
  */
 class MintPersonalAccessToken
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     /**
      * @param  list<string>  $abilities  The granted scopes (least-privilege).
      */
@@ -32,9 +30,9 @@ class MintPersonalAccessToken
 
         $token->accessToken->forceFill(['team_id' => $team->id])->save();
 
-        $this->recorder->record($team, $user, AuditAction::PersonalAccessTokenCreated, $user, [
+        event(new AuditableActionOccurred($team, $user, AuditAction::PersonalAccessTokenCreated, $user, [
             'token_name' => $name,
-        ]);
+        ]));
 
         return $token;
     }

--- a/app/Actions/Integrations/ReenableWebhookSubscription.php
+++ b/app/Actions/Integrations/ReenableWebhookSubscription.php
@@ -6,9 +6,9 @@ namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
 use App\Enums\WebhookSubscriptionStatus;
+use App\Events\AuditableActionOccurred;
 use App\Models\User;
 use App\Models\WebhookSubscription;
-use App\Support\AuditRecorder;
 
 /**
  * Re-enables an auto-disabled webhook subscription and records it in the audit
@@ -18,8 +18,6 @@ use App\Support\AuditRecorder;
  */
 class ReenableWebhookSubscription
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     public function handle(User $actor, WebhookSubscription $subscription): void
     {
         if ($subscription->isActive()) {
@@ -32,8 +30,8 @@ class ReenableWebhookSubscription
             'disabled_at' => null,
         ])->save();
 
-        $this->recorder->record($subscription->team, $actor, AuditAction::WebhookSubscriptionReenabled, $subscription, [
+        event(new AuditableActionOccurred($subscription->team, $actor, AuditAction::WebhookSubscriptionReenabled, $subscription, [
             'subscription_name' => $subscription->name,
-        ]);
+        ]));
     }
 }

--- a/app/Actions/Integrations/ReplayWebhookDelivery.php
+++ b/app/Actions/Integrations/ReplayWebhookDelivery.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Jobs\DeliverWebhook;
 use App\Models\User;
 use App\Models\WebhookDelivery;
-use App\Support\AuditRecorder;
 
 /**
  * Re-fires one past delivery attempt by hand, queueing a fresh single-shot
@@ -23,8 +23,6 @@ use App\Support\AuditRecorder;
  */
 class ReplayWebhookDelivery
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     /**
      * Queue the replay and record it in the workspace audit log. The caller is
      * responsible for rejecting an attempt that {@see WebhookDelivery::isReplayable()}
@@ -39,10 +37,10 @@ class ReplayWebhookDelivery
 
         dispatch(new DeliverWebhook($subscription->id, $envelope, isReplay: true));
 
-        $this->recorder->record($subscription->team, $actor, AuditAction::WebhookDeliveryReplayed, $subscription, [
+        event(new AuditableActionOccurred($subscription->team, $actor, AuditAction::WebhookDeliveryReplayed, $subscription, [
             'subscription_name' => $subscription->name,
             'event_type' => $delivery->event_type,
             'event_id' => $delivery->event_id,
-        ]);
+        ]));
     }
 }

--- a/app/Actions/Integrations/RevokeBotToken.php
+++ b/app/Actions/Integrations/RevokeBotToken.php
@@ -3,8 +3,8 @@
 namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Laravel\Sanctum\PersonalAccessToken;
 
 /**
@@ -14,8 +14,6 @@ use Laravel\Sanctum\PersonalAccessToken;
  */
 class RevokeBotToken
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     public function handle(User $actor, PersonalAccessToken $token): void
     {
         $bot = $token->tokenable;
@@ -24,9 +22,9 @@ class RevokeBotToken
         $tokenName = $token->name;
         $token->delete();
 
-        $this->recorder->record($bot->ownerTeam()->firstOrFail(), $actor, AuditAction::BotTokenRevoked, $bot, [
+        event(new AuditableActionOccurred($bot->ownerTeam()->firstOrFail(), $actor, AuditAction::BotTokenRevoked, $bot, [
             'token_name' => $tokenName,
             'bot_name' => $bot->name,
-        ]);
+        ]));
     }
 }

--- a/app/Actions/Integrations/RevokeIncomingWebhook.php
+++ b/app/Actions/Integrations/RevokeIncomingWebhook.php
@@ -3,9 +3,9 @@
 namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\IncomingWebhook;
 use App\Models\User;
-use App\Support\AuditRecorder;
 
 /**
  * Revokes an incoming webhook and records the revocation in the workspace audit
@@ -14,8 +14,6 @@ use App\Support\AuditRecorder;
  */
 class RevokeIncomingWebhook
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     public function handle(User $actor, IncomingWebhook $webhook): void
     {
         if ($webhook->revoked_at !== null) {
@@ -24,10 +22,10 @@ class RevokeIncomingWebhook
 
         $webhook->forceFill(['revoked_at' => now()])->save();
 
-        $this->recorder->record($webhook->team, $actor, AuditAction::IncomingWebhookRevoked, $webhook, [
+        event(new AuditableActionOccurred($webhook->team, $actor, AuditAction::IncomingWebhookRevoked, $webhook, [
             'webhook_name' => $webhook->name,
             'bot_name' => $webhook->bot->name,
             'channel_name' => $webhook->channel->name,
-        ]);
+        ]));
     }
 }

--- a/app/Actions/Integrations/RevokePersonalAccessToken.php
+++ b/app/Actions/Integrations/RevokePersonalAccessToken.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\PersonalAccessToken;
 use App\Models\Team;
 use App\Models\User;
-use App\Support\AuditRecorder;
 
 /**
  * Revokes a human's own personal access token and records the revocation in the
@@ -17,8 +17,6 @@ use App\Support\AuditRecorder;
  */
 class RevokePersonalAccessToken
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     public function handle(User $user, PersonalAccessToken $token): void
     {
         $team = $token->team;
@@ -27,9 +25,9 @@ class RevokePersonalAccessToken
         $token->delete();
 
         if ($team instanceof Team) {
-            $this->recorder->record($team, $user, AuditAction::PersonalAccessTokenRevoked, $user, [
+            event(new AuditableActionOccurred($team, $user, AuditAction::PersonalAccessTokenRevoked, $user, [
                 'token_name' => $tokenName,
-            ]);
+            ]));
         }
     }
 }

--- a/app/Actions/Integrations/RevokeWebhookSubscription.php
+++ b/app/Actions/Integrations/RevokeWebhookSubscription.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\User;
 use App\Models\WebhookSubscription;
-use App\Support\AuditRecorder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -17,8 +17,6 @@ use Illuminate\Support\Facades\DB;
  */
 class RevokeWebhookSubscription
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     public function handle(User $actor, WebhookSubscription $subscription): void
     {
         $team = $subscription->team;
@@ -27,9 +25,9 @@ class RevokeWebhookSubscription
         DB::transaction(function () use ($team, $actor, $subscription, $name): void {
             $subscription->delete();
 
-            $this->recorder->record($team, $actor, AuditAction::WebhookSubscriptionRevoked, $subscription, [
+            event(new AuditableActionOccurred($team, $actor, AuditAction::WebhookSubscriptionRevoked, $subscription, [
                 'subscription_name' => $name,
-            ]);
+            ]));
         });
     }
 }

--- a/app/Actions/Integrations/RotateWebhookSecret.php
+++ b/app/Actions/Integrations/RotateWebhookSecret.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Actions\Integrations;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\User;
 use App\Models\WebhookSubscription;
-use App\Support\AuditRecorder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -18,8 +18,6 @@ use Illuminate\Support\Facades\DB;
  */
 class RotateWebhookSecret
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     /**
      * @return string The new plaintext signing secret, shown to the caller once.
      */
@@ -30,9 +28,9 @@ class RotateWebhookSecret
         return DB::transaction(function () use ($actor, $subscription, $secret): string {
             $subscription->forceFill(['secret' => $secret])->save();
 
-            $this->recorder->record($subscription->team, $actor, AuditAction::WebhookSubscriptionSecretRotated, $subscription, [
+            event(new AuditableActionOccurred($subscription->team, $actor, AuditAction::WebhookSubscriptionSecretRotated, $subscription, [
                 'subscription_name' => $subscription->name,
-            ]);
+            ]));
 
             return $secret;
         });

--- a/app/Actions/Sso/ProvisionSsoUser.php
+++ b/app/Actions/Sso/ProvisionSsoUser.php
@@ -5,11 +5,11 @@ namespace App\Actions\Sso;
 use App\Actions\Teams\CreateTeam;
 use App\Enums\SecurityEventType;
 use App\Enums\TeamRole;
+use App\Events\SecurityEventOccurred;
 use App\Exceptions\Sso\UnverifiedSsoEmailException;
 use App\Models\SsoIdentity;
 use App\Models\Team;
 use App\Models\User;
-use App\Support\SecurityEventRecorder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -20,10 +20,7 @@ use Illuminate\Support\Facades\DB;
  */
 class ProvisionSsoUser
 {
-    public function __construct(
-        private readonly CreateTeam $createTeam,
-        private readonly SecurityEventRecorder $securityEvents,
-    ) {}
+    public function __construct(private readonly CreateTeam $createTeam) {}
 
     /**
      * Resolve the app user for a directory-verified identity.
@@ -123,7 +120,7 @@ class ProvisionSsoUser
 
         $this->assignToDefaultTeam($user);
 
-        $this->securityEvents->record($user, SecurityEventType::AccountProvisioned);
+        event(new SecurityEventOccurred($user, SecurityEventType::AccountProvisioned));
 
         return $user;
     }

--- a/app/Actions/Teams/AcceptTeamInvitation.php
+++ b/app/Actions/Teams/AcceptTeamInvitation.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Turns a pending invitation into a workspace membership.
+ *
+ * The membership, the stamped invitation and the team switch commit together,
+ * so an accepted invitation can never exist without the membership it granted.
+ * The person accepting is the actor: this is the one workspace fact its own
+ * subject causes.
+ */
+class AcceptTeamInvitation
+{
+    public function handle(TeamInvitation $invitation, User $user): void
+    {
+        $team = $invitation->team;
+
+        DB::transaction(function () use ($user, $invitation, $team): void {
+            $team->memberships()->firstOrCreate(
+                ['user_id' => $user->id],
+                ['role' => $invitation->role],
+            );
+
+            $invitation->update(['accepted_at' => now()]);
+
+            $user->switchTeam($team);
+        });
+
+        event(new AuditableActionOccurred($team, $user, AuditAction::InvitationAccepted, $invitation, [
+            'email' => $invitation->email,
+        ]));
+    }
+}

--- a/app/Actions/Teams/CreateTeamInvitation.php
+++ b/app/Actions/Teams/CreateTeamInvitation.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\AuditAction;
+use App\Enums\TeamRole;
+use App\Events\AuditableActionOccurred;
+use App\Models\Team;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * Invites someone to a workspace by email.
+ *
+ * The invitation, the mail that carries it and the audit entry are one act, so
+ * they live together: a surface that invites someone can never send the mail
+ * without recording who opened the door.
+ */
+class CreateTeamInvitation
+{
+    /**
+     * The window an invitation stays valid for.
+     */
+    public const int EXPIRY_DAYS = 3;
+
+    public function handle(Team $team, User $actor, string $email, TeamRole $role): TeamInvitation
+    {
+        /** @var TeamInvitation $invitation */
+        $invitation = $team->invitations()->create([
+            'email' => $email,
+            'role' => $role,
+            'invited_by' => $actor->id,
+            'expires_at' => now()->addDays(self::EXPIRY_DAYS),
+        ]);
+
+        event(new AuditableActionOccurred($team, $actor, AuditAction::InvitationCreated, $invitation, [
+            'email' => $invitation->email,
+            'role' => $role->label(),
+        ]));
+
+        Notification::route('mail', $invitation->email)
+            ->notify(new TeamInvitationNotification($invitation));
+
+        return $invitation;
+    }
+}

--- a/app/Actions/Teams/DeleteTeam.php
+++ b/app/Actions/Teams/DeleteTeam.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\SecurityEventType;
+use App\Events\SecurityEventOccurred;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Deletes a workspace and everything that only makes sense inside it.
+ *
+ * Members parked on the deleted workspace are moved to their personal team
+ * first, so nobody is left pointing at a workspace that no longer exists; the
+ * deleter is left alone, since the caller decides where they land. Destroying a
+ * workspace is a security-relevant account action, so it is recorded here.
+ */
+class DeleteTeam
+{
+    public function handle(Team $team, User $actor): void
+    {
+        DB::transaction(function () use ($team, $actor): void {
+            User::where('current_team_id', $team->id)
+                ->where('id', '!=', $actor->id)
+                ->each(fn (User $affectedUser): bool => $affectedUser->switchTeam($affectedUser->personalTeam()));
+
+            $team->invitations()->delete();
+            $team->memberships()->delete();
+            $team->delete();
+        });
+
+        event(new SecurityEventOccurred($actor, SecurityEventType::TeamDeleted));
+    }
+}

--- a/app/Actions/Teams/RemoveTeamMember.php
+++ b/app/Actions/Teams/RemoveTeamMember.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Removes a member from a workspace, along with everything their membership
+ * carried.
+ *
+ * Their user groups go with the membership, and a member parked on this
+ * workspace is moved to their personal team so they never land on one they no
+ * longer belong to.
+ */
+class RemoveTeamMember
+{
+    public function handle(Team $team, User $member, User $actor): void
+    {
+        $team->memberships()
+            ->where('user_id', $member->id)
+            ->delete();
+
+        $member->leaveUserGroups($team);
+
+        if ($member->isCurrentTeam($team)) {
+            $member->switchTeam($member->personalTeam());
+        }
+
+        event(new AuditableActionOccurred($team, $actor, AuditAction::MemberRemoved, $member, [
+            'member_name' => $member->name,
+        ]));
+    }
+}

--- a/app/Actions/Teams/RequestAuditExport.php
+++ b/app/Actions/Teams/RequestAuditExport.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\AuditAction;
+use App\Enums\AuditExportFormat;
+use App\Enums\AuditExportLogType;
+use App\Enums\AuditExportStatus;
+use App\Events\AuditableActionOccurred;
+use App\Jobs\GenerateAuditExport;
+use App\Models\AuditExport;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Throwable;
+
+/**
+ * Queues an export of one of a workspace's admin logs.
+ *
+ * Exporting a log is itself an audited workspace action — it takes a copy of
+ * who did what out of the app — so the entry is recorded here, alongside the
+ * request that caused it.
+ */
+class RequestAuditExport
+{
+    /**
+     * @throws Throwable when the export could not be queued; the row is marked
+     *                   failed first, so it never blocks the team's next request.
+     */
+    public function handle(
+        Team $team,
+        User $actor,
+        AuditExportLogType $logType,
+        AuditExportFormat $format,
+        ?string $rangeStart,
+        ?string $rangeEnd,
+    ): AuditExport {
+        /** @var AuditExport $export */
+        $export = $team->auditExports()->create([
+            'requested_by' => $actor->id,
+            'log_type' => $logType,
+            'format' => $format,
+            'range_start' => $rangeStart,
+            'range_end' => $rangeEnd,
+            'status' => AuditExportStatus::Pending,
+        ]);
+
+        // Dispatch eagerly so a queue-push failure surfaces to the caller rather
+        // than leaving a pending row that would block the team's next request
+        // forever (a pending export never reaches the retention purge).
+        try {
+            Bus::dispatch(new GenerateAuditExport($export->id));
+        } catch (Throwable $exception) {
+            $export->update(['status' => AuditExportStatus::Failed]);
+
+            throw $exception;
+        }
+
+        event(new AuditableActionOccurred($team, $actor, AuditAction::AuditExported, $export, [
+            'log' => $logType->label(),
+            'format' => $format->label(),
+            'range' => $this->rangeLabel($rangeStart, $rangeEnd),
+        ]));
+
+        return $export;
+    }
+
+    /**
+     * Build the human range label recorded on the export's audit entry.
+     */
+    private function rangeLabel(?string $rangeStart, ?string $rangeEnd): string
+    {
+        if ($rangeStart === null && $rangeEnd === null) {
+            return __('All time');
+        }
+
+        if ($rangeStart === null) {
+            return sprintf(__('Until %s'), $rangeEnd);
+        }
+
+        if ($rangeEnd === null) {
+            return sprintf(__('From %s'), $rangeStart);
+        }
+
+        return sprintf('%s – %s', $rangeStart, $rangeEnd);
+    }
+}

--- a/app/Actions/Teams/ResendTeamInvitation.php
+++ b/app/Actions/Teams/ResendTeamInvitation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * Sends a pending invitation again, on a fresh expiry window.
+ *
+ * The mail is only useful if the link it carries still works, so refreshing the
+ * expiry is part of resending rather than a separate step the caller has to
+ * remember. Throttling belongs to the surface, not here.
+ */
+class ResendTeamInvitation
+{
+    public function handle(TeamInvitation $invitation, User $actor): void
+    {
+        $invitation->update(['expires_at' => now()->addDays(CreateTeamInvitation::EXPIRY_DAYS)]);
+
+        event(new AuditableActionOccurred($invitation->team, $actor, AuditAction::InvitationResent, $invitation, [
+            'email' => $invitation->email,
+        ]));
+
+        Notification::route('mail', $invitation->email)
+            ->notify(new TeamInvitationNotification($invitation));
+    }
+}

--- a/app/Actions/Teams/RevokeCustomEmoji.php
+++ b/app/Actions/Teams/RevokeCustomEmoji.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace App\Actions\Teams;
 
 use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
 use App\Models\CustomEmoji;
 use App\Models\Team;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Illuminate\Support\Facades\Storage;
 
 class RevokeCustomEmoji
 {
-    public function __construct(private readonly AuditRecorder $recorder) {}
-
     /**
      * Remove a custom emoji and its image.
      *
@@ -26,9 +24,9 @@ class RevokeCustomEmoji
     public function handle(Team $team, User $actor, CustomEmoji $emoji): void
     {
         if ($emoji->created_by !== $actor->id) {
-            $this->recorder->record($team, $actor, AuditAction::EmojiRevoked, context: [
+            event(new AuditableActionOccurred($team, $actor, AuditAction::EmojiRevoked, context: [
                 'emoji_name' => $emoji->name,
-            ]);
+            ]));
         }
 
         Storage::disk(CustomEmoji::DISK)->delete($emoji->path);

--- a/app/Actions/Teams/RevokeTeamInvitation.php
+++ b/app/Actions/Teams/RevokeTeamInvitation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\AuditAction;
+use App\Events\AuditableActionOccurred;
+use App\Models\TeamInvitation;
+use App\Models\User;
+
+/**
+ * Cancels a pending invitation, so its link stops working.
+ *
+ * The audit entry is raised before the row goes, since it is recorded against
+ * the invitation as its subject.
+ */
+class RevokeTeamInvitation
+{
+    public function handle(TeamInvitation $invitation, User $actor): void
+    {
+        event(new AuditableActionOccurred($invitation->team, $actor, AuditAction::InvitationRevoked, $invitation, [
+            'email' => $invitation->email,
+        ]));
+
+        $invitation->delete();
+    }
+}

--- a/app/Actions/Teams/TransferTeamOwnership.php
+++ b/app/Actions/Teams/TransferTeamOwnership.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Actions\Teams;
 
+use App\Enums\AuditAction;
 use App\Enums\TeamRole;
+use App\Events\AuditableActionOccurred;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -28,6 +30,10 @@ class TransferTeamOwnership
             $team->memberships()
                 ->where('user_id', $newOwner->id)
                 ->update(['role' => TeamRole::Owner]);
+
+            event(new AuditableActionOccurred($team, $currentOwner, AuditAction::OwnershipTransferred, $newOwner, [
+                'new_owner_name' => $newOwner->name,
+            ]));
         });
     }
 }

--- a/app/Actions/Teams/UpdateTeam.php
+++ b/app/Actions/Teams/UpdateTeam.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\AuditAction;
+use App\Enums\ChannelCreationPolicy;
+use App\Enums\ChannelVisibility;
+use App\Events\AuditableActionOccurred;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Applies a partial update to a workspace's own settings and records what
+ * actually moved.
+ *
+ * The admin page edits the workspace through several small forms, so only the
+ * submitted attributes are applied. Each is audited only when its value really
+ * changed — which is why the read and the write share one lock: a concurrent
+ * update slipping between them would leave an audit entry naming a value that
+ * was never replaced.
+ */
+class UpdateTeam
+{
+    /**
+     * @param  array<string, mixed>  $attributes  The validated subset to apply.
+     */
+    public function handle(Team $team, User $actor, array $attributes): Team
+    {
+        return DB::transaction(function () use ($team, $actor, $attributes): Team {
+            $locked = Team::whereKey($team->id)->lockForUpdate()->firstOrFail();
+
+            $before = $locked->only(array_keys($attributes));
+
+            $locked->update($attributes);
+
+            $this->recordChanges($locked, $actor, $before);
+
+            return $locked;
+        });
+    }
+
+    /**
+     * Dispatch an audit event for each workspace attribute the update moved.
+     *
+     * @param  array<string, mixed>  $before  The submitted attributes as they stood beforehand.
+     */
+    private function recordChanges(Team $team, User $actor, array $before): void
+    {
+        if (array_key_exists('name', $before) && $before['name'] !== $team->name) {
+            event(new AuditableActionOccurred($team, $actor, AuditAction::TeamRenamed, $team, [
+                'old_name' => $before['name'],
+                'new_name' => $team->name,
+            ]));
+        }
+
+        foreach (ChannelVisibility::cases() as $visibility) {
+            $column = $visibility->value.'_channel_creation_policy';
+            $old = $before[$column] ?? null;
+            if (! $old instanceof ChannelCreationPolicy) {
+                continue;
+            }
+            if ($old === $team->creationPolicyFor($visibility)) {
+                continue;
+            }
+
+            event(new AuditableActionOccurred($team, $actor, AuditAction::ChannelCreationPolicyChanged, $team, [
+                'visibility' => $visibility->label(),
+                'old_policy' => $old->label(),
+                'new_policy' => $team->creationPolicyFor($visibility)->label(),
+            ]));
+        }
+    }
+}

--- a/app/Actions/Teams/UpdateTeamMemberRole.php
+++ b/app/Actions/Teams/UpdateTeamMemberRole.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Teams;
+
+use App\Enums\AuditAction;
+use App\Enums\TeamRole;
+use App\Events\AuditableActionOccurred;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Moves a member to a different role in the workspace.
+ *
+ * Re-submitting the role someone already holds is a no-op that records nothing:
+ * a role change is only auditable when the role actually moved.
+ */
+class UpdateTeamMemberRole
+{
+    public function handle(Team $team, User $member, TeamRole $role, User $actor): void
+    {
+        $membership = $team->memberships()
+            ->where('user_id', $member->id)
+            ->firstOrFail();
+
+        $oldRole = $membership->role;
+
+        $membership->update(['role' => $role]);
+
+        if ($role === $oldRole) {
+            return;
+        }
+
+        event(new AuditableActionOccurred($team, $actor, AuditAction::MemberRoleChanged, $member, [
+            'member_name' => $member->name,
+            'old_role' => $oldRole->label(),
+            'new_role' => $role->label(),
+        ]));
+    }
+}

--- a/app/Actions/Users/ChangePassword.php
+++ b/app/Actions/Users/ChangePassword.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Users;
+
+use App\Enums\SecurityEventType;
+use App\Events\SecurityEventOccurred;
+use App\Models\User;
+
+/**
+ * Replaces a user's password from the in-app security settings.
+ *
+ * The current-password check and confirmation rules belong to the request; by
+ * the time this runs the change is authorized. Fortify's own reset flow fires
+ * `PasswordReset`, but an in-app change fires no framework event, so the
+ * security activity is raised here — next to the mutation, so any future
+ * surface that changes a password records it too.
+ */
+class ChangePassword
+{
+    public function handle(User $user, string $password): void
+    {
+        $user->update(['password' => $password]);
+
+        event(new SecurityEventOccurred($user, SecurityEventType::PasswordChanged));
+    }
+}

--- a/app/Actions/Users/RequestDataExport.php
+++ b/app/Actions/Users/RequestDataExport.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Users;
+
+use App\Enums\DataExportStatus;
+use App\Enums\SecurityEventType;
+use App\Events\SecurityEventOccurred;
+use App\Jobs\ExportUserData;
+use App\Models\DataExport;
+use App\Models\User;
+
+/**
+ * Queues a fresh export of a user's personal data.
+ *
+ * The row is created pending and the archive is built off-request by
+ * {@see ExportUserData}; requesting one is a security-relevant account action,
+ * so it is recorded here rather than by whichever surface asked for it.
+ */
+class RequestDataExport
+{
+    public function handle(User $user): DataExport
+    {
+        /** @var DataExport $export */
+        $export = $user->dataExports()->create([
+            'status' => DataExportStatus::Pending,
+        ]);
+
+        dispatch(new ExportUserData($export->id));
+
+        event(new SecurityEventOccurred($user, SecurityEventType::DataExportRequested));
+
+        return $export;
+    }
+}

--- a/app/Events/AuditableActionOccurred.php
+++ b/app/Events/AuditableActionOccurred.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Enums\AuditAction;
+use App\Listeners\RecordAuditActivity;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Something worth recording in a workspace's audit log happened. This is the
+ * single emission abstraction for the audit half of ADR-0005: the mutation —
+ * in its Action — dispatches one of these, and {@see RecordAuditActivity}
+ * appends the row. Recording never lives in a controller, so every caller of
+ * that Action gets the audit, HTTP or not.
+ *
+ * Actor and team are carried explicitly rather than read from the live request:
+ * the REST API resolves both from the token subject (which may be a bot), and a
+ * queued directory sync has no request at all.
+ */
+class AuditableActionOccurred
+{
+    use Dispatchable;
+
+    /**
+     * @param  User|null  $actor  The acting user, or null for a platform-initiated
+     *                            action with no human causer.
+     * @param  Model|null  $target  The entity acted upon, stored as the subject.
+     * @param  array<string, mixed>  $context  Extra detail needed to render a
+     *                                         human sentence (names, old->new role).
+     */
+    public function __construct(
+        public readonly Team $team,
+        public readonly ?User $actor,
+        public readonly AuditAction $action,
+        public readonly ?Model $target = null,
+        public readonly array $context = [],
+    ) {}
+}

--- a/app/Events/SecurityEventOccurred.php
+++ b/app/Events/SecurityEventOccurred.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Enums\SecurityEventType;
+use App\Listeners\RecordSecurityEvents;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Something worth recording in a user's security activity happened outside the
+ * framework's own auth events. Fortify and Laravel already emit their own
+ * events for sign-in, password resets and two-factor changes; this covers the
+ * account facts the app raises itself — a password change, a revoked session, a
+ * data export, a directory provision.
+ *
+ * {@see RecordSecurityEvents} records it, stamping the live request's device
+ * context if there is one. The event carries none of that itself, so a queued
+ * directory sync can dispatch it just as well as a controller.
+ */
+class SecurityEventOccurred
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Authenticatable $user,
+        public readonly SecurityEventType $type,
+    ) {}
+}

--- a/app/Http/Controllers/Api/V1/ChannelController.php
+++ b/app/Http/Controllers/Api/V1/ChannelController.php
@@ -4,14 +4,12 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Actions\Channels\ArchiveChannel;
 use App\Actions\Channels\CreateChannel;
-use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\StoreChannelRequest;
 use App\Http\Resources\Api\V1\ChannelResource;
 use App\Models\Channel;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use App\Support\Integrations\ApiChannelAccess;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -57,7 +55,7 @@ class ChannelController extends Controller
      * Create a channel in the subject's acting team; the subject is seeded as its
      * first member.
      */
-    public function store(StoreChannelRequest $request, CreateChannel $createChannel, AuditRecorder $recorder): JsonResponse
+    public function store(StoreChannelRequest $request, CreateChannel $createChannel): JsonResponse
     {
         $subject = $request->user();
         assert($subject instanceof User);
@@ -71,10 +69,6 @@ class ChannelController extends Controller
             creator: $subject,
             topic: $request->validated('topic'),
         );
-
-        $recorder->record($team, $subject, AuditAction::ChannelCreated, $channel, [
-            'channel_name' => $channel->name,
-        ]);
 
         return ChannelResource::make($channel)->response()->setStatusCode(201);
     }
@@ -101,7 +95,7 @@ class ChannelController extends Controller
      * web `archive` policy — the channel's creator or a team Admin+ — so the
      * token can never exceed what the person could do in the app.
      */
-    public function archive(Request $request, Channel $channel, ArchiveChannel $archiveChannel, AuditRecorder $recorder): ChannelResource
+    public function archive(Request $request, Channel $channel, ArchiveChannel $archiveChannel): ChannelResource
     {
         $subject = $request->user();
         assert($subject instanceof User);
@@ -120,11 +114,7 @@ class ChannelController extends Controller
             abort_unless(Gate::forUser($subject)->allows('archive', $channel), 403);
         }
 
-        $channel = $archiveChannel->handle($channel);
-
-        $recorder->record(ApiChannelAccess::team($subject), $subject, AuditAction::ChannelArchived, $channel, [
-            'channel_name' => $channel->name,
-        ]);
+        $channel = $archiveChannel->handle($channel, $subject);
 
         return ChannelResource::make($channel);
     }

--- a/app/Http/Controllers/Api/V1/MemberController.php
+++ b/app/Http/Controllers/Api/V1/MemberController.php
@@ -4,14 +4,12 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Actions\Channels\JoinChannel;
 use App\Actions\Channels\RemoveChannelMember;
-use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\AddMemberRequest;
 use App\Http\Resources\Api\V1\UserResource;
 use App\Models\Channel;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use App\Support\Integrations\ApiChannelAccess;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -38,19 +36,14 @@ class MemberController extends Controller
     /**
      * Add a team member to one of the subject's private channels.
      */
-    public function store(AddMemberRequest $request, Channel $channel, JoinChannel $joinChannel, AuditRecorder $recorder): JsonResponse
+    public function store(AddMemberRequest $request, Channel $channel, JoinChannel $joinChannel): JsonResponse
     {
         $subject = $request->user();
         assert($subject instanceof User);
 
         $user = User::findOrFail((string) $request->validated('user_id'));
 
-        $joinChannel->handle($channel, $user);
-
-        $recorder->record(ApiChannelAccess::team($subject), $subject, AuditAction::ChannelMemberAdded, $channel, [
-            'channel_name' => $channel->name,
-            'member_name' => $user->name,
-        ]);
+        $joinChannel->handle($channel, $user, addedBy: $subject);
 
         return UserResource::make($user)->response()->setStatusCode(201);
     }
@@ -63,7 +56,7 @@ class MemberController extends Controller
      * the private channel, or a team Admin+ — so the token never exceeds what the
      * person could do in-app.
      */
-    public function destroy(Request $request, Channel $channel, User $user, RemoveChannelMember $removeChannelMember, AuditRecorder $recorder): JsonResponse
+    public function destroy(Request $request, Channel $channel, User $user, RemoveChannelMember $removeChannelMember): JsonResponse
     {
         $subject = $request->user();
         assert($subject instanceof User);
@@ -78,12 +71,7 @@ class MemberController extends Controller
 
         abort_unless($channel->channelMembers()->where('user_id', $user->id)->exists(), 404);
 
-        $removeChannelMember->handle($channel, $user);
-
-        $recorder->record(ApiChannelAccess::team($subject), $subject, AuditAction::ChannelMemberRemoved, $channel, [
-            'channel_name' => $channel->name,
-            'member_name' => $user->name,
-        ]);
+        $removeChannelMember->handle($channel, $user, removedBy: $subject);
 
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Api/V1/MessageController.php
+++ b/app/Http/Controllers/Api/V1/MessageController.php
@@ -102,7 +102,7 @@ class MessageController extends Controller
         abort_unless($message->channel_id === $channel->id, 404);
         abort_unless(Gate::allows('delete', $message), 403);
 
-        $deleteMessage->handle($channel, $message);
+        $deleteMessage->handle($channel, $message, deletedBy: $subject);
 
         return response()->json(null, 204);
     }

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -15,7 +15,6 @@ use App\Data\ChannelReaderData;
 use App\Data\MessageData;
 use App\Data\ScheduledMessageData;
 use App\Data\UserData;
-use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
 use App\Enums\NotificationLevel;
 use App\Enums\UserType;
@@ -24,11 +23,9 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\CreateChannelRequest;
 use App\Http\Requests\Channels\DeleteChannelRequest;
 use App\Http\Requests\Channels\UpdateChannelRequest;
-use App\Jobs\PurgeDeletedChannel;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
-use App\Support\AuditRecorder;
 use App\Support\ChannelTimelineWindow;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Http\RedirectResponse;
@@ -381,19 +378,11 @@ class ChannelController extends Controller
      * direct messages) and re-checks the typed channel name, so reaching here is
      * a deliberate, authorized destruction. The channel disappears from every
      * surface at once, so #general — which always exists — is where the admin
-     * lands. The audit entry carries the purge date, since the entry is the only
-     * lasting record once the window closes.
+     * lands.
      */
-    public function destroy(DeleteChannelRequest $request, Team $team, Channel $channel, DeleteChannel $deleteChannel, AuditRecorder $recorder): RedirectResponse
+    public function destroy(DeleteChannelRequest $request, Team $team, Channel $channel, DeleteChannel $deleteChannel): RedirectResponse
     {
-        // The action returns the row it actually stamped, so the audit entry
-        // below reads the deletion date the database settled on.
-        $channel = $deleteChannel->handle($channel);
-
-        $recorder->record($team, $request->user(), AuditAction::ChannelDeleted, $channel, [
-            'channel_name' => $channel->name,
-            'purge_at' => $channel->deleted_at->addDays(PurgeDeletedChannel::GRACE_WINDOW_DAYS)->toDateString(),
-        ]);
+        $channel = $deleteChannel->handle($channel, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Deleted #:channel', ['channel' => $channel->name])]);
 

--- a/app/Http/Controllers/Channels/ChannelController.php
+++ b/app/Http/Controllers/Channels/ChannelController.php
@@ -60,7 +60,7 @@ class ChannelController extends Controller
     /**
      * Store a newly created channel and redirect to it.
      */
-    public function store(CreateChannelRequest $request, Team $team, CreateChannel $createChannel, AuditRecorder $recorder): RedirectResponse
+    public function store(CreateChannelRequest $request, Team $team, CreateChannel $createChannel): RedirectResponse
     {
         $channel = $createChannel->handle(
             team: $team,
@@ -69,10 +69,6 @@ class ChannelController extends Controller
             creator: $request->user(),
             topic: $request->validated('topic'),
         );
-
-        $recorder->record($team, $request->user(), AuditAction::ChannelCreated, $channel, [
-            'channel_name' => $channel->name,
-        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Channel created')]);
 
@@ -367,17 +363,11 @@ class ChannelController extends Controller
      * sidebar, so we send the user back to #general rather than to a channel
      * that no longer appears in their list.
      */
-    public function archive(Request $request, Team $team, Channel $channel, ArchiveChannel $archiveChannel, AuditRecorder $recorder): RedirectResponse
+    public function archive(Request $request, Team $team, Channel $channel, ArchiveChannel $archiveChannel): RedirectResponse
     {
-        // The policy rejects archiving #general or an already-archived channel,
-        // so reaching here always represents a fresh archive worth recording.
         Gate::authorize('archive', $channel);
 
-        $archiveChannel->handle($channel);
-
-        $recorder->record($team, $request->user(), AuditAction::ChannelArchived, $channel, [
-            'channel_name' => $channel->name,
-        ]);
+        $archiveChannel->handle($channel, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Archived #:channel', ['channel' => $channel->name])]);
 

--- a/app/Http/Controllers/Channels/ChannelMemberController.php
+++ b/app/Http/Controllers/Channels/ChannelMemberController.php
@@ -4,14 +4,12 @@ namespace App\Http\Controllers\Channels;
 
 use App\Actions\Channels\JoinChannel;
 use App\Actions\Channels\RemoveChannelMember;
-use App\Enums\AuditAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\AddChannelMemberRequest;
 use App\Http\Requests\Channels\RemoveChannelMemberRequest;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 
@@ -20,16 +18,11 @@ class ChannelMemberController extends Controller
     /**
      * Add a team member to a private channel.
      */
-    public function store(AddChannelMemberRequest $request, Team $team, Channel $channel, JoinChannel $joinChannel, AuditRecorder $recorder): RedirectResponse
+    public function store(AddChannelMemberRequest $request, Team $team, Channel $channel, JoinChannel $joinChannel): RedirectResponse
     {
         $user = User::findOrFail((string) $request->validated('user_id'));
 
-        $joinChannel->handle($channel, $user);
-
-        $recorder->record($team, $request->user(), AuditAction::ChannelMemberAdded, $channel, [
-            'channel_name' => $channel->name,
-            'member_name' => $user->name,
-        ]);
+        $joinChannel->handle($channel, $user, addedBy: $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member added')]);
 
@@ -39,16 +32,11 @@ class ChannelMemberController extends Controller
     /**
      * Remove a member from a private channel.
      */
-    public function destroy(RemoveChannelMemberRequest $request, Team $team, Channel $channel, RemoveChannelMember $removeChannelMember, AuditRecorder $recorder): RedirectResponse
+    public function destroy(RemoveChannelMemberRequest $request, Team $team, Channel $channel, RemoveChannelMember $removeChannelMember): RedirectResponse
     {
         $user = User::findOrFail((string) $request->validated('user_id'));
 
-        $removeChannelMember->handle($channel, $user);
-
-        $recorder->record($team, $request->user(), AuditAction::ChannelMemberRemoved, $channel, [
-            'channel_name' => $channel->name,
-            'member_name' => $user->name,
-        ]);
+        $removeChannelMember->handle($channel, $user, removedBy: $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member removed')]);
 

--- a/app/Http/Controllers/Channels/MessageController.php
+++ b/app/Http/Controllers/Channels/MessageController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Channels;
 use App\Actions\Channels\DeleteMessage;
 use App\Actions\Channels\EditMessage;
 use App\Actions\Channels\PostMessage;
-use App\Enums\AuditAction;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Channels\DeleteMessageRequest;
 use App\Http\Requests\Channels\EditMessageRequest;
@@ -13,7 +12,6 @@ use App\Http\Requests\Channels\PostMessageRequest;
 use App\Models\Channel;
 use App\Models\Message;
 use App\Models\Team;
-use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 
 class MessageController extends Controller
@@ -50,22 +48,9 @@ class MessageController extends Controller
     /**
      * Soft-delete a message, leaving a tombstone in its place.
      */
-    public function destroy(DeleteMessageRequest $request, Team $team, Channel $channel, Message $message, DeleteMessage $deleteMessage, AuditRecorder $recorder): RedirectResponse
+    public function destroy(DeleteMessageRequest $request, Team $team, Channel $channel, Message $message, DeleteMessage $deleteMessage): RedirectResponse
     {
-        $message->loadMissing('user');
-        $author = $message->user;
-        $isModeration = ! $request->user()->is($author);
-
-        $deleteMessage->handle($channel, $message);
-
-        // Only moderation deletions (an admin removing another member's message)
-        // are audited; a member deleting their own message is not an admin action.
-        if ($isModeration) {
-            $recorder->record($team, $request->user(), AuditAction::MessageDeleted, $message, [
-                'channel_name' => $channel->name,
-                'author_name' => $author->name,
-            ]);
-        }
+        $deleteMessage->handle($channel, $message, deletedBy: $request->user());
 
         return to_route('channels.show', ['team' => $team->slug, 'channel' => $channel->slug]);
     }

--- a/app/Http/Controllers/Settings/DataExportController.php
+++ b/app/Http/Controllers/Settings/DataExportController.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Controllers\Settings;
 
+use App\Actions\Users\RequestDataExport;
 use App\Data\DataExportData;
-use App\Enums\DataExportStatus;
 use App\Enums\SecurityEventType;
+use App\Events\SecurityEventOccurred;
 use App\Http\Controllers\Controller;
-use App\Jobs\ExportUserData;
 use App\Models\DataExport;
 use App\Support\ExportLifecycle;
-use App\Support\SecurityEventRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
@@ -34,15 +33,9 @@ class DataExportController extends Controller
     /**
      * Queue a fresh export of the authenticated user's personal data.
      */
-    public function store(Request $request, SecurityEventRecorder $securityEvents): RedirectResponse
+    public function store(Request $request, RequestDataExport $requestDataExport): RedirectResponse
     {
-        $export = $request->user()->dataExports()->create([
-            'status' => DataExportStatus::Pending,
-        ]);
-
-        dispatch(new ExportUserData($export->id));
-
-        $securityEvents->record($request->user(), SecurityEventType::DataExportRequested);
+        $requestDataExport->handle($request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __("Preparing your data export. We'll email you when it's ready.")]);
 
@@ -54,15 +47,18 @@ class DataExportController extends Controller
      *
      * Guards ownership and the download window: another user's export is
      * forbidden, and one that is still pending, failed, or expired is a 404.
+     *
+     * A download mutates nothing, so there is no Action for the security event
+     * to sit next to; handing the archive over *is* the fact being recorded.
      */
-    public function download(Request $request, DataExport $dataExport, SecurityEventRecorder $securityEvents): StreamedResponse
+    public function download(Request $request, DataExport $dataExport): StreamedResponse
     {
         abort_unless($dataExport->user_id === $request->user()->id, 403);
         abort_unless($dataExport->isReady() && ! $dataExport->isExpired(), 404);
 
         $response = Storage::disk(ExportLifecycle::DISK)->download($dataExport->path, 'data-export.zip');
 
-        $securityEvents->record($request->user(), SecurityEventType::DataExportDownloaded);
+        event(new SecurityEventOccurred($request->user(), SecurityEventType::DataExportDownloaded));
 
         return $response;
     }

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -2,18 +2,17 @@
 
 namespace App\Http\Controllers\Settings;
 
+use App\Actions\Users\ChangePassword;
 use App\Data\PasskeyData;
 use App\Data\SecurityEventData;
 use App\Data\SessionData;
 use App\Data\TwoFactorStateData;
-use App\Enums\SecurityEventType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\PasswordUpdateRequest;
 use App\Http\Requests\Settings\TwoFactorAuthenticationRequest;
 use App\Models\SecurityEvent;
 use App\Support\IpGeolocator;
 use App\Support\PasskeyAvailability;
-use App\Support\SecurityEventRecorder;
 use App\Support\SessionRegistry;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Validation\Rules\Password;
@@ -132,19 +131,10 @@ class SecurityController extends Controller
 
     /**
      * Update the user's password.
-     *
-     * The in-app password change fires no framework event, so the security
-     * activity is recorded explicitly here.
      */
-    public function update(PasswordUpdateRequest $request, SecurityEventRecorder $recorder): RedirectResponse
+    public function update(PasswordUpdateRequest $request, ChangePassword $changePassword): RedirectResponse
     {
-        $user = $request->user();
-
-        $user->update([
-            'password' => $request->password,
-        ]);
-
-        $recorder->record($user, SecurityEventType::PasswordChanged);
+        $changePassword->handle($request->user(), $request->password);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Password updated')]);
 

--- a/app/Http/Controllers/Settings/SessionController.php
+++ b/app/Http/Controllers/Settings/SessionController.php
@@ -5,19 +5,22 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Settings;
 
 use App\Enums\SecurityEventType;
+use App\Events\SecurityEventOccurred;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\SessionRevokeRequest;
-use App\Support\SecurityEventRecorder;
 use App\Support\SessionRegistry;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 
+/**
+ * Revoking a session is a mutation of the {@see SessionRegistry} rather than of
+ * a domain model, so there is no Action for the security event to sit next to;
+ * these two dispatch it themselves. Both facts also depend on the request's own
+ * session, which only a controller has.
+ */
 class SessionController extends Controller
 {
-    public function __construct(
-        private readonly SessionRegistry $registry,
-        private readonly SecurityEventRecorder $securityEvents,
-    ) {}
+    public function __construct(private readonly SessionRegistry $registry) {}
 
     /**
      * Revoke a single session, protecting the request's own session.
@@ -29,7 +32,7 @@ class SessionController extends Controller
     {
         if ($session !== $request->session()->getId()
             && $this->registry->forget($request->user()->id, $session)) {
-            $this->securityEvents->record($request->user(), SecurityEventType::SessionRevoked);
+            event(new SecurityEventOccurred($request->user(), SecurityEventType::SessionRevoked));
 
             Inertia::flash('toast', ['type' => 'success', 'message' => __('Session revoked')]);
         }
@@ -47,7 +50,7 @@ class SessionController extends Controller
         $revoked = $this->registry->forgetOthers($request->user()->id, $request->session()->getId());
 
         if ($revoked > 0) {
-            $this->securityEvents->record($request->user(), SecurityEventType::OtherSessionsRevoked);
+            event(new SecurityEventOccurred($request->user(), SecurityEventType::OtherSessionsRevoked));
 
             Inertia::flash('toast', ['type' => 'success', 'message' => __('Logged out of your other devices')]);
         }

--- a/app/Http/Controllers/Teams/AuditExportController.php
+++ b/app/Http/Controllers/Teams/AuditExportController.php
@@ -2,21 +2,18 @@
 
 namespace App\Http\Controllers\Teams;
 
+use App\Actions\Teams\RequestAuditExport;
 use App\Data\AuditExportData;
-use App\Enums\AuditAction;
 use App\Enums\AuditExportFormat;
 use App\Enums\AuditExportLogType;
 use App\Enums\AuditExportStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\RequestAuditExportRequest;
-use App\Jobs\GenerateAuditExport;
 use App\Models\AuditExport;
 use App\Models\Team;
-use App\Support\AuditRecorder;
 use App\Support\ExportLifecycle;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
@@ -67,7 +64,7 @@ class AuditExportController extends Controller
      * Only one export may be generating per team at a time; a second request is
      * rejected with a toast until the first finishes.
      */
-    public function store(RequestAuditExportRequest $request, Team $team, AuditRecorder $recorder): RedirectResponse
+    public function store(RequestAuditExportRequest $request, Team $team, RequestAuditExport $requestExport): RedirectResponse
     {
         if ($team->auditExports()->where('status', AuditExportStatus::Pending)->exists()) {
             Inertia::flash('toast', ['type' => 'error', 'message' => __('An export is already generating')]);
@@ -75,39 +72,22 @@ class AuditExportController extends Controller
             return back();
         }
 
-        $logType = AuditExportLogType::from((string) $request->validated('log_type'));
-        $format = AuditExportFormat::from((string) $request->validated('format'));
-        $rangeStart = $request->validated('range_start');
-        $rangeEnd = $request->validated('range_end');
-
-        $export = $team->auditExports()->create([
-            'requested_by' => $request->user()->id,
-            'log_type' => $logType,
-            'format' => $format,
-            'range_start' => $rangeStart,
-            'range_end' => $rangeEnd,
-            'status' => AuditExportStatus::Pending,
-        ]);
-
-        // Dispatch eagerly so a queue-push failure surfaces here rather than
-        // leaving a pending row that would block the team's next request forever
-        // (a pending export never reaches the retention purge).
         try {
-            Bus::dispatch(new GenerateAuditExport($export->id));
+            $requestExport->handle(
+                $team,
+                $request->user(),
+                AuditExportLogType::from((string) $request->validated('log_type')),
+                AuditExportFormat::from((string) $request->validated('format')),
+                $request->validated('range_start'),
+                $request->validated('range_end'),
+            );
         } catch (Throwable $exception) {
-            $export->update(['status' => AuditExportStatus::Failed]);
             report($exception);
 
             Inertia::flash('toast', ['type' => 'error', 'message' => __('Could not start the export')]);
 
             return back();
         }
-
-        $recorder->record($team, $request->user(), AuditAction::AuditExported, $export, [
-            'log' => $logType->label(),
-            'format' => $format->label(),
-            'range' => $this->rangeLabel($rangeStart, $rangeEnd),
-        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __("Preparing your export. We'll email you when it's ready.")]);
 
@@ -136,25 +116,5 @@ class AuditExportController extends Controller
         $filename = $auditExport->log_type->value.'-export.'.$auditExport->format->extension();
 
         return Storage::disk(ExportLifecycle::DISK)->download($auditExport->path, $filename);
-    }
-
-    /**
-     * Build the human range label recorded on the export's audit entry.
-     */
-    private function rangeLabel(?string $rangeStart, ?string $rangeEnd): string
-    {
-        if ($rangeStart === null && $rangeEnd === null) {
-            return __('All time');
-        }
-
-        if ($rangeStart === null) {
-            return sprintf(__('Until %s'), $rangeEnd);
-        }
-
-        if ($rangeEnd === null) {
-            return sprintf(__('From %s'), $rangeStart);
-        }
-
-        return sprintf('%s – %s', $rangeStart, $rangeEnd);
     }
 }

--- a/app/Http/Controllers/Teams/DeletedChannelController.php
+++ b/app/Http/Controllers/Teams/DeletedChannelController.php
@@ -4,11 +4,9 @@ namespace App\Http\Controllers\Teams;
 
 use App\Actions\Channels\RestoreChannel;
 use App\Data\DeletedChannelData;
-use App\Enums\AuditAction;
 use App\Http\Controllers\Controller;
 use App\Models\Channel;
 use App\Models\Team;
-use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -44,15 +42,11 @@ class DeletedChannelController extends Controller
      * deletion did. A slug taken in the meantime aborts the restore with a
      * validation error rather than moving the channel's URL.
      */
-    public function restore(Request $request, Team $team, Channel $channel, RestoreChannel $restoreChannel, AuditRecorder $recorder): RedirectResponse
+    public function restore(Request $request, Team $team, Channel $channel, RestoreChannel $restoreChannel): RedirectResponse
     {
         Gate::authorize('restore', $channel);
 
-        $restoreChannel->handle($channel);
-
-        $recorder->record($team, $request->user(), AuditAction::ChannelRestored, $channel, [
-            'channel_name' => $channel->name,
-        ]);
+        $restoreChannel->handle($channel, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Restored #:channel', ['channel' => $channel->name])]);
 

--- a/app/Http/Controllers/Teams/Integrations/BotChannelController.php
+++ b/app/Http/Controllers/Teams/Integrations/BotChannelController.php
@@ -6,7 +6,6 @@ namespace App\Http\Controllers\Teams\Integrations;
 
 use App\Actions\Channels\JoinChannel;
 use App\Actions\Channels\RemoveChannelMember;
-use App\Enums\AuditAction;
 use App\Enums\ChannelType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\Integrations\StoreBotChannelRequest;
@@ -14,7 +13,6 @@ use App\Models\Channel;
 use App\Models\ChannelMember;
 use App\Models\Team;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -34,19 +32,14 @@ class BotChannelController extends Controller
     /**
      * Add the bot to one of the team's channels.
      */
-    public function store(StoreBotChannelRequest $request, Team $team, User $bot, JoinChannel $joinChannel, AuditRecorder $recorder): RedirectResponse
+    public function store(StoreBotChannelRequest $request, Team $team, User $bot, JoinChannel $joinChannel): RedirectResponse
     {
         $this->ensureBotBelongsToTeam($bot, $team);
 
         /** @var Channel $channel */
         $channel = $team->channels()->whereKey($request->validated('channel_id'))->firstOrFail();
 
-        $joinChannel->handle($channel, $bot);
-
-        $recorder->record($team, $request->user(), AuditAction::ChannelMemberAdded, $channel, [
-            'channel_name' => $channel->name,
-            'member_name' => $bot->name,
-        ]);
+        $joinChannel->handle($channel, $bot, addedBy: $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Bot added to :channel', ['channel' => $channel->name])]);
 
@@ -56,7 +49,7 @@ class BotChannelController extends Controller
     /**
      * Remove the bot from a channel, revoking its posting there.
      */
-    public function destroy(Request $request, Team $team, User $bot, Channel $channel, RemoveChannelMember $removeChannelMember, AuditRecorder $recorder): RedirectResponse
+    public function destroy(Request $request, Team $team, User $bot, Channel $channel, RemoveChannelMember $removeChannelMember): RedirectResponse
     {
         Gate::authorize('manageIntegrations', $team);
 
@@ -64,12 +57,7 @@ class BotChannelController extends Controller
 
         abort_unless($channel->team_id === $team->id && $channel->type === ChannelType::Standard, 404);
 
-        $removeChannelMember->handle($channel, $bot);
-
-        $recorder->record($team, $request->user(), AuditAction::ChannelMemberRemoved, $channel, [
-            'channel_name' => $channel->name,
-            'member_name' => $bot->name,
-        ]);
+        $removeChannelMember->handle($channel, $bot, removedBy: $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Bot removed from :channel', ['channel' => $channel->name])]);
 

--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers\Teams;
 
 use App\Actions\Teams\CreateTeam;
 use App\Actions\Teams\DeleteTeam;
+use App\Actions\Teams\UpdateTeam;
 use App\Data\UserStatusData;
-use App\Enums\AuditAction;
 use App\Enums\ChannelCreationPolicy;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamPermission;
@@ -18,11 +18,9 @@ use App\Models\Membership;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -144,69 +142,16 @@ class TeamController extends Controller
 
     /**
      * Update the specified team.
-     *
-     * The admin page edits the workspace through several small forms, so this is
-     * a partial update: only the submitted attributes are applied, and each one
-     * is audited only when it actually changes.
      */
-    public function update(SaveTeamRequest $request, Team $team, AuditRecorder $recorder): RedirectResponse
+    public function update(SaveTeamRequest $request, Team $team, UpdateTeam $updateTeam): RedirectResponse
     {
         Gate::authorize('update', $team);
 
-        $attributes = $request->validated();
-
-        // Read under the same lock as the write, so a concurrent update cannot
-        // slip between the two and leave the audit entry naming a value that was
-        // never actually replaced.
-        $before = [];
-
-        $team = DB::transaction(function () use ($attributes, $team, &$before) {
-            $team = Team::whereKey($team->id)->lockForUpdate()->firstOrFail();
-
-            $before = $team->only(array_keys($attributes));
-
-            $team->update($attributes);
-
-            return $team;
-        });
-
-        $this->recordTeamChanges($recorder, $team, $request->user(), $before);
+        $team = $updateTeam->handle($team, $request->user(), $request->validated());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Team updated')]);
 
         return to_route('teams.edit', ['team' => $team->slug]);
-    }
-
-    /**
-     * Write an audit entry for each workspace attribute the update moved.
-     *
-     * @param  array<string, mixed>  $before  The submitted attributes as they stood beforehand.
-     */
-    private function recordTeamChanges(AuditRecorder $recorder, Team $team, User $actor, array $before): void
-    {
-        if (array_key_exists('name', $before) && $before['name'] !== $team->name) {
-            $recorder->record($team, $actor, AuditAction::TeamRenamed, $team, [
-                'old_name' => $before['name'],
-                'new_name' => $team->name,
-            ]);
-        }
-
-        foreach (ChannelVisibility::cases() as $visibility) {
-            $column = $visibility->value.'_channel_creation_policy';
-            $old = $before[$column] ?? null;
-            if (! $old instanceof ChannelCreationPolicy) {
-                continue;
-            }
-            if ($old === $team->creationPolicyFor($visibility)) {
-                continue;
-            }
-
-            $recorder->record($team, $actor, AuditAction::ChannelCreationPolicyChanged, $team, [
-                'visibility' => $visibility->label(),
-                'old_policy' => $old->label(),
-                'new_policy' => $team->creationPolicyFor($visibility)->label(),
-            ]);
-        }
     }
 
     /**

--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers\Teams;
 
 use App\Actions\Teams\CreateTeam;
+use App\Actions\Teams\DeleteTeam;
 use App\Data\UserStatusData;
 use App\Enums\AuditAction;
 use App\Enums\ChannelCreationPolicy;
 use App\Enums\ChannelVisibility;
-use App\Enums\SecurityEventType;
 use App\Enums\TeamPermission;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
@@ -19,7 +19,6 @@ use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use App\Support\AuditRecorder;
-use App\Support\SecurityEventRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -251,22 +250,12 @@ class TeamController extends Controller
     /**
      * Delete the specified team.
      */
-    public function destroy(DeleteTeamRequest $request, Team $team, SecurityEventRecorder $securityEvents): RedirectResponse
+    public function destroy(DeleteTeamRequest $request, Team $team, DeleteTeam $deleteTeam): RedirectResponse
     {
         $user = $request->user();
         $fallbackTeam = $user->isCurrentTeam($team) ? $user->fallbackTeam($team) : null;
 
-        DB::transaction(function () use ($user, $team): void {
-            User::where('current_team_id', $team->id)
-                ->where('id', '!=', $user->id)
-                ->each(fn (User $affectedUser): bool => $affectedUser->switchTeam($affectedUser->personalTeam()));
-
-            $team->invitations()->delete();
-            $team->memberships()->delete();
-            $team->delete();
-        });
-
-        $securityEvents->record($user, SecurityEventType::TeamDeleted);
+        $deleteTeam->handle($team, $user);
 
         if ($fallbackTeam) {
             $user->switchTeam($fallbackTeam);

--- a/app/Http/Controllers/Teams/TeamInvitationController.php
+++ b/app/Http/Controllers/Teams/TeamInvitationController.php
@@ -2,20 +2,19 @@
 
 namespace App\Http\Controllers\Teams;
 
-use App\Enums\AuditAction;
+use App\Actions\Teams\AcceptTeamInvitation;
+use App\Actions\Teams\CreateTeamInvitation;
+use App\Actions\Teams\ResendTeamInvitation;
+use App\Actions\Teams\RevokeTeamInvitation;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\CreateTeamInvitationRequest;
 use App\Http\Requests\Teams\RespondToTeamInvitationRequest;
 use App\Models\Team;
 use App\Models\TeamInvitation;
-use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
-use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\RateLimiter;
 use Inertia\Inertia;
 
@@ -24,26 +23,16 @@ class TeamInvitationController extends Controller
     /**
      * Store a newly created invitation.
      */
-    public function store(CreateTeamInvitationRequest $request, Team $team, AuditRecorder $recorder): RedirectResponse
+    public function store(CreateTeamInvitationRequest $request, Team $team, CreateTeamInvitation $createInvitation): RedirectResponse
     {
         Gate::authorize('inviteMember', $team);
 
-        $role = TeamRole::from($request->validated('role'));
-
-        $invitation = $team->invitations()->create([
-            'email' => $request->validated('email'),
-            'role' => $role,
-            'invited_by' => $request->user()->id,
-            'expires_at' => now()->addDays(3),
-        ]);
-
-        $recorder->record($team, $request->user(), AuditAction::InvitationCreated, $invitation, [
-            'email' => $invitation->email,
-            'role' => $role->label(),
-        ]);
-
-        Notification::route('mail', $invitation->email)
-            ->notify(new TeamInvitationNotification($invitation));
+        $createInvitation->handle(
+            $team,
+            $request->user(),
+            (string) $request->validated('email'),
+            TeamRole::from($request->validated('role')),
+        );
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation sent')]);
 
@@ -53,17 +42,13 @@ class TeamInvitationController extends Controller
     /**
      * Cancel the specified invitation.
      */
-    public function destroy(Request $request, Team $team, TeamInvitation $invitation, AuditRecorder $recorder): RedirectResponse
+    public function destroy(Request $request, Team $team, TeamInvitation $invitation, RevokeTeamInvitation $revokeInvitation): RedirectResponse
     {
         abort_unless($invitation->team_id === $team->id, 404);
 
         Gate::authorize('cancelInvitation', $team);
 
-        $recorder->record($team, $request->user(), AuditAction::InvitationRevoked, $invitation, [
-            'email' => $invitation->email,
-        ]);
-
-        $invitation->delete();
+        $revokeInvitation->handle($invitation, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation cancelled')]);
 
@@ -72,8 +57,11 @@ class TeamInvitationController extends Controller
 
     /**
      * Resend the specified pending invitation, refreshing its expiry.
+     *
+     * The throttle is a property of this surface — a person clicking the button
+     * again — so it stays here rather than in the Action.
      */
-    public function resend(Request $request, Team $team, TeamInvitation $invitation, AuditRecorder $recorder): RedirectResponse
+    public function resend(Request $request, Team $team, TeamInvitation $invitation, ResendTeamInvitation $resendInvitation): RedirectResponse
     {
         abort_unless($invitation->team_id === $team->id, 404);
 
@@ -91,14 +79,7 @@ class TeamInvitationController extends Controller
 
         RateLimiter::hit($throttleKey, 60);
 
-        $invitation->update(['expires_at' => now()->addDays(3)]);
-
-        $recorder->record($team, $request->user(), AuditAction::InvitationResent, $invitation, [
-            'email' => $invitation->email,
-        ]);
-
-        Notification::route('mail', $invitation->email)
-            ->notify(new TeamInvitationNotification($invitation));
+        $resendInvitation->handle($invitation, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation resent')]);
 
@@ -108,26 +89,9 @@ class TeamInvitationController extends Controller
     /**
      * Accept the invitation.
      */
-    public function accept(RespondToTeamInvitationRequest $request, TeamInvitation $invitation, AuditRecorder $recorder): RedirectResponse
+    public function accept(RespondToTeamInvitationRequest $request, TeamInvitation $invitation, AcceptTeamInvitation $acceptInvitation): RedirectResponse
     {
-        $user = $request->user();
-
-        DB::transaction(function () use ($user, $invitation): void {
-            $team = $invitation->team;
-
-            $team->memberships()->firstOrCreate(
-                ['user_id' => $user->id],
-                ['role' => $invitation->role],
-            );
-
-            $invitation->update(['accepted_at' => now()]);
-
-            $user->switchTeam($team);
-        });
-
-        $recorder->record($invitation->team, $user, AuditAction::InvitationAccepted, $invitation, [
-            'email' => $invitation->email,
-        ]);
+        $acceptInvitation->handle($invitation, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation accepted')]);
 

--- a/app/Http/Controllers/Teams/TeamMemberController.php
+++ b/app/Http/Controllers/Teams/TeamMemberController.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Controllers\Teams;
 
+use App\Actions\Teams\RemoveTeamMember;
 use App\Actions\Teams\TransferTeamOwnership;
+use App\Actions\Teams\UpdateTeamMemberRole;
 use App\Data\UserProfileData;
-use App\Enums\AuditAction;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\TransferTeamOwnershipRequest;
@@ -12,7 +13,6 @@ use App\Http\Requests\Teams\UpdateTeamMemberRequest;
 use App\Models\Membership;
 use App\Models\Team;
 use App\Models\User;
-use App\Support\AuditRecorder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
@@ -72,27 +72,11 @@ class TeamMemberController extends Controller
     /**
      * Update the specified team member's role.
      */
-    public function update(UpdateTeamMemberRequest $request, Team $team, User $user, AuditRecorder $recorder): RedirectResponse
+    public function update(UpdateTeamMemberRequest $request, Team $team, User $user, UpdateTeamMemberRole $updateRole): RedirectResponse
     {
         Gate::authorize('updateMember', $team);
 
-        $newRole = TeamRole::from($request->validated('role'));
-
-        $membership = $team->memberships()
-            ->where('user_id', $user->id)
-            ->firstOrFail();
-
-        $oldRole = $membership->role;
-
-        $membership->update(['role' => $newRole]);
-
-        if ($newRole !== $oldRole) {
-            $recorder->record($team, $request->user(), AuditAction::MemberRoleChanged, $user, [
-                'member_name' => $user->name,
-                'old_role' => $oldRole->label(),
-                'new_role' => $newRole->label(),
-            ]);
-        }
+        $updateRole->handle($team, $user, TeamRole::from($request->validated('role')), $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member role updated')]);
 
@@ -106,7 +90,7 @@ class TeamMemberController extends Controller
      * member of the team. The outgoing owner is demoted to Admin and the new
      * owner holds the sole Owner pivot row (see {@see TransferTeamOwnership}).
      */
-    public function transferOwnership(TransferTeamOwnershipRequest $request, Team $team, User $user, TransferTeamOwnership $transferOwnership, AuditRecorder $recorder): RedirectResponse
+    public function transferOwnership(TransferTeamOwnershipRequest $request, Team $team, User $user, TransferTeamOwnership $transferOwnership): RedirectResponse
     {
         Gate::authorize('transferOwnership', $team);
 
@@ -116,10 +100,6 @@ class TeamMemberController extends Controller
 
         $transferOwnership->handle($team, $request->user(), $user);
 
-        $recorder->record($team, $request->user(), AuditAction::OwnershipTransferred, $user, [
-            'new_owner_name' => $user->name,
-        ]);
-
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Team ownership transferred')]);
 
         return to_route('teams.edit', ['team' => $team->slug]);
@@ -128,25 +108,13 @@ class TeamMemberController extends Controller
     /**
      * Remove the specified team member.
      */
-    public function destroy(Request $request, Team $team, User $user, AuditRecorder $recorder): RedirectResponse
+    public function destroy(Request $request, Team $team, User $user, RemoveTeamMember $removeMember): RedirectResponse
     {
         Gate::authorize('removeMember', $team);
 
         abort_if($team->owner()?->is($user), 403, __('The team owner cannot be removed.'));
 
-        $team->memberships()
-            ->where('user_id', $user->id)
-            ->delete();
-
-        $user->leaveUserGroups($team);
-
-        if ($user->isCurrentTeam($team)) {
-            $user->switchTeam($user->personalTeam());
-        }
-
-        $recorder->record($team, $request->user(), AuditAction::MemberRemoved, $user, [
-            'member_name' => $user->name,
-        ]);
+        $removeMember->handle($team, $user, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member removed')]);
 

--- a/app/Jobs/DeliverWebhook.php
+++ b/app/Jobs/DeliverWebhook.php
@@ -6,8 +6,8 @@ namespace App\Jobs;
 
 use App\Enums\AuditAction;
 use App\Enums\WebhookSubscriptionStatus;
+use App\Events\AuditableActionOccurred;
 use App\Models\WebhookSubscription;
-use App\Support\AuditRecorder;
 use App\Support\Http\OutboundUrlGuard;
 use App\Support\Webhooks\WebhookSignature;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -83,7 +83,7 @@ class DeliverWebhook implements ShouldQueue
     /**
      * Attempt one delivery.
      */
-    public function handle(AuditRecorder $recorder, OutboundUrlGuard $guard): void
+    public function handle(OutboundUrlGuard $guard): void
     {
         if (! config('integrations.enabled')) {
             return;
@@ -100,7 +100,7 @@ class DeliverWebhook implements ShouldQueue
         }
 
         if (! OutboundUrlGuard::isPublic($subscription->url)) {
-            $this->recordFailure($subscription, $recorder, null, 'Blocked non-public webhook URL', 0);
+            $this->recordFailure($subscription, null, 'Blocked non-public webhook URL', 0);
 
             return;
         }
@@ -108,7 +108,7 @@ class DeliverWebhook implements ShouldQueue
         $pinnedIp = $guard->resolveDeliveryIp($subscription->url);
 
         if ($pinnedIp === false) {
-            $this->recordFailure($subscription, $recorder, null, 'Blocked webhook URL resolving to a non-public address', 0);
+            $this->recordFailure($subscription, null, 'Blocked webhook URL resolving to a non-public address', 0);
 
             return;
         }
@@ -129,7 +129,7 @@ class DeliverWebhook implements ShouldQueue
                 ->withBody($body, 'application/json')
                 ->post($subscription->url);
         } catch (Throwable $exception) {
-            $this->recordFailure($subscription, $recorder, null, $this->summarize($exception->getMessage()), $this->elapsedMs($startedAt));
+            $this->recordFailure($subscription, null, $this->summarize($exception->getMessage()), $this->elapsedMs($startedAt));
 
             return;
         }
@@ -140,7 +140,7 @@ class DeliverWebhook implements ShouldQueue
             return;
         }
 
-        $this->recordFailure($subscription, $recorder, $response->status(), 'HTTP '.$response->status(), $this->elapsedMs($startedAt));
+        $this->recordFailure($subscription, $response->status(), 'HTTP '.$response->status(), $this->elapsedMs($startedAt));
     }
 
     /**
@@ -177,9 +177,9 @@ class DeliverWebhook implements ShouldQueue
      * lock so a concurrent delivery can't miscount the streak. The retry throw
      * happens after the transaction commits.
      */
-    private function recordFailure(WebhookSubscription $subscription, AuditRecorder $recorder, ?int $status, string $error, int $durationMs): void
+    private function recordFailure(WebhookSubscription $subscription, ?int $status, string $error, int $durationMs): void
     {
-        $stopRetrying = DB::transaction(function () use ($subscription, $recorder, $status, $error, $durationMs): bool {
+        $stopRetrying = DB::transaction(function () use ($subscription, $status, $error, $durationMs): bool {
             $locked = $this->lockSubscription($subscription);
 
             $this->logAttempt($locked, false, $status, $error, $durationMs);
@@ -192,7 +192,7 @@ class DeliverWebhook implements ShouldQueue
             $locked->forceFill(['consecutive_failures' => $failures])->save();
 
             if ($failures >= (int) config('integrations.webhooks.disable_after')) {
-                $this->autoDisable($locked, $recorder, $failures);
+                $this->autoDisable($locked, $failures);
 
                 return true;
             }
@@ -239,17 +239,17 @@ class DeliverWebhook implements ShouldQueue
     /**
      * Flip the subscription to disabled and record the reason in the audit log.
      */
-    private function autoDisable(WebhookSubscription $subscription, AuditRecorder $recorder, int $failures): void
+    private function autoDisable(WebhookSubscription $subscription, int $failures): void
     {
         $subscription->forceFill([
             'status' => WebhookSubscriptionStatus::Disabled,
             'disabled_at' => now(),
         ])->save();
 
-        $recorder->record($subscription->team, $subscription->creator, AuditAction::WebhookSubscriptionAutoDisabled, $subscription, [
+        event(new AuditableActionOccurred($subscription->team, $subscription->creator, AuditAction::WebhookSubscriptionAutoDisabled, $subscription, [
             'subscription_name' => $subscription->name,
             'failures' => $failures,
-        ]);
+        ]));
     }
 
     /**

--- a/app/Listeners/RecordAuditActivity.php
+++ b/app/Listeners/RecordAuditActivity.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\AuditableActionOccurred;
+use App\Support\AuditRecorder;
+
+/**
+ * Appends the audit row for an {@see AuditableActionOccurred}. Auto-discovered
+ * (the app has no EventServiceProvider), and runs inline so the entry lands in
+ * the same request — and the same transaction — as the mutation that caused it.
+ *
+ * This is the audit counterpart of {@see RecordSecurityEvents}: the one place
+ * that turns a domain event into a recorded row.
+ */
+class RecordAuditActivity
+{
+    public function __construct(private readonly AuditRecorder $recorder) {}
+
+    /**
+     * Handle the event.
+     */
+    public function handle(AuditableActionOccurred $event): void
+    {
+        $this->recorder->record(
+            $event->team,
+            $event->actor,
+            $event->action,
+            $event->target,
+            $event->context,
+        );
+    }
+}

--- a/app/Listeners/RecordSecurityEvents.php
+++ b/app/Listeners/RecordSecurityEvents.php
@@ -3,11 +3,14 @@
 namespace App\Listeners;
 
 use App\Enums\SecurityEventType;
+use App\Events\SecurityEventOccurred;
 use App\Support\SecurityEventRecorder;
 use App\Support\SessionRegistry;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
 use Laravel\Fortify\Events\RecoveryCodesGenerated;
 use Laravel\Fortify\Events\TwoFactorAuthenticationConfirmed;
 use Laravel\Fortify\Events\TwoFactorAuthenticationDisabled;
@@ -16,24 +19,38 @@ use Laravel\Passkeys\Events\PasskeyDeleted;
 use Laravel\Passkeys\Events\PasskeyRegistered;
 
 /**
- * Records framework and Fortify authentication events into the security
+ * Records framework, Fortify and application security events into the security
  * activity log. Each `handle*` method is wired to its event by Laravel's event
  * discovery. Runs synchronously (never queued) so the live request's IP and
  * User-Agent are available when the event is captured.
+ *
+ * This listener is the one place that reaches for the request: it holds the
+ * HTTP coupling so {@see SecurityEventRecorder} does not, which is what lets a
+ * queued directory sync record the same facts (ADR-0005). Off a request — a
+ * job, a console command — there is simply no device context to stamp.
  */
 class RecordSecurityEvents
 {
     public function __construct(
         private readonly SecurityEventRecorder $recorder,
         private readonly SessionRegistry $registry,
+        private readonly Request $request,
     ) {}
+
+    /**
+     * Handle an application security event raised outside the framework's own.
+     */
+    public function handleSecurityEvent(SecurityEventOccurred $event): void
+    {
+        $this->record($event->user, $event->type);
+    }
 
     /**
      * Handle a successful sign in.
      */
     public function handleLogin(Login $event): void
     {
-        $this->recorder->record($event->user, SecurityEventType::LoggedIn);
+        $this->record($event->user, SecurityEventType::LoggedIn);
     }
 
     /**
@@ -47,7 +64,7 @@ class RecordSecurityEvents
 
         $this->registry->forget((string) $event->user->getAuthIdentifier(), session()->getId());
 
-        $this->recorder->record($event->user, SecurityEventType::LoggedOut);
+        $this->record($event->user, SecurityEventType::LoggedOut);
     }
 
     /**
@@ -55,7 +72,7 @@ class RecordSecurityEvents
      */
     public function handlePasswordReset(PasswordReset $event): void
     {
-        $this->recorder->record($event->user, SecurityEventType::PasswordReset);
+        $this->record($event->user, SecurityEventType::PasswordReset);
     }
 
     /**
@@ -63,7 +80,7 @@ class RecordSecurityEvents
      */
     public function handleTwoFactorEnabled(TwoFactorAuthenticationEnabled $event): void
     {
-        $this->recorder->record($event->user, SecurityEventType::TwoFactorEnabled);
+        $this->record($event->user, SecurityEventType::TwoFactorEnabled);
     }
 
     /**
@@ -71,7 +88,7 @@ class RecordSecurityEvents
      */
     public function handleTwoFactorDisabled(TwoFactorAuthenticationDisabled $event): void
     {
-        $this->recorder->record($event->user, SecurityEventType::TwoFactorDisabled);
+        $this->record($event->user, SecurityEventType::TwoFactorDisabled);
     }
 
     /**
@@ -79,7 +96,7 @@ class RecordSecurityEvents
      */
     public function handleTwoFactorConfirmed(TwoFactorAuthenticationConfirmed $event): void
     {
-        $this->recorder->record($event->user, SecurityEventType::TwoFactorConfirmed);
+        $this->record($event->user, SecurityEventType::TwoFactorConfirmed);
     }
 
     /**
@@ -87,7 +104,7 @@ class RecordSecurityEvents
      */
     public function handleRecoveryCodesGenerated(RecoveryCodesGenerated $event): void
     {
-        $this->recorder->record($event->user, SecurityEventType::RecoveryCodesGenerated);
+        $this->record($event->user, SecurityEventType::RecoveryCodesGenerated);
     }
 
     /**
@@ -95,7 +112,7 @@ class RecordSecurityEvents
      */
     public function handlePasskeyRegistered(PasskeyRegistered $event): void
     {
-        $this->recorder->record($event->user, SecurityEventType::PasskeyRegistered);
+        $this->record($event->user, SecurityEventType::PasskeyRegistered);
     }
 
     /**
@@ -103,6 +120,14 @@ class RecordSecurityEvents
      */
     public function handlePasskeyDeleted(PasskeyDeleted $event): void
     {
-        $this->recorder->record($event->user, SecurityEventType::PasskeyRemoved);
+        $this->record($event->user, SecurityEventType::PasskeyRemoved);
+    }
+
+    /**
+     * Record the event, stamping the device context of the request behind it.
+     */
+    private function record(Authenticatable $user, SecurityEventType $type): void
+    {
+        $this->recorder->record($user, $type, $this->request->ip(), $this->request->userAgent());
     }
 }

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Observers;
 
 use App\Enums\SecurityEventType;
+use App\Events\SecurityEventOccurred;
 use App\Models\User;
-use App\Support\SecurityEventRecorder;
 
 class UserObserver
 {
@@ -27,11 +27,11 @@ class UserObserver
             return;
         }
 
-        app(SecurityEventRecorder::class)->record(
+        event(new SecurityEventOccurred(
             $user,
             $user->deactivated_at === null
                 ? SecurityEventType::AccountReactivated
                 : SecurityEventType::AccountDeactivated,
-        );
+        ));
     }
 }

--- a/app/Support/SecurityEventRecorder.php
+++ b/app/Support/SecurityEventRecorder.php
@@ -3,27 +3,33 @@
 namespace App\Support;
 
 use App\Enums\SecurityEventType;
+use App\Listeners\RecordSecurityEvents;
 use App\Models\SecurityEvent;
 use Illuminate\Contracts\Auth\Authenticatable;
-use Illuminate\Http\Request;
 
 /**
- * Persists security-relevant account events, capturing the live request's IP
- * and User-Agent. Must be resolved during a real request so the request context
- * is available — never from a queued job.
+ * Persists security-relevant account events. The device context is passed in
+ * explicitly rather than read from a live request, so this resolves anywhere —
+ * a controller, a queued directory sync, a console command. Capturing that
+ * context is {@see RecordSecurityEvents}' job, since only it knows whether an
+ * HTTP request is behind the event.
  */
 class SecurityEventRecorder
 {
-    public function __construct(private readonly Request $request) {}
-
     /**
-     * Record a security event for the given user against the current request.
+     * Record a security event for the given user against the given device.
+     *
+     * @param  string|null  $ipAddress  The originating IP, or null when the event
+     *                                  has no request behind it.
+     * @param  string|null  $userAgent  The originating User-Agent, on the same terms.
      */
-    public function record(Authenticatable $user, SecurityEventType $type): SecurityEvent
-    {
+    public function record(
+        Authenticatable $user,
+        SecurityEventType $type,
+        ?string $ipAddress,
+        ?string $userAgent,
+    ): SecurityEvent {
         $userId = $user->getAuthIdentifier();
-        $ipAddress = $this->request->ip();
-        $userAgent = $this->request->userAgent();
 
         return SecurityEvent::create([
             'user_id' => $userId,

--- a/dev-docs/adr/0005-domain-event-recording-seam.md
+++ b/dev-docs/adr/0005-domain-event-recording-seam.md
@@ -1,8 +1,20 @@
 # ADR-0005: Record audit & security events via the event→listener seam
 
-- Status: Accepted
+- Status: Accepted — applied across every recording site (2026-07-30)
 - Date: 2026-07-10
 - Relates to: epic architecture-hardening (audit locality; supersedes divergent recorders)
+
+> **Status note (2026-07-30).** As accepted, this landed on `Actions/Integrations/*`
+> only: 23 `AuditRecorder` call sites across 11 controllers and 6
+> `SecurityEventRecorder` sites stayed where they were, and `ChannelMemberAdded`,
+> `ChannelMemberRemoved`, `ChannelCreated` and `ChannelArchived` were each recorded
+> by two or three controllers with identical bodies while the Action already
+> dispatched the webhook half. It is now applied everywhere: every auditable
+> mutation dispatches `AuditableActionOccurred` and every account event dispatches
+> `SecurityEventOccurred`, both from the Action that owns the mutation, and
+> `RecordAuditActivity` / `RecordSecurityEvents` are their only recorders.
+> `SecurityEventRecorder` no longer takes the `Request` — the listener captures the
+> device context, so recording works from a queued job.
 
 ## Context
 

--- a/tests/Browser/A11yChannelDeletionTest.php
+++ b/tests/Browser/A11yChannelDeletionTest.php
@@ -48,7 +48,7 @@ test('the delete-channel dialog passes the axe audit in either theme', function 
 test('the recently-deleted panel passes the axe audit in either theme', function (): void {
     ['owner' => $alice, 'team' => $team, 'channel' => $channel] = browserTeamWithDeletableChannel();
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     $page = signInThroughBrowser($alice)
         ->navigate("/settings/teams/{$team->slug}/deleted-channels")

--- a/tests/Feature/Auth/Sso/ProvisionSsoUserTest.php
+++ b/tests/Feature/Auth/Sso/ProvisionSsoUserTest.php
@@ -32,6 +32,24 @@ test('a new directory user is just-in-time provisioned into the sole team as a m
         ->user_id->toBe($user->id);
 });
 
+test('a directory user can be provisioned from a queued job', function (): void {
+    Team::factory()->create();
+
+    // A queued directory sync has no live request behind it. Nothing on this
+    // path may reach for one, which is what lets the sync run off-request at
+    // all (ADR-0005).
+    dispatch(function (): void {
+        app(ProvisionSsoUser::class)->handle('oidc', 'sub-123', 'jordan@example.com', 'Jordan Rivers');
+    });
+
+    $user = User::query()->where('email', 'jordan@example.com')->sole();
+
+    expect(SecurityEvent::query()
+        ->where('user_id', $user->id)
+        ->where('type', SecurityEventType::AccountProvisioned)
+        ->exists())->toBeTrue();
+});
+
 test('a just-in-time provisioned user records an account provisioned security event', function (): void {
     Team::factory()->create();
 

--- a/tests/Feature/Channels/ChannelRecordingSeamTest.php
+++ b/tests/Feature/Channels/ChannelRecordingSeamTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Channels\ArchiveChannel;
+use App\Actions\Channels\CreateChannel;
+use App\Actions\Channels\JoinChannel;
+use App\Actions\Channels\LeaveChannel;
+use App\Actions\Channels\RemoveChannelMember;
+use App\Enums\AuditAction;
+use App\Enums\ChannelVisibility;
+use App\Enums\WebhookEvent;
+use App\Jobs\DeliverWebhook;
+use App\Models\AuditActivity;
+use App\Models\Channel;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\WebhookSubscription;
+use Illuminate\Support\Facades\Bus;
+
+/**
+ * The four channel facts that used to be recorded by their controllers now live
+ * in their Actions, so every caller — a console command, a queued directory
+ * sync, a slash command — records them, not just the HTTP surfaces.
+ */
+beforeEach(function (): void {
+    $this->team = Team::factory()->create();
+    $this->admin = User::factory()->create();
+    $this->member = User::factory()->create();
+    $this->channel = Channel::factory()->for($this->team)->private()->create();
+});
+
+/**
+ * Count the audit entries of an action recorded against the test's team.
+ */
+function seamEntries(AuditAction $action): int
+{
+    return AuditActivity::query()
+        ->where('team_id', test()->team->id)
+        ->where('event', $action->value)
+        ->count();
+}
+
+it('records both the webhook delivery and the audit row for a non-HTTP member add', function (): void {
+    WebhookSubscription::factory()->for($this->team)->create([
+        'events' => [WebhookEvent::ChannelMemberAdded->value],
+    ]);
+
+    Bus::fake([DeliverWebhook::class]);
+
+    app(JoinChannel::class)->handle($this->channel, $this->member, addedBy: $this->admin);
+
+    Bus::assertDispatched(DeliverWebhook::class);
+
+    $entry = AuditActivity::query()
+        ->where('team_id', $this->team->id)
+        ->where('event', AuditAction::ChannelMemberAdded->value)
+        ->sole();
+
+    expect($entry->causer_id)->toBe($this->admin->id);
+    expect($entry->subject_id)->toBe($this->channel->id);
+    expect($entry->properties['member_name'])->toBe($this->member->name);
+    expect($entry->properties['channel_name'])->toBe($this->channel->name);
+});
+
+it('does not audit a member joining a channel of their own accord', function (): void {
+    app(JoinChannel::class)->handle($this->channel, $this->member);
+
+    expect(seamEntries(AuditAction::ChannelMemberAdded))->toBe(0);
+});
+
+it('does not audit a repeat add that changes no membership', function (): void {
+    app(JoinChannel::class)->handle($this->channel, $this->member, addedBy: $this->admin);
+    app(JoinChannel::class)->handle($this->channel, $this->member, addedBy: $this->admin);
+
+    expect(seamEntries(AuditAction::ChannelMemberAdded))->toBe(1);
+});
+
+it('records a non-HTTP member removal against the actor who removed them', function (): void {
+    app(JoinChannel::class)->handle($this->channel, $this->member);
+
+    app(RemoveChannelMember::class)->handle($this->channel, $this->member, removedBy: $this->admin);
+
+    $entry = AuditActivity::query()
+        ->where('team_id', $this->team->id)
+        ->where('event', AuditAction::ChannelMemberRemoved->value)
+        ->sole();
+
+    expect($entry->causer_id)->toBe($this->admin->id);
+    expect($entry->properties['member_name'])->toBe($this->member->name);
+});
+
+it('does not audit a member leaving a channel', function (): void {
+    app(JoinChannel::class)->handle($this->channel, $this->member);
+
+    app(LeaveChannel::class)->handle($this->channel, $this->member);
+
+    expect(seamEntries(AuditAction::ChannelMemberRemoved))->toBe(0);
+});
+
+it('records a channel creation against its team', function (): void {
+    $channel = app(CreateChannel::class)->handle($this->team, 'marketing', ChannelVisibility::Public, $this->admin);
+
+    $entry = AuditActivity::query()
+        ->where('team_id', $this->team->id)
+        ->where('event', AuditAction::ChannelCreated->value)
+        ->sole();
+
+    expect($entry->causer_id)->toBe($this->admin->id);
+    expect($entry->subject_id)->toBe($channel->id);
+    expect($entry->properties['channel_name'])->toBe('marketing');
+});
+
+it('does not audit the protected general channel a new workspace bootstraps', function (): void {
+    $team = Team::factory()->create();
+
+    $team->memberships()->create(['user_id' => User::factory()->create()->id, 'role' => 'owner']);
+
+    expect(AuditActivity::query()
+        ->where('team_id', $team->id)
+        ->where('event', AuditAction::ChannelCreated->value)
+        ->count())->toBe(0);
+});
+
+it('records a channel archive against the actor who archived it', function (): void {
+    app(ArchiveChannel::class)->handle($this->channel, $this->admin);
+
+    $entry = AuditActivity::query()
+        ->where('team_id', $this->team->id)
+        ->where('event', AuditAction::ChannelArchived->value)
+        ->sole();
+
+    expect($entry->causer_id)->toBe($this->admin->id);
+    expect($entry->properties['channel_name'])->toBe($this->channel->name);
+});

--- a/tests/Feature/Channels/ChannelRecordingSeamTest.php
+++ b/tests/Feature/Channels/ChannelRecordingSeamTest.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 use App\Actions\Channels\ArchiveChannel;
 use App\Actions\Channels\CreateChannel;
+use App\Actions\Channels\DeleteChannel;
+use App\Actions\Channels\DeleteMessage;
 use App\Actions\Channels\JoinChannel;
 use App\Actions\Channels\LeaveChannel;
 use App\Actions\Channels\RemoveChannelMember;
+use App\Actions\Channels\RestoreChannel;
 use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
 use App\Enums\WebhookEvent;
 use App\Jobs\DeliverWebhook;
+use App\Jobs\PurgeDeletedChannel;
 use App\Models\AuditActivity;
 use App\Models\Channel;
+use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\WebhookSubscription;
@@ -120,6 +125,63 @@ it('does not audit the protected general channel a new workspace bootstraps', fu
         ->where('team_id', $team->id)
         ->where('event', AuditAction::ChannelCreated->value)
         ->count())->toBe(0);
+});
+
+it('records a channel deletion with the date its content is purged', function (): void {
+    $channel = app(DeleteChannel::class)->handle($this->channel, $this->admin);
+
+    $entry = AuditActivity::query()
+        ->where('team_id', $this->team->id)
+        ->where('event', AuditAction::ChannelDeleted->value)
+        ->sole();
+
+    expect($entry->causer_id)->toBe($this->admin->id);
+    expect($entry->properties['purge_at'])
+        ->toBe($channel->deleted_at->addDays(PurgeDeletedChannel::GRACE_WINDOW_DAYS)->toDateString());
+});
+
+it('does not audit deleting a channel that is already deleted', function (): void {
+    app(DeleteChannel::class)->handle($this->channel, $this->admin);
+    app(DeleteChannel::class)->handle($this->channel, $this->admin);
+
+    expect(seamEntries(AuditAction::ChannelDeleted))->toBe(1);
+});
+
+it('records a channel restore', function (): void {
+    $channel = app(DeleteChannel::class)->handle($this->channel, $this->admin);
+
+    app(RestoreChannel::class)->handle($channel, $this->admin);
+
+    $entry = AuditActivity::query()
+        ->where('team_id', $this->team->id)
+        ->where('event', AuditAction::ChannelRestored->value)
+        ->sole();
+
+    expect($entry->causer_id)->toBe($this->admin->id);
+    expect($entry->properties['channel_name'])->toBe($this->channel->name);
+});
+
+it('records a moderator deleting another members message', function (): void {
+    $message = Message::factory()->for($this->channel)->for($this->member)->create();
+
+    app(DeleteMessage::class)->handle($this->channel, $message, deletedBy: $this->admin);
+
+    $entry = AuditActivity::query()
+        ->where('team_id', $this->team->id)
+        ->where('event', AuditAction::MessageDeleted->value)
+        ->sole();
+
+    expect($entry->causer_id)->toBe($this->admin->id);
+    expect($entry->properties['author_name'])->toBe($this->member->name);
+    expect($entry->properties['channel_name'])->toBe($this->channel->name);
+});
+
+it('does not audit a member deleting their own message', function (): void {
+    $message = Message::factory()->for($this->channel)->for($this->member)->create();
+
+    app(DeleteMessage::class)->handle($this->channel, $message, deletedBy: $this->member);
+
+    expect(seamEntries(AuditAction::MessageDeleted))->toBe(0);
 });
 
 it('records a channel archive against the actor who archived it', function (): void {

--- a/tests/Feature/Channels/DeleteChannelTest.php
+++ b/tests/Feature/Channels/DeleteChannelTest.php
@@ -27,11 +27,11 @@ test('deleting an already-deleted channel keeps its original deletion date, so t
     $team = app(CreateTeam::class)->handle($owner, 'Acme');
     $channel = Channel::factory()->for($team)->create(['name' => 'Roadmap', 'slug' => 'roadmap']);
 
-    $deleted = app(DeleteChannel::class)->handle($channel);
+    $deleted = app(DeleteChannel::class)->handle($channel, null);
 
     $this->travel(1)->days();
 
-    expect(app(DeleteChannel::class)->handle($channel)->deleted_at->equalTo($deleted->deleted_at))->toBeTrue();
+    expect(app(DeleteChannel::class)->handle($channel, null)->deleted_at->equalTo($deleted->deleted_at))->toBeTrue();
 });
 
 test('deleting a channel records it in the workspace audit log', function (): void {

--- a/tests/Feature/Channels/DeletedChannelVisibilityTest.php
+++ b/tests/Feature/Channels/DeletedChannelVisibilityTest.php
@@ -37,7 +37,7 @@ function deletedChannelFixture(ChannelVisibility $visibility = ChannelVisibility
 test('a deleted channel leaves the sidebar at once', function (): void {
     [$owner, $team, $channel] = deletedChannelFixture();
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => Channel::GENERAL_SLUG]))
@@ -50,7 +50,7 @@ test('a deleted channel leaves the sidebar at once', function (): void {
 test('a deleted channel is no longer reachable by URL', function (): void {
     [$owner, $team, $channel] = deletedChannelFixture();
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     $this->actingAs($owner)
         ->get(route('channels.show', ['team' => $team->slug, 'channel' => 'roadmap']))
@@ -61,7 +61,7 @@ test('a deleted public channel drops out of the browse list', function (): void 
     [$owner, $team, $channel] = deletedChannelFixture();
     $channel->channelMembers()->delete();
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     $this->actingAs($owner)
         ->get(route('channels.browse', ['team' => $team->slug]))
@@ -74,7 +74,7 @@ test('a deleted public channel drops out of the browse list', function (): void 
 test('a deleted channel drops out of the visible-channel ACL', function (): void {
     [$owner, $team, $channel] = deletedChannelFixture();
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     expect($owner->visibleChannelIds($team)->all())->not->toContain($channel->id)
         ->and($owner->visibleChannelIdsAcrossTeams()->all())->not->toContain($channel->id);
@@ -88,7 +88,7 @@ test('messages in a deleted channel stop matching search', function (): void {
 
     expect(app(SearchMessages::class)->handle($owner, $team, $criteria))->toHaveCount(1);
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     expect(app(SearchMessages::class)->handle($owner, $team, $criteria))->toHaveCount(0);
 });
@@ -110,7 +110,7 @@ test('a direct message can never be deleted, however senior the admin', function
 test('deleting a channel releases its name, so the same one can be created again', function (): void {
     [$owner, $team, $channel] = deletedChannelFixture();
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     $this->actingAs($owner)
         ->post(route('channels.store', ['team' => $team->slug]), [

--- a/tests/Feature/Channels/PurgeDeletedChannelTest.php
+++ b/tests/Feature/Channels/PurgeDeletedChannelTest.php
@@ -45,7 +45,7 @@ function purgeableChannel(): array
 
     ScheduledMessage::factory()->for($channel)->for($owner)->create();
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     return [$channel, $attachment];
 }

--- a/tests/Feature/Settings/SecurityActivityTest.php
+++ b/tests/Feature/Settings/SecurityActivityTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\SecurityEventType;
+use App\Events\SecurityEventOccurred;
 use App\Models\SecurityEvent;
 use App\Models\User;
 use Illuminate\Auth\Events\Logout;
@@ -74,10 +75,14 @@ test('changing the password records a security event', function (): void {
         ])
         ->assertRedirect(route('security.edit'));
 
-    expect(SecurityEvent::query()
+    $event = SecurityEvent::query()
         ->where('user_id', $user->id)
         ->where('type', SecurityEventType::PasswordChanged)
-        ->exists())->toBeTrue();
+        ->sole();
+
+    // The event seam carries no request of its own, so this also pins that the
+    // listener still stamps the live request's device context onto the row.
+    expect($event->ip_address)->toBe('127.0.0.1');
 });
 
 test('resetting the password records a security event', function (): void {
@@ -110,6 +115,17 @@ test('two factor changes are recorded', function (): void {
         SecurityEventType::RecoveryCodesGenerated,
         SecurityEventType::TwoFactorDisabled,
     );
+});
+
+test('dispatching a security event records it', function (): void {
+    $user = User::factory()->create();
+
+    event(new SecurityEventOccurred($user, SecurityEventType::TeamDeleted));
+
+    expect(SecurityEvent::query()
+        ->where('user_id', $user->id)
+        ->where('type', SecurityEventType::TeamDeleted)
+        ->exists())->toBeTrue();
 });
 
 test('the security page lists recent activity newest first', function (): void {

--- a/tests/Feature/Teams/AuditLogTest.php
+++ b/tests/Feature/Teams/AuditLogTest.php
@@ -5,6 +5,7 @@ use App\Actions\Teams\CreateTeam;
 use App\Enums\AuditAction;
 use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
+use App\Events\AuditableActionOccurred;
 use App\Exceptions\AuditLogImmutableException;
 use App\Models\AuditActivity;
 use App\Models\Channel;
@@ -47,6 +48,29 @@ function auditEntry(Team $team, AuditAction $action): AuditActivity
         ->where('event', $action->value)
         ->sole();
 }
+
+test('dispatching an auditable action records it against the team', function (): void {
+    [$owner, $team] = auditTeam();
+    $channel = Channel::factory()->for($team)->create();
+
+    event(new AuditableActionOccurred($team, $owner, AuditAction::ChannelArchived, $channel, [
+        'channel_name' => $channel->name,
+    ]));
+
+    $entry = auditEntry($team, AuditAction::ChannelArchived);
+
+    expect($entry->causer_id)->toBe($owner->id);
+    expect($entry->subject_id)->toBe($channel->id);
+    expect($entry->properties['channel_name'])->toBe($channel->name);
+});
+
+test('an auditable action with no human causer is recorded without an actor', function (): void {
+    [, $team] = auditTeam();
+
+    event(new AuditableActionOccurred($team, null, AuditAction::WebhookSubscriptionAutoDisabled));
+
+    expect(auditEntry($team, AuditAction::WebhookSubscriptionAutoDisabled)->causer_id)->toBeNull();
+});
 
 test('renaming a team records an audit entry with old and new names', function (): void {
     [$owner, $team] = auditTeam();

--- a/tests/Feature/Teams/AuditLogTest.php
+++ b/tests/Feature/Teams/AuditLogTest.php
@@ -1,15 +1,12 @@
 <?php
 
-use App\Actions\Channels\JoinChannel;
 use App\Actions\Teams\CreateTeam;
 use App\Enums\AuditAction;
-use App\Enums\ChannelVisibility;
 use App\Enums\TeamRole;
 use App\Events\AuditableActionOccurred;
 use App\Exceptions\AuditLogImmutableException;
 use App\Models\AuditActivity;
 use App\Models\Channel;
-use App\Models\Message;
 use App\Models\Team;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -72,188 +69,18 @@ test('an auditable action with no human causer is recorded without an actor', fu
     expect(auditEntry($team, AuditAction::WebhookSubscriptionAutoDisabled)->causer_id)->toBeNull();
 });
 
-test('renaming a team records an audit entry with old and new names', function (): void {
-    [$owner, $team] = auditTeam();
-
-    $this->actingAs($owner)
-        ->patch(route('teams.update', $team), ['name' => 'Acme Corp'])
-        ->assertRedirect();
-
-    $entry = auditEntry($team, AuditAction::TeamRenamed);
-
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->properties['old_name'])->toBe('Acme');
-    expect($entry->properties['new_name'])->toBe('Acme Corp');
-});
-
-test('renaming a team to the same name records nothing', function (): void {
-    [$owner, $team] = auditTeam();
-
-    $this->actingAs($owner)
-        ->patch(route('teams.update', $team), ['name' => 'Acme'])
-        ->assertRedirect();
-
-    expect(AuditActivity::query()->where('team_id', $team->id)->count())->toBe(0);
-});
-
-test('changing a member role records an audit entry with old and new roles', function (): void {
+test('an audit entry keeps the target it was recorded against', function (): void {
     [$owner, $team] = auditTeam();
     $member = auditMember($team);
 
-    $this->actingAs($owner)
-        ->patch(route('teams.members.update', [$team, $member]), ['role' => TeamRole::Admin->value])
-        ->assertRedirect();
-
-    $entry = auditEntry($team, AuditAction::MemberRoleChanged);
-
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->subject_id)->toBe($member->id);
-    expect($entry->properties['old_role'])->toBe(TeamRole::Member->label());
-    expect($entry->properties['new_role'])->toBe(TeamRole::Admin->label());
-});
-
-test('changing a member role to the same role records nothing', function (): void {
-    [$owner, $team] = auditTeam();
-    $member = auditMember($team);
-
-    $this->actingAs($owner)
-        ->patch(route('teams.members.update', [$team, $member]), ['role' => TeamRole::Member->value])
-        ->assertRedirect();
-
-    expect(AuditActivity::query()->where('team_id', $team->id)->count())->toBe(0);
-});
-
-test('removing a member records an audit entry', function (): void {
-    [$owner, $team] = auditTeam();
-    $member = auditMember($team);
-
-    $this->actingAs($owner)
-        ->delete(route('teams.members.destroy', [$team, $member]))
-        ->assertRedirect();
+    event(new AuditableActionOccurred($team, $owner, AuditAction::MemberRemoved, $member, [
+        'member_name' => $member->name,
+    ]));
 
     $entry = auditEntry($team, AuditAction::MemberRemoved);
 
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->properties['member_name'])->toBe($member->name);
-});
-
-test('transferring ownership records an audit entry', function (): void {
-    [$owner, $team] = auditTeam();
-    $member = auditMember($team, TeamRole::Admin);
-
-    $this->actingAs($owner)
-        ->post(route('teams.members.transfer-ownership', [$team, $member]), ['password' => 'password'])
-        ->assertRedirect();
-
-    $entry = auditEntry($team, AuditAction::OwnershipTransferred);
-
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->properties['new_owner_name'])->toBe($member->name);
-});
-
-test('creating a channel records an audit entry', function (): void {
-    [$owner, $team] = auditTeam();
-
-    $this->actingAs($owner)
-        ->post(route('channels.store', $team), [
-            'name' => 'marketing',
-            'visibility' => ChannelVisibility::Public->value,
-        ])
-        ->assertRedirect();
-
-    $entry = auditEntry($team, AuditAction::ChannelCreated);
-
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->properties['channel_name'])->toBe('marketing');
-});
-
-test('archiving a channel records an audit entry', function (): void {
-    [$owner, $team] = auditTeam();
-    $channel = Channel::factory()->for($team)->create(['created_by' => $owner->id]);
-
-    $this->actingAs($owner)
-        ->post(route('channels.archive', ['team' => $team->slug, 'channel' => $channel->slug]))
-        ->assertRedirect();
-
-    $entry = auditEntry($team, AuditAction::ChannelArchived);
-
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->properties['channel_name'])->toBe($channel->name);
-});
-
-test('adding a channel member records an audit entry', function (): void {
-    [$owner, $team] = auditTeam();
-    $member = auditMember($team);
-    $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
-    app(JoinChannel::class)->handle($channel, $owner);
-
-    $this->actingAs($owner)
-        ->post(route('channels.members.store', ['team' => $team->slug, 'channel' => $channel->slug]), [
-            'user_id' => $member->id,
-        ])
-        ->assertRedirect();
-
-    $entry = auditEntry($team, AuditAction::ChannelMemberAdded);
-
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->properties['channel_name'])->toBe($channel->name);
-    expect($entry->properties['member_name'])->toBe($member->name);
-});
-
-test('removing a channel member records an audit entry', function (): void {
-    [$owner, $team] = auditTeam();
-    $member = auditMember($team);
-    $channel = Channel::factory()->for($team)->private()->create(['slug' => 'secret']);
-    app(JoinChannel::class)->handle($channel, $owner);
-    app(JoinChannel::class)->handle($channel, $member);
-
-    $this->actingAs($owner)
-        ->delete(route('channels.members.destroy', ['team' => $team->slug, 'channel' => $channel->slug]), [
-            'user_id' => $member->id,
-        ])
-        ->assertRedirect();
-
-    $entry = auditEntry($team, AuditAction::ChannelMemberRemoved);
-
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->properties['member_name'])->toBe($member->name);
-});
-
-test('a moderator deleting another members message records an audit entry', function (): void {
-    [$owner, $team] = auditTeam();
-    $member = auditMember($team);
-    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
-    $message = Message::factory()->for($general)->for($member)->create();
-
-    $this->actingAs($owner)
-        ->delete(route('channels.messages.destroy', [
-            'team' => $team->slug,
-            'channel' => $general->slug,
-            'message' => $message->id,
-        ]))
-        ->assertRedirect();
-
-    $entry = auditEntry($team, AuditAction::MessageDeleted);
-
-    expect($entry->causer_id)->toBe($owner->id);
-    expect($entry->properties['author_name'])->toBe($member->name);
-});
-
-test('a member deleting their own message records nothing', function (): void {
-    [$owner, $team] = auditTeam();
-    $member = auditMember($team);
-    $general = $team->channels()->where('slug', Channel::GENERAL_SLUG)->firstOrFail();
-    $message = Message::factory()->for($general)->for($member)->create();
-
-    $this->actingAs($member)
-        ->delete(route('channels.messages.destroy', [
-            'team' => $team->slug,
-            'channel' => $general->slug,
-            'message' => $message->id,
-        ]))
-        ->assertRedirect();
-
-    expect(AuditActivity::query()->where('event', AuditAction::MessageDeleted->value)->count())->toBe(0);
+    expect($entry->subject_id)->toBe($member->id);
+    expect($entry->description)->toBe(AuditAction::MemberRemoved->label());
 });
 
 test('an audit entry belongs to its team', function (): void {

--- a/tests/Feature/Teams/DeletedChannelsTest.php
+++ b/tests/Feature/Teams/DeletedChannelsTest.php
@@ -24,7 +24,7 @@ function recentlyDeletedFixture(): array
     $channel = Channel::factory()->for($team)->create(['name' => 'Roadmap', 'slug' => 'roadmap']);
     $channel->channelMembers()->create(['user_id' => $owner->id]);
 
-    app(DeleteChannel::class)->handle($channel);
+    app(DeleteChannel::class)->handle($channel, null);
 
     return [$owner, $team, $channel];
 }
@@ -133,7 +133,7 @@ test('a channel from another workspace is not restorable through this one', func
     $stranger = User::factory()->create();
     $otherTeam = app(CreateTeam::class)->handle($stranger, 'Globex');
     $otherChannel = Channel::factory()->for($otherTeam)->create();
-    app(DeleteChannel::class)->handle($otherChannel);
+    app(DeleteChannel::class)->handle($otherChannel, null);
 
     $this->actingAs($owner)
         ->post(route('teams.deleted-channels.restore', ['team' => $team->slug, 'channel' => $otherChannel->id]))

--- a/tests/Feature/Teams/TeamRecordingSeamTest.php
+++ b/tests/Feature/Teams/TeamRecordingSeamTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Teams\AcceptTeamInvitation;
+use App\Actions\Teams\CreateTeam;
+use App\Actions\Teams\CreateTeamInvitation;
+use App\Actions\Teams\RemoveTeamMember;
+use App\Actions\Teams\ResendTeamInvitation;
+use App\Actions\Teams\RevokeTeamInvitation;
+use App\Actions\Teams\TransferTeamOwnership;
+use App\Actions\Teams\UpdateTeam;
+use App\Actions\Teams\UpdateTeamMemberRole;
+use App\Enums\AuditAction;
+use App\Enums\ChannelCreationPolicy;
+use App\Enums\ChannelVisibility;
+use App\Enums\TeamRole;
+use App\Models\AuditActivity;
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * The workspace-administration facts, recorded by the Actions that own the
+ * mutation rather than by the controllers that used to. Every rule is reached
+ * by calling the Action, not by driving HTTP.
+ */
+beforeEach(function (): void {
+    Notification::fake();
+
+    $this->owner = User::factory()->create();
+    $this->team = app(CreateTeam::class)->handle($this->owner, 'Acme');
+    $this->member = User::factory()->create();
+    $this->team->memberships()->create(['user_id' => $this->member->id, 'role' => TeamRole::Member]);
+});
+
+/**
+ * Fetch the single audit entry of an action recorded against the test's team.
+ */
+function teamSeamEntry(AuditAction $action): AuditActivity
+{
+    return AuditActivity::query()
+        ->where('team_id', test()->team->id)
+        ->where('event', $action->value)
+        ->sole();
+}
+
+/**
+ * Count the audit entries of an action recorded against the test's team.
+ */
+function teamSeamEntries(AuditAction $action): int
+{
+    return AuditActivity::query()
+        ->where('team_id', test()->team->id)
+        ->where('event', $action->value)
+        ->count();
+}
+
+it('records a workspace rename with the name it replaced', function (): void {
+    app(UpdateTeam::class)->handle($this->team, $this->owner, ['name' => 'Acme Corp']);
+
+    $entry = teamSeamEntry(AuditAction::TeamRenamed);
+
+    expect($entry->causer_id)->toBe($this->owner->id);
+    expect($entry->properties['old_name'])->toBe('Acme');
+    expect($entry->properties['new_name'])->toBe('Acme Corp');
+});
+
+it('records nothing when an update moves no attribute', function (): void {
+    app(UpdateTeam::class)->handle($this->team, $this->owner, ['name' => 'Acme']);
+
+    expect(AuditActivity::query()->where('team_id', $this->team->id)->count())->toBe(0);
+});
+
+it('records a channel creation policy change per visibility', function (): void {
+    app(UpdateTeam::class)->handle($this->team, $this->owner, [
+        'public_channel_creation_policy' => ChannelCreationPolicy::Admins,
+    ]);
+
+    $entry = teamSeamEntry(AuditAction::ChannelCreationPolicyChanged);
+
+    expect($entry->properties['visibility'])->toBe(ChannelVisibility::Public->label());
+    expect($entry->properties['new_policy'])->toBe(ChannelCreationPolicy::Admins->label());
+});
+
+it('records a member role change with the roles it moved between', function (): void {
+    app(UpdateTeamMemberRole::class)->handle($this->team, $this->member, TeamRole::Admin, $this->owner);
+
+    $entry = teamSeamEntry(AuditAction::MemberRoleChanged);
+
+    expect($entry->causer_id)->toBe($this->owner->id);
+    expect($entry->subject_id)->toBe($this->member->id);
+    expect($entry->properties['old_role'])->toBe(TeamRole::Member->label());
+    expect($entry->properties['new_role'])->toBe(TeamRole::Admin->label());
+});
+
+it('records nothing when a member keeps the role they had', function (): void {
+    app(UpdateTeamMemberRole::class)->handle($this->team, $this->member, TeamRole::Member, $this->owner);
+
+    expect(teamSeamEntries(AuditAction::MemberRoleChanged))->toBe(0);
+});
+
+it('records a member being removed from the workspace', function (): void {
+    app(RemoveTeamMember::class)->handle($this->team, $this->member, $this->owner);
+
+    $entry = teamSeamEntry(AuditAction::MemberRemoved);
+
+    expect($entry->causer_id)->toBe($this->owner->id);
+    expect($entry->properties['member_name'])->toBe($this->member->name);
+    expect($this->team->memberships()->where('user_id', $this->member->id)->exists())->toBeFalse();
+});
+
+it('records an ownership transfer', function (): void {
+    app(TransferTeamOwnership::class)->handle($this->team, $this->owner, $this->member);
+
+    $entry = teamSeamEntry(AuditAction::OwnershipTransferred);
+
+    expect($entry->causer_id)->toBe($this->owner->id);
+    expect($entry->properties['new_owner_name'])->toBe($this->member->name);
+});
+
+it('records an invitation being created', function (): void {
+    $invitation = app(CreateTeamInvitation::class)->handle($this->team, $this->owner, 'new@example.test', TeamRole::Admin);
+
+    $entry = teamSeamEntry(AuditAction::InvitationCreated);
+
+    expect($entry->causer_id)->toBe($this->owner->id);
+    expect($entry->subject_id)->toBe($invitation->id);
+    expect($entry->properties['email'])->toBe('new@example.test');
+    expect($entry->properties['role'])->toBe(TeamRole::Admin->label());
+});
+
+it('records an invitation being revoked while it still exists', function (): void {
+    $invitation = app(CreateTeamInvitation::class)->handle($this->team, $this->owner, 'new@example.test', TeamRole::Member);
+
+    app(RevokeTeamInvitation::class)->handle($invitation, $this->owner);
+
+    expect(teamSeamEntry(AuditAction::InvitationRevoked)->properties['email'])->toBe('new@example.test');
+    expect(TeamInvitation::query()->whereKey($invitation->id)->exists())->toBeFalse();
+});
+
+it('records an invitation being resent and refreshes its expiry', function (): void {
+    $invitation = app(CreateTeamInvitation::class)->handle($this->team, $this->owner, 'new@example.test', TeamRole::Member);
+    $invitation->update(['expires_at' => now()->subDay()]);
+
+    app(ResendTeamInvitation::class)->handle($invitation, $this->owner);
+
+    expect(teamSeamEntry(AuditAction::InvitationResent)->properties['email'])->toBe('new@example.test');
+    expect($invitation->fresh()->expires_at->isFuture())->toBeTrue();
+});
+
+it('records an invitation being accepted by the person who accepted it', function (): void {
+    $invitation = app(CreateTeamInvitation::class)->handle($this->team, $this->owner, 'new@example.test', TeamRole::Member);
+    $newcomer = User::factory()->create(['email' => 'new@example.test']);
+
+    app(AcceptTeamInvitation::class)->handle($invitation, $newcomer);
+
+    $entry = teamSeamEntry(AuditAction::InvitationAccepted);
+
+    expect($entry->causer_id)->toBe($newcomer->id);
+    expect($newcomer->fresh()->belongsToTeam($this->team))->toBeTrue();
+});

--- a/tests/Feature/Webhooks/WebhookDeliveryTest.php
+++ b/tests/Feature/Webhooks/WebhookDeliveryTest.php
@@ -11,7 +11,6 @@ use App\Models\AuditActivity;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\WebhookSubscription;
-use App\Support\AuditRecorder;
 use App\Support\HostResolver;
 use App\Support\Http\OutboundUrlGuard;
 use App\Support\Webhooks\WebhookSignature;
@@ -146,7 +145,7 @@ it('skips an already-queued job once the platform is disabled', function (): voi
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
     expect($this->subscription->deliveries()->count())->toBe(0);
@@ -162,7 +161,7 @@ it('refuses to deliver to a non-public URL and logs the blocked attempt', functi
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+        ]))->handle(app(OutboundUrlGuard::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -184,7 +183,7 @@ it('blocks delivery when the hostname resolves to a private address', function (
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+        ]))->handle(app(OutboundUrlGuard::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -210,7 +209,7 @@ it('auto-disables a subscription whose hostname resolves private once it hits th
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
@@ -225,7 +224,7 @@ it('delivers to a hostname resolving to a public IPv6 address', function (): voi
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     Http::assertSentCount(1);
     expect($this->subscription->deliveries()->sole()->succeeded)->toBeTrue();
@@ -240,7 +239,7 @@ it('delivers to a literal public IP without pinning', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     Http::assertSentCount(1);
     expect($this->subscription->deliveries()->sole()->succeeded)->toBeTrue();
@@ -258,7 +257,7 @@ it('does not follow a redirect to an internal address and records the attempt as
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+        ]))->handle(app(OutboundUrlGuard::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -286,7 +285,7 @@ it('auto-disables a subscription whose URL is blocked once it hits the threshold
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
@@ -295,7 +294,6 @@ it('auto-disables a subscription whose URL is blocked once it hits the threshold
 it('retries a failing endpoint, then auto-disables after the threshold and logs every attempt', function (): void {
     Http::fake(['example.test/*' => Http::response('nope', 500)]);
     $threshold = (int) config('integrations.webhooks.disable_after');
-    $recorder = app(AuditRecorder::class);
 
     $envelope = [
         'id' => (string) Str::uuid(),
@@ -308,7 +306,7 @@ it('retries a failing endpoint, then auto-disables after the threshold and logs 
     // final attempt reaches the threshold and disables without throwing.
     for ($attempt = 1; $attempt < $threshold; $attempt++) {
         try {
-            (new DeliverWebhook($this->subscription->id, $envelope))->handle($recorder, app(OutboundUrlGuard::class));
+            (new DeliverWebhook($this->subscription->id, $envelope))->handle(app(OutboundUrlGuard::class));
         } catch (RuntimeException) {
             // expected retry signal
         }
@@ -318,7 +316,7 @@ it('retries a failing endpoint, then auto-disables after the threshold and logs 
             ->and($this->subscription->status)->toBe(WebhookSubscriptionStatus::Active);
     }
 
-    (new DeliverWebhook($this->subscription->id, $envelope))->handle($recorder, app(OutboundUrlGuard::class));
+    (new DeliverWebhook($this->subscription->id, $envelope))->handle(app(OutboundUrlGuard::class));
 
     $this->subscription->refresh();
     expect($this->subscription->status)->toBe(WebhookSubscriptionStatus::Disabled)
@@ -337,7 +335,7 @@ it('resets the failure streak after a success', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     expect($this->subscription->refresh()->consecutive_failures)->toBe(0);
 });
@@ -351,7 +349,7 @@ it('records a transport error as a failed attempt with no status code', function
             'type' => WebhookEvent::MessageCreated->value,
             'created_at' => now()->toIso8601String(),
             'data' => [],
-        ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+        ]))->handle(app(OutboundUrlGuard::class));
     } catch (RuntimeException) {
         // expected retry signal
     }
@@ -374,7 +372,7 @@ it('auto-disables on a transport error that reaches the threshold', function ():
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     expect($this->subscription->refresh()->status)->toBe(WebhookSubscriptionStatus::Disabled);
 });
@@ -388,7 +386,7 @@ it('is a no-op when the subscription has since been disabled', function (): void
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
     expect($this->subscription->deliveries()->count())->toBe(0);
@@ -402,7 +400,7 @@ it('is a no-op when the subscription no longer exists', function (): void {
         'type' => WebhookEvent::MessageCreated->value,
         'created_at' => now()->toIso8601String(),
         'data' => [],
-    ]))->handle(app(AuditRecorder::class), app(OutboundUrlGuard::class));
+    ]))->handle(app(OutboundUrlGuard::class));
 
     Http::assertNothingSent();
 });


### PR DESCRIPTION
Closes #1091.

ADR-0005 said recording "what happened" uses one seam — the mutation, in its
Action, dispatches a domain event and a listener records the row — and that
"recording does not live in controllers". It had only ever landed on
`Actions/Integrations/*`. This applies it everywhere.

## What changed

**The seam.** Two events and their listeners:

- `AuditableActionOccurred(team, actor, AuditAction, target, context)` →
  `RecordAuditActivity`, mirroring the shape `WebhookEventOccurred` already uses.
- `SecurityEventOccurred(user, SecurityEventType)` → a new handler on the
  existing `RecordSecurityEvents`.

Actor and team are carried explicitly, never read from the live request: the
REST API resolves both from the token subject (which may be a bot), and a queued
directory sync has no request at all.

**The four duplicated facts.** `ChannelMemberAdded`, `ChannelMemberRemoved`,
`ChannelCreated` and `ChannelArchived` were recorded by two or three controllers
with identical bodies while `JoinChannel` already dispatched the webhook half of
the same fact. They now live in `JoinChannel`, `RemoveChannelMember`,
`CreateChannel` and `ArchiveChannel`, so a fourth surface gets both halves.

"Is this auditable?" moved with them, because it is a rule of the mutation:
`addedBy`/`removedBy`/`deletedBy` name the member who acted on someone else, so a
self-join, a leave and deleting your own message stay unrecorded exactly as
before, and the #general a new workspace bootstraps is not an admin creating a
channel.

**The remaining 19 sites.** `grep -rn 'AuditRecorder' app/Http/Controllers` is
now empty, and so is the `SecurityEventRecorder` equivalent. Where the mutation
was still inline in a controller it got the Action it never had: `UpdateTeam`
(which absorbs the `lockForUpdate` + read-under-lock + diff transaction, and with
it the `&$before` out-parameter escaping a closure), `UpdateTeamMemberRole`,
`RemoveTeamMember`, the four invitation flows, `RequestAuditExport`, `DeleteTeam`,
`ChangePassword` and `RequestDataExport`. Three security facts have no mutation to
sit next to — a revoked session, other sessions revoked, and an export *download*
— so those dispatch from their controller.

**One shape, not two.** The 17 Actions that recorded directly (the 14 in
`Actions/Integrations/*`, `RevokeCustomEmoji`, and `DeliverWebhook`'s auto-disable)
now dispatch the same event. `AuditRecorder` and `SecurityEventRecorder` each have
exactly one caller — their listener — so a new call site is a visible sign the
seam was skipped.

**Request coupling.** `SecurityEventRecorder` no longer takes `Request`;
`RecordSecurityEvents` captures the device context and passes it in, which is the
one place that legitimately knows whether HTTP is behind the event. `UserObserver`
stops service-locating around the constructor, and `ProvisionSsoUser` is resolvable
from a queued job — a test drives it through one.

## Behaviour change worth naming

A moderator deleting another member's message **through the REST API** is now
audited. It wasn't before: the audit lived in the web controller only, which is
precisely the silent-skip the issue describes. Every other path records exactly
what it recorded before.

## Testing

`sail composer test` green at `Total: 100.0 %`, Pint/PHPStan/Rector clean, plus
the five frontend checks. New: `tests/Feature/Channels/ChannelRecordingSeamTest.php`
and `tests/Feature/Teams/TeamRecordingSeamTest.php` reach every rule by calling the
Action rather than driving HTTP — including the headline case, a non-HTTP caller of
`JoinChannel` producing both the webhook delivery and the audit row. The bot-actor
path stays covered by `MemberApiTest`. `AuditLogTest` no longer reaches its rules
through `actingAs(...)->patch(...)`.

`dev-docs/adr/0005` gains a status note and CONTEXT.md's named seams entry is updated.

## Two review findings consciously declined

- *Move `UpdateTeam`'s recording outside the transaction.* It would invert an
  invariant two existing tests assert (the mutation rolls back when audit
  recording fails), and recording under the lock that read the before-values is
  why an entry cannot name a value that was never replaced.
- *Lock `ArchiveChannel` before checking `isArchived()`.* Real but theoretical —
  two concurrent archives could each write an entry. The code it replaces recorded
  unconditionally, so this is already strictly better; adding the lock changes what
  the Action returns and deserves its own change.

`RemoveTeamMember`'s three writes are not atomic. Neither were they in the
controller this lifted them from; making them so is a behaviour change outside
this refactor's scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788050425&installation_model_id=428379&pr_number=1098&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1098&signature=d79cad737d1956b0176b5dbd3eae176e803028c60a5c8330d41848efe010ee3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->