### PR TITLE
refactor: collapse the message-action relay behind one provided context

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,13 +114,15 @@ built; build them once, then reuse.
   channel all share it). One tested reconcile/teardown lifecycle.
 - **`useDebouncedPost`** — the debounced, focus-gated, auto-teardown router POST
   used by mark-read, mark-thread-read, and draft persistence.
-- **The message-action context** _(ADR-0009)_ — the eleven message actions and the
-  viewer's channel capabilities are **provided** by the channel page and read
-  through `useMessageActionsContext()` / `useMessageSubtree()` /
-  `useMessageActionGuards()`, never drilled and never a raw `inject`. A new message
-  action is one method on the facade, not a prop and an emit at five levels;
-  `pending` is the only per-row fact and stays a prop. The accessors throw without a
-  provider, which is what makes a row mountable against a stub facade.
+- **The message-action context** _(ADR-0009)_ — every action a message row can ask
+  for (`MessageActionHandlers`: the eleven writes, plus the `reply` and `openThread`
+  navigations that rode the same relay) and the viewer's channel capabilities are
+  **provided** by the channel page and read through `useMessageActionsContext()` /
+  `useMessageSubtree()` / `useMessageActionGuards()`, never drilled and never a raw
+  `inject`. A new message action is one method on the facade, not a prop and an emit
+  at five levels; `pending` is the only per-row fact and stays a prop. The accessors
+  throw without a provider, which is what makes a row mountable against a stub
+  facade.
 - **`ScrollableMessageList`** — the shared scroll container + "jump to latest / N
   new" pill for the channel view and the thread panel. The pin decision core stays
   in `useScrollPin` (each consumer owns how appends reach it and wires the pin

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,6 +114,13 @@ built; build them once, then reuse.
   channel all share it). One tested reconcile/teardown lifecycle.
 - **`useDebouncedPost`** — the debounced, focus-gated, auto-teardown router POST
   used by mark-read, mark-thread-read, and draft persistence.
+- **The message-action context** _(ADR-0009)_ — the eleven message actions and the
+  viewer's channel capabilities are **provided** by the channel page and read
+  through `useMessageActionsContext()` / `useMessageSubtree()` /
+  `useMessageActionGuards()`, never drilled and never a raw `inject`. A new message
+  action is one method on the facade, not a prop and an emit at five levels;
+  `pending` is the only per-row fact and stays a prop. The accessors throw without a
+  provider, which is what makes a row mountable against a stub facade.
 - **`ScrollableMessageList`** — the shared scroll container + "jump to latest / N
   new" pill for the channel view and the thread panel. The pin decision core stays
   in `useScrollPin` (each consumer owns how appends reach it and wires the pin
@@ -138,5 +145,7 @@ built; build them once, then reuse.
 - New auditable mutation → record it via the **domain-event seam**, next to the
   mutation.
 - New channel-member preference → the **channel membership settings** concern.
+- New message action (a row affordance that writes) → one method on the **message-action
+  context**; never a new prop/emit pair through the timeline.
 - A `.vue` file crossing ~400 lines or owning several independent lifecycles →
   decompose into composables before adding more.

--- a/dev-docs/adr/0009-message-action-context-is-provided.md
+++ b/dev-docs/adr/0009-message-action-context-is-provided.md
@@ -1,0 +1,76 @@
+# ADR-0009: The message-action context is provided, not drilled
+
+- Status: Accepted
+- Date: 2026-07-31
+- Relates to: epic architecture-hardening II (#1089), child #1092
+
+## Context
+
+`composables/useMessageActions.ts` was already a deep module: one options object in,
+one flat facade of eleven actions out. All the friction was in getting a click to it.
+
+Eleven actions (`react`, `vote`, `closePoll`, `pin`, `unpin`, `remind`,
+`remindCustom`, `forward`, `jump`, `edit`, `delete`) were re-declared and
+re-forwarded, unchanged, at every level between `pages/channels/Show.vue` and the
+button that fires them: `ChannelPane` (21 props / 17 emits), `ThreadPanel` (15/14),
+`MessageList` (22/16), `MessageRow` (19/16), `MessageActions` (8/10) — **85 props and
+73 emits**, most of them the same eleven names spelled again. `Show.vue` bound the
+identical twelve-line handler block twice, once for the pane and once for the panel.
+
+The viewer's capabilities rode the same chain: `canReact` appeared in 8 `.vue` files,
+`canModerate` in 12, `canPin` in 7. `lib/messageActions.ts` already defined
+`MessageActionContext` — the right shape — but it was *reconstructed* from
+individually-drilled booleans in three components. One concept even had two
+spellings, `viewerTimeZone` and `viewerTimezone`, both computed and both passed down.
+
+The cost was not the line count. It was that no module below `Show.vue` could be
+mounted without it: a row's behaviour was only reachable by threading twenty props
+through four intermediaries, so ten test files did exactly that.
+
+## Decision
+
+The viewer-and-channel scope and the action facade are **provided** by the channel
+page and read through a **named accessor pair**, never a raw `inject`:
+
+- `provideMessageActions(context)` / `useMessageActionsContext()` — who the viewer
+  is, what the open channel lets them do, the single viewer time zone, and the
+  eleven actions. Provided once, by the page.
+- `provideMessageSubtree(scope)` / `useMessageSubtree()` — what one timeline answers
+  differently: `inThread`, and the composer a mention lands in. `ChannelPane`
+  provides `false` and the channel composer; `ThreadPanel` provides `true` and its
+  own reply composer.
+- `useMessageActionGuards()` — builds `MessageActionContext` from those two scopes
+  plus the one fact only a row has: `pending`, which stays a row-local prop.
+
+Intermediate modules declare none of the eleven. `ChannelPane`, `ThreadPanel`,
+`MessageList`, `MessageRow` and `MessageActions` read the context where they use it.
+
+**The accessors throw when no provider is above them.** That is the point of the
+pair: raw `inject` returns `undefined` with no signal, and the failure would surface
+as a dead button rather than a mount-time error.
+
+Two affordances deliberately stay events, because they open UI the *timeline* owns
+rather than performing a write: `startEdit` (swap a row for its inline editor) and
+`requestDelete` (raise the confirmation). The writes they eventually reach —
+`edit(message, body)` and `delete(message)` — go through the facade like everything
+else, and the events are named apart from them so the distinction is legible.
+
+## Consequences
+
+- Props fall from 85 to 60 and emits from 73 to 15 across the five modules; the
+  duplicated binding block in `Show.vue` is gone.
+- `MessageRow` and `MessageActions` are mountable on their own against a stub
+  facade, which `components/timeline/MessageRow.test.ts` does — no `Show.vue`
+  involved. The ten suites that used to thread props now provide one facade and
+  assert on its spies, and together they lost about 430 lines.
+- One spelling of the viewer time zone (`viewerTimeZone`) across the whole app.
+- A twelfth action (#524's "save for later") is one method on the facade, not a new
+  prop and emit at five levels.
+- **The cost, stated plainly:** provide/inject is implicit. A reader of
+  `MessageRow.vue` cannot see where `scope.actions.pin` comes from by looking at its
+  props. That is the trade this ADR makes, and it is why the accessors are named,
+  typed, and throwing rather than a bare `inject(key)` — the seam is greppable, and
+  a missing provider fails loudly at mount.
+- Reactivity is the provider's job: the page provides a `reactive()` bag of
+  computeds, so a capability revised mid-session (a channel switch, an archive)
+  reaches every row.

--- a/dev-docs/adr/0009-message-action-context-is-provided.md
+++ b/dev-docs/adr/0009-message-action-context-is-provided.md
@@ -34,7 +34,9 @@ page and read through a **named accessor pair**, never a raw `inject`:
 
 - `provideMessageActions(context)` / `useMessageActionsContext()` — who the viewer
   is, what the open channel lets them do, the single viewer time zone, and the
-  eleven actions. Provided once, by the page.
+  actions. Provided once, by the page. `MessageActionHandlers` holds thirteen: the
+  eleven writes above plus `reply` and `openThread`, which are navigations rather
+  than writes but rode the identical relay, so they belong to the same facade.
 - `provideMessageSubtree(scope)` / `useMessageSubtree()` — what one timeline answers
   differently: `inThread`, and the composer a mention lands in. `ChannelPane`
   provides `false` and the channel composer; `ThreadPanel` provides `true` and its

--- a/dev-docs/adr/0009-message-action-context-is-provided.md
+++ b/dev-docs/adr/0009-message-action-context-is-provided.md
@@ -7,7 +7,7 @@
 ## Context
 
 `composables/useMessageActions.ts` was already a deep module: one options object in,
-one flat facade of eleven actions out. All the friction was in getting a click to it.
+one flat facade of eleven writes out. All the friction was in getting a click to it.
 
 Eleven actions (`react`, `vote`, `closePoll`, `pin`, `unpin`, `remind`,
 `remindCustom`, `forward`, `jump`, `edit`, `delete`) were re-declared and
@@ -44,7 +44,7 @@ page and read through a **named accessor pair**, never a raw `inject`:
 - `useMessageActionGuards()` — builds `MessageActionContext` from those two scopes
   plus the one fact only a row has: `pending`, which stays a row-local prop.
 
-Intermediate modules declare none of the eleven. `ChannelPane`, `ThreadPanel`,
+Intermediate modules declare none of the thirteen. `ChannelPane`, `ThreadPanel`,
 `MessageList`, `MessageRow` and `MessageActions` read the context where they use it.
 
 **The accessors throw when no provider is above them.** That is the point of the
@@ -66,7 +66,7 @@ else, and the events are named apart from them so the distinction is legible.
   involved. The ten suites that used to thread props now provide one facade and
   assert on its spies, and together they lost about 430 lines.
 - One spelling of the viewer time zone (`viewerTimeZone`) across the whole app.
-- A twelfth action (#524's "save for later") is one method on the facade, not a new
+- A twelfth *write* (#524's "save for later") is one method on the facade, not a new
   prop and emit at five levels.
 - **The cost, stated plainly:** provide/inject is implicit. A reader of
   `MessageRow.vue` cannot see where `scope.actions.pin` comes from by looking at its

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -13,3 +13,4 @@ seams live in [`CONTEXT.md`](../../CONTEXT.md).
 | [0005](0005-domain-event-recording-seam.md) | Record audit & security events via event→listener |
 | [0006](0006-realtime-lives-in-composables.md) | Realtime subscription lifecycles live in composables |
 | [0007](0007-in-process-browser-realtime-harness.md) | Browser E2E realtime tests run against the app served in-process |
+| [0009](0009-message-action-context-is-provided.md) | The message-action context is provided, not drilled |

--- a/resources/js/components/MessageActions.quickReact.test.ts
+++ b/resources/js/components/MessageActions.quickReact.test.ts
@@ -1,61 +1,52 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { App } from 'vue';
-import { createApp, defineComponent, h } from 'vue';
-import { translate } from '@/lib/i18n';
-import type { Message, Reaction } from '@/types';
+import type { Reaction } from '@/types';
 
-/** Mutable stand-in for the shared Inertia props the bar reads. */
-const props = vi.hoisted(() => ({
-    frequentEmojis: [] as string[],
-    customEmojis: {} as Record<string, string>,
-}));
+/**
+ * Covers the hover toolbar's quick-react cluster, mounted on its own against a
+ * stub facade — no timeline, no page. What is pinned here is the ranked list it
+ * renders, how a shortcut reads once the viewer has used it, and that a press
+ * reaches the provided `react` rather than an emit up a relay.
+ */
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaPageProps } = await import('./MessageList.doubles');
 
-vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props }),
-}));
+    return { usePage: () => ({ props: inertiaPageProps }) };
+});
 
 // The picker popover pulls in reka-ui portals and the emoji library; the quick
 // cluster only needs its trigger slot, so stub it down to a passthrough.
-vi.mock('@/components/EmojiPickerPopover.vue', () => ({
-    default: defineComponent({
-        name: 'EmojiPickerPopover',
-        setup:
-            (_p, { slots }) =>
-            () =>
-                h('div', slots.default?.({ open: false })),
-    }),
-}));
+vi.mock('@/components/EmojiPickerPopover.vue', async () => {
+    const { popover } = await import('./MessageList.doubles');
 
-vi.mock('@/components/ui/tooltip', () => {
-    const pass = (name: string) =>
-        defineComponent({
-            name,
-            setup:
-                (_p, { slots }) =>
-                () =>
-                    h('div', slots.default?.()),
-        });
+    return { default: popover('EmojiPickerPopover') };
+});
+
+vi.mock('@/components/MessageReminderPopover.vue', async () => {
+    const { popover } = await import('./MessageList.doubles');
+
+    return { default: popover('MessageReminderPopover') };
+});
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { passthrough } = await import('./MessageList.doubles');
 
     return {
-        Tooltip: pass('Tooltip'),
-        TooltipContent: pass('TooltipContent'),
-        TooltipProvider: pass('TooltipProvider'),
-        TooltipTrigger: pass('TooltipTrigger'),
+        Tooltip: passthrough('Tooltip'),
+        TooltipContent: passthrough('TooltipContent'),
+        TooltipProvider: passthrough('TooltipProvider'),
+        TooltipTrigger: passthrough('TooltipTrigger'),
     };
 });
 
-vi.mock('@/components/MessageReminderPopover.vue', () => ({
-    default: defineComponent({
-        name: 'MessageReminderPopover',
-        setup:
-            (_p, { slots }) =>
-            () =>
-                h('div', slots.default?.({ open: false })),
-    }),
-}));
-
 import MessageActions from './MessageActions.vue';
