### PR TITLE
refactor: give the channel-traffic predicate one home per language

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -138,6 +138,17 @@ built; build them once, then reuse.
 - **Message thread-state scopes** (`Message::withThreadReadState`, `followedBy`) —
   exemplary depth; correlated-subquery logic hidden behind a scope that reuses one
   SQL constant so scope and filter can't disagree. The model to aspire to.
+- **Channel-traffic predicate** _(ADR-0010)_ — "a thread-only reply is not ordinary
+  channel traffic" lives once, on `Message`: `channelTraffic()` for a query,
+  `channelTrafficSql()` for the one conditional aggregate a scope cannot express
+  (`WorkspaceUnread`'s grouped tally), and `isChannelTraffic()` for a path holding a
+  `MessageData` rather than a query (the push listener). It is the rule that decides
+  whether a badge, a chime, a push and the timeline agree about one message, and it was
+  spelled seven times before. **Opt-in per call site, deliberately** — `mention_count`
+  must *not* carry it, because a mention inside a thread still badges its channel, so
+  never fold it into `WorkspaceUnread::forChannelsOf()` or make it a global scope. Its
+  client twin is `lib/channelTraffic.ts`, and both are pinned against one shared case
+  table (`tests/Fixtures/channel-traffic-cases.json`).
 
 ### Frontend (`resources/js/`)
 
@@ -145,6 +156,14 @@ built; build them once, then reuse.
   a `*.test.ts`. New pure logic (formatting, parsing, decisions) goes here, not
   into a `.vue` setup block. Examples: `messageBody`, `reactions`, `shouldChime`,
   `unreadDivider`, `readReceipts`, `scheduleTime`.
+- **`lib/channelTraffic.ts`** _(ADR-0010)_ — the client half of the channel-traffic
+  rule above: `isChannelTraffic(message)`, called by the chime, the sidebar-badge
+  refresh and `messagePlacement`, so a live append, a badge and the server's own
+  paging cannot disagree about which messages belong to a channel. It shares its case
+  table with the server's tests, so a change made on one side of the wire turns the
+  other side's suite red. Answering "is this a reply?" or "which of these is the root?"
+  is a *different* question — read `threadRootId` for those; this helper is only for
+  the channel-traffic one.
 - **`useMessageStream`** — deep composable: a simple `appendLive`/`applyPatch`
   interface hiding a three-source merge engine. The model for composables.
 - **`useChannelRealtime`** _(ADR-0006)_ — owns the channel's Echo

--- a/app/Listeners/SendMessagePushNotifications.php
+++ b/app/Listeners/SendMessagePushNotifications.php
@@ -7,6 +7,7 @@ namespace App\Listeners;
 use App\Data\MentionData;
 use App\Events\MessageSent;
 use App\Models\ChannelMember;
+use App\Models\Message;
 use App\Notifications\NewMessageNotification;
 use App\Support\PushDecision;
 use App\Support\WebPushConfig;
@@ -47,10 +48,7 @@ class SendMessagePushNotifications implements ShouldQueue
             $message->mentions,
         );
 
