### PR TITLE
ci: enforce the coverage gate in CI

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -20,6 +20,7 @@ paths:
 
 - **100% code coverage is required — this is non-negotiable.** The test suite is gated at `--min=100` (see the `test` script in `composer.json`), so any line left uncovered fails the build.
 - **Always check coverage before pushing.** Run the full gate — which also runs Pint, PHPStan, and Rector — with `./vendor/bin/sail composer test` (this executes `lint:check`, `types:check`, `refactor:check`, and `php artisan test --parallel --coverage --min=100`). Do not push or open/update a PR until it reports `Total: 100.0 %` with a clean Rector dry-run.
+- **CI enforces the same floor** (#1133): the `ci` job loads PCOV and runs the suite with `--coverage --min=100`, so a PR that drops below 100% goes red on the PR rather than on the next person's unrelated run. The local gate is still the faster place to find out — but it is no longer the only place. Note the printed `Total: 100.0 %` is *rounded* while `--min=100` compares the unrounded figure, so a red gate can read as green right up to the `FAIL` line under it; trust the exit status, not the percentage.
 - If new code drops coverage, add or update tests until it is back at 100%. When a line reads as uncovered even though a test exercises it (e.g. the `: null` branch of a multi-line ternary is a known PCOV line-attribution quirk), collapse it onto a single line rather than leaving the gate red.
 
 ## Parallelism

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,10 +90,16 @@ jobs:
           php-version: '8.5'
           extensions: gd, imagick
           tools: composer:v2
-          # CI does not enforce the coverage gate — that stays local via
-          # `composer test` (--min=100 with PCOV). Loading a coverage driver
-          # here would only slow the suite down (see #582).
-          coverage: none
+          # CI enforces the 100% coverage gate, so it needs a driver (#1133).
+          # PCOV, not Xdebug: it only records line hits, where Xdebug rewrites
+          # execution wholesale and roughly doubles the suite. #582 turned the
+          # driver off here on the assumption that every author runs `composer
+          # test` before merging, which #1102 and #1118 disproved in consecutive
+          # merges — a refactor that drops a method's last caller breaks no
+          # test, so the hole it opens is only found by the next person to run
+          # the gate on unrelated work. Matches the local pcov.directory (`.`),
+          # so the figure CI reports is the one `composer test` reports.
+          coverage: pcov
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
@@ -160,9 +166,18 @@ jobs:
       # Spelled this way rather than as pest's `--bail`, which Collision rejects
       # before it spawns pest — it validates the options it forwards against
       # paratest's own input definition, and `--bail` is pest-side sugar.
-      # Guarded by tests/Unit/LocalTestGateTest.php.
+      #
+      # `--coverage --min=100` so the floor is enforced where the cost of
+      # dropping below it is paid by whoever dropped it, rather than by the next
+      # person to run `composer test` on unrelated work (#1133). Note the two
+      # flags interact: a bailed run exits non-zero before Collision prints a
+      # figure, so a red suite reports the failing test and never a coverage
+      # number — the floor is only ever reported on an otherwise-green run,
+      # which is the only run whose figure means anything.
+      # Guarded by tests/Unit/LocalTestGateTest.php and
+      # tests/Unit/CiCoverageGateTest.php.
       - name: Tests
-        run: php artisan test --parallel --stop-on-defect
+        run: php artisan test --parallel --stop-on-defect --coverage --min=100
 
   # Browser (E2E) realtime suite: drives real Playwright browsers against the
   # app served in-process, with a live Reverb server so two clients exchange

--- a/tests/Unit/CiCoverageGateTest.php
+++ b/tests/Unit/CiCoverageGateTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * The 100% floor used to be enforced only by `composer test`, on whichever
+ * machine happened to run it (#582 turned the driver off in CI to save minutes).
+ * That assumes every author runs the local gate, and #1102 and #1118 each landed
+ * a hole in consecutive merges to prove they do not: a refactor that drops the
+ * last caller of a method breaks no test, so nothing goes red until the next
+ * person runs the gate on unrelated work. These tests pin the floor to CI, where
+ * the cost of a hole is paid by whoever opened it.
+ */
+function coverageGateJob(string $job): array
+{
+    return Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/tests.yml')['jobs'][$job];
+}
+
+/**
+ * The `coverage` input the job hands shivammathur/setup-php, which is what
+ * decides whether a driver is loaded at all — `none` leaves `--coverage` with
+ * nothing to collect.
+ */
+function coverageGateDriver(string $job): ?string
+{
+    $setup = collect(coverageGateJob($job)['steps'])
+        ->first(static fn (array $step): bool => str_contains($step['uses'] ?? '', 'setup-php'));
+
+    return $setup['with']['coverage'] ?? null;
+}
+
+/**
+ * The step running a test suite in the given job — `artisan test` in `ci`,
+ * `bin/browser-tests` in `browser`. Both spellings are matched so neither job's
+ * assertions can pass by matching nothing.
+ */
+function coverageGateSuiteCommand(string $job): string
+{
+    return collect(coverageGateJob($job)['steps'])
+        ->pluck('run')
+        ->filter(static fn (?string $run): bool => str_contains((string) $run, 'artisan test') || str_contains((string) $run, 'browser-tests'))
+        ->implode("\n");
+}
+
+/**
+ * The floor the local gate enforces, so the two cannot drift apart silently.
+ */
+function coverageGateLocalFloor(): string
+{
+    $test = implode(' ', json_decode((string) file_get_contents(dirname(__DIR__, 2).'/composer.json'), true)['scripts']['test']);
+
+    preg_match('/--min=\d+/', $test, $matches);
+
+    return $matches[0] ?? '';
+}
+
+test('the ci job loads a coverage driver', function (): void {
+    expect(coverageGateDriver('ci'))->toBe('pcov', '--coverage collects nothing without a driver');
+});
+
+test('the ci job enforces the coverage floor', function (): void {
+    expect(coverageGateSuiteCommand('ci'))->not->toBeEmpty('the suite step must be found, or the assertions below pass on nothing')
+        ->and(coverageGateSuiteCommand('ci'))->toContain('--coverage')
+        ->and(coverageGateSuiteCommand('ci'))->toContain(coverageGateLocalFloor());
+});
+
+test('the local gate still names a floor for ci to match', function (): void {
+    expect(coverageGateLocalFloor())->toBe('--min=100');
+});
+
+/*
+ * The browser suite is deliberately outside the gate — it is not declared as a
+ * `<testsuite>` in phpunit.xml, and its job must not grow a driver either, or a
+ * run of it would start reporting a figure nobody intends to gate on.
+ */
+test('the browser job stays out of the coverage gate', function (): void {
+    expect(coverageGateDriver('browser'))->toBeNull()
+        ->and(coverageGateSuiteCommand('browser'))->not->toBeEmpty('the browser runner must be found, or the assertion below passes on nothing')
+        ->and(coverageGateSuiteCommand('browser'))->not->toContain('--coverage');
+});


### PR DESCRIPTION
Closes #1133.

## What

The `ci` job now loads PCOV and runs the PHP suite as
`php artisan test --parallel --stop-on-defect --coverage --min=100` — the same
floor `composer test` has always enforced, moved to where the cost of dropping
below it is paid by whoever dropped it.

- `.github/workflows/tests.yml` — `coverage: none` → `coverage: pcov` on the `ci`
  job's setup-php step, `--coverage --min=100` on the Tests step, and the
  comment at the old `coverage: none` line rewritten (it stated the opposite
  policy). The `browser` job is untouched and still carries no driver.
- `tests/Unit/CiCoverageGateTest.php` — new guard: the `ci` job must load a
  driver, must carry the floor, and that floor is read out of `composer.json`'s
  `test` script so CI and the local gate cannot drift apart. A fourth test keeps
  the browser job out of the gate.
- `.claude/rules/testing.md` — the Code Coverage section said the gate was local;
  it now says CI enforces the same floor, and notes that the printed
  `Total: 100.0 %` is rounded while `--min=100` compares the unrounded figure.

## Why

#582 turned the driver off on the assumption that every author runs the local
gate before merging. #1102 and #1118 disproved it in consecutive merges: a
refactor that drops a method's last caller breaks no test, so nothing goes red
until the next person runs the gate on unrelated work. The second landed after
the first was already filed and visible on `develop`.

## Cost — the measurement #582 asked for

Baseline, from the last 12 green `tests.yml` runs on `develop` (`ubuntu-latest`,
same steps, no driver): the `ci` job's **Tests** step ran **130s median / 121s
mean** (range 82–135s), inside a **~5m45s** job.

The figure for this PR's own run is added below once it lands, so the delta is
measured on the same runner class rather than asserted.

Locally the overhead did not clear the noise floor on a loaded dev machine —
two paired runs in the same container gave 130s → 119s and 252s → 255s, i.e.
the run-to-run spread is larger than the effect. That is consistent with PCOV
being a small constant cost (it records line hits; it does not rewrite execution
the way Xdebug does), but the CI number below is the one that answers #582.

PCOV runs with the same `pcov.directory` (`.`) the Sail image uses, so the
figure CI reports is the figure `composer test` reports.

## Testing

- `tests/Unit/CiCoverageGateTest.php` — 4 new tests, red before the workflow
  change (`coverage: none`, no `--coverage`), green after.
- Full backend gate green: Pint, PHPStan, Rector dry-run, and
  `artisan test --parallel --coverage --min=100` reporting `Total: 100.0 %`.
- Frontend gate green: `lint:check`, `format:check`, `types:check`, `test:js`
  (2593 tests), `build`.

No user-facing copy and no operator-facing setting, so no i18n or `docs/`
changes.

## Notes

A `--stop-on-defect` run exits non-zero before Collision prints a coverage
figure, so a red suite reports the failing test and never a coverage number.
The floor is therefore only ever reported on an otherwise-green run — which is
the only run whose figure means anything. That interaction is written into the
step's comment.

The local CodeRabbit pass raised one finding — `coverageGateSuiteCommand()`
filtered on `artisan test`, which matches nothing in the `browser` job, so that
test's `--coverage` assertion was vacuous. Fixed by matching `bin/browser-tests`
too and asserting the command was found at all. A second pass hit the free
tier's rate limit, so the remaining review is this PR's own.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788174046&installation_model_id=428379&pr_number=1138&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1138&signature=2d188a8dfdd4fae3543db25a3142c9268005c04a35fcc3d07b327df9c0dec63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->