+import {
+    all,
+    inertiaPageProps,
+    message,
+    mountWithActions,
+    unmountAll,
+} from './MessageList.doubles';
 
 function reaction(emoji: string, reactorIds: string[]): Reaction {
     return {
@@ -65,83 +56,33 @@ function reaction(emoji: string, reactorIds: string[]): Reaction {
     };
 }
 
-function message(overrides: Partial<Message> = {}): Message {
-    return {
-        id: 'm1',
-        clientUuid: 'uuid-1',
-        body: 'hello',
-        type: 'standard',
-        user: { id: 'peer', name: 'Peer' },
-        createdAt: '2024-01-01T00:00:00.000Z',
-        editedAt: null,
-        isDeleted: false,
-        mentions: [],
-        linkPreviews: [],
-        attachments: [],
-        reactions: [],
-        pin: null,
-        poll: null,
-        replyTo: null,
-        forwardedFrom: null,
-        threadRootId: null,
-        sentToChannel: false,
-        threadReplyCount: 0,
-        threadLastReplyAt: null,
-        threadParticipants: [],
-        threadFollowed: false,
-        threadUnread: false,
-        ...overrides,
-    } as Message;
-}
-
-let app: App | null = null;
-
-function mount(componentProps: Record<string, unknown> = {}): {
-    host: HTMLElement;
-    reacted: string[];
-} {
-    const reacted: string[] = [];
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-
-    app = createApp({
-        render: () =>
-            h(MessageActions, {
-                message: message(),
-                currentUserId: 'me',
-                canReact: true,
-                viewerTimezone: null,
-                onReact: (emoji: string) => reacted.push(emoji),
-                ...componentProps,
-            }),
-    });
-    app.config.globalProperties.$t = translate;
-    app.mount(host);
-
-    return { host, reacted };
+function mount(
+    props: Record<string, unknown> = {},
+    overrides: Parameters<typeof mountWithActions>[2] = {},
+) {
+    return mountWithActions(
+        MessageActions,
+        { message: message(), ...props },
+        overrides,
+    );
 }
 
 function shortcuts(host: HTMLElement): HTMLElement[] {
-    return [...host.querySelectorAll<HTMLElement>('[data-test="quick-react"]')];
+    return all(host, 'quick-react');
 }
 
 beforeEach(() => {
-    props.frequentEmojis = ['👍', '❤️', '🎉', ':shipit:', '👀'];
-    props.customEmojis = { shipit: 'https://desk.test/shipit.png' };
+    inertiaPageProps.frequentEmojis = ['👍', '❤️', '🎉', ':shipit:', '👀'];
+    inertiaPageProps.customEmojis = { shipit: 'https://desk.test/shipit.png' };
 });
 
-afterEach(() => {
-    app?.unmount();
-    app = null;
-    document.body.innerHTML = '';
-});
+afterEach(unmountAll);
 
 describe('MessageActions quick-react cluster', () => {
     it('renders one shortcut per frequently-used emoji, ahead of the picker trigger', () => {
         const { host } = mount();
-        const cells = shortcuts(host);
 
-        expect(cells.map((cell) => cell.dataset.emoji)).toEqual([
+        expect(shortcuts(host).map((cell) => cell.dataset.emoji)).toEqual([
             '👍',
             '❤️',
             '🎉',
@@ -172,7 +113,7 @@ describe('MessageActions quick-react cluster', () => {
     });
 
     it('shows only the top three shortcuts inside a thread panel', () => {
-        const { host } = mount({ inThread: true });
+        const { host } = mount({}, { subtree: { inThread: true } });
 
         expect(shortcuts(host).map((cell) => cell.dataset.emoji)).toEqual([
             '👍',
@@ -182,7 +123,7 @@ describe('MessageActions quick-react cluster', () => {
     });
 
     it('hides the cluster when the viewer may not react', () => {
-        const { host } = mount({ canReact: false });
+        const { host } = mount({}, { scope: { canReact: false } });
 
         expect(shortcuts(host)).toHaveLength(0);
     });
@@ -206,16 +147,18 @@ describe('MessageActions quick-react cluster', () => {
         expect(unpressed.getAttribute('aria-label')).toBe('React with 👍');
     });
 
-    it('emits the react toggle on click, pressed or not', () => {
-        const { host, reacted } = mount({
-            message: message({ reactions: [reaction('🎉', ['me'])] }),
-        });
+    it('reaches the provided react action on click, pressed or not', () => {
+        const target = message({ reactions: [reaction('🎉', ['me'])] });
+        const { host, actions } = mount({ message: target });
 
         shortcuts(host)[0].click();
         shortcuts(host)
             .find((cell) => cell.dataset.emoji === '🎉')!
             .click();
 
-        expect(reacted).toEqual(['👍', '🎉']);
+        expect(actions.react.mock.calls).toEqual([
+            [target, '👍'],
+            [target, '🎉'],
+        ]);
     });
 });

--- a/resources/js/components/MessageActions.vue
+++ b/resources/js/components/MessageActions.vue
@@ -21,6 +21,11 @@ import {
 } from '@/components/ui/tooltip';
 import { useCustomEmojis } from '@/composables/useCustomEmojis';
 import { useFrequentEmojis } from '@/composables/useFrequentEmojis';
+import {
+    useMessageActionGuards,
+    useMessageActionsContext,
+    useMessageSubtree,
+} from '@/composables/useMessageActionsContext';
 import { useTranslations } from '@/composables/useTranslations';
 import type { CustomEmojiEntry } from '@/lib/customEmoji';
 import {
@@ -34,48 +39,27 @@ import {
     canStartThreadFromMessage,
     hasAnyMessageAction,
 } from '@/lib/messageActions';
-import type { MessageActionContext } from '@/lib/messageActions';
 import { hasReacted } from '@/lib/reactions';
 import type { Message } from '@/types';
 
 const props = defineProps<{
     message: Message;
-    currentUserId: string;
-    /** Whether the viewer may add/remove reactions (member of a live channel). */
-    canReact?: boolean;
-    /** Whether the viewer may pin/unpin messages (member of a non-archived channel). */
-    canPin?: boolean;
-    /** Whether the viewer may moderate others' messages (delete them). */
-    canModerate?: boolean;
-    /** Rendered inside a thread panel: suppresses the reply/thread affordances. */
-    inThread?: boolean;
     /** Whether this row is an optimistic send with no stable server id yet. */
     pending?: boolean;
-    /** The viewer's stored zone, feeding the reminder popover's wall-clock presets. */
-    viewerTimezone: string | null;
 }>();
 
 const emit = defineEmits<{
-    react: [emoji: string];
-    reply: [];
-    forward: [];
-    pin: [];
-    unpin: [];
-    openThread: [];
-    remind: [remindAt: string];
-    remindCustom: [];
-    edit: [];
-    delete: [];
+    /** Swap this row for its inline editor, which the timeline owns. */
+    startEdit: [];
+    /** Ask to delete this row, which the timeline confirms first. */
+    requestDelete: [];
 }>();
 
-const context = computed<MessageActionContext>(() => ({
-    currentUserId: props.currentUserId,
-    canReact: props.canReact ?? false,
-    canPin: props.canPin ?? false,
-    canModerate: props.canModerate ?? false,
-    inThread: props.inThread ?? false,
-    pending: props.pending ?? false,
-}));
+const scope = useMessageActionsContext();
+const subtree = useMessageSubtree();
+const { contextFor } = useMessageActionGuards();
+
+const context = computed(() => contextFor(props.pending ?? false));
 
 const showReact = computed(() =>
     canReactToMessage(props.message, context.value),
@@ -113,7 +97,7 @@ const { list: frequentEmojis } = useFrequentEmojis();
  * than a list of its own.
  */
 const quickEmojis = computed(() =>
-    props.inThread ? frequentEmojis.value.slice(0, 3) : frequentEmojis.value,
+    subtree.inThread ? frequentEmojis.value.slice(0, 3) : frequentEmojis.value,
 );
 
 /** The emoji the viewer has already reacted with on this message. */
@@ -121,7 +105,7 @@ const ownReactions = computed(
     () =>
         new Set(
             props.message.reactions
-                .filter((reaction) => hasReacted(reaction, props.currentUserId))
+                .filter((reaction) => hasReacted(reaction, scope.currentUserId))
                 .map((reaction) => reaction.emoji),
         ),
 );
@@ -217,7 +201,7 @@ const deleteButtonClass =
                             :aria-pressed="ownReactions.has(emoji)"
                             :aria-label="quickLabel(emoji)"
                             :class="quickButtonClass"
-                            @click="emit('react', emoji)"
+                            @click="scope.actions.react(props.message, emoji)"
                         >
                             <img
                                 v-if="quickCustomEmoji(emoji)"
@@ -240,7 +224,9 @@ const deleteButtonClass =
 
                 <EmojiPickerPopover
                     v-slot="{ open }"
-                    @select="(emoji) => emit('react', emoji)"
+                    @select="
+                        (emoji) => scope.actions.react(props.message, emoji)
+                    "
                 >
                     <Button
                         variant="ghost"
@@ -271,7 +257,7 @@ const deleteButtonClass =
                         data-test="message-thread"
                         :aria-label="$t('Reply in thread')"
                         :class="iconButtonClass"
-                        @click="emit('openThread')"
+                        @click="scope.actions.openThread(props.message.id)"
                     >
                         <MessageSquareText />
                     </Button>
@@ -290,7 +276,7 @@ const deleteButtonClass =
                         data-test="message-reply"
                         :aria-label="$t('Reply to message')"
                         :class="iconButtonClass"
-                        @click="emit('reply')"
+                        @click="scope.actions.reply(props.message)"
                     >
                         <CornerUpLeft />
                     </Button>
@@ -315,7 +301,7 @@ const deleteButtonClass =
                         data-test="message-forward"
                         :aria-label="$t('Forward message')"
                         :class="iconButtonClass"
-                        @click="emit('forward')"
+                        @click="scope.actions.forward(props.message)"
                     >
                         <Forward />
                     </Button>
@@ -338,7 +324,11 @@ const deleteButtonClass =
                                 : $t('Pin to channel')
                         "
                         :class="iconButtonClass"
-                        @click="isPinned ? emit('unpin') : emit('pin')"
+                        @click="
+                            isPinned
+                                ? scope.actions.unpin(props.message)
+                                : scope.actions.pin(props.message)
+                        "
                     >
                         <Pin :class="isPinned ? 'fill-brass text-brass' : ''" />
                     </Button>
@@ -355,9 +345,11 @@ const deleteButtonClass =
             <MessageReminderPopover
                 v-if="showRemind"
                 v-slot="{ open }"
-                :timezone="props.viewerTimezone"
-                @set="(remindAt) => emit('remind', remindAt)"
-                @custom="emit('remindCustom')"
+                :timezone="scope.viewerTimeZone"
+                @set="
+                    (remindAt) => scope.actions.remind(props.message, remindAt)
+                "
+                @custom="scope.actions.remindCustom(props.message)"
             >
                 <Button
                     variant="ghost"
@@ -381,7 +373,7 @@ const deleteButtonClass =
                         data-test="message-edit"
                         :aria-label="$t('Edit message')"
                         :class="iconButtonClass"
-                        @click="emit('edit')"
+                        @click="emit('startEdit')"
                     >
                         <Pencil />
                     </Button>
@@ -400,7 +392,7 @@ const deleteButtonClass =
                         data-test="message-delete"
                         :aria-label="$t('Delete message')"
                         :class="deleteButtonClass"
-                        @click="emit('delete')"
+                        @click="emit('requestDelete')"
                     >
                         <Trash2 />
                     </Button>

--- a/resources/js/components/MessageActionsSheet.test.ts
+++ b/resources/js/components/MessageActionsSheet.test.ts
@@ -1,21 +1,19 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { App } from 'vue';
-import { createApp, defineComponent, h } from 'vue';
-import { translate } from '@/lib/i18n';
-import type { Message, Reaction } from '@/types';
+import type { Reaction } from '@/types';
 
-/** Mutable stand-in for the shared Inertia props the sheet reads. */
-const props = vi.hoisted(() => ({
-    frequentEmojis: [] as string[],
-    customEmojis: {} as Record<string, string>,
-}));
-
-vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props }),
-}));
-
+/**
+ * Covers the touch actions sheet mounted on its own against a stub facade: which
+ * rows it offers for a given viewer, where each row lands, the clipboard row's
+ * two outcomes, and the lifted card echoing the pressed message.
+ */
 const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaPageProps } = await import('./MessageList.doubles');
+
+    return { usePage: () => ({ props: inertiaPageProps }) };
+});
 
 vi.mock('@/composables/useToast', () => {
     const toast = {
@@ -30,37 +28,35 @@ vi.mock('@/composables/useToast', () => {
 
 // The sheet rides the app's dialog primitive; its portal/focus behaviour is the
 // primitive's own tested concern, so render it down to a passthrough.
-vi.mock('@/components/ui/dialog', () => {
-    const pass = (name: string) =>
-        defineComponent({
-            name,
-            setup:
-                (_p, { slots }) =>
-                () =>
-                    h('div', slots.default?.()),
-        });
+vi.mock('@/components/ui/dialog', async () => {
+    const { passthrough } = await import('./MessageList.doubles');
 
     return {
-        Dialog: pass('Dialog'),
-        DialogContent: pass('DialogContent'),
-        DialogDescription: pass('DialogDescription'),
-        DialogTitle: pass('DialogTitle'),
+        Dialog: passthrough('Dialog'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogTitle: passthrough('DialogTitle'),
     };
 });
 
 // The picker popover pulls in reka-ui portals and the emoji library; the sheet
 // only needs its trigger slot, so stub it down to a passthrough.
-vi.mock('@/components/EmojiPickerPopover.vue', () => ({
-    default: defineComponent({
-        name: 'EmojiPickerPopover',
-        setup:
-            (_p, { slots }) =>
-            () =>
-                h('div', slots.default?.({ open: false })),
-    }),
-}));
+vi.mock('@/components/EmojiPickerPopover.vue', async () => {
+    const { popover } = await import('./MessageList.doubles');
+
+    return { default: popover('EmojiPickerPopover') };
+});
 
 import MessageActionsSheet from './MessageActionsSheet.vue';
+import {
+    all,
+    click,
+    find,
+    inertiaPageProps,
+    message,
+    mountWithActions,
+    unmountAll,
+} from './MessageList.doubles';
 
 function reaction(emoji: string, reactorIds: string[]): Reaction {
     return {
@@ -70,76 +66,22 @@ function reaction(emoji: string, reactorIds: string[]): Reaction {
     };
 }
 
-function message(overrides: Partial<Message> = {}): Message {
-    return {
-        id: 'm1',
-        clientUuid: 'uuid-1',
-        body: 'hello',
-        type: 'standard',
-        user: { id: 'peer', name: 'Peer' },
-        createdAt: '2024-01-01T00:00:00.000Z',
-        editedAt: null,
-        isDeleted: false,
-        mentions: [],
-        linkPreviews: [],
-        attachments: [],
-        reactions: [],
-        pin: null,
-        poll: null,
-        replyTo: null,
-        forwardedFrom: null,
-        threadRootId: null,
-        sentToChannel: false,
-        threadReplyCount: 0,
-        threadLastReplyAt: null,
-        threadParticipants: [],
-        threadFollowed: false,
-        threadUnread: false,
-        ...overrides,
-    } as Message;
-}
-
-let app: App | null = null;
-
-function mount(componentProps: Record<string, unknown> = {}): {
-    host: HTMLElement;
-    emitted: Record<string, unknown[][]>;
-} {
-    const emitted: Record<string, unknown[][]> = {};
-    const capture =
-        (name: string) =>
-        (...args: unknown[]) => {
-            (emitted[name] ??= []).push(args);
-        };
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-
-    app = createApp({
-        render: () =>
-            h(MessageActionsSheet, {
-                open: true,
-                message: message(),
-                currentUserId: 'me',
-                canReact: true,
-                canPin: true,
-                viewerTimeZone: 'UTC',
-                'onUpdate:open': capture('update:open'),
-                onReact: capture('react'),
-                onOpenThread: capture('openThread'),
-                onReply: capture('reply'),
-                onForward: capture('forward'),
-                onPin: capture('pin'),
-                onUnpin: capture('unpin'),
-                onRemindCustom: capture('remindCustom'),
-                onEdit: capture('edit'),
-                onDelete: capture('delete'),
-                ...componentProps,
-            }),
-    });
-    app.config.globalProperties.$t = translate;
-    app.mount(host);
-
-    return { host, emitted };
+function mount(
+    props: Record<string, unknown> = {},
+    overrides: Parameters<typeof mountWithActions>[2] = {},
+) {
+    return mountWithActions(
+        MessageActionsSheet,
+        {
+            open: true,
+            message: message(),
+            'onUpdate:open': () => {},
+            onStartEdit: () => {},
+            onRequestDelete: () => {},
+            ...props,
+        },
+        overrides,
+    );
 }
 
 function rowNames(host: HTMLElement): string[] {
@@ -148,16 +90,26 @@ function rowNames(host: HTMLElement): string[] {
     );
 }
 
+function shortcut(host: HTMLElement, emoji: string): HTMLElement {
+    return all(host, 'sheet-quick-react').find(
+        (cell) => cell.dataset.emoji === emoji,
+    )!;
+}
+
+/** Stub the clipboard with a write that either lands or is refused. */
+function stubClipboard(writeText: ReturnType<typeof vi.fn>): void {
+    Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+    });
+}
+
 beforeEach(() => {
-    props.frequentEmojis = ['👍', '❤️', '🎉', ':shipit:', '👀'];
-    props.customEmojis = { shipit: 'https://desk.test/shipit.png' };
+    inertiaPageProps.frequentEmojis = ['👍', '❤️', '🎉', ':shipit:', '👀'];
+    inertiaPageProps.customEmojis = { shipit: 'https://desk.test/shipit.png' };
 });
 
-afterEach(() => {
-    app?.unmount();
-    app = null;
-    document.body.innerHTML = '';
-});
+afterEach(unmountAll);
 
 describe('MessageActionsSheet action rows', () => {
     it('offers every toolbar action on a peer root message, minus the author-only pair', () => {
@@ -189,14 +141,14 @@ describe('MessageActionsSheet action rows', () => {
     });
 
     it('adds delete alone when the viewer moderates a peer message', () => {
-        const { host } = mount({ canModerate: true });
+        const { host } = mount({}, { scope: { canModerate: true } });
 
         expect(rowNames(host)).not.toContain('edit');
         expect(rowNames(host)).toContain('delete');
     });
 
     it('drops the thread and reply rows inside a thread panel, like the toolbar', () => {
-        const { host } = mount({ inThread: true });
+        const { host } = mount({}, { subtree: { inThread: true } });
 
         expect(rowNames(host)).not.toContain('thread');
         expect(rowNames(host)).not.toContain('reply');
@@ -212,83 +164,89 @@ describe('MessageActionsSheet action rows', () => {
     });
 
     it('hides the quick-reaction strip when the viewer may not react', () => {
-        const { host } = mount({ canReact: false });
+        const { host } = mount({}, { scope: { canReact: false } });
 
         expect(rowNames(host)).not.toContain('quick-react');
         expect(rowNames(host)).not.toContain('react');
     });
 
     it('flips the pin row to unpin on a pinned message', () => {
-        const pinned = mount({
-            message: message({
-                pin: {
-                    pinnedBy: { id: 'peer', name: 'Peer' },
-                    pinnedAt: '2024-01-01T00:00:00.000Z',
-                },
-            }),
+        const pinned = message({
+            pin: {
+                pinnedBy: { id: 'peer', name: 'Peer' },
+                pinnedAt: '2024-01-01T00:00:00.000Z',
+            },
         });
+        const { host, actions } = mount({ message: pinned });
 
-        expect(
-            pinned.host.querySelector<HTMLElement>('[data-test="sheet-pin"]')!
-                .textContent,
-        ).toContain('Unpin from channel');
+        expect(find(host, 'sheet-pin')?.textContent).toContain(
+            'Unpin from channel',
+        );
 
-        pinned.host
-            .querySelector<HTMLElement>('[data-test="sheet-pin"]')!
-            .click();
+        click(host, 'sheet-pin');
 
-        expect(pinned.emitted.unpin).toHaveLength(1);
-        expect(pinned.emitted.pin).toBeUndefined();
+        expect(actions.unpin).toHaveBeenCalledExactlyOnceWith(pinned);
+        expect(actions.pin).not.toHaveBeenCalled();
     });
 
-    it('emits the chosen action and dismisses itself', () => {
-        const { host, emitted } = mount();
+    it('reaches the chosen action and dismisses itself', () => {
+        const target = message();
+        const { host, actions, events } = mount({ message: target });
 
-        host.querySelector<HTMLElement>('[data-test="sheet-forward"]')!.click();
+        click(host, 'sheet-forward');
 
-        expect(emitted.forward).toHaveLength(1);
-        expect(emitted['update:open']).toEqual([[false]]);
+        expect(actions.forward).toHaveBeenCalledExactlyOnceWith(target);
+        expect(events).toEqual([['update:open', false]]);
+    });
+
+    it('hands the timeline the edit and delete affordances it owns', () => {
+        const { host, events } = mount({
+            message: message({ user: { id: 'me', name: 'Me' } }),
+        });
+
+        click(host, 'sheet-edit');
+        click(host, 'sheet-delete');
+
+        expect(events.map(([name]) => name)).toEqual([
+            'startEdit',
+            'update:open',
+            'requestDelete',
+            'update:open',
+        ]);
     });
 
     it('copies the message text as typed and dismisses', async () => {
         const writeText = vi.fn().mockResolvedValue(undefined);
-        Object.defineProperty(navigator, 'clipboard', {
-            value: { writeText },
-            configurable: true,
-        });
+        stubClipboard(writeText);
 
-        const { host, emitted } = mount({
+        const { host, events } = mount({
             message: message({
                 body: 'hi @[Alice](a1b2c3d4-e5f6-7890-1234-567890abcdef)\n**bold**',
             }),
         });
 
-        host.querySelector<HTMLElement>('[data-test="sheet-copy"]')!.click();
+        click(host, 'sheet-copy');
         await Promise.resolve();
 
         expect(writeText).toHaveBeenCalledExactlyOnceWith(
             'hi @Alice\n**bold**',
         );
-        expect(emitted['update:open']).toEqual([[false]]);
+        expect(events).toEqual([['update:open', false]]);
     });
 
     it('reports a copy that could not reach the clipboard and still dismisses', async () => {
-        const writeText = vi.fn().mockRejectedValue(new Error('denied'));
-        Object.defineProperty(navigator, 'clipboard', {
-            value: { writeText },
-            configurable: true,
-        });
+        stubClipboard(vi.fn().mockRejectedValue(new Error('denied')));
 
-        const { host, emitted } = mount();
+        const { host, events } = mount();
 
-        host.querySelector<HTMLElement>('[data-test="sheet-copy"]')!.click();
+        click(host, 'sheet-copy');
         await Promise.resolve();
         await Promise.resolve();
 
         expect(toastError).toHaveBeenCalledExactlyOnceWith(
             'The message text could not be copied',
         );
-        expect(emitted['update:open']).toEqual([[false]]);
+        expect(events).toEqual([['update:open', false]]);
     });
 
     it('hides the copy row when the message has no text to copy', () => {
@@ -298,31 +256,25 @@ describe('MessageActionsSheet action rows', () => {
     });
 
     it('routes the remind row to the custom reminder flow', () => {
-        const { host, emitted } = mount();
+        const target = message();
+        const { host, actions, events } = mount({ message: target });
 
-        host.querySelector<HTMLElement>('[data-test="sheet-remind"]')!.click();
+        click(host, 'sheet-remind');
 
-        expect(emitted.remindCustom).toHaveLength(1);
-        expect(emitted['update:open']).toEqual([[false]]);
+        expect(actions.remindCustom).toHaveBeenCalledExactlyOnceWith(target);
+        expect(events).toEqual([['update:open', false]]);
     });
 });
 
-function shortcut(host: HTMLElement, emoji: string): HTMLElement {
-    return [
-        ...host.querySelectorAll<HTMLElement>(
-            '[data-test="sheet-quick-react"]',
-        ),
-    ].find((cell) => cell.dataset.emoji === emoji)!;
-}
-
 describe('MessageActionsSheet quick reactions', () => {
     it('applies a shortcut reaction and dismisses', () => {
-        const { host, emitted } = mount();
+        const target = message();
+        const { host, actions, events } = mount({ message: target });
 
         shortcut(host, '🎉').click();
 
-        expect(emitted.react).toEqual([['🎉']]);
-        expect(emitted['update:open']).toEqual([[false]]);
+        expect(actions.react).toHaveBeenCalledExactlyOnceWith(target, '🎉');
+        expect(events).toEqual([['update:open', false]]);
     });
 
     it('marks an already-reacted shortcut pressed and labels it as a retraction', () => {
@@ -352,9 +304,7 @@ describe('MessageActionsSheet selection suppression', () => {
     it('renders every surface non-selectable, like a native sheet', () => {
         const { host } = mount();
 
-        const sheet = host.querySelector<HTMLElement>(
-            '[data-test="message-actions-sheet"]',
-        )!;
+        const sheet = find(host, 'message-actions-sheet')!;
 
         expect(sheet.classList.contains('select-none')).toBe(true);
         expect(sheet.classList.contains('[-webkit-touch-callout:none]')).toBe(
@@ -381,19 +331,15 @@ describe('MessageActionsSheet selection suppression', () => {
 describe('MessageActionsSheet lifted card', () => {
     it('echoes the pressed message: avatar initials, author, time, plain body', () => {
         const { host } = mount({
-            message: message({
-                body: 'Shipped the **thread panel**',
-            }),
+            message: message({ body: 'Shipped the **thread panel**' }),
         });
 
-        const card = host.querySelector<HTMLElement>(
-            '[data-test="lifted-message"]',
-        )!;
+        const card = find(host, 'lifted-message')!;
 
         expect(card.textContent).toContain('Peer');
         expect(card.textContent).toContain('P');
         expect(card.textContent).toContain('Shipped the thread panel');
         expect(card.innerHTML).not.toContain('<strong>');
-        expect(card.textContent).toMatch(/12:00|0:00/);
+        expect(card.textContent).toMatch(/10:30/);
     });
 });

--- a/resources/js/components/MessageActionsSheet.vue
+++ b/resources/js/components/MessageActionsSheet.vue
@@ -23,6 +23,10 @@ import {
 import { useCustomEmojis } from '@/composables/useCustomEmojis';
 import { useFrequentEmojis } from '@/composables/useFrequentEmojis';
 import { useInitials } from '@/composables/useInitials';
+import {
+    useMessageActionGuards,
+    useMessageActionsContext,
+} from '@/composables/useMessageActionsContext';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatTimeOfDay } from '@/lib/datetime';
@@ -37,7 +41,6 @@ import {
     canReplyToMessage,
     canStartThreadFromMessage,
 } from '@/lib/messageActions';
-import type { MessageActionContext } from '@/lib/messageActions';
 import { messageBodyCopyText, messageBodyPreview } from '@/lib/messageBody';
 import { hasReacted } from '@/lib/reactions';
 import type { Message } from '@/types';
@@ -47,32 +50,16 @@ const props = defineProps<{
     open: boolean;
     /** The long-pressed message, kept through the close animation. */
     message: Message | null;
-    currentUserId: string;
-    /** Whether the viewer may add/remove reactions (member of a live channel). */
-    canReact?: boolean;
-    /** Whether the viewer may pin/unpin messages (member of a non-archived channel). */
-    canPin?: boolean;
-    /** Whether the viewer may moderate others' messages (delete them). */
-    canModerate?: boolean;
-    /** Rendered from a thread panel: suppresses the reply/thread affordances. */
-    inThread?: boolean;
     /** Whether the pressed row is an optimistic send with no stable server id yet. */
     pending?: boolean;
-    /** The viewer's stored zone, so the lifted card's timestamp matches the row's. */
-    viewerTimeZone?: string;
 }>();
 
 const emit = defineEmits<{
     'update:open': [open: boolean];
-    react: [emoji: string];
-    openThread: [];
-    reply: [];
-    forward: [];
-    pin: [];
-    unpin: [];
-    remindCustom: [];
-    edit: [];
-    delete: [];
+    /** Swap the pressed row for its inline editor, which the timeline owns. */
+    startEdit: [];
+    /** Ask to delete the pressed row, which the timeline confirms first. */
+    requestDelete: [];
 }>();
 
 const { t } = useTranslations();
@@ -81,14 +68,10 @@ const { getInitials } = useInitials();
 const { parseToken } = useCustomEmojis();
 const { list: frequentEmojis } = useFrequentEmojis();
 
-const context = computed<MessageActionContext>(() => ({
-    currentUserId: props.currentUserId,
-    canReact: props.canReact ?? false,
-    canPin: props.canPin ?? false,
-    canModerate: props.canModerate ?? false,
-    inThread: props.inThread ?? false,
-    pending: props.pending ?? false,
-}));
+const scope = useMessageActionsContext();
+const { contextFor } = useMessageActionGuards();
+
+const context = computed(() => contextFor(props.pending ?? false));
 
 /**
  * The sheet mirrors the hover toolbar action for action, so both surfaces read
@@ -155,7 +138,7 @@ const ownReactions = computed(
     () =>
         new Set(
             (props.message?.reactions ?? [])
-                .filter((entry) => hasReacted(entry, props.currentUserId))
+                .filter((entry) => hasReacted(entry, scope.currentUserId))
                 .map((entry) => entry.emoji),
         ),
 );
@@ -177,7 +160,10 @@ const bodyPreview = computed(() =>
 const timestamp = computed(() =>
     props.message === null
         ? ''
-        : formatTimeOfDay(props.message.createdAt, props.viewerTimeZone),
+        : formatTimeOfDay(
+              props.message.createdAt,
+              scope.viewerTimeZone ?? undefined,
+          ),
 );
 
 function close(): void {
@@ -197,28 +183,16 @@ watch(
     { immediate: true },
 );
 
-type ActionEvent =
-    | 'openThread'
-    | 'reply'
-    | 'forward'
-    | 'pin'
-    | 'unpin'
-    | 'remindCustom'
-    | 'edit'
-    | 'delete';
-
 /**
- * Every action leaves the sheet behind: emit, then dismiss. Vue types `emit`
- * per event literal; widening to the union is sound because every action event
- * carries no payload.
+ * Every action leaves the sheet behind: run it against the pressed message,
+ * then dismiss. Each row is guarded by a rule that already requires a message,
+ * so the null branch is only reachable if a row outlives its own guard.
  */
-function act(event: ActionEvent): void {
-    (emit as (event: ActionEvent) => void)(event);
-    close();
-}
+function act(run: (message: Message) => void): void {
+    if (props.message !== null) {
+        run(props.message);
+    }
 
-function react(emoji: string): void {
-    emit('react', emoji);
     close();
 }
 
@@ -315,7 +289,7 @@ const rowClass =
                     :aria-pressed="ownReactions.has(emoji)"
                     :aria-label="quickLabel(emoji)"
                     class="flex size-11 items-center justify-center rounded-full bg-muted text-[19px] leading-none transition-colors hover:bg-accent aria-pressed:bg-brass-fill aria-pressed:text-brass-fill-foreground aria-pressed:inset-ring-1 aria-pressed:inset-ring-brass-border"
-                    @click="react(emoji)"
+                    @click="act((target) => scope.actions.react(target, emoji))"
                 >
                     <img
                         v-if="parseToken(emoji)"
@@ -326,7 +300,12 @@ const rowClass =
                     <span v-else aria-hidden="true">{{ emoji }}</span>
                 </Button>
 
-                <EmojiPickerPopover @select="react">
+                <EmojiPickerPopover
+                    @select="
+                        (emoji) =>
+                            act((target) => scope.actions.react(target, emoji))
+                    "
+                >
                     <Button
                         variant="unstyled"
                         size="none"
@@ -351,7 +330,9 @@ const rowClass =
                     type="button"
                     data-test="sheet-thread"
                     :class="rowClass"
-                    @click="act('openThread')"
+                    @click="
+                        act((target) => scope.actions.openThread(target.id))
+                    "
                 >
                     <MessageSquareText class="size-4 text-muted-foreground" />
                     {{ $t('Reply in thread') }}
@@ -363,7 +344,7 @@ const rowClass =
                     type="button"
                     data-test="sheet-reply"
                     :class="rowClass"
-                    @click="act('reply')"
+                    @click="act(scope.actions.reply)"
                 >
                     <CornerUpLeft class="size-4 text-muted-foreground" />
                     {{ $t('Reply to message') }}
@@ -375,7 +356,7 @@ const rowClass =
                     type="button"
                     data-test="sheet-forward"
                     :class="rowClass"
-                    @click="act('forward')"
+                    @click="act(scope.actions.forward)"
                 >
                     <Forward class="size-4 text-muted-foreground" />
                     {{ $t('Forward') }}
@@ -399,7 +380,9 @@ const rowClass =
                     type="button"
                     data-test="sheet-pin"
                     :class="rowClass"
-                    @click="act(isPinned ? 'unpin' : 'pin')"
+                    @click="
+                        act(isPinned ? scope.actions.unpin : scope.actions.pin)
+                    "
                 >
                     <Pin
                         class="size-4"
@@ -422,7 +405,7 @@ const rowClass =
                     type="button"
                     data-test="sheet-remind"
                     :class="rowClass"
-                    @click="act('remindCustom')"
+                    @click="act(scope.actions.remindCustom)"
                 >
                     <AlarmClock class="size-4 text-muted-foreground" />
                     {{ $t('Remind me…') }}
@@ -434,7 +417,7 @@ const rowClass =
                     type="button"
                     data-test="sheet-edit"
                     :class="rowClass"
-                    @click="act('edit')"
+                    @click="act(() => emit('startEdit'))"
                 >
                     <Pencil class="size-4 text-muted-foreground" />
                     {{ $t('Edit message') }}
@@ -446,7 +429,7 @@ const rowClass =
                     type="button"
                     data-test="sheet-delete"
                     class="flex h-11.5 w-full items-center gap-3 rounded-[11px] px-3.5 text-left text-[14.5px] font-medium text-destructive-text transition-colors hover:bg-destructive/10 active:bg-destructive/10"
-                    @click="act('delete')"
+                    @click="act(() => emit('requestDelete'))"
                 >
                     <Trash2 class="size-4" />
                     {{ $t('Delete message') }}

--- a/resources/js/components/MessageList.actionSheet.test.ts
+++ b/resources/js/components/MessageList.actionSheet.test.ts
@@ -1,10 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { App } from 'vue';
-import { createApp, defineComponent, h, nextTick, reactive } from 'vue';
+import { defineComponent, h, nextTick, reactive } from 'vue';
 import { LONG_PRESS_MS } from '@/composables/useLongPress';
-import { translate } from '@/lib/i18n';
-import type { Message } from '@/types';
+import {
+    find,
+    message,
+    mountWithActions,
+    unmountAll,
+} from './MessageList.doubles';
 
 /**
  * Covers the touch stand-in for the hover toolbar: the actions sheet a hold on a
@@ -12,19 +15,15 @@ import type { Message } from '@/types';
  * itself again. It survives a split of `MessageList.vue` unchanged, so what is
  * pinned here is when it opens and which message it resolves.
  */
-const pageProps = vi.hoisted(() => ({
-    auth: { user: { timezone: 'UTC' } },
-    customEmojis: {} as Record<string, string>,
-    userGroups: [] as unknown[],
-}));
-
-vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props: pageProps }),
-}));
-
 const mobile = vi.hoisted(() => ({
     current: null as { value: boolean } | null,
 }));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaPageProps } = await import('./MessageList.doubles');
+
+    return { usePage: () => ({ props: inertiaPageProps }) };
+});
 
 vi.mock('@/composables/useIsMobile', async () => {
     const { ref } = await import('vue');
@@ -34,17 +33,11 @@ vi.mock('@/composables/useIsMobile', async () => {
     return { useIsMobile: () => value };
 });
 
-/** Renders an empty marker element, so a stubbed leaf is still findable. */
-function marker(name: string) {
-    return defineComponent({
-        name,
-        setup: () => () => h('div', { 'data-stub': name }),
-    });
-}
+vi.mock('@/components/MessageActions.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageActions.vue', () => ({
-    default: marker('MessageActions'),
-}));
+    return { default: marker('MessageActions') };
+});
 
 /** Reports the sheet's open state and the message it resolved, nothing more. */
 vi.mock('@/components/MessageActionsSheet.vue', () => ({
@@ -73,79 +66,41 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
     }),
 }));
 
-vi.mock('@/components/MessageAttachments.vue', () => ({
-    default: marker('MessageAttachments'),
-}));
+vi.mock('@/components/MessageAttachments.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessagePoll.vue', () => ({
-    default: marker('MessagePoll'),
-}));
+    return { default: marker('MessageAttachments') };
+});
 
-vi.mock('@/components/MessageReactions.vue', () => ({
-    default: marker('MessageReactions'),
-}));
+vi.mock('@/components/MessagePoll.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageForward.vue', () => ({
-    default: marker('MessageForward'),
-}));
+    return { default: marker('MessagePoll') };
+});
+
+vi.mock('@/components/MessageReactions.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageReactions') };
+});
+
+vi.mock('@/components/MessageForward.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageForward') };
+});
 
 import MessageList from './MessageList.vue';
 
-function message(overrides: Partial<Message> = {}): Message {
-    return {
-        id: 'm1',
-        clientUuid: 'uuid-1',
-        body: 'hello',
-        type: 'standard',
-        user: { id: 'peer', name: 'Peer' },
-        createdAt: '2024-03-04T10:30:00.000Z',
-        editedAt: null,
-        isDeleted: false,
-        mentions: [],
-        linkPreviews: [],
-        attachments: [],
-        reactions: [],
-        pin: null,
-        poll: null,
-        replyTo: null,
-        forwardedFrom: null,
-        threadRootId: null,
-        sentToChannel: false,
-        threadReplyCount: 0,
-        threadLastReplyAt: null,
-        threadParticipants: [],
-        threadFollowed: false,
-        threadUnread: false,
-        threadUnreadReplyCount: 0,
-        ...overrides,
-    } as Message;
-}
-
-let active: Array<{ app: App; host: HTMLElement }> = [];
-
-function mount(props: Record<string, unknown> = {}): HTMLElement {
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-
-    const app = createApp({
-        render: () =>
-            h(MessageList, {
-                messages: [message()],
-                teamSlug: 'acme',
-                currentUserId: 'peer',
-                canReact: true,
-                ...props,
-            }),
-    });
-    app.config.globalProperties.$t = translate;
-    app.mount(host);
-    active.push({ app, host });
-
-    return host;
-}
-
-function find(host: HTMLElement, selector: string): HTMLElement | null {
-    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+function mount(
+    props: Record<string, unknown> = {},
+    canReact = true,
+): HTMLElement {
+    return mountWithActions(
+        MessageList,
+        { messages: [message()], teamSlug: 'acme', ...props },
+        { scope: { currentUserId: 'peer', canReact } },
+    ).host;
 }
 
 /** A pointer event shaped the way the row's long-press handlers read it. */
@@ -162,117 +117,82 @@ function pointer(type: string, target: HTMLElement): PointerEvent {
     return event as PointerEvent;
 }
 
+/** Hold the given row long enough for the sheet's gesture to fire. */
+async function hold(host: HTMLElement, selector: string): Promise<void> {
+    const row = find(host, selector) as HTMLElement;
+    row.dispatchEvent(pointer('pointerdown', row));
+    vi.advanceTimersByTime(LONG_PRESS_MS);
+    await nextTick();
+}
+
+function sheetOpen(host: HTMLElement): string | undefined {
+    return find(host, 'actions-sheet')?.getAttribute('data-open') ?? undefined;
+}
+
 beforeEach(() => {
+    vi.useFakeTimers();
+
     if (mobile.current) {
         mobile.current.value = false;
     }
 });
 
 afterEach(() => {
-    for (const { app, host } of active) {
-        app.unmount();
-        host.remove();
-    }
-
-    active = [];
+    unmountAll();
+    vi.useRealTimers();
 });
 
 describe('the touch actions sheet', () => {
-    beforeEach(() => {
-        vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-        vi.useRealTimers();
-    });
-
-    async function hold(host: HTMLElement): Promise<void> {
-        const body = find(host, 'message-body') as HTMLElement;
-        body.dispatchEvent(pointer('pointerdown', body));
-        vi.advanceTimersByTime(LONG_PRESS_MS);
-        await nextTick();
-    }
-
     it('opens on a hold below the breakpoint, resolving the message live', async () => {
         mobile.current!.value = true;
         const host = mount();
-        await hold(host);
+        await hold(host, 'message-body');
 
-        const sheet = find(host, 'actions-sheet');
-
-        expect(sheet?.getAttribute('data-open')).toBe('true');
-        expect(sheet?.getAttribute('data-message')).toBe('m1');
+        expect(sheetOpen(host)).toBe('true');
+        expect(find(host, 'actions-sheet')?.getAttribute('data-message')).toBe(
+            'm1',
+        );
     });
 
     it('stays shut on a hover-capable layout, where the toolbar owns the actions', async () => {
         const host = mount();
-        await hold(host);
+        await hold(host, 'message-body');
 
-        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
-            'false',
-        );
+        expect(sheetOpen(host)).toBe('false');
     });
 
     it('stays shut on a row that offers no actions at all', async () => {
         mobile.current!.value = true;
-        const host = mount({
-            messages: [message({ isDeleted: true })],
-            canReact: false,
-        });
+        const host = mount({ messages: [message({ isDeleted: true })] }, false);
 
-        const tombstone = find(host, 'message-tombstone') as HTMLElement;
-        tombstone.dispatchEvent(pointer('pointerdown', tombstone));
-        vi.advanceTimersByTime(LONG_PRESS_MS);
-        await nextTick();
+        await hold(host, 'message-tombstone');
 
-        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
-            'false',
-        );
+        expect(sheetOpen(host)).toBe('false');
     });
 
     it('closes when the viewport crosses up over the breakpoint mid-press', async () => {
         mobile.current!.value = true;
         const host = mount();
-        await hold(host);
+        await hold(host, 'message-body');
 
         mobile.current!.value = false;
         await nextTick();
 
-        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
-            'false',
-        );
+        expect(sheetOpen(host)).toBe('false');
     });
 
     it('closes when the message it is open on is tombstoned in place', async () => {
         mobile.current!.value = true;
         const messages = reactive([message()]);
-        const host = document.createElement('div');
-        document.body.appendChild(host);
+        const host = mount({ messages });
 
-        const app = createApp({
-            render: () =>
-                h(MessageList, {
-                    messages,
-                    teamSlug: 'acme',
-                    currentUserId: 'peer',
-                    canReact: true,
-                }),
-        });
-        app.config.globalProperties.$t = translate;
-        app.mount(host);
-        active.push({ app, host });
+        await hold(host, 'message-body');
 
-        await hold(host);
-
-        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
-            'true',
-        );
+        expect(sheetOpen(host)).toBe('true');
 
         messages[0].isDeleted = true;
         await nextTick();
 
-        expect(find(host, 'actions-sheet')?.getAttribute('data-open')).toBe(
-            'false',
-        );
+        expect(sheetOpen(host)).toBe('false');
     });
 });

--- a/resources/js/components/MessageList.affordances.test.ts
+++ b/resources/js/components/MessageList.affordances.test.ts
@@ -1,9 +1,14 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { App } from 'vue';
-import { createApp, defineComponent, h, ref } from 'vue';
-import { translate } from '@/lib/i18n';
-import type { ChannelReader, Message } from '@/types';
+import { defineComponent, h, ref } from 'vue';
+import type { ChannelReader } from '@/types';
+import {
+    find,
+    inertiaPageProps,
+    message,
+    mountWithActions,
+    unmountAll,
+} from './MessageList.doubles';
 
 /**
  * Covers the affordances hanging off the timeline rather than sitting in a row:
@@ -12,35 +17,18 @@ import type { ChannelReader, Message } from '@/types';
  * `MessageList.vue` is split, so what is pinned here is the rendered markup and
  * the guards deciding whether it renders at all.
  */
-const pageProps = vi.hoisted(() => ({
-    auth: { user: { timezone: 'UTC' } },
-    customEmojis: {} as Record<string, string>,
-    userGroups: [] as Array<{ id: string }>,
-}));
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaPageProps } = await import('./MessageList.doubles');
 
-vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props: pageProps }),
-}));
-
-const mobile = vi.hoisted(() => ({
-    current: null as { value: boolean } | null,
-}));
+    return { usePage: () => ({ props: inertiaPageProps }) };
+});
 
 vi.mock('@/composables/useIsMobile', async () => {
     const { ref } = await import('vue');
     const value = ref(false);
-    mobile.current = value;
 
     return { useIsMobile: () => value };
 });
-
-/** Renders an empty marker element, so a stubbed leaf is still findable. */
-function marker(name: string) {
-    return defineComponent({
-        name,
-        setup: () => () => h('div', { 'data-stub': name }),
-    });
-}
 
 vi.mock('@/components/UserHoverCard.vue', () => ({
     default: defineComponent({
@@ -52,112 +40,61 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
     }),
 }));
 
-vi.mock('@/components/MessageActions.vue', () => ({
-    default: marker('MessageActions'),
-}));
+vi.mock('@/components/MessageActions.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageActionsSheet.vue', () => ({
-    default: marker('MessageActionsSheet'),
-}));
+    return { default: marker('MessageActions') };
+});
 
-vi.mock('@/components/MessageAttachments.vue', () => ({
-    default: marker('MessageAttachments'),
-}));
+vi.mock('@/components/MessageActionsSheet.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessagePoll.vue', () => ({
-    default: marker('MessagePoll'),
-}));
+    return { default: marker('MessageActionsSheet') };
+});
 
-vi.mock('@/components/MessageReactions.vue', () => ({
-    default: marker('MessageReactions'),
-}));
+vi.mock('@/components/MessageAttachments.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageForward.vue', () => ({
-    default: marker('MessageForward'),
-}));
+    return { default: marker('MessageAttachments') };
+});
+
+vi.mock('@/components/MessagePoll.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessagePoll') };
+});
+
+vi.mock('@/components/MessageReactions.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageReactions') };
+});
+
+vi.mock('@/components/MessageForward.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageForward') };
+});
 
 import MessageList from './MessageList.vue';
 
