### PR TITLE
fix: delete a user's API tokens when the account is deleted

### DIFF
--- a/app/Actions/Integrations/DeleteBot.php
+++ b/app/Actions/Integrations/DeleteBot.php
@@ -17,8 +17,10 @@ use Illuminate\Support\Facades\DB;
  * The bot's authored messages (and any pins it created) are reassigned to the
  * retained "Deleted User" tombstone so channel history stays coherent — the same
  * anonymize-not-remove policy applied to humans (see {@see App\Support\AccountDeleter}).
- * Deleting the bot row then cascades its API tokens, incoming webhooks, and
- * channel memberships away, so no credential or posting path survives it.
+ * Deleting the bot row then takes every credential and posting path with it: its
+ * incoming webhooks and channel memberships by foreign-key cascade, and its API
+ * tokens through {@see App\Observers\UserObserver::deleting()}, which sweeps the
+ * polymorphic `personal_access_tokens` rows no cascade reaches.
  */
 class DeleteBot
 {

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -34,4 +34,29 @@ class UserObserver
                 : SecurityEventType::AccountDeactivated,
         ));
     }
+
+    /**
+     * Handle the User "deleting" event, dropping the account's API tokens.
+     *
+     * Sanctum's `personal_access_tokens` addresses its owner through a
+     * polymorphic pair (`tokenable_type` + `tokenable_id`) with no foreign key,
+     * so no cascade reaches these rows the way one reaches a bot's incoming
+     * webhooks or channel memberships. Left alone they outlive their owner
+     * forever, in the table every API request's token lookup scans.
+     *
+     * Sweeping here rather than in a caller covers every deletion path at once
+     * — {@see App\Actions\Integrations\DeleteBot} for a bot and
+     * {@see App\Support\AccountDeleter} for a human — and runs inside whatever
+     * transaction that caller opened, since it fires from `delete()` itself.
+     *
+     * The rows are already inert by the time they are swept: Sanctum resolves a
+     * token's `tokenable` on every request and refuses when it is gone, so this
+     * is hygiene, not a live credential being closed off. Deleting them nulls
+     * `messages.token_id` on anything the tokens posted, exactly as revoking a
+     * token by hand already does — the attribution thins, the messages stay.
+     */
+    public function deleting(User $user): void
+    {
+        $user->tokens()->delete();
+    }
 }

--- a/app/Support/AccountDeleter.php
+++ b/app/Support/AccountDeleter.php
@@ -27,7 +27,10 @@ class AccountDeleter
      *
      * Their web-push subscriptions are dropped explicitly: the owning column is
      * a polymorphic reference, so no foreign key sweeps them, and a stale row
-     * would keep this instance pushing to a device whose account is gone.
+     * would keep this instance pushing to a device whose account is gone. Their
+     * API tokens are polymorphic for the same reason and go the same way, swept
+     * by {@see App\Observers\UserObserver::deleting()} so that every deletion
+     * path is covered rather than only this one.
      */
     public function delete(User $user): void
     {

--- a/database/migrations/2026_08_01_101500_prune_orphaned_personal_access_tokens.php
+++ b/database/migrations/2026_08_01_101500_prune_orphaned_personal_access_tokens.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Delete the API tokens left behind by accounts deleted before the sweep in
+     * App\Observers\UserObserver existed.
+     *
+     * `personal_access_tokens` addresses its owner through a polymorphic pair
+     * with no foreign key, so every bot and human deleted before that observer
+     * left one row per token it had been minted, pointing at a `tokenable_id`
+     * that no longer resolves. Nothing removes them and the table is scanned on
+     * every API request's token lookup.
+     *
+     * Deleting them is safe rather than merely tidy: Sanctum resolves a token's
+     * `tokenable` on each request and refuses when it is gone, so these rows are
+     * already dead credentials — no live access is withdrawn here.
+     *
+     * Scoped to the User morph, the only tokenable this application mints for,
+     * so a token type added later is judged against its own table and not
+     * silently pruned by this one.
+     */
+    public function up(): void
+    {
+        DB::table('personal_access_tokens')
+            ->where('tokenable_type', (new User)->getMorphClass())
+            ->whereNotExists(fn ($query) => $query
+                ->select(DB::raw(1))
+                ->from('users')
+                ->whereColumn('users.id', 'personal_access_tokens.tokenable_id'))
+            ->delete();
+    }
+
+    /**
+     * Irreversible: the deleted rows named owners that no longer exist, so there
+     * is nothing to restore them to.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/tests/Feature/Api/V1/ApiAuthTest.php
+++ b/tests/Feature/Api/V1/ApiAuthTest.php
@@ -2,9 +2,12 @@
 
 declare(strict_types=1);
 
+use App\Actions\Integrations\DeleteBot;
+use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 use Laravel\Sanctum\Sanctum;
 
 beforeEach(function (): void {
@@ -64,4 +67,20 @@ it('authenticates a real bearer token and enforces its abilities', function (): 
     $this->withToken($token)
         ->postJson("/api/v1/channels/{$this->channel->id}/messages", ['body' => 'hi'])
         ->assertForbidden();
+});
+
+it('refuses a deleted bot token with 401', function (): void {
+    $owner = User::factory()->create();
+    $this->team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $token = $this->bot->createToken('CI', ['channels:read'])->plainTextToken;
+    $this->withToken($token)->getJson('/api/v1/channels')->assertOk();
+
+    app(DeleteBot::class)->handle($owner, $this->bot);
+
+    // Without this the RequestGuard hands back the user it resolved above and
+    // the request passes, hiding whether the credential is really gone.
+    Auth::forgetGuards();
+
+    $this->withToken($token)->getJson('/api/v1/channels')->assertUnauthorized();
 });

--- a/tests/Feature/Integrations/BotManagementTest.php
+++ b/tests/Feature/Integrations/BotManagementTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 use App\Actions\Integrations\CreateBot;
 use App\Actions\Integrations\DeleteBot;
+use App\Actions\Integrations\MintBotToken;
 use App\Enums\AuditAction;
+use App\Enums\IntegrationScope;
 use App\Enums\TeamRole;
 use App\Enums\UserType;
 use App\Models\Channel;
 use App\Models\Message;
+use App\Models\PersonalAccessToken;
 use App\Models\Team;
 use App\Models\User;
 use App\Support\AuditRecorder;
@@ -75,4 +78,17 @@ it('deletes a bot, reassigns its messages to the tombstone, and audits it', func
         'event' => AuditAction::BotDeleted->value,
         'causer_id' => $this->owner->id,
     ]);
+});
+
+it('deletes the bot API tokens along with the bot', function (): void {
+    $bot = app(CreateBot::class)->handle($this->team, $this->owner, 'Deploy Bot');
+
+    app(MintBotToken::class)->handle($bot, $this->owner, 'CI', [IntegrationScope::ChannelsRead->value]);
+    app(MintBotToken::class)->handle($bot, $this->owner, 'Deploys', [IntegrationScope::MessagesWrite->value]);
+
+    app(DeleteBot::class)->handle($this->owner, $bot);
+
+    // `personal_access_tokens` is a polymorphic pair with no foreign key, so
+    // nothing in the schema sweeps these rows — only the observer does.
+    expect(PersonalAccessToken::where('tokenable_id', $bot->id)->count())->toBe(0);
 });

--- a/tests/Feature/Integrations/PruneOrphanedTokensMigrationTest.php
+++ b/tests/Feature/Integrations/PruneOrphanedTokensMigrationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Load the orphaned-token prune as an instance so its up() can be exercised
+ * against rows orphaned behind the observer's back (RefreshDatabase has already
+ * run it once, on empty tables, during setup).
+ */
+function pruneOrphanedPersonalAccessTokensMigration(): object
+{
+    return require base_path('database/migrations/2026_08_01_101500_prune_orphaned_personal_access_tokens.php');
+}
+
+/**
+ * Delete a user's row directly, bypassing the observer that now sweeps their
+ * tokens — reproducing the state installs upgrading from before it accumulated.
+ */
+function orphanTokensOf(User $user): void
+{
+    DB::table('users')->where('id', $user->id)->delete();
+}
+
+test('the migration deletes tokens whose owner is gone', function (): void {
+    $team = Team::factory()->create();
+    $bot = User::factory()->bot($team)->create();
+
+    $bot->createToken('CI', ['channels:read']);
+    orphanTokensOf($bot);
+
+    expect(DB::table('personal_access_tokens')->where('tokenable_id', $bot->id)->count())->toBe(1);
+
+    pruneOrphanedPersonalAccessTokensMigration()->up();
+
+    expect(DB::table('personal_access_tokens')->where('tokenable_id', $bot->id)->count())->toBe(0);
+});
+
+test('the migration leaves tokens with a living owner alone', function (): void {
+    $team = Team::factory()->create();
+    $bot = User::factory()->bot($team)->create();
+    $human = User::factory()->create();
+
+    $bot->createToken('CI', ['channels:read']);
+    $human->createToken('Scripts', ['channels:read']);
+
+    pruneOrphanedPersonalAccessTokensMigration()->up();
+
+    expect(DB::table('personal_access_tokens')->where('tokenable_id', $bot->id)->count())->toBe(1)
+        ->and(DB::table('personal_access_tokens')->where('tokenable_id', $human->id)->count())->toBe(1);
+});
+
+test('the migration leaves a tokenable type it does not own alone', function (): void {
+    $team = Team::factory()->create();
+    $bot = User::factory()->bot($team)->create();
+
+    $bot->createToken('CI', ['channels:read']);
+
+    // A hypothetical future tokenable: same table, an id that resolves against
+    // its own table rather than `users`, so the prune must not judge it.
+    DB::table('personal_access_tokens')
+        ->where('tokenable_id', $bot->id)
+        ->update(['tokenable_type' => 'App\Models\Widget']);
+
+    pruneOrphanedPersonalAccessTokensMigration()->up();
+
+    expect(DB::table('personal_access_tokens')->where('tokenable_id', $bot->id)->count())->toBe(1);
+});

--- a/tests/Feature/Settings/AccountDeletionTest.php
+++ b/tests/Feature/Settings/AccountDeletionTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Actions\Integrations\MintPersonalAccessToken;
+use App\Enums\IntegrationScope;
 use App\Enums\TeamRole;
 use App\Models\Channel;
 use App\Models\Message;
+use App\Models\PersonalAccessToken;
 use App\Models\Team;
 use App\Models\User;
 
@@ -111,6 +114,21 @@ test('membership of a shared team is dropped when the account is deleted', funct
     expect($member->fresh())->toBeNull();
     expect(Team::find($team->id))->not->toBeNull();
     expect($team->fresh()->members()->whereKey($member->id)->exists())->toBeFalse();
+});
+
+test('personal access tokens are deleted with the account', function (): void {
+    $user = User::factory()->create();
+    $team = attachToSharedTeam($user, TeamRole::Member);
+
+    app(MintPersonalAccessToken::class)->handle($user, $team, 'Scripts', [IntegrationScope::ChannelsRead->value]);
+
+    $this->actingAs($user)
+        ->delete(route('profile.destroy'), ['password' => 'password'])
+        ->assertSessionHasNoErrors();
+
+    // No foreign key reaches the polymorphic `tokenable` pair, so without the
+    // observer these rows outlive the person they were minted for.
+    expect(PersonalAccessToken::where('tokenable_id', $user->id)->count())->toBe(0);
 });
 
 test('the deleted-user tombstone is a reused singleton', function (): void {


### PR DESCRIPTION
Closes #1109.

## What

Sanctum's `personal_access_tokens` addresses its owner through a polymorphic pair (`tokenable_type` + `tokenable_id`) with **no foreign key**, and `User` had no `deleting` hook. Nothing removed a deleted bot's token rows — they survived pointing at a `tokenable_id` that no longer resolved.

While confirming the diagnosis I found `App\Support\AccountDeleter` has the identical gap for humans, who mint their own PATs via `MintPersonalAccessToken`. Same table, same cause, same one-line defect. Rather than fix the bot half and file a twin issue for the human half, this sweeps the tokens from `UserObserver::deleting()`, which covers **every** deletion path at once and still runs inside whatever transaction the caller opened, since it fires from `delete()` itself.

## Changes

- **`UserObserver::deleting()`** drops `$user->tokens()`. Covers `DeleteBot` and `AccountDeleter` alike, and any path added later.
- **`DeleteBot`'s docblock corrected.** It claimed deletion "cascades its API tokens, incoming webhooks, and channel memberships away". The webhook and membership halves are genuinely backed by `cascadeOnDelete` foreign keys (verified); only the tokens half was unbacked, which is what made the inaccuracy easy to miss. It now says which mechanism does which.
- **`AccountDeleter`'s docblock** notes the tokens go the same way as the push subscriptions beside them, and why the sweep lives in the observer.
- **Prune migration** for orphans existing installs have already accumulated, scoped to the `User` morph so a tokenable added later is judged against its own table rather than silently pruned by this one. `down()` is a no-op: the deleted rows named owners that no longer exist.

## Severity

Hygiene, not a security hole. Sanctum resolves a token's `tokenable` on every request and refuses when it is gone, so an orphan was already a dead credential. The cost was unbounded accumulation in the table every API request's token lookup scans, plus a docblock stating a guarantee the code did not provide.

Deleting a bot's tokens nulls `messages.token_id` on anything they posted (`nullOnDelete`), exactly as revoking a token by hand already does — the attribution thins, the messages stay.

## How tested

- `deletes the bot API tokens along with the bot` (`BotManagementTest`) — the direct pin. Red before the fix with 2 surviving rows.
- `personal access tokens are deleted with the account` (`AccountDeletionTest`) — the human path. Verified red (1 surviving row) by disabling the observer, which is what confirmed `AccountDeleter` had the same bug.
- `refuses a deleted bot token with 401` (`ApiAuthTest`) — pins the guarantee end to end through a real bearer token, calling `Auth::forgetGuards()` between requests. Without that the `RequestGuard` hands back the user it already resolved and the request passes, which is the trap the issue warned about. Note this one passed before the fix too, since orphans never authenticated; it pins Sanctum's behaviour rather than the sweep.
- `PruneOrphanedTokensMigrationTest` — three cases: orphans go, live-owner tokens stay, a foreign tokenable type is left alone.

Full gate green, `Total: 100.0 %` (3197 tests). No user-facing copy, so no i18n; no `.env`/config/install change, so no docs.

## Notes

- CodeRabbit's local pass could not run — free-tier rate limit (23 min). Leaving it to the app's review here.
- PHPStan hit a transient `Too many open files` on the first gate run with three Sail stacks up concurrently; it passed on retry and is unrelated to this diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788175878&installation_model_id=428379&pr_number=1139&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1139&signature=3d19e0187e10f07e0f6fc8199891c702b1b25beafc2d8ae6ee1ca1b10cfa34ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->