### PR TITLE
fix: route seeded avatars through the image proxy so the CSP loads them

### DIFF
--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -22,6 +22,7 @@ use App\Models\ScheduledMessage;
 use App\Models\Team;
 use App\Models\User;
 use App\Support\Gravatar;
+use App\Support\Images\ImageProxy;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
@@ -209,6 +210,11 @@ class DemoSeeder extends Seeder
      * Create one demo persona with the shared demo password and a generated
      * identicon avatar (a distinct, deterministic picture per email, so every
      * avatar surface renders without an initials fallback).
+     *
+     * The URL is routed through the image proxy, exactly as {@see User::avatar}
+     * routes a derived Gravatar: `img-src` is `'self' data: blob:`, so a raw
+     * gravatar.com URL stored here would be refused by the app's own policy on
+     * every avatar surface (#1126).
      */
     private function seedPersona(string $name, string $email): User
     {
@@ -216,7 +222,7 @@ class DemoSeeder extends Seeder
             'name' => $name,
             'email' => $email,
             'password' => Hash::make(self::DEMO_PASSWORD),
-            'avatar_url' => Gravatar::url($email, 'identicon'),
+            'avatar_url' => ImageProxy::url(Gravatar::url($email, 'identicon')),
         ]);
     }
 

--- a/database/seeders/WorkspaceSeeder.php
+++ b/database/seeders/WorkspaceSeeder.php
@@ -28,6 +28,7 @@ use App\Models\TeamInvitation;
 use App\Models\User;
 use App\Support\AuditRecorder;
 use App\Support\Gravatar;
+use App\Support\Images\ImageProxy;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
@@ -120,6 +121,11 @@ class WorkspaceSeeder extends Seeder
      * per user — a distinct, deterministic picture — to show the avatar surfaces
      * populated across the demo.
      *
+     * The URL is routed through the image proxy, exactly as {@see User::avatar}
+     * routes a derived Gravatar: `img-src` is `'self' data: blob:`, so a raw
+     * gravatar.com URL stored here would be refused by the app's own policy on
+     * every avatar surface (#1126).
+     *
      * @param  array{name: string, email: string}  $attributes
      * @param  Factory<User>|null  $factory
      */
@@ -127,7 +133,7 @@ class WorkspaceSeeder extends Seeder
     {
         return ($factory ?? User::factory())->createOne([
             ...$attributes,
-            'avatar_url' => Gravatar::url($attributes['email'], 'identicon'),
+            'avatar_url' => ImageProxy::url(Gravatar::url($attributes['email'], 'identicon')),
         ]);
     }
 

--- a/tests/Feature/DatabaseSeederTest.php
+++ b/tests/Feature/DatabaseSeederTest.php
@@ -70,8 +70,11 @@ test('every seeded avatar is first-party, so the app loads it under its own imag
     expect($users)->not->toBeEmpty();
 
     foreach ($users as $user) {
-        expect($user->avatar)->toStartWith('/images/proxy?')
-            ->and($user->avatar)->toBe(ImageProxy::url(Gravatar::url($user->email, 'identicon')));
+        $proxied = ImageProxy::url(Gravatar::url($user->email, 'identicon'));
+
+        expect($user->avatar_url)->toStartWith('/images/proxy?')
+            ->and($user->avatar_url)->toBe($proxied)
+            ->and($user->avatar)->toBe($proxied);
     }
 });
 

--- a/tests/Feature/DatabaseSeederTest.php
+++ b/tests/Feature/DatabaseSeederTest.php
@@ -16,10 +16,18 @@ use App\Models\SsoIdentity;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
+use App\Support\Csp\TheDeskPolicy;
+use App\Support\Gravatar;
+use App\Support\Images\ImageProxy;
 use Database\Seeders\WorkspaceSeeder;
 use Ramsey\Uuid\Uuid;
 
 beforeEach(function (): void {
+    // The seeder gives every fixture user a generated `identicon` avatar, which
+    // is derived from a Gravatar URL — and the suite disables Gravatar by default
+    // so no test reaches gravatar.com. Opt back in for the seeded workspace.
+    config()->set('gravatar.enabled', true);
+
     $this->seed();
 
     $this->demo = User::where('email', WorkspaceSeeder::DEMO_EMAIL)->firstOrFail();
@@ -46,6 +54,24 @@ test('every team role is represented in the membership table', function (): void
 
     foreach (TeamRole::cases() as $role) {
         expect($roles)->toContain($role->value);
+    }
+});
+
+/**
+ * {@see TheDeskPolicy} pins `img-src` to `'self' data: blob:`, so a raw
+ * `https://www.gravatar.com/…` in `avatar_url` short-circuits `User::avatar`'s
+ * proxy branch and the browser then refuses every seeded avatar (#1126). The
+ * contract: a seeded `avatar_url` is already proxied, exactly as the model
+ * would have proxied a derived Gravatar.
+ */
+test('every seeded avatar is first-party, so the app loads it under its own image policy', function (): void {
+    $users = User::all();
+
+    expect($users)->not->toBeEmpty();
+
+    foreach ($users as $user) {
+        expect($user->avatar)->toStartWith('/images/proxy?')
+            ->and($user->avatar)->toBe(ImageProxy::url(Gravatar::url($user->email, 'identicon')));
     }
 });
 

--- a/tests/Feature/DemoSeederTest.php
+++ b/tests/Feature/DemoSeederTest.php
@@ -105,8 +105,11 @@ test('every seeded avatar is first-party, so the demo loads it under its own ima
     expect($users)->not->toBeEmpty();
 
     foreach ($users as $user) {
-        expect($user->avatar)->toStartWith('/images/proxy?')
-            ->and($user->avatar)->toBe(ImageProxy::url(Gravatar::url($user->email, 'identicon')));
+        $proxied = ImageProxy::url(Gravatar::url($user->email, 'identicon'));
+
+        expect($user->avatar_url)->toStartWith('/images/proxy?')
+            ->and($user->avatar_url)->toBe($proxied)
+            ->and($user->avatar)->toBe($proxied);
     }
 });
 

