### PR TITLE
test: give a DB-backed module somewhere to be tested without HTTP

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -9,6 +9,13 @@ paths:
 
 # Testing
 
+## Where a new test goes
+
+- **Three suites run under the gate, named for how much of the application each boots** (see [ADR-0012](../../dev-docs/adr/0012-three-test-suites.md)): `tests/Unit` is pure — a function, or a repository file such as a workflow or the Dockerfile; `tests/Integration` boots the application **and** the database and drives the module directly; `tests/Feature` adds HTTP and drives `route()`. `tests/Browser` is the fourth, deliberately *not* declared as a `<testsuite>` in `phpunit.xml`, which is what keeps it out of the coverage gate.
+- **`Integration` and `Feature` are handed exactly the same thing** — `TestCase` plus `RefreshDatabase`. What separates them is not what they are given but what they drive. A test belongs in `Feature` when the HTTP contract is its subject: routing, validation, authorization, redirects, the Inertia props a page ships. **Everything else that needs a database belongs in `Integration`** — construct the module, call it, assert on what it returned or wrote. Do not reach for a controller to exercise an Action, a `Data` class or an `app/Support` seam.
+- **Do not bulk-move the older route-less tests out of `tests/Feature`.** 115 of them predate this suite and stay where they are; a file relocates only when something is already rewriting its assertions (#1110's child 6b). Likewise, `tests/Unit`'s repo-hygiene files stay in `tests/Unit`.
+- **Use the shared arrange in `tests/Helpers.php`, don't re-declare it.** `teamWithChannel()` returns `['owner' => …, 'team' => …, 'channel' => …]` for a team and its `#general`; `teamMemberInChannel($channel, $attributes, $role, $state)` adds someone to both; `channelMembership($channel, $user, $state)` sets the pivot's state, taking a closure over `ChannelMemberFactory` (`fn ($membership) => $membership->muted()->draft('…')`) rather than an attribute array. It restates an existing membership rather than replacing it, so it works on the owner, who is auto-joined to `#general`. All three are global — `tests/Pest.php` requires the file — so **check `grep -rn "^function " tests/` before naming a new global helper**: ~520 are already declared and a redeclaration is a fatal error, not a test failure.
+
 ## Code Coverage
 
 - **100% code coverage is required — this is non-negotiable.** The test suite is gated at `--min=100` (see the `test` script in `composer.json`), so any line left uncovered fails the build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,46 @@ below the PHP coverage gate. It needs no database and runs in seconds.
 
 Auto-fix with `./vendor/bin/sail npm run lint` and `./vendor/bin/sail npm run format`.
 
+### Where a new test goes
+
+There are four directories under `tests/`, three of which the coverage gate runs.
+They are named for **how much of the application each one boots**:
+
+| directory | boots | drives |
+| --- | --- | --- |
+| `tests/Unit` | nothing, usually | a pure function, or a file in the repository (a workflow, the Dockerfile, a shell script) |
+| `tests/Integration` | the application **and** the database | the module itself — construct it, call it, assert on what it returned or wrote |
+| `tests/Feature` | the same, plus HTTP | `route()`, and what the response carries |
+| `tests/Browser` | the same, plus a real browser and a live Reverb | the realtime and rendered-page paths nothing headless can reach |
+
+`Integration` and `Feature` are handed exactly the same thing — `TestCase` plus
+`RefreshDatabase`. **What separates them is not what they are given but what they
+drive.** Put a test in `Feature` when the HTTP contract is its subject: routing,
+validation, authorization, redirects, the Inertia props a page ships. Everything
+else that needs a database belongs in `Integration`. If you are unsure, ask which
+failure the test should catch — a broken route, or a broken module.
+
+`tests/Browser` is deliberately not declared as a `<testsuite>` in `phpunit.xml`,
+which is what keeps it out of the coverage gate; it runs by path through
+`bin/browser-tests` (see the README).
+
+The arrange nearly every test opens with — a team, its `#general` channel, and
+someone in both — lives in `tests/Helpers.php` and is available everywhere
+without an import:
+
+```php
+['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+$member = teamMemberInChannel($general, ['name' => 'Ada Lovelace']);
+
+channelMembership($general, $member, fn ($membership) => $membership->muted()->draft('half a thought'));
+```
+
+Reach for those rather than re-declaring the arrange locally, and take membership
+state from `ChannelMemberFactory` rather than writing the pivot's columns by hand.
+[ADR-0012](dev-docs/adr/0012-three-test-suites.md) has the reasoning, including
+why the older route-less tests in `tests/Feature` are being left where they are.
+
 ### The product shots: refreshing them when the shell changes
 
 The landing page, the README and the docs all advertise the app with real

--- a/dev-docs/adr/0012-three-test-suites.md
+++ b/dev-docs/adr/0012-three-test-suites.md
@@ -1,0 +1,103 @@
+# ADR-0012: Three test suites — pure, database, HTTP contract
+
+- Status: Accepted
+- Date: 2026-07-31
+- Relates to: epic architecture-hardening III (#1110), child #1111
+
+## Context
+
+There were two suites and three shapes of test.
+
+`tests/Pest.php` bound `RefreshDatabase` with `->in('Feature')`, and nothing else
+distinguished the two directories. So the split on the ground was **"needs a database"
+against "doesn't"** — not "through HTTP" against "direct", which is what the names
+`Unit` and `Feature` suggest and what everybody read them as. Both consequences of that
+were load-bearing:
+
+**`tests/Unit` was not a unit suite.** Only 33 of its 81 files named `App\` at all —
+1,761 of 8,875 lines. The other 80% tested YAML, Dockerfiles, shell scripts and
+documentation; `ReleaseFlowTest.php` alone was 1,392 lines and never named `App\`. That
+is real and valuable work, and it is *repo hygiene*, not unit testing.
+
+**115 of 265 `tests/Feature` files never called `route()`.** They were unit-shaped tests
+exiled to `Feature` purely to get a database. `tests/Feature/Support/SidebarChannelsTest.php`
+said so in its own docblock: *"The read-model is driven straight against these — no HTTP
+round-trip."*
+
+The cost was not misfiling. It was that **a module which is perfectly constructible could
+only be reached through a rendered page.** 36 of 89 Actions were never named in any test.
+57 `app/Data` DTOs had no unit test, including `MessageData`, which `CONTEXT.md` calls the
+canonical read-model DTO. Six named `app/Support` seams had zero test references at all —
+`ExpirySweep` (124 lines) and `SecurityEventRecorder` (56) among them. Every one of those
+reached 100% line coverage as a side effect of somebody else's HTTP test, which is
+coverage without specification: the gate was green and no test said what those modules do.
+
+`CONTEXT.md` states that **the interface is the test surface**. For 36 Actions and 57 DTOs
+it was not, and the reason was that there was nowhere to put the test.
+
+The same gap had already been closed once, in the other direction. `tests/Pest.php` has
+`require_once`'d `tests/Browser/Helpers.php` since #53, and `browserTeamWithChannel()` is
+used by 68 of the browser suite's 74 files with **zero** local clones. The headless
+channel/team files never got the same treatment: **37 byte-identical `*TeamWithGeneral()`
+bodies** (`threadTeamWithGeneral`, `pinTeamWithGeneral`, `draftTeamWithGeneral`, …) across
+about 481 lines, another ~20 "add a user to the team and the channel" clones across ~220,
+and 116 hand-rolled `channelMembers()->firstOrCreate()` calls against a
+`ChannelMemberFactory` whose four purpose-built states had two usages in the whole
+repository.
+
+## Decision
+
+**Three suites, named for how much of the application each one boots**, declared in
+`phpunit.xml` in that order and bound in `tests/Pest.php`:
+
+| suite | boots | drives | example |
+| --- | --- | --- | --- |
+| `tests/Unit` | nothing, usually | a pure function, or a repository file | `ReleaseFlowTest`, `TeamRoleTest` |
+| `tests/Integration` | the application **and** the database | the module, constructed and called | `ExpirySweepTest`, `ScheduleMessageTest` |
+| `tests/Feature` | the same, plus HTTP | `route()`, and what the response carries | `ThreadTest`, `ChannelStarTest` |
+
+`Integration` and `Feature` are given exactly the same thing — `TestCase` plus
+`RefreshDatabase`. **What separates them is not what they are given but what they drive.**
+A test belongs in `Feature` when the HTTP contract is the subject: routing, validation,
+authorization, redirects, the Inertia props a page ships. Everything else that needs a
+database belongs in `Integration`.
+
+`tests/Browser` stays undeclared as a `<testsuite>`, which is what keeps it out of the
+coverage gate; it runs by path through `bin/browser-tests`.
+
+**One shared arrange, `tests/Helpers.php`**, `require_once`'d from `tests/Pest.php`
+alongside the three helper files that already were. It carries the team/channel/member
+arrange the local clones re-declare — `teamWithChannel()`, `teamMemberInChannel()`,
+`channelMembership()` — and takes membership state as a closure over
+`ChannelMemberFactory`, so the four states have one spelling and the helper itself names
+none of the pivot's columns.
+
+**No existing test file moved.** The 115 route-less `Feature` files stay where they are.
+
+## Consequences
+
+- A DB-backed module has somewhere to be specified directly. `ExpirySweep`'s
+  compare-and-swap — the guard that spares a status a user re-set while the sweep was
+  running — is now stated by a test that opens exactly that window, which no HTTP test
+  was ever going to express.
+- **Coverage stops standing in for specification.** A module at 100% because a controller
+  test walked over it reads identically to one that is actually specified; the gate cannot
+  tell them apart and never could. A third home does not fix that by itself, but it
+  removes the excuse.
+- The five remaining children of #1110 have somewhere to prove themselves, which is why
+  this one merged first.
+- **The cost, stated plainly: three homes is one more judgement call than two.** The line
+  between `Integration` and `Feature` is a *judgement about the subject of the test*, not
+  a mechanical property a linter can check, and a test that reads a page's Inertia props
+  to assert a read-model's output sits right on it. The table above and the entry in
+  `CONTRIBUTING.md` are the whole of the guidance; when it is genuinely ambiguous, ask
+  which failure the test should catch — a broken route, or a broken module.
+- **Nothing was moved, so for now the new suite is the smallest of the three and
+  `tests/Feature` still holds ~115 tests that belong in it.** That is deliberate. A bulk
+  move changes no behaviour, wrecks `git blame` on a third of the test suite, and does not
+  address the actual complaint, which was that new modules had nowhere to go rather than
+  that old files were misfiled. #1110's child 6b relocates a file only when it is already
+  rewriting that file's assertions.
+- **`tests/Unit` keeps its 48 repo-hygiene files.** Renaming the suite to match what those
+  files really are would rename the one part of the suite causing nobody any friction, and
+  would touch every pointer in the workflows and rules that names a file inside it.

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -15,3 +15,7 @@ seams live in [`CONTEXT.md`](../../CONTEXT.md).
 | [0007](0007-in-process-browser-realtime-harness.md) | Browser E2E realtime tests run against the app served in-process |
 | [0008](0008-workspace-shell-read-model.md) | The shared-props middleware is glue; the workspace shell is a read-model |
 | [0009](0009-message-action-context-is-provided.md) | The message-action context is provided, not drilled |
+| [0012](0012-three-test-suites.md) | Three test suites: pure, database, HTTP contract |
+
+0010 and 0011 are reserved for two children of [#1110](https://github.com/deskhq/the-desk/issues/1110)
+that have not merged yet; the epic declares a merge order, and this one goes first.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,8 +5,18 @@
          colors="true"
 >
     <testsuites>
+        <!--
+            Three suites, ordered by how much of the application each one boots:
+            `Unit` is pure, `Integration` reaches the database but never HTTP,
+            and `Feature` drives the HTTP contract. See ADR-0012 for why the
+            middle one exists — and note that `tests/Browser` is deliberately
+            not declared here, which is what keeps it out of the coverage gate.
+        -->
         <testsuite name="Unit">
             <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
         </testsuite>
         <testsuite name="Feature">
             <directory>tests/Feature</directory>

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Teams\CreateTeam;
+use App\Enums\TeamRole;
+use App\Models\Channel;
+use App\Models\ChannelMember;
+use App\Models\Team;
+use App\Models\User;
+use Database\Factories\ChannelMemberFactory;
+
+/*
+|--------------------------------------------------------------------------
+| The shared arrange (#1111)
+|--------------------------------------------------------------------------
+|
+| A team, a channel, and someone in both — what nearly every test in this
+| repository opens with, and what fifty-odd test files each re-declared for
+| themselves under a private prefix (`threadTeamWithGeneral`,
+| `pinTeamWithGeneral`, `draftMember`, ...). `tests/Browser/Helpers.php` has
+| carried the same arrange for the browser suite since #53 and is used by 68
+| of its 74 files with no local clones at all, so the mechanism is proven;
+| these are its headless counterparts, required from `tests/Pest.php`.
+|
+| Membership state goes through `ChannelMemberFactory` rather than an
+| attribute array, so `muted`, `starred`, `draft` and `notification_level`
+| have exactly one spelling in the test suite too, and a fifth state is
+| reachable from here the day the factory declares it.
+|
+*/
+
+/**
+ * A team and its auto-created #general channel, with the owner in both.
+ *
+ * Built through {@see CreateTeam} rather than the factories directly, because
+ * the arrange every caller actually wants includes what creating a team *does*
+ * — the owner's membership, their current team, and #general itself.
+ *
+ * @return array{owner: User, team: Team, channel: Channel}
+ */
+function teamWithChannel(string $name = 'Acme'): array
+{
+    $owner = User::factory()->create();
+    $team = app(CreateTeam::class)->handle($owner, $name);
+
+    $channel = Channel::query()
+        ->where('team_id', $team->id)
+        ->where('slug', Channel::GENERAL_SLUG)
+        ->firstOrFail();
+
+    return ['owner' => $owner, 'team' => $team, 'channel' => $channel];
+}
+
+/**
+ * Another user, in the channel's team and in the channel itself.
+ *
+ * The team is taken from the channel rather than passed alongside it: the two
+ * can only ever be the one pair, and a signature that accepts both is a
+ * signature that can be handed a mismatched one.
+ *
+ * @param  array<string, mixed>  $attributes  overrides for the user, e.g. a name a mention has to match
+ * @param  (Closure(ChannelMemberFactory): ChannelMemberFactory)|null  $state  the membership state, see {@see channelMembership()}
+ */
+function teamMemberInChannel(
+    Channel $channel,
+    array $attributes = [],
+    TeamRole $role = TeamRole::Member,
+    ?Closure $state = null,
+): User {
+    $user = User::factory()->create($attributes);
+
+    $channel->team->memberships()->create(['user_id' => $user->id, 'role' => $role]);
+
+    channelMembership($channel, $user, $state);
+
+    return $user;
+}
+
+/**
+ * The membership joining a user to a channel, in whatever state the test needs:
+ *
+ *     channelMembership($general, $viewer, fn ($membership) => $membership->muted());
+ *
+ * The state arrives as a closure over {@see ChannelMemberFactory} so that this
+ * helper names none of the columns the states write — which is the point, given
+ * the pivot's column set is already declared in more places than it should be.
+ *
+ * A membership that already exists is *restated* rather than replaced: the team
+ * owner is auto-joined to #general, so a good half of the arranges land on a
+ * row that is already there, and the rest of it — a read cursor, a section, a
+ * position — belongs to whatever put it there and not to this helper.
+ *
+ * @param  (Closure(ChannelMemberFactory): ChannelMemberFactory)|null  $state
+ */
+function channelMembership(Channel $channel, User $user, ?Closure $state = null): ChannelMember
+{
+    $keys = ['channel_id' => $channel->id, 'user_id' => $user->id];
+
+    $factory = ChannelMember::factory();
+    $stated = $state instanceof Closure ? $state($factory) : $factory;
+
+    $membership = $channel->channelMembers()->firstWhere('user_id', $user->id);
+
+    if (! $membership instanceof ChannelMember) {
+        return $stated->create($keys);
+    }
+
+    $defaults = ChannelMember::factory()->make($keys)->getAttributes();
+
+    $changes = array_filter(
+        $stated->make($keys)->getAttributes(),
+        fn (mixed $value, string $column): bool => ($defaults[$column] ?? null) !== $value,
+        ARRAY_FILTER_USE_BOTH,
+    );
+
+    if ($changes !== []) {
+        $membership->fill($changes)->save();
+    }
+
+    return $membership;
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -39,10 +39,10 @@ use Database\Factories\ChannelMemberFactory;
  *
  * @return array{owner: User, team: Team, channel: Channel}
  */
-function teamWithChannel(string $name = 'Acme'): array
+function teamWithChannel(string $teamName = 'Acme'): array
 {
     $owner = User::factory()->create();
-    $team = app(CreateTeam::class)->handle($owner, $name);
+    $team = app(CreateTeam::class)->handle($owner, $teamName);
 
     $channel = Channel::query()
         ->where('team_id', $team->id)
@@ -95,28 +95,22 @@ function teamMemberInChannel(
  */
 function channelMembership(Channel $channel, User $user, ?Closure $state = null): ChannelMember
 {
-    $keys = ['channel_id' => $channel->id, 'user_id' => $user->id];
-
-    $factory = ChannelMember::factory();
-    $stated = $state instanceof Closure ? $state($factory) : $factory;
-
     $membership = $channel->channelMembers()->firstWhere('user_id', $user->id);
 
+    // Seeded from the row when there is one, so the states overwrite only what
+    // the test asked for and the rest of it is left standing.
+    $seed = $membership instanceof ChannelMember
+        ? $membership->getAttributes()
+        : ['channel_id' => $channel->id, 'user_id' => $user->id];
+
+    $factory = ChannelMember::factory()->state($seed);
+    $stated = $state instanceof Closure ? $state($factory) : $factory;
+
     if (! $membership instanceof ChannelMember) {
-        return $stated->create($keys);
+        return $stated->create();
     }
 
-    $defaults = ChannelMember::factory()->make($keys)->getAttributes();
-
-    $changes = array_filter(
-        $stated->make($keys)->getAttributes(),
-        fn (mixed $value, string $column): bool => ($defaults[$column] ?? null) !== $value,
-        ARRAY_FILTER_USE_BOTH,
-    );
-
-    if ($changes !== []) {
-        $membership->fill($changes)->save();
-    }
+    $membership->forceFill($stated->make()->getAttributes())->save();
 
     return $membership;
 }

--- a/tests/Integration/Channels/ScheduleMessageTest.php
+++ b/tests/Integration/Channels/ScheduleMessageTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Actions\Channels\ScheduleMessage;
+use App\Enums\ScheduledMessageStatus;
+use App\Models\Message;
+use App\Models\ScheduledMessage;
+use Database\Factories\ChannelMemberFactory;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * An hour out, whole seconds, and mutable — the action takes the same
+ * `Illuminate\Support\Carbon` the controller parses out of the request, not the
+ * immutable instance `now()` hands back.
+ */
+function anHourFromNow(): Carbon
+{
+    return Carbon::now()->addHour()->startOfSecond();
+}
+
+test('scheduling stores the message pending and consumes the author\'s draft', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+    channelMembership($general, $owner, fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->draft('half-typed'));
+
+    $sendAt = anHourFromNow();
+    $clientUuid = (string) Str::uuid7();
+
+    $scheduled = app(ScheduleMessage::class)
+        ->handle($general, $owner, 'the finished thought', $clientUuid, $sendAt);
+
+    expect($scheduled->status)->toBe(ScheduledMessageStatus::Pending)
+        ->and($scheduled->body)->toBe('the finished thought')
+        ->and($scheduled->client_uuid)->toBe($clientUuid)
+        ->and($scheduled->send_at->equalTo($sendAt))->toBeTrue()
+        ->and($general->channelMembers()->where('user_id', $owner->id)->value('draft'))->toBeNull();
+
+    // Nothing is posted now — the per-minute dispatcher delivers it later.
+    $this->assertDatabaseCount('messages', 0);
+});
+
+test('scheduling leaves every other member\'s draft where it was', function (): void {
+    ['channel' => $general] = teamWithChannel();
+
+    $author = teamMemberInChannel($general, ['name' => 'Ada Lovelace'],
+        state: fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->draft('mine'));
+    $bystander = teamMemberInChannel($general,
+        state: fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->draft('theirs'));
+
+    app(ScheduleMessage::class)
+        ->handle($general, $author, 'later', (string) Str::uuid7(), anHourFromNow());
+
+    expect($general->channelMembers()->where('user_id', $author->id)->value('draft'))->toBeNull()
+        ->and($general->channelMembers()->where('user_id', $bystander->id)->value('draft'))->toBe('theirs');
+});
+
+test('a scheduled reply carries the message it answers through to delivery', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+    $replyTo = Message::factory()->for($general)->for($owner)->create();
+
+    $scheduled = app(ScheduleMessage::class)
+        ->handle($general, $owner, 'answering later', (string) Str::uuid7(), anHourFromNow(), $replyTo->id);
+
+    expect(ScheduledMessage::findOrFail($scheduled->id)->reply_to_id)->toBe($replyTo->id);
+});

--- a/tests/Integration/Channels/ScheduleMessageTest.php
+++ b/tests/Integration/Channels/ScheduleMessageTest.php
@@ -28,10 +28,15 @@ test('scheduling stores the message pending and consumes the author\'s draft', f
     $scheduled = app(ScheduleMessage::class)
         ->handle($general, $owner, 'the finished thought', $clientUuid, $sendAt);
 
-    expect($scheduled->status)->toBe(ScheduledMessageStatus::Pending)
-        ->and($scheduled->body)->toBe('the finished thought')
-        ->and($scheduled->client_uuid)->toBe($clientUuid)
-        ->and($scheduled->send_at->equalTo($sendAt))->toBeTrue()
+    // Read back rather than asserted on the returned model: what has to survive
+    // until the dispatcher runs is the row, and `send_at` in particular only
+    // round-trips through the column at whole-second precision.
+    $stored = ScheduledMessage::findOrFail($scheduled->id);
+
+    expect($stored->status)->toBe(ScheduledMessageStatus::Pending)
+        ->and($stored->body)->toBe('the finished thought')
+        ->and($stored->client_uuid)->toBe($clientUuid)
+        ->and($stored->send_at->equalTo($sendAt))->toBeTrue()
         ->and($general->channelMembers()->where('user_id', $owner->id)->value('draft'))->toBeNull();
 
     // Nothing is posted now — the per-minute dispatcher delivers it later.
@@ -53,7 +58,7 @@ test('scheduling leaves every other member\'s draft where it was', function (): 
         ->and($general->channelMembers()->where('user_id', $bystander->id)->value('draft'))->toBe('theirs');
 });
 
-test('a scheduled reply carries the message it answers through to delivery', function (): void {
+test('a scheduled reply stores the message it answers', function (): void {
     ['owner' => $owner, 'channel' => $general] = teamWithChannel();
     $replyTo = Message::factory()->for($general)->for($owner)->create();
 

--- a/tests/Integration/SharedArrangeTest.php
+++ b/tests/Integration/SharedArrangeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Enums\NotificationLevel;
+use App\Enums\TeamRole;
+use App\Models\Message;
+use Database\Factories\ChannelMemberFactory;
+
+/**
+ * The shared arrange in tests/Helpers.php, which fifty-odd files will lean on
+ * once #1110's sweep converts them. Its one non-obvious promise — that stating
+ * a membership *restates* it rather than replacing it — is the one worth
+ * holding still, because breaking it would surface as unrelated arranges
+ * quietly losing a read cursor rather than as a failure here.
+ */
+test('a team arrives with its general channel and its owner in both', function (): void {
+    ['owner' => $owner, 'team' => $team, 'channel' => $general] = teamWithChannel('Acme');
+
+    expect($team->name)->toBe('Acme')
+        ->and($general->team_id)->toBe($team->id)
+        ->and($owner->fresh()->current_team_id)->toBe($team->id)
+        ->and($team->memberships()->where('user_id', $owner->id)->value('role'))->toBe(TeamRole::Owner)
+        ->and($general->channelMembers()->where('user_id', $owner->id)->exists())->toBeTrue();
+});
+
+test('a member is put in the team and the channel, in the role and state asked for', function (): void {
+    ['team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $member = teamMemberInChannel($general, ['name' => 'Ada Lovelace'], TeamRole::Admin,
+        fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->starred()->notificationLevel(NotificationLevel::Mentions));
+
+    $pivot = $general->channelMembers()->where('user_id', $member->id)->firstOrFail();
+
+    expect($member->name)->toBe('Ada Lovelace')
+        ->and($team->memberships()->where('user_id', $member->id)->value('role'))->toBe(TeamRole::Admin)
+        ->and($pivot->starred)->toBeTrue()
+        ->and($pivot->notification_level)->toBe(NotificationLevel::Mentions);
+});
+
+test('stating an existing membership leaves the rest of the row standing', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+    $read = Message::factory()->for($general)->for($owner)->create();
+
+    // The owner is auto-joined to #general, so this row already exists and is
+    // already carrying something the arrange did not put there.
+    $general->channelMembers()->where('user_id', $owner->id)->update([
+        'last_read_message_id' => $read->id,
+        'notification_level' => NotificationLevel::Mentions,
+    ]);
+
+    channelMembership($general, $owner, fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->muted());
+
+    $pivot = $general->channelMembers()->where('user_id', $owner->id)->firstOrFail();
+
+    expect($pivot->muted)->toBeTrue()
+        ->and($pivot->last_read_message_id)->toBe($read->id)
+        ->and($pivot->notification_level)->toBe(NotificationLevel::Mentions);
+});
+
+test('a state is applied even when it asks for the column default', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+
+    $general->channelMembers()->where('user_id', $owner->id)
+        ->update(['notification_level' => NotificationLevel::Nothing]);
+
+    channelMembership($general, $owner,
+        fn (ChannelMemberFactory $membership): ChannelMemberFactory => $membership->notificationLevel(NotificationLevel::All));
+
+    expect($general->channelMembers()->where('user_id', $owner->id)->firstOrFail()->notification_level)
+        ->toBe(NotificationLevel::All);
+});

--- a/tests/Integration/SharedArrangeTest.php
+++ b/tests/Integration/SharedArrangeTest.php
@@ -36,6 +36,21 @@ test('a member is put in the team and the channel, in the role and state asked f
         ->and($pivot->notification_level)->toBe(NotificationLevel::Mentions);
 });
 
+test('a membership can be asked for with no state at all', function (): void {
+    ['owner' => $owner, 'channel' => $general] = teamWithChannel();
+
+    $plain = teamMemberInChannel($general);
+
+    $general->channelMembers()->where('user_id', $owner->id)->update(['draft' => 'kept']);
+    channelMembership($general, $owner);
+
+    expect($general->channelMembers()->where('user_id', $plain->id)->firstOrFail()->notification_level)
+        ->toBe(NotificationLevel::All)
+        // Restating without a state is a no-op, not a reset — this is the shape
+        // the 116 hand-rolled `firstOrCreate` calls will convert to.
+        ->and($general->channelMembers()->where('user_id', $owner->id)->value('draft'))->toBe('kept');
+});
+
 test('stating an existing membership leaves the rest of the row standing', function (): void {
     ['owner' => $owner, 'channel' => $general] = teamWithChannel();
     $read = Message::factory()->for($general)->for($owner)->create();

--- a/tests/Integration/Support/ExpirySweepTest.php
+++ b/tests/Integration/Support/ExpirySweepTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Events\UserProfileUpdated;
+use App\Models\DataExport;
+use App\Models\User;
+use App\Support\ExpirySweep;
+use App\Support\ExportLifecycle;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * A user whose custom status lapsed an hour ago.
+ */
+function userWithLapsedStatus(): User
+{
+    return User::factory()->create([
+        'status_emoji' => ':spiral_calendar_pad:',
+        'status_text' => 'In a meeting',
+        'status_expires_at' => now()->subHour(),
+    ]);
+}
+
+test('purging expired exports removes the file before the row and leaves live ones alone', function (): void {
+    Storage::fake(ExportLifecycle::DISK);
+
+    $expired = DataExport::factory()->expired()->create();
+    $live = DataExport::factory()->ready()->create();
+
+    Storage::disk(ExportLifecycle::DISK)->put($expired->path, 'expired archive');
+    Storage::disk(ExportLifecycle::DISK)->put($live->path, 'live archive');
+
+    $purged = ExpirySweep::purgeExpiredExports(DataExport::query(), ExportLifecycle::DISK);
+
+    expect($purged)->toBe(1);
+
+    Storage::disk(ExportLifecycle::DISK)->assertMissing($expired->path);
+    Storage::disk(ExportLifecycle::DISK)->assertExists($live->path);
+
+    $this->assertDatabaseMissing('data_exports', ['id' => $expired->id]);
+    $this->assertDatabaseHas('data_exports', ['id' => $live->id]);
+});
+
+test('an export whose window closed before it produced a file is still purged', function (): void {
+    Storage::fake(ExportLifecycle::DISK);
+
+    $pathless = DataExport::factory()->create(['expires_at' => now()->subDay()]);
+
+    expect(ExpirySweep::purgeExpiredExports(DataExport::query(), ExportLifecycle::DISK))->toBe(1);
+
+    $this->assertDatabaseMissing('data_exports', ['id' => $pathless->id]);
+});
+
+test('a lapsed profile instant is nulled along with the columns riding on it, and broadcast', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $lapsed = userWithLapsedStatus();
+
+    $cleared = ExpirySweep::clearLapsedProfileInstant(
+        User::query()->whereNotNull('status_emoji'),
+        'status_expires_at',
+        ['status_emoji', 'status_text'],
+    );
+
+    expect($cleared)->toBe(1);
+
+    $this->assertDatabaseHas('users', [
+        'id' => $lapsed->id,
+        'status_expires_at' => null,
+        'status_emoji' => null,
+        'status_text' => null,
+    ]);
+
+    Event::assertDispatched(
+        UserProfileUpdated::class,
+        fn (UserProfileUpdated $event): bool => $event->user->is($lapsed),
+    );
+});
+
+test('an instant set afresh while the pass was running is left alone, uncounted and unbroadcast', function (): void {
+    Event::fake([UserProfileUpdated::class]);
+
+    $racer = userWithLapsedStatus();
+    // Whole seconds, because the column stores no finer and the assertion below
+    // compares the instant the sweep spared against the one that was written.
+    $renewed = now()->addHour()->startOfSecond();
+
+    // The window the compare-and-swap exists for: the cursor hands back the row
+    // it read, and by the time this pass acts on it the user has set a fresh
+    // status. Writing on `retrieved` is how that window is opened deterministically
+    // — it is the moment between the cursor's read and the sweep's write. Once,
+    // because ExpirySweep re-reads the user it does clear.
+    $raced = false;
+
+    User::retrieved(function (User $user) use (&$raced, $renewed): void {
+        if ($raced) {
+            return;
+        }
+
+        $raced = true;
+
+        User::query()->whereKey($user->getKey())->update([
+            'status_emoji' => ':wave:',
+            'status_text' => 'Back',
+            'status_expires_at' => $renewed,
+        ]);
+    });
+
+    $cleared = ExpirySweep::clearLapsedProfileInstant(
+        User::query()->whereNotNull('status_emoji'),
+        'status_expires_at',
+        ['status_emoji', 'status_text'],
+    );
+
+    expect($cleared)->toBe(0)
+        ->and($racer->fresh()->status_emoji)->toBe(':wave:')
+        ->and($racer->fresh()->status_expires_at?->equalTo($renewed))->toBeTrue();
+
+    Event::assertNotDispatched(UserProfileUpdated::class);
+});

--- a/tests/Integration/Support/SecurityEventRecorderTest.php
+++ b/tests/Integration/Support/SecurityEventRecorderTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Enums\SecurityEventType;
+use App\Models\User;
+use App\Support\SecurityEventRecorder;
+
+/**
+ * The device context of a sign-in, as the recorder receives it: an address and
+ * a user agent, already captured. The listener that reads them off a live
+ * request is deliberately not in the way here — that separation is the whole
+ * reason this module resolves outside HTTP.
+ *
+ * @return array{0: string, 1: string}
+ */
+function officeDevice(): array
+{
+    return ['203.0.113.7', 'Mozilla/5.0 (Macintosh) TheDesk/1.0'];
+}
+
+test('an event is recorded against the user and the device context it was handed', function (): void {
+    $user = User::factory()->create();
+    [$ip, $agent] = officeDevice();
+
+    $event = app(SecurityEventRecorder::class)
+        ->record($user, SecurityEventType::PasswordChanged, $ip, $agent);
+
+    expect($event->user_id)->toBe($user->id)
+        ->and($event->type)->toBe(SecurityEventType::PasswordChanged)
+        ->and($event->ip_address)->toBe($ip)
+        ->and($event->user_agent)->toBe($agent);
+});
+
+test('the context is optional, for an event with no request behind it', function (): void {
+    $user = User::factory()->create();
+
+    $event = app(SecurityEventRecorder::class)
+        ->record($user, SecurityEventType::AccountProvisioned, null, null);
+
+    expect($event->ip_address)->toBeNull()
+        ->and($event->user_agent)->toBeNull();
+});
+
+test('the first sign-in from an address and agent is a new device, and the next one is not', function (): void {
+    $user = User::factory()->create();
+    $recorder = app(SecurityEventRecorder::class);
+    [$ip, $agent] = officeDevice();
+
+    $first = $recorder->record($user, SecurityEventType::LoggedIn, $ip, $agent);
+    $repeat = $recorder->record($user, SecurityEventType::LoggedIn, $ip, $agent);
+    $elsewhere = $recorder->record($user, SecurityEventType::LoggedIn, '198.51.100.4', $agent);
+
+    expect($first->is_new_device)->toBeTrue()
+        ->and($repeat->is_new_device)->toBeFalse()
+        ->and($elsewhere->is_new_device)->toBeTrue();
+});
+
+test('a device another account has signed in from is still new to this one', function (): void {
+    $stranger = User::factory()->create();
+    $user = User::factory()->create();
+    $recorder = app(SecurityEventRecorder::class);
+    [$ip, $agent] = officeDevice();
+
+    $recorder->record($stranger, SecurityEventType::LoggedIn, $ip, $agent);
+
+    expect($recorder->record($user, SecurityEventType::LoggedIn, $ip, $agent)->is_new_device)
+        ->toBeTrue();
+});
+
+test('only a sign-in is ever flagged as a new device', function (): void {
+    $user = User::factory()->create();
+    [$ip, $agent] = officeDevice();
+
+    $event = app(SecurityEventRecorder::class)
+        ->record($user, SecurityEventType::PasskeyRegistered, $ip, $agent);
+
+    expect($event->is_new_device)->toBeFalse();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -58,6 +58,26 @@ pest()->extend(TestCase::class)
     ->use(RefreshDatabase::class)
     ->in('Feature');
 
+/*
+|--------------------------------------------------------------------------
+| Integration Test Case (#1111)
+|--------------------------------------------------------------------------
+|
+| The same booted application and the same migrated database as `Feature`,
+| and deliberately so: what separates the two suites is not what they are
+| given but what they drive. An `Integration` test constructs the module and
+| calls it; a `Feature` test goes through `route()`. Before this suite existed
+| the split was "needs a database" against "doesn't", which is why 115 files
+| in `tests/Feature` never name a route — they were unit-shaped tests exiled
+| there to get a database, and modules that were perfectly constructible could
+| only be reached through a rendered page. ADR-0012 has the full account.
+|
+*/
+
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->in('Integration');
+
 // The slash-command unit tests exercise command copy through the translator, so
 // they need the application booted (but no database).
 pest()->extend(TestCase::class)->in('Unit/SlashCommands');
@@ -155,6 +175,7 @@ function something(): void
     // ..
 }
 
+require_once __DIR__.'/Helpers.php';
 require_once __DIR__.'/Browser/Helpers.php';
 require_once __DIR__.'/Feature/Auth/Sso/Helpers.php';
 require_once __DIR__.'/Feature/Scim/Helpers.php';


### PR DESCRIPTION
Closes #1111. First child of the architecture-hardening III epic (#1110) — the
one the other five write their acceptance criteria against.

## What this changes

**A third suite and one shared arrange.** `tests/Pest.php` bound `RefreshDatabase`
with `->in('Feature')`, so the split on the ground was *"needs a database"* against
*"doesn't"* rather than *"through HTTP"* against *"direct"*. Two consequences: 115 of
265 `tests/Feature` files never call `route()` (unit-shaped tests exiled there to get a
database), and modules that are perfectly constructible were only reachable through a
rendered page — 36 Actions never named in any test, 57 `app/Data` DTOs with no unit
test, six `app/Support` seams with zero test references.

- **`tests/Integration/`** — new `<testsuite>` in `phpunit.xml`, `RefreshDatabase`
  bound to it in `tests/Pest.php`. The same booted application and migrated database
  as `Feature`; what separates them is not what they are given but what they drive.
- **`tests/Helpers.php`** — `require_once`'d alongside the three helper files that
  already were. `teamWithChannel()`, `teamMemberInChannel()`, `channelMembership()`,
  carrying the arrange ~57 files re-declare under a private prefix
  (`threadTeamWithGeneral`, `pinTeamWithGeneral`, `draftMember`, …). Membership state
  arrives as a closure over `ChannelMemberFactory`
  (`fn ($m) => $m->muted()->draft('…')`), so the helper names none of the pivot's
  columns and a fifth state needs no change here. It *restates* an existing membership
  rather than replacing it — the owner is auto-joined to `#general`, so a good half of
  the arranges land on a row that already exists and whose read cursor is not the
  helper's to reset.

**Nothing was moved.** The 115 route-less `Feature` files and the 48 repo-hygiene files
in `tests/Unit` stay exactly where they are; the sweep is child 6b, and it relocates a
file only when it is already rewriting that file's assertions.

## Proving it works end to end

17 integration tests against three modules that had **zero** test references — they
reached 100% line coverage only as a side effect of somebody else's HTTP test:

- **`ExpirySweep`** — purging expired exports (file before row), and the
  compare-and-swap that spares a status a user re-set while the pass was running. That
  last one opens the race deterministically on `retrieved`; no HTTP test was ever going
  to express it.
- **`SecurityEventRecorder`** — the device context it is handed, and the new-device flag
  (first sign-in from a pair, not the repeat, never for a non-sign-in, and not shared
  across accounts).
- **`ScheduleMessage`** — stores the row pending and consumes the author's draft. Picked
  because it needs the full team + channel + member arrange *and* a membership carrying
  a `draft`, so it exercises the helper rather than only the suite.

Plus `tests/Integration/SharedArrangeTest.php`, which holds the arrange's one
non-obvious promise still: restating a membership does not reset the rest of the row.
Breaking that would surface as unrelated arranges quietly losing a read cursor.

## Docs

- **ADR-0012** (`dev-docs/adr/0012-three-test-suites.md`) — the three suites, why the
  old split pushed 115 unit-shaped tests into `Feature`, and why the fix is a third home
  rather than renaming `Unit`. Records the cost too: three homes is one more judgement
  call than two.
- **`CONTRIBUTING.md`** and **`.claude/rules/testing.md`** — where a new test goes, and
  the shared arrange.

## Testing

| gate | result |
| --- | --- |
| Pint / PHPStan / Rector | pass |
| PHP suite, three suites in parallel | 3151 passed |
| Browser suite (`bin/browser-tests`) | 352/352, exit 0 — unaffected |
| ESLint / Prettier / vue-tsc / Vitest / build | pass |

No user-facing copy, so no i18n keys; nothing operator-facing, so no `docs/` change.

## One thing found on the way, not fixed here

**The coverage gate is already red on `develop`** — `MessageSearchPanel::fromRequest()`
has had no caller since #1102 and leaves one line uncovered. This branch's coverage
report is byte-identical to a clean `develop`'s, so it adds nothing to the hole. Filed
as **#1119**, together with the reason it went unnoticed: CI sets `coverage: none`
deliberately (`tests.yml:93`), so the gate only ever runs on someone's laptop.

Because "Closes #NNN" does not fire for PRs merged into `develop`, #1111 needs closing
by hand once this lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788120128&installation_model_id=428379&pr_number=1122&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1122&signature=2a0424145dd712bebb2f82b2ca695fa0a06fbd4122168df331d48dd309b81943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->