### PR TITLE
fix: keep a refused write's rollback off the channel switched to

### DIFF
--- a/resources/js/composables/useChannelPreferences.test.ts
+++ b/resources/js/composables/useChannelPreferences.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { effectScope, ref } from 'vue';
+import { effectScope, nextTick, ref } from 'vue';
 import type { Ref } from 'vue';
 
 const { patch, toastError } = vi.hoisted(() => ({
@@ -138,6 +138,36 @@ describe('useChannelPreferences', () => {
         failPatch();
         expect(prefs.muted.value).toBe(false);
         expect(toastError).toHaveBeenCalledOnce();
+    });
+
+    it('leaves the channel switched to untouched when a write is refused late', async () => {
+        // Every preference write rides `backgroundVisit`, so it can outlive the
+        // navigation that follows it; its rollback must not land on the channel
+        // the reader moved to (#1120).
+        const channel = ref(channelState());
+        const id = ref('id-1');
+        const { prefs } = withScope(channel, id);
+
+        prefs.toggleStar();
+        prefs.onMuteChange(true);
+        prefs.onNotificationLevelChange('mentions' as NotificationLevel);
+
+        channel.value = channelState({
+            notificationLevel: 'nothing',
+            muted: true,
+            starred: true,
+        });
+        id.value = 'id-2';
+        await nextTick();
+
+        failPatch(0);
+        failPatch(1);
+        failPatch(2);
+
+        expect(prefs.starred.value).toBe(true);
+        expect(prefs.muted.value).toBe(true);
+        expect(prefs.notificationLevel.value).toBe('nothing');
+        expect(toastError).not.toHaveBeenCalled();
     });
 
     it('saves every preference in the background so none interrupts a navigation', () => {

--- a/resources/js/composables/useChannelPreferences.ts
+++ b/resources/js/composables/useChannelPreferences.ts
@@ -95,6 +95,10 @@ export function useChannelPreferences(
             apply: () => {
                 starred.value = !starred.value;
             },
+            // These refs are shared across channels and reseeded on every
+            // switch, so a rollback is only ever right for the channel the write
+            // was fired from.
+            subject: options.channelId,
             method: 'patch',
             url: updateChannelStar({
                 team: options.teamSlug(),
@@ -121,6 +125,7 @@ export function useChannelPreferences(
         write({
             capture: () => snapshotRef(changed),
             apply,
+            subject: options.channelId,
             method: 'patch',
             url: updateChannelPreferences({
                 team: options.teamSlug(),

--- a/resources/js/composables/useOptimisticWrite.test.ts
+++ b/resources/js/composables/useOptimisticWrite.test.ts
@@ -356,6 +356,70 @@ describe('useOptimisticWrite', () => {
         expect(onSuccess).toHaveBeenCalledWith({ flash: { forwarded: null } });
     });
 
+    it('leaves a rollback undone when its subject is no longer the one on screen', () => {
+        const { write } = useOptimisticWrite();
+        const starred = ref(false);
+        const openChannel = ref('general');
+
+        write({
+            capture: () => snapshotRef(starred),
+            apply: () => {
+                starred.value = true;
+            },
+            subject: () => openChannel.value,
+            url: '/acme/general/star',
+            failure: 'Failed to update the channel',
+        });
+
+        // The reader moved on, and the ref now holds the new channel's state —
+        // which the outgoing channel's snapshot would overwrite.
+        openChannel.value = 'random';
+        starred.value = true;
+
+        optionsOf(post).onError({});
+
+        expect(starred.value).toBe(true);
+    });
+
+    it('stays quiet about a refusal the reader has navigated away from', () => {
+        // The copy names no channel, so a toast raised after the switch reads as
+        // the channel now on screen having failed.
+        const { write } = useOptimisticWrite();
+        const openChannel = ref('general');
+
+        write({
+            capture: () => () => undefined,
+            subject: () => openChannel.value,
+            url: '/acme/general/star',
+            failure: 'Failed to update the channel',
+        });
+
+        openChannel.value = 'random';
+        optionsOf(post).onError({});
+
+        expect(toastError).not.toHaveBeenCalled();
+    });
+
+    it('still rolls back and says so while the subject is the one on screen', () => {
+        const { write } = useOptimisticWrite();
+        const starred = ref(false);
+        const openChannel = ref('general');
+
+        write({
+            capture: () => snapshotRef(starred),
+            apply: () => {
+                starred.value = true;
+            },
+            subject: () => openChannel.value,
+            url: '/acme/general/star',
+            failure: 'Failed to update the channel',
+        });
+        optionsOf(post).onError({});
+
+        expect(starred.value).toBe(false);
+        expect(toastError).toHaveBeenCalledWith('Failed to update the channel');
+    });
+
     it('captures and restores without applying, for a mutation already made', () => {
         // vuedraggable has already written to the bound list by the time its
         // change handler fires, so that site restores by reseeding rather than

--- a/resources/js/composables/useOptimisticWrite.ts
+++ b/resources/js/composables/useOptimisticWrite.ts
@@ -142,8 +142,9 @@ export function useOptimisticWrite(): OptimisticWriter {
         const rollback = spec.capture();
         spec.apply?.();
 
-        // A write the reader has navigated away from has nothing left to undo:
-        // its refs now describe someone else's channel.
+        // A refusal that arrives after its subject has left the screen has
+        // nothing left to undo: the state the rollback closed over now belongs
+        // to whatever took its place. See {@link OptimisticWrite.subject}.
         const stillRelevant = (): boolean =>
             spec.subject === undefined || Object.is(spec.subject(), subject);
 

--- a/resources/js/composables/useOptimisticWrite.ts
+++ b/resources/js/composables/useOptimisticWrite.ts
@@ -52,6 +52,26 @@ export interface OptimisticWrite {
      * bound to, so that site captures and restores but applies nothing.
      */
     apply?: () => void;
+    /**
+     * What the write is *for*, read once before the write and again before the
+     * rollback: whatever this returns identifies the thing on screen the
+     * mutation belongs to, and the rollback runs only while the two still
+     * agree.
+     *
+     * A background write can outlive the surface that fired it. Star `#general`,
+     * navigate to `#random`, and let the star be refused: the refs the rollback
+     * closed over now hold `#random`'s preferences, and restoring `#general`'s
+     * snapshot over them shows the reader a channel's state they have left
+     * (#1120). Passing `subject: options.channelId` makes that restore a no-op.
+     *
+     * Capturing the identity here rather than taking a ready-made predicate is
+     * the same call as capturing strictly before {@link apply}: a call site
+     * asked to snapshot its own subject first is a call site that can forget to.
+     *
+     * Omit it for a write whose subject cannot change identity underneath it —
+     * a message row keyed on its own uuid, a sidebar that reseeds from props.
+     */
+    subject?: () => unknown;
     /** Defaults to `post`. */
     method?: OptimisticMethod;
     url: string;
@@ -118,8 +138,14 @@ export function useOptimisticWrite(): OptimisticWriter {
     const toast = useToast();
 
     function write(spec: OptimisticWrite): void {
+        const subject = spec.subject?.();
         const rollback = spec.capture();
         spec.apply?.();
+
+        // A write the reader has navigated away from has nothing left to undo:
+        // its refs now describe someone else's channel.
+        const stillRelevant = (): boolean =>
+            spec.subject === undefined || Object.is(spec.subject(), subject);
 
         const options = {
             ...(spec.background ? backgroundVisit : {}),
@@ -128,6 +154,10 @@ export function useOptimisticWrite(): OptimisticWriter {
             ...(spec.only ? { only: spec.only } : {}),
             ...(spec.onSuccess ? { onSuccess: spec.onSuccess } : {}),
             onError: (errors: Record<string, string>): void => {
+                if (!stillRelevant()) {
+                    return;
+                }
+
                 rollback();
                 toast.error(
                     typeof spec.failure === 'function'


### PR DESCRIPTION
Closes #1120.

## What

An optimistic write can outlive the surface that fired it. All three channel-preference writes — `toggleStar`, and `savePreferences` behind `onNotificationLevelChange` and `onMuteChange` — ride `backgroundVisit` (`async: true`), so a refusal can land after the reader has navigated away. The `watch(options.channelId, …)` reseed has already put the new channel's star/mute/level into the refs by then, and the late rollback wrote the *outgoing* channel's snapshot over them. The header and sidebar then showed preferences belonging to a channel the reader had left, until the next full reload.

## How

The guard lives on the shared module, not at the call sites, so every adopter can have it: `OptimisticWrite` gains an optional `subject: () => unknown`. `useOptimisticWrite` reads it once before the write and again in `onError`, and skips the rollback when the two no longer agree.

Two notes on the shape:

- The module captures the identity itself rather than taking a ready-made `stillRelevant` predicate (as the issue sketched). A call site asked to snapshot its own subject first is a call site that can forget to — the same reasoning that already put capture-strictly-before-apply inside the module.
- The failure toast is skipped along with the rollback. Its copy names no channel ("Failed to update the channel"), so raising it after the switch reads as the channel now on screen having failed. A misattributed toast is worse than none.

`useChannelPreferences` passes `subject: options.channelId` on both writes. No other adopter needs it: they either key a message row on its own uuid or reseed from props.

## Testing

`resources/js/composables/useOptimisticWrite.test.ts`
- leaves a rollback undone when its subject is no longer the one on screen
- stays quiet about a refusal the reader has navigated away from
- still rolls back and says so while the subject is the one on screen

`resources/js/composables/useChannelPreferences.test.ts`
- leaves the channel switched to untouched when a write is refused late — fires all three writes, switches channel, then fails all three, asserting the new channel's star, mute and level are untouched. Red against `develop` for the reason in the issue.

Full gate green: Pint / PHPStan / Rector / Pest at `Total: 100.0 %`, and `lint:check`, `format:check`, `types:check`, `test:js` (2597 tests) and `build`.

No i18n or docs changes: no new user-facing copy, nothing operator-facing.

Local CodeRabbit could not run — the free tier was rate-limited across ~35 minutes of retries. Leaving it to the PR review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/deskhq/codesmith/the-desk/pr/1140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788176192&installation_model_id=428379&pr_number=1140&repository=deskhq%2Fthe-desk&return_to=https%3A%2F%2Fgithub.com%2Fdeskhq%2Fthe-desk%2Fpull%2F1140&signature=a4ec7e78bf8a1887d332bc01dbec06c1ec1eb9e230e7357950de150f74448cea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->