-        // A thread-only reply is not ordinary channel traffic: it stays out of
-        // the timeline and out of the sidebar's unread badge, so it only ever
-        // alerts through the mention path.
-        $isChannelMessage = $message->threadRootId === null || $message->sentToChannel;
+        $isChannelMessage = Message::isChannelTraffic($message->threadRootId, $message->sentToChannel);
 
         foreach ($this->recipients($event) as $member) {
             $recipient = $member->user;

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -6,6 +6,7 @@ use App\Data\MessageData;
 use App\Enums\MessageType;
 use App\Enums\NotificationLevel;
 use App\Support\MessagePlainText;
+use App\Support\WorkspaceUnread;
 use Database\Factories\MessageFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -300,6 +301,74 @@ class Message extends Model
     public function attachments(): HasMany
     {
         return $this->hasMany(Attachment::class)->oldest()->orderBy('id');
+    }
+
+    /**
+     * The rule that decides whether a message is ordinary channel traffic: a
+     * top-level message, or a thread reply its author explicitly also sent to
+     * the channel. A thread-only reply is not — it lives in the thread view, so
+     * it stays out of the main timeline and out of the plain unread badge, and
+     * only ever alerts through the mention path.
+     *
+     * Qualified against `messages` because the sidebar correlates this against a
+     * query that has `channels` and `channel_members` joined in.
+     *
+     * One constant, so the scope below, the conditional aggregate in
+     * {@see WorkspaceUnread} and the timeline's filter cannot
+     * disagree about what "channel traffic" means. Its client twin is
+     * `resources/js/lib/channelTraffic.ts`; ADR-0010 records why both exist and
+     * why neither may be re-inlined.
+     */
+    private const string CHANNEL_TRAFFIC_SQL = '(messages.thread_root_id is null or messages.sent_to_channel = true)';
+
+    /**
+     * Constrain a message query to ordinary channel traffic, per
+     * {@see self::CHANNEL_TRAFFIC_SQL}.
+     *
+     * Deliberately opt-in per call site rather than a global scope: a mention
+     * anywhere — including inside a thread — still badges its channel, so the
+     * sidebar's mention count is one of the queries that must *not* carry it.
+     *
+     * @param  Builder<Message>  $query
+     */
+    protected function scopeChannelTraffic(Builder $query): void
+    {
+        $query->whereRaw(self::CHANNEL_TRAFFIC_SQL);
+    }
+
+    /**
+     * The same rule as a SQL fragment, for the one caller that needs it inside
+     * an expression rather than as a `where`: {@see WorkspaceUnread}
+     * counts channel traffic and mentions in a single grouped query, so its
+     * unread half is a conditional aggregate that no scope can express.
+     *
+     * Reach for {@see self::scopeChannelTraffic()} everywhere else — a `where`
+     * that goes through this instead is a `whereRaw` with extra steps.
+     *
+     * Typed `literal-string` because that is what the query builder's raw
+     * methods take: it is what makes "this fragment can hold no user input" a
+     * static guarantee rather than a promise in a comment.
+     *
+     * @return literal-string
+     */
+    public static function channelTrafficSql(): string
+    {
+        return self::CHANNEL_TRAFFIC_SQL;
+    }
+
+    /**
+     * The in-memory twin of {@see self::CHANNEL_TRAFFIC_SQL}, for the paths that
+     * hold a payload rather than a query — the push listener decides from the
+     * broadcast {@see MessageData}, and re-reading the row to ask the
+     * database would be a query per message per send.
+     *
+     * Kept beside the SQL, and pinned against the same case table
+     * (`tests/Fixtures/channel-traffic-cases.json`) as both the scope and the
+     * client twin, so the three cannot drift.
+     */
+    public static function isChannelTraffic(?string $threadRootId, bool $sentToChannel): bool
+    {
+        return $threadRootId === null || $sentToChannel;
     }
 
     /**

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -6,7 +6,6 @@ use App\Data\MessageData;
 use App\Enums\MessageType;
 use App\Enums\NotificationLevel;
 use App\Support\MessagePlainText;
-use App\Support\WorkspaceUnread;
 use Database\Factories\MessageFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -314,8 +313,8 @@ class Message extends Model
      * query that has `channels` and `channel_members` joined in.
      *
      * One constant, so the scope below, the conditional aggregate in
-     * {@see WorkspaceUnread} and the timeline's filter cannot
-     * disagree about what "channel traffic" means. Its client twin is
+     * `WorkspaceUnread` and the timeline's filter cannot disagree about what
+     * "channel traffic" means. Its client twin is
      * `resources/js/lib/channelTraffic.ts`; ADR-0010 records why both exist and
      * why neither may be re-inlined.
      */
@@ -338,9 +337,9 @@ class Message extends Model
 
     /**
      * The same rule as a SQL fragment, for the one caller that needs it inside
-     * an expression rather than as a `where`: {@see WorkspaceUnread}
-     * counts channel traffic and mentions in a single grouped query, so its
-     * unread half is a conditional aggregate that no scope can express.
+     * an expression rather than as a `where`: `WorkspaceUnread` counts channel
+     * traffic and mentions in a single grouped query, so its unread half is a
+     * conditional aggregate that no scope can express.
      *
      * Reach for {@see self::scopeChannelTraffic()} everywhere else — a `where`
      * that goes through this instead is a `whereRaw` with extra steps.

--- a/app/Support/ChannelTimelineWindow.php
+++ b/app/Support/ChannelTimelineWindow.php
@@ -302,7 +302,6 @@ class ChannelTimelineWindow
      */
     private function mainTimeline(): Builder
     {
-        return $this->channel->messages()->withTrashed()->getQuery()
-            ->where(fn (Builder $inner) => $inner->whereNull('thread_root_id')->orWhere('sent_to_channel', true));
+        return $this->channel->messages()->withTrashed()->getQuery()->channelTraffic();
     }
 }

--- a/app/Support/SidebarChannels.php
+++ b/app/Support/SidebarChannels.php
@@ -98,9 +98,10 @@ final readonly class SidebarChannels
             ->selectRaw("case when channel_members.draft is not null and channel_members.draft != '' then 1 else 0 end as has_draft")
             // Thread-only replies stay out of the plain unread badge (they live
             // in the thread view), but a mention anywhere — including inside a