-function message(overrides: Partial<Message> = {}): Message {
-    return {
-        id: 'm1',
-        clientUuid: 'uuid-1',
-        body: 'hello',
-        type: 'standard',
-        user: { id: 'peer', name: 'Peer' },
-        createdAt: '2024-03-04T10:30:00.000Z',
-        editedAt: null,
-        isDeleted: false,
-        mentions: [],
-        linkPreviews: [],
-        attachments: [],
-        reactions: [],
-        pin: null,
-        poll: null,
-        replyTo: null,
-        forwardedFrom: null,
-        threadRootId: null,
-        sentToChannel: false,
-        threadReplyCount: 0,
-        threadLastReplyAt: null,
-        threadParticipants: [],
-        threadFollowed: false,
-        threadUnread: false,
-        threadUnreadReplyCount: 0,
-        ...overrides,
-    } as Message;
-}
-
-let active: Array<{ app: App; host: HTMLElement }> = [];
-
-type Mounted = {
-    host: HTMLElement;
-    events: Array<[string, unknown]>;
-};
-
-function mount(props: Record<string, unknown> = {}): Mounted {
-    const events: Array<[string, unknown]> = [];
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-
-    const app = createApp({
-        render: () =>
-            h(MessageList, {
-                messages: [message()],
-                teamSlug: 'acme',
-                currentUserId: 'me',
-                onJump: (id: string) => events.push(['jump', id]),
-                onOpenThread: (id: string) => events.push(['openThread', id]),
-                ...props,
-            }),
-    });
-    app.config.globalProperties.$t = translate;
-    app.mount(host);
-    active.push({ app, host });
-
-    return { host, events };
-}
-
-function find(host: HTMLElement, selector: string): HTMLElement | null {
-    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+function mount(props: Record<string, unknown> = {}, inThread = false) {
+    return mountWithActions(
+        MessageList,
+        { messages: [message()], teamSlug: 'acme', ...props },
+        { subtree: { inThread } },
+    );
 }
 
 beforeEach(() => {
-    pageProps.customEmojis = {};
-    pageProps.userGroups = [];
+    inertiaPageProps.customEmojis = {};
+    inertiaPageProps.userGroups = [];
 });
 
-afterEach(() => {
-    for (const { app, host } of active) {
-        app.unmount();
-        host.remove();
-    }
-
-    active = [];
-});
+afterEach(unmountAll);
 
 describe('the thread summary', () => {
-    const root = (overrides: Partial<Message> = {}) =>
+    const root = (overrides: Partial<ReturnType<typeof message>> = {}) =>
         message({
             threadReplyCount: 2,
             threadParticipants: [
@@ -168,7 +105,7 @@ describe('the thread summary', () => {
         });
 
     it('opens the thread when pressed, naming the reply count', () => {
-        const { host, events } = mount({ messages: [root()] });
+        const { host, actions } = mount({ messages: [root()] });
 
         const summary = find(host, 'thread-summary');
 
@@ -178,13 +115,11 @@ describe('the thread summary', () => {
         expect(summary?.textContent).toContain('2 replies');
         summary?.click();
 
-        expect(events).toEqual([['openThread', 'm1']]);
+        expect(actions.openThread).toHaveBeenCalledExactlyOnceWith('m1');
     });
 
     it('reads in the singular for a lone reply', () => {
-        const { host } = mount({
-            messages: [root({ threadReplyCount: 1 })],
-        });
+        const { host } = mount({ messages: [root({ threadReplyCount: 1 })] });
 
         expect(find(host, 'thread-summary')?.getAttribute('aria-label')).toBe(
             'View thread, 1 reply',
@@ -228,15 +163,13 @@ describe('the thread summary', () => {
     });
 
     it('survives its root being deleted, since the thread outlives it', () => {
-        const { host } = mount({
-            messages: [root({ isDeleted: true })],
-        });
+        const { host } = mount({ messages: [root({ isDeleted: true })] });
 
         expect(find(host, 'thread-summary')).not.toBeNull();
     });
 
     it('stays out of a thread panel, where the reader is already in the thread', () => {
-        const { host } = mount({ messages: [root()], inThread: true });
+        const { host } = mount({ messages: [root()] }, true);
 
         expect(find(host, 'thread-summary')).toBeNull();
     });
@@ -258,17 +191,17 @@ describe('the "Seen by" row', () => {
     it('names a single reader', () => {
         const { host } = mount({ readers: readers('Alice') });
 
-        expect(
-            host.querySelector('[data-test="seen-by"]')?.getAttribute('title'),
-        ).toBe('Seen by Alice');
+        expect(find(host, 'seen-by')?.getAttribute('title')).toBe(
+            'Seen by Alice',
+        );
     });
 
     it('joins two readers with "and"', () => {
         const { host } = mount({ readers: readers('Alice', 'Bob') });
 
-        expect(
-            host.querySelector('[data-test="seen-by"]')?.getAttribute('title'),
-        ).toBe('Seen by Alice and Bob');
+        expect(find(host, 'seen-by')?.getAttribute('title')).toBe(
+            'Seen by Alice and Bob',
+        );
     });
 
     it('collapses the tail into a "+N" chip past three avatars', () => {
@@ -276,7 +209,7 @@ describe('the "Seen by" row', () => {
             readers: readers('Alice', 'Bob', 'Cara', 'Dan', 'Eve'),
         });
 
-        const row = host.querySelector('[data-test="seen-by"]');
+        const row = find(host, 'seen-by');
 
         expect(row?.getAttribute('title')).toBe(
             'Seen by Alice, Bob, Cara and 2 others',
@@ -290,9 +223,9 @@ describe('the "Seen by" row', () => {
             readers: readers('Alice', 'Bob', 'Cara', 'Dan'),
         });
 
-        expect(
-            host.querySelector('[data-test="seen-by"]')?.getAttribute('title'),
-        ).toBe('Seen by Alice, Bob, Cara and 1 other');
+        expect(find(host, 'seen-by')?.getAttribute('title')).toBe(
+            'Seen by Alice, Bob, Cara and 1 other',
+        );
     });
 
     it('drops the viewer’s own read position from the roster', () => {
@@ -302,19 +235,19 @@ describe('the "Seen by" row', () => {
             ],
         });
 
-        expect(host.querySelector('[data-test="seen-by"]')).toBeNull();
+        expect(find(host, 'seen-by')).toBeNull();
     });
 
     it('stays out of a thread panel', () => {
-        const { host } = mount({ inThread: true, readers: readers('Alice') });
+        const { host } = mount({ readers: readers('Alice') }, true);
 
-        expect(host.querySelector('[data-test="seen-by"]')).toBeNull();
+        expect(find(host, 'seen-by')).toBeNull();
     });
 
     it('stays out of an empty timeline', () => {
         const { host } = mount({ messages: [], readers: readers('Alice') });
 
-        expect(host.querySelector('[data-test="seen-by"]')).toBeNull();
+        expect(find(host, 'seen-by')).toBeNull();
     });
 });
 
@@ -328,28 +261,17 @@ describe('the windowed timeline', () => {
         });
 
         expect(host.querySelectorAll('[role="listitem"]')).toHaveLength(2);
-        expect(host.querySelector('[data-test="message-skeleton"]')).toBeNull();
+        expect(find(host, 'message-skeleton')).toBeNull();
     });
 
     it('exposes the jump helpers the parent drives the list with', () => {
         const exposed = ref<Record<string, unknown> | null>(null);
-        const host = document.createElement('div');
-        document.body.appendChild(host);
 
-        const app = createApp({
-            render: () =>
-                h(MessageList, {
-                    messages: [message()],
-                    teamSlug: 'acme',
-                    currentUserId: 'me',
-                    ref: (instance: unknown) => {
-                        exposed.value = instance as Record<string, unknown>;
-                    },
-                }),
+        mount({
+            ref: (instance: unknown) => {
+                exposed.value = instance as Record<string, unknown>;
+            },
         });
-        app.config.globalProperties.$t = translate;
-        app.mount(host);
-        active.push({ app, host });
 
         expect(typeof exposed.value?.scrollToIndex).toBe('function');
         expect(typeof exposed.value?.scrollToLatest).toBe('function');

--- a/resources/js/components/MessageList.doubles.ts
+++ b/resources/js/components/MessageList.doubles.ts
@@ -1,0 +1,241 @@
+import { vi } from 'vitest';
+import type { Mock } from 'vitest';
+import type { App, Component } from 'vue';
+import { createApp, defineComponent, h } from 'vue';
+import {
+    provideMessageActions,
+    provideMessageSubtree,
+} from '@/composables/useMessageActionsContext';
+import type {
+    MessageActionHandlers,
+    MessageActionsContext,
+    MessageSubtreeContext,
+} from '@/composables/useMessageActionsContext';
+import { translate } from '@/lib/i18n';
+import type { Message } from '@/types';
+
+/**
+ * The doubles the timeline's suites share: the Inertia props its leaves read,
+ * the message factory, the stub component shapes, and the mount that stands a
+ * component up under a provided message-actions facade.
+ *
+ * The facade is the seam (ADR-0009): every suite here asserts against these
+ * spies rather than threading a handler down as a prop, which is what lets a
+ * row, the hover toolbar and the touch sheet each mount on their own.
+ *
+ * A `vi.mock` factory is hoisted above the imports, so a suite pulls what it
+ * needs from here with a dynamic `import()` inside the factory.
+ */
+export const inertiaPageProps = {
+    auth: { user: { timezone: 'UTC' } },
+    customEmojis: {} as Record<string, string>,
+    userGroups: [] as Array<{ id: string }>,
+    frequentEmojis: [] as string[],
+};
+
+/** Renders nothing, standing in for a leaf whose own tests cover it. */
+export function inert(name: string): Component {
+    return defineComponent({ name, setup: () => () => null });
+}
+
+/** Renders an empty marker element, so a stubbed leaf is still findable. */
+export function marker(name: string): Component {
+    return defineComponent({
+        name,
+        setup: () => () => h('div', { 'data-stub': name }),
+    });
+}
+
+/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
+export function passthrough(name: string): Component {
+    return defineComponent({
+        name,
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', { 'data-stub': name }, slots.default?.()),
+    });
+}
+
+/** A wrapper that hands its slot the `{ open }` a popover trigger reads. */
+export function popover(name: string): Component {
+    return defineComponent({
+        name,
+        setup:
+            (_props, { slots }) =>
+            () =>
+                h('div', slots.default?.({ open: false })),
+    });
+}
+
+export function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-03-04T10:30:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    } as Message;
+}
+
+/**
+ * The facade's handlers as spies, so a suite can read `.mock.calls` on any of
+ * them while the bag still satisfies {@link MessageActionHandlers}.
+ */
+export type MockedHandlers = {
+    [K in keyof MessageActionHandlers]: Mock<MessageActionHandlers[K]>;
+};
+
+/** Every action a row can ask for, as spies. */
+export function actionsDouble(): MockedHandlers {
+    return {
+        react: vi.fn(),
+        vote: vi.fn(),
+        closePoll: vi.fn(),
+        pin: vi.fn(),
+        unpin: vi.fn(),
+        remind: vi.fn(),
+        remindCustom: vi.fn(),
+        forward: vi.fn(),
+        jump: vi.fn(),
+        edit: vi.fn(),
+        delete: vi.fn(),
+        reply: vi.fn(),
+        openThread: vi.fn(),
+    };
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+export type Mounted = {
+    host: HTMLElement;
+    /** The provided facade's spies, which every action lands on. */
+    actions: MockedHandlers;
+    /** The subtree's mention sink, which a hover card lands on. */
+    mention: MessageSubtreeContext['mention'];
+    /** What the component emitted, in order, as `[name, ...payload]`. */
+    events: Array<[string, ...unknown[]]>;
+};
+
+/**
+ * Mount `component` under a provided facade, the way the channel page provides
+ * one. `scope` and `subtree` override the viewer capabilities and the timeline
+ * scope a suite cares about; everything else stays at a permissive default.
+ *
+ * Every `onX` in `props` is also captured into `events`, so a suite can assert
+ * on what the component emitted without wiring a listener per test.
+ */
+export function mountWithActions(
+    component: Component,
+    props: Record<string, unknown> = {},
+    overrides: {
+        scope?: Omit<Partial<MessageActionsContext>, 'actions'>;
+        subtree?: Partial<MessageSubtreeContext>;
+    } = {},
+): Mounted {
+    const events: Array<[string, ...unknown[]]> = [];
+    const actions = actionsDouble();
+    const mention = overrides.subtree?.mention ?? vi.fn();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp(
+        defineComponent({
+            setup() {
+                provideMessageActions({
+                    currentUserId: 'me',
+                    canReact: true,
+                    canPin: true,
+                    canModerate: false,
+                    viewerTimeZone: 'UTC',
+                    ...overrides.scope,
+                    actions,
+                });
+                provideMessageSubtree({
+                    inThread: false,
+                    ...overrides.subtree,
+                    mention,
+                });
+
+                return () => h(component, capture(props, events));
+            },
+        }),
+    );
+    app.config.globalProperties.$t = translate;
+    app.mount(host);
+    active.push({ app, host });
+
+    return { host, actions, mention, events };
+}
+
+/**
+ * Wrap each `onX` listener so the emit is recorded before it runs, leaving a
+ * suite free to pass its own listener on top.
+ */
+function capture(
+    props: Record<string, unknown>,
+    events: Array<[string, ...unknown[]]>,
+): Record<string, unknown> {
+    return Object.fromEntries(
+        Object.entries(props).map(([key, value]) => {
+            if (!/^on[A-Z]/.test(key) || typeof value !== 'function') {
+                return [key, value];
+            }
+
+            const name = key.slice(2, 3).toLowerCase() + key.slice(3);
+
+            return [
+                key,
+                (...payload: unknown[]) => {
+                    events.push([name, ...payload]);
+                    (value as (...args: unknown[]) => void)(...payload);
+                },
+            ];
+        }),
+    );
+}
+
+export function unmountAll(): void {
+    for (const { app, host } of active.splice(0)) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+}
+
+export function find(host: HTMLElement, selector: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
+}
+
+export function all(host: HTMLElement, selector: string): HTMLElement[] {
+    return [...host.querySelectorAll<HTMLElement>(`[data-test="${selector}"]`)];
+}
+
+export function stub(host: HTMLElement, name: string): HTMLElement | null {
+    return host.querySelector<HTMLElement>(`[data-stub="${name}"]`);
+}
+
+export function click(host: HTMLElement, selector: string): void {
+    find(host, selector)?.click();
+}

--- a/resources/js/components/MessageList.doubles.ts
+++ b/resources/js/components/MessageList.doubles.ts
@@ -236,6 +236,16 @@ export function stub(host: HTMLElement, name: string): HTMLElement | null {
     return host.querySelector<HTMLElement>(`[data-stub="${name}"]`);
 }
 
+/**
+ * Press the named target, or fail naming it. A no-op on a stale selector would
+ * leave the assertion below it passing for the wrong reason.
+ */
 export function click(host: HTMLElement, selector: string): void {
-    find(host, selector)?.click();
+    const target = find(host, selector);
+
+    if (target === null) {
+        throw new Error(`No [data-test="${selector}"] to press.`);
+    }
+
+    target.click();
 }

--- a/resources/js/components/MessageList.editing.test.ts
+++ b/resources/js/components/MessageList.editing.test.ts
@@ -1,94 +1,65 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { App } from 'vue';
-import { createApp, defineComponent, h, nextTick } from 'vue';
-import { translate } from '@/lib/i18n';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, nextTick } from 'vue';
 import type { Message } from '@/types';
+import {
+    click,
+    find,
+    message,
+    mountWithActions,
+    unmountAll,
+} from './MessageList.doubles';
 
 /**
  * Covers the two pieces of state the timeline owns on top of its rows: the
  * inline editor a row swaps into, and the delete confirmation standing between
- * the toolbar and the emit. Both survive a split of `MessageList.vue` unchanged,
- * so what is pinned here is when each opens, what it suppresses while open, and
- * which event it emits on the way out.
+ * the toolbar and the write. Both survive a split of `MessageList.vue`
+ * unchanged, so what is pinned here is when each opens, what it suppresses while
+ * open, and which action it reaches on the way out.
  */
-const pageProps = vi.hoisted(() => ({
-    auth: { user: { timezone: 'UTC' } },
-    customEmojis: {} as Record<string, string>,
-    userGroups: [] as unknown[],
-}));
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaPageProps } = await import('./MessageList.doubles');
 
-vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props: pageProps }),
-}));
-
-const mobile = vi.hoisted(() => ({
-    current: null as { value: boolean } | null,
-}));
+    return { usePage: () => ({ props: inertiaPageProps }) };
+});
 
 vi.mock('@/composables/useIsMobile', async () => {
     const { ref } = await import('vue');
     const value = ref(false);
-    mobile.current = value;
 
     return { useIsMobile: () => value };
 });
 
-/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
-function passthrough(name: string) {
-    return defineComponent({
-        name,
-        setup:
-            (_props, { slots }) =>
-            () =>
-                h('div', { 'data-stub': name }, slots.default?.()),
-    });
-}
-
-/** Renders an empty marker element, so a stubbed leaf is still findable. */
-function marker(name: string) {
-    return defineComponent({
-        name,
-        setup: () => () => h('div', { 'data-stub': name }),
-    });
-}
-
 /**
  * Stands in for the hover toolbar with a button per event the timeline listens
- * for, so the row's response to `edit` and `delete` is driven the way the real
- * toolbar drives it.
+ * for, so the row's response to `startEdit` and `requestDelete` is driven the
+ * way the real toolbar drives it.
  */
 vi.mock('@/components/MessageActions.vue', () => ({
     default: defineComponent({
         name: 'MessageActionsStub',
-        emits: ['edit', 'delete'],
+        emits: ['startEdit', 'requestDelete'],
         setup:
             (_props, { emit }) =>
             () =>
                 h('div', [
-                    h(
-                        'button',
-                        {
-                            'data-test': 'stub-edit',
-                            onClick: () => emit('edit'),
-                        },
-                        'edit',
-                    ),
-                    h(
-                        'button',
-                        {
-                            'data-test': 'stub-delete',
-                            onClick: () => emit('delete'),
-                        },
-                        'delete',
-                    ),
+                    h('button', {
+                        'data-test': 'stub-edit',
+                        onClick: () => emit('startEdit'),
+                    }),
+                    h('button', {
+                        'data-test': 'stub-delete',
+                        onClick: () => emit('requestDelete'),
+                    }),
                 ]),
     }),
 }));
 
-vi.mock('@/components/MessageActionsSheet.vue', () => ({
-    default: marker('MessageActionsSheet'),
-}));
+vi.mock('@/components/MessageActionsSheet.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageActionsSheet') };
+});
 
 vi.mock('@/components/UserHoverCard.vue', () => ({
     default: defineComponent({
@@ -100,117 +71,65 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
     }),
 }));
 
