### PR TITLE
refactor: deepen the optimistic write, 12 hand-rolled snapshot and rollback triples

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -154,11 +154,31 @@ built; build them once, then reuse.
   rather than at each call site, and the inverse stays `useReminderUndo`'s.
   A new reminder surface calls it; it does not hand-roll a `router.post` with its
   own toast.
+- **`useOptimisticWrite`** — the one module behind every write that shows its
+  outcome before the server has agreed: capture → apply → post →
+  restore-on-error → toast, plus the visit options an optimistic write always
+  wants (`preserveScroll`, `preserveState` — it is not a navigation) and the
+  two-stream case, where a message on screen in both the timeline and the thread
+  panel has to roll back in both (`snapshotStreams`). A call site supplies only
+  what differs: what to snapshot, what to show, where to post, which props that
+  invalidates, and what to say when it fails. The line is behavioural — a write
+  with *nothing* to roll back stays a plain `router.post`, because it would gain
+  uniformity and nothing else. `useReminders` is the reference: it is where the
+  lesson was first written down, and its snapshot feeds an *Undo* rather than a
+  rollback, which is why it stays its own shape.
+- **`lib/reloadProps`** — the prop sets a write invalidates, named once each
+  (`CHANNEL_LIST_PROPS`, `CHANNEL_SECTION_PROPS`, `COLLAPSED_SECTION_PROPS`,
+  `PIN_PROPS`, `SCHEDULED_MESSAGE_PROPS`, `THREAD_PROPS`). The pairs are the
+  sharp edge: `pins`/`pinCount` are two readings of one fact, so a surface
+  refreshing one goes stale against the other. `reloadProps.test.ts` fails on a
+  second copy of any of them, so a new `only: [...]` is an import, never an
+  array literal.
 - **`lib/reminderReload`** — the props a reminder mutation invalidates
   (`reminders` + `firedReminders`) and the visit options carrying them. The two
   move together, so a surface refreshing one without the other goes stale; the
   set is named here and nowhere else (`reminderReload.test.ts` fails on a second
-  copy).
+  copy). The seventh set, kept beside the six above because the visit options
+  belong with it.
 - **`useDialog` + `DialogHost`** — the shell's dialog registry. Open state is one
   module-scoped entry per dialog, and every one of them is mounted once by
   `DialogHost`; a dialog is opened by name from wherever the gesture is, never by
@@ -192,6 +212,11 @@ built; build them once, then reuse.
 - New channel-member preference → the **channel membership settings** concern.
 - New message action (a row affordance that writes) → one method on the **message-action
   context**; never a new prop/emit pair through the timeline.
+- A write that shows its outcome before the server answers →
+  **`useOptimisticWrite`**; never a hand-rolled snapshot / `onError` restore /
+  toast triple. A write with nothing to roll back stays a plain `router` call.
+- The props a write invalidates → a named set in **`lib/reloadProps`**; never an
+  inline `only: [...]` array.
 - New reminder behaviour → **`useReminders`**; new reminder *props* → the set in
   **`lib/reminderReload`**.
 - A new dialog the shell puts over itself → an entry in **`useDialog`**'s

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -327,6 +327,7 @@
   "Failed to open the conversation": "Échec de l’ouverture de la conversation",
   "Failed to pin the message. Please try again.": "Échec de l’épinglage du message. Veuillez réessayer.",
   "Failed to rename the section": "Échec du renommage de la section",
+  "Failed to save the clock style": "Échec de l’enregistrement du format de l’heure",
   "Failed to save the section order": "Échec de l’enregistrement de l’ordre des sections",
   "Failed to save the sidebar layout": "Échec de l’enregistrement de la disposition de la barre latérale",
   "Failed to schedule your message": "Échec de la programmation de votre message",