-            // thread — still badges the channel.
-            ->selectSub(WorkspaceUnread::forChannelsOf($this->viewer)
-                ->where(fn (Builder $query) => $query->whereNull('messages.thread_root_id')->orWhere('messages.sent_to_channel', true)), 'unread_count')
+            // thread — still badges the channel. That asymmetry is why the
+            // predicate is opt-in per call site: only the first of these two
+            // sub-queries asks for it.
+            ->selectSub(WorkspaceUnread::forChannelsOf($this->viewer)->channelTraffic(), 'unread_count')
             ->selectSub(
                 WorkspaceUnread::forChannelsOf($this->viewer)->whereHas('mentionedUsers', fn (Builder $query) => $query->whereKey($this->viewer->id)),
                 'mention_count'

--- a/app/Support/WorkspaceUnread.php
+++ b/app/Support/WorkspaceUnread.php
@@ -112,9 +112,13 @@ class WorkspaceUnread
             ->select('channels.team_id')
             // Thread-only replies live in the thread view and stay out of the
             // plain unread count, and the "mentions" level silences it entirely.
+            // The channel-traffic half is {@see Message::channelTrafficSql()}
+            // rather than a copy: both counts are aggregated in this one grouped
+            // query, so the unread half has to be a conditional aggregate, which
+            // is the one shape the scope cannot express.
             ->selectRaw(
-                'sum(case when channel_members.notification_level = ? and (messages.thread_root_id is null or messages.sent_to_channel = ?) then 1 else 0 end) as unread_count',
-                [NotificationLevel::All->value, true],
+                'sum(case when channel_members.notification_level = ? and '.Message::channelTrafficSql().' then 1 else 0 end) as unread_count',
+                [NotificationLevel::All->value],
             )
             ->selectRaw('sum(case when mentions.message_id is not null then 1 else 0 end) as mention_count')
             ->toBase();

--- a/app/Support/WorkspaceUnread.php
+++ b/app/Support/WorkspaceUnread.php
@@ -112,10 +112,10 @@ class WorkspaceUnread
             ->select('channels.team_id')
             // Thread-only replies live in the thread view and stay out of the
             // plain unread count, and the "mentions" level silences it entirely.
-            // The channel-traffic half is {@see Message::channelTrafficSql()}
-            // rather than a copy: both counts are aggregated in this one grouped
-            // query, so the unread half has to be a conditional aggregate, which
-            // is the one shape the scope cannot express.
+            // The channel-traffic half is Message's own SQL fragment rather
+            // than a copy of it: both counts are aggregated in this one grouped
+            // query, so the unread half has to be a conditional aggregate — the
+            // one shape `Message::channelTraffic()` cannot express.
             ->selectRaw(
                 'sum(case when channel_members.notification_level = ? and '.Message::channelTrafficSql().' then 1 else 0 end) as unread_count',
                 [NotificationLevel::All->value],

--- a/dev-docs/adr/0010-channel-traffic-predicate-has-one-home-per-language.md
+++ b/dev-docs/adr/0010-channel-traffic-predicate-has-one-home-per-language.md
@@ -1,0 +1,113 @@
+# ADR-0010: The channel-traffic predicate has one home per language
+
+- Status: Accepted
+- Date: 2026-07-31
+- Relates to: epic architecture-hardening III ([#1110](https://github.com/deskhq/the-desk/issues/1110), child: [#1114](https://github.com/deskhq/the-desk/issues/1114))
+
+## Context
+
+One domain rule — **a thread-only reply is not ordinary channel traffic** — was spelled
+seven times, in two languages, in five different forms:
+
+| # | location | form |
+|---|---|---|
+| 1 | `app/Listeners/SendMessagePushNotifications.php` | PHP expression on a DTO |
+| 2 | `app/Support/WorkspaceUnread.php` | raw SQL inside a `selectRaw` aggregate |
+| 3 | `app/Support/SidebarChannels.php` | builder closure |
+| 4 | `app/Support/ChannelTimelineWindow.php` | builder closure |
+| 5 | `resources/js/composables/useChimeNotifications.ts` | TS expression |
+| 6 | `resources/js/composables/useSidebarBadges.ts` | TS expression |
+| 7 | `resources/js/lib/messagePlacement.ts` | TS expression, via a local `isReply` |
+
+Six of the seven had no test. The push listener even wrote the rule out in prose before
+restating it in code, which is what a rule with nowhere to live looks like.
+
+This is the highest-stakes rule in the epic, because it is the one that decides whether a
+**badge, a chime, a push notification and the timeline agree about the same message**.
+Those four surfaces are the whole of what a user experiences as "did this message reach
+me?", and they were four independent transcriptions. Changing what counts as channel
+traffic meant seven synchronised edits across PHP, SQL and TypeScript, and **nothing
+failed if you missed one** — the failure would surface as a badge disagreeing with a
+timeline, weeks later, for one message shape.
+
+The rule also has a deliberate asymmetry that a careless fix would erase.
+`SidebarChannels` documents that `mention_count` does **not** carry the thread filter — *"a
+mention anywhere, including inside a thread, still badges the channel"* — while
+`unread_count`, built from the very same shared sub-query, does. So the rule cannot simply
+be pushed down into `WorkspaceUnread::forChannelsOf()`: that would take the mention count
+with it, and a mention nobody was badged for is the worst outcome this module has.
+
+## Decision
+
+**The rule has one home per language, and both are named after the rule rather than after
+the columns it reads.**
+
+Server, in `app/Models/Message.php`:
+
+- `Message::CHANNEL_TRAFFIC_SQL` — the rule, once, as SQL.
+- `Message::channelTraffic()` — the query scope every filtering call site uses. It is
+  `whereRaw` over that constant, so the scope and the constant cannot disagree. This is the
+  shape `Message::followedBy` / `withThreadReadState` already established and that
+  `CONTEXT.md` calls "the model to aspire to".
+- `Message::channelTrafficSql()` — the same constant, for the one caller that needs the
+  fragment inside an expression rather than as a `where`. `WorkspaceUnread` counts channel
+  traffic and mentions in a single grouped query, so its unread half is a conditional
+  aggregate (`sum(case when … then 1 else 0 end)`), which no scope can express.
+- `Message::isChannelTraffic(?string $threadRootId, bool $sentToChannel)` — the in-memory
+  twin, for the paths that hold a payload rather than a query. The push listener decides
+  from the broadcast `MessageData`; re-reading the row to ask the database would be a query
+  per message per send.
+
+Client, in `resources/js/lib/channelTraffic.ts`: `isChannelTraffic(message)`, the pure
+helper the chime, the sidebar refresh and the timeline placement all call. This mirrors
+`PushDecision` ↔ `shouldChime` — the app already accepts that one rule may need a server
+statement and a client statement — and `lib/reminderReload.ts`, whose test fails on a
+second copy of the prop set.
+
+**The predicate stays opt-in per call site.** It is not folded into
+`WorkspaceUnread::forChannelsOf()`, nor made a global scope, precisely because
+`mention_count` must not have it. The asymmetry is the feature; a call site asks for the
+rule when the rule applies.
+
+**Three implementations, one specification.** `tests/Fixtures/channel-traffic-cases.json`
+holds the case table — all four combinations of the two facts the rule reads — and is read
+by both `tests/Integration/Models/ChannelTrafficPredicateTest.php` (the scope and the
+in-memory twin, the scope proven against real rows) and
+`resources/js/lib/channelTraffic.test.ts` (the client twin). Neither suite owns the table,
+so a row added or flipped on one side of the wire has to satisfy the other.
+
+## Consequences
+
+- Changing what counts as channel traffic is now **two edits** — one per language — and the
+  shared case table fails the *other* language's suite if only one is made. It was seven
+  edits with no failure at all.
+- The raw-SQL copy in `WorkspaceUnread` is gone; it references the shared fragment. The two
+  builder closures and the listener's expression are gone too, replaced by the scope and
+  the in-memory twin.
+- Six previously untested sites are now covered by the tests the one home carries, plus two
+  new pins on the surfaces the rule decides: `WorkspaceUnreadTest` now states that a
+  thread-only reply does not tally for a workspace and that a **mention** inside one still
+  does, and `SidebarChannelsTest` states the same asymmetry per channel. The workspace
+  tally had no thread coverage whatsoever — the rail's dot could have been counting thread
+  replies indefinitely and agreed with nothing.
+- `tests/Unit/ChannelTrafficPredicateHomeTest.php` fails if an eighth spelling appears in
+  `app/` or `resources/js/`, matching all five forms the seven copies actually took.
+  **Stated plainly: it is a tripwire, not a proof.** A copy written in a shape none of the
+  patterns anticipate escapes it, and the guard deliberately matches only the
+  *disjunction* — `thread_root_id` alone is a legitimate question ("is this a reply?"), and
+  so is `threadRootId === null` ("which of these is the root?", which `ThreadPanel.vue` and
+  `MessageList.vue` both ask, and which is **not** this rule). The specification is the case
+  table; the guard only catches the lazy way back.
+- **The cost: the rule is stated twice on the server**, once as SQL and once in PHP, and the
+  compiler cannot connect them. That is not avoidable — one call site holds a query, another
+  holds a DTO — so the mitigation is that both live in the same file, adjacent, and are
+  proven against the same table. The alternative, having the listener re-query, trades a
+  provable duplication for a per-message query.
+- **The tempting alternative — "it is one boolean, just inline it" — is exactly what produced
+  the seven copies.** Each of them was individually reasonable: two lines, obvious at the
+  call site, no indirection. It is the seventh that is expensive, and by then no single edit
+  is where the cost shows up.
+- The five server spellings of **"unread"** are deliberately left alone. Their
+  archived/muted/`nothing` exclusions genuinely differ per call site and at least one of
+  those differences is intended, so collapsing them is a behaviour change, not a mechanical
+  one. That is a separate decision from this one.

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -15,9 +15,6 @@ seams live in [`CONTEXT.md`](../../CONTEXT.md).
 | [0007](0007-in-process-browser-realtime-harness.md) | Browser E2E realtime tests run against the app served in-process |
 | [0008](0008-workspace-shell-read-model.md) | The shared-props middleware is glue; the workspace shell is a read-model |
 | [0009](0009-message-action-context-is-provided.md) | The message-action context is provided, not drilled |
+| [0010](0010-channel-traffic-predicate-has-one-home-per-language.md) | The channel-traffic predicate has one home per language |
 | [0011](0011-read-model-dto-takes-its-viewer.md) | A read-model DTO takes its viewer, and batches its roster |
 | [0012](0012-three-test-suites.md) | Three test suites: pure, database, HTTP contract |
-
-0010 is reserved for the child of [#1110](https://github.com/deskhq/the-desk/issues/1110) that
-names the channel-traffic predicate and has not merged yet; the epic declares a merge order,
-and it goes after this one.

--- a/resources/js/composables/useChimeNotifications.ts
+++ b/resources/js/composables/useChimeNotifications.ts
@@ -1,6 +1,7 @@
 import { usePage } from '@inertiajs/vue3';
 import { computed, onBeforeUnmount, onMounted } from 'vue';
 import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
+import { isChannelTraffic } from '@/lib/channelTraffic';
 import { playChime, unlockChimeAudio } from '@/lib/chimeSounds';
 import { isDndActiveNow } from '@/lib/dnd';
 import { shouldChime } from '@/lib/shouldChime';
@@ -35,8 +36,7 @@ export function useChimeNotifications(): void {
         const decision = shouldChime({
             chimeEnabled: chimeSound.value !== 'off',
             isOwnMessage: message.user.id === currentUserId.value,
-            isChannelMessage:
-                message.threadRootId === null || message.sentToChannel,
+            isChannelMessage: isChannelTraffic(message),
             mentionsCurrentUser: message.mentions.some(
                 (mention) => mention.id === currentUserId.value,
             ),

--- a/resources/js/composables/useSidebarBadges.ts
+++ b/resources/js/composables/useSidebarBadges.ts
@@ -4,6 +4,7 @@ import { computed, onBeforeUnmount, onMounted } from 'vue';
 import { useChannelFleetSubscription } from '@/composables/useChannelFleetSubscription';
 import { useDebouncedPost } from '@/composables/useDebouncedPost';
 import { backgroundVisit } from '@/lib/backgroundVisit';
+import { isChannelTraffic } from '@/lib/channelTraffic';
 import { shouldRefreshSidebar } from '@/lib/shouldRefreshSidebar';
 
 /** Coalesce a burst of arrivals into a single sidebar reload. */
@@ -72,8 +73,7 @@ export function useSidebarBadges(): void {
     useChannelFleetSubscription((channelId, message) => {
         const decision = shouldRefreshSidebar({
             isOwnMessage: message.user.id === currentUserId.value,
-            isChannelMessage:
-                message.threadRootId === null || message.sentToChannel,
+            isChannelMessage: isChannelTraffic(message),
             mentionsCurrentUser: message.mentions.some(
                 (mention) => mention.id === currentUserId.value,
             ),

--- a/resources/js/lib/channelTraffic.test.ts
+++ b/resources/js/lib/channelTraffic.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { isChannelTraffic } from '@/lib/channelTraffic';
+
+/**
+ * One case per row of the shared table
+ * (`tests/Fixtures/channel-traffic-cases.json`), which
+ * `tests/Integration/Models/ChannelTrafficPredicateTest.php` reads to prove the
+ * server scope and its in-memory twin. Reading the same file — rather than
+ * re-typing the rows here — is what makes the two languages provably agree: a
+ * row added or flipped on either side has to satisfy both suites.
+ */
+type ChannelTrafficCase = {
+    name: string;
+    threadRootId: string | null;
+    sentToChannel: boolean;
+    isChannelTraffic: boolean;
+};
+
+const cases = JSON.parse(
+    readFileSync(
+        fileURLToPath(
+            new URL(
+                '../../../tests/Fixtures/channel-traffic-cases.json',
+                import.meta.url,
+            ),
+        ),
+        'utf8',
+    ),
+) as ChannelTrafficCase[];
+
+describe('isChannelTraffic', () => {
+    it.each(cases)('$name', (testCase) => {
+        expect(
+            isChannelTraffic({
+                threadRootId: testCase.threadRootId,
+                sentToChannel: testCase.sentToChannel,
+            }),
+        ).toBe(testCase.isChannelTraffic);
+    });
+
+    it('covers every combination of the two facts the rule reads', () => {
+        const combinations = new Set(
+            cases.map(
+                (testCase) =>
+                    `${testCase.threadRootId}/${testCase.sentToChannel}`,
+            ),
+        );
+
+        expect(combinations.size).toBe(4);
+    });
+});

--- a/resources/js/lib/channelTraffic.ts
+++ b/resources/js/lib/channelTraffic.ts
@@ -1,0 +1,26 @@
+export type ChannelTrafficInput = {
+    /** The reply's root message id, or `null` for a top-level channel message. */
+    threadRootId: string | null;
+    /** A thread reply the author also chose to echo into the channel timeline. */
+    sentToChannel: boolean;
+};
+
+/**
+ * Whether a message is ordinary channel traffic: a top-level message, or a
+ * thread reply its author explicitly also sent to the channel.
+ *
+ * A thread-only reply is not. It lives in the thread view, so it stays out of
+ * the main timeline and out of the sidebar's unread badge, and only ever alerts
+ * through the mention path — which is why the chime, the sidebar refresh and the
+ * timeline placement all ask this one question rather than each re-deriving it.
+ *
+ * The client twin of `Message::channelTraffic()` / `Message::isChannelTraffic()`,
+ * pinned against the same case table (`tests/Fixtures/channel-traffic-cases.json`)
+ * so a change made on one side of the wire cannot land without the other. Its
+ * counterpart in kind is {@see shouldFlagThreadUnread}, which answers the
+ * *thread's* unread question; this one answers the channel's. ADR-0010 records
+ * why the rule has exactly one home per language.
+ */
+export function isChannelTraffic(message: ChannelTrafficInput): boolean {
+    return message.threadRootId === null || message.sentToChannel;
+}

--- a/resources/js/lib/messagePlacement.ts
+++ b/resources/js/lib/messagePlacement.ts
@@ -1,10 +1,8 @@
+import { isChannelTraffic } from '@/lib/channelTraffic';
+import type { ChannelTrafficInput } from '@/lib/channelTraffic';
 import { shouldFlagThreadUnread } from '@/lib/shouldFlagThreadUnread';
 
-export type IncomingPlacementInput = {
-    /** The reply's root message id, or `null` for a top-level channel message. */
-    threadRootId: string | null;
-    /** A thread reply the author also chose to echo into the channel timeline. */
-    sentToChannel: boolean;
+export type IncomingPlacementInput = ChannelTrafficInput & {
     /** The arriving message was authored by the current viewer. */
     isOwnMessage: boolean;
     /** The root id of the thread currently open in the panel, or `null`. */
@@ -36,12 +34,13 @@ export type IncomingPlacement = {
  * open thread, both, or neither — and whether it advances or dots the thread's
  * read state.
  *
- * This is the pure decision core of `Show.vue`'s realtime routing. A top-level
- * message (or a reply explicitly sent to the channel) shows in the main timeline;
- * a reply into the *open* thread appends there and, while the tab is focused,
- * keeps that thread read; a reply into a *closed* followed thread raises its
- * unread dot instead — the last branch deferring to {@see shouldFlagThreadUnread}
- * so a live dot and a navigation-time dot agree.
+ * This is the pure decision core of `Show.vue`'s realtime routing. Whatever
+ * {@see isChannelTraffic} calls channel traffic shows in the main timeline — the
+ * same rule the server pages the timeline with, so a live append and a reload
+ * agree on what is in it; a reply into the *open* thread appends there and, while
+ * the tab is focused, keeps that thread read; a reply into a *closed* followed
+ * thread raises its unread dot instead — the last branch deferring to
+ * {@see shouldFlagThreadUnread} so a live dot and a navigation-time dot agree.
  */
 export function placeIncomingMessage(
     input: IncomingPlacementInput,
@@ -52,7 +51,7 @@ export function placeIncomingMessage(
     const isViewingThreadFocused = isActiveThread && input.isTabFocused;
 
     return {
-        appendToMain: !isReply || input.sentToChannel,
+        appendToMain: isChannelTraffic(input),
         appendToThread: isActiveThread,
         markThreadReadNow: isViewingThreadFocused,
         flagRootThreadUnread:

--- a/tests/Feature/Support/WorkspaceUnreadTest.php
+++ b/tests/Feature/Support/WorkspaceUnreadTest.php
@@ -77,6 +77,58 @@ test('the per-workspace tally sums a team\'s unread and mentions', function (): 
     ]);
 });
 
+/**
+ * The workspace tally is where the channel-traffic rule used to be spelled as
+ * raw SQL inside the conditional aggregate, and it had no test at all: the dot
+ * on the rail could have counted thread-only replies for as long as anyone cared
+ * to look, and would still have agreed with nothing. It now shares
+ * {@see Message::channelTrafficSql()} with the sidebar, and this is what says so.
+ */
+test('the per-workspace tally counts a thread reply only when it was also sent to the channel', function (): void {
+    [$viewer, $mate, $team, $general] = unreadWorkspace();
+
+    $root = Message::factory()->for($general)->for($mate)->create();
+
+    Message::factory()->for($general)->for($mate)->create([
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => false,
+    ]);
+
+    // The root alone; the thread-only reply lives in the thread view.
+    expect(WorkspaceUnread::forUser($viewer))->toBe([
+        $team->id => ['unread' => 1, 'mention' => 0],
+    ]);
+
+    Message::factory()->for($general)->for($mate)->create([
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => true,
+    ]);
+
+    expect(WorkspaceUnread::forUser($viewer))->toBe([
+        $team->id => ['unread' => 2, 'mention' => 0],
+    ]);
+});
+
+/**
+ * The mention half of the same aggregate deliberately does not carry the
+ * predicate — a mention anywhere, thread included, still badges — which is why
+ * the rule is opt-in per call site rather than folded into the shared query.
+ */
+test('a mention inside a thread-only reply still tallies for the workspace', function (): void {
+    [$viewer, $mate, $team, $general] = unreadWorkspace();
+
+    $root = Message::factory()->for($general)->for($mate)->create();
+
+    Message::factory()->for($general)->for($mate)->create([
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => false,
+    ])->mentionedUsers()->attach($viewer);
+
+    expect(WorkspaceUnread::forUser($viewer))->toBe([
+        $team->id => ['unread' => 1, 'mention' => 1],
+    ]);
+});
+
 test('a muted channel is silent in the per-workspace tally but still counted per channel', function (): void {
     [$viewer, $mate, , $general] = unreadWorkspace();
 

--- a/tests/Fixtures/channel-traffic-cases.json
+++ b/tests/Fixtures/channel-traffic-cases.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "a top-level message is channel traffic",
+        "threadRootId": null,
+        "sentToChannel": false,
+        "isChannelTraffic": true
+    },
+    {
+        "name": "a top-level message carrying the flag is still channel traffic",
+        "threadRootId": null,
+        "sentToChannel": true,
+        "isChannelTraffic": true
+    },
+    {
+        "name": "a thread-only reply is not channel traffic",
+        "threadRootId": "root",
+        "sentToChannel": false,
+        "isChannelTraffic": false
+    },
+    {
+        "name": "a thread reply also sent to the channel is channel traffic",
+        "threadRootId": "root",
+        "sentToChannel": true,
+        "isChannelTraffic": true
+    }
+]

--- a/tests/Integration/Models/ChannelTrafficPredicateTest.php
+++ b/tests/Integration/Models/ChannelTrafficPredicateTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Models\Message;
+use App\Support\SidebarChannels;
+
+/*
+|--------------------------------------------------------------------------
+| The channel-traffic predicate, server half (#1114)
+|--------------------------------------------------------------------------
+|
+| "A thread-only reply is not ordinary channel traffic" is one rule with two
+| server forms — `Message::channelTraffic()` in SQL, and
+| `Message::isChannelTraffic()` for a payload already in memory — and one client
+| twin in `resources/js/lib/channelTraffic.ts`.
+|
+| All three are proven against the *same* table of cases,
+| `tests/Fixtures/channel-traffic-cases.json`, which the sibling
+| `resources/js/lib/channelTraffic.test.ts` reads too. That shared table is the
+| parity: a change to what counts as channel traffic made in one language and
+| not the other turns the other language's run red, which is exactly what seven
+| hand-written copies could not do.
+|
+*/
+
+/**
+ * The shared case table, decoded.
+ *
+ * @return array<int, array{name: string, threadRootId: string|null, sentToChannel: bool, isChannelTraffic: bool}>
+ */
+function channelTrafficCases(): array
+{
+    return json_decode(
+        (string) file_get_contents(dirname(__DIR__, 2).'/Fixtures/channel-traffic-cases.json'),
+        associative: true,
+        flags: JSON_THROW_ON_ERROR,
+    );
+}
+
+test('the case table is exhaustive over the two facts the rule reads', function (): void {
+    $combinations = array_map(
+        fn (array $case): string => ($case['threadRootId'] === null ? 'top-level' : 'reply')
+            .'/'.($case['sentToChannel'] ? 'flagged' : 'unflagged'),
+        channelTrafficCases(),
+    );
+
+    // The rule reads exactly two booleans, so anything short of all four
+    // combinations leaves a branch neither language is pinned on.
+    expect(array_unique($combinations))->toHaveCount(4);
+});
+
+test('the scope keeps exactly the messages the case table calls channel traffic', function (): void {
+    ['owner' => $author, 'channel' => $channel] = teamWithChannel();
+
+    $root = Message::factory()->for($channel)->for($author)->create();
+
+    // The root itself is top-level, so it is channel traffic too.
+    $expected = [$root->id];
+
+    foreach (channelTrafficCases() as $case) {
+        $message = Message::factory()->for($channel)->for($author)->create([
+            'thread_root_id' => $case['threadRootId'] === null ? null : $root->id,
+            'sent_to_channel' => $case['sentToChannel'],
+        ]);
+
+        if ($case['isChannelTraffic']) {
+            $expected[] = $message->id;
+        }
+    }
+
+    expect(Message::query()->channelTraffic()->pluck('id')->sort()->values()->all())
+        ->toBe(collect($expected)->sort()->values()->all());
+});
+
+test('the in-memory twin answers the case table the way the scope does', function (array $case): void {
+    expect(Message::isChannelTraffic($case['threadRootId'], $case['sentToChannel']))
+        ->toBe($case['isChannelTraffic']);
+})->with(function (): array {
+    $sets = [];
+
+    foreach (channelTrafficCases() as $case) {
+        $sets[$case['name']] = [$case];
+    }
+
+    return $sets;
+});
+
+/**
+ * The scope is correlated against the outer query in {@see SidebarChannels},
+ * where `channels` and `channel_members` are joined in, so an unqualified column
+ * would be ambiguous the day either table grew one of the same name. Pinned here
+ * rather than left to the sidebar's own tests, which would only fail on that day.
+ */
+test('the scope names its columns against the messages table', function (): void {
+    expect(Message::query()->channelTraffic()->toRawSql())
+        ->toContain('messages.thread_root_id')
+        ->toContain('messages.sent_to_channel');
+});

--- a/tests/Integration/Support/SidebarChannelsTest.php
+++ b/tests/Integration/Support/SidebarChannelsTest.php
@@ -121,6 +121,47 @@ test('unread and mention counts ride along, ignoring the viewer\'s own messages'
         ->and($channels[0]->mentionCount)->toBe(1);
 });
 
+/**
+ * The predicate is opt-in per sub-query, and this is the asymmetry that makes it
+ * so: the unread badge asks for channel traffic, the mention badge deliberately
+ * does not. Baking the rule into `WorkspaceUnread::forChannelsOf()` — the shared
+ * half both counts ride — would silently take the second half with it, and a
+ * mention nobody was badged for is the worst failure this module has.
+ */
+test('a thread-only reply raises the mention badge without touching the unread count', function (): void {
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $mate = teamMemberInChannel($general);
+
+    $root = Message::factory()->for($general)->for($mate)->create();
+
+    // The reply lives only in the thread, and it @mentions the viewer.
+    Message::factory()->for($general)->for($mate)->create([
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => false,
+    ])->mentionedUsers()->attach($user);
+
+    $channels = new SidebarChannels($user, $team)->forSidebar();
+
+    expect($channels[0]->unreadCount)->toBe(1)
+        ->and($channels[0]->mentionCount)->toBe(1);
+});
+
+test('a thread reply also sent to the channel counts towards the unread badge', function (): void {
+    ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
+
+    $mate = teamMemberInChannel($general);
+
+    $root = Message::factory()->for($general)->for($mate)->create();
+
+    Message::factory()->for($general)->for($mate)->create([
+        'thread_root_id' => $root->id,
+        'sent_to_channel' => true,
+    ]);
+
+    expect(new SidebarChannels($user, $team)->forSidebar()[0]->unreadCount)->toBe(2);
+});
+
 test('a draft is reported as a flag without shipping its text', function (): void {
     ['owner' => $user, 'team' => $team, 'channel' => $general] = teamWithChannel();
 

--- a/tests/Unit/ChannelTrafficPredicateHomeTest.php
+++ b/tests/Unit/ChannelTrafficPredicateHomeTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Message;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * The channel-traffic rule — "a thread-only reply is not ordinary channel
+ * traffic" — was spelled seven times across two languages before #1114: a PHP
+ * expression on a DTO, raw SQL inside a `selectRaw`, two builder closures and
+ * three TypeScript expressions. Six of the seven had no test, so changing what
+ * counts as channel traffic meant seven synchronised edits and nothing failed
+ * if you missed one.
+ *
+ * It now has one server home ({@see Message}) and one client twin
+ * (`resources/js/lib/channelTraffic.ts`), proven against a shared case table in
+ * `tests/Integration/Models/ChannelTrafficPredicateTest.php` and
+ * `resources/js/lib/channelTraffic.test.ts`. This test is what keeps it that
+ * way: an eighth spelling fails here rather than in production, months later,
+ * in whichever surface was missed. See ADR-0010.
+ */
+$sourceRoot = dirname(__DIR__, 2);
+
+/**
+ * Every file under `app/` and `resources/js/` that spells the rule out, as
+ * repository-relative paths.
+ *
+ * The patterns match the *disjunction*, never either half of it. `thread_root_id`
+ * on its own is a legitimate question ("is this a reply?", "load only the
+ * roots"), and so is `threadRootId === null` ("which of these messages is the
+ * root?", which both `ThreadPanel.vue` and `MessageList.vue` ask). It is the two
+ * facts read together, as one boolean, that is this rule.
+ *
+ * @return array<int, string>
+ */
+$spellings = function () use ($sourceRoot): array {
+    $patterns = [
+        // The raw-SQL form: `... thread_root_id is null or ... sent_to_channel`.
+        '/thread_root_id\s+is\s+null\s+or/i',
+        // The query-builder form the two support modules used.
+        "/whereNull\(\s*'[\w.]*thread_root_id'\s*\)\s*->\s*orWhere\(\s*'[\w.]*sent_to_channel'/",
+        // The in-memory form, in PHP and in TypeScript, either way round.
+        '/threadRootId\s*===\s*null\s*\|\|/',
+        '/sentToChannel\s*\|\|\s*[\w.$>-]*threadRootId\s*===\s*null/',
+        // The seventh spelling, which read the reply-ness off a local first
+        // (`!isReply || input.sentToChannel`). Worth its own pattern because it
+        // is the form a reader who already has "is this a reply?" in hand
+        // reaches for, and the one none of the above would catch.
+        '/!\s*is\w*[Rr]eply\s*\|\|\s*[\w.]*sentToChannel/',
+    ];
+
+    $files = (new Finder)
+        ->files()
+        ->in([$sourceRoot.'/app', $sourceRoot.'/resources/js'])
+        ->name(['*.php', '*.ts', '*.vue']);
+
+    $found = [];
+
+    foreach ($files as $file) {
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $file->getContents()) === 1) {
+                $found[] = str_replace($sourceRoot.'/', '', $file->getPathname());
+
+                break;
+            }
+        }
+    }
+
+    sort($found);
+
+    return $found;
+};
+
+test('the rule is spelled in exactly two places, one per language', function () use ($spellings): void {
+    expect($spellings())->toBe([
+        'app/Models/Message.php',
+        'resources/js/lib/channelTraffic.ts',
+    ]);
+});


### PR DESCRIPTION
Closes #1114. Child of #1110 (architecture hardening III), mints **ADR-0010**. Last of the
backend children, after #1111, #1112 and #1113 — all four land in `SidebarChannels::query()`,
this one at the unread sub-query.

## What

One domain rule — **a thread-only reply is not ordinary channel traffic** — was spelled
**seven times, in two languages, in five different forms**. Six of the seven had no test.

It now has **one server home and one client twin**.

Server, `app/Models/Message.php`:

| member | for |
| --- | --- |
| `CHANNEL_TRAFFIC_SQL` | the rule, once, as SQL |
| `channelTraffic()` scope | the three filtering call sites — `whereRaw` over that constant, so the two cannot disagree |
| `channelTrafficSql()` | the one caller needing the fragment inside an expression (see below) |
| `isChannelTraffic()` | the push listener, which holds a `MessageData`, not a query |

Client: `resources/js/lib/channelTraffic.ts`, called by `useChimeNotifications`,
`useSidebarBadges` and `messagePlacement`.

`grep -rn "forChannelsOf\|channelTraffic\|isChannelTraffic" app/ resources/js` shows all
seven former sites routing through the two homes; the raw-SQL copy in `WorkspaceUnread` is
gone.

## Why the shapes differ

**`WorkspaceUnread` gets a fragment, not the scope.** It counts channel traffic *and*
mentions in a single grouped query, so its unread half has to be a conditional aggregate
(`sum(case when … then 1 else 0 end)`) — the one shape a `where` scope cannot express. It
references the shared constant rather than restating it.

**The predicate stays opt-in per call site.** `SidebarChannels` documents that
`mention_count` deliberately does *not* carry the thread filter — a mention anywhere,
thread included, still badges the channel — and both counts ride the same shared
sub-query. Folding the rule into `WorkspaceUnread::forChannelsOf()` would silently take
the mention count with it. That asymmetry is now pinned by tests on both surfaces.

**The rule is stated twice on the server** — once as SQL, once in PHP — because one call
site holds a query and another holds a DTO. Unavoidable; the mitigation is that both live
in the same file, adjacent, and are proven against the same table. The alternative was a
per-message query on every send.

## How tested

- **`tests/Fixtures/channel-traffic-cases.json`** — the case table, all four combinations
  of the two facts the rule reads. Read by **both**
  `tests/Integration/Models/ChannelTrafficPredicateTest.php` (the scope, against real rows,
  and the in-memory twin) and **`resources/js/lib/channelTraffic.test.ts`** (the client
  twin). Neither suite owns it, so a row added or flipped on one side of the wire has to
  satisfy the other. A test also asserts the table stays exhaustive.
- **`tests/Unit/ChannelTrafficPredicateHomeTest.php`** — fails if an eighth spelling
  appears in `app/` or `resources/js/`. It matches all five forms the seven copies actually
  took; verified red against the pre-change tree, where it named six of the seven.
- **`WorkspaceUnreadTest`** — the workspace tally had **no thread coverage at all**. Two
  new tests: a thread-only reply does not tally, one also sent to the channel does, and a
  **mention** inside a thread-only reply still does.
- **`SidebarChannelsTest`** — the same asymmetry per channel: a thread-only reply raises
  the mention badge without touching the unread count.
- The scope is pinned as table-qualified, because the sidebar correlates it against a
  query with `channels` and `channel_members` joined in.

Gate: 3190/3190 tests, Pint, PHPStan, Rector clean; frontend `lint:check`, `format:check`,
`types:check`, `test:js` and `build` all pass. **Coverage-neutral** — every file this
change touches reports 100.0%; the two lines short of the gate (`MessageSearchPanel:65`,
`MessageController:126`) are the pre-existing ones already tracked on #1119 and are
unchanged from `develop`.

## Docs

- `dev-docs/adr/0010-channel-traffic-predicate-has-one-home-per-language.md` — records
  *why*: seven copies, six untested, and that the tempting alternative ("it is one boolean,
  just inline it") is exactly what produced them. It also states the guard's limit plainly:
  it is a tripwire, not a proof, and the case table is the specification.
- `CONTEXT.md` names the predicate in **both** halves of the named-seams list, including
  the "do not fold it into `forChannelsOf()`" warning.
- ADR README: 0010 takes its reserved row.

Out of scope, deliberately: the five server spellings of **"unread"**. Their
archived/muted/`nothing` exclusions genuinely differ per call site and at least one
difference is intended, so collapsing them is a behaviour change, not a mechanical one.

No operator-facing change and no user-facing copy, so `docs/` and `lang/fr.json` are
untouched. The DTO shapes are unchanged, so the generated TypeScript does not move.

## CodeRabbit

One finding, declined: it suggested the home-guard count *occurrences* rather than files
and drop the per-file `break`. The test's claim is which **files** hold the rule, and
`Message.php` holds it twice by design (the SQL constant and its in-memory twin), so an
occurrence count would either encode an arbitrary number or fail on the intended pair.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788134297&installation_model_id=428379&pr_number=1132&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1132&signature=f86ce792b6d30ee0a111077e8d3d2148ed4d2e5a783e05de2414a1cad9bb044a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->