-vi.mock('@/components/ui/dialog', () => ({
-    Dialog: defineComponent({
-        name: 'DialogStub',
-        props: { open: { type: Boolean, default: false } },
-        setup:
-            (props, { slots }) =>
-            () =>
-                props.open
-                    ? h(
-                          'div',
-                          { 'data-test': 'delete-dialog' },
-                          slots.default?.(),
-                      )
-                    : null,
-    }),
-    DialogClose: passthrough('DialogClose'),
-    DialogContent: passthrough('DialogContent'),
-    DialogDescription: passthrough('DialogDescription'),
-    DialogFooter: passthrough('DialogFooter'),
-    DialogHeader: passthrough('DialogHeader'),
-    DialogTitle: passthrough('DialogTitle'),
-}));
+vi.mock('@/components/ui/dialog', async () => {
+    const { passthrough } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageAttachments.vue', () => ({
-    default: marker('MessageAttachments'),
-}));
+    return {
+        Dialog: defineComponent({
+            name: 'DialogStub',
+            props: { open: { type: Boolean, default: false } },
+            setup:
+                (props, { slots }) =>
+                () =>
+                    props.open
+                        ? h(
+                              'div',
+                              { 'data-test': 'delete-dialog' },
+                              slots.default?.(),
+                          )
+                        : null,
+        }),
+        DialogClose: passthrough('DialogClose'),
+        DialogContent: passthrough('DialogContent'),
+        DialogDescription: passthrough('DialogDescription'),
+        DialogFooter: passthrough('DialogFooter'),
+        DialogHeader: passthrough('DialogHeader'),
+        DialogTitle: passthrough('DialogTitle'),
+    };
+});
 
-vi.mock('@/components/MessagePoll.vue', () => ({
-    default: marker('MessagePoll'),
-}));
+vi.mock('@/components/MessageAttachments.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageReactions.vue', () => ({
-    default: marker('MessageReactions'),
-}));
+    return { default: marker('MessageAttachments') };
+});
 
-vi.mock('@/components/MessageForward.vue', () => ({
-    default: marker('MessageForward'),
-}));
+vi.mock('@/components/MessagePoll.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessagePoll') };
+});
+
+vi.mock('@/components/MessageReactions.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageReactions') };
+});
+
+vi.mock('@/components/MessageForward.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageForward') };
+});
 
 import MessageList from './MessageList.vue';
 
-function message(overrides: Partial<Message> = {}): Message {
-    return {
-        id: 'm1',
-        clientUuid: 'uuid-1',
-        body: 'hello',
-        type: 'standard',
-        user: { id: 'peer', name: 'Peer' },
-        createdAt: '2024-03-04T10:30:00.000Z',
-        editedAt: null,
-        isDeleted: false,
-        mentions: [],
-        linkPreviews: [],
-        attachments: [],
-        reactions: [],
-        pin: null,
-        poll: null,
-        replyTo: null,
-        forwardedFrom: null,
-        threadRootId: null,
-        sentToChannel: false,
-        threadReplyCount: 0,
-        threadLastReplyAt: null,
-        threadParticipants: [],
-        threadFollowed: false,
-        threadUnread: false,
-        threadUnreadReplyCount: 0,
-        ...overrides,
-    } as Message;
-}
-
-let active: Array<{ app: App; host: HTMLElement }> = [];
-
-type Mounted = {
-    host: HTMLElement;
-    edits: Array<[string, string]>;
-    deletes: string[];
-};
-
-function mount(props: Record<string, unknown> = {}): Mounted {
-    const edits: Array<[string, string]> = [];
-    const deletes: string[] = [];
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-
-    const app = createApp({
-        render: () =>
-            h(MessageList, {
-                messages: [message()],
-                teamSlug: 'acme',
-                currentUserId: 'peer',
-                canReact: true,
-                onEdit: (target: Message, body: string) =>
-                    edits.push([target.id, body]),
-                onDelete: (target: Message) => deletes.push(target.id),
-                ...props,
-            }),
+function mount(props: Record<string, unknown> = {}) {
+    return mountWithActions(MessageList, {
+        messages: [message()],
+        teamSlug: 'acme',
+        ...props,
     });
-    app.config.globalProperties.$t = translate;
-    app.mount(host);
-    active.push({ app, host });
-
-    return { host, edits, deletes };
-}
-
-function find(host: HTMLElement, selector: string): HTMLElement | null {
-    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
-}
-
-function click(host: HTMLElement, selector: string): void {
-    find(host, selector)?.click();
 }
 
 async function startEditing(host: HTMLElement): Promise<HTMLTextAreaElement> {
@@ -220,20 +139,26 @@ async function startEditing(host: HTMLElement): Promise<HTMLTextAreaElement> {
     return find(host, 'message-edit-input') as HTMLTextAreaElement;
 }
 
-beforeEach(() => {
-    if (mobile.current) {
-        mobile.current.value = false;
-    }
-});
+/** Type into the editor the way the editor's own `v-model` reads it. */
+async function type(field: HTMLTextAreaElement, text: string): Promise<void> {
+    field.value = text;
+    field.dispatchEvent(new Event('input'));
+    await nextTick();
+}
 
-afterEach(() => {
-    for (const { app, host } of active) {
-        app.unmount();
-        host.remove();
-    }
+async function press(field: HTMLTextAreaElement, key: string): Promise<void> {
+    field.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+    await nextTick();
+}
 
-    active = [];
-});
+async function pressButton(host: HTMLElement, label: string): Promise<void> {
+    [...host.querySelectorAll('button')]
+        .find((button) => button.textContent?.trim() === label)
+        ?.click();
+    await nextTick();
+}
+
+afterEach(unmountAll);
 
 describe('editing a message inline', () => {
     it('swaps the body for a textarea seeded with it', async () => {
@@ -272,113 +197,91 @@ describe('editing a message inline', () => {
     });
 
     it('saves the edited body on Enter and leaves the editor', async () => {
-        const { host, edits } = mount();
+        const { host, actions } = mount();
         const field = await startEditing(host);
 
-        field.value = 'hello again';
-        field.dispatchEvent(new Event('input'));
-        await nextTick();
-        field.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
-        );
-        await nextTick();
+        await type(field, 'hello again');
+        await press(field, 'Enter');
 
-        expect(edits).toEqual([['m1', 'hello again']]);
+        expect(actions.edit).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ id: 'm1' }),
+            'hello again',
+        );
         expect(find(host, 'message-edit-input')).toBeNull();
     });
 
     it('saves from the Save button too', async () => {
-        const { host, edits } = mount();
+        const { host, actions } = mount();
         const field = await startEditing(host);
 
-        field.value = 'from the button';
-        field.dispatchEvent(new Event('input'));
-        await nextTick();
-        [...host.querySelectorAll('button')]
-            .find((button) => button.textContent?.trim() === 'Save')
-            ?.click();
-        await nextTick();
+        await type(field, 'from the button');
+        await pressButton(host, 'Save');
 
-        expect(edits).toEqual([['m1', 'from the button']]);
+        expect(actions.edit).toHaveBeenCalledExactlyOnceWith(
+            expect.anything(),
+            'from the button',
+        );
     });
 
     it('trims the draft before saving it', async () => {
-        const { host, edits } = mount();
+        const { host, actions } = mount();
         const field = await startEditing(host);
 
-        field.value = '   spaced   ';
-        field.dispatchEvent(new Event('input'));
-        await nextTick();
-        field.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
-        );
-        await nextTick();
+        await type(field, '   spaced   ');
+        await press(field, 'Enter');
 
-        expect(edits).toEqual([['m1', 'spaced']]);
+        expect(actions.edit).toHaveBeenCalledExactlyOnceWith(
+            expect.anything(),
+            'spaced',
+        );
     });
 
     it('treats an unchanged draft as a no-op', async () => {
-        const { host, edits } = mount();
+        const { host, actions } = mount();
         const field = await startEditing(host);
 
-        field.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
-        );
-        await nextTick();
+        await press(field, 'Enter');
 
-        expect(edits).toEqual([]);
+        expect(actions.edit).not.toHaveBeenCalled();
         expect(find(host, 'message-edit-input')).toBeNull();
     });
 
     it('treats an emptied draft as a no-op, since the server would reject it', async () => {
-        const { host, edits } = mount();
+        const { host, actions } = mount();
         const field = await startEditing(host);
 
-        field.value = '   ';
-        field.dispatchEvent(new Event('input'));
-        await nextTick();
-        field.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
-        );
-        await nextTick();
+        await type(field, '   ');
+        await press(field, 'Enter');
 
-        expect(edits).toEqual([]);
+        expect(actions.edit).not.toHaveBeenCalled();
     });
 
     it('abandons the edit on Esc', async () => {
-        const { host, edits } = mount();
+        const { host, actions } = mount();
         const field = await startEditing(host);
 
-        field.value = 'discarded';
-        field.dispatchEvent(new Event('input'));
-        await nextTick();
-        field.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
-        );
-        await nextTick();
+        await type(field, 'discarded');
+        await press(field, 'Escape');
 
-        expect(edits).toEqual([]);
+        expect(actions.edit).not.toHaveBeenCalled();
         expect(find(host, 'message-edit-input')).toBeNull();
         expect(find(host, 'message-body')?.textContent?.trim()).toBe('hello');
     });
 
     it('abandons the edit from the Cancel button', async () => {
-        const { host, edits } = mount();
+        const { host, actions } = mount();
         await startEditing(host);
 
-        [...host.querySelectorAll('button')]
-            .find((button) => button.textContent?.trim() === 'Cancel')
-            ?.click();
-        await nextTick();
+        await pressButton(host, 'Cancel');
 
-        expect(edits).toEqual([]);
+        expect(actions.edit).not.toHaveBeenCalled();
         expect(find(host, 'message-edit-input')).toBeNull();
     });
 });
 
 describe('deleting a message', () => {
-    it('asks before deleting, and emits only once confirmed', async () => {
-        const { host, deletes } = mount();
+    it('asks before deleting, and writes only once confirmed', async () => {
+        const { host, actions } = mount();
 
         expect(find(host, 'delete-dialog')).toBeNull();
 
@@ -389,12 +292,14 @@ describe('deleting a message', () => {
         expect(host.textContent).toContain(
             "Are you sure you want to delete this message? This can't be undone.",
         );
-        expect(deletes).toEqual([]);
+        expect(actions.delete).not.toHaveBeenCalled();
 
         click(host, 'delete-message-confirm');
         await nextTick();
 
-        expect(deletes).toEqual(['m1']);
+        expect(actions.delete).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ id: 'm1' }),
+        );
         expect(find(host, 'delete-dialog')).toBeNull();
     });
 });

--- a/resources/js/components/MessageList.row.test.ts
+++ b/resources/js/components/MessageList.row.test.ts
@@ -1,9 +1,15 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { App } from 'vue';
-import { createApp, defineComponent, h } from 'vue';
-import { translate } from '@/lib/i18n';
+import { defineComponent, h } from 'vue';
 import type { Message } from '@/types';
+import {
+    find,
+    inertiaPageProps,
+    message,
+    mountWithActions,
+    stub,
+    unmountAll,
+} from './MessageList.doubles';
 
 /**
  * Covers a single message row: the body and the segments it tokenizes into, the
@@ -12,46 +18,18 @@ import type { Message } from '@/types';
  * `MessageList.vue` is split, so what is pinned here is the rendered markup —
  * every selector, every guard that decides whether a piece renders at all.
  */
-const pageProps = vi.hoisted(() => ({
-    auth: { user: { timezone: 'UTC' } },
-    customEmojis: {} as Record<string, string>,
-    userGroups: [] as Array<{ id: string }>,
-}));
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaPageProps } = await import('./MessageList.doubles');
 
-vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props: pageProps }),
-}));
-
-const mobile = vi.hoisted(() => ({
-    current: null as { value: boolean } | null,
-}));
+    return { usePage: () => ({ props: inertiaPageProps }) };
+});
 
 vi.mock('@/composables/useIsMobile', async () => {
     const { ref } = await import('vue');
     const value = ref(false);
-    mobile.current = value;
 
     return { useIsMobile: () => value };
 });
-
-/** Renders a child's default slot, so a stubbed wrapper stays transparent. */
-function passthrough(name: string) {
-    return defineComponent({
-        name,
-        setup:
-            (_props, { slots }) =>
-            () =>
-                h('div', { 'data-stub': name }, slots.default?.()),
-    });
-}
-
-/** Renders an empty marker element, so a stubbed leaf is still findable. */
-function marker(name: string) {
-    return defineComponent({
-        name,
-        setup: () => () => h('div', { 'data-stub': name }),
-    });
-}
 
 vi.mock('@/components/UserHoverCard.vue', () => ({
     default: defineComponent({
@@ -63,123 +41,74 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
     }),
 }));
 
-vi.mock('@/components/ui/hover-card', () => ({
-    HoverCard: passthrough('HoverCard'),
-    HoverCardTrigger: passthrough('HoverCardTrigger'),
-    HoverCardContent: passthrough('HoverCardContent'),
-}));
+vi.mock('@/components/ui/hover-card', async () => {
+    const { passthrough } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageActions.vue', () => ({
-    default: marker('MessageActions'),
-}));
+    return {
+        HoverCard: passthrough('HoverCard'),
+        HoverCardTrigger: passthrough('HoverCardTrigger'),
+        HoverCardContent: passthrough('HoverCardContent'),
+    };
+});
 
-vi.mock('@/components/MessageActionsSheet.vue', () => ({
-    default: marker('MessageActionsSheet'),
-}));
+vi.mock('@/components/MessageActions.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageAttachments.vue', () => ({
-    default: marker('MessageAttachments'),
-}));
+    return { default: marker('MessageActions') };
+});
 
-vi.mock('@/components/MessagePoll.vue', () => ({
-    default: marker('MessagePoll'),
-}));
+vi.mock('@/components/MessageActionsSheet.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageReactions.vue', () => ({
-    default: marker('MessageReactions'),
-}));
+    return { default: marker('MessageActionsSheet') };
+});
 
-vi.mock('@/components/MessageForward.vue', () => ({
-    default: marker('MessageForward'),
-}));
+vi.mock('@/components/MessageAttachments.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
 
-vi.mock('@/components/LinkPreview.vue', () => ({
-    default: marker('LinkPreview'),
-}));
+    return { default: marker('MessageAttachments') };
+});
+
+vi.mock('@/components/MessagePoll.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessagePoll') };
+});
+
+vi.mock('@/components/MessageReactions.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageReactions') };
+});
+
+vi.mock('@/components/MessageForward.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('MessageForward') };
+});
+
+vi.mock('@/components/LinkPreview.vue', async () => {
+    const { marker } = await import('./MessageList.doubles');
+
+    return { default: marker('LinkPreview') };
+});
 
 import MessageList from './MessageList.vue';
 