--- a/resources/js/components/ChannelListItem.vue
+++ b/resources/js/components/ChannelListItem.vue
@@ -22,6 +22,7 @@ import {
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { notificationIndicator } from '@/lib/notificationIndicator';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import type { Channel, ChannelSection } from '@/types/channels';
 
 const props = defineProps<{
@@ -70,7 +71,7 @@ function toggleStar(): void {
         {
             preserveScroll: true,
             preserveState: true,
-            only: ['channels'],
+            only: CHANNEL_LIST_PROPS,
             onError: () => {
                 toast.error(t('Failed to update the channel'));
             },

--- a/resources/js/components/DirectMessageListItem.vue
+++ b/resources/js/components/DirectMessageListItem.vue
@@ -22,6 +22,7 @@ import { groupDmSidebarName } from '@/lib/groupDm';
 import { notificationIndicator } from '@/lib/notificationIndicator';
 import { presenceLabelKey } from '@/lib/presence';
 import type { RenderedPresence } from '@/lib/presence';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import type { Channel } from '@/types/channels';
 
 const props = defineProps<{
@@ -104,7 +105,7 @@ function hide(): void {
             // Leaving: let the redirect home drive a normal visit.
             preserveScroll: !leaving,
             preserveState: !leaving,
-            ...(leaving ? {} : { only: ['channels'] }),
+            ...(leaving ? {} : { only: CHANNEL_LIST_PROPS }),
             onError: () => {
                 toast.error(t('Failed to close the conversation'));
             },

--- a/resources/js/components/PollComposerPanel.vue
+++ b/resources/js/components/PollComposerPanel.vue
@@ -6,6 +6,7 @@ import { store as storePoll } from '@/actions/App/Http/Controllers/Channels/Poll
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import { generateUuid } from '@/lib/uuid';
 
 const props = defineProps<{
@@ -119,7 +120,7 @@ function submit(): void {
         {
             preserveScroll: true,
             preserveState: true,
-            only: ['channels'],
+            only: CHANNEL_LIST_PROPS,
             onSuccess: () => emit('close'),
             onFinish: () => {
                 posting.value = false;

--- a/resources/js/composables/messageWrites.harness.ts
+++ b/resources/js/composables/messageWrites.harness.ts
@@ -1,0 +1,61 @@
+import { effectScope, ref } from 'vue';
+import { useMessageStream } from '@/composables/useMessageStream';
+import type { Message } from '@/types';
+
+/**
+ * Test-only: the two streams a message write patches, built directly rather
+ * than through `useMessageActions`.
+ *
+ * Five of the eleven writes behind the message-action facade were only ever
+ * exercised through that aggregate, which meant a dropped rollback was caught
+ * by nothing — a stream restored in the timeline and not in the thread panel
+ * beside it looks identical from the facade's outside (#1115). Driving each
+ * composable directly is what makes that assertable, and every one of them
+ * takes the same pair.
+ *
+ * The fixtures and mock accessors are shared with
+ * {@see useMessageActions.harness}, so a message means the same thing on both
+ * sides. Nothing the app ships imports this.
+ */
+
+type Stream = ReturnType<typeof useMessageStream>;
+
+export interface MessageStreams {
+    /** The channel timeline's stream. */
+    mainStream: Stream;
+    /** The open thread panel's stream, over the same rows where they overlap. */
+    threadStream: Stream;
+    /** Tear the scope down, as unmounting the channel page would. */
+    unmount: () => void;
+}
+
+/**
+ * A main and a thread stream, both seeded with `rows` — the case that matters,
+ * since a message showing in both places has to roll back in both.
+ */
+export function streams(rows: Message[]): MessageStreams {
+    const scope = effectScope();
+
+    let mainStream!: Stream;
+    let threadStream!: Stream;
+
+    scope.run(() => {
+        mainStream = useMessageStream(ref(rows));
+        threadStream = useMessageStream(ref(rows));
+    });
+
+    return { mainStream, threadStream, unmount: () => scope.stop() };
+}
+
+/** The rendered row for `id`, as a stream currently shows it. */
+export function shown(stream: Stream, id: string): Message {
+    const row = stream.displayMessages.value.find(
+        (message) => message.id === id,
+    );
+
+    if (!row) {
+        throw new Error(`No message ${id} in the stream.`);
+    }
+
+    return row;
+}

--- a/resources/js/composables/useChannelDraft.ts
+++ b/resources/js/composables/useChannelDraft.ts
@@ -3,6 +3,7 @@ import { watch } from 'vue';
 import { update as saveChannelDraft } from '@/actions/App/Http/Controllers/Channels/ChannelDraftController';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 
 /**
  * How long to coalesce composer keystrokes before persisting the draft. Long
@@ -54,7 +55,7 @@ export function useChannelDraft(options: ChannelDraftOptions): ChannelDraft {
                 ...backgroundVisit,
                 preserveScroll: true,
                 preserveState: true,
-                only: ['channels'],
+                only: CHANNEL_LIST_PROPS,
             },
         );
     }

--- a/resources/js/composables/useChannelPins.ts
+++ b/resources/js/composables/useChannelPins.ts
@@ -1,6 +1,7 @@
 import { router } from '@inertiajs/vue3';
 import { ref, watch } from 'vue';
 import type { Ref } from 'vue';
+import { PIN_PROPS } from '@/lib/reloadProps';
 
 export interface ChannelPinsOptions {
     /** The server's pin count for the open channel. */
@@ -40,7 +41,7 @@ export function useChannelPins(options: ChannelPinsOptions): ChannelPins {
      */
     function openPinsPanel(): void {
         pinsPanelOpen.value = true;
-        router.reload({ only: ['pins', 'pinCount'] });
+        router.reload({ only: PIN_PROPS });
     }
 
     /** Jump to a pinned message from the panel, closing the popover on the way. */

--- a/resources/js/composables/useChannelPlacement.ts
+++ b/resources/js/composables/useChannelPlacement.ts
@@ -1,12 +1,13 @@
-import { router, usePage } from '@inertiajs/vue3';
+import { usePage } from '@inertiajs/vue3';
 import { computed, ref, watch } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
 import { update as updateChannelPlacement } from '@/actions/App/Http/Controllers/Channels/ChannelPlacementController';
 import { reorder as reorderSections } from '@/actions/App/Http/Controllers/Channels/ChannelSectionController';
-import { useToast } from '@/composables/useToast';
+import { useOptimisticWrite } from '@/composables/useOptimisticWrite';
 import { useTranslations } from '@/composables/useTranslations';
 import { partitionChannels } from '@/lib/channelSections';
 import type { ChannelSectionGroup } from '@/lib/channelSections';
+import { CHANNEL_LIST_PROPS, CHANNEL_SECTION_PROPS } from '@/lib/reloadProps';
 import type { Channel, ChannelSection } from '@/types/channels';
 
 /**
@@ -58,7 +59,7 @@ export interface ChannelPlacement {
 export function useChannelPlacement(): ChannelPlacement {
     const page = usePage();
     const { t } = useTranslations();
-    const toast = useToast();
+    const { write } = useOptimisticWrite();
 
     const currentTeam = computed(() => page.props.currentTeam);
     const channels = computed(() => page.props.channels ?? []);
@@ -92,6 +93,10 @@ export function useChannelPlacement(): ChannelPlacement {
      * when `sectionId` is provided — file it under that section (null for the
      * default "Channels" group). Only the shared `channels` prop is reloaded so
      * the sidebar re-partitions in place.
+     *
+     * The drag itself is the optimistic mutation, and vuedraggable has already
+     * made it by the time this runs — so the write applies nothing of its own,
+     * and its rollback drops the refused drag by re-partitioning from the props.
      */
     function persistPlacement(
         channel: Channel,
@@ -106,22 +111,17 @@ export function useChannelPlacement(): ChannelPlacement {
             payload.section_id = sectionId;
         }
 
-        router.patch(
-            updateChannelPlacement({
+        write({
+            capture: () => syncSidebarGroups,
+            method: 'patch',
+            url: updateChannelPlacement({
                 team: currentTeam.value?.slug ?? '',
                 channel: channel.slug,
             }).url,
-            payload,
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channels'],
-                onError: () => {
-                    syncSidebarGroups();
-                    toast.error(t('Failed to save the sidebar layout'));
-                },
-            },
-        );
+            data: payload,
+            only: CHANNEL_LIST_PROPS,
+            failure: t('Failed to save the sidebar layout'),
+        });
     }
 
     function onChannelChange(
@@ -169,19 +169,16 @@ export function useChannelPlacement(): ChannelPlacement {
     }
 
     function onSectionReorder(): void {
-        router.patch(
-            reorderSections({ team: currentTeam.value?.slug ?? '' }).url,
-            { sections: customGroups.value.map((group) => group.section.id) },
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channelSections'],
-                onError: () => {
-                    syncSidebarGroups();
-                    toast.error(t('Failed to save the section order'));
-                },
+        write({
+            capture: () => syncSidebarGroups,
+            method: 'patch',
+            url: reorderSections({ team: currentTeam.value?.slug ?? '' }).url,
+            data: {
+                sections: customGroups.value.map((group) => group.section.id),
             },
-        );
+            only: CHANNEL_SECTION_PROPS,
+            failure: t('Failed to save the section order'),
+        });
     }
 
     return {

--- a/resources/js/composables/useChannelPreferences.ts
+++ b/resources/js/composables/useChannelPreferences.ts
@@ -1,14 +1,16 @@
-import { router } from '@inertiajs/vue3';
 import type { AcceptableValue } from 'reka-ui';
 import { computed, ref, watch } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
 import { update as updateChannelPreferences } from '@/actions/App/Http/Controllers/Channels/ChannelPreferenceController';
 import { update as updateChannelStar } from '@/actions/App/Http/Controllers/Channels/ChannelStarController';
-import { useToast } from '@/composables/useToast';
+import {
+    snapshotRef,
+    useOptimisticWrite,
+} from '@/composables/useOptimisticWrite';
 import { useTranslations } from '@/composables/useTranslations';
-import { backgroundVisit } from '@/lib/backgroundVisit';
 import { notificationIndicator } from '@/lib/notificationIndicator';
 import type { NotificationIndicator } from '@/lib/notificationIndicator';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import type { Channel, NotificationLevel } from '@/types';
 
 /** The member's own star/mute/notification state for the open channel. */
@@ -57,7 +59,7 @@ export function useChannelPreferences(
     options: ChannelPreferencesOptions,
 ): ChannelPreferences {
     const { t } = useTranslations();
-    const toast = useToast();
+    const { write } = useOptimisticWrite();
     const notificationLevel = ref<NotificationLevel>(
         options.channel().notificationLevel,
     );
@@ -88,66 +90,63 @@ export function useChannelPreferences(
     );
 
     function toggleStar(): void {
-        const previous = starred.value;
-        starred.value = !previous;
-
-        router.patch(
-            updateChannelStar({
+        write({
+            capture: () => snapshotRef(starred),
+            apply: () => {
+                starred.value = !starred.value;
+            },
+            method: 'patch',
+            url: updateChannelStar({
                 team: options.teamSlug(),
                 channel: options.channelSlug(),
             }).url,
-            { starred: starred.value },
-            {
-                // Applied optimistically, so nothing on screen waits for it: it
-                // must not interrupt the navigation a user often fires right
-                // after starring; see {@see backgroundVisit}.
-                ...backgroundVisit,
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channels'],
-                onError: () => {
-                    starred.value = previous;
-                    toast.error(t('Failed to update the channel'));
-                },
-            },
-        );
+            // Read after `apply`, because the endpoint takes the new value and
+            // the write is what decided it.
+            data: () => ({ starred: starred.value }),
+            only: CHANNEL_LIST_PROPS,
+            // Applied optimistically, so nothing on screen waits for it: it must
+            // not interrupt the navigation a user often fires right after
+            // starring; see {@see backgroundVisit}.
+            background: true,
+            failure: t('Failed to update the channel'),
+        });
     }
 
-    function savePreferences(rollback: () => void): void {
-        router.patch(
-            updateChannelPreferences({
+    /**
+     * Save the notification pair. Both preferences post together — the endpoint
+     * takes them as one payload — so a change to either snapshots only the ref
+     * it moves and the other rides along at whatever it already was.
+     */
+    function savePreferences(changed: Ref<unknown>, apply: () => void): void {
+        write({
+            capture: () => snapshotRef(changed),
+            apply,
+            method: 'patch',
+            url: updateChannelPreferences({
                 team: options.teamSlug(),
                 channel: options.channelSlug(),
             }).url,
-            { muted: muted.value, notification_level: notificationLevel.value },
-            {
-                // Optimistic like the star above, and dismissing the menu often
-                // coincides with a navigation; see {@see backgroundVisit}.
-                ...backgroundVisit,
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channels'],
-                onError: () => {
-                    rollback();
-                    toast.error(t('Failed to update notification preferences'));
-                },
-            },
-        );
+            data: () => ({
+                muted: muted.value,
+                notification_level: notificationLevel.value,
+            }),
+            only: CHANNEL_LIST_PROPS,
+            // Optimistic like the star above, and dismissing the menu often
+            // coincides with a navigation; see {@see backgroundVisit}.
+            background: true,
+            failure: t('Failed to update notification preferences'),
+        });
     }
 
     function onNotificationLevelChange(value: AcceptableValue): void {
-        const previous = notificationLevel.value;
-        notificationLevel.value = value as NotificationLevel;
-        savePreferences(() => {
-            notificationLevel.value = previous;
+        savePreferences(notificationLevel, () => {
+            notificationLevel.value = value as NotificationLevel;
         });
     }
 
     function onMuteChange(value: boolean): void {
-        const previous = muted.value;
-        muted.value = value;
-        savePreferences(() => {
-            muted.value = previous;
+        savePreferences(muted, () => {
+            muted.value = value;
         });
     }
 

--- a/resources/js/composables/useChannelSections.ts
+++ b/resources/js/composables/useChannelSections.ts
@@ -1,14 +1,19 @@
 import { router, usePage } from '@inertiajs/vue3';
-import { computed, ref } from 'vue';
+import { computed, ref, toRef } from 'vue';
 import type { Ref } from 'vue';
 import {
     destroy as destroySection,
     store as storeSection,
     update as updateSection,
 } from '@/actions/App/Http/Controllers/Channels/ChannelSectionController';
+import {
+    snapshotRef,
+    useOptimisticWrite,
+} from '@/composables/useOptimisticWrite';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import type { ChannelSectionGroup } from '@/lib/channelSections';
+import { CHANNEL_LIST_PROPS, CHANNEL_SECTION_PROPS } from '@/lib/reloadProps';
 import type { ChannelSection } from '@/types/channels';
 
 /**
@@ -70,6 +75,7 @@ export function useChannelSections(): ChannelSections {
     const page = usePage();
     const { t } = useTranslations();
     const toast = useToast();
+    const { write } = useOptimisticWrite();
 
     const teamSlug = computed(() => page.props.currentTeam?.slug ?? '');
 
@@ -98,7 +104,7 @@ export function useChannelSections(): ChannelSections {
             {
                 preserveScroll: true,
                 preserveState: true,
-                only: ['channelSections'],
+                only: CHANNEL_SECTION_PROPS,
                 onSuccess: () => cancelSectionForm(),
                 onError: () => {
                     toast.error(t('Failed to create the section'));
@@ -132,7 +138,7 @@ export function useChannelSections(): ChannelSections {
             {
                 preserveScroll: true,
                 preserveState: true,
-                only: ['channelSections'],
+                only: CHANNEL_SECTION_PROPS,
                 onSuccess: () => cancelRename(),
                 onError: () => {
                     toast.error(t('Failed to rename the section'));
@@ -147,7 +153,7 @@ export function useChannelSections(): ChannelSections {
             {
                 preserveScroll: true,
                 preserveState: true,
-                only: ['channels', 'channelSections'],
+                only: [...CHANNEL_LIST_PROPS, ...CHANNEL_SECTION_PROPS],
                 onError: () => {
                     toast.error(t('Failed to delete the section'));
                 },
@@ -156,23 +162,24 @@ export function useChannelSections(): ChannelSections {
     }
 
     function toggleCustomSection(group: ChannelSectionGroup): void {
-        const previous = group.section.collapsed;
-        group.section.collapsed = !previous;
+        // The flag lives on the section row rather than in a ref of its own, so
+        // the snapshot is taken through a writable ref into that property.
+        const collapsed = toRef(group.section, 'collapsed');
 
-        router.patch(
-            updateSection({ team: teamSlug.value, section: group.section.id })
-                .url,
-            { collapsed: group.section.collapsed },
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channelSections'],
-                onError: () => {
-                    group.section.collapsed = previous;
-                    toast.error(t('Failed to save the sidebar layout'));
-                },
+        write({
+            capture: () => snapshotRef(collapsed),
+            apply: () => {
+                collapsed.value = !collapsed.value;
             },
-        );
+            method: 'patch',
+            url: updateSection({
+                team: teamSlug.value,
+                section: group.section.id,
+            }).url,
+            data: () => ({ collapsed: collapsed.value }),
+            only: CHANNEL_SECTION_PROPS,
+            failure: t('Failed to save the sidebar layout'),
+        });
     }
 
     return {

--- a/resources/js/composables/useCollapsedSections.ts
+++ b/resources/js/composables/useCollapsedSections.ts
@@ -1,10 +1,14 @@
-import { router, usePage } from '@inertiajs/vue3';
+import { usePage } from '@inertiajs/vue3';
 import { ref, watch } from 'vue';
 import { update as updateSidebarSections } from '@/actions/App/Http/Controllers/SidebarSectionController';
-import { useToast } from '@/composables/useToast';
+import {
+    snapshotRef,
+    useOptimisticWrite,
+} from '@/composables/useOptimisticWrite';
 import { useTranslations } from '@/composables/useTranslations';
 import { toggleCollapsedSection } from '@/lib/channelSections';
 import type { SidebarSectionKey } from '@/lib/channelSections';
+import { COLLAPSED_SECTION_PROPS } from '@/lib/reloadProps';
 
 export interface CollapsedSections {
     /** Whether the given built-in section is currently collapsed. */
@@ -25,7 +29,7 @@ export interface CollapsedSections {
 export function useCollapsedSections(): CollapsedSections {
     const page = usePage();
     const { t } = useTranslations();
-    const toast = useToast();
+    const { write } = useOptimisticWrite();
 
     const collapsedSections = ref<string[]>([
         ...(page.props.collapsedChannelSections ?? []),
@@ -43,23 +47,19 @@ export function useCollapsedSections(): CollapsedSections {
     }
 
     function toggleSection(section: SidebarSectionKey): void {
-        const previous = collapsedSections.value;
-        const next = toggleCollapsedSection(previous, section);
-        collapsedSections.value = next;
+        const next = toggleCollapsedSection(collapsedSections.value, section);
 
-        router.patch(
-            updateSidebarSections().url,
-            { collapsed: next },
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['collapsedChannelSections'],
-                onError: () => {
-                    collapsedSections.value = previous;
-                    toast.error(t('Failed to save the sidebar layout'));
-                },
+        write({
+            capture: () => snapshotRef(collapsedSections),
+            apply: () => {
+                collapsedSections.value = next;
             },
-        );
+            method: 'patch',
+            url: updateSidebarSections().url,
+            data: { collapsed: next },
+            only: COLLAPSED_SECTION_PROPS,
+            failure: t('Failed to save the sidebar layout'),
+        });
     }
 
     return { isSectionCollapsed, toggleSection };

--- a/resources/js/composables/useMessageEdits.test.ts
+++ b/resources/js/composables/useMessageEdits.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { post, patch, destroy, toastError } = vi.hoisted(() => ({
+    post: vi.fn(),
+    patch: vi.fn(),
+    destroy: vi.fn(),
+    toastError: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post, patch, delete: destroy },
+}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
+
+import { shown, streams } from '@/composables/messageWrites.harness';
+import { channel, me, message } from '@/composables/useMessageActions.harness';
+import { useMessageEdits } from '@/composables/useMessageEdits';
+import type { Message } from '@/types';
+
+function harness(overrides: Partial<Message> = {}) {
+    const row = message(overrides);
+    const { mainStream, threadStream, unmount } = streams([row]);
+
+    const edits = useMessageEdits({
+        teamSlug: () => 'acme',
+        channel: () => channel,
+        currentUser: () => me,
+        mainStream,
+        threadStream,
+    });
+
+    return { edits, row, mainStream, threadStream, unmount };
+}
+
+describe('useMessageEdits', () => {
+    beforeEach(() => {
+        post.mockClear();
+        patch.mockClear();
+        destroy.mockClear();
+        toastError.mockClear();
+    });
+
+    it('puts the original body back in both streams when an edit is refused', () => {
+        const { edits, row, mainStream, threadStream, unmount } = harness();
+
+        edits.editMessage(row, 'a better sentence');
+
+        expect(shown(mainStream, row.id).body).toBe('a better sentence');
+        expect(shown(threadStream, row.id).body).toBe('a better sentence');
+
+        patch.mock.calls[0][2].onError({});
+
+        expect(shown(mainStream, row.id).body).toBe('hello');
+        expect(shown(threadStream, row.id).body).toBe('hello');
+        expect(toastError).toHaveBeenCalledWith('Your edit failed to save');
+
+        unmount();
+    });
+
+    it('takes the tombstone back out of both streams when a delete is refused', () => {
+        const { edits, row, mainStream, threadStream, unmount } = harness();
+
+        edits.deleteMessage(row);
+
+        expect(shown(mainStream, row.id).isDeleted).toBe(true);
+        expect(shown(threadStream, row.id).isDeleted).toBe(true);
+
+        destroy.mock.calls[0][1].onError({});
+
+        expect(shown(mainStream, row.id).isDeleted).toBe(false);
+        expect(shown(mainStream, row.id).body).toBe('hello');
+        expect(shown(threadStream, row.id).isDeleted).toBe(false);
+        expect(toastError).toHaveBeenCalledWith('Failed to delete the message');
+
+        unmount();
+    });
+
+    it('takes the reaction back out of both streams when the write is refused', () => {
+        const { edits, row, mainStream, threadStream, unmount } = harness();
+
+        edits.reactToMessage(row, '🎉');
+
+        expect(shown(mainStream, row.id).reactions).toHaveLength(1);
+        expect(shown(threadStream, row.id).reactions).toHaveLength(1);
+
+        post.mock.calls[0][2].onError({});
+
+        expect(shown(mainStream, row.id).reactions).toEqual([]);
+        expect(shown(threadStream, row.id).reactions).toEqual([]);
+        expect(toastError).toHaveBeenCalledWith(
+            'Failed to update the reaction',
+        );
+
+        unmount();
+    });
+
+    it('restores an edit made over an earlier one to that earlier one', () => {
+        // The snapshot is whatever the streams were already carrying, not the
+        // server's row: editing twice and having the second refused must land
+        // back on the first edit rather than on the original body.
+        const { edits, row, mainStream, unmount } = harness();
+
+        edits.editMessage(row, 'first edit');
+        patch.mock.calls[0][2].onSuccess?.({});
+
+        edits.editMessage(shown(mainStream, row.id), 'second edit');
+        patch.mock.calls[1][2].onError({});
+
+        expect(shown(mainStream, row.id).body).toBe('first edit');
+
+        unmount();
+    });
+});

--- a/resources/js/composables/useMessageEdits.ts
+++ b/resources/js/composables/useMessageEdits.ts
@@ -1,13 +1,17 @@
-import { router } from '@inertiajs/vue3';
 import {
     destroy as destroyMessage,
     update as updateMessage,
 } from '@/actions/App/Http/Controllers/Channels/MessageController';
 import { store as toggleReactionAction } from '@/actions/App/Http/Controllers/Channels/ReactionController';
 import type { MessageActionsOptions } from '@/composables/useMessageActions';
-import { useToast } from '@/composables/useToast';
+import {
+    snapshotStreams,
+    useOptimisticWrite,
+} from '@/composables/useOptimisticWrite';
+import type { Rollback } from '@/composables/useOptimisticWrite';
 import { useTranslations } from '@/composables/useTranslations';
 import { toggleReaction } from '@/lib/reactions';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import type { Message } from '@/types';
 
 export interface MessageEdits {
@@ -31,7 +35,7 @@ export type MessageEditsOptions = Pick<
  */
 export function useMessageEdits(options: MessageEditsOptions): MessageEdits {
     const { t } = useTranslations();
-    const toast = useToast();
+    const { write } = useOptimisticWrite();
 
     /** Patch a message into both timelines at once; ignored where it isn't shown. */
     function applyPatch(message: Message): void {
@@ -39,112 +43,83 @@ export function useMessageEdits(options: MessageEditsOptions): MessageEdits {
         options.threadStream.applyPatch(message);
     }
 
+    /** Snapshot the row wherever it is showing, so a refusal restores both. */
+    function snapshotBothStreams(message: Message): Rollback {
+        return snapshotStreams(
+            message.clientUuid,
+            options.mainStream,
+            options.threadStream,
+        );
+    }
+
     function editMessage(message: Message, body: string): void {
         const channel = options.channel();
-        const previousMain = options.mainStream.getPatch(message.clientUuid);
-        const previousThread = options.threadStream.getPatch(
-            message.clientUuid,
-        );
 
-        // Optimistically show the edit; the broadcast echo later confirms it.
-        applyPatch({ ...message, body, editedAt: new Date().toISOString() });
-
-        router.patch(
-            updateMessage({
+        write({
+            capture: () => snapshotBothStreams(message),
+            // Optimistically show the edit; the broadcast echo later confirms it.
+            apply: () =>
+                applyPatch({
+                    ...message,
+                    body,
+                    editedAt: new Date().toISOString(),
+                }),
+            method: 'patch',
+            url: updateMessage({
                 team: options.teamSlug(),
                 channel: channel.slug,
                 message: message.id,
             }).url,
-            { body },
-            {
-                preserveScroll: true,
-                onError: () => {
-                    options.mainStream.restorePatch(
-                        message.clientUuid,
-                        previousMain,
-                    );
-                    options.threadStream.restorePatch(
-                        message.clientUuid,
-                        previousThread,
-                    );
-                    toast.error(t('Your edit failed to save'));
-                },
-            },
-        );
+            data: { body },
+            // Named no props and kept none: the response replaces the whole page
+            // prop set, which is how the edited row reaches every surface reading
+            // it rather than just the two streams patched above.
+            preserveState: false,
+            failure: t('Your edit failed to save'),
+        });
     }
 
     function deleteMessage(message: Message): void {
         const channel = options.channel();
-        const previousMain = options.mainStream.getPatch(message.clientUuid);
-        const previousThread = options.threadStream.getPatch(
-            message.clientUuid,
-        );
 
-        // Optimistically show the tombstone; the broadcast echo later confirms it.
-        applyPatch({ ...message, body: '', isDeleted: true });
-
-        router.delete(
-            destroyMessage({
+        write({
+            capture: () => snapshotBothStreams(message),
+            // Optimistically show the tombstone; the broadcast echo later confirms it.
+            apply: () => applyPatch({ ...message, body: '', isDeleted: true }),
+            method: 'delete',
+            url: destroyMessage({
                 team: options.teamSlug(),
                 channel: channel.slug,
                 message: message.id,
             }).url,
-            {
-                preserveScroll: true,
-                onError: () => {
-                    options.mainStream.restorePatch(
-                        message.clientUuid,
-                        previousMain,
-                    );
-                    options.threadStream.restorePatch(
-                        message.clientUuid,
-                        previousThread,
-                    );
-                    toast.error(t('Failed to delete the message'));
-                },
-            },
-        );
+            preserveState: false,
+            failure: t('Failed to delete the message'),
+        });
     }
 
     function reactToMessage(message: Message, emoji: string): void {
         const channel = options.channel();
-        const previousMain = options.mainStream.getPatch(message.clientUuid);
-        const previousThread = options.threadStream.getPatch(
-            message.clientUuid,
-        );
-
         const next = toggleReaction(
             message.reactions,
             emoji,
             options.currentUser(),
         );
-        options.mainStream.patchReactions(message.id, next);
-        options.threadStream.patchReactions(message.id, next);
 
-        router.post(
-            toggleReactionAction({
+        write({
+            capture: () => snapshotBothStreams(message),
+            apply: () => {
+                options.mainStream.patchReactions(message.id, next);
+                options.threadStream.patchReactions(message.id, next);
+            },
+            url: toggleReactionAction({
                 team: options.teamSlug(),
                 channel: channel.slug,
                 message: message.id,
             }).url,
-            { emoji },
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channels'],
-                onError: () => {
-                    options.mainStream.restorePatch(
-                        message.clientUuid,
-                        previousMain,
-                    );
-                    options.threadStream.restorePatch(
-                        message.clientUuid,
-                        previousThread,
-                    );
-                    toast.error(t('Failed to update the reaction'));
-                },
-            },
-        );
+            data: { emoji },
+            only: CHANNEL_LIST_PROPS,
+            failure: t('Failed to update the reaction'),
+        });
     }
 
     return { editMessage, deleteMessage, reactToMessage };

--- a/resources/js/composables/useMessageForwarding.test.ts
+++ b/resources/js/composables/useMessageForwarding.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { post, destroy, toastError, toastSuccess } = vi.hoisted(() => ({
+    post: vi.fn(),
+    destroy: vi.fn(),
+    toastError: vi.fn(),
+    toastSuccess: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post, patch: vi.fn(), delete: destroy },
+}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: toastSuccess,
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
+
+import { streams } from '@/composables/messageWrites.harness';
+import { channel, me, message } from '@/composables/useMessageActions.harness';
+import { useMessageForwarding } from '@/composables/useMessageForwarding';
+import type { Message } from '@/types';
+import type { ForwardTarget } from '@/types/forward';
+
+/** The open channel, so the copy renders optimistically in the timeline. */
+const HERE: ForwardTarget = {
+    kind: 'channel',
+    id: channel.id,
+    name: channel.name,
+};
+
+/** Somewhere else, so the copy is only reported by a toast. */
+const ELSEWHERE: ForwardTarget = {
+    kind: 'channel',
+    id: 'chan-2',
+    name: 'random',
+};
+
+function harness() {
+    const source = message();
+    const { mainStream, unmount } = streams([source]);
+    const appended: Message[] = [];
+
+    const forwarding = useMessageForwarding({
+        teamSlug: () => 'acme',
+        channel: () => channel,
+        currentUser: () => me,
+        mainStream,
+        appendPendingMain: (row) => {
+            appended.push(row);
+            mainStream.addPending(row);
+        },
+    });
+
+    return { forwarding, source, mainStream, appended, unmount };
+}
+
+/** The client uuid the forward minted, as it posted it. */
+function postedUuid(): string {
+    return post.mock.calls[0][1].client_uuid as string;
+}
+
+describe('useMessageForwarding', () => {
+    beforeEach(() => {
+        post.mockClear();
+        destroy.mockClear();
+        toastError.mockClear();
+        toastSuccess.mockClear();
+    });
+
+    it('renders the copy in the timeline when it lands in the open channel', () => {
+        const { forwarding, source, mainStream, appended, unmount } = harness();
+
+        forwarding.forwardMessage(source, { target: HERE, note: 'look' });
+
+        expect(appended).toHaveLength(1);
+        expect(mainStream.pendingUuids.value).toEqual([postedUuid()]);
+
+        unmount();
+    });
+
+    it('takes the optimistic copy back out when the forward is refused', () => {
+        const { forwarding, source, mainStream, unmount } = harness();
+
+        forwarding.forwardMessage(source, { target: HERE, note: 'look' });
+        post.mock.calls[0][2].onError({});
+
+        expect(mainStream.pendingUuids.value).toEqual([]);
+        expect(toastError).toHaveBeenCalledWith(
+            'Failed to forward the message',
+        );
+
+        unmount();
+    });
+
+    it('renders nothing locally for a forward sent somewhere else', () => {
+        const { forwarding, source, mainStream, appended, unmount } = harness();
+
+        forwarding.forwardMessage(source, { target: ELSEWHERE, note: 'look' });
+
+        expect(appended).toEqual([]);
+        expect(mainStream.pendingUuids.value).toEqual([]);
+
+        unmount();
+    });
+
+    it('says a forward sent elsewhere failed, with no row to take back', () => {
+        const { forwarding, source, mainStream, unmount } = harness();
+
+        forwarding.forwardMessage(source, { target: ELSEWHERE, note: 'look' });
+        post.mock.calls[0][2].onError({});
+
+        expect(mainStream.pendingUuids.value).toEqual([]);
+        expect(toastError).toHaveBeenCalledWith(
+            'Failed to forward the message',
+        );
+
+        unmount();
+    });
+
+    it('confirms a forward sent elsewhere, with an Undo onto the copy', () => {
+        const { forwarding, source, unmount } = harness();
+
+        forwarding.forwardMessage(source, { target: ELSEWHERE, note: 'look' });
+        post.mock.calls[0][2].onSuccess({
+            flash: { forwarded: { messageId: 'm9', channelSlug: 'random' } },
+        });
+
+        expect(toastSuccess).toHaveBeenCalledWith(
+            'Message forwarded to #random',
+            expect.objectContaining({
+                action: expect.objectContaining({ label: 'Undo' }),
+            }),
+        );
+
+        toastSuccess.mock.calls[0][1].action.run();
+
+        expect(destroy).toHaveBeenCalledWith(
+            '/t/acme/c/random/messages/m9',
+            expect.objectContaining({ preserveUrl: true }),
+        );
+
+        unmount();
+    });
+
+    it('stays silent for a forward that landed in the channel on screen', () => {
+        const { forwarding, source, unmount } = harness();
+
+        forwarding.forwardMessage(source, { target: HERE, note: 'look' });
+        post.mock.calls[0][2].onSuccess({ flash: {} });
+
+        expect(toastSuccess).not.toHaveBeenCalled();
+
+        unmount();
+    });
+});

--- a/resources/js/composables/useMessageForwarding.ts
+++ b/resources/js/composables/useMessageForwarding.ts
@@ -106,14 +106,19 @@ export function useMessageForwarding(
         const clientUuid = generateUuid();
         const plan = planForward({ target, channel });
 
+        /**
+         * The rollback. A copy only renders here when it lands in the open
+         * channel, so a forward sent elsewhere has nothing to take back and
+         * this is a no-op for it.
+         */
+        function dropOptimisticCopy(): void {
+            if (plan.toCurrentChannel) {
+                options.mainStream.removePending(clientUuid);
+            }
+        }
+
         write({
-            // The copy only renders here when it lands in the open channel; a
-            // forward sent elsewhere shows nothing to take back.
-            capture: () => () => {
-                if (plan.toCurrentChannel) {
-                    options.mainStream.removePending(clientUuid);
-                }
-            },
+            capture: () => dropOptimisticCopy,
             apply: () => {
                 if (!plan.toCurrentChannel) {
                     return;

--- a/resources/js/composables/useMessageForwarding.ts
+++ b/resources/js/composables/useMessageForwarding.ts
@@ -3,9 +3,11 @@ import { store as forwardMessageAction } from '@/actions/App/Http/Controllers/Ch
 import { destroy as destroyMessage } from '@/actions/App/Http/Controllers/Channels/MessageController';
 import type { MessageActionsOptions } from '@/composables/useMessageActions';
 import { optimisticMessage } from '@/composables/useMessageStream';
+import { useOptimisticWrite } from '@/composables/useOptimisticWrite';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { planForward } from '@/lib/forwardPlacement';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import { generateUuid } from '@/lib/uuid';
 import type { Message } from '@/types';
 import type { ForwardTarget } from '@/types/forward';
@@ -67,6 +69,7 @@ export function useMessageForwarding(
 ): MessageForwarding {
     const { t } = useTranslations();
     const toast = useToast();
+    const { write } = useOptimisticWrite();
 
     /**
      * Delete the forwarded copy where it landed. The destroy route redirects to
@@ -88,7 +91,7 @@ export function useMessageForwarding(
                 preserveScroll: true,
                 preserveState: true,
                 preserveUrl: true,
-                only: ['channels'],
+                only: CHANNEL_LIST_PROPS,
                 onError: () => toast.error(t('Failed to undo the forward')),
             },
         );
@@ -103,72 +106,72 @@ export function useMessageForwarding(
         const clientUuid = generateUuid();
         const plan = planForward({ target, channel });
 
-        if (plan.toCurrentChannel) {
-            options.appendPendingMain(
-                optimisticMessage({
-                    clientUuid,
-                    body: note,
-                    author: options.currentUser(),
-                    mentions: [],
-                    forwardedFrom: {
-                        id: source.id,
-                        body: source.body,
-                        authorName: source.user.name,
-                        authorIsBot: source.user.isBot,
-                        authorOverride: source.authorOverride ?? null,
-                        channelName: plan.quoteChannelName,
-                        isDeleted: source.isDeleted,
-                        mentions: source.mentions,
-                    },
-                }),
-            );
-        }
+        write({
+            // The copy only renders here when it lands in the open channel; a
+            // forward sent elsewhere shows nothing to take back.
+            capture: () => () => {
+                if (plan.toCurrentChannel) {
+                    options.mainStream.removePending(clientUuid);
+                }
+            },
+            apply: () => {
+                if (!plan.toCurrentChannel) {
+                    return;
+                }
 
-        router.post(
-            forwardMessageAction({
+                options.appendPendingMain(
+                    optimisticMessage({
+                        clientUuid,
+                        body: note,
+                        author: options.currentUser(),
+                        mentions: [],
+                        forwardedFrom: {
+                            id: source.id,
+                            body: source.body,
+                            authorName: source.user.name,
+                            authorIsBot: source.user.isBot,
+                            authorOverride: source.authorOverride ?? null,
+                            channelName: plan.quoteChannelName,
+                            isDeleted: source.isDeleted,
+                            mentions: source.mentions,
+                        },
+                    }),
+                );
+            },
+            url: forwardMessageAction({
                 team: options.teamSlug(),
                 channel: channel.slug,
                 message: source.id,
             }).url,
-            { body: note, client_uuid: clientUuid, ...plan.destination },
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channels'],
-                onSuccess: (page) => {
-                    if (plan.toCurrentChannel) {
-                        return;
-                    }
+            data: { body: note, client_uuid: clientUuid, ...plan.destination },
+            only: CHANNEL_LIST_PROPS,
+            onSuccess: (page) => {
+                if (plan.toCurrentChannel) {
+                    return;
+                }
 
-                    const copy = forwardedCopy(page);
+                const copy = forwardedCopy(page);
 
-                    toast.success(
-                        target.kind === 'channel'
-                            ? t('Message forwarded to #:channel', {
-                                  channel: target.name,
-                              })
-                            : t('Message forwarded to :name', {
-                                  name: target.name,
-                              }),
-                        copy
-                            ? {
-                                  action: {
-                                      label: t('Undo'),
-                                      run: () => undoForward(copy),
-                                  },
-                              }
-                            : {},
-                    );
-                },
-                onError: () => {
-                    if (plan.toCurrentChannel) {
-                        options.mainStream.removePending(clientUuid);
-                    }
-
-                    toast.error(t('Failed to forward the message'));
-                },
+                toast.success(
+                    target.kind === 'channel'
+                        ? t('Message forwarded to #:channel', {
+                              channel: target.name,
+                          })
+                        : t('Message forwarded to :name', {
+                              name: target.name,
+                          }),
+                    copy
+                        ? {
+                              action: {
+                                  label: t('Undo'),
+                                  run: () => undoForward(copy),
+                              },
+                          }
+                        : {},
+                );
             },
-        );
+            failure: t('Failed to forward the message'),
+        });
     }
 
     return { forwardMessage };

--- a/resources/js/composables/useMessagePins.test.ts
+++ b/resources/js/composables/useMessagePins.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { post, destroy, toastError } = vi.hoisted(() => ({
+    post: vi.fn(),
+    destroy: vi.fn(),
+    toastError: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post, patch: vi.fn(), delete: destroy },
+}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
+
+import { shown, streams } from '@/composables/messageWrites.harness';
+import { channel, me, message } from '@/composables/useMessageActions.harness';
+import { useMessagePins } from '@/composables/useMessagePins';
+import type { MessagePin } from '@/types';
+
+const EXISTING_PIN: MessagePin = {
+    pinnedBy: { id: 'peer', name: 'Peer' },
+    pinnedAt: '2024-01-01T12:00:00.000Z',
+};
+
+function harness(pin: MessagePin | null = null) {
+    const row = message({ pin });
+    const { mainStream, threadStream, unmount } = streams([row]);
+
+    const pins = useMessagePins({
+        teamSlug: () => 'acme',
+        channel: () => channel,
+        currentUser: () => me,
+        mainStream,
+        threadStream,
+    });
+
+    return { pins, row, mainStream, threadStream, unmount };
+}
+
+describe('useMessagePins', () => {
+    beforeEach(() => {
+        post.mockClear();
+        destroy.mockClear();
+        toastError.mockClear();
+    });
+
+    it('shows the pin in both streams before the server has agreed', () => {
+        const { pins, row, mainStream, threadStream, unmount } = harness();
+
+        pins.pinMessage(row);
+
+        expect(shown(mainStream, row.id).pin?.pinnedBy).toEqual(me);
+        expect(shown(threadStream, row.id).pin?.pinnedBy).toEqual(me);
+
+        unmount();
+    });
+
+    it('takes the pin back out of both streams when the write is refused', () => {
+        // The two streams are independent, so a rollback that reached only the
+        // timeline would leave the same message pinned in the thread beside it.
+        const { pins, row, mainStream, threadStream, unmount } = harness();
+
+        pins.pinMessage(row);
+        post.mock.calls[0][2].onError({});
+
+        expect(shown(mainStream, row.id).pin).toBeNull();
+        expect(shown(threadStream, row.id).pin).toBeNull();
+
+        unmount();
+    });
+
+    it('says the pin failed', () => {
+        const { pins, row, unmount } = harness();
+
+        pins.pinMessage(row);
+        post.mock.calls[0][2].onError({});
+
+        expect(toastError).toHaveBeenCalledWith(
+            'Failed to pin the message. Please try again.',
+        );
+
+        unmount();
+    });
+
+    it('prefers the cap message the server refused with', () => {
+        const { pins, row, unmount } = harness();
+
+        pins.pinMessage(row);
+        post.mock.calls[0][2].onError({
+            message: 'This channel already has 100 pins.',
+        });
+
+        expect(toastError).toHaveBeenCalledWith(
+            'This channel already has 100 pins.',
+        );
+
+        unmount();
+    });
+
+    it('puts the existing pin back in both streams when an unpin is refused', () => {
+        const { pins, row, mainStream, threadStream, unmount } =
+            harness(EXISTING_PIN);
+
+        pins.unpinMessage(row);
+
+        expect(shown(mainStream, row.id).pin).toBeNull();
+        expect(shown(threadStream, row.id).pin).toBeNull();
+
+        destroy.mock.calls[0][1].onError({});
+
+        expect(shown(mainStream, row.id).pin).toEqual(EXISTING_PIN);
+        expect(shown(threadStream, row.id).pin).toEqual(EXISTING_PIN);
+        expect(toastError).toHaveBeenCalledWith('Failed to unpin the message');
+
+        unmount();
+    });
+});

--- a/resources/js/composables/useMessagePins.ts
+++ b/resources/js/composables/useMessagePins.ts
@@ -1,11 +1,14 @@
-import { router } from '@inertiajs/vue3';
 import {
     destroy as unpinMessageAction,
     store as pinMessageAction,
 } from '@/actions/App/Http/Controllers/Channels/PinController';
 import type { MessageActionsOptions } from '@/composables/useMessageActions';
-import { useToast } from '@/composables/useToast';
+import {
+    snapshotStreams,
+    useOptimisticWrite,
+} from '@/composables/useOptimisticWrite';
 import { useTranslations } from '@/composables/useTranslations';
+import { PIN_PROPS } from '@/lib/reloadProps';
 import type { Message, MessagePin } from '@/types';
 
 export interface MessagePins {
@@ -23,7 +26,7 @@ export type MessagePinsOptions = Pick<
 /** The channel's shared pin toggle, from either side. */
 export function useMessagePins(options: MessagePinsOptions): MessagePins {
     const { t } = useTranslations();
-    const toast = useToast();
+    const { write } = useOptimisticWrite();
 
     /**
      * Pin a message to its channel. The indicator is applied optimistically to
@@ -34,45 +37,32 @@ export function useMessagePins(options: MessagePinsOptions): MessagePins {
      */
     function pinMessage(message: Message): void {
         const channel = options.channel();
-        const previousMain = options.mainStream.getPatch(message.clientUuid);
-        const previousThread = options.threadStream.getPatch(
-            message.clientUuid,
-        );
-
         const optimisticPin: MessagePin = {
             pinnedBy: options.currentUser(),
             pinnedAt: new Date().toISOString(),
         };
-        options.mainStream.patchPin(message.id, optimisticPin);
-        options.threadStream.patchPin(message.id, optimisticPin);
 
-        router.post(
-            pinMessageAction({
+        write({
+            capture: () =>
+                snapshotStreams(
+                    message.clientUuid,
+                    options.mainStream,
+                    options.threadStream,
+                ),
+            apply: () => {
+                options.mainStream.patchPin(message.id, optimisticPin);
+                options.threadStream.patchPin(message.id, optimisticPin);
+            },
+            url: pinMessageAction({
                 team: options.teamSlug(),
                 channel: channel.slug,
                 message: message.id,
             }).url,
-            {},
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['pins', 'pinCount'],
-                onError: (errors: Record<string, string>) => {
-                    options.mainStream.restorePatch(
-                        message.clientUuid,
-                        previousMain,
-                    );
-                    options.threadStream.restorePatch(
-                        message.clientUuid,
-                        previousThread,
-                    );
-                    toast.error(
-                        errors.message ??
-                            t('Failed to pin the message. Please try again.'),
-                    );
-                },
-            },
-        );
+            only: PIN_PROPS,
+            failure: (errors) =>
+                errors.message ??
+                t('Failed to pin the message. Please try again.'),
+        });
     }
 
     /**
@@ -82,37 +72,27 @@ export function useMessagePins(options: MessagePinsOptions): MessagePins {
      */
     function unpinMessage(message: Message): void {
         const channel = options.channel();
-        const previousMain = options.mainStream.getPatch(message.clientUuid);
-        const previousThread = options.threadStream.getPatch(
-            message.clientUuid,
-        );
 
-        options.mainStream.patchPin(message.id, null);
-        options.threadStream.patchPin(message.id, null);
-
-        router.delete(
-            unpinMessageAction({
+        write({
+            capture: () =>
+                snapshotStreams(
+                    message.clientUuid,
+                    options.mainStream,
+                    options.threadStream,
+                ),
+            apply: () => {
+                options.mainStream.patchPin(message.id, null);
+                options.threadStream.patchPin(message.id, null);
+            },
+            method: 'delete',
+            url: unpinMessageAction({
                 team: options.teamSlug(),
                 channel: channel.slug,
                 message: message.id,
             }).url,
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['pins', 'pinCount'],
-                onError: () => {
-                    options.mainStream.restorePatch(
-                        message.clientUuid,
-                        previousMain,
-                    );
-                    options.threadStream.restorePatch(
-                        message.clientUuid,
-                        previousThread,
-                    );
-                    toast.error(t('Failed to unpin the message'));
-                },
-            },
-        );
+            only: PIN_PROPS,
+            failure: t('Failed to unpin the message'),
+        });
     }
 
     return { pinMessage, unpinMessage };

--- a/resources/js/composables/useMessagePolls.test.ts
+++ b/resources/js/composables/useMessagePolls.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { post, toastError } = vi.hoisted(() => ({
+    post: vi.fn(),
+    toastError: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post, patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
+
+import { shown, streams } from '@/composables/messageWrites.harness';
+import { channel, me, message } from '@/composables/useMessageActions.harness';
+import { useMessagePolls } from '@/composables/useMessagePolls';
+import type { Poll } from '@/types';
+
+function poll(): Poll {
+    return {
+        id: 'poll-1',
+        question: 'Lunch?',
+        allowMultiple: false,
+        isAnonymous: false,
+        closedAt: null,
+        totalVotes: 0,
+        voterCount: 0,
+        options: [
+            {
+                id: 'o1',
+                label: 'Ramen',
+                position: 0,
+                voteCount: 0,
+                voters: [],
+                votedByViewer: false,
+            },
+            {
+                id: 'o2',
+                label: 'Tacos',
+                position: 1,
+                voteCount: 0,
+                voters: [],
+                votedByViewer: false,
+            },
+        ],
+    };
+}
+
+function harness() {
+    const row = message({ poll: poll() });
+    const { mainStream, threadStream, unmount } = streams([row]);
+
+    const polls = useMessagePolls({
+        teamSlug: () => 'acme',
+        channel: () => channel,
+        currentUser: () => me,
+        mainStream,
+        threadStream,
+    });
+
+    return { polls, row, mainStream, threadStream, unmount };
+}
+
+/** The viewer's standing on the first option, as a stream currently shows it. */
+function firstOption(
+    stream: ReturnType<typeof streams>['mainStream'],
+    id: string,
+) {
+    return shown(stream, id).poll?.options[0];
+}
+
+describe('useMessagePolls', () => {
+    beforeEach(() => {
+        post.mockClear();
+        toastError.mockClear();
+    });
+
+    it('counts the vote in both streams before the server has agreed', () => {
+        const { polls, row, mainStream, threadStream, unmount } = harness();
+
+        polls.voteOnPoll(row, 'o1');
+
+        expect(firstOption(mainStream, row.id)?.votedByViewer).toBe(true);
+        expect(firstOption(threadStream, row.id)?.votedByViewer).toBe(true);
+
+        unmount();
+    });
+
+    it('takes the vote back out of both streams when the write is refused', () => {
+        const { polls, row, mainStream, threadStream, unmount } = harness();
+
+        polls.voteOnPoll(row, 'o1');
+        post.mock.calls[0][2].onError({});
+
+        expect(firstOption(mainStream, row.id)?.votedByViewer).toBe(false);
+        expect(firstOption(mainStream, row.id)?.voteCount).toBe(0);
+        expect(firstOption(threadStream, row.id)?.votedByViewer).toBe(false);
+        expect(firstOption(threadStream, row.id)?.voteCount).toBe(0);
+        expect(toastError).toHaveBeenCalledWith('Failed to record your vote');
+
+        unmount();
+    });
+
+    it('ignores a vote on a message carrying no poll', () => {
+        const row = message();
+        const { mainStream, threadStream, unmount } = streams([row]);
+
+        useMessagePolls({
+            teamSlug: () => 'acme',
+            channel: () => channel,
+            currentUser: () => me,
+            mainStream,
+            threadStream,
+        }).voteOnPoll(row, 'o1');
+
+        expect(post).not.toHaveBeenCalled();
+
+        unmount();
+    });
+
+    it('says closing the poll failed, having shown nothing to take back', () => {
+        // Closing is not optimistic: the frozen tally arrives over the
+        // broadcast, so there is no local patch a refusal would have to undo.
+        const { polls, row, mainStream, unmount } = harness();
+
+        polls.closePoll(row);
+        post.mock.calls[0][2].onError({});
+
+        expect(shown(mainStream, row.id).poll?.closedAt).toBeNull();
+        expect(toastError).toHaveBeenCalledWith('Failed to close the poll');
+
+        unmount();
+    });
+});

--- a/resources/js/composables/useMessagePolls.ts
+++ b/resources/js/composables/useMessagePolls.ts
@@ -4,9 +4,14 @@ import {
     vote as voteOnPollAction,
 } from '@/actions/App/Http/Controllers/Channels/PollController';
 import type { MessageActionsOptions } from '@/composables/useMessageActions';
+import {
+    snapshotStreams,
+    useOptimisticWrite,
+} from '@/composables/useOptimisticWrite';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { applyVote } from '@/lib/polls';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 import type { Message } from '@/types';
 
 export interface MessagePolls {
@@ -25,6 +30,7 @@ export type MessagePollsOptions = Pick<
 export function useMessagePolls(options: MessagePollsOptions): MessagePolls {
     const { t } = useTranslations();
     const toast = useToast();
+    const { write } = useOptimisticWrite();
 
     /**
      * Toggle the viewer's vote for a poll option. The tally is applied
@@ -39,45 +45,39 @@ export function useMessagePolls(options: MessagePollsOptions): MessagePolls {
         }
 
         const channel = options.channel();
-        const previousMain = options.mainStream.getPatch(message.clientUuid);
-        const previousThread = options.threadStream.getPatch(
-            message.clientUuid,
-        );
-
         const next = applyVote(message.poll, optionId, options.currentUser());
-        options.mainStream.patchThreadState(message.id, { poll: next });
-        options.threadStream.patchThreadState(message.id, { poll: next });
 
-        router.post(
-            voteOnPollAction({
+        write({
+            capture: () =>
+                snapshotStreams(
+                    message.clientUuid,
+                    options.mainStream,
+                    options.threadStream,
+                ),
+            apply: () => {
+                options.mainStream.patchThreadState(message.id, { poll: next });
+                options.threadStream.patchThreadState(message.id, {
+                    poll: next,
+                });
+            },
+            url: voteOnPollAction({
                 team: options.teamSlug(),
                 channel: channel.slug,
                 poll: message.poll.id,
             }).url,
-            { option_id: optionId },
-            {
-                preserveScroll: true,
-                preserveState: true,
-                only: ['channels'],
-                onError: () => {
-                    options.mainStream.restorePatch(
-                        message.clientUuid,
-                        previousMain,
-                    );
-                    options.threadStream.restorePatch(
-                        message.clientUuid,
-                        previousThread,
-                    );
-                    toast.error(t('Failed to record your vote'));
-                },
-            },
-        );
+            data: { option_id: optionId },
+            only: CHANNEL_LIST_PROPS,
+            failure: t('Failed to record your vote'),
+        });
     }
 
     /**
      * Close a poll, freezing its tally. Non-optimistic: the frozen state reaches
      * every client — including this one — over the `PollVoteChanged` broadcast, so
-     * nothing is patched locally up front. A no-op when the message carries no poll.
+     * nothing is patched locally up front. With nothing shown ahead of the
+     * server there is nothing to roll back, which is why this one stays a plain
+     * post rather than joining {@see useOptimisticWrite}. A no-op when the
+     * message carries no poll.
      */
     function closePoll(message: Message): void {
         if (message.poll === null) {
@@ -96,7 +96,7 @@ export function useMessagePolls(options: MessagePollsOptions): MessagePolls {
             {
                 preserveScroll: true,
                 preserveState: true,
-                only: ['channels'],
+                only: CHANNEL_LIST_PROPS,
                 onError: () => {
                     toast.error(t('Failed to close the poll'));
                 },

--- a/resources/js/composables/useMessageSends.test.ts
+++ b/resources/js/composables/useMessageSends.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, ref } from 'vue';
+
+const { post, toastError } = vi.hoisted(() => ({
+    post: vi.fn(),
+    toastError: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post, patch: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
+
+import { streams } from '@/composables/messageWrites.harness';
+import { channel, me } from '@/composables/useMessageActions.harness';
+import { useMessageSends } from '@/composables/useMessageSends';
+import { createOutbox } from '@/lib/outbox';
+import type { Message } from '@/types';
+
+function harness() {
+    const scope = effectScope();
+    const { mainStream, unmount } = streams([]);
+    const onSendFailure = vi.fn();
+    const onRejected = vi.fn();
+    const replyTarget = ref<Message | null>(null);
+
+    const outbox = createOutbox();
+
+    let sends!: ReturnType<typeof useMessageSends>;
+
+    scope.run(() => {
+        sends = useMessageSends({
+            teamSlug: () => 'acme',
+            channel: () => channel,
+            currentUser: () => me,
+            mainStream,
+            replyTarget,
+            scrollToBottom: vi.fn(),
+            cancelDraft: vi.fn(),
+            clearDraft: vi.fn(),
+            cancelReply: vi.fn(),
+            isOnline: () => true,
+            outbox,
+            onSendFailure,
+        });
+    });
+
+    return {
+        sends,
+        mainStream,
+        onSendFailure,
+        onRejected,
+        unmount: () => {
+            scope.stop();
+            unmount();
+        },
+    };
+}
+
+describe('useMessageSends', () => {
+    beforeEach(() => {
+        post.mockClear();
+        toastError.mockClear();
+    });
+
+    it('renders the message optimistically before the server has taken it', () => {
+        const { sends, mainStream, unmount } = harness();
+
+        sends.send('hello', []);
+
+        expect(mainStream.pendingUuids.value).toHaveLength(1);
+
+        unmount();
+    });
+
+    it('takes the optimistic row back out when the send is refused', () => {
+        const { sends, mainStream, onSendFailure, onRejected, unmount } =
+            harness();
+
+        sends.send('hello', [], [], { onRejected });
+        post.mock.calls[0][2].onError({});
+
+        expect(mainStream.pendingUuids.value).toEqual([]);
+        expect(toastError).toHaveBeenCalledWith(
+            'Your message failed to send. Please try again.',
+        );
+        // The staged attachments come back with it, so the send is retryable
+        // without re-picking the files.
+        expect(onRejected).toHaveBeenCalled();
+        expect(onSendFailure).toHaveBeenCalledWith(
+            'Your message failed to send. Please try again.',
+        );
+
+        unmount();
+    });
+});

--- a/resources/js/composables/useNewDirectMessages.ts
+++ b/resources/js/composables/useNewDirectMessages.ts
@@ -2,6 +2,7 @@ import { router, usePage } from '@inertiajs/vue3';
 import { echo } from '@laravel/echo-vue';
 import { computed, onBeforeUnmount, onMounted } from 'vue';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 
 /**
  * Surface a brand-new direct message in the sidebar live.
@@ -33,7 +34,10 @@ export function useNewDirectMessages(): void {
             .listen('DirectMessageStarted', () => {
                 // A teammate's action schedules this, so it fires at a moment the
                 // viewer did not choose; see {@see backgroundVisit}.
-                router.reload({ ...backgroundVisit, only: ['channels'] });
+                router.reload({
+                    ...backgroundVisit,
+                    only: CHANNEL_LIST_PROPS,
+                });
             });
     });
 

--- a/resources/js/composables/useOptimisticWrite.test.ts
+++ b/resources/js/composables/useOptimisticWrite.test.ts
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+
+const { post, patch, destroy, toastError } = vi.hoisted(() => ({
+    post: vi.fn(),
+    patch: vi.fn(),
+    destroy: vi.fn(),
+    toastError: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post, patch, delete: destroy },
+}));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: toastError,
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
+
+import { useMessageStream } from '@/composables/useMessageStream';
+import {
+    snapshotRef,
+    snapshotStreams,
+    useOptimisticWrite,
+} from '@/composables/useOptimisticWrite';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
+import type { Message } from '@/types';
+
+/** A message carrying just the fields the streams key and patch on. */
+function message(overrides: Partial<Message> = {}): Message {
+    return {
+        id: 'm1',
+        clientUuid: 'uuid-1',
+        body: 'hello',
+        type: 'standard',
+        user: { id: 'peer', name: 'Peer' },
+        createdAt: '2024-01-01T00:00:00.000Z',
+        editedAt: null,
+        isDeleted: false,
+        mentions: [],
+        linkPreviews: [],
+        attachments: [],
+        reactions: [],
+        pin: null,
+        poll: null,
+        replyTo: null,
+        forwardedFrom: null,
+        threadRootId: null,
+        sentToChannel: false,
+        threadReplyCount: 0,
+        threadLastReplyAt: null,
+        threadParticipants: [],
+        threadFollowed: false,
+        threadUnread: false,
+        threadUnreadReplyCount: 0,
+        ...overrides,
+    };
+}
+
+/** The options bag (third argument) of the nth recorded call on a mock. */
+function optionsOf(
+    mock: typeof post,
+    call = 0,
+): {
+    only?: string[];
+    async?: boolean;
+    preserveUrl?: boolean;
+    preserveScroll?: boolean;
+    preserveState?: boolean;
+    onSuccess?: (page: unknown) => void;
+    onError: (errors: Record<string, string>) => void;
+} {
+    return mock.mock.calls[call][2];
+}
+
+describe('useOptimisticWrite', () => {
+    beforeEach(() => {
+        post.mockClear();
+        patch.mockClear();
+        destroy.mockClear();
+        toastError.mockClear();
+    });
+
+    it('applies the mutation and posts, leaving the reader where they are', () => {
+        const { write } = useOptimisticWrite();
+        const starred = ref(false);
+
+        write({
+            capture: () => snapshotRef(starred),
+            apply: () => {
+                starred.value = true;
+            },
+            url: '/acme/general/star',
+            data: { starred: true },
+            only: CHANNEL_LIST_PROPS,
+            failure: 'Failed to update the channel',
+        });
+
+        expect(starred.value).toBe(true);
+        expect(post).toHaveBeenCalledWith(
+            '/acme/general/star',
+            { starred: true },
+            expect.objectContaining({
+                only: ['channels'],
+                preserveScroll: true,
+                preserveState: true,
+            }),
+        );
+    });
+
+    it('leaves the mutation standing while the write is in flight', () => {
+        const { write } = useOptimisticWrite();
+        const starred = ref(false);
+
+        write({
+            capture: () => snapshotRef(starred),
+            apply: () => {
+                starred.value = true;
+            },
+            url: '/acme/general/star',
+            failure: 'Failed to update the channel',
+        });
+
+        expect(starred.value).toBe(true);
+        expect(toastError).not.toHaveBeenCalled();
+    });
+
+    it('restores the snapshot when the write is refused', () => {
+        const { write } = useOptimisticWrite();
+        const starred = ref(false);
+
+        write({
+            capture: () => snapshotRef(starred),
+            apply: () => {
+                starred.value = true;
+            },
+            url: '/acme/general/star',
+            failure: 'Failed to update the channel',
+        });
+        optionsOf(post).onError({});
+
+        expect(starred.value).toBe(false);
+    });
+
+    it('says what went wrong when the write is refused', () => {
+        const { write } = useOptimisticWrite();
+
+        write({
+            capture: () => () => undefined,
+            url: '/acme/general/star',
+            failure: 'Failed to update the channel',
+        });
+        optionsOf(post).onError({});
+
+        expect(toastError).toHaveBeenCalledWith('Failed to update the channel');
+    });
+
+    it('prefers the sentence the server refused with, when there is one', () => {
+        const { write } = useOptimisticWrite();
+
+        write({
+            capture: () => () => undefined,
+            url: '/acme/general/pins',
+            failure: (errors) => errors.message ?? 'Failed to pin the message',
+        });
+        optionsOf(post).onError({
+            message: 'This channel has 100 pins already',
+        });
+
+        expect(toastError).toHaveBeenCalledWith(
+            'This channel has 100 pins already',
+        );
+    });
+
+    it('reads a payload function after applying, so it posts the new value', () => {
+        const { write } = useOptimisticWrite();
+        const starred = ref(false);
+
+        write({
+            capture: () => snapshotRef(starred),
+            apply: () => {
+                starred.value = !starred.value;
+            },
+            url: '/acme/general/star',
+            data: () => ({ starred: starred.value }),
+            failure: 'Failed to update the channel',
+        });
+
+        expect(post.mock.calls[0][1]).toEqual({ starred: true });
+    });
+
+    it('captures before applying, so the snapshot predates the mutation', () => {
+        const { write } = useOptimisticWrite();
+        const level = ref('all');
+
+        write({
+            capture: () => snapshotRef(level),
+            apply: () => {
+                level.value = 'mentions';
+            },
+            url: '/acme/general/preferences',
+            failure: 'Failed to update notification preferences',
+        });
+        optionsOf(post).onError({});
+
+        expect(level.value).toBe('all');
+    });
+
+    it('rolls both streams back together when a two-stream write fails', () => {
+        const { write } = useOptimisticWrite();
+        const row = message();
+        const mainStream = useMessageStream(ref([row]));
+        const threadStream = useMessageStream(ref([row]));
+
+        write({
+            capture: () =>
+                snapshotStreams(row.clientUuid, mainStream, threadStream),
+            apply: () => {
+                mainStream.patchPin(row.id, {
+                    pinnedBy: { id: 'me', name: 'Me' },
+                    pinnedAt: '2024-01-02T00:00:00.000Z',
+                });
+                threadStream.patchPin(row.id, {
+                    pinnedBy: { id: 'me', name: 'Me' },
+                    pinnedAt: '2024-01-02T00:00:00.000Z',
+                });
+            },
+            url: '/acme/general/m1/pin',
+            failure: 'Failed to pin the message. Please try again.',
+        });
+
+        expect(mainStream.displayMessages.value[0].pin).not.toBeNull();
+        expect(threadStream.displayMessages.value[0].pin).not.toBeNull();
+
+        optionsOf(post).onError({});
+
+        expect(mainStream.displayMessages.value[0].pin).toBeNull();
+        expect(threadStream.displayMessages.value[0].pin).toBeNull();
+    });
+
+    it('restores a stream that already carried a patch to that same patch', () => {
+        const { write } = useOptimisticWrite();
+        const row = message();
+        const stream = useMessageStream(ref([row]));
+
+        stream.applyPatch({ ...row, body: 'edited once' });
+
+        write({
+            capture: () => snapshotStreams(row.clientUuid, stream),
+            apply: () => stream.applyPatch({ ...row, body: 'edited twice' }),
+            url: '/acme/general/m1',
+            method: 'patch',
+            failure: 'Your edit failed to save',
+        });
+        optionsOf(patch).onError({});
+
+        expect(stream.displayMessages.value[0].body).toBe('edited once');
+    });
+
+    it('posts a delete with its options in the argument slot delete uses', () => {
+        const { write } = useOptimisticWrite();
+
+        write({
+            capture: () => () => undefined,
+            url: '/acme/general/m1',
+            method: 'delete',
+            only: CHANNEL_LIST_PROPS,
+            failure: 'Failed to delete the message',
+        });
+
+        expect(destroy).toHaveBeenCalledWith(
+            '/acme/general/m1',
+            expect.objectContaining({ only: ['channels'] }),
+        );
+    });
+
+    it('rolls a delete back through the options it was given', () => {
+        const { write } = useOptimisticWrite();
+        const shown = ref(true);
+
+        write({
+            capture: () => snapshotRef(shown),
+            apply: () => {
+                shown.value = false;
+            },
+            url: '/acme/general/m1',
+            method: 'delete',
+            failure: 'Failed to delete the message',
+        });
+        destroy.mock.calls[0][1].onError({});
+
+        expect(shown.value).toBe(true);
+        expect(toastError).toHaveBeenCalledWith('Failed to delete the message');
+    });
+
+    it('takes a write nobody is waiting on out of the synchronous queue', () => {
+        const { write } = useOptimisticWrite();
+
+        write({
+            capture: () => () => undefined,
+            url: '/acme/general/star',
+            method: 'patch',
+            background: true,
+            failure: 'Failed to update the channel',
+        });
+
+        expect(optionsOf(patch)).toMatchObject({
+            async: true,
+            preserveUrl: true,
+        });
+    });
+
+    it('stays on the synchronous queue by default', () => {
+        const { write } = useOptimisticWrite();
+
+        write({
+            capture: () => () => undefined,
+            url: '/acme/general/star',
+            failure: 'Failed to update the channel',
+        });
+
+        expect(optionsOf(post).async).toBeUndefined();
+    });
+
+    it('lets a write that must replace the page props opt out of preserveState', () => {
+        const { write } = useOptimisticWrite();
+
+        write({
+            capture: () => () => undefined,
+            url: '/acme/general/m1',
+            method: 'patch',
+            preserveState: false,
+            failure: 'Your edit failed to save',
+        });
+
+        expect(optionsOf(patch).preserveState).toBe(false);
+    });
+
+    it('hands the response on to a write that reports its own success', () => {
+        const { write } = useOptimisticWrite();
+        const onSuccess = vi.fn();
+
+        write({
+            capture: () => () => undefined,
+            url: '/acme/general/m1/forward',
+            onSuccess,
+            failure: 'Failed to forward the message',
+        });
+        optionsOf(post).onSuccess?.({ flash: { forwarded: null } });
+
+        expect(onSuccess).toHaveBeenCalledWith({ flash: { forwarded: null } });
+    });
+
+    it('captures and restores without applying, for a mutation already made', () => {
+        // vuedraggable has already written to the bound list by the time its
+        // change handler fires, so that site restores by reseeding rather than
+        // by applying anything of its own.
+        const { write } = useOptimisticWrite();
+        const reseed = vi.fn();
+
+        write({
+            capture: () => reseed,
+            url: '/acme/general/placement',
+            method: 'patch',
+            failure: 'Failed to save the sidebar layout',
+        });
+
+        expect(reseed).not.toHaveBeenCalled();
+
+        optionsOf(patch).onError({});
+
+        expect(reseed).toHaveBeenCalledTimes(1);
+    });
+});

--- a/resources/js/composables/useOptimisticWrite.ts
+++ b/resources/js/composables/useOptimisticWrite.ts
@@ -1,0 +1,196 @@
+import { router } from '@inertiajs/vue3';
+import type { Ref } from 'vue';
+import type { useMessageStream } from '@/composables/useMessageStream';
+import { useToast } from '@/composables/useToast';
+import { backgroundVisit } from '@/lib/backgroundVisit';
+
+type MessageStream = ReturnType<typeof useMessageStream>;
+
+/**
+ * How to put back exactly what a capture read, when the server refuses the
+ * write it was taken for.
+ */
+export type Rollback = () => void;
+
+/** The verbs an optimistic write posts under. */
+export type OptimisticMethod = 'post' | 'patch' | 'delete';
+
+/**
+ * A value an optimistic write's payload may carry.
+ *
+ * Structurally Inertia's own `FormDataConvertible`, spelled out here because
+ * that type lives in `@inertiajs/core` — a package this app reaches only
+ * through `@inertiajs/vue3`, which does not re-export it. Files are left out on
+ * purpose: an upload is not something to show before the server has taken it.
+ */
+type PayloadValue =
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | PayloadValue[]
+    | { [key: string]: PayloadValue };
+
+/** The request body an optimistic write posts. */
+export type OptimisticPayload = Record<string, PayloadValue>;
+
+/** One optimistic write: what it shows, what it posts, and what it undoes. */
+export interface OptimisticWrite {
+    /**
+     * Read whatever {@link apply} is about to overwrite, and hand back how to
+     * put it back. Run before the mutation, so the closure always closes over
+     * the pre-write value — the module owns that ordering rather than trusting
+     * each call site to get it right.
+     */
+    capture: () => Rollback;
+    /**
+     * Show the outcome the reader asked for, ahead of the server's answer.
+     *
+     * Optional, because one shape of optimistic write has already happened: a
+     * vuedraggable handler fires *after* the drag has written to the list it is
+     * bound to, so that site captures and restores but applies nothing.
+     */
+    apply?: () => void;
+    /** Defaults to `post`. */
+    method?: OptimisticMethod;
+    url: string;
+    /**
+     * The request body. Ignored by `delete`, which sends none.
+     *
+     * A function is read *after* {@link apply}, for the endpoints that take the
+     * value the mutation just decided — a star toggle posts the new star state,
+     * so spelling it out up front would say it twice.
+     */
+    data?: OptimisticPayload | (() => OptimisticPayload);
+    /** The props the write invalidates — one of the named sets in `lib/reloadProps`. */
+    only?: string[];
+    /**
+     * Whether the page component's state survives the response. True by
+     * default: an optimistic write is not a navigation, so the surface that
+     * fired it should still be there afterwards. A write that deliberately
+     * replaces the whole prop set passes false.
+     */
+    preserveState?: boolean;
+    /** True for a write nobody on screen is waiting on; see {@see backgroundVisit}. */
+    background?: boolean;
+    /**
+     * What the reader is told when the write is refused, already translated.
+     * A function receives the server's validation errors, for the endpoints that
+     * refuse with a sentence of their own (the per-channel pin cap).
+     */
+    failure: string | ((errors: Record<string, string>) => string);
+    /** Runs on a successful write, for the writes that also confirm themselves. */
+    onSuccess?: (page: unknown) => void;
+}
+
+export interface OptimisticWriter {
+    /** Run one optimistic write end to end. */
+    write: (spec: OptimisticWrite) => void;
+}
+
+/**
+ * The optimistic write, as one module.
+ *
+ * Capture → apply → post → restore-on-error → toast is the shape behind roughly
+ * a dozen writes across the sidebar, the timeline and the thread panel: a star,
+ * a vote, a reaction, an edit, a pin, a drag. Every one of them mutates the
+ * interface before the server has agreed, which means every one of them owes the
+ * reader a way back if the server refuses — and a written-out copy of the shape
+ * is a copy that can quietly lose its rollback, leaving the interface showing
+ * something the account never stored.
+ *
+ * So the ordering (snapshot strictly before the mutation), the visit options an
+ * optimistic write always wants (`preserveScroll`, `preserveState` — it is not a
+ * navigation), the restore and the failure toast live here, and a call site
+ * supplies only what actually differs: what to snapshot, what to show, where to
+ * post, which props that invalidates, and what to say when it fails.
+ *
+ * {@see useReminders} is the reference adopter, and the one that named the
+ * lesson first: set and snooze are the same write, so their triple was written
+ * once there rather than at each call site (#1115).
+ *
+ * Writes with *nothing* to roll back — a post that only toasts on failure — do
+ * not belong here. They would gain uniformity and nothing else, and the line
+ * this module draws is behavioural.
+ */
+export function useOptimisticWrite(): OptimisticWriter {
+    const toast = useToast();
+
+    function write(spec: OptimisticWrite): void {
+        const rollback = spec.capture();
+        spec.apply?.();
+
+        const options = {
+            ...(spec.background ? backgroundVisit : {}),
+            preserveScroll: true,
+            preserveState: spec.preserveState ?? true,
+            ...(spec.only ? { only: spec.only } : {}),
+            ...(spec.onSuccess ? { onSuccess: spec.onSuccess } : {}),
+            onError: (errors: Record<string, string>): void => {
+                rollback();
+                toast.error(
+                    typeof spec.failure === 'function'
+                        ? spec.failure(errors)
+                        : spec.failure,
+                );
+            },
+        };
+
+        // `router.delete` takes its options in the second slot: it sends no body.
+        if (spec.method === 'delete') {
+            router.delete(spec.url, options);
+
+            return;
+        }
+
+        const data = typeof spec.data === 'function' ? spec.data() : spec.data;
+
+        router[spec.method ?? 'post'](spec.url, data ?? {}, options);
+    }
+
+    return { write };
+}
+
+/**
+ * Capture a ref's current value, restoring exactly that value.
+ *
+ * The single-ref case — a star, a mute, a notification level, a collapsed set —
+ * where the optimistic mutation is an assignment and its inverse is the
+ * assignment back.
+ */
+export function snapshotRef<T>(target: Ref<T>): Rollback {
+    const previous = target.value;
+
+    return () => {
+        target.value = previous;
+    };
+}
+
+/**
+ * Capture one message row across every stream showing it, restoring all of them
+ * together.
+ *
+ * A message can be on screen twice at once — in the channel timeline and in the
+ * open thread panel — over two independent {@see useMessageStream} instances, so
+ * a pin, a vote, a reaction, an edit or a delete patches both and a refusal has
+ * to undo both. Restoring one and not the other is the failure this exists to
+ * make unwritable: the same message would render pinned in the timeline and
+ * unpinned in the thread beside it.
+ *
+ * The row is keyed on its client uuid, which is what a stream files patches
+ * under; `undefined` for a stream that carried no patch is a meaningful
+ * snapshot, and restores to carrying none.
+ */
+export function snapshotStreams(
+    clientUuid: string,
+    ...streams: MessageStream[]
+): Rollback {
+    const previous = streams.map((stream) => stream.getPatch(clientUuid));
+
+    return () => {
+        streams.forEach((stream, index) => {
+            stream.restorePatch(clientUuid, previous[index]);
+        });
+    };
+}

--- a/resources/js/composables/useReadPointer.ts
+++ b/resources/js/composables/useReadPointer.ts
@@ -3,6 +3,7 @@ import { echo } from '@laravel/echo-vue';
 import { read as markChannelRead } from '@/actions/App/Http/Controllers/Channels/ChannelController';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import { CHANNEL_LIST_PROPS } from '@/lib/reloadProps';
 
 export interface ReadPointerOptions {
     teamSlug: () => string;
@@ -40,7 +41,7 @@ export function useReadPointer(options: ReadPointerOptions): {
                     ...backgroundVisit,
                     preserveScroll: true,
                     preserveState: true,
-                    only: ['channels'],
+                    only: CHANNEL_LIST_PROPS,
                     headers: socketId ? { 'X-Socket-ID': socketId } : {},
                 },
             );

--- a/resources/js/composables/useScheduledMessages.ts
+++ b/resources/js/composables/useScheduledMessages.ts
@@ -8,6 +8,7 @@ import type { MessageActionsOptions } from '@/composables/useMessageActions';
 import { useToast } from '@/composables/useToast';
 import { useTranslations } from '@/composables/useTranslations';
 import { formatDateTime } from '@/lib/datetime';
+import { CHANNEL_LIST_PROPS, SCHEDULED_MESSAGE_PROPS } from '@/lib/reloadProps';
 import { generateUuid } from '@/lib/uuid';
 import type { Mention } from '@/types';
 
@@ -74,7 +75,7 @@ export function useScheduledMessages(
             {
                 preserveScroll: true,
                 preserveState: true,
-                only: ['scheduledMessages', 'channels'],
+                only: [...SCHEDULED_MESSAGE_PROPS, ...CHANNEL_LIST_PROPS],
                 onSuccess: () =>
                     toast.success(t('Message scheduled'), {
                         // The value that was just set belongs on the detail
@@ -110,7 +111,7 @@ export function useScheduledMessages(
             {
                 preserveScroll: true,
                 preserveState: true,
-                only: ['scheduledMessages'],
+                only: SCHEDULED_MESSAGE_PROPS,
                 onError: () =>
                     toast.error(t('Failed to update the scheduled message')),
             },
@@ -144,7 +145,7 @@ export function useScheduledMessages(
             {
                 preserveScroll: true,
                 preserveState: true,
-                only: ['scheduledMessages'],
+                only: SCHEDULED_MESSAGE_PROPS,
                 onSuccess: () =>
                     toast.success(t('Scheduled message cancelled')),
                 onError: () =>

--- a/resources/js/composables/useThreadPanel.ts
+++ b/resources/js/composables/useThreadPanel.ts
@@ -8,6 +8,11 @@ import {
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { useMessageStream } from '@/composables/useMessageStream';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import {
+    CHANNEL_LIST_PROPS,
+    THREAD_PROPS,
+    THREAD_RESET_PROPS,
+} from '@/lib/reloadProps';
 import type { Message, MessagePage, Thread } from '@/types';
 
 type MessageStream = ReturnType<typeof useMessageStream>;
@@ -110,7 +115,7 @@ export function useThreadPanel(options: ThreadPanelOptions): ThreadPanel {
                     ...backgroundVisit,
                     preserveScroll: true,
                     preserveState: true,
-                    only: ['channels'],
+                    only: CHANNEL_LIST_PROPS,
                 },
             );
 
@@ -159,8 +164,8 @@ export function useThreadPanel(options: ThreadPanelOptions): ThreadPanel {
             ).url,
             {},
             {
-                only: ['thread', 'threadReplies'],
-                reset: ['threadReplies'],
+                only: THREAD_PROPS,
+                reset: THREAD_RESET_PROPS,
                 preserveState: true,
                 preserveScroll: true,
                 replace: true,
@@ -186,8 +191,8 @@ export function useThreadPanel(options: ThreadPanelOptions): ThreadPanel {
             }).url,
             {},
             {
-                only: ['thread', 'threadReplies'],
-                reset: ['threadReplies'],
+                only: THREAD_PROPS,
+                reset: THREAD_RESET_PROPS,
                 preserveState: true,
                 preserveScroll: true,
                 replace: true,

--- a/resources/js/composables/useTimeFormat.test.ts
+++ b/resources/js/composables/useTimeFormat.test.ts
@@ -6,6 +6,7 @@ const page = reactive({
 });
 
 const patch = vi.fn();
+const toastError = vi.fn();
 
 vi.mock('@inertiajs/vue3', () => ({
     router: {
@@ -13,12 +14,23 @@ vi.mock('@inertiajs/vue3', () => ({
     },
     usePage: () => page,
 }));
+vi.mock('@/composables/useToast', () => {
+    const toast = {
+        error: (...args: unknown[]) => toastError(...args),
+        success: vi.fn(),
+        warning: vi.fn(),
+        progress: vi.fn(),
+    };
+
+    return { useToast: () => toast };
+});
 
 import { useTimeFormat } from '@/composables/useTimeFormat';
 import { setTimeFormat, timeFormat } from '@/lib/clock';
 
 beforeEach(() => {
     patch.mockReset();
+    toastError.mockReset();
     page.props.auth.user.time_format = 'auto';
     setTimeFormat('auto');
 });
@@ -63,5 +75,22 @@ describe('useTimeFormat', () => {
         options.onError();
 
         expect(timeFormat()).toBe('auto');
+    });
+
+    it('says the clock style failed to save, rather than silently reverting', () => {
+        // The revert is visible — every rendered time of day changes back — so
+        // without a sentence it reads as the switch simply not working.
+        useTimeFormat().updateTimeFormat('24h');
+
+        const [, , options] = patch.mock.calls[0] as [
+            string,
+            unknown,
+            { onError: () => void },
+        ];
+        options.onError();
+
+        expect(toastError).toHaveBeenCalledWith(
+            'Failed to save the clock style',
+        );
     });
 });

--- a/resources/js/composables/useTimeFormat.ts
+++ b/resources/js/composables/useTimeFormat.ts
@@ -1,5 +1,7 @@
-import { router, usePage } from '@inertiajs/vue3';
+import { usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
+import { useOptimisticWrite } from '@/composables/useOptimisticWrite';
+import { useTranslations } from '@/composables/useTranslations';
 import { setTimeFormat } from '@/lib/clock';
 import { update } from '@/routes/time-format';
 import type { TimeFormat } from '@/types';
@@ -10,6 +12,8 @@ import type { TimeFormat } from '@/types';
  */
 export function useTimeFormat() {
     const page = usePage();
+    const { t } = useTranslations();
+    const { write } = useOptimisticWrite();
 
     const timeFormat = computed<TimeFormat>(
         () => page.props.auth.user?.time_format ?? 'auto',
@@ -25,19 +29,18 @@ export function useTimeFormat() {
      * reload reseeds it from the shared prop.
      */
     function updateTimeFormat(next: TimeFormat): void {
-        const previous = timeFormat.value;
+        write({
+            capture: () => {
+                const previous = timeFormat.value;
 
-        setTimeFormat(next);
-
-        router.patch(
-            update().url,
-            { time_format: next },
-            {
-                preserveScroll: true,
-                preserveState: true,
-                onError: () => setTimeFormat(previous),
+                return () => setTimeFormat(previous);
             },
-        );
+            apply: () => setTimeFormat(next),
+            method: 'patch',
+            url: update().url,
+            data: { time_format: next },
+            failure: t('Failed to save the clock style'),
+        });
     }
 
     return { timeFormat, updateTimeFormat };

--- a/resources/js/lib/backgroundVisit.test.ts
+++ b/resources/js/lib/backgroundVisit.test.ts
@@ -1,7 +1,7 @@
-import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import { sourceFiles } from '@/lib/sourceScan.harness';
 
 const SOURCE_ROOT = 'resources/js';
 
@@ -24,26 +24,10 @@ const FOREGROUND_RELOADS: { file: string; call: string; reason: string }[] = [
     },
     {
         file: 'composables/useChannelPins.ts',
-        call: "router.reload({ only: ['pins', 'pinCount'] })",
+        call: 'router.reload({ only: PIN_PROPS })',
         reason: 'the user opened the pins popover and is waiting on it',
     },
 ];
-
-/** Every source file under `resources/js`, tests excluded. */
-function sourceFiles(directory = SOURCE_ROOT): string[] {
-    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-        const path = join(directory, entry.name);
-
-        if (entry.isDirectory()) {
-            return sourceFiles(path);
-        }
-
-        return /\.(ts|vue)$/.test(entry.name) &&
-            !entry.name.endsWith('.test.ts')
-            ? [path]
-            : [];
-    });
-}
 
 /** The full source text of each `router.reload(...)` call in `source`. */
 function reloadCalls(source: string): string[] {

--- a/resources/js/lib/backgroundVisit.ts
+++ b/resources/js/lib/backgroundVisit.ts
@@ -18,7 +18,9 @@
  *   when it resolves after their visit.
  *
  * Spread it into the options of any such request:
- * `{ ...backgroundVisit, preserveScroll: true, only: ['channels'] }`.
+ * `{ ...backgroundVisit, preserveScroll: true, only: CHANNEL_LIST_PROPS }` —
+ * the prop set being one of the named ones in {@see reloadProps}, never an
+ * inline array.
  *
  * Requests the user *did* ask for stay synchronous: form submits, navigations,
  * and reloads whose whole point is to rewrite the URL (the search page's

--- a/resources/js/lib/reloadProps.test.ts
+++ b/resources/js/lib/reloadProps.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+    CHANNEL_LIST_PROPS,
+    CHANNEL_SECTION_PROPS,
+    COLLAPSED_SECTION_PROPS,
+    PIN_PROPS,
+    SCHEDULED_MESSAGE_PROPS,
+    THREAD_PROPS,
+    THREAD_RESET_PROPS,
+} from '@/lib/reloadProps';
+import { filesSpelling } from '@/lib/sourceScan.harness';
+
+/** The module that owns the sets; every other site imports them from here. */
+const HOME = 'lib/reloadProps.ts';
+
+/**
+ * A set spelled out as an array literal. The leading lookbehind keeps an
+ * indexed access — `TokenLookup['channels']`, which is a type, not a prop set —
+ * from reading as one.
+ */
+function arrayLiteralOf(members: RegExp): RegExp {
+    return new RegExp(`(?<![\\w\\]])\\[\\s*${members.source}\\s*\\]`);
+}
+
+describe('reloadProps', () => {
+    it('names the sidebar channel read-model', () => {
+        expect(CHANNEL_LIST_PROPS).toEqual(['channels']);
+    });
+
+    it('names the sidebar section read-model', () => {
+        expect(CHANNEL_SECTION_PROPS).toEqual(['channelSections']);
+    });
+
+    it('keeps the built-in groups collapse set apart from the custom sections', () => {
+        // A custom section carries its collapse flag on its own row; the
+        // built-in groups have no rows, so their set lives on the account.
+        expect(COLLAPSED_SECTION_PROPS).toEqual(['collapsedChannelSections']);
+    });
+
+    it('names the later-delivery tray', () => {
+        expect(SCHEDULED_MESSAGE_PROPS).toEqual(['scheduledMessages']);
+    });
+
+    it('names both pin props, since a pin write moves the count too', () => {
+        // The masthead reads `pinCount` and the panel reads `pins`. Refreshing
+        // one leaves the badge and the list disagreeing about the same message.
+        expect(PIN_PROPS).toEqual(['pins', 'pinCount']);
+    });
+
+    it('names both thread props, since a root arrives with its replies', () => {
+        expect(THREAD_PROPS).toEqual(['thread', 'threadReplies']);
+    });
+
+    it('resets only the paginated half of the thread pair', () => {
+        // `threadReplies` is a merging paginator: without the reset, opening a
+        // second thread appends its first page to the previous thread's.
+        expect(THREAD_RESET_PROPS).toEqual(['threadReplies']);
+    });
+
+    it.each([
+        ['CHANNEL_LIST_PROPS', arrayLiteralOf(/'channels'/)],
+        ['CHANNEL_SECTION_PROPS', arrayLiteralOf(/'channelSections'/)],
+        [
+            'COLLAPSED_SECTION_PROPS',
+            arrayLiteralOf(/'collapsedChannelSections'/),
+        ],
+        ['PIN_PROPS', arrayLiteralOf(/'pins',\s*'pinCount'/)],
+        ['SCHEDULED_MESSAGE_PROPS', arrayLiteralOf(/'scheduledMessages'/)],
+        ['THREAD_PROPS', arrayLiteralOf(/'thread',\s*'threadReplies'/)],
+    ])('is the only place %s is spelled out', (_name, pattern) => {
+        // Sixteen copies of `only: ['channels']` across twelve files is what
+        // this replaces: a surface refreshing one prop of a pair goes stale, and
+        // adding a prop to a set meant finding every copy of it (#1115).
+        expect(filesSpelling(pattern, HOME)).toEqual([]);
+    });
+});

--- a/resources/js/lib/reloadProps.test.ts
+++ b/resources/js/lib/reloadProps.test.ts
@@ -67,6 +67,7 @@ describe('reloadProps', () => {
         ['PIN_PROPS', arrayLiteralOf(/'pins',\s*'pinCount'/)],
         ['SCHEDULED_MESSAGE_PROPS', arrayLiteralOf(/'scheduledMessages'/)],
         ['THREAD_PROPS', arrayLiteralOf(/'thread',\s*'threadReplies'/)],
+        ['THREAD_RESET_PROPS', arrayLiteralOf(/'threadReplies'/)],
     ])('is the only place %s is spelled out', (_name, pattern) => {
         // Sixteen copies of `only: ['channels']` across twelve files is what
         // this replaces: a surface refreshing one prop of a pair goes stale, and

--- a/resources/js/lib/reloadProps.ts
+++ b/resources/js/lib/reloadProps.ts
@@ -1,0 +1,72 @@
+/**
+ * The shared prop sets a write invalidates, named once each.
+ *
+ * A partial reload names the props it wants back, and those names travel with
+ * the write rather than with the surface: the same `only` list appeared at
+ * sixteen call sites across twelve files, so adding a prop to a set meant
+ * finding every copy of it, and a surface refreshing one prop of a pair went
+ * stale against the other (#1115). The pairs are the sharp edge — `pins` and
+ * `pinCount` are two readings of one fact, and so are `thread` and
+ * `threadReplies`.
+ *
+ * The fifth set lives next door in {@see reminderReload}, with the visit options
+ * a reminder mutation carries; both are enforced the same way, by a test that
+ * fails on a second copy.
+ *
+ * Every set is typed as a mutable `string[]` because that is what Inertia's
+ * `only` takes; a `readonly` tuple would force an `as string[]` cast back at
+ * every call site, which is exactly the noise this replaces.
+ */
+
+/**
+ * The sidebar's channel list.
+ *
+ * Nearly every workspace write touches it, because the prop carries far more
+ * than the roster: unread counts, the member's star/mute/notification state,
+ * placement, and the last-activity order the direct-message group sorts on. A
+ * reaction, a vote, a read pointer and a drag all move something the sidebar
+ * draws.
+ */
+export const CHANNEL_LIST_PROPS: string[] = ['channels'];
+
+/** The viewer's custom sidebar sections, in their persisted order. */
+export const CHANNEL_SECTION_PROPS: string[] = ['channelSections'];
+
+/**
+ * Which of the sidebar's *built-in* groups the viewer has collapsed.
+ *
+ * Separate from {@link CHANNEL_SECTION_PROPS} because the two are stored
+ * differently: a custom section carries its own collapse flag on its row, while
+ * the built-in groups have no rows and are a set on the account.
+ */
+export const COLLAPSED_SECTION_PROPS: string[] = ['collapsedChannelSections'];
+
+/**
+ * The channel's pins, both readings of them.
+ *
+ * The masthead shows `pinCount` and the panel lists `pins`; a write refreshing
+ * one without the other leaves the badge and the list disagreeing about the
+ * same message.
+ */
+export const PIN_PROPS: string[] = ['pins', 'pinCount'];
+
+/**
+ * The open thread: its root and metadata, plus the reply page.
+ *
+ * The root is only meaningful alongside the replies it heads, so the panel asks
+ * for both or neither — a load that returned one would render a thread whose
+ * body belongs to a different one.
+ */
+export const THREAD_PROPS: string[] = ['thread', 'threadReplies'];
+
+/**
+ * The half of {@link THREAD_PROPS} a thread load must reset rather than merge.
+ *
+ * `threadReplies` is a merging paginator, so its pages accumulate as older
+ * replies scroll in. Opening a *different* thread has to start that accumulation
+ * over, or the new thread's first page appends to the previous thread's.
+ */
+export const THREAD_RESET_PROPS: string[] = ['threadReplies'];
+
+/** The channel's pending scheduled messages, as the later-delivery tray lists them. */
+export const SCHEDULED_MESSAGE_PROPS: string[] = ['scheduledMessages'];

--- a/resources/js/lib/reloadProps.ts
+++ b/resources/js/lib/reloadProps.ts
@@ -9,9 +9,11 @@
  * `pinCount` are two readings of one fact, and so are `thread` and
  * `threadReplies`.
  *
- * The fifth set lives next door in {@see reminderReload}, with the visit options
- * a reminder mutation carries; both are enforced the same way, by a test that
- * fails on a second copy.
+ * Six invalidation sets live here; the seventh, {@see REMINDER_PROPS}, is next
+ * door in {@see reminderReload} with the visit options a reminder mutation
+ * carries. All seven are enforced the same way, by a test that fails on a second
+ * copy. {@link THREAD_RESET_PROPS} is not one of them — it names what a thread
+ * load *resets* rather than what a write invalidates.
  *
  * Every set is typed as a mutable `string[]` because that is what Inertia's
  * `only` takes; a `readonly` tuple would force an `as string[]` cast back at

--- a/resources/js/lib/reminderReload.test.ts
+++ b/resources/js/lib/reminderReload.test.ts
@@ -1,28 +1,9 @@
-import { readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { REMINDER_PROPS, reminderReload } from '@/lib/reminderReload';
-
-const SOURCE_ROOT = 'resources/js';
+import { filesSpelling } from '@/lib/sourceScan.harness';
 
 /** The module that owns the set; every other site imports it from here. */
 const HOME = 'lib/reminderReload.ts';
-
-/** Every source file under `resources/js`, tests excluded. */
-function sourceFiles(directory = SOURCE_ROOT): string[] {
-    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-        const path = join(directory, entry.name);
-
-        if (entry.isDirectory()) {
-            return sourceFiles(path);
-        }
-
-        return /\.(ts|vue)$/.test(entry.name) &&
-            !entry.name.endsWith('.test.ts')
-            ? [path]
-            : [];
-    });
-}
 
 describe('reminderReload', () => {
     it('names both reminder props, since a mutation moves rows between them', () => {
@@ -44,15 +25,8 @@ describe('reminderReload', () => {
     it('is the only place the set is spelled out', () => {
         // Six copies across five files is what this replaces: adding a reminder
         // field meant finding all six (#1093).
-        const spelledOut = sourceFiles()
-            .filter((path) => !path.endsWith(HOME))
-            .filter((path) =>
-                /'reminders',\s*'firedReminders'/.test(
-                    readFileSync(path, 'utf8'),
-                ),
-            )
-            .map((path) => path.slice(`${SOURCE_ROOT}/`.length));
-
-        expect(spelledOut).toEqual([]);
+        expect(filesSpelling(/'reminders',\s*'firedReminders'/, HOME)).toEqual(
+            [],
+        );
     });
 });

--- a/resources/js/lib/reminderReload.ts
+++ b/resources/js/lib/reminderReload.ts
@@ -12,7 +12,7 @@
  * `readonly` tuple would force an `as string[]` cast back at every call site,
  * which is exactly the noise this replaces.
  *
- * The other four sets that travel with a write live next door in
+ * The other six sets that travel with a write live next door in
  * {@see CHANNEL_LIST_PROPS} and its neighbours; this one keeps its own home
  * because the visit options below belong with it.
  */

--- a/resources/js/lib/reminderReload.ts
+++ b/resources/js/lib/reminderReload.ts
@@ -11,6 +11,10 @@
  * Typed as a mutable `string[]` because that is what Inertia's `only` takes; a
  * `readonly` tuple would force an `as string[]` cast back at every call site,
  * which is exactly the noise this replaces.
+ *
+ * The other four sets that travel with a write live next door in
+ * {@see CHANNEL_LIST_PROPS} and its neighbours; this one keeps its own home
+ * because the visit options below belong with it.
  */
 export const REMINDER_PROPS: string[] = ['reminders', 'firedReminders'];
 

--- a/resources/js/lib/sourceScan.harness.ts
+++ b/resources/js/lib/sourceScan.harness.ts
@@ -1,0 +1,44 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Test-only: the source walk the "spelled in exactly one place" tests share.
+ *
+ * Two suites enforce that rule — `reminderReload.test.ts` for the reminder pair
+ * and `reloadProps.test.ts` for the four sets beside it — and a set that has to
+ * be named once deserves a scanner that is written once. Nothing the app ships
+ * imports this, so `node:fs` never reaches a bundle.
+ */
+
+const SOURCE_ROOT = 'resources/js';
+
+/**
+ * Every source file under `resources/js`, with the test files and their
+ * harnesses left out: an assertion naturally spells the set it is asserting on,
+ * and so does a harness building the options a call is expected to carry.
+ */
+export function sourceFiles(directory = SOURCE_ROOT): string[] {
+    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            return sourceFiles(path);
+        }
+
+        return /\.(ts|vue)$/.test(entry.name) &&
+            !/\.(test|harness|doubles)\.ts$/.test(entry.name)
+            ? [path]
+            : [];
+    });
+}
+
+/**
+ * The source files outside `home` that spell `pattern` out, relative to
+ * `resources/js` so a failure names the file to fix rather than a path prefix.
+ */
+export function filesSpelling(pattern: RegExp, home: string): string[] {
+    return sourceFiles()
+        .filter((path) => !path.endsWith(home))
+        .filter((path) => pattern.test(readFileSync(path, 'utf8')))
+        .map((path) => path.slice(`${SOURCE_ROOT}/`.length));
+}

--- a/resources/js/lib/sourceScan.harness.ts
+++ b/resources/js/lib/sourceScan.harness.ts
@@ -5,8 +5,8 @@ import { join } from 'node:path';
  * Test-only: the source walk the "spelled in exactly one place" tests share.
  *
  * Two suites enforce that rule — `reminderReload.test.ts` for the reminder pair
- * and `reloadProps.test.ts` for the four sets beside it — and a set that has to
- * be named once deserves a scanner that is written once. Nothing the app ships
+ * and `reloadProps.test.ts` for the sets beside it — and a set that has to be
+ * named once deserves a scanner that is written once. Nothing the app ships
  * imports this, so `node:fs` never reaches a bundle.
  */
 


### PR DESCRIPTION
Closes #1115. Part of the architecture-hardening III epic (#1110) — frontend lane, `resources/js/` only, merges independently.

## What

Capture → apply → post → restore-on-error → toast was written out at every optimistic write across the sidebar, the timeline and the thread panel. `CONTEXT.md` already said why `useReminders` exists ("the snapshot → post → toast-with-Undo triple is written once here rather than at each call site") — that lesson is now generalised.

**`composables/useOptimisticWrite.ts`** owns the ordering (snapshot strictly *before* the mutation), the visit options an optimistic write always wants (`preserveScroll`/`preserveState` — it is not a navigation), the `background` flag, the restore, and the failure toast. Two capture helpers ship with it:

- `snapshotRef(ref)` — the single-ref case (a star, a mute, a level, a collapsed set).
- `snapshotStreams(clientUuid, ...streams)` — the multi-stream case. A message can be on screen twice at once, over two independent `useMessageStream` instances, so a refusal has to undo both. Restoring one and not the other is now unwritable.

**`lib/reloadProps.ts`** names the prop sets that travel with those writes, because the module takes one as an argument: `CHANNEL_LIST_PROPS`, `CHANNEL_SECTION_PROPS`, `COLLAPSED_SECTION_PROPS`, `PIN_PROPS`, `SCHEDULED_MESSAGE_PROPS`, `THREAD_PROPS` (+ `THREAD_RESET_PROPS`). `REMINDER_PROPS` stays next door with the visit options that belong to it. `reloadProps.test.ts` fails on a second copy of any of them, matching `reminderReload.test.ts`; no product file spells a set any more.

### Routed through the module

`useMessagePins` (2) · `useMessagePolls` (1) · `useMessageEdits` (3) · `useMessageForwarding` (1) · `useChannelPreferences` (3, and its local `savePreferences(rollback)` is gone) · `useChannelPlacement` (2) · `useChannelSections` · `useCollapsedSections` · `useTimeFormat`.

### Deliberately not routed

Three judgement calls worth a reviewer's attention:

1. **`useReminders` / `useReminderUndo`.** Their snapshot feeds an *Undo* on the success path, not a rollback on failure — there is no optimistic mutation to restore. Routing them would mean `capture: () => () => undefined` with the real snapshot still outside, which is worse than what is there. They already adopt the prop-set half, and `useReminders` is documented as the reference in both the module and `CONTEXT.md`.
2. **`useThreadPanel`, `useScheduledMessages`, `useMessagePolls.closePoll`, and the ~26 other write sites.** They post and toast with nothing to roll back. Per the issue, the line is behavioural, not stylistic — they took the named prop-set constants and nothing else. `useThreadPanel`'s mark-read in particular is deliberate fire-and-forget with no error handling at all, so routing it would be *adding* behaviour inside a refactor.
3. **`useMessageSends.postMessage`** keeps its own post: it wraps the request in a promise with `onCancel` and a substitutable `onFailure` so a flushed offline send goes back on the queue instead of being lost. It gained the direct rollback test the issue asks for, without being reshaped to fit.

## Behaviour change

**`useTimeFormat` gained a failure toast it did not have.** A refused write silently reverted the clock style, so every rendered time of day changed back with no explanation — it read as the switch simply not working. New key + `lang/fr.json` translation, asserted in its test.

## Testing

- `useOptimisticWrite.test.ts` — successful write, failed write restores the snapshot, failed write toasts, two-stream rollback restores both, capture-before-apply ordering, server-supplied failure sentence, delete's options slot, `background`, the payload thunk, and the capture-only (vuedraggable) shape.
- `reloadProps.test.ts` — each set's members, plus a duplicate scan that fails on a second spelling anywhere under `resources/js`.
- The five writes behind the ADR-0009 facade that had no test of their own — `useMessageSends`, `useMessageForwarding`, `useMessageEdits`, `useMessagePins`, `useMessagePolls` — each gained a direct file asserting its rollback fires. They were previously exercised only through the aggregate, so a dropped rollback was caught by nothing.
- `sourceScan.harness.ts` replaces the source-walk that `reminderReload.test.ts` and `backgroundVisit.test.ts` each had a copy of.

Gates green: `composer test` (Pint, PHPStan, Rector, 3134 tests at `--min=100`) and the frontend five (lint, format, `vue-tsc`, 2566 Vitest tests across 256 files, build). Local CodeRabbit pass returns 0 findings.

## Found while here

**#1120** — a refused channel-preference write rolls back onto whatever channel is open now. Pre-existing (`git show develop:…useChannelPreferences.ts` has the identical shape); this PR moved it behind the module without changing semantics, so it was filed rather than fixed inside a refactor. The proposed fix is a relevance guard on `useOptimisticWrite`, which every adopter then gets at once — cheap precisely because these writes now have one home.

## Docs

`CONTEXT.md`'s frontend named-seams list gains both modules, and the quick reference gains two entries: a write that shows its outcome before the server answers → `useOptimisticWrite`; the props a write invalidates → a named set in `lib/reloadProps`.

Note that "Closes #1115" does not fire for a PR merged into `develop`, so the issue needs closing by hand.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788120031&installation_model_id=428379&pr_number=1121&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1121&signature=2162bb2da73d6a5bfe6302a3429dde7e0e6fcd59ab910f30ab86289f0653370e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->