--- a/tests/Feature/DemoSeederTest.php
+++ b/tests/Feature/DemoSeederTest.php
@@ -19,6 +19,9 @@ use App\Models\SecurityEvent;
 use App\Models\SsoIdentity;
 use App\Models\Team;
 use App\Models\User;
+use App\Support\Csp\TheDeskPolicy;
+use App\Support\Gravatar;
+use App\Support\Images\ImageProxy;
 use Database\Seeders\DemoSeeder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
@@ -86,6 +89,24 @@ test('it seeds a supporting cast with varied roles and identicon avatars', funct
 
     foreach ($team->members as $member) {
         expect($member->avatar_url)->toContain('identicon');
+    }
+});
+
+/**
+ * {@see TheDeskPolicy} pins `img-src` to `'self' data: blob:`, so a raw
+ * `https://www.gravatar.com/…` in `avatar_url` short-circuits `User::avatar`'s
+ * proxy branch and the browser then refuses every seeded avatar (#1126). The
+ * contract: a seeded `avatar_url` is already proxied, exactly as the model
+ * would have proxied a derived Gravatar.
+ */
+test('every seeded avatar is first-party, so the demo loads it under its own image policy', function (): void {
+    $users = User::all();
+
+    expect($users)->not->toBeEmpty();
+
+    foreach ($users as $user) {
+        expect($user->avatar)->toStartWith('/images/proxy?')
+            ->and($user->avatar)->toBe(ImageProxy::url(Gravatar::url($user->email, 'identicon')));
     }
 });
 


### PR DESCRIPTION
Closes #1126.

## What

`WorkspaceSeeder::seedUser()` and `DemoSeeder::seedPersona()` stored a **raw**
`https://www.gravatar.com/avatar/…?d=identicon` in `avatar_url`. Both now store
that URL **routed through `ImageProxy`**, exactly as `User::avatar` routes a
derived Gravatar.

## Why

`avatar_url` short-circuits `User::avatar`'s image-proxy branch, so a raw remote
URL stored there reaches the browser untouched. Since #648 tightened `img-src`
to `'self' data: blob:`, the app's own policy refused every one of them: ~185
console errors on a seeded channel, every avatar surface falling back to
initials, and enough noise to bury any error actually worth reading.

It was the seeders disagreeing with the model's contract, not a CSP bug — the
proxy exists precisely so a remote avatar is allowed.

## How tested

- `DatabaseSeederTest` and `DemoSeederTest` each gained *every seeded avatar is
  first-party…*, asserting the persisted `avatar_url` is a `/images/proxy?…` URL
  **and** equals what the model would have proxied. A seeder that drifts back to
  a raw Gravatar URL fails both. `DatabaseSeederTest` now enables Gravatar in
  `beforeEach` (the suite disables it by default), which is what makes the
  assertion bite there.
- Verified headless against the seeded worktree: the proxy route answers `200`,
  the `<img>` reports `naturalWidth=200`, and the page raises no `img-src`
  violation for any avatar.
- Full gate green — `composer test` at `Total: 100.0 %`, plus lint/format/types/
  `test:js`/build.

No i18n or docs changes: the seeders are dev- and demo-only, and nothing
user-facing or operator-facing changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788174040&installation_model_id=428379&pr_number=1137&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1137&signature=f310596cc197d91ee1f43e1c9bc53cc95b5f0ec3d2c0e2f4e7e6371eb4370f4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->