### PR TITLE
test: close the two gaps holding the coverage gate below 100%

### DIFF
--- a/app/Support/MessageSearchPanel.php
+++ b/app/Support/MessageSearchPanel.php
@@ -58,16 +58,9 @@ final readonly class MessageSearchPanel
     ) {}
 
     /**
-     * Resolve the panel from the search params pinned on the current URL.
-     */
-    public static function fromRequest(Request $request, User $viewer, Team $team): self
-    {
-        return new self($viewer, $team, self::criteriaFromRequest($request));
-    }
-
-    /**
-     * The criteria alone, for a caller that already holds the viewer and team —
-     * the workspace shell resolves those once and only needs the URL read.
+     * The criteria pinned on the current URL, for a caller that already holds
+     * the viewer and team — the workspace shell resolves those once and only
+     * needs the URL read.
      *
      * The date facets are widened to whole-day bounds — `after` from the start of
      * its day, `before` to the end — so a single-day range is inclusive of every

--- a/tests/Feature/Api/V1/MessageApiTest.php
+++ b/tests/Feature/Api/V1/MessageApiTest.php
@@ -58,6 +58,21 @@ it('records which token posted the message', function (): void {
     ]);
 });
 
+it('records no token when the subject arrived by session rather than by token', function (): void {
+    // Sanctum answers a session-authenticated subject with a keyless transient
+    // token, which names no credential at all.
+    $this->actingAs($this->bot)
+        ->postJson("/api/v1/channels/{$this->channel->id}/messages", ['body' => 'Deployed v2'])
+        ->assertCreated();
+
+    // There is nothing to revoke, so the row records no attribution rather than
+    // a key that would point nowhere.
+    $this->assertDatabaseHas('messages', [
+        'body' => 'Deployed v2',
+        'token_id' => null,
+    ]);
+});
+
 it('is idempotent on a repeated client_uuid', function (): void {
     Sanctum::actingAs($this->bot, ['messages:write']);
 


### PR DESCRIPTION
Closes #1119. Closes #1129, which reported the same red gate from the other end: its
first two acceptance criteria are the two fixes below, and its fourth (`Total: 100.0 %`
with no per-file entry under 100) is what the clover run verifies. Its third — make
`composer test` itself exit non-zero on a short gate — is answered by #1133 rather than
here; see *The CI question* below.

`./vendor/bin/sail composer test` was red on a clean `develop` for two independent
reasons. Both are closed here, and the whole of `app/` is back to **9947/9947 lines
covered**.

## What

**1. `MessageSearchPanel::fromRequest()` is deleted.** #1102 moved the middleware onto
`criteriaFromRequest()` and left the wrapper behind; `grep -rn "MessageSearchPanel"` over
`app/ tests/ routes/ resources/` finds the constructor, `criteriaFromRequest` and the
`HAS_FILE` constant, never `fromRequest`. As the issue asks, it is removed rather than
given a test — a test written for it would exist only to hold the gate open. Its
docblock's one useful sentence is folded into `criteriaFromRequest()`, which is now the
only URL read.

**2. `MessageController::actingTokenId()`'s `null` return gets a test.** Unlike the
above, this one is not dead: Sanctum answers a subject that arrived by session rather
than by token with a keyless `TransientToken`, and the row must then record no
attribution rather than a key pointing nowhere. Added to `MessageApiTest` next to the
test that pins the opposite case (a real token *is* recorded), so the pair reads together.

Worth knowing for review: that branch is reachable only for a **bot** subject arriving by
session — `ApiChannelAccess::team()` refuses a *human* session subject with a 403 before
the controller runs. The test drives the real HTTP path with no mocking, so it pins
behaviour rather than shape, but the branch is narrower than "any session request".

## Why not just delete that one too

Collapsing the guard into a ternary would make the line execute on every call and so
read as covered, without any test ever exercising the branch. That trades a visible hole
for an invisible one.

## The CI question

The issue's third acceptance criterion asked for a decision on whether CI should enforce
the gate, since `tests.yml` sets `coverage: none`. **Decision: yes**, recorded with its
reasoning and a measurement requirement in #1133, kept out of this PR so a change to
every CI run's cost gets its own argument rather than riding along on a two-line repair.
The evidence is in the issue: #1102 and #1118 each opened a hole, and the second landed
after the first was already filed and visible.

## Testing

- `./vendor/bin/sail composer test` — Pint, PHPStan, Rector and 3179 tests pass.
- Coverage verified from a real clover run over the full suite rather than the in-session
  summary (which strips `--coverage`): **9947/9947 = 100.0000%**, zero uncovered lines
  anywhere in `app/`.
- Frontend: `lint:check`, `format:check`, `types:check`, `test:js` and `build` all pass.

No user-facing copy and no operator-facing behaviour changes, so no i18n keys and no
`docs/` updates are needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788134866&installation_model_id=428379&pr_number=1134&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1134&signature=c7f9e47c02b88b9ebae80812eb1389ca1ed07a059f95452c4a4d8e9ee042f0df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