-function message(overrides: Partial<Message> = {}): Message {
-    return {
-        id: 'm1',
-        clientUuid: 'uuid-1',
-        body: 'hello',
-        type: 'standard',
-        user: { id: 'peer', name: 'Peer' },
-        createdAt: '2024-03-04T10:30:00.000Z',
-        editedAt: null,
-        isDeleted: false,
-        mentions: [],
-        linkPreviews: [],
-        attachments: [],
-        reactions: [],
-        pin: null,
-        poll: null,
-        replyTo: null,
-        forwardedFrom: null,
-        threadRootId: null,
-        sentToChannel: false,
-        threadReplyCount: 0,
-        threadLastReplyAt: null,
-        threadParticipants: [],
-        threadFollowed: false,
-        threadUnread: false,
-        threadUnreadReplyCount: 0,
-        ...overrides,
-    } as Message;
-}
-
-let active: Array<{ app: App; host: HTMLElement }> = [];
-
-type Mounted = {
-    host: HTMLElement;
-    events: Array<[string, unknown]>;
-};
-
-function mount(props: Record<string, unknown> = {}): Mounted {
-    const events: Array<[string, unknown]> = [];
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-
-    const app = createApp({
-        render: () =>
-            h(MessageList, {
-                messages: [message()],
-                teamSlug: 'acme',
-                currentUserId: 'me',
-                onJump: (id: string) => events.push(['jump', id]),
-                onOpenThread: (id: string) => events.push(['openThread', id]),
-                ...props,
-            }),
+function mount(props: Record<string, unknown> = {}) {
+    return mountWithActions(MessageList, {
+        messages: [message()],
+        teamSlug: 'acme',
+        ...props,
     });
-    app.config.globalProperties.$t = translate;
-    app.mount(host);
-    active.push({ app, host });
-
-    return { host, events };
-}
-
-function find(host: HTMLElement, selector: string): HTMLElement | null {
-    return host.querySelector<HTMLElement>(`[data-test="${selector}"]`);
-}
-
-function stub(host: HTMLElement, name: string): HTMLElement | null {
-    return host.querySelector<HTMLElement>(`[data-stub="${name}"]`);
 }
 
 beforeEach(() => {
-    pageProps.customEmojis = {};
-    pageProps.userGroups = [];
+    inertiaPageProps.customEmojis = {};
+    inertiaPageProps.userGroups = [];
 });
 
-afterEach(() => {
-    for (const { app, host } of active) {
-        app.unmount();
-        host.remove();
-    }
-
-    active = [];
-});
+afterEach(unmountAll);
 
 describe('the message body', () => {
     it('renders the body text with an anchor id for jump targets', () => {
@@ -190,9 +119,7 @@ describe('the message body', () => {
     });
 
     it('leaves the body out when the message carries only an attachment', () => {
-        const { host } = mount({
-            messages: [message({ body: '' })],
-        });
+        const { host } = mount({ messages: [message({ body: '' })] });
 
         expect(find(host, 'message-body')).toBeNull();
     });
@@ -213,7 +140,7 @@ describe('the message body', () => {
 
     it('renders a resolved group mention as an inert pill of its own hue', () => {
         const id = '22222222-2222-4222-8222-222222222222';
-        pageProps.userGroups = [{ id }];
+        inertiaPageProps.userGroups = [{ id }];
         const { host } = mount({
             messages: [message({ body: `@[design](group:${id})` })],
         });
@@ -225,7 +152,9 @@ describe('the message body', () => {
     });
 
     it('renders a custom emoji shortcode as its image', () => {
-        pageProps.customEmojis = { shipit: 'https://desk.test/shipit.png' };
+        inertiaPageProps.customEmojis = {
+            shipit: 'https://desk.test/shipit.png',
+        };
         const { host } = mount({
             messages: [message({ body: 'ship it :shipit:' })],
         });
@@ -379,7 +308,7 @@ describe('the reply quote', () => {
     });
 
     it('jumps to the replied message when pressed', () => {
-        const { host, events } = mount({ messages: [replied] });
+        const { host, actions } = mount({ messages: [replied] });
 
         const quote = find(host, 'message-quote');
 
@@ -388,7 +317,7 @@ describe('the reply quote', () => {
         );
         quote?.click();
 
-        expect(events).toEqual([['jump', 'parent']]);
+        expect(actions.jump).toHaveBeenCalledExactlyOnceWith('parent');
     });
 
     it('bleeds the quote to the full timeline width below the breakpoint', () => {

--- a/resources/js/components/MessageList.timeline.test.ts
+++ b/resources/js/components/MessageList.timeline.test.ts
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { App } from 'vue';
-import { createApp, defineComponent, h } from 'vue';
-import { translate } from '@/lib/i18n';
-import type { Message } from '@/types';
+import { defineComponent, h } from 'vue';
+import {
+    all,
+    inertiaPageProps,
+    message,
+    mountWithActions,
+    unmountAll,
+} from './MessageList.doubles';
 
 /**
  * Covers the timeline's structural chrome: the day and unread dividers, system
@@ -12,19 +16,15 @@ import type { Message } from '@/types';
  * moves wholesale, so what is pinned here is the markup and the copy — every
  * `data-test` selector, every guard on whether a row renders at all.
  */
-const pageProps = vi.hoisted(() => ({
-    auth: { user: { timezone: 'UTC' } },
-    customEmojis: {} as Record<string, string>,
-    userGroups: [] as unknown[],
-}));
-
-vi.mock('@inertiajs/vue3', () => ({
-    usePage: () => ({ props: pageProps }),
-}));
-
 const mobile = vi.hoisted(() => ({
     current: null as { value: boolean } | null,
 }));
+
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaPageProps } = await import('./MessageList.doubles');
+
+    return { usePage: () => ({ props: inertiaPageProps }) };
+});
 
 vi.mock('@/composables/useIsMobile', async () => {
     const { ref } = await import('vue');
@@ -33,11 +33,6 @@ vi.mock('@/composables/useIsMobile', async () => {
 
     return { useIsMobile: () => value };
 });
-
-/** Renders nothing, standing in for a leaf whose own tests cover it. */
-function inert(name: string) {
-    return defineComponent({ name, setup: () => () => null });
-}
 
 vi.mock('@/components/UserHoverCard.vue', () => ({
     default: defineComponent({
@@ -57,90 +52,41 @@ vi.mock('@/components/UserHoverCard.vue', () => ({
     }),
 }));
 
-vi.mock('@/components/MessageActions.vue', () => ({
-    default: inert('MessageActionsStub'),
-}));
+vi.mock('@/components/MessageActions.vue', async () => {
+    const { inert } = await import('./MessageList.doubles');
 
-vi.mock('@/components/MessageActionsSheet.vue', () => ({
-    default: inert('MessageActionsSheetStub'),
-}));
+    return { default: inert('MessageActionsStub') };
+});
+
+vi.mock('@/components/MessageActionsSheet.vue', async () => {
+    const { inert } = await import('./MessageList.doubles');
+
+    return { default: inert('MessageActionsSheetStub') };
+});
 
 import MessageList from './MessageList.vue';
 
-function message(overrides: Partial<Message> = {}): Message {
-    return {
-        id: 'm1',
-        clientUuid: 'uuid-1',
-        body: 'hello',
-        type: 'standard',
-        user: { id: 'peer', name: 'Peer' },
-        createdAt: '2024-03-04T10:30:00.000Z',
-        editedAt: null,
-        isDeleted: false,
-        mentions: [],
-        linkPreviews: [],
-        attachments: [],
-        reactions: [],
-        pin: null,
-        poll: null,
-        replyTo: null,
-        forwardedFrom: null,
-        threadRootId: null,
-        sentToChannel: false,
-        threadReplyCount: 0,
-        threadLastReplyAt: null,
-        threadParticipants: [],
-        threadFollowed: false,
-        threadUnread: false,
-        threadUnreadReplyCount: 0,
-        ...overrides,
-    } as Message;
-}
-
-let active: Array<{ app: App; host: HTMLElement }> = [];
-
-function mount(props: Record<string, unknown> = {}): HTMLElement {
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-
-    const app = createApp({
-        render: () =>
-            h(MessageList, {
-                messages: [message()],
-                teamSlug: 'acme',
-                currentUserId: 'me',
-                ...props,
-            }),
-    });
-    app.config.globalProperties.$t = translate;
-    app.mount(host);
-    active.push({ app, host });
-
-    return host;
+function mount(props: Record<string, unknown> = {}, inThread = false) {
+    return mountWithActions(
+        MessageList,
+        { messages: [message()], teamSlug: 'acme', ...props },
+        { subtree: { inThread } },
+    ).host;
 }
 
 function texts(host: HTMLElement, selector: string): string[] {
-    return [...host.querySelectorAll(`[data-test="${selector}"]`)].map(
-        (node) => node.textContent?.trim() ?? '',
-    );
+    return all(host, selector).map((node) => node.textContent?.trim() ?? '');
 }
 
 beforeEach(() => {
-    pageProps.auth.user.timezone = 'UTC';
+    inertiaPageProps.auth.user.timezone = 'UTC';
 
     if (mobile.current) {
         mobile.current.value = false;
     }
 });
 
-afterEach(() => {
-    for (const { app, host } of active) {
-        app.unmount();
-        host.remove();
-    }
-
-    active = [];
-});
+afterEach(unmountAll);
 
 describe('the timeline’s dividers', () => {
     it('opens the list with a day divider carrying the crossing message’s date', () => {
@@ -257,8 +203,11 @@ describe('an author group', () => {
     });
 
     it('renders each timestamp in the viewer’s stored zone', () => {
-        pageProps.auth.user.timezone = 'Australia/Sydney';
-        const host = mount();
+        const host = mountWithActions(
+            MessageList,
+            { messages: [message()], teamSlug: 'acme' },
+            { scope: { viewerTimeZone: 'Australia/Sydney' } },
+        ).host;
 
         expect(texts(host, 'message-group-time')).toEqual(['9:30 PM']);
     });
@@ -267,8 +216,8 @@ describe('an author group', () => {
         const host = mount();
 
         expect(
-            [...host.querySelectorAll('[data-test="user-hover-card"]')].map(
-                (node) => node.getAttribute('data-user-id'),
+            all(host, 'user-hover-card').map((node) =>
+                node.getAttribute('data-user-id'),
             ),
         ).toEqual(['peer', 'peer']);
         expect(texts(host, 'message-author-name')).toEqual(['Peer']);
@@ -388,7 +337,7 @@ describe('an author group', () => {
     });
 
     it('marks the thread root with a brass accent inside a thread panel', () => {
-        const host = mount({ inThread: true });
+        const host = mount({}, true);
 
         expect(
             host
@@ -398,10 +347,10 @@ describe('an author group', () => {
     });
 
     it('keeps the ordinary border on a reply inside a thread panel', () => {
-        const host = mount({
-            messages: [message({ threadRootId: 'root' })],
-            inThread: true,
-        });
+        const host = mount(
+            { messages: [message({ threadRootId: 'root' })] },
+            true,
+        );
 
         expect(
             host
@@ -413,7 +362,7 @@ describe('an author group', () => {
 
 describe('the thread reply rule', () => {
     it('separates the root from its replies when a count is given', () => {
-        const host = mount({ inThread: true, replyDividerCount: 3 });
+        const host = mount({ replyDividerCount: 3 }, true);
 
         const rule = host.querySelector('[data-test="thread-replies-divider"]');
 
@@ -423,7 +372,7 @@ describe('the thread reply rule', () => {
     });
 
     it('reads in the singular for a lone reply', () => {
-        const host = mount({ inThread: true, replyDividerCount: 1 });
+        const host = mount({ replyDividerCount: 1 }, true);
 
         expect(
             host
@@ -441,7 +390,7 @@ describe('the thread reply rule', () => {
     });
 
     it('stays out of a thread with no replies yet', () => {
-        const host = mount({ inThread: true, replyDividerCount: 0 });
+        const host = mount({ replyDividerCount: 0 }, true);
 
         expect(
             host.querySelector('[data-test="thread-replies-divider"]'),

--- a/resources/js/components/MessageList.vue
+++ b/resources/js/components/MessageList.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { usePage } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
 import MessageActionsSheet from '@/components/MessageActionsSheet.vue';
 import DayDivider from '@/components/timeline/DayDivider.vue';
@@ -13,6 +12,11 @@ import SystemNotice from '@/components/timeline/SystemNotice.vue';
 import ThreadRepliesDivider from '@/components/timeline/ThreadRepliesDivider.vue';
 import UnreadDivider from '@/components/timeline/UnreadDivider.vue';
 import { useIsMobile } from '@/composables/useIsMobile';
+import {
+    useMessageActionGuards,
+    useMessageActionsContext,
+    useMessageSubtree,
+} from '@/composables/useMessageActionsContext';
 import { useMessageActionSheet } from '@/composables/useMessageActionSheet';
 import { useTimelineWindow } from '@/composables/useTimelineWindow';
 import { displayAuthorName } from '@/lib/authorIdentity';
@@ -37,23 +41,11 @@ const props = defineProps<{
      * renders a "Queued — will send on reconnect" marker until it flushes.
      */
     queuedUuids?: string[];
-    currentUserId: string;
     /**
      * Whether the timeline belongs to a direct message, so a "member left" notice
      * reads "left the conversation" rather than "left the channel".
      */
     isDirect?: boolean;
-    canModerate?: boolean;
-    /**
-     * Whether the viewer may add/remove reactions (member of a non-archived
-     * channel); existing reaction pills still render read-only when false.
-     */
-    canReact?: boolean;
-    /**
-     * Whether the viewer may pin/unpin messages (member of a non-archived
-     * channel); the "Pinned by" indicator still renders read-only when false.
-     */
-    canPin?: boolean;
     /**
      * How each author reads on the team presence roster. Absent on the surfaces
      * that render a timeline without one, where every author reads as offline.
@@ -70,11 +62,6 @@ const props = defineProps<{
      * channel open — or null when there's no unread boundary to mark.
      */
     unreadDividerId?: string | null;
-    /**
-     * Rendered inside a thread panel: hides the per-message thread affordances
-     * (you're already in the thread), so the panel only shows the conversation.
-     */
-    inThread?: boolean;
     /**
      * When set (> 0) inside a thread, a ":count replies" rule renders under the
      * root message, separating it from the replies — the mobile thread push's
@@ -114,20 +101,6 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-    edit: [message: Message, body: string];
-    delete: [message: Message];
-    reply: [message: Message];
-    forward: [message: Message];
-    react: [message: Message, emoji: string];
-    vote: [message: Message, optionId: string];
-    closePoll: [message: Message];
-    pin: [message: Message];
-    unpin: [message: Message];
-    remind: [message: Message, remindAt: string];
-    remindCustom: [message: Message];
-    openThread: [messageId: string];
-    jump: [messageId: string];
-    mention: [member: { id: string; name: string }];
     /** The reader has scrolled near the top of the loaded history: fetch older. */
     loadOlder: [];
     /**
@@ -137,17 +110,12 @@ const emit = defineEmits<{
     rangeChange: [range: { startIndex: number; endIndex: number }];
 }>();
 
-const page = usePage();
-
-/** The viewer's stored zone, feeding the reminder popover's wall-clock presets. */
-const viewerTimezone = computed<string | null>(
-    () => page.props.auth.user.timezone ?? null,
-);
+const scope = useMessageActionsContext();
+const subtree = useMessageSubtree();
+const { contextFor } = useMessageActionGuards();
 
 /** Render timestamps in the viewer's stored zone, falling back to the browser's. */
-const viewerTimeZone = computed(
-    () => page.props.auth.user.timezone ?? undefined,
-);
+const viewerTimeZone = computed(() => scope.viewerTimeZone ?? undefined);
 
 function formatTime(iso: string): string {
     return formatTimeOfDay(iso, viewerTimeZone.value);
@@ -159,7 +127,7 @@ function formatTime(iso: string): string {
  * setting it apart from the replies below.
  */
 function isThreadRoot(item: TimelineGroup): boolean {
-    return props.inThread === true && item.messages[0]?.threadRootId === null;
+    return subtree.inThread && item.messages[0]?.threadRootId === null;
 }
 
 /**
@@ -167,7 +135,7 @@ function isThreadRoot(item: TimelineGroup): boolean {
  * Empty inside a thread panel and on an empty timeline.
  */
 const seenByReaders = computed<MessageAuthor[]>(() => {
-    if (props.inThread || props.messages.length === 0) {
+    if (subtree.inThread || props.messages.length === 0) {
         return [];
     }
 
@@ -176,7 +144,7 @@ const seenByReaders = computed<MessageAuthor[]>(() => {
     return readersForMessage(
         props.readers ?? [],
         lastMessageId,
-        props.currentUserId,
+        scope.currentUserId,
     );
 });
 
@@ -254,7 +222,7 @@ function saveEdit(message: Message, draft: string): void {
 
     // An empty or unchanged draft is a no-op; the server would reject the former.
     if (body !== '' && body !== message.body) {
-        emit('edit', message, body);
+        scope.actions.edit(message, body);
     }
 
     cancelEdit();
@@ -272,14 +240,7 @@ const {
     messages: () => props.messages,
     canOpen: (message) =>
         editingId.value !== message.id &&
-        hasAnyMessageAction(message, {
-            currentUserId: props.currentUserId,
-            canReact: Boolean(props.canReact),
-            canPin: Boolean(props.canPin),
-            canModerate: Boolean(props.canModerate),
-            inThread: Boolean(props.inThread),
-            pending: isPending(message),
-        }),
+        hasAnyMessageAction(message, contextFor(isPending(message))),
 });
 
 /** The message queued for deletion; a non-null value drives the confirm dialog. */
@@ -291,7 +252,7 @@ function requestDelete(message: Message): void {
 
 function confirmDelete(): void {
     if (pendingDelete.value) {
-        emit('delete', pendingDelete.value);
+        scope.actions.delete(pendingDelete.value);
     }
 
     pendingDelete.value = null;
@@ -355,7 +316,7 @@ function confirmDelete(): void {
                         :is-dnd="dndOf(item.author.id)"
                         :time="formatTime(item.leadCreatedAt)"
                         :is-mobile="isMobile"
-                        @mention="(member) => emit('mention', member)"
+                        @mention="(member) => subtree.mention(member)"
                     />
                     <div
                         data-test="message-column"
@@ -374,7 +335,7 @@ function confirmDelete(): void {
                             :presence="presenceOf(item.author.id)"
                             :is-dnd="dndOf(item.author.id)"
                             :time="formatTime(item.leadCreatedAt)"
-                            @mention="(member) => emit('mention', member)"
+                            @mention="(member) => subtree.mention(member)"
                         />
                         <div role="list">
                             <MessageRow
@@ -388,11 +349,6 @@ function confirmDelete(): void {
                                     )
                                 "
                                 :team-slug="props.teamSlug"
-                                :current-user-id="props.currentUserId"
-                                :can-react="props.canReact"
-                                :can-pin="props.canPin"
-                                :can-moderate="props.canModerate"
-                                :in-thread="props.inThread"
                                 :is-lead="row === 0"
                                 :pending="isPending(message)"
                                 :queued="isQueued(message)"
@@ -407,33 +363,11 @@ function confirmDelete(): void {
                                 :composer-editing="
                                     message.id === props.editingMessageId
                                 "
-                                :viewer-time-zone="viewerTimeZone"
-                                :viewer-timezone="viewerTimezone"
                                 :long-press="longPress"
                                 @start-edit="startEdit(message)"
                                 @save-edit="(body) => saveEdit(message, body)"
                                 @cancel-edit="cancelEdit"
                                 @request-delete="requestDelete(message)"
-                                @reply="emit('reply', message)"
-                                @forward="emit('forward', message)"
-                                @pin="emit('pin', message)"
-                                @unpin="emit('unpin', message)"
-                                @close-poll="emit('closePoll', message)"
-                                @remind-custom="emit('remindCustom', message)"
-                                @open-thread="(id) => emit('openThread', id)"
-                                @react="
-                                    (emoji) => emit('react', message, emoji)
-                                "
-                                @vote="
-                                    (optionId) =>
-                                        emit('vote', message, optionId)
-                                "
-                                @remind="
-                                    (remindAt) =>
-                                        emit('remind', message, remindAt)
-                                "
-                                @jump="(id) => emit('jump', id)"
-                                @mention="(member) => emit('mention', member)"
                             />
                         </div>
                     </div>
@@ -461,32 +395,13 @@ function confirmDelete(): void {
         <MessageActionsSheet
             v-model:open="actionSheetOpen"
             :message="actionSheetMessage"
-            :current-user-id="props.currentUserId"
-            :can-react="props.canReact"
-            :can-pin="props.canPin"
-            :can-moderate="props.canModerate"
-            :in-thread="props.inThread"
             :pending="
                 actionSheetMessage ? isPending(actionSheetMessage) : false
             "
-            :viewer-time-zone="viewerTimeZone"
-            @react="
-                (emoji) =>
-                    actionSheetMessage &&
-                    emit('react', actionSheetMessage, emoji)
+            @start-edit="actionSheetMessage && startEdit(actionSheetMessage)"
+            @request-delete="
+                actionSheetMessage && requestDelete(actionSheetMessage)
             "
-            @open-thread="
-                actionSheetMessage && emit('openThread', actionSheetMessage.id)
-            "
-            @reply="actionSheetMessage && emit('reply', actionSheetMessage)"
-            @forward="actionSheetMessage && emit('forward', actionSheetMessage)"
-            @pin="actionSheetMessage && emit('pin', actionSheetMessage)"
-            @unpin="actionSheetMessage && emit('unpin', actionSheetMessage)"
-            @remind-custom="
-                actionSheetMessage && emit('remindCustom', actionSheetMessage)
-            "
-            @edit="actionSheetMessage && startEdit(actionSheetMessage)"
-            @delete="actionSheetMessage && requestDelete(actionSheetMessage)"
         />
     </div>
 </template>

--- a/resources/js/components/PinsPanel.test.ts
+++ b/resources/js/components/PinsPanel.test.ts
@@ -59,7 +59,7 @@ function mount(componentProps: Record<string, unknown> = {}): {
                 pins: [message()],
                 pinCount: 1,
                 canPin: true,
-                viewerTimezone: 'UTC',
+                viewerTimeZone: 'UTC',
                 onClose: capture('close'),
                 onJump: capture('jump'),
                 onUnpin: capture('unpin'),

--- a/resources/js/components/PinsPanel.vue
+++ b/resources/js/components/PinsPanel.vue
@@ -20,7 +20,7 @@ const props = defineProps<{
      */
     canPin: boolean;
     /** The viewer's stored zone, so pinned-at and authored-at read in their clock. */
-    viewerTimezone: string | null;
+    viewerTimeZone: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -162,7 +162,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                                 >{{
                                     formatDateTime(
                                         message.pin.pinnedAt,
-                                        props.viewerTimezone ?? undefined,
+                                        props.viewerTimeZone ?? undefined,
                                     )
                                 }}</span
                             >
@@ -207,7 +207,7 @@ onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown));
                                         >{{
                                             formatDateTime(
                                                 message.createdAt,
-                                                props.viewerTimezone ??
+                                                props.viewerTimeZone ??
                                                     undefined,
                                             )
                                         }}</span

--- a/resources/js/components/ThreadPanel.vue
+++ b/resources/js/components/ThreadPanel.vue
@@ -14,6 +14,10 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useIsMobile } from '@/composables/useIsMobile';
+import {
+    provideMessageSubtree,
+    useMessageActionsContext,
+} from '@/composables/useMessageActionsContext';
 import { useRailInset } from '@/composables/useRailInset';
 import { useScrollPin } from '@/composables/useScrollPin';
 import type { RenderedPresence } from '@/lib/presence';
@@ -37,10 +41,6 @@ const props = defineProps<{
     // Whether the channel has a bot member, forwarded to the reply composer's
     // mention menu footnote.
     hasBots?: boolean;
-    currentUserId: string;
-    canModerate?: boolean;
-    canReact?: boolean;
-    canPin?: boolean;
     /** How each author reads on the team presence roster, passed straight down. */
     presenceFor?: (userId: string) => RenderedPresence;
     /** Whether each author is in do-not-disturb, threaded through to the list. */
@@ -52,19 +52,10 @@ const props = defineProps<{
 const emit = defineEmits<{
     close: [];
     send: [body: string, mentions: Mention[], sendToChannel?: boolean];
-    edit: [message: Message, body: string];
-    delete: [message: Message];
-    forward: [message: Message];
-    react: [message: Message, emoji: string];
-    vote: [message: Message, optionId: string];
-    closePoll: [message: Message];
-    pin: [message: Message];
-    unpin: [message: Message];
-    remind: [message: Message, remindAt: string];
-    remindCustom: [message: Message];
     typing: [];
-    jump: [messageId: string];
 }>();
+
+const scope = useMessageActionsContext();
 
 /** The root is the thread's only top-level message; everything else is a reply. */
 const root = computed(() =>
@@ -189,6 +180,13 @@ const threadComposer = ref<InstanceType<typeof MessageComposer> | null>(null);
 function mentionInThread(member: { id: string; name: string }): void {
     threadComposer.value?.insertMention(member);
 }
+
+/**
+ * The panel's own scope: the reader is already in the thread, so the rows drop
+ * their reply/thread affordances, and a mention lands in the reply composer
+ * beside them rather than in the channel's.
+ */
+provideMessageSubtree({ inThread: true, mention: mentionInThread });
 
 /**
  * The reply the thread composer is editing in place (via the ↑ shortcut), or
@@ -394,32 +392,11 @@ watch(
                     :messages="props.messages"
                     :team-slug="props.teamSlug"
                     :pending-uuids="props.pendingUuids"
-                    :current-user-id="props.currentUserId"
-                    :can-moderate="props.canModerate"
-                    :can-react="props.canReact"
-                    :can-pin="props.canPin"
                     :presence-for="props.presenceFor"
                     :is-dnd-for="props.isDndFor"
                     :editing-message-id="editingMessageId"
                     :reply-divider-count="isMobile ? replyCount : 0"
-                    in-thread
                     @load-older="loadOlderReplies"
-                    @edit="(message, body) => emit('edit', message, body)"
-                    @delete="(message) => emit('delete', message)"
-                    @forward="(message) => emit('forward', message)"
-                    @react="(message, emoji) => emit('react', message, emoji)"
-                    @vote="
-                        (message, optionId) => emit('vote', message, optionId)
-                    "
-                    @close-poll="(message) => emit('closePoll', message)"
-                    @pin="(message) => emit('pin', message)"
-                    @unpin="(message) => emit('unpin', message)"
-                    @remind="
-                        (message, remindAt) => emit('remind', message, remindAt)
-                    "
-                    @remind-custom="(message) => emit('remindCustom', message)"
-                    @jump="(id) => emit('jump', id)"
-                    @mention="mentionInThread"
                 />
             </InfiniteScroll>
         </ScrollableMessageList>
@@ -433,7 +410,7 @@ watch(
             :members="props.members"
             :placeholder="isMobile ? $t('Reply in thread') : $t('Reply…')"
             :messages="props.messages"
-            :current-user-id="props.currentUserId"
+            :current-user-id="scope.currentUserId"
             :pending-uuids="props.pendingUuids"
             allow-send-to-channel
             autofocus
@@ -442,7 +419,7 @@ watch(
                     emit('send', body, mentions, sendToChannel)
             "
             @typing="emit('typing')"
-            @edit="(message, body) => emit('edit', message, body)"
+            @edit="(message, body) => scope.actions.edit(message, body)"
             @editing-change="editingMessageId = $event"
         />
     </aside>

--- a/resources/js/components/channel/ChannelHeader.vue
+++ b/resources/js/components/channel/ChannelHeader.vue
@@ -44,7 +44,7 @@ const props = defineProps<{
     connectionPill: ConnectionPill;
     /** Whether conversation has scrolled under the masthead, taking a shadow. */
     scrolled: boolean;
-    viewerTimezone: string | null;
+    viewerTimeZone: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -137,7 +137,7 @@ defineExpose({
             :pins="props.pins"
             :pin-count="pinCount"
             :can-pin="props.canPin"
-            :viewer-timezone="props.viewerTimezone"
+            :viewer-time-zone="props.viewerTimeZone"
             @close="pinsPanelOpen = false"
             @jump="jumpToPin"
             @unpin="(message) => emit('unpin', message)"

--- a/resources/js/components/channel/ChannelPane.vue
+++ b/resources/js/components/channel/ChannelPane.vue
@@ -9,6 +9,10 @@ import ChannelEmptyState from '@/components/ChannelEmptyState.vue';
 import MessageList from '@/components/MessageList.vue';
 import ScrollableMessageList from '@/components/ScrollableMessageList.vue';
 import { useChannelHistory } from '@/composables/useChannelHistory';
+import {
+    provideMessageSubtree,
+    useMessageActionsContext,
+} from '@/composables/useMessageActionsContext';
 import { useMessageHighlight } from '@/composables/useMessageHighlight';
 import { usePaneFileDrop } from '@/composables/usePaneFileDrop';
 import { useStickyDayLabel } from '@/composables/useStickyDayLabel';
@@ -38,13 +42,10 @@ const props = defineProps<{
      * on a channel switch.
      */
     serverMessages: Message[];
-    currentUserId: string;
     /** Whether this is the viewer's own self-DM, so the empty state reads "You". */
     isSelfDm: boolean;
     pendingUuids: string[];
     queuedUuids: string[];
-    canModerate: boolean;
-    canReact: boolean;
     /** Whether a file drop would be staged (a member of a live channel). */
     canDropFiles: boolean;
     presenceFor: (userId: string) => RenderedPresence;
@@ -69,21 +70,23 @@ const emit = defineEmits<{
     files: [files: File[]];
     /** The empty state's "Post your first message" card was used. */
     focusComposer: [];
-    edit: [message: Message, body: string];
-    delete: [message: Message];
-    reply: [message: Message];
-    forward: [message: Message];
-    react: [message: Message, emoji: string];
-    vote: [message: Message, optionId: string];
-    closePoll: [message: Message];
-    pin: [message: Message];
-    unpin: [message: Message];
-    remind: [message: Message, remindAt: string];
-    remindCustom: [message: Message];
-    openThread: [messageId: string];
-    jump: [messageId: string];
+    /**
+     * A hover card in the main timeline offered a mention; the page drops it
+     * into the channel composer, which it owns through the pane's bottom slot.
+     */
     mention: [member: { id: string; name: string }];
 }>();
+
+/**
+ * The main timeline's own scope: not a thread, and a mention lands in the
+ * channel composer. Every row below reads this instead of being told.
+ */
+provideMessageSubtree({
+    inThread: false,
+    mention: (member) => emit('mention', member),
+});
+
+const scope = useMessageActionsContext();
 
 /**
  * The scroll element the virtualizer and the unread divider bind to. It reaches
@@ -161,7 +164,7 @@ const { unreadDividerId } = useUnreadDivider({
     scrollContainer: scrollElement,
     messages: () => props.serverMessages,
     lastReadMessageId: () => props.lastReadMessageId,
-    currentUserId: () => props.currentUserId,
+    currentUserId: () => scope.currentUserId,
 });
 
 /**
@@ -271,11 +274,7 @@ defineExpose({
                         :team-slug="props.team.slug"
                         :pending-uuids="props.pendingUuids"
                         :queued-uuids="props.queuedUuids"
-                        :current-user-id="props.currentUserId"
                         :is-direct="props.channel.isDirect"
-                        :can-moderate="props.canModerate"
-                        :can-react="props.canReact"
-                        :can-pin="props.canReact"
                         :presence-for="props.presenceFor"
                         :is-dnd-for="props.isDndFor"
                         :readers="props.readers"
@@ -283,27 +282,6 @@ defineExpose({
                         :unread-divider-id="unreadDividerId"
                         :active-thread-root-id="props.activeThreadRootId"
                         :editing-message-id="props.editingMessageId"
-                        @edit="(message, body) => emit('edit', message, body)"
-                        @delete="(message) => emit('delete', message)"
-                        @reply="(message) => emit('reply', message)"
-                        @forward="(message) => emit('forward', message)"
-                        @react="
-                            (message, emoji) => emit('react', message, emoji)
-                        "
-                        @vote="
-                            (message, optionId) =>
-                                emit('vote', message, optionId)
-                        "
-                        @close-poll="(message) => emit('closePoll', message)"
-                        @pin="(message) => emit('pin', message)"
-                        @unpin="(message) => emit('unpin', message)"
-                        @remind="(message, at) => emit('remind', message, at)"
-                        @remind-custom="
-                            (message) => emit('remindCustom', message)
-                        "
-                        @open-thread="(id) => emit('openThread', id)"
-                        @jump="(id) => emit('jump', id)"
-                        @mention="(member) => emit('mention', member)"
                         @load-older="loadOlderMessages"
                         @range-change="timelineRange = $event"
                     />

--- a/resources/js/components/timeline/MessageRow.test.ts
+++ b/resources/js/components/timeline/MessageRow.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import type { UseLongPress } from '@/composables/useLongPress';
+import type { Message } from '@/types';
+import {
+    click,
+    find,
+    inertiaPageProps,
+    message,
+    mountWithActions,
+    unmountAll,
+} from '../MessageList.doubles';
+
+/**
+ * Mounts one row with its real hover toolbar and nothing else — no timeline, no
+ * channel page — against a stub message-actions facade. That mount is only
+ * possible because the eleven actions are provided rather than drilled
+ * (ADR-0009), and what it pins is that each affordance reaches the facade
+ * carrying its own message, with the two timeline-owned affordances (the inline
+ * editor, the delete confirmation) still leaving as events.
+ */
+vi.mock('@inertiajs/vue3', async () => {
+    const { inertiaPageProps } = await import('../MessageList.doubles');
+
+    return { usePage: () => ({ props: inertiaPageProps }) };
+});
+
+vi.mock('@/components/EmojiPickerPopover.vue', async () => {
+    const { popover } = await import('../MessageList.doubles');
+
+    return { default: popover('EmojiPickerPopover') };
+});
+
+vi.mock('@/components/MessageReminderPopover.vue', () => ({
+    default: {
+        name: 'MessageReminderPopoverStub',
+        emits: ['set', 'custom'],
+        template: `
+            <div>
+                <slot :open="false" />
+                <button data-test="stub-remind-preset" @click="$emit('set', '2024-03-06T09:00:00.000Z')"></button>
+                <button data-test="stub-remind-custom" @click="$emit('custom')"></button>
+            </div>
+        `,
+    },
+}));
+
+vi.mock('@/components/ui/tooltip', async () => {
+    const { passthrough } = await import('../MessageList.doubles');
+
+    return {
+        Tooltip: passthrough('Tooltip'),
+        TooltipContent: passthrough('TooltipContent'),
+        TooltipProvider: passthrough('TooltipProvider'),
+        TooltipTrigger: passthrough('TooltipTrigger'),
+    };
+});
+
+vi.mock('@/components/MessageAttachments.vue', async () => {
+    const { marker } = await import('../MessageList.doubles');
+
+    return { default: marker('MessageAttachments') };
+});
+
+vi.mock('@/components/MessageForward.vue', async () => {
+    const { marker } = await import('../MessageList.doubles');
+
+    return { default: marker('MessageForward') };
+});
+
+vi.mock('@/components/UserHoverCard.vue', async () => {
+    const { passthrough } = await import('../MessageList.doubles');
+
+    return { default: passthrough('UserHoverCard') };
+});
+
+import MessageRow from './MessageRow.vue';
+
+/** A gesture that records nothing: the touch sheet is the timeline's concern. */
+const longPress: UseLongPress<Message> = {
+    start: vi.fn(),
+    move: vi.fn(),
+    end: vi.fn(),
+    cancel: vi.fn(),
+    onContextMenu: vi.fn(),
+    pressing: ref(null),
+};
+
+function mount(
+    props: Record<string, unknown> = {},
+    overrides: Parameters<typeof mountWithActions>[2] = {},
+) {
+    return mountWithActions(
+        MessageRow,
+        {
+            message: message(),
+            authorName: 'Peer',
+            teamSlug: 'acme',
+            isLead: true,
+            pending: false,
+            queued: false,
+            held: false,
+            editing: false,
+            highlighted: false,
+            activeThreadRoot: false,
+            composerEditing: false,
+            longPress,
+            onStartEdit: () => {},
+            onRequestDelete: () => {},
+            ...props,
+        },
+        overrides,
+    );
+}
+
+beforeEach(() => {
+    inertiaPageProps.frequentEmojis = ['👍'];
+    inertiaPageProps.customEmojis = {};
+    inertiaPageProps.userGroups = [];
+});
+
+afterEach(unmountAll);
+
+describe('a message row on its own', () => {
+    it('reaches the provided facade for every toolbar action, carrying its message', () => {
+        const target = message({ threadReplyCount: 0 });
+        const { host, actions } = mount({ message: target });
+
+        click(host, 'message-thread');
+        click(host, 'message-reply');
+        click(host, 'message-forward');
+        click(host, 'message-pin');
+        click(host, 'stub-remind-preset');
+        click(host, 'stub-remind-custom');
+
+        expect(actions.openThread).toHaveBeenCalledExactlyOnceWith('m1');
+        expect(actions.reply).toHaveBeenCalledExactlyOnceWith(target);
+        expect(actions.forward).toHaveBeenCalledExactlyOnceWith(target);
+        expect(actions.pin).toHaveBeenCalledExactlyOnceWith(target);
+        expect(actions.remind).toHaveBeenCalledExactlyOnceWith(
+            target,
+            '2024-03-06T09:00:00.000Z',
+        );
+        expect(actions.remindCustom).toHaveBeenCalledExactlyOnceWith(target);
+    });
+
+    it('unpins a pinned message through the same toggle', () => {
+        const target = message({
+            pin: {
+                pinnedBy: { id: 'peer', name: 'Peer' },
+                pinnedAt: '2024-03-04T10:31:00.000Z',
+            },
+        });
+        const { host, actions } = mount({ message: target });
+
+        click(host, 'message-pin');
+
+        expect(actions.unpin).toHaveBeenCalledExactlyOnceWith(target);
+        expect(actions.pin).not.toHaveBeenCalled();
+    });
+
+    it('leaves the editor and the delete confirmation to the timeline', () => {
+        const { host, actions, events } = mount({
+            message: message({ user: { id: 'me', name: 'Me' } }),
+        });
+
+        click(host, 'message-edit');
+        click(host, 'message-delete');
+
+        expect(events.map(([name]) => name)).toEqual([
+            'startEdit',
+            'requestDelete',
+        ]);
+        expect(actions.edit).not.toHaveBeenCalled();
+        expect(actions.delete).not.toHaveBeenCalled();
+    });
+
+    it('reads the viewer capabilities off the facade rather than off a prop', () => {
+        const { host } = mount({}, { scope: { canReact: false } });
+
+        expect(find(host, 'message-react')).toBeNull();
+        expect(find(host, 'quick-react')).toBeNull();
+        expect(find(host, 'message-forward')).not.toBeNull();
+    });
+
+    it('lets a moderator delete a peer message it does not own', () => {
+        const { host } = mount({}, { scope: { canModerate: true } });
+
+        expect(find(host, 'message-delete')).not.toBeNull();
+        expect(find(host, 'message-edit')).toBeNull();
+    });
+
+    it('drops the thread and reply affordances inside a thread panel', () => {
+        const { host } = mount({}, { subtree: { inThread: true } });
+
+        expect(find(host, 'message-thread')).toBeNull();
+        expect(find(host, 'message-reply')).toBeNull();
+    });
+
+    it('renders its timestamps in the zone the facade carries', () => {
+        const { host } = mount(
+            {},
+            { scope: { viewerTimeZone: 'Australia/Sydney' } },
+        );
+
+        expect(
+            host.querySelector('[role="listitem"]')?.getAttribute('aria-label'),
+        ).toBe('Peer, 9:30 PM');
+    });
+
+    it('offers no toolbar at all while the send is still in flight', () => {
+        const { host } = mount({ pending: true });
+
+        expect(find(host, 'message-forward')).toBeNull();
+        expect(find(host, 'message-react')).toBeNull();
+    });
+});

--- a/resources/js/components/timeline/MessageRow.vue
+++ b/resources/js/components/timeline/MessageRow.vue
@@ -11,9 +11,13 @@ import MessageEditForm from '@/components/timeline/MessageEditForm.vue';
 import MessageReplyQuote from '@/components/timeline/MessageReplyQuote.vue';
 import ThreadSummary from '@/components/timeline/ThreadSummary.vue';
 import type { UseLongPress } from '@/composables/useLongPress';
+import {
+    useMessageActionGuards,
+    useMessageActionsContext,
+    useMessageSubtree,
+} from '@/composables/useMessageActionsContext';
 import { formatTimeOfDay } from '@/lib/datetime';
 import { canReactToMessage, showsThreadSummary } from '@/lib/messageActions';
-import type { MessageActionContext } from '@/lib/messageActions';
 import { messageAccessibleName } from '@/lib/timeline';
 import type { Message } from '@/types';
 
@@ -35,11 +39,6 @@ const props = defineProps<{
     /** The group author's name, naming the row for assistive technology. */
     authorName: string;
     teamSlug: string;
-    currentUserId: string;
-    canReact?: boolean;
-    canPin?: boolean;
-    canModerate?: boolean;
-    inThread?: boolean;
     /** Whether this row leads its author group, which sets its top margin. */
     isLead: boolean;
     /** Whether the send is still in flight to the server. */
@@ -56,10 +55,6 @@ const props = defineProps<{
     activeThreadRoot: boolean;
     /** Whether the composer holds this row's text for an edit. */
     composerEditing: boolean;
-    /** The viewer's zone, rendering every timestamp on the row. */
-    viewerTimeZone: string | undefined;
-    /** The viewer's stored zone, feeding the reminder popover's presets. */
-    viewerTimezone: string | null;
     /** The gesture opening the touch actions sheet, owned by the timeline. */
     longPress: UseLongPress<Message>;
 }>();
@@ -73,22 +68,20 @@ const emit = defineEmits<{
     cancelEdit: [];
     /** Ask to delete this row, which the timeline confirms first. */
     requestDelete: [];
-    reply: [];
-    forward: [];
-    pin: [];
-    unpin: [];
-    closePoll: [];
-    remindCustom: [];
-    openThread: [messageId: string];
-    react: [emoji: string];
-    vote: [optionId: string];
-    remind: [remindAt: string];
-    jump: [messageId: string];
-    mention: [member: { id: string; name: string }];
 }>();
 
+const scope = useMessageActionsContext();
+const subtree = useMessageSubtree();
+const { contextFor } = useMessageActionGuards();
+
+/**
+ * The viewer's zone as `Intl` takes it: the context stores "none" as null, and
+ * an absent zone is what renders a timestamp in the browser's own.
+ */
+const timeZone = computed(() => scope.viewerTimeZone ?? undefined);
+
 function formatTime(iso: string): string {
-    return formatTimeOfDay(iso, props.viewerTimeZone);
+    return formatTimeOfDay(iso, timeZone.value);
 }
 
 /**
@@ -97,14 +90,7 @@ function formatTime(iso: string): string {
  * stay here because they drive non-toolbar UI — the reaction pills and the
  * thread summary — and share the same context.
  */
-const actionContext = computed<MessageActionContext>(() => ({
-    currentUserId: props.currentUserId,
-    canReact: Boolean(props.canReact),
-    canPin: Boolean(props.canPin),
-    canModerate: Boolean(props.canModerate),
-    inThread: Boolean(props.inThread),
-    pending: props.pending,
-}));
+const actionContext = computed(() => contextFor(props.pending));
 
 /**
  * The viewer may react to any live, confirmed message when they're a member of
@@ -129,7 +115,7 @@ const showThreadSummary = computed(() =>
         :id="`message-${message.id}`"
         role="listitem"
         :aria-label="
-            messageAccessibleName(authorName, message.createdAt, viewerTimeZone)
+            messageAccessibleName(authorName, message.createdAt, timeZone)
         "
         class="group/message relative -mx-2 rounded-md px-2 transition-colors duration-1000 hover:bg-muted/40 max-md:select-none max-md:[-webkit-touch-callout:none]"
         :class="[
@@ -186,7 +172,7 @@ const showThreadSummary = computed(() =>
             v-if="message.replyTo && !message.isDeleted && !editing"
             :reply-to="message.replyTo"
             :bleed-class="CARD_BLEED"
-            @jump="(id) => emit('jump', id)"
+            @jump="(id) => scope.actions.jump(id)"
         />
 
         <p
@@ -209,7 +195,7 @@ const showThreadSummary = computed(() =>
             :message="message"
             :team-slug="teamSlug"
             :pending="pending"
-            @mention="(member) => emit('mention', member)"
+            @mention="(member) => subtree.mention(member)"
         />
 
         <MessageAttachments
@@ -220,20 +206,20 @@ const showThreadSummary = computed(() =>
             :attachments="message.attachments"
             :author-name="message.user.name"
             :created-at="message.createdAt"
-            :viewer-time-zone="viewerTimeZone"
+            :viewer-time-zone="timeZone"
         />
 
         <MessagePoll
             v-if="message.poll && !message.isDeleted && !editing"
             :class="CARD_BLEED"
             :poll="message.poll"
-            :current-user-id="currentUserId"
+            :current-user-id="scope.currentUserId"
             :can-vote="canReactTo"
             :can-manage="
-                message.user.id === currentUserId || Boolean(canModerate)
+                message.user.id === scope.currentUserId || scope.canModerate
             "
-            @vote="(optionId) => emit('vote', optionId)"
-            @close="emit('closePoll')"
+            @vote="(optionId) => scope.actions.vote(message, optionId)"
+            @close="scope.actions.closePoll(message)"
         />
 
         <span
@@ -260,9 +246,9 @@ const showThreadSummary = computed(() =>
         <MessageReactions
             v-if="!message.isDeleted && !editing"
             :reactions="message.reactions"
-            :current-user-id="currentUserId"
+            :current-user-id="scope.currentUserId"
             :can-react="canReactTo"
-            @toggle="(emoji) => emit('react', emoji)"
+            @toggle="(emoji) => scope.actions.react(message, emoji)"
         />
 
         <ThreadSummary
@@ -273,29 +259,15 @@ const showThreadSummary = computed(() =>
                     ? formatTime(message.threadLastReplyAt)
                     : ''
             "
-            @open-thread="(id) => emit('openThread', id)"
+            @open-thread="(id) => scope.actions.openThread(id)"
         />
 
         <MessageActions
             v-if="!editing"
             :message="message"
-            :current-user-id="currentUserId"
-            :can-react="canReact"
-            :can-pin="canPin"
-            :can-moderate="canModerate"
-            :in-thread="inThread"
             :pending="pending"
-            :viewer-timezone="viewerTimezone"
-            @react="(emoji) => emit('react', emoji)"
-            @reply="emit('reply')"
-            @forward="emit('forward')"
-            @pin="emit('pin')"
-            @unpin="emit('unpin')"
-            @open-thread="emit('openThread', message.id)"
-            @remind="(remindAt) => emit('remind', remindAt)"
-            @remind-custom="emit('remindCustom')"
-            @edit="emit('startEdit')"
-            @delete="emit('requestDelete')"
+            @start-edit="emit('startEdit')"
+            @request-delete="emit('requestDelete')"
         />
     </div>
 </template>

--- a/resources/js/composables/useMessageActionsContext.test.ts
+++ b/resources/js/composables/useMessageActionsContext.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { App, Component } from 'vue';
+import { computed, createApp, defineComponent, h, reactive } from 'vue';
+import {
+    provideMessageActions,
+    provideMessageSubtree,
+    useMessageActionGuards,
+    useMessageActionsContext,
+    useMessageSubtree,
+} from '@/composables/useMessageActionsContext';
+import type {
+    MessageActionHandlers,
+    MessageActionsContext,
+    MessageSubtreeContext,
+} from '@/composables/useMessageActionsContext';
+
+/**
+ * Covers the seam the message-action relay collapsed into: what the page
+ * provides, what a subtree narrows, and the guard context a row builds from the
+ * two. Every consumer reaches these through the named pair, so what is pinned
+ * here is the accessor's contract — including the throw that makes a missing
+ * provider a mount-time error rather than an `undefined` at click time.
+ */
+function handlers(): MessageActionHandlers {
+    return {
+        react: vi.fn(),
+        vote: vi.fn(),
+        closePoll: vi.fn(),
+        pin: vi.fn(),
+        unpin: vi.fn(),
+        remind: vi.fn(),
+        remindCustom: vi.fn(),
+        forward: vi.fn(),
+        jump: vi.fn(),
+        edit: vi.fn(),
+        delete: vi.fn(),
+        reply: vi.fn(),
+        openThread: vi.fn(),
+    };
+}
+
+function context(
+    overrides: Partial<MessageActionsContext> = {},
+): MessageActionsContext {
+    return {
+        currentUserId: 'me',
+        canReact: true,
+        canPin: true,
+        canModerate: false,
+        viewerTimeZone: 'UTC',
+        actions: handlers(),
+        ...overrides,
+    };
+}
+
+function subtree(
+    overrides: Partial<MessageSubtreeContext> = {},
+): MessageSubtreeContext {
+    return { inThread: false, mention: vi.fn(), ...overrides };
+}
+
+let active: Array<{ app: App; host: HTMLElement }> = [];
+
+/**
+ * Mount `child` under a provider, so the accessors run exactly where a real
+ * consumer runs them: inside a descendant's own `setup`.
+ */
+function mount(child: Component, provided?: () => void): HTMLElement {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = createApp(
+        defineComponent({
+            setup() {
+                provided?.();
+
+                return () => h(child);
+            },
+        }),
+    );
+    app.mount(host);
+    active.push({ app, host });
+
+    return host;
+}
+
+/** A leaf that runs `read` in its own setup and reports what it saw. */
+function reader<T>(read: () => T, seen: { value: T | null }): Component {
+    return defineComponent({
+        setup() {
+            seen.value = read();
+
+            return () => h('div');
+        },
+    });
+}
+
+afterEach(() => {
+    for (const { app, host } of active) {
+        app.unmount();
+        host.remove();
+    }
+
+    active = [];
+});
+
+describe('the message-actions context', () => {
+    it('hands a descendant exactly what the page provided', () => {
+        const provided = context();
+        const seen: { value: MessageActionsContext | null } = { value: null };
+
+        mount(
+            reader(() => useMessageActionsContext(), seen),
+            () => provideMessageActions(provided),
+        );
+
+        expect(seen.value).toBe(provided);
+    });
+
+    it('throws where a provider is missing, rather than reading undefined later', () => {
+        const seen: { value: MessageActionsContext | null } = { value: null };
+
+        expect(() =>
+            mount(reader(() => useMessageActionsContext(), seen)),
+        ).toThrow('No message-actions context was provided');
+    });
+
+    it('tracks a capability the page revises after mount', () => {
+        const page = reactive({ canReact: true });
+        const provided = reactive({
+            ...context(),
+            canReact: computed(() => page.canReact),
+        });
+        const seen: { value: MessageActionsContext | null } = { value: null };
+
+        mount(
+            reader(() => useMessageActionsContext(), seen),
+            () => provideMessageActions(provided),
+        );
+
+        page.canReact = false;
+
+        expect(seen.value!.canReact).toBe(false);
+    });
+});
+
+describe('the per-subtree context', () => {
+    it('hands a descendant the scope its own subtree provided', () => {
+        const provided = subtree({ inThread: true });
+        const seen: { value: MessageSubtreeContext | null } = { value: null };
+
+        mount(
+            reader(() => useMessageSubtree(), seen),
+            () => provideMessageSubtree(provided),
+        );
+
+        expect(seen.value).toBe(provided);
+    });
+
+    it('throws where a subtree provider is missing', () => {
+        const seen: { value: MessageSubtreeContext | null } = { value: null };
+
+        expect(() => mount(reader(() => useMessageSubtree(), seen))).toThrow(
+            'No message subtree was provided',
+        );
+    });
+});
+
+describe('the guard context for one row', () => {
+    /** Build the guard context a row with the given pending state resolves against. */
+    function guards(
+        overrides: Partial<MessageActionsContext> = {},
+        scope: Partial<MessageSubtreeContext> = {},
+    ) {
+        const seen: {
+            value: ReturnType<typeof useMessageActionGuards> | null;
+        } = { value: null };
+
+        mount(
+            reader(() => useMessageActionGuards(), seen),
+            () => {
+                provideMessageActions(context(overrides));
+                provideMessageSubtree(subtree(scope));
+            },
+        );
+
+        return seen.value!;
+    }
+
+    it('resolves the viewer capabilities, the subtree and the row into one shape', () => {
+        const { contextFor } = guards(
+            { currentUserId: 'me', canModerate: true },
+            { inThread: true },
+        );
+
+        expect(contextFor(true)).toEqual({
+            currentUserId: 'me',
+            canReact: true,
+            canPin: true,
+            canModerate: true,
+            inThread: true,
+            pending: true,
+        });
+    });
+
+    it('leaves the pending flag to the row, since only it knows', () => {
+        const { contextFor } = guards();
+
+        expect(contextFor(false).pending).toBe(false);
+        expect(contextFor(true).pending).toBe(true);
+    });
+});

--- a/resources/js/composables/useMessageActionsContext.test.ts
+++ b/resources/js/composables/useMessageActionsContext.test.ts
@@ -79,7 +79,18 @@ function mount(child: Component, provided?: () => void): HTMLElement {
             },
         }),
     );
-    app.mount(host);
+
+    // Two of the tests below mount an accessor with no provider above it, which
+    // is meant to throw. Clean up here rather than in `afterEach`: the app never
+    // finished mounting, so it is the host alone that would be left behind.
+    try {
+        app.mount(host);
+    } catch (error) {
+        host.remove();
+
+        throw error;
+    }
+
     active.push({ app, host });
 
     return host;

--- a/resources/js/composables/useMessageActionsContext.ts
+++ b/resources/js/composables/useMessageActionsContext.ts
@@ -1,0 +1,145 @@
+import type { InjectionKey } from 'vue';
+import { inject, provide } from 'vue';
+import type { MessageActionContext } from '@/lib/messageActions';
+import type { Message } from '@/types';
+
+/**
+ * Every write a message row can ask for, each taking the message (or its id) it
+ * acts on. Declared once here and provided once by the channel page, so no
+ * module between the page and the row re-declares them (ADR-0009).
+ *
+ * `edit` and `delete` are the writes themselves, not the affordances that lead
+ * to them: opening the inline editor and raising the delete confirmation are
+ * timeline-local UI, which `MessageList` owns and reaches through its own
+ * `startEdit` / `requestDelete` events.
+ */
+export interface MessageActionHandlers {
+    react: (message: Message, emoji: string) => void;
+    vote: (message: Message, optionId: string) => void;
+    closePoll: (message: Message) => void;
+    pin: (message: Message) => void;
+    unpin: (message: Message) => void;
+    remind: (message: Message, remindAt: string) => void;
+    remindCustom: (message: Message) => void;
+    forward: (message: Message) => void;
+    jump: (messageId: string) => void;
+    edit: (message: Message, body: string) => void;
+    delete: (message: Message) => void;
+    reply: (message: Message) => void;
+    openThread: (messageId: string) => void;
+}
+
+/**
+ * The viewer-and-channel scope: who is reading, what the open channel lets them
+ * do, and the actions they can ask for. Provided once by the channel page and
+ * read by every descendant that renders a message.
+ */
+export interface MessageActionsContext {
+    currentUserId: string;
+    /** Whether the viewer may add/remove reactions (member of a live channel). */
+    canReact: boolean;
+    /**
+     * Whether the viewer may pin/unpin messages (member of a non-archived
+     * channel). Pinning is a shared toggle — any member may unpin any pin.
+     */
+    canPin: boolean;
+    /** Whether the viewer may moderate others' messages (delete them). */
+    canModerate: boolean;
+    /**
+     * The viewer's stored zone, rendering every timestamp and feeding the
+     * reminder popover's wall-clock presets; null when they have none stored,
+     * which reads as the browser's own zone.
+     */
+    viewerTimeZone: string | null;
+    actions: MessageActionHandlers;
+}
+
+/**
+ * The scope one timeline owns rather than the page: the main pane and the
+ * thread panel each render the same rows, but answer these two differently.
+ */
+export interface MessageSubtreeContext {
+    /** Rendered inside a thread panel: suppresses the reply/thread affordances. */
+    inThread: boolean;
+    /** Drop a mention into the composer this subtree replies through. */
+    mention: (member: { id: string; name: string }) => void;
+}
+
+const messageActionsKey: InjectionKey<MessageActionsContext> =
+    Symbol('messageActions');
+
+const messageSubtreeKey: InjectionKey<MessageSubtreeContext> =
+    Symbol('messageSubtree');
+
+/**
+ * Publish the viewer-and-channel scope for the whole page. Reactivity is the
+ * caller's: pass a `reactive()` bag of computeds and a capability revised
+ * mid-session (a channel switch, an archive) reaches every row.
+ */
+export function provideMessageActions(context: MessageActionsContext): void {
+    provide(messageActionsKey, context);
+}
+
+/**
+ * Read the page's message-action scope.
+ *
+ * Throws rather than returning `undefined`: a missing provider is a wiring
+ * mistake, and raw `inject` would hide it until a click landed on a handler
+ * that was never there. Tests provide a stub facade through
+ * {@link provideMessageActions} and assert against it, which is what makes a
+ * row mountable without its page.
+ */
+export function useMessageActionsContext(): MessageActionsContext {
+    const context = inject(messageActionsKey, null);
+
+    if (context === null) {
+        throw new Error(
+            'No message-actions context was provided. Call provideMessageActions() on the page rendering this timeline.',
+        );
+    }
+
+    return context;
+}
+
+/** Publish the scope one timeline owns, from the component that owns it. */
+export function provideMessageSubtree(subtree: MessageSubtreeContext): void {
+    provide(messageSubtreeKey, subtree);
+}
+
+/** Read the enclosing timeline's scope; throws for the same reason as above. */
+export function useMessageSubtree(): MessageSubtreeContext {
+    const subtree = inject(messageSubtreeKey, null);
+
+    if (subtree === null) {
+        throw new Error(
+            'No message subtree was provided. Call provideMessageSubtree() on the pane or panel rendering this timeline.',
+        );
+    }
+
+    return subtree;
+}
+
+/**
+ * The bridge from the provided scopes to the pure guards in
+ * `lib/messageActions`: everything but `pending` is already known here, and
+ * `pending` is the one fact only the row has. Building
+ * {@link MessageActionContext} in this one place is what keeps the hover
+ * toolbar, the touch sheet and the row itself from drifting apart.
+ */
+export function useMessageActionGuards(): {
+    contextFor: (pending: boolean) => MessageActionContext;
+} {
+    const context = useMessageActionsContext();
+    const subtree = useMessageSubtree();
+
+    return {
+        contextFor: (pending) => ({
+            currentUserId: context.currentUserId,
+            canReact: context.canReact,
+            canPin: context.canPin,
+            canModerate: context.canModerate,
+            inThread: subtree.inThread,
+            pending,
+        }),
+    };
+}

--- a/resources/js/composables/useMessageActionsContext.ts
+++ b/resources/js/composables/useMessageActionsContext.ts
@@ -4,9 +4,11 @@ import type { MessageActionContext } from '@/lib/messageActions';
 import type { Message } from '@/types';
 
 /**
- * Every write a message row can ask for, each taking the message (or its id) it
- * acts on. Declared once here and provided once by the channel page, so no
- * module between the page and the row re-declares them (ADR-0009).
+ * Every action a message row can ask for, each taking the message (or its id) it
+ * acts on: the eleven writes, plus `reply` and `openThread`, which move the
+ * reader rather than writing but rode the identical relay. Declared once here
+ * and provided once by the channel page, so no module between the page and the
+ * row re-declares them (ADR-0009).
  *
  * `edit` and `delete` are the writes themselves, not the affordances that lead
  * to them: opening the inline editor and raising the delete confirmation are

--- a/resources/js/pages/channels/Show.actions.test.ts
+++ b/resources/js/pages/channels/Show.actions.test.ts
@@ -115,34 +115,41 @@ vi.mock('@/components/ChannelMasthead.vue', () => ({
     }),
 }));
 
+/**
+ * Stands in for the timeline, reaching the page's provided facade the way a row
+ * does — the page no longer listens for these as events (ADR-0009).
+ */
 vi.mock('@/components/MessageList.vue', async () => {
     const { message } = await import('./Show.doubles');
+    const { useMessageActionsContext } =
+        await import('@/composables/useMessageActionsContext');
 
     return {
         default: defineComponent({
             name: 'MessageListStub',
-            emits: ['forward', 'remind', 'remindCustom'],
-            setup(_props, { emit, expose }) {
+            setup(_props, { expose }) {
+                const scope = useMessageActionsContext();
+
                 expose({ scrollToIndex: vi.fn(), scrollToLatest: vi.fn() });
 
                 return () =>
                     h('div', [
                         h('button', {
                             'data-test': 'stub-forward',
-                            onClick: () => emit('forward', message()),
+                            onClick: () => scope.actions.forward(message()),
                         }),
                         h('button', {
                             'data-test': 'stub-remind',
                             onClick: () =>
-                                emit(
-                                    'remind',
+                                scope.actions.remind(
                                     message(),
                                     '2024-03-06T09:00:00.000Z',
                                 ),
                         }),
                         h('button', {
                             'data-test': 'stub-remind-custom',
-                            onClick: () => emit('remindCustom', message()),
+                            onClick: () =>
+                                scope.actions.remindCustom(message()),
                         }),
                     ]);
             },

--- a/resources/js/pages/channels/Show.vue
+++ b/resources/js/pages/channels/Show.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3';
-import { computed, nextTick, onMounted, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue';
 import ArchivedNotice from '@/components/channel/ArchivedNotice.vue';
 import ChannelAnnouncers from '@/components/channel/ChannelAnnouncers.vue';
 import ChannelComposerDock from '@/components/channel/ChannelComposerDock.vue';
@@ -17,6 +17,7 @@ import { useChannelTimeline } from '@/composables/useChannelTimeline';
 import { useChannelTyping } from '@/composables/useChannelTyping';
 import { useComposerTarget } from '@/composables/useComposerTarget';
 import { useMessageActions } from '@/composables/useMessageActions';
+import { provideMessageActions } from '@/composables/useMessageActionsContext';
 import { useOfflineOutbox } from '@/composables/useOfflineOutbox';
 import { useRailBottomInset } from '@/composables/useRailInset';
 import { useReadOnFocus } from '@/composables/useReadOnFocus';
@@ -229,11 +230,6 @@ function jumpToMessage(id: string | null | undefined): void {
     }
 }
 
-/** Raise the "remind me at…" picker, from either timeline. */
-function openCustomReminder(message: Message): void {
-    dialogs.value?.openCustomReminder(message);
-}
-
 const { markRead } = useReadPointer({
     teamSlug: () => props.team.slug,
     channelSlug: () => props.channel.slug,
@@ -367,6 +363,43 @@ flushOnReconnect(actions.flushOutbox);
  * list's "sends at" labels so a scheduled time always reads in their own zone.
  */
 const { timezone } = useTimezone();
+
+/**
+ * Publish what a message row needs, once, for the whole page (ADR-0009): who
+ * the viewer is, what this channel lets them do, and every action they can ask
+ * for. Nothing between here and a row re-declares any of it — the pane, the
+ * thread panel, the timeline and the row itself read it where they use it.
+ *
+ * Some actions are writes the engine above owns; the rest raise a dialog or
+ * move the reader. Both kinds look the same from a row, which is the point.
+ */
+provideMessageActions(
+    reactive({
+        currentUserId: computed(() => currentUser.value.id),
+        canReact: computed(() => props.canReact),
+        // Pinning is a shared toggle gated on the same membership as reacting.
+        canPin: computed(() => props.canReact),
+        canModerate,
+        viewerTimeZone: timezone,
+        actions: {
+            react: actions.reactToMessage,
+            vote: actions.voteOnPoll,
+            closePoll: actions.closePoll,
+            pin: actions.pinMessage,
+            unpin: actions.unpinMessage,
+            remind: (message: Message, remindAt: string) =>
+                dialogs.value?.remindWith(message, remindAt),
+            remindCustom: (message: Message) =>
+                dialogs.value?.openCustomReminder(message),
+            forward: (message: Message) => dialogs.value?.openForward(message),
+            jump: jumpToMessage,
+            edit: actions.editMessage,
+            delete: actions.deleteMessage,
+            reply: startReply,
+            openThread,
+        },
+    }),
+);
 </script>
 
 <template>
@@ -403,7 +436,7 @@ const { timezone } = useTimezone();
                 :pin-count="props.pinCount"
                 :connection-pill="connection.pill.value"
                 :scrolled="pane?.scrolled ?? false"
-                :viewer-timezone="timezone"
+                :viewer-time-zone="timezone"
                 @open-details="dialogs?.openDetails()"
                 @archive="dialogs?.confirmArchive()"
                 @delete="dialogs?.confirmDelete()"
@@ -419,12 +452,9 @@ const { timezone } = useTimezone();
                 :channel="props.channel"
                 :messages="displayMessages"
                 :server-messages="serverMessages"
-                :current-user-id="currentUser.id"
                 :is-self-dm="isSelfDm"
                 :pending-uuids="pendingUuids"
                 :queued-uuids="queuedUuids"
-                :can-moderate="canModerate"
-                :can-react="props.canReact"
                 :can-drop-files="props.isMember && !props.channel.isArchived"
                 :presence-for="presenceFor"
                 :is-dnd-for="isDndFor"
@@ -439,19 +469,6 @@ const { timezone } = useTimezone();
                 @scroll="onScroll"
                 @files="(files) => dock?.addFiles(files)"
                 @focus-composer="dock?.focus()"
-                @edit="actions.editMessage"
-                @delete="actions.deleteMessage"
-                @reply="startReply"
-                @forward="(message) => dialogs?.openForward(message)"
-                @react="actions.reactToMessage"
-                @vote="actions.voteOnPoll"
-                @close-poll="actions.closePoll"
-                @pin="actions.pinMessage"
-                @unpin="actions.unpinMessage"
-                @remind="(message, at) => dialogs?.remindWith(message, at)"
-                @remind-custom="openCustomReminder"
-                @open-thread="openThread"
-                @jump="jumpToMessage"
                 @mention="(member) => dock?.insertMention(member)"
             >
                 <ArchivedNotice v-if="props.channel.isArchived" />
@@ -516,28 +533,13 @@ const { timezone } = useTimezone();
                 :pending-uuids="threadPendingUuids"
                 :members="mentionableMembers"
                 :has-bots="channelHasBots"
-                :current-user-id="currentUser.id"
-                :can-moderate="canModerate"
-                :can-react="props.canReact"
-                :can-pin="props.canReact"
                 :presence-for="presenceFor"
                 :is-dnd-for="isDndFor"
                 :loading="threadLoading"
                 :read-only="props.channel.isArchived"
                 @close="closeThread"
                 @send="actions.sendThreadReply"
-                @edit="actions.editMessage"
-                @delete="actions.deleteMessage"
-                @forward="(message) => dialogs?.openForward(message)"
-                @react="actions.reactToMessage"
-                @vote="actions.voteOnPoll"
-                @close-poll="actions.closePoll"
-                @pin="actions.pinMessage"
-                @unpin="actions.unpinMessage"
-                @remind="(message, at) => dialogs?.remindWith(message, at)"
-                @remind-custom="openCustomReminder"
                 @typing="typing.signalTyping"
-                @jump="jumpToMessage"
             />
         </Transition>
     </div>


### PR DESCRIPTION
Closes #1092. Part of the architecture-hardening II epic (#1089); lands before #524.

## What

`useMessageActions` was already a deep module — one options object in, one flat facade out. All the friction was in getting a click to it. Eleven actions were re-declared and re-forwarded, unchanged, at every level between `Show.vue` and the button that fires them, and the viewer's capabilities rode the same chain.

The channel page now **provides** them once behind an `InjectionKey`, read through a named accessor pair that throws when no provider is above it. Nothing between the page and a row re-declares any of it.

| module | props | emits |
|---|---|---|
| `ChannelPane` | 21 → 18 | 17 → 4 |
| `ThreadPanel` | 15 → 11 | 14 → 3 |
| `MessageList` | 22 → 17 | 16 → 2 |
| `MessageRow` | 19 → 12 | 16 → 4 |
| `MessageActions` | 8 → 2 | 10 → 2 |
| **total** | **85 → 60** | **73 → 15** |

(`MessageActionsSheet`, not in the issue's table, goes 9 → 3 props and 10 → 3 emits.)

The new seam is `composables/useMessageActionsContext.ts`:

- `provideMessageActions()` / `useMessageActionsContext()` — the viewer/channel scope: `currentUserId`, `canReact`, `canPin`, `canModerate`, the single viewer time zone, and the action facade. Provided once, by the page.
- `provideMessageSubtree()` / `useMessageSubtree()` — what one timeline answers differently: `inThread`, and the composer a mention lands in. `ChannelPane` provides `false` + the channel composer; `ThreadPanel` provides `true` + its own reply composer.
- `useMessageActionGuards()` — builds `MessageActionContext` from those two plus `pending`, the one fact only a row has, which stays a row-local prop. That replaces the three places the shape was reassembled from drilled booleans.

Also in scope, from the issue's criteria:

- The duplicated twelve-line binding block in `Show.vue` (one for the pane, one for the panel) is gone.
- **One spelling of the viewer time zone.** `viewerTimezone` and `viewerTimeZone` no longer coexist anywhere — the lower-case spelling is renamed out of `PinsPanel` and `ChannelHeader` too, so the rule holds across the app rather than just the chain.

Two affordances deliberately stay events, because they open UI the *timeline* owns rather than performing a write: `startEdit` (swap a row for its inline editor) and `requestDelete` (raise the confirmation). The writes they eventually reach — `edit(message, body)`, `delete(message)` — go through the facade like everything else, and they are named apart from it so the distinction is legible.

Two deliberate deviations from the issue text, both noted here rather than buried:

- The facade holds **thirteen** handlers, not eleven: the eleven writes plus `reply` and `openThread`, which are navigations but rode the identical relay. Leaving them as emits would have kept two of the five modules re-declaring them.
- `mention` is part of the per-subtree scope rather than staying an emit, for the same reason — otherwise `MessageRow` and `MessageList` both keep declaring it.

## Why

`MessageList` (22 props / 16 emits) and `ChannelPane` (21/17) were the definition of shallow: the interface was wider than what the body did with it. The real cost was not the line count but that no module below `Show.vue` could be mounted without it, so ten test files threaded props to reach behaviour.

`#524` (save messages for later) adds a message action. Landed before this, it becomes the twelfth write re-declared through all five levels and then has to be un-threaded; after this it is one method on the facade.

## How tested

- **`resources/js/composables/useMessageActionsContext.test.ts`** (new, 7 tests) constructs the seam directly: what the page provides, what a subtree narrows, the guard context a row builds from the two, and the throw on a missing provider.
- **`resources/js/components/timeline/MessageRow.test.ts`** (new, 8 tests) mounts a row with its *real* hover toolbar and nothing else — no timeline, no `Show.vue` — against a stub facade, and asserts each affordance reaches the facade carrying its own message. That mount is only possible because of this change.
- The ten existing suites now provide one stub facade through a shared `MessageList.doubles.ts` and assert on its spies. **Seven got shorter** (−437 lines between them), two are untouched, and `Show.actions` grew by 8 lines where its `MessageList` stub became explicit about reaching the provided facade. Net across the ten: **−429 lines**.
- Backend gate green: Pint, PHPStan, Rector clean, 3155 tests at `--min=100`. (No PHP file is touched by this PR.)
- Frontend gate green: `lint:check`, `format:check`, `types:check`, `test:js` (240 files / 2415 tests) and `build`.
- Browser suite green: 348 tests, no new browser tests added (per the epic's shared definition of done). A later sweep of identical product code hit one unrelated flake — `ThreadsDestinationTest` landing on `/login` — which passes in isolation and is filed as #1099.

## Docs

- **ADR-0009** (`dev-docs/adr/0009-message-action-context-is-provided.md`), which the issue asked this child to mint. It states the cost as plainly as the benefit: provide/inject is implicit, and a reader of `MessageRow.vue` cannot see where `scope.actions.pin` comes from by looking at its props — which is why the accessors are named, typed and throwing rather than a bare `inject(key)`.
- `CONTEXT.md` "Named seams" and the "where new work goes" quick reference both gain the message-action context.
- No operator-facing change, so `docs/` is untouched.

## Notes

- Local CodeRabbit found three minor issues across the passes, all applied: the documented action count vs. the thirteen actually declared, a test-double `click()` that silently no-opped on a stale selector, and a host element leaked by a mount that was meant to throw. The final pass hit the free tier's rate limit before it could report, so the app's PR review is the remaining check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788054870&installation_model_id=428379&pr_number=1100&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1100&signature=26e58b875a811a10e79bf1b4acbe23d2ec54688c68468266583d772854b3147d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->