### PR TITLE
deps: update deskhq/laravel-worktree to v0.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/dom-crawler": "^8.1"
     },
     "require-dev": {
-        "deskhq/laravel-worktree": "^0.1.0",
+        "deskhq/laravel-worktree": "^0.3.0",
         "driftingly/rector-laravel": "^2.5",
         "larastan/larastan": "^3.9",
         "laravel/boost": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d9d653b2d137acd53332784c19cf2a3",
+    "content-hash": "2cb86c9f783c9cfcd20a182481e99947",
     "packages": [
         {
             "name": "arietimmerman/laravel-scim-server",
@@ -12562,16 +12562,16 @@
         },
         {
             "name": "deskhq/laravel-worktree",
-            "version": "v0.1.0",
+            "version": "v0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/deskhq/laravel-worktree.git",
-                "reference": "08a0043d5de05c3c16d6694973e656f7d165a40a"
+                "reference": "8e24166e11e86e0df28ab1cf8f924d192ccb8dba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/deskhq/laravel-worktree/zipball/08a0043d5de05c3c16d6694973e656f7d165a40a",
-                "reference": "08a0043d5de05c3c16d6694973e656f7d165a40a",
+                "url": "https://api.github.com/repos/deskhq/laravel-worktree/zipball/8e24166e11e86e0df28ab1cf8f924d192ccb8dba",
+                "reference": "8e24166e11e86e0df28ab1cf8f924d192ccb8dba",
                 "shasum": ""
             },
             "require": {
@@ -12632,9 +12632,9 @@
             ],
             "support": {
                 "issues": "https://github.com/deskhq/laravel-worktree/issues",
-                "source": "https://github.com/deskhq/laravel-worktree/tree/v0.1.0"
+                "source": "https://github.com/deskhq/laravel-worktree/tree/v0.3.0"
             },
-            "time": "2026-07-31T10:26:16+00:00"
+            "time": "2026-07-31T16:05:33+00:00"
         },
         {
             "name": "driftingly/rector-laravel",


### PR DESCRIPTION
Updates the worktree tooling from v0.1.0 to v0.3.0.

`^0.1.0` could not reach either release on its own — a caret on a `0.x`
version does not cross a minor — so the constraint moves to `^0.3.0`.

## What landed upstream

Both intervening releases are features, neither breaking:

- **v0.2.0** — refuse a `create` when a started service publishes a host port nothing offsets ([deskhq/laravel-worktree#45](https://github.com/deskhq/laravel-worktree/issues/45))
- **v0.3.0** — fit `list` to the terminal it is read in, and make the TSV contract true ([deskhq/laravel-worktree#48](https://github.com/deskhq/laravel-worktree/issues/48))

## Why nothing else changes

- `config/worktree.php` is untouched: neither release changes the config surface.
- Nothing in this repo parses `worktree list` output programmatically — it appears only as a human command in `dev-docs/concurrent-worktrees.md` and the `implement-issue` skill — so the TSV contract change is inert here.
- The package is a `require-dev` entry, so there is no operator-facing surface and no `docs/` change is implicated.

## Verification

`composer.lock` moved and `package-lock.json` did not, so only the backend gate applies. `./vendor/bin/sail composer test` is green:

| Check | Result |
| --- | --- |
| Pint | passed |
| PHPStan | passed, 0 errors |
| Rector (dry-run) | passed, 0 changed files |
| Pest | 3134/3134 passing, 14611 assertions |
| Coverage | `--min=100` held |

`./vendor/bin/sail composer audit` reports no security advisories.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788106292&installation_model_id=428379&pr_number=1108&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1108&signature=a88fa4a9fa1183d44b521c5b514da3188bebc72fef2e10d6f3bc39552862dd9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->