### PR TITLE
fix: open the date picker on the selected day's month

### DIFF
--- a/resources/js/components/ui/date-picker/DatePicker.test.ts
+++ b/resources/js/components/ui/date-picker/DatePicker.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { App } from 'vue';
 import { createApp, h, nextTick, ref } from 'vue';
 import { DatePicker } from '.';
@@ -11,6 +11,15 @@ import { DatePicker } from '.';
  * is all the component's own copy needs.
  */
 let app: App | null = null;
+
+/**
+ * The clock every test here runs on. Which month the calendar draws is derived
+ * from a date, so a fixture that happens to sit in the *current* month asserts
+ * nothing — it passes on a coincidence and fails at the next month boundary,
+ * which is exactly how #1135 reached `develop`. Every fixture below is
+ * deliberately in a different month from this one.
+ */
+const NOW = '2026-08-12T12:00:00.000Z';
 
 type DatePickerProps = InstanceType<typeof DatePicker>['$props'];
 
@@ -39,10 +48,29 @@ function trigger(): HTMLElement {
     return element;
 }
 
+/** Opens the popover and settles the calendar it portals into the document. */
+async function openCalendar(): Promise<void> {
+    trigger().click();
+    await nextTick();
+    await nextTick();
+}
+
+function dayCell(day: string): HTMLElement | null {
+    return document.querySelector<HTMLElement>(
+        `[data-reka-calendar-cell-trigger][data-value="${day}"]`,
+    );
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
+});
+
 afterEach(() => {
     app?.unmount();
     app = null;
     document.body.innerHTML = '';
+    vi.useRealTimers();
 });
 
 describe('DatePicker', () => {
@@ -77,6 +105,23 @@ describe('DatePicker', () => {
         );
     });
 
+    it('opens on the selected day rather than on today', async () => {
+        mount({ modelValue: '2026-03-10', fieldLabel: 'Start date' });
+
+        await openCalendar();
+
+        expect(dayCell('2026-03-10')?.dataset.selected).toBe('true');
+        expect(dayCell(NOW.slice(0, 10))).toBeNull();
+    });
+
+    it('opens on the current month while nothing is selected', async () => {
+        mount({ modelValue: null, fieldLabel: 'Start date' });
+
+        await openCalendar();
+
+        expect(dayCell(NOW.slice(0, 10))).not.toBeNull();
+    });
+
     it('emits the picked day as an ISO string', async () => {
         const selected = ref<string | null>('2026-07-10');
 
@@ -88,13 +133,9 @@ describe('DatePicker', () => {
             },
         });
 
-        trigger().click();
-        await nextTick();
-        await nextTick();
+        await openCalendar();
 
-        const cell = document.querySelector<HTMLElement>(
-            '[data-reka-calendar-cell-trigger][data-value="2026-07-15"]',
-        );
+        const cell = dayCell('2026-07-15');
 
         expect(cell).not.toBeNull();
 

--- a/resources/js/components/ui/date-picker/DatePicker.vue
+++ b/resources/js/components/ui/date-picker/DatePicker.vue
@@ -63,6 +63,13 @@ defineOptions({
 
 const open = ref(false);
 
+/**
+ * The selected day in the calendar's own value type. It also seeds which month
+ * the popover opens on: reka derives that from `today()` alone, so without it a
+ * value in any other month opens on the current one with the selection nowhere
+ * on screen (#1135). Seeding it as the *default* placeholder rather than
+ * binding it leaves the reader free to page to another month once open.
+ */
 const selected = computed<DateValue | undefined>(() =>
     toCalendarDate(props.modelValue),
 );
@@ -103,6 +110,7 @@ function select(value: DateValue | undefined): void {
             <PopoverContent class="w-auto p-0" align="start">
                 <Calendar
                     :model-value="selected"
+                    :default-placeholder="selected"
                     :min-value="toCalendarDate(min)"
                     :max-value="toCalendarDate(max)"
                     :locale="i18n.locale"


### PR DESCRIPTION
Closes #1135.

## What

`<DatePicker>` opened on **today's** month regardless of the day it held. Open the
audit-export range on a report covering June and the calendar showed you August,
with your own selection nowhere on screen and no way to it but paging back.

It now opens on the selected day's month, with that day selected. An empty picker
still opens on today.

## Why

The shadcn calendar wrapper derives the month it draws from the clock alone, never
from the value:

```js
// resources/js/components/ui/calendar/Calendar.vue:22-25
const placeholder = useVModel(props, "placeholder", emits, {
  passive: true,
  defaultValue: props.defaultPlaceholder ?? today(getLocalTimeZone()),
})
```

`DatePicker.vue` passed `:model-value` and nothing else, so that fallback was always
what applied. Seeding `:default-placeholder` from the same value fixes it — as the
*default* rather than a binding, so paging to another month still works once open.

Left `Calendar.vue` alone: it is vendored shadcn, its `modelValue` is an array for
range calendars, and its three other callers (`ScheduleMessageDialog`,
`DndPauseDialog`, `StatusExpiryFields`) all pick a day at or after now, where today's
month is the right place to land.

## How it surfaced

Every `ci` job started after 2026-08-01 00:00 UTC failed at *Run Frontend Tests* on a
test nobody had touched — PR #1132 and PR #1134 alike, on the same line. Nothing could
merge.

`DatePicker.test.ts` selected `2026-07-10` and clicked the cell `2026-07-15`. That cell
existed only while `today()` was still in July 2026, so the test asserted through a
coincidence with the wall clock and expired on a date rather than on a change — while
masking the bug above, since the value was always in the current month anyway.

The clock is now pinned with `vi.setSystemTime`, and every fixture sits deliberately in
a *different* month from it, so the month choice is actually asserted. Two tests cover
it directly: a value in another month opens there, and an empty picker opens on today.

## Testing

- `npm run test:js` — 257 files / 2588 tests pass (6 in `DatePicker.test.ts`, up from 4).
- Verified red first: the two new assertions fail on the unfixed component.
- `tests/Browser/DatePickerTest.php` — 2 pass, 23 assertions, including the axe audits
  in both light and dark. Both browser tests drive an empty picker, so they exercise the
  today fallback that the change leaves intact.
- `lint:check`, `format:check`, `types:check`, `build` — all pass.
- Pint, PHPStan, Rector, and the full Pest suite (3178) pass. PHP coverage is untouched:
  the diff is two lines of Vue with no PHP surface. `develop`'s known shortfall is #1129,
  which PR #1134 closes.

No new user-facing copy, so no i18n keys. Nothing operator-facing, so no `docs/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788136046&installation_model_id=428379&pr_number=1136&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1136&signature=ea3be87391a4fcdc8bc5af4833971e3450a31e2e3a1ddcf93badd482bcec011b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->