### PR TITLE
feat: take a photo into a message from the composer's Camera tile

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -1495,7 +1495,6 @@
   "Add to your message, or format it.": "Ajoutez à votre message, ou mettez-le en forme.",
   "Photos": "Photos",
   "Camera": "Appareil photo",
-  "Camera (coming later)": "Appareil photo (bientôt disponible)",
   "Voice": "Vocal",
   "Command": "Commande"
 }

--- a/resources/js/components/MessageComposer.mobile.doubles.ts
+++ b/resources/js/components/MessageComposer.mobile.doubles.ts
@@ -123,14 +123,33 @@ export async function stage(
     hook: string,
     file: File,
 ): Promise<void> {
+    await fireChange(container, hook, [file]);
+}
+
+/**
+ * Fire `change` on a hidden input that carries no file, which is what a browser
+ * does when the picker (or the camera) is dismissed after an earlier pick.
+ */
+export async function stageNothing(
+    container: HTMLElement,
+    hook: string,
+): Promise<void> {
+    await fireChange(container, hook, []);
+}
+
+async function fireChange(
+    container: HTMLElement,
+    hook: string,
+    files: File[],
+): Promise<void> {
     const input = container.querySelector<HTMLInputElement>(
         `[data-test="${hook}"]`,
     )!;
     Object.defineProperty(input, 'files', {
         value: {
-            0: file,
-            length: 1,
-            item: (index: number) => (index === 0 ? file : null),
+            ...files,
+            length: files.length,
+            item: (index: number) => files[index] ?? null,
         },
         configurable: true,
     });

--- a/resources/js/components/MessageComposer.mobileControls.test.ts
+++ b/resources/js/components/MessageComposer.mobileControls.test.ts
@@ -56,6 +56,7 @@ import {
     mountComposer,
     openSheet,
     stage,
+    stageNothing,
     tile,
     tiles,
     type,
@@ -258,15 +259,16 @@ describe('the attach sheet', () => {
         expect(tiles(container)).not.toContain('command');
     });
 
-    it('ships the camera tile disabled until native capture lands', async () => {
+    it('offers the camera tile as a live control, with nothing left of its held-back state', async () => {
         const container = mountComposer();
 
         await openSheet(container);
 
         const camera = tile(container, 'camera');
 
-        expect(camera.hasAttribute('disabled')).toBe(true);
-        expect(camera.getAttribute('aria-label')).toBe('Camera (coming later)');
+        expect(camera.hasAttribute('disabled')).toBe(false);
+        expect(camera.getAttribute('aria-label')).toBe('Camera');
+        expect(camera.textContent).not.toContain('Later');
     });
 });
 
@@ -287,6 +289,56 @@ describe('the attach sheet’s tiles', () => {
         );
 
         expect(find(container, 'composer-attachment')).not.toBeNull();
+    });
+
+    it('asks the OS for the rear camera, one still photo at a time', () => {
+        const container = mountComposer();
+        const cameraInput = container.querySelector<HTMLInputElement>(
+            '[data-test="composer-camera-input"]',
+        );
+
+        expect(cameraInput?.getAttribute('accept')).toBe('image/*');
+        expect(cameraInput?.getAttribute('capture')).toBe('environment');
+        // Video would walk straight into the size cap with nothing to trim it,
+        // and a capture session hands back one file regardless.
+        expect(cameraInput?.hasAttribute('multiple')).toBe(false);
+    });
+
+    it('proxies the camera tile to that input, leaving the sheet and the draft behind', async () => {
+        const container = mountComposer();
+        const cameraInput = container.querySelector<HTMLInputElement>(
+            '[data-test="composer-camera-input"]',
+        )!;
+        const opened = vi.spyOn(cameraInput, 'click');
+
+        await type(container, 'look at this');
+        await openSheet(container);
+        tile(container, 'camera').click();
+        await nextTick();
+
+        expect(opened).toHaveBeenCalledTimes(1);
+        expect(find(container, 'composer-attach-sheet')).toBeNull();
+        expect(field(container).value).toBe('look at this');
+    });
+
+    it('stages a captured photo exactly like a picked file', async () => {
+        const container = mountComposer();
+
+        await stage(
+            container,
+            'composer-camera-input',
+            new File(['x'], 'IMG_0001.jpg', { type: 'image/jpeg' }),
+        );
+
+        expect(find(container, 'composer-attachment')).not.toBeNull();
+    });
+
+    it('stages nothing when the capture is cancelled', async () => {
+        const container = mountComposer();
+
+        await stageNothing(container, 'composer-camera-input');
+
+        expect(find(container, 'composer-attachment')).toBeNull();
     });
 
     it('opens the GIF picker and keeps the draft the user was part-way through', async () => {

--- a/resources/js/components/composer/ComposerAttachSheet.vue
+++ b/resources/js/components/composer/ComposerAttachSheet.vue
@@ -50,6 +50,8 @@ const emit = defineEmits<{
     format: [marker: string];
     /** Open the photo-library picker, which takes images and video. */
     photos: [];
+    /** Open the device camera on a still photo. */
+    camera: [];
     /** Open the unrestricted file picker. */
     file: [];
     /** Open the Giphy picker. */
@@ -157,29 +159,22 @@ const rowClass =
                     {{ $t('Photos') }}
                 </Button>
 
-                <!-- Native capture is #890. The tile is drawn now, disabled and
-                     marked, so the grid does not reflow when it lands. -->
+                <!-- Hands off to the OS camera through a `capture` input, so
+                     the tile is worth offering only where one answers it —
+                     which is this sheet, and this sheet is below `md` only. -->
                 <Button
                     v-if="attachmentsEnabled"
                     variant="unstyled"
                     size="none"
                     type="button"
-                    disabled
                     data-test="composer-attach-tile"
                     data-tile="camera"
-                    :class="`${tileClass} relative bg-transparent inset-ring inset-ring-border`"
-                    :aria-label="$t('Camera (coming later)')"
+                    :class="tileClass"
+                    :aria-label="$t('Camera')"
+                    @click="act(() => emit('camera'))"
                 >
-                    <Camera class="size-5.5 text-muted-foreground" />
-                    <span class="text-muted-foreground">{{
-                        $t('Camera')
-                    }}</span>
-                    <span
-                        aria-hidden="true"
-                        class="absolute top-1.5 right-1.5 rounded border border-border px-1 py-px font-mono text-[8.5px] font-medium tracking-wider text-muted-foreground uppercase"
-                    >
-                        {{ $t('Later') }}
-                    </span>
+                    <Camera class="size-5.5 text-brass-fill-foreground" />
+                    {{ $t('Camera') }}
                 </Button>
 
                 <Button

--- a/resources/js/components/composer/ComposerInputRow.vue
+++ b/resources/js/components/composer/ComposerInputRow.vue
@@ -100,12 +100,23 @@ const fileInput = ref<HTMLInputElement | null>(null);
  */
 const photoInput = ref<HTMLInputElement | null>(null);
 
+/**
+ * A third input that asks the OS for the camera rather than for a file. Only a
+ * phone honours `capture`; everywhere else it degrades to the normal picker,
+ * which is why only the mobile sheet offers a control onto it.
+ */
+const cameraInput = ref<HTMLInputElement | null>(null);
+
 function openFilePicker(): void {
     fileInput.value?.click();
 }
 
 function openPhotoPicker(): void {
     photoInput.value?.click();
+}
+
+function openCamera(): void {
+    cameraInput.value?.click();
 }
 
 function onFilesPicked(event: Event): void {
@@ -230,6 +241,18 @@ function onFilesPicked(event: Event): void {
                 data-test="composer-photo-input"
                 @change="onFilesPicked"
             />
+            <!-- One capture hands back one still, so this input is neither
+                 `multiple` nor open to video: a clip would meet the size cap
+                 with nothing on the client able to trim it. -->
+            <input
+                ref="cameraInput"
+                type="file"
+                accept="image/*"
+                capture="environment"
+                class="hidden"
+                data-test="composer-camera-input"
+                @change="onFilesPicked"
+            />
             <template v-if="isMobile">
                 <ComposerAttachSheet
                     v-model:open="attachSheetOpen"
@@ -245,6 +268,7 @@ function onFilesPicked(event: Event): void {
                     :timezone="timezone"
                     @format="emit('format', $event)"
                     @photos="openPhotoPicker"
+                    @camera="openCamera"
                     @file="openFilePicker"
                     @gif="emit('gif')"
                     @poll="emit('poll')"


### PR DESCRIPTION
Closes #890.

## What

The Camera tile in the mobile attach sheet is live. Tapping it opens the OS camera, and the photo it hands back is staged in the composer tray exactly like a picked file. The tile's held-back state is gone: no `disabled`, no "Later" badge, no ghost outline, and the `Camera (coming later)` string is deleted from `lang/fr.json`.

## Why

Follow-up to #889, which drew the tile disabled so the grid would not reflow when capture landed. Until now, "send a photo of this" on a phone meant leaving the app for the Camera, shooting, coming back, tapping `+`, Photos, and hunting for the shot — the one flow a phone is better at than a laptop was the one we did not have.

## How

A third hidden input beside the existing file and photo inputs, in `ComposerInputRow.vue`:

```html
<input type="file" accept="image/*" capture="environment" class="hidden" data-test="composer-camera-input" @change="onFilesPicked" />
```

The tile emits `camera`, the row clicks that input, and the returned `File` lands in the same `onFilesPicked` → `uploads.addFiles` path as every other pick — so the size cap, the per-message count cap and the executable denylist all still apply, with no new bypass. No `getUserMedia`, so no viewfinder, no shutter, no secure-context requirement that would kill it on plain-HTTP LAN self-host installs; where `capture` is unsupported the input simply opens the normal picker, which is why the control stays in the mobile-only sheet and nothing is added to the desktop tool cluster.

`accept="image/*"` and no `multiple`, per the issue: video would walk straight into the 25 MB cap with no client-side transcode, and that is worth its own issue. The existing `act()` wrapper already runs the tile's action inside the tap's user gesture *before* dismissing the sheet, which is what Safari requires and what keeps the draft text intact.

`ThreadPanel.vue` follows for free through the shared composer.

## Testing

Five Vitest specs in `MessageComposer.mobileControls.test.ts` (the tile is enabled and named, with nothing left of the held-back copy; the input asks for the rear camera one still at a time; the tile proxies to that input and leaves the sheet and the draft behind; a captured `File` reaches the tray; a cancelled capture stages nothing and raises nothing). `stage()` in the doubles was generalised so a zero-file `change` — what a browser fires on a dismissed picker — can be driven too.

Gate green: `composer test` (Pint, PHPStan, Rector, 3134 tests, `--min=100`), `lint:check`, `format:check`, `types:check`, `test:js` (249 files, 2514 tests), `build`. Browser suites touching the sheet re-run green: `MobileComposerControlsTest`, `MobileShellTest`, `MobileUndrawnScreensTest`, `A11yShellTest`, `A11yTimelineTest`.

Verified visually headless at 390×844 in both themes: the tile renders identically to its Photos/File/Poll siblings and the grid does not reflow. Real device capture cannot be exercised by the Pest browser suite (no camera, and the in-process server takes no multipart), so that half wants a hand check on iOS and Android.

## i18n & docs

`Camera` was already translated; `Camera (coming later)` is removed as its last call site is gone. Nothing operator-facing — no config, no `.env` key, no migration, no new dependency — so no `docs/` change.

## Review notes

One local CodeRabbit finding, consciously declined: it asked the test to derive the expected `Camera`/`Later` copy from `translate()` instead of hardcoding it. Our keys *are* the English source strings, so that expectation would recompute itself the way the code does, and every sibling assertion in the same suite hardcodes its copy (`Record a voice message`, `Send message`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788105626&installation_model_id=428379&pr_number=1107&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1107&signature=eb8662cb4d695c82ae6e9b687edfa69a50ba115bde69498005520caa78